### PR TITLE
feat: Implement Spark-compatible CAST from non-integral numeric types to integral types

### DIFF
--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -810,7 +810,7 @@ impl Cast {
             }
             _ => unreachable!(
                 "{}",
-                format!("invalid non-integral numeric type {to_type} in cast from {from_type}")
+                format!("invalid cast from non-integral numeric type: {from_type} to integral numeric type: {to_type}")
             ),
         }
     }

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -744,11 +744,13 @@ fn cast_decimal_to_int3(
         .iter()
         .map(|value| match value {
             Some(value) => {
-                let truncated: i128 = value / 10_i128.pow(scale as u32);
+                let divisor = 10_i128.pow(scale as u32);
+                let truncated: i128 = value / divisor;
+                let remainder: i128 = (value % divisor).abs();
                 let is_overflow = truncated > std::i32::MAX.into();
                 match (is_overflow, eval_mode) {
                     (true, EvalMode::Ansi) => Err(CometError::CastOverFlow {
-                        value: truncated.to_string(),
+                        value: format!("{}.{}BD", truncated, remainder),
                         from_type: format!("DECIMAL({},{})", precision, scale),
                         to_type: "INT32".to_string(),
                     }),
@@ -777,18 +779,20 @@ fn cast_decimal_to_int4(
         .iter()
         .map(|value| match value {
             Some(value) => {
-                let truncated: i128 = value / 10_i128.pow(scale as u32);
+                let divisor = 10_i128.pow(scale as u32);
+                let truncated: i128 = value / divisor;
+                let remainder: i128 = (value % divisor).abs();
                 let is_overflow = truncated > std::i32::MAX.into();
                 let i32_value = truncated as i32;
                 match (is_overflow, eval_mode) {
                     (true, EvalMode::Ansi) => Err(CometError::CastOverFlow {
-                        value: truncated.to_string(),
+                        value: format!("{}.{}BD", truncated, remainder),
                         from_type: format!("DECIMAL({},{})", precision, scale),
                         to_type: "INT32".to_string(),
                     }),
                     (false, EvalMode::Ansi) => i16::try_from(i32_value)
                         .map_err(|_| CometError::CastOverFlow {
-                            value: format!("DECIMAL({},{})", precision, scale),
+                            value: format!("{}.{}BD", truncated, remainder),
                             from_type: format!("DECIMAL({},{})", precision, scale),
                             to_type: "SMALLINT".to_string(),
                         })

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -810,7 +810,7 @@ impl Cast {
             }
             _ => unreachable!(
                 "{}",
-                format!("invalid decimal type {to_type} in cast from {from_type}")
+                format!("invalid non-integral numeric type {to_type} in cast from {from_type}")
             ),
         }
     }

--- a/docs/source/user-guide/compatibility.md
+++ b/docs/source/user-guide/compatibility.md
@@ -88,11 +88,23 @@ The following cast operations are generally compatible with Spark except for the
 | long | double |  |
 | long | string |  |
 | float | boolean |  |
+| float | byte |  |
+| float | short |  |
+| float | integer |  |
+| float | long |  |
 | float | double |  |
 | float | string | There can be differences in precision. For example, the input "1.4E-45" will produce 1.0E-45 instead of 1.4E-45 |
 | double | boolean |  |
+| double | byte |  |
+| double | short |  |
+| double | integer |  |
+| double | long |  |
 | double | float |  |
 | double | string | There can be differences in precision. For example, the input "1.4E-45" will produce 1.0E-45 instead of 1.4E-45 |
+| decimal | byte |  |
+| decimal | short |  |
+| decimal | integer |  |
+| decimal | long |  |
 | decimal | float |  |
 | decimal | double |  |
 | string | boolean |  |

--- a/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
+++ b/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
@@ -226,19 +226,25 @@ object CometCast {
   }
 
   private def canCastFromFloat(toType: DataType): SupportLevel = toType match {
-    case DataTypes.BooleanType | DataTypes.DoubleType => Compatible()
+    case DataTypes.BooleanType | DataTypes.DoubleType | DataTypes.ByteType | DataTypes.ShortType |
+        DataTypes.IntegerType | DataTypes.LongType =>
+      Compatible()
     case _: DecimalType => Incompatible(Some("No overflow check"))
     case _ => Unsupported
   }
 
   private def canCastFromDouble(toType: DataType): SupportLevel = toType match {
-    case DataTypes.BooleanType | DataTypes.FloatType => Compatible()
+    case DataTypes.BooleanType | DataTypes.FloatType | DataTypes.ByteType | DataTypes.ShortType |
+        DataTypes.IntegerType | DataTypes.LongType =>
+      Compatible()
     case _: DecimalType => Incompatible(Some("No overflow check"))
     case _ => Unsupported
   }
 
   private def canCastFromDecimal(toType: DataType): SupportLevel = toType match {
-    case DataTypes.FloatType | DataTypes.DoubleType => Compatible()
+    case DataTypes.FloatType | DataTypes.DoubleType | DataTypes.ByteType | DataTypes.ShortType |
+        DataTypes.IntegerType | DataTypes.LongType =>
+      Compatible()
     case _ => Unsupported
   }
 

--- a/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
+++ b/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
@@ -178,12 +178,16 @@ object CometCast {
   }
 
   private def canCastFromFloat(toType: DataType): SupportLevel = toType match {
-    case DataTypes.BooleanType | DataTypes.DoubleType | DataTypes.IntegerType | DataTypes.LongType | DataTypes.ShortType | DataTypes.ByteType => Compatible
+    case DataTypes.BooleanType | DataTypes.DoubleType | DataTypes.IntegerType |
+        DataTypes.LongType | DataTypes.ShortType | DataTypes.ByteType =>
+      Compatible
     case _ => Unsupported
   }
 
   private def canCastFromDouble(toType: DataType): SupportLevel = toType match {
-    case DataTypes.BooleanType | DataTypes.FloatType | DataTypes.IntegerType | DataTypes.LongType | DataTypes.ShortType | DataTypes.ByteType => Compatible
+    case DataTypes.BooleanType | DataTypes.FloatType | DataTypes.IntegerType |
+        DataTypes.LongType | DataTypes.ShortType | DataTypes.ByteType =>
+      Compatible
     case _: DecimalType => Incompatible()
     case _ => Unsupported
   }

--- a/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
+++ b/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
@@ -178,7 +178,7 @@ object CometCast {
   }
 
   private def canCastFromFloat(toType: DataType): SupportLevel = toType match {
-    case DataTypes.BooleanType | DataTypes.DoubleType => Compatible
+    case DataTypes.BooleanType | DataTypes.DoubleType | DataTypes.IntegerType => Compatible
     case _ => Unsupported
   }
 

--- a/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
+++ b/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
@@ -178,12 +178,12 @@ object CometCast {
   }
 
   private def canCastFromFloat(toType: DataType): SupportLevel = toType match {
-    case DataTypes.BooleanType | DataTypes.DoubleType | DataTypes.IntegerType => Compatible
+    case DataTypes.BooleanType | DataTypes.DoubleType | DataTypes.IntegerType | DataTypes.LongType | DataTypes.ShortType | DataTypes.ByteType => Compatible
     case _ => Unsupported
   }
 
   private def canCastFromDouble(toType: DataType): SupportLevel = toType match {
-    case DataTypes.BooleanType | DataTypes.FloatType => Compatible
+    case DataTypes.BooleanType | DataTypes.FloatType | DataTypes.IntegerType | DataTypes.LongType | DataTypes.ShortType | DataTypes.ByteType => Compatible
     case _: DecimalType => Incompatible()
     case _ => Unsupported
   }

--- a/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
+++ b/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
@@ -193,7 +193,9 @@ object CometCast {
   }
 
   private def canCastFromDecimal(toType: DataType): SupportLevel = toType match {
-    case DataTypes.FloatType | DataTypes.DoubleType => Compatible
+    case DataTypes.FloatType | DataTypes.DoubleType | DataTypes.IntegerType |
+         DataTypes.LongType | DataTypes.ShortType | DataTypes.ByteType =>
+      Compatible
     case _ => Unsupported
   }
 

--- a/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
+++ b/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
@@ -193,8 +193,8 @@ object CometCast {
   }
 
   private def canCastFromDecimal(toType: DataType): SupportLevel = toType match {
-    case DataTypes.FloatType | DataTypes.DoubleType | DataTypes.IntegerType |
-         DataTypes.LongType | DataTypes.ShortType | DataTypes.ByteType =>
+    case DataTypes.FloatType | DataTypes.DoubleType | DataTypes.IntegerType | DataTypes.LongType |
+        DataTypes.ShortType | DataTypes.ByteType =>
       Compatible
     case _ => Unsupported
   }

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -303,23 +303,21 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     castTest(generateFloats(), DataTypes.BooleanType)
   }
 
-  ignore("cast FloatType to ByteType") {
+  test("cast FloatType to ByteType") {
     // https://github.com/apache/datafusion-comet/issues/350
     castTest(generateFloats(), DataTypes.ByteType)
   }
 
-  ignore("cast FloatType to ShortType") {
+  test("cast FloatType to ShortType") {
     // https://github.com/apache/datafusion-comet/issues/350
     castTest(generateFloats(), DataTypes.ShortType)
   }
 
   test("cast FloatType to IntegerType") {
-    // https://github.com/apache/datafusion-comet/issues/350
     castTest(generateFloats(), DataTypes.IntegerType)
   }
 
-  ignore("cast FloatType to LongType") {
-    // https://github.com/apache/datafusion-comet/issues/350
+  test("cast FloatType to LongType") {
     castTest(generateFloats(), DataTypes.LongType)
   }
 
@@ -361,22 +359,22 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     castTest(generateDoubles(), DataTypes.BooleanType)
   }
 
-  ignore("cast DoubleType to ByteType") {
+  test("cast DoubleType to ByteType") {
     // https://github.com/apache/datafusion-comet/issues/350
     castTest(generateDoubles(), DataTypes.ByteType)
   }
 
-  ignore("cast DoubleType to ShortType") {
+  test("cast DoubleType to ShortType") {
     // https://github.com/apache/datafusion-comet/issues/350
     castTest(generateDoubles(), DataTypes.ShortType)
   }
 
-  ignore("cast DoubleType to IntegerType") {
+  test("cast DoubleType to IntegerType") {
     // https://github.com/apache/datafusion-comet/issues/350
     castTest(generateDoubles(), DataTypes.IntegerType)
   }
 
-  ignore("cast DoubleType to LongType") {
+  test("cast DoubleType to LongType") {
     // https://github.com/apache/datafusion-comet/issues/350
     castTest(generateDoubles(), DataTypes.LongType)
   }

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -313,7 +313,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     castTest(generateFloats(), DataTypes.ShortType)
   }
 
-  ignore("cast FloatType to IntegerType") {
+  test("cast FloatType to IntegerType") {
     // https://github.com/apache/datafusion-comet/issues/350
     castTest(generateFloats(), DataTypes.IntegerType)
   }

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -20,16 +20,13 @@
 package org.apache.comet
 
 import java.io.File
-
 import scala.util.Random
-
 import org.apache.spark.sql.{CometTestBase, DataFrame, SaveMode}
 import org.apache.spark.sql.catalyst.expressions.Cast
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{DataType, DataTypes}
-
+import org.apache.spark.sql.types.{DataType, DataTypes, DecimalType}
 import org.apache.comet.expressions.CometCast
 
 class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
@@ -304,12 +301,10 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("cast FloatType to ByteType") {
-    // https://github.com/apache/datafusion-comet/issues/350
     castTest(generateFloats(), DataTypes.ByteType)
   }
 
   test("cast FloatType to ShortType") {
-    // https://github.com/apache/datafusion-comet/issues/350
     castTest(generateFloats(), DataTypes.ShortType)
   }
 
@@ -360,22 +355,18 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("cast DoubleType to ByteType") {
-    // https://github.com/apache/datafusion-comet/issues/350
     castTest(generateDoubles(), DataTypes.ByteType)
   }
 
   test("cast DoubleType to ShortType") {
-    // https://github.com/apache/datafusion-comet/issues/350
     castTest(generateDoubles(), DataTypes.ShortType)
   }
 
   test("cast DoubleType to IntegerType") {
-    // https://github.com/apache/datafusion-comet/issues/350
     castTest(generateDoubles(), DataTypes.IntegerType)
   }
 
   test("cast DoubleType to LongType") {
-    // https://github.com/apache/datafusion-comet/issues/350
     castTest(generateDoubles(), DataTypes.LongType)
   }
 
@@ -414,22 +405,22 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     castTest(generateDecimals(), DataTypes.BooleanType)
   }
 
-  ignore("cast DecimalType(10,2) to ByteType") {
+  test("cast DecimalType(10,2) to ByteType") {
     // https://github.com/apache/datafusion-comet/issues/350
     castTest(generateDecimals(), DataTypes.ByteType)
   }
 
-  ignore("cast DecimalType(10,2) to ShortType") {
+  test("cast DecimalType(10,2) to ShortType") {
     // https://github.com/apache/datafusion-comet/issues/350
     castTest(generateDecimals(), DataTypes.ShortType)
   }
 
-  ignore("cast DecimalType(10,2) to IntegerType") {
+  test("cast DecimalType(10,2) to IntegerType") {
     // https://github.com/apache/datafusion-comet/issues/350
     castTest(generateDecimals(), DataTypes.IntegerType)
   }
 
-  ignore("cast DecimalType(10,2) to LongType") {
+  test("cast DecimalType(10,2) to LongType") {
     // https://github.com/apache/datafusion-comet/issues/350
     castTest(generateDecimals(), DataTypes.LongType)
   }
@@ -780,7 +771,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   private def generateDecimals(): DataFrame = {
     // TODO improve this
     val values = Seq(BigDecimal("123456.789"), BigDecimal("-123456.789"), BigDecimal("0.0"))
-    withNulls(values).toDF("a")
+    withNulls(values).toDF("b").withColumn("a", col("b").cast(DecimalType(10,2))).drop("b")
   }
 
   private def generateDates(): DataFrame = {


### PR DESCRIPTION
## Which issue does this PR close?
Closes #350 

## Rationale for this change
Improve compatibility with Spark

## What changes are included in this PR?
1) Functionality to "Spark compatible cast" floats, doubles, and decimals to bytes, shorts, ints, and longs
2) Enhanced decimal tests to check for cast edge cases 

## How are these changes tested?
CometCastSuite tests pass.
