### PR TITLE
fix: newFileScanRDD should not take constructor from custom Spark versions

### DIFF
--- a/spark/src/main/spark-3.x/org/apache/comet/shims/ShimCometScanExec.scala
+++ b/spark/src/main/spark-3.x/org/apache/comet/shims/ShimCometScanExec.scala
@@ -69,7 +69,7 @@ trait ShimCometScanExec {
       readSchema: StructType,
       options: ParquetOptions): FileScanRDD =
     classOf[FileScanRDD].getDeclaredConstructors
-      // workaround for aws spark 3.4 implementation
+      // Prevent to pick up incorrect constructors from any custom Spark forks.
       .filter(c => List(3,5,6).contains(c.getParameterCount()) )
       .map { c =>
         c.getParameterCount match {

--- a/spark/src/main/spark-3.x/org/apache/comet/shims/ShimCometScanExec.scala
+++ b/spark/src/main/spark-3.x/org/apache/comet/shims/ShimCometScanExec.scala
@@ -70,7 +70,7 @@ trait ShimCometScanExec {
       options: ParquetOptions): FileScanRDD =
     classOf[FileScanRDD].getDeclaredConstructors
       // Prevent to pick up incorrect constructors from any custom Spark forks.
-      .filter(c => List(3,5,6).contains(c.getParameterCount()) )
+      .filter(c => List(3, 5, 6).contains(c.getParameterCount()) )
       .map { c =>
         c.getParameterCount match {
           case 3 => c.newInstance(sparkSession, readFunction, filePartitions)

--- a/spark/src/main/spark-3.x/org/apache/comet/shims/ShimCometScanExec.scala
+++ b/spark/src/main/spark-3.x/org/apache/comet/shims/ShimCometScanExec.scala
@@ -69,6 +69,8 @@ trait ShimCometScanExec {
       readSchema: StructType,
       options: ParquetOptions): FileScanRDD =
     classOf[FileScanRDD].getDeclaredConstructors
+      // workaround for aws spark 3.4 implementation
+      .filter(c => List(3,5,6).contains(c.getParameterCount()) )
       .map { c =>
         c.getParameterCount match {
           case 3 => c.newInstance(sparkSession, readFunction, filePartitions)


### PR DESCRIPTION

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #411 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

the file spark-sql_2.12-3.4.1-amzn-2.jar is a custom version of spark and contains the class org.apache.spark.sql.execution.datasources.FileScanRDD with 2 constructs, one with 6 parameters and the second with 8 parameters. The suggested  workaround  filters out the custom constructor.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
