### PR TITLE
feat: Implement Spark-compatible CAST from floating-point/double to decimal

### DIFF
--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -72,6 +72,13 @@ pub enum CometError {
         to_type: String,
     },
 
+    #[error("[NUMERIC_VALUE_OUT_OF_RANGE] {value} cannot be represented as Decimal({precision}, {scale}). If necessary set \"spark.sql.ansi.enabled\" to \"false\" to bypass this error, and return NULL instead.")]
+    NumericValueOutOfRange {
+        value: String,
+        precision: u8,
+        scale: i8,
+    },
+
     #[error(transparent)]
     Arrow {
         #[from]
@@ -196,6 +203,10 @@ impl jni::errors::ToException for CometError {
                 msg: self.to_string(),
             },
             CometError::CastInvalidValue { .. } => Exception {
+                class: "org/apache/spark/SparkException".to_string(),
+                msg: self.to_string(),
+            },
+            CometError::NumericValueOutOfRange { .. } => Exception {
                 class: "org/apache/spark/SparkException".to_string(),
                 msg: self.to_string(),
             },

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -332,7 +332,6 @@ impl Cast {
             (DataType::Float32, DataType::LargeUtf8) => {
                 Self::spark_cast_float32_to_utf8::<i64>(&array, self.eval_mode)?
             }
-
             (DataType::Float64, DataType::Decimal128(precision, scale)) => {
                 Self::cast_float64_to_decimal128(&array, *precision, *scale, self.eval_mode)?
             }
@@ -408,7 +407,7 @@ impl Cast {
         let input = array.as_any().downcast_ref::<Float64Array>().unwrap();
         let mut cast_array = PrimitiveArray::<Decimal128Type>::builder(input.len());
 
-        let mul = (precision as f64).powi(scale as i32);
+        let mul = 10_f64.powi(scale as i32);
 
         for i in 0..input.len() {
             if input.is_null(i) {

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -25,7 +25,7 @@ use std::{
 use crate::errors::{CometError, CometResult};
 use arrow::{
     compute::{cast_with_options, CastOptions},
-    datatypes::{DecimalType, Decimal128Type, TimestampMicrosecondType},
+    datatypes::{Decimal128Type, DecimalType, TimestampMicrosecondType},
     record_batch::RecordBatch,
     util::display::FormatOptions,
 };
@@ -335,7 +335,7 @@ impl Cast {
 
             (DataType::Float64, DataType::Decimal128(precision, scale)) => {
                 Self::cast_float64_to_decimal128(&array, *precision, *scale, self.eval_mode)?
-            }            
+            }
             _ => {
                 // when we have no Spark-specific casting we delegate to DataFusion
                 cast_with_options(&array, to_type, &CAST_OPTIONS)?
@@ -399,7 +399,7 @@ impl Cast {
         Ok(cast_array)
     }
 
-    fn cast_float64_to_decimal128 (
+    fn cast_float64_to_decimal128(
         array: &dyn Array,
         precision: u8,
         scale: i8,
@@ -407,16 +407,16 @@ impl Cast {
     ) -> CometResult<ArrayRef> {
         let input = array.as_any().downcast_ref::<Float64Array>().unwrap();
         let mut cast_array = PrimitiveArray::<Decimal128Type>::builder(input.len());
-    
+
         let mul = (precision as f64).powi(scale as i32);
-    
+
         for i in 0..input.len() {
             if input.is_null(i) {
                 cast_array.append_null();
             } else {
-                let input_value = input.value(i);    
+                let input_value = input.value(i);
                 let value = (input_value * mul).round().to_i128();
-        
+
                 match value {
                     Some(v) => {
                         if Decimal128Type::validate_decimal_precision(v, precision).is_err() {
@@ -441,11 +441,15 @@ impl Cast {
                     }
                 }
             }
-        }        
-    
-        let res = Arc::new(cast_array.with_precision_and_scale(precision, scale)?.finish()) as ArrayRef;
+        }
+
+        let res = Arc::new(
+            cast_array
+                .with_precision_and_scale(precision, scale)?
+                .finish(),
+        ) as ArrayRef;
         Ok(res)
-    }        
+    }
 
     fn spark_cast_float64_to_utf8<OffsetSize>(
         from: &dyn Array,

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -446,11 +446,15 @@ impl Cast {
                 match value {
                     Some(v) => {
                         if Decimal128Type::validate_decimal_precision(v, precision).is_err() {
-                            return Err(CometError::NumericValueOutOfRange {
-                                value: input_value.to_string(),
-                                precision,
-                                scale,
-                            });
+                            if eval_mode == EvalMode::Ansi {
+                                return Err(CometError::NumericValueOutOfRange {
+                                    value: input_value.to_string(),
+                                    precision,
+                                    scale,
+                                });
+                            } else {
+                                cast_array.append_null();
+                            }
                         }
                         cast_array.append_value(v);
                     }

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -25,7 +25,10 @@ use std::{
 use crate::errors::{CometError, CometResult};
 use arrow::{
     compute::{cast_with_options, CastOptions},
-    datatypes::{Decimal128Type, DecimalType, TimestampMicrosecondType},
+    datatypes::{
+        ArrowPrimitiveType, Decimal128Type, DecimalType, Float32Type, Float64Type,
+        TimestampMicrosecondType,
+    },
     record_batch::RecordBatch,
     util::display::FormatOptions,
 };
@@ -39,7 +42,7 @@ use chrono::{TimeZone, Timelike};
 use datafusion::logical_expr::ColumnarValue;
 use datafusion_common::{internal_err, Result as DataFusionResult, ScalarValue};
 use datafusion_physical_expr::PhysicalExpr;
-use num::{traits::CheckedNeg, CheckedSub, Integer, Num, ToPrimitive};
+use num::{cast::AsPrimitive, traits::CheckedNeg, CheckedSub, Integer, Num, ToPrimitive};
 use regex::Regex;
 
 use crate::execution::datafusion::expressions::utils::{
@@ -332,6 +335,9 @@ impl Cast {
             (DataType::Float32, DataType::LargeUtf8) => {
                 Self::spark_cast_float32_to_utf8::<i64>(&array, self.eval_mode)?
             }
+            (DataType::Float32, DataType::Decimal128(precision, scale)) => {
+                Self::cast_float32_to_decimal128(&array, *precision, *scale, self.eval_mode)?
+            }
             (DataType::Float64, DataType::Decimal128(precision, scale)) => {
                 Self::cast_float64_to_decimal128(&array, *precision, *scale, self.eval_mode)?
             }
@@ -404,7 +410,28 @@ impl Cast {
         scale: i8,
         eval_mode: EvalMode,
     ) -> CometResult<ArrayRef> {
-        let input = array.as_any().downcast_ref::<Float64Array>().unwrap();
+        Self::cast_floating_point_to_decimal128::<Float64Type>(array, precision, scale, eval_mode)
+    }
+
+    fn cast_float32_to_decimal128(
+        array: &dyn Array,
+        precision: u8,
+        scale: i8,
+        eval_mode: EvalMode,
+    ) -> CometResult<ArrayRef> {
+        Self::cast_floating_point_to_decimal128::<Float32Type>(array, precision, scale, eval_mode)
+    }
+
+    fn cast_floating_point_to_decimal128<T: ArrowPrimitiveType>(
+        array: &dyn Array,
+        precision: u8,
+        scale: i8,
+        eval_mode: EvalMode,
+    ) -> CometResult<ArrayRef>
+    where
+        <T as ArrowPrimitiveType>::Native: AsPrimitive<f64>,
+    {
+        let input = array.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
         let mut cast_array = PrimitiveArray::<Decimal128Type>::builder(input.len());
 
         let mul = 10_f64.powi(scale as i32);
@@ -413,7 +440,7 @@ impl Cast {
             if input.is_null(i) {
                 cast_array.append_null();
             } else {
-                let input_value = input.value(i);
+                let input_value = input.value(i).as_();
                 let value = (input_value * mul).round().to_i128();
 
                 match value {

--- a/docs/source/user-guide/compatibility.md
+++ b/docs/source/user-guide/compatibility.md
@@ -89,9 +89,11 @@ The following cast operations are generally compatible with Spark except for the
 | long | string |  |
 | float | boolean |  |
 | float | double |  |
+| float | decimal |  |
 | float | string | There can be differences in precision. For example, the input "1.4E-45" will produce 1.0E-45 instead of 1.4E-45 |
 | double | boolean |  |
 | double | float |  |
+| double | decimal |  |
 | double | string | There can be differences in precision. For example, the input "1.4E-45" will produce 1.0E-45 instead of 1.4E-45 |
 | decimal | float |  |
 | decimal | double |  |
@@ -115,8 +117,6 @@ The following cast operations are not compatible with Spark for all inputs and a
 |-|-|-|
 | integer | decimal  | No overflow check |
 | long | decimal  | No overflow check |
-| float | decimal  | No overflow check |
-| double | decimal  | No overflow check |
 | string | timestamp  | Not all valid formats are supported |
 | binary | string  | Only works for binary data representing valid UTF-8 strings |
 

--- a/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
+++ b/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
@@ -227,7 +227,7 @@ object CometCast {
 
   private def canCastFromFloat(toType: DataType): SupportLevel = toType match {
     case DataTypes.BooleanType | DataTypes.DoubleType => Compatible()
-    case _: DecimalType => Incompatible(Some("No overflow check"))
+    case _: DecimalType => Compatible()
     case _ => Unsupported
   }
 

--- a/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
+++ b/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
@@ -184,7 +184,7 @@ object CometCast {
 
   private def canCastFromDouble(toType: DataType): SupportLevel = toType match {
     case DataTypes.BooleanType | DataTypes.FloatType => Compatible
-    case _: DecimalType => Incompatible()
+    case _: DecimalType => Compatible
     case _ => Unsupported
   }
 

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -403,7 +403,6 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("cast DoubleType to DecimalType(10,2)") {
-    // Comet should have failed with [NUMERIC_VALUE_OUT_OF_RANGE]
     castTest(generateDoubles(), DataTypes.createDecimalType(10, 2))
   }
 

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -958,11 +958,19 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
               val cometMessageModified = cometMessage
                 .replace("[CAST_INVALID_INPUT] ", "")
                 .replace("[CAST_OVERFLOW] ", "")
-              assert(cometMessageModified == sparkMessage)
+                .replace("[NUMERIC_VALUE_OUT_OF_RANGE] ", "")
+
+              if (sparkMessage.contains("cannot be represented as")) {
+                assert(cometMessage.contains("cannot be represented as"))
+              } else {
+                assert(cometMessageModified == sparkMessage)
+              }
             } else {
               // for Spark 3.2 we just make sure we are seeing a similar type of error
               if (sparkMessage.contains("causes overflow")) {
                 assert(cometMessage.contains("due to an overflow"))
+              } else if (sparkMessage.contains("cannot be represented as")) {
+                assert(cometMessage.contains("cannot be represented as"))
               } else {
                 // assume that this is an invalid input message in the form:
                 // `invalid input syntax for type numeric: -9223372036854775809`

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -385,7 +385,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     castTest(generateDoubles(), DataTypes.FloatType)
   }
 
-  ignore("cast DoubleType to DecimalType(10,2)") {
+  test("cast DoubleType to DecimalType(10,2)") {
     // Comet should have failed with [NUMERIC_VALUE_OUT_OF_RANGE]
     castTest(generateDoubles(), DataTypes.createDecimalType(10, 2))
   }

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -344,8 +344,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     castTest(generateFloats(), DataTypes.DoubleType)
   }
 
-  ignore("cast FloatType to DecimalType(10,2)") {
-    // Comet should have failed with [NUMERIC_VALUE_OUT_OF_RANGE]
+  test("cast FloatType to DecimalType(10,2)") {
     castTest(generateFloats(), DataTypes.createDecimalType(10, 2))
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #371 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Improve compatibility with spark

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add custom implementation of CAST from double to timestamp to handle eval_modes if error in casting.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

CometCastSuite test case passes.