### PR TITLE
docs: Running ScalaTest suites from the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,3 @@ See the [DataFusion Comet User Guide](https://datafusion.apache.org/comet/user-g
 ## Contributing
 See the [DataFusion Comet Contribution Guide](https://datafusion.apache.org/comet/contributor-guide/contributing.html)
 for information on how to get started contributing to the project.
-
-## Running ScalaTest suites from the CLI
-
-Running single ScalaTest suites from the CLI is possible using the `suites`
-argument, for example if you only want to execute the test cases that contains *valid*
-in their name in `org.apache.comet.CometCastSuite` you can use
-
-```sh
-mvn test -Dsuites="org.apache.comet.CometCastSuite valid" -Dskip.surefire.tests=true
-```
-
-Other options for selecting specific suites are described in the [ScalaTest Maven Plugin documentation](https://www.scalatest.org/user_guide/using_the_scalatest_maven_plugin)

--- a/README.md
+++ b/README.md
@@ -74,3 +74,15 @@ See the [DataFusion Comet User Guide](https://datafusion.apache.org/comet/user-g
 ## Contributing
 See the [DataFusion Comet Contribution Guide](https://datafusion.apache.org/comet/contributor-guide/contributing.html)
 for information on how to get started contributing to the project.
+
+## Running ScalaTest suites from the CLI
+
+Running single ScalaTest suites from the CLI is possible using the `suites`
+argument, for example if you only want to execute the test cases that contains *valid*
+in their name in `org.apache.comet.CometCastSuite` you can use
+
+```sh
+mvn test -Dsuites="org.apache.comet.CometCastSuite valid" -Dskip.surefire.tests=true
+```
+
+Other options for selecting specific suites are described in the [ScalaTest Maven Plugin documentation](https://www.scalatest.org/user_guide/using_the_scalatest_maven_plugin)

--- a/docs/source/contributor-guide/development.md
+++ b/docs/source/contributor-guide/development.md
@@ -73,6 +73,18 @@ After that you can open the project in CLion. The IDE should automatically detec
 Like other Maven projects, you can run tests in IntelliJ IDEA by right-clicking on the test class or test method and selecting "Run" or "Debug".
 However if the tests is related to the native side. Please make sure to run `make core` or `cd core && cargo build` before running the tests in IDEA.
 
+### Running Tests from command line
+
+It is possible to specify which ScalaTest suites you want to run from the CLI using the `suites`
+argument, for example if you only want to execute the test cases that contains *valid*
+in their name in `org.apache.comet.CometCastSuite` you can use
+
+```sh
+mvn test -Dsuites="org.apache.comet.CometCastSuite valid" -Dskip.surefire.tests=true
+```
+
+Other options for selecting specific suites are described in the [ScalaTest Maven Plugin documentation](https://www.scalatest.org/user_guide/using_the_scalatest_maven_plugin)
+
 ## Benchmark
 
 There's a `make` command to run micro benchmarks in the repo. For

--- a/pom.xml
+++ b/pom.xml
@@ -727,7 +727,6 @@ under the License.
             </systemPropertyVariables>
             <skipTests>${skip.surefire.tests}</skipTests>
           </configuration>
-
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -725,7 +725,9 @@ under the License.
             <systemPropertyVariables>
               <log4j.configurationFile>file:src/test/resources/log4j2.properties</log4j.configurationFile>
             </systemPropertyVariables>
+            <skipTests>${skip.surefire.tests}</skipTests>
           </configuration>
+
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
As discussed in the Discord channel, some developers have setup that relies on the CLI to execute single tests. 

When using only ScalaTest variables to select a suite, modules that do not use scalaTest but uses maven-surefire-plugin runs all the tests, which is not desirable sometime
