### PR TITLE
feat: Use enum to represent CAST eval_mode in expr.proto

### DIFF
--- a/core/src/execution/datafusion/planner.rs
+++ b/core/src/execution/datafusion/planner.rs
@@ -346,10 +346,10 @@ impl PhysicalPlanner {
                 let child = self.create_expr(expr.child.as_ref().unwrap(), input_schema)?;
                 let datatype = to_arrow_datatype(expr.datatype.as_ref().unwrap());
                 let timezone = expr.timezone.clone();
-                let eval_mode = match expr.eval_mode.as_str() {
-                    "ANSI" => EvalMode::Ansi,
-                    "TRY" => EvalMode::Try,
-                    "LEGACY" => EvalMode::Legacy,
+                let eval_mode = match expr.eval_mode {
+                    0 => EvalMode::Legacy,
+                    1 => EvalMode::Try,
+                    2 => EvalMode::Ansi,
                     other => {
                         return Err(ExecutionError::GeneralError(format!(
                             "Invalid Cast EvalMode: \"{other}\""

--- a/core/src/execution/datafusion/planner.rs
+++ b/core/src/execution/datafusion/planner.rs
@@ -346,16 +346,12 @@ impl PhysicalPlanner {
                 let child = self.create_expr(expr.child.as_ref().unwrap(), input_schema)?;
                 let datatype = to_arrow_datatype(expr.datatype.as_ref().unwrap());
                 let timezone = expr.timezone.clone();
-                let eval_mode = match expr.eval_mode {
-                    0 => EvalMode::Legacy,
-                    1 => EvalMode::Try,
-                    2 => EvalMode::Ansi,
-                    other => {
-                        return Err(ExecutionError::GeneralError(format!(
-                            "Invalid Cast EvalMode: \"{other}\""
-                        )))
-                    }
+                let eval_mode = match spark_expression::EvalMode::try_from(expr.eval_mode)? {
+                    spark_expression::EvalMode::Legacy => EvalMode::Legacy,
+                    spark_expression::EvalMode::Try => EvalMode::Try,
+                    spark_expression::EvalMode::Ansi => EvalMode::Ansi,
                 };
+
                 Ok(Arc::new(Cast::new(child, datatype, eval_mode, timezone)))
             }
             ExprStruct::Hour(expr) => {

--- a/core/src/execution/proto/expr.proto
+++ b/core/src/execution/proto/expr.proto
@@ -233,16 +233,20 @@ message Remainder {
   DataType return_type = 4;
 }
 
+enum EvalMode {
+  LEGACY = 0;
+  TRY = 1;
+  ANSI = 2;
+}
+
 message Cast {
   Expr child = 1;
   DataType datatype = 2;
   string timezone = 3;
-  // LEGACY, ANSI, or TRY
-  enum EvalMode {
-  LEGACY = 0;
-  TRY = 1;
-  ANSI = 2;
-  }
+  // Depreciateid: LEGACY, ANSI, or TRY - preserved for backward compatibity
+  string eval_mode_string= 4; // for backward compatibility 
+  EvalMode eval_mode = 5; // New enum field
+  
 }
 
 message Equal {

--- a/core/src/execution/proto/expr.proto
+++ b/core/src/execution/proto/expr.proto
@@ -238,7 +238,11 @@ message Cast {
   DataType datatype = 2;
   string timezone = 3;
   // LEGACY, ANSI, or TRY
-  string eval_mode = 4;
+  enum EvalMode {
+  LEGACY = 0;
+  TRY = 1;
+  ANSI = 2;
+  }
 }
 
 message Equal {

--- a/core/src/execution/proto/expr.proto
+++ b/core/src/execution/proto/expr.proto
@@ -243,9 +243,7 @@ message Cast {
   Expr child = 1;
   DataType datatype = 2;
   string timezone = 3;
-  // Depreciateid: LEGACY, ANSI, or TRY - preserved for backward compatibity
-  string eval_mode_string= 4; // for backward compatibility 
-  EvalMode eval_mode = 5; // New enum field
+  EvalMode eval_mode = 4; 
   
 }
 

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -19,6 +19,8 @@
 
 package org.apache.comet.serde
 
+import java.util.Locale
+
 import scala.collection.JavaConverters._
 
 import org.apache.spark.internal.Logging
@@ -527,7 +529,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde {
    */
 
   def stringToEvalMode(evalModeStr: String): ExprOuterClass.EvalMode =
-    evalModeStr.toUpperCase match {
+    evalModeStr.toUpperCase(Locale.ROOT) match {
       case "LEGACY" => ExprOuterClass.EvalMode.LEGACY
       case "TRY" => ExprOuterClass.EvalMode.TRY
       case "ANSI" => ExprOuterClass.EvalMode.ANSI

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -533,9 +533,9 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde {
       case "LEGACY" => ExprOuterClass.EvalMode.LEGACY
       case "TRY" => ExprOuterClass.EvalMode.TRY
       case "ANSI" => ExprOuterClass.EvalMode.ANSI
-      case _ =>
+      case invalid =>
         throw new IllegalArgumentException(
-          "Invalid eval mode"
+          s"Invalid eval mode '$invalid' "
         ) // Assuming we want to catch errors strictly
     }
 
@@ -1223,7 +1223,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde {
                     .newBuilder()
                     .setChild(e)
                     .setDatatype(serializeDataType(IntegerType).get)
-                    .setEvalMode(stringToEvalMode("LEGACY")) // year is not affected by ANSI mode
+                    .setEvalMode(ExprOuterClass.EvalMode.LEGACY)
                     .build())
                 .build()
             })

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -555,7 +555,6 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde {
         val castBuilder = ExprOuterClass.Cast.newBuilder()
         castBuilder.setChild(childExpr.get)
         castBuilder.setDatatype(dataType.get)
-        // castBuilder.setEvalMode(evalMode)
         castBuilder.setEvalMode(evalModeEnum) // Set the enum in protobuf
 
         val timeZone = timeZoneId.getOrElse("UTC")


### PR DESCRIPTION
## Which issue does this PR close?


Closes #361 

## Rationale for this change

The updates to `expr.proto` by using enums instead of strings, which prevents potential errors in type interpretation. Modifications in `planner.rs` and `QueryPlanSerde.scala` resolve issues found during compilation and style checks.

## What changes are included in this PR?

- `expr.proto`: Updated the `eval_mode` field from a string type to an enum type (`EvalMode`), with defined values `LEGACY`, `TRY`, and `ANSI`. 
- Rust Code: Modified `ExprStruct::Cast(expr)` in `planner.rs` to handle `eval_mode` as integers corresponding to the new protobuf enum. Updated the match statement to directly convert integers to the EvalMode Rust enum and added error handling for invalid integers.
- `QueryPlanSerde.scala`: 
    - Introduced the `stringToEvalMode` function, which converts input strings to `ExprOuterClass.EvalMode` enum values using a case-insensitive match, enhancing our error handling by throwing exceptions for invalid modes.
    - Corrected the use of `toUpperCase` to include `Locale.ROOT` to avoid locale-sensitive behavior, aligning with internationalization best practices.
    - Reorganized imports to comply with project's Scalastyle guidelines, clearly separating Java standard library imports from those specific to the project, which aids in code clarity and maintenance.
    - Addressed and resolved Scalastyle violations related to locale-specific string manipulations. Fixed the Scalastyle violation by correcting the usage of `toUpperCase` without specifying a locale. Reorganized import statements to adhere to the project's coding standards, ensuring that Java standard library imports are correctly grouped.

## How are these changes tested?

I have run 
- `make test-rust`: No failures.
- `make test-jvm`: No failures. 



