### PR TITLE
feat: Support murmur3_hash and sha2 family hash functions

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -67,8 +67,8 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 chrono-tz = { version = "0.8" }
 paste = "1.0.14"
 datafusion-common = { git = "https://github.com/viirya/arrow-datafusion.git", rev = "57b3be4" }
-datafusion = { default-features = false, git = "https://github.com/viirya/arrow-datafusion.git", rev = "57b3be4", features = ["unicode_expressions"] }
-datafusion-functions = { git = "https://github.com/viirya/arrow-datafusion.git", rev = "57b3be4" }
+datafusion = { default-features = false, git = "https://github.com/viirya/arrow-datafusion.git", rev = "57b3be4", features = ["unicode_expressions", "crypto_expressions"] }
+datafusion-functions = { git = "https://github.com/viirya/arrow-datafusion.git", rev = "57b3be4", features = ["crypto_expressions"]}
 datafusion-physical-expr = { git = "https://github.com/viirya/arrow-datafusion.git", rev = "57b3be4", default-features = false, features = ["unicode_expressions"] }
 unicode-segmentation = "^1.10.1"
 once_cell = "1.18.0"

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -1930,7 +1930,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde {
 
         case Sha2(left, numBits) =>
           if (!numBits.foldable) {
-            withInfo(expr, s"non literal numBits is not supported")
+            withInfo(expr, "non literal numBits is not supported")
             return None
           }
           // it's possible for spark to dynamically compute the number of bits from input

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -1573,10 +1573,9 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde {
           optExprWithInfo(optExpr, expr, castExpr)
 
         case Md5(child) =>
-          val castExpr = Cast(child, StringType)
-          val childExpr = exprToProtoInternal(castExpr, inputs)
+          val childExpr = exprToProtoInternal(child, inputs)
           val optExpr = scalarExprToProto("md5", childExpr)
-          optExprWithInfo(optExpr, expr, castExpr)
+          optExprWithInfo(optExpr, expr, child)
 
         case OctetLength(child) =>
           val castExpr = Cast(child, StringType)
@@ -1912,6 +1911,44 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde {
           } else {
             withInfo(expr, bloomFilter, value)
             None
+          }
+
+        case Murmur3Hash(children, seed) =>
+          val firstUnSupportedInput = children.find(c => !supportedDataType(c.dataType))
+          if (firstUnSupportedInput.isDefined) {
+            withInfo(expr, s"Unsupported datatype ${firstUnSupportedInput.get.dataType}")
+            return None
+          }
+          val exprs = children.map(exprToProtoInternal(_, inputs))
+          val seedBuilder = ExprOuterClass.Literal
+            .newBuilder()
+            .setDatatype(serializeDataType(IntegerType).get)
+            .setIntVal(seed)
+          val seedExpr = Some(ExprOuterClass.Expr.newBuilder().setLiteral(seedBuilder).build())
+          // the seed is put at the end of the arguments
+          scalarExprToProtoWithReturnType("murmur3_hash", IntegerType, exprs :+ seedExpr: _*)
+
+        case Sha2(left, numBits) =>
+          if (!numBits.foldable) {
+            withInfo(expr, s"non literal numBits is not supported")
+            return None
+          }
+          // it's possible for spark to dynamically compute the number of bits from input
+          // expression, however DataFusion does not support that yet.
+          val childExpr = exprToProtoInternal(left, inputs)
+          val bits = numBits.eval().asInstanceOf[Int]
+          val algorithm = bits match {
+            case 224 => "sha224"
+            case 256 | 0 => "sha256"
+            case 384 => "sha384"
+            case 512 => "sha512"
+            case _ =>
+              null
+          }
+          if (algorithm == null) {
+            exprToProtoInternal(Literal(null, StringType), inputs)
+          } else {
+            scalarExprToProtoWithReturnType(algorithm, StringType, childExpr)
           }
 
         case _ =>


### PR DESCRIPTION
## Which issue does this PR close?
This partially closes #205 

## Rationale for this change
More expression coverage for comet

## What changes are included in this PR?
2. add user_defined scalar function: `spark_murmur3_hash` to support murmur3_hash in comet 
3. refine and re-enable md5 expression test.
4. bridge sha2 family functions to Datafusion's built-in scalar functions
5. glue code to convert Spark expression to proto messages
6. new test code

## How are these changes tested?
Added new test code
