### PR TITLE
feat: Add a test for supported types of SortMergeJoin in DataFusion

### DIFF
--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -383,6 +383,13 @@ object CometConf {
     .booleanConf
     .createWithDefault(false)
 
+  val COMET_SORTMERGEJOIN_ALLOW_ALL_KEY_TYPES: ConfigEntry[Boolean] =
+    conf(s"$COMET_EXEC_CONFIG_PREFIX.sortmergejoin.allow.all.key.types")
+      .doc("Allows SortMergeJoin to be executed natively regardless of the key type" +
+        "By default, this config is false. This config is only used for unit test.")
+      .booleanConf
+      .createWithDefault(false)
+
 }
 
 object ConfigHelpers {

--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -383,12 +383,12 @@ object CometConf {
     .booleanConf
     .createWithDefault(false)
 
-  val COMET_SORTMERGEJOIN_ALLOW_ALL_KEY_TYPES: ConfigEntry[Boolean] =
-    conf(s"$COMET_EXEC_CONFIG_PREFIX.sortmergejoin.allow.all.key.types")
+  val COMET_SORTMERGEJOIN_CHECK_KEY_TYPES: ConfigEntry[Boolean] =
+    conf(s"$COMET_EXEC_CONFIG_PREFIX.sortmergejoin.check.key.types")
       .doc("Allows SortMergeJoin to be executed natively regardless of the key type" +
         "By default, this config is false. This config is only used for unit test.")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
 }
 

--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -385,8 +385,8 @@ object CometConf {
 
   val COMET_SORTMERGEJOIN_CHECK_KEY_TYPES: ConfigEntry[Boolean] =
     conf(s"$COMET_EXEC_CONFIG_PREFIX.sortmergejoin.check.key.types")
-      .doc("Allows SortMergeJoin to be executed natively regardless of the key type" +
-        "By default, this config is false. This config is only used for unit test.")
+      .doc("Enable key type checking in SortMergeJoin" +
+        "By default, this config is true. This config is only used for unit test.")
       .booleanConf
       .createWithDefault(true)
 

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -2424,7 +2424,8 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde {
 
         // Checks if the join keys are supported by DataFusion SortMergeJoin.
         val errorMsgs = join.leftKeys.flatMap { key =>
-          if (!supportedSortMergeJoinEqualType(key.dataType)) {
+          if (!CometConf.COMET_SORTMERGEJOIN_ALLOW_ALL_KEY_TYPES.get(op.conf)
+            && !supportedSortMergeJoinEqualType(key.dataType)) {
             Some(s"Unsupported join key type ${key.dataType} on key: ${key.sql}")
           } else {
             None

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -2424,7 +2424,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde {
 
         // Checks if the join keys are supported by DataFusion SortMergeJoin.
         val errorMsgs = join.leftKeys.flatMap { key =>
-          if (!CometConf.COMET_SORTMERGEJOIN_ALLOW_ALL_KEY_TYPES.get(op.conf)
+          if (CometConf.COMET_SORTMERGEJOIN_CHECK_KEY_TYPES.get(op.conf)
             && !supportedSortMergeJoinEqualType(key.dataType)) {
             Some(s"Unsupported join key type ${key.dataType} on key: ${key.sql}")
           } else {

--- a/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
@@ -259,7 +259,7 @@ class CometJoinSuite extends CometTestBase {
     // This test will be deleted when this type is supported
     assert(!QueryPlanSerde.supportedSortMergeJoinEqualType(TimestampType))
     withSQLConf(
-      CometConf.COMET_SORTMERGEJOIN_ALLOW_ALL_KEY_TYPES.key -> "true",
+      CometConf.COMET_SORTMERGEJOIN_CHECK_KEY_TYPES.key -> "false",
       SQLConf.SESSION_LOCAL_TIMEZONE.key -> "Asia/Kathmandu",
       SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
@@ -284,7 +284,7 @@ class CometJoinSuite extends CometTestBase {
     // This test will be deleted when this type is supported
     assert(!QueryPlanSerde.supportedSortMergeJoinEqualType(BinaryType))
     withSQLConf(
-      CometConf.COMET_SORTMERGEJOIN_ALLOW_ALL_KEY_TYPES.key -> "true",
+      CometConf.COMET_SORTMERGEJOIN_CHECK_KEY_TYPES.key -> "false",
       SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #357 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
The goal of these tests is that if Datafusion supports more data types, we remember to support them here.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Add new tests

## How are these changes tested?

Unit testing
We have yet configuration to support testing (COMET_EXEC_BROADCAST_FORCE_ENABLED) so this PR add new configuration to support the tests.
I can't do complex type testing because we don't support it in most operators.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
