### PR TITLE
build: Add scala-version to matrix

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -54,7 +54,7 @@ jobs:
           - java_version: 11
             is_push_event: false
       fail-fast: false
-    name: ${{ matrix.os }}/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}/${{ matrix.test-target }}
+    name: ${{ matrix.os }}/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}-scala-${{matrix.scala-version}}/${{ matrix.test-target }}
     runs-on: ${{ matrix.os }}
     container:
       image: amd64/rust
@@ -92,7 +92,7 @@ jobs:
           - spark-version: '3.2'
             scala-version: '2.13'
       fail-fast: false
-    name: ${{ matrix.os }}/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}/${{ matrix.test-target }}
+    name: ${{ matrix.os }}/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}-scala-${{matrix.scala-version}}/${{ matrix.test-target }}
     runs-on: ${{ matrix.os }}
     container:
       image: amd64/rust
@@ -118,7 +118,7 @@ jobs:
         scala-version: ['2.12', '2.13']
       fail-fast: false
     if: github.event_name == 'push'
-    name: ${{ matrix.os }}/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}/${{ matrix.test-target }}
+    name: ${{ matrix.os }}/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}-scala-${{matrix.scala-version}}/${{ matrix.test-target }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -149,7 +149,7 @@ jobs:
           - java_version: 11
             is_push_event: false
       fail-fast: false
-    name: macos-14(Silicon)/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}/${{ matrix.test-target }}
+    name: macos-14(Silicon)/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}-scala-${{matrix.scala-version}}/${{ matrix.test-target }}
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
@@ -184,7 +184,7 @@ jobs:
           - spark-version: '3.2'
             scala-version: '2.13'
       fail-fast: false
-    name: macos-14(Silicon)/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}/${{ matrix.test-target }}
+    name: macos-14(Silicon)/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}-scala-${{matrix.scala-version}}/${{ matrix.test-target }}
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -47,6 +47,7 @@ jobs:
         java_version: [8, 11, 17]
         test-target: [rust, java]
         spark-version: ['3.4']
+        scala-version: ['2.12', '2.13']
         is_push_event:
           - ${{ github.event_name == 'push' }}
         exclude: # exclude java 11 for pull_request event
@@ -71,7 +72,7 @@ jobs:
         name: Java test steps
         uses: ./.github/actions/java-test
         with:
-          maven_opts: -Pspark-${{ matrix.spark-version }}
+          maven_opts: -Pspark-${{ matrix.spark-version }},scala-${{ matrix.scala-version }}
           # upload test reports only for java 17
           upload-test-reports: ${{ matrix.java_version == '17' }}
 
@@ -82,11 +83,14 @@ jobs:
         java_version: [8, 11, 17]
         test-target: [java]
         spark-version: ['3.2', '3.3']
+        scala-version: ['2.12', '2.13']
         exclude:
           - java_version: 17
             spark-version: '3.2'
           - java_version: 11
             spark-version: '3.2'
+          - spark-version: '3.2'
+            scala-version: '2.13'
       fail-fast: false
     name: ${{ matrix.os }}/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}/${{ matrix.test-target }}
     runs-on: ${{ matrix.os }}
@@ -102,7 +106,7 @@ jobs:
       - name: Java test steps
         uses: ./.github/actions/java-test
         with:
-          maven_opts: -Pspark-${{ matrix.spark-version }}
+          maven_opts: -Pspark-${{ matrix.spark-version }},scala-${{ matrix.scala-version }}
 
   macos-test:
     strategy:
@@ -111,6 +115,7 @@ jobs:
         java_version: [8, 11, 17]
         test-target: [rust, java]
         spark-version: ['3.4']
+        scala-version: ['2.12', '2.13']
       fail-fast: false
     if: github.event_name == 'push'
     name: ${{ matrix.os }}/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}/${{ matrix.test-target }}
@@ -129,7 +134,7 @@ jobs:
         name: Java test steps
         uses: ./.github/actions/java-test
         with:
-          maven_opts: -Pspark-${{ matrix.spark-version }}
+          maven_opts: -Pspark-${{ matrix.spark-version }},scala-${{ matrix.scala-version }}
 
   macos-aarch64-test:
     strategy:
@@ -137,6 +142,7 @@ jobs:
         java_version: [8, 11, 17]
         test-target: [rust, java]
         spark-version: ['3.4']
+        scala-version: ['2.12', '2.13']
         is_push_event:
           - ${{ github.event_name == 'push' }}
         exclude: # exclude java 11 for pull_request event
@@ -161,7 +167,7 @@ jobs:
         name: Java test steps
         uses: ./.github/actions/java-test
         with:
-          maven_opts: -Pspark-${{ matrix.spark-version }}
+          maven_opts: -Pspark-${{ matrix.spark-version }},scala-${{ matrix.scala-version }}
 
   macos-aarch64-test-with-old-spark:
     strategy:
@@ -169,11 +175,14 @@ jobs:
         java_version: [8, 17]
         test-target: [java]
         spark-version: ['3.2', '3.3']
+        scala-version: ['2.12', '2.13']
         exclude:
           - java_version: 17
             spark-version: '3.2'
           - java_version: 8
             spark-version: '3.3'
+          - spark-version: '3.2'
+            scala-version: '2.13'
       fail-fast: false
     name: macos-14(Silicon)/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}/${{ matrix.test-target }}
     runs-on: macos-14
@@ -190,5 +199,5 @@ jobs:
         name: Java test steps
         uses: ./.github/actions/java-test
         with:
-          maven_opts: -Pspark-${{ matrix.spark-version }}
+          maven_opts: -Pspark-${{ matrix.spark-version }},scala-${{ matrix.scala-version }}
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -334,7 +334,7 @@ object CometShuffleExchangeExec extends ShimCometShuffleExchangeExec {
         // seed by hashing will help. Refer to SPARK-21782 for more details.
         val partitionId = TaskContext.get().partitionId()
         var position = new XORShiftRandom(partitionId).nextInt(numPartitions)
-        (row: InternalRow) => {
+        (_: InternalRow) => {
           // The HashPartitioner will handle the `mod` by the number of partitions
           position += 1
           position

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -867,26 +867,27 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
-  private def castFallbackTestTimezone(
-      input: DataFrame,
-      toType: DataType,
-      expectedMessage: String): Unit = {
-    withTempPath { dir =>
-      val data = roundtripParquet(input, dir).coalesce(1)
-      data.createOrReplaceTempView("t")
-
-      withSQLConf(
-        (SQLConf.ANSI_ENABLED.key, "false"),
-        (CometConf.COMET_CAST_ALLOW_INCOMPATIBLE.key, "true"),
-        (SQLConf.SESSION_LOCAL_TIMEZONE.key, "America/Los_Angeles")) {
-        val df = data.withColumn("converted", col("a").cast(toType))
-        df.collect()
-        val str =
-          new ExtendedExplainInfo().generateExtendedInfo(df.queryExecution.executedPlan)
-        assert(str.contains(expectedMessage))
-      }
-    }
-  }
+  // TODO Commented out to work around scalafix since this is currently unused.
+  // private def castFallbackTestTimezone(
+  //     input: DataFrame,
+  //     toType: DataType,
+  //     expectedMessage: String): Unit = {
+  //   withTempPath { dir =>
+  //     val data = roundtripParquet(input, dir).coalesce(1)
+  //     data.createOrReplaceTempView("t")
+  //
+  //     withSQLConf(
+  //       (SQLConf.ANSI_ENABLED.key, "false"),
+  //       (CometConf.COMET_CAST_ALLOW_INCOMPATIBLE.key, "true"),
+  //       (SQLConf.SESSION_LOCAL_TIMEZONE.key, "America/Los_Angeles")) {
+  //       val df = data.withColumn("converted", col("a").cast(toType))
+  //       df.collect()
+  //       val str =
+  //         new ExtendedExplainInfo().generateExtendedInfo(df.queryExecution.executedPlan)
+  //       assert(str.contains(expectedMessage))
+  //     }
+  //   }
+  // }
 
   private def castTimestampTest(input: DataFrame, toType: DataType) = {
     withTempPath { dir =>

--- a/spark/src/test/scala/org/apache/comet/exec/CometColumnarShuffleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometColumnarShuffleSuite.scala
@@ -587,7 +587,7 @@ abstract class CometColumnarShuffleSuite extends CometTestBase with AdaptiveSpar
   }
 
   test("columnar shuffle on nested array") {
-    Seq("false", "true").foreach { execEnabled =>
+    Seq("false", "true").foreach { _ =>
       Seq(10, 201).foreach { numPartitions =>
         Seq("1.0", "10.0").foreach { ratio =>
           withSQLConf(CometConf.COMET_SHUFFLE_PREFER_DICTIONARY_RATIO.key -> ratio) {


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/datafusion-comet/issues/388

## Rationale for this change

scalafix check will fail when running Scala 2.13, but is skipped for Scala 2.12.

## What changes are included in this PR?

Add testing of Scala 2.13 along with 2.12 by adding `scala-version` to the matrix.  Explicitly exclude combinations of Spark `3.2` and Scala `2.13`.

## How are these changes tested?

Local repo