### PR TITLE
chore: Change maven group id from org.apache.comet to org.apache.datafusion.comet

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -24,7 +24,7 @@ under the License.
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.comet</groupId>
+    <groupId>org.apache.datafusion.comet</groupId>
     <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
     <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>

--- a/dev/diffs/3.4.2.diff
+++ b/dev/diffs/3.4.2.diff
@@ -16,7 +16,7 @@ index fab98342498..f2156d790d1 100644
          <version>${netlib.ludovic.dev.version}</version>
        </dependency>
 +      <dependency>
-+        <groupId>org.apache.comet</groupId>
++        <groupId>org.apache.datafusion.comet</groupId>
 +        <artifactId>comet-spark-spark${spark.version.short}_${scala.binary.version}</artifactId>
 +        <version>${comet.version}</version>
 +        <exclusions>
@@ -46,7 +46,7 @@ index 5b6cc8cb7af..5ce708adc38 100644
        <artifactId>spark-tags_${scala.binary.version}</artifactId>
      </dependency>
 +    <dependency>
-+      <groupId>org.apache.comet</groupId>
++      <groupId>org.apache.datafusion.comet</groupId>
 +      <artifactId>comet-spark-spark${spark.version.short}_${scala.binary.version}</artifactId>
 +    </dependency>
  

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@ under the License.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.apache.comet</groupId>
+  <groupId>org.apache.datafusion.comet</groupId>
   <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
   <version>0.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
@@ -247,7 +247,7 @@ under the License.
         <scope>test</scope>
         <exclusions>
           <exclusion>
-            <groupId>org.apache.comet</groupId>
+            <groupId>org.apache.datafusion.comet</groupId>
             <artifactId>*</artifactId>
           </exclusion>
 
@@ -311,7 +311,7 @@ under the License.
             <artifactId>parquet-column</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.apache.comet</groupId>
+            <groupId>org.apache.datafusion.comet</groupId>
             <artifactId>*</artifactId>
           </exclusion>
 
@@ -329,7 +329,7 @@ under the License.
         <scope>test</scope>
         <exclusions>
           <exclusion>
-            <groupId>org.apache.comet</groupId>
+            <groupId>org.apache.datafusion.comet</groupId>
             <artifactId>*</artifactId>
           </exclusion>
           <exclusion>

--- a/spark-integration/pom.xml
+++ b/spark-integration/pom.xml
@@ -24,7 +24,7 @@ under the License.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.apache.comet</groupId>
+        <groupId>org.apache.datafusion.comet</groupId>
         <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
         <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -41,13 +41,13 @@ under the License.
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.comet</groupId>
+            <groupId>org.apache.datafusion.comet</groupId>
             <artifactId>comet-spark-spark${spark.version.short}_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <exclusions>
               <!-- This is shaded into the jar -->
               <exclusion>
-                <groupId>org.apache.comet</groupId>
+                <groupId>org.apache.datafusion.comet</groupId>
                 <artifactId>comet-common-spark${spark.version.short}_${scala.binary.version}</artifactId>
               </exclusion>
             </exclusions>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -24,7 +24,7 @@ under the License.
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.comet</groupId>
+    <groupId>org.apache.datafusion.comet</groupId>
     <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
     <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
@@ -40,7 +40,7 @@ under the License.
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.comet</groupId>
+      <groupId>org.apache.datafusion.comet</groupId>
       <artifactId>comet-common-spark${spark.version.short}_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <exclusions>


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The Maven group ID of `org.apache.comet` implies that Comet is a top-level Apache project, and this could cause confusion.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Change the group ID to `org.apache.datafusion.comet` to reflect the fact that Comet is a subproject of the Apache DataFusion top-level project (at least, it will be in the next week or so).

We should also change the Java package names, but I would prefer that we do this as a separate PR.

## How are these changes tested?

Existing tests.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
