### PR TITLE
chore: Add allocation source to StreamReader

### DIFF
--- a/common/src/main/scala/org/apache/comet/vector/NativeUtil.scala
+++ b/common/src/main/scala/org/apache/comet/vector/NativeUtil.scala
@@ -33,6 +33,7 @@ class NativeUtil {
   import Utils._
 
   private val allocator = new RootAllocator(Long.MaxValue)
+    .newChildAllocator(this.getClass.getSimpleName, 0, Long.MaxValue)
   private val dictionaryProvider: CDataDictionaryProvider = new CDataDictionaryProvider
   private val importer = new ArrowImporter(allocator)
 

--- a/common/src/main/scala/org/apache/comet/vector/StreamReader.scala
+++ b/common/src/main/scala/org/apache/comet/vector/StreamReader.scala
@@ -30,8 +30,9 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 /**
  * A reader that consumes Arrow data from an input channel, and produces Comet batches.
  */
-case class StreamReader(channel: ReadableByteChannel) extends AutoCloseable {
+case class StreamReader(channel: ReadableByteChannel, source: String) extends AutoCloseable {
   private var allocator = new RootAllocator(Long.MaxValue)
+    .newChildAllocator(s"${this.getClass.getSimpleName}/$source", 0, Long.MaxValue)
   private val channelReader = new MessageChannelReader(new ReadChannel(channel), allocator)
   private var arrowReader = new ArrowStreamReader(channelReader, allocator)
   private var root = arrowReader.getVectorSchemaRoot

--- a/common/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/ArrowReaderIterator.scala
+++ b/common/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/ArrowReaderIterator.scala
@@ -25,9 +25,10 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import org.apache.comet.vector._
 
-class ArrowReaderIterator(channel: ReadableByteChannel) extends Iterator[ColumnarBatch] {
+class ArrowReaderIterator(channel: ReadableByteChannel, source: String)
+    extends Iterator[ColumnarBatch] {
 
-  private val reader = StreamReader(channel)
+  private val reader = StreamReader(channel, source)
   private var batch = nextBatch()
   private var currentBatch: ColumnarBatch = null
 

--- a/common/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometBlockStoreShuffleReader.scala
+++ b/common/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometBlockStoreShuffleReader.scala
@@ -108,7 +108,7 @@ class CometBlockStoreShuffleReader[K, C](
               // Closes previous read iterator.
               currentReadIterator.close()
             }
-            currentReadIterator = new ArrowReaderIterator(channel)
+            currentReadIterator = new ArrowReaderIterator(channel, "shuffle reader")
             currentReadIterator.map((0, _)) // use 0 as key since it's not used
           }
       }

--- a/common/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometBlockStoreShuffleReader.scala
+++ b/common/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometBlockStoreShuffleReader.scala
@@ -108,7 +108,7 @@ class CometBlockStoreShuffleReader[K, C](
               // Closes previous read iterator.
               currentReadIterator.close()
             }
-            currentReadIterator = new ArrowReaderIterator(channel, "shuffle reader")
+            currentReadIterator = new ArrowReaderIterator(channel, this.getClass.getSimpleName)
             currentReadIterator.map((0, _)) // use 0 as key since it's not used
           }
       }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometBroadcastExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometBroadcastExchangeExec.scala
@@ -284,7 +284,8 @@ class CometBatchRDD(
 
   override def compute(split: Partition, context: TaskContext): Iterator[ColumnarBatch] = {
     val partition = split.asInstanceOf[CometBatchPartition]
-    partition.value.value.toIterator.flatMap(CometExec.decodeBatches(_, "broadcast"))
+    partition.value.value.toIterator
+      .flatMap(CometExec.decodeBatches(_, this.getClass.getSimpleName))
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometBroadcastExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometBroadcastExchangeExec.scala
@@ -284,7 +284,7 @@ class CometBatchRDD(
 
   override def compute(split: Partition, context: TaskContext): Iterator[ColumnarBatch] = {
     val partition = split.asInstanceOf[CometBatchPartition]
-    partition.value.value.toIterator.flatMap(CometExec.decodeBatches)
+    partition.value.value.toIterator.flatMap(CometExec.decodeBatches(_, "broadcast"))
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -78,7 +78,8 @@ abstract class CometExec extends CometPlan {
     val countsAndBytes = CometExec.getByteArrayRdd(this).collect()
     val total = countsAndBytes.map(_._1).sum
     val rows = countsAndBytes.iterator
-      .flatMap(countAndBytes => CometExec.decodeBatches(countAndBytes._2, "collect"))
+      .flatMap(countAndBytes =>
+        CometExec.decodeBatches(countAndBytes._2, this.getClass.getSimpleName))
     (total, rows)
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -78,7 +78,7 @@ abstract class CometExec extends CometPlan {
     val countsAndBytes = CometExec.getByteArrayRdd(this).collect()
     val total = countsAndBytes.map(_._1).sum
     val rows = countsAndBytes.iterator
-      .flatMap(countAndBytes => CometExec.decodeBatches(countAndBytes._2))
+      .flatMap(countAndBytes => CometExec.decodeBatches(countAndBytes._2, "collect"))
     (total, rows)
   }
 }
@@ -118,7 +118,7 @@ object CometExec {
   /**
    * Decodes the byte arrays back to ColumnarBatchs and put them into buffer.
    */
-  def decodeBatches(bytes: ChunkedByteBuffer): Iterator[ColumnarBatch] = {
+  def decodeBatches(bytes: ChunkedByteBuffer, source: String): Iterator[ColumnarBatch] = {
     if (bytes.size == 0) {
       return Iterator.empty
     }
@@ -127,7 +127,7 @@ object CometExec {
     val cbbis = bytes.toInputStream()
     val ins = new DataInputStream(codec.compressedInputStream(cbbis))
 
-    new ArrowReaderIterator(Channels.newChannel(ins))
+    new ArrowReaderIterator(Channels.newChannel(ins), source)
   }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

There is a memory leak reported by Java Arrow in #324. When looking at the error message for debugging:

```
Memory was leaked by query. Memory leaked: (49152)
Allocator(ROOT) 0/49152/180352/9223372036854775807 (res/actual/peak/limit)
```

I figured that it is hard to know where the allocation comes from. In this PR, I added the source of allocators.

The error message is updated to:

```
Memory was leaked by query. Memory leaked: (49152)                                                                                                                                                                                     
Allocator(StreamReader/shuffle reader) 0/49152/180352/9223372036854775807 (res/actual/peak/limit)                                                                                                                                      
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
