### PR TITLE
chore: Fix NPE when running CometTPCHQueriesList directly

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/CometTPCHQueriesList.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTPCHQueriesList.scala
@@ -49,9 +49,12 @@ object CometTPCHQueriesList extends CometTPCQueryListBase with CometTPCQueryBase
 
     // List of all TPC-H queries
     val tpchQueries = (1 to 22).map(n => s"q$n")
+    // Only q1 in the extended queries
+    val tpchExtendedQueries = Seq("q1")
 
     // If `--query-filter` defined, filters the queries that this option selects
     val queries = filterQueries(tpchQueries, benchmarkArgs.queryFilter)
+    val extendedQueries = filterQueries(tpchExtendedQueries, benchmarkArgs.queryFilter)
 
     if (queries.isEmpty) {
       throw new RuntimeException(
@@ -63,6 +66,6 @@ object CometTPCHQueriesList extends CometTPCQueryListBase with CometTPCQueryBase
     setupCBO(cometSpark, benchmarkArgs.cboEnabled, tables)
 
     runQueries("tpch", queries, " TPCH Snappy")
-    runQueries("tpch-extended", queries, " TPCH Extended Snappy")
+    runQueries("tpch-extended", extendedQueries, " TPCH Extended Snappy")
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/CometTPCQueryListBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTPCQueryListBase.scala
@@ -88,8 +88,10 @@ trait CometTPCQueryListBase
 
         val df = cometSpark.sql(queryString)
         val cometPlans = mutable.HashSet.empty[String]
-        stripAQEPlan(df.queryExecution.executedPlan).foreach { case op: CometExec =>
-          cometPlans += s"${op.nodeName}"
+        stripAQEPlan(df.queryExecution.executedPlan).foreach {
+          case op: CometExec =>
+            cometPlans += s"${op.nodeName}"
+          case _ =>
         }
 
         if (cometPlans.nonEmpty) {


### PR DESCRIPTION
## Which issue does this PR close?
Closes #.

## Rationale for this change
When running `org.apache.spark.sql.CometTPCHQueriesList` directly from console/IDEA, I notice it failed with NPE. The exception track is showed as below:
```
Exception in thread "main" java.lang.NullPointerException
	at org.apache.spark.sql.catalyst.util.package$.resourceToBytes(package.scala:67)
	at org.apache.spark.sql.catalyst.util.package$.resourceToString(package.scala:75)
	at org.apache.spark.sql.CometTPCQueryListBase.$anonfun$runQueries$1(CometTPCQueryListBase.scala:82)
	at org.apache.spark.sql.CometTPCQueryListBase.$anonfun$runQueries$1$adapted(CometTPCQueryListBase.scala:79)
	at scala.collection.immutable.List.foreach(List.scala:431)
	at org.apache.spark.sql.CometTPCQueryListBase.runQueries(CometTPCQueryListBase.scala:79)
	at org.apache.spark.sql.CometTPCQueryListBase.runQueries$(CometTPCQueryListBase.scala:68)
	at org.apache.spark.sql.CometTPCHQueriesList$.runQueries(CometTPCHQueriesList.scala:43)
	at org.apache.spark.sql.CometTPCHQueriesList$.runSuite(CometTPCHQueriesList.scala:69)
	at org.apache.spark.sql.CometTPCQueryListBase.main(CometTPCQueryListBase.scala:59)
	at org.apache.spark.sql.CometTPCQueryListBase.main$(CometTPCQueryListBase.scala:42)
	at org.apache.spark.sql.CometTPCHQueriesList$.main(CometTPCHQueriesList.scala:43)
	at org.apache.spark.sql.CometTPCHQueriesList.main(CometTPCHQueriesList.scala)
```

 The reason is that there's only a `q1` query in the `spark/src/test/resources/tpch-extended` dir, loading other queries such as `q2`, `q3` will result an NPE.

## What changes are included in this PR?
Make sure only "q1" is in the tpch extended queries list.

## How are these changes tested?
Manul test