### PR TITLE
chore: Store EXTENSION_INFO as Set[String] instead of newline-delimited String

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -1042,16 +1042,11 @@ object CometSparkSessionExtensions extends Logging {
    *   The node with information (if any) attached
    */
   def withInfo[T <: TreeNode[_]](node: T, info: String, exprs: T*): T = {
-    val exprInfo = exprs
-      .flatMap { e => Seq(e.getTagValue(CometExplainInfo.EXTENSION_INFO)) }
-      .flatten
-      .mkString("\n")
-    if (info != null && info.nonEmpty && exprInfo.nonEmpty) {
-      node.setTagValue(CometExplainInfo.EXTENSION_INFO, Seq(exprInfo, info).mkString("\n"))
-    } else if (exprInfo.nonEmpty) {
+    val exprInfo = exprs.flatMap(_.getTagValue(CometExplainInfo.EXTENSION_INFO)).flatten.toSet
+    if (info != null && info.nonEmpty) {
+      node.setTagValue(CometExplainInfo.EXTENSION_INFO, exprInfo + info)
+    } else {
       node.setTagValue(CometExplainInfo.EXTENSION_INFO, exprInfo)
-    } else if (info != null && info.nonEmpty) {
-      node.setTagValue(CometExplainInfo.EXTENSION_INFO, info)
     }
     node
   }

--- a/spark/src/main/scala/org/apache/comet/ExtendedExplainInfo.scala
+++ b/spark/src/main/scala/org/apache/comet/ExtendedExplainInfo.scala
@@ -32,7 +32,7 @@ class ExtendedExplainInfo extends ExtendedExplainGenerator {
 
   override def generateExtendedInfo(plan: SparkPlan): String = {
     val info = extensionInfo(plan)
-    info.distinct.mkString("\n").trim
+    info.mkString("\n").trim
   }
 
   private def getActualPlan(node: TreeNode[_]): TreeNode[_] = {
@@ -45,17 +45,17 @@ class ExtendedExplainInfo extends ExtendedExplainGenerator {
     }
   }
 
-  private def extensionInfo(node: TreeNode[_]): mutable.Seq[String] = {
+  private def extensionInfo(node: TreeNode[_]): Set[String] = {
     var info = mutable.Seq[String]()
     val sorted = sortup(node)
     sorted.foreach { p =>
-      val all: Array[String] =
-        getActualPlan(p).getTagValue(CometExplainInfo.EXTENSION_INFO).getOrElse("").split("\n")
+      val all: Set[String] =
+        getActualPlan(p).getTagValue(CometExplainInfo.EXTENSION_INFO).getOrElse(Set.empty[String])
       for (s <- all) {
         info = info :+ s
       }
     }
-    info.filter(!_.contentEquals("\n"))
+    info.toSet
   }
 
   // get all plan nodes, breadth first traversal, then returned the reversed list so
@@ -84,5 +84,5 @@ class ExtendedExplainInfo extends ExtendedExplainGenerator {
 }
 
 object CometExplainInfo {
-  val EXTENSION_INFO = new TreeNodeTag[String]("CometExtensionInfo")
+  val EXTENSION_INFO = new TreeNodeTag[Set[String]]("CometExtensionInfo")
 }

--- a/spark/src/main/scala/org/apache/comet/ExtendedExplainInfo.scala
+++ b/spark/src/main/scala/org/apache/comet/ExtendedExplainInfo.scala
@@ -32,7 +32,7 @@ class ExtendedExplainInfo extends ExtendedExplainGenerator {
 
   override def generateExtendedInfo(plan: SparkPlan): String = {
     val info = extensionInfo(plan)
-    info.mkString("\n").trim
+    info.toSeq.sorted.mkString("\n").trim
   }
 
   private def getActualPlan(node: TreeNode[_]): TreeNode[_] = {

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1382,29 +1382,30 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
         Seq(
           (
             s"SELECT cast(make_interval(c0, c1, c0, c1, c0, c0, c2) as string) as C from $table",
-            "make_interval is not supported"),
+            Set("make_interval is not supported")),
           (
             "SELECT "
               + "date_part('YEAR', make_interval(c0, c1, c0, c1, c0, c0, c2))"
               + " + "
               + "date_part('MONTH', make_interval(c0, c1, c0, c1, c0, c0, c2))"
               + s" as yrs_and_mths from $table",
-            "extractintervalyears is not supported\n" +
-              "extractintervalmonths is not supported"),
+            Set(
+              "extractintervalyears is not supported",
+              "extractintervalmonths is not supported")),
           (
             s"SELECT sum(c0), sum(c2) from $table group by c1",
-            "Native shuffle is not enabled\n" +
-              "AQEShuffleRead is not supported"),
+            Set("Native shuffle is not enabled", "AQEShuffleRead is not supported")),
           (
             "SELECT A.c1, A.sum_c0, A.sum_c2, B.casted from "
               + s"(SELECT c1, sum(c0) as sum_c0, sum(c2) as sum_c2 from $table group by c1) as A, "
               + s"(SELECT c1, cast(make_interval(c0, c1, c0, c1, c0, c0, c2) as string) as casted from $table) as B "
               + "where A.c1 = B.c1 ",
-            "Native shuffle is not enabled\n" +
-              "AQEShuffleRead is not supported\n" +
-              "make_interval is not supported\n" +
-              "BroadcastExchange is not supported\n" +
-              "BroadcastHashJoin disabled because not all child plans are native"))
+            Set(
+              "Native shuffle is not enabled",
+              "AQEShuffleRead is not supported",
+              "make_interval is not supported",
+              "BroadcastExchange is not supported",
+              "BroadcastHashJoin disabled because not all child plans are native")))
           .foreach(test => {
             val qry = test._1
             val expected = test._2

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -244,7 +244,7 @@ abstract class CometTestBase
 
   protected def checkSparkAnswerAndCompareExplainPlan(
       df: DataFrame,
-      expectedInfo: String): Unit = {
+      expectedInfo: Set[String]): Unit = {
     var expected: Array[Row] = Array.empty
     var dfSpark: Dataset[Row] = null
     withSQLConf(
@@ -263,7 +263,7 @@ abstract class CometTestBase
     }
     val extendedInfo =
       new ExtendedExplainInfo().generateExtendedInfo(dfComet.queryExecution.executedPlan)
-    assert(extendedInfo.equalsIgnoreCase(expectedInfo))
+    assert(extendedInfo.equalsIgnoreCase(expectedInfo.toSeq.sorted.mkString("\n")))
   }
 
   private var _spark: SparkSession = _


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I think it would be cleaner to store extension info as `Set[String]` rather than using a newline-delimited string, because:

- It removes the need to use `split("\n")` and `mkString("\n")` when manipulating the info
- It ensures that we do not have duplicate entries

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Some refactoring inside `CometSparkSessionExtensions`

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests