### PR TITLE
tests: Move random data generation methods from CometCastSuite to new DataGenerator class

### DIFF
--- a/docs/source/user-guide/compatibility.md
+++ b/docs/source/user-guide/compatibility.md
@@ -110,10 +110,6 @@ The following cast operations are generally compatible with Spark except for the
 | decimal | float |  |
 | decimal | double |  |
 | string | boolean |  |
-| string | byte |  |
-| string | short |  |
-| string | integer |  |
-| string | long |  |
 | string | binary |  |
 | date | string |  |
 | timestamp | long |  |
@@ -129,6 +125,10 @@ The following cast operations are not compatible with Spark for all inputs and a
 |-|-|-|
 | integer | decimal  | No overflow check |
 | long | decimal  | No overflow check |
+| string | byte  | Not all invalid inputs are detected |
+| string | short  | Not all invalid inputs are detected |
+| string | integer  | Not all invalid inputs are detected |
+| string | long  | Not all invalid inputs are detected |
 | string | timestamp  | Not all valid formats are supported |
 | binary | string  | Only works for binary data representing valid UTF-8 strings |
 

--- a/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
+++ b/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
@@ -108,7 +108,7 @@ object CometCast {
         Compatible()
       case DataTypes.ByteType | DataTypes.ShortType | DataTypes.IntegerType |
           DataTypes.LongType =>
-        Compatible()
+        Incompatible(Some("Not all invalid inputs are detected"))
       case DataTypes.BinaryType =>
         Compatible()
       case DataTypes.FloatType | DataTypes.DoubleType =>

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -745,35 +745,11 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   private def generateFloats(): DataFrame = {
-    val r = new Random(0)
-    val values = Seq(
-      Float.MaxValue,
-      Float.MinPositiveValue,
-      Float.MinValue,
-      Float.NaN,
-      Float.PositiveInfinity,
-      Float.NegativeInfinity,
-      1.0f,
-      -1.0f,
-      Short.MinValue.toFloat,
-      Short.MaxValue.toFloat,
-      0.0f) ++
-      Range(0, dataSize).map(_ => r.nextFloat())
-    withNulls(values).toDF("a")
+    withNulls(gen.generateFloats(dataSize)).toDF("a")
   }
 
   private def generateDoubles(): DataFrame = {
-    val r = new Random(0)
-    val values = Seq(
-      Double.MaxValue,
-      Double.MinPositiveValue,
-      Double.MinValue,
-      Double.NaN,
-      Double.PositiveInfinity,
-      Double.NegativeInfinity,
-      0.0d) ++
-      Range(0, dataSize).map(_ => r.nextDouble())
-    withNulls(values).toDF("a")
+    withNulls(gen.generateDoubles(dataSize)).toDF("a")
   }
 
   private def generateBools(): DataFrame = {
@@ -781,31 +757,19 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   private def generateBytes(): DataFrame = {
-    val r = new Random(0)
-    val values = Seq(Byte.MinValue, Byte.MaxValue) ++
-      Range(0, dataSize).map(_ => r.nextInt().toByte)
-    withNulls(values).toDF("a")
+    withNulls(gen.generateBytes(dataSize)).toDF("a")
   }
 
   private def generateShorts(): DataFrame = {
-    val r = new Random(0)
-    val values = Seq(Short.MinValue, Short.MaxValue) ++
-      Range(0, dataSize).map(_ => r.nextInt().toShort)
-    withNulls(values).toDF("a")
+    withNulls(gen.generateShorts(dataSize)).toDF("a")
   }
 
   private def generateInts(): DataFrame = {
-    val r = new Random(0)
-    val values = Seq(Int.MinValue, Int.MaxValue) ++
-      Range(0, dataSize).map(_ => r.nextInt())
-    withNulls(values).toDF("a")
+    withNulls(gen.generateInts(dataSize)).toDF("a")
   }
 
   private def generateLongs(): DataFrame = {
-    val r = new Random(0)
-    val values = Seq(Long.MinValue, Long.MaxValue) ++
-      Range(0, dataSize).map(_ => r.nextLong())
-    withNulls(values).toDF("a")
+    withNulls(gen.generateLongs(dataSize)).toDF("a")
   }
 
   private def generateDecimalsPrecision10Scale2(): DataFrame = {
@@ -901,28 +865,6 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       }
     }
   }
-
-  // TODO Commented out to work around scalafix since this is currently unused.
-  // private def castFallbackTestTimezone(
-  //     input: DataFrame,
-  //     toType: DataType,
-  //     expectedMessage: String): Unit = {
-  //   withTempPath { dir =>
-  //     val data = roundtripParquet(input, dir).coalesce(1)
-  //     data.createOrReplaceTempView("t")
-  //
-  //     withSQLConf(
-  //       (SQLConf.ANSI_ENABLED.key, "false"),
-  //       (CometConf.COMET_CAST_ALLOW_INCOMPATIBLE.key, "true"),
-  //       (SQLConf.SESSION_LOCAL_TIMEZONE.key, "America/Los_Angeles")) {
-  //       val df = data.withColumn("converted", col("a").cast(toType))
-  //       df.collect()
-  //       val str =
-  //         new ExtendedExplainInfo().generateExtendedInfo(df.queryExecution.executedPlan)
-  //       assert(str.contains(expectedMessage))
-  //     }
-  //   }
-  // }
 
   private def castTimestampTest(input: DataFrame, toType: DataType) = {
     withTempPath { dir =>

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -36,7 +36,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   import testImplicits._
 
   /** Create a data generator using a fixed seed so that tests are reproducible */
-  private val gen = new DataGenerator(new Random(42))
+  private val gen = DataGenerator.DEFAULT
 
   /** Number of random data items to generate in each test */
   private val dataSize = 10000

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -38,7 +38,8 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   /** Create a data generator using a fixed seed so that tests are reproducible */
   private val gen = new DataGenerator(new Random(42))
 
-  private val dataSize = 1000
+  /** Number of random data items to generate in each test */
+  private val dataSize = 10000
 
   // we should eventually add more whitespace chars here as documented in
   // https://docs.oracle.com/javase/8/docs/api/java/lang/Character.html#isWhitespace-char-
@@ -518,28 +519,28 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     "9223372036854775808" // Long.MaxValue + 1
   )
 
-  test("cast StringType to ByteType") {
+  ignore("cast StringType to ByteType") {
     // test with hand-picked values
     castTest(castStringToIntegralInputs.toDF("a"), DataTypes.ByteType)
     // fuzz test
     castTest(gen.generateStrings(dataSize, numericPattern, 4).toDF("a"), DataTypes.ByteType)
   }
 
-  test("cast StringType to ShortType") {
+  ignore("cast StringType to ShortType") {
     // test with hand-picked values
     castTest(castStringToIntegralInputs.toDF("a"), DataTypes.ShortType)
     // fuzz test
     castTest(gen.generateStrings(dataSize, numericPattern, 5).toDF("a"), DataTypes.ShortType)
   }
 
-  test("cast StringType to IntegerType") {
+  ignore("cast StringType to IntegerType") {
     // test with hand-picked values
     castTest(castStringToIntegralInputs.toDF("a"), DataTypes.IntegerType)
     // fuzz test
     castTest(gen.generateStrings(dataSize, numericPattern, 8).toDF("a"), DataTypes.IntegerType)
   }
 
-  test("cast StringType to LongType") {
+  ignore("cast StringType to LongType") {
     // test with hand-picked values
     castTest(castStringToIntegralInputs.toDF("a"), DataTypes.LongType)
     // fuzz test

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -942,7 +942,9 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
 
   test("Chr") {
     Seq(false, true).foreach { dictionary =>
-      withSQLConf("parquet.enable.dictionary" -> dictionary.toString) {
+      withSQLConf(
+        "parquet.enable.dictionary" -> dictionary.toString,
+        CometConf.COMET_CAST_ALLOW_INCOMPATIBLE.key -> "true") {
         val table = "test"
         withTable(table) {
           sql(s"create table $table(col varchar(20)) using parquet")

--- a/spark/src/test/scala/org/apache/comet/DataGenerator.scala
+++ b/spark/src/test/scala/org/apache/comet/DataGenerator.scala
@@ -39,4 +39,53 @@ class DataGenerator(r: Random) {
     Range(0, n).map(_ => generateString(chars, maxLen))
   }
 
+  def generateFloats(n: Int): Seq[Float] = {
+    Seq(
+      Float.MaxValue,
+      Float.MinPositiveValue,
+      Float.MinValue,
+      Float.NaN,
+      Float.PositiveInfinity,
+      Float.NegativeInfinity,
+      1.0f,
+      -1.0f,
+      Short.MinValue.toFloat,
+      Short.MaxValue.toFloat,
+      0.0f) ++
+      Range(0, n).map(_ => r.nextFloat())
+  }
+
+  def generateDoubles(n: Int): Seq[Double] = {
+    Seq(
+      Double.MaxValue,
+      Double.MinPositiveValue,
+      Double.MinValue,
+      Double.NaN,
+      Double.PositiveInfinity,
+      Double.NegativeInfinity,
+      0.0d) ++
+      Range(0, n).map(_ => r.nextDouble())
+  }
+
+  def generateBytes(n: Int): Seq[Byte] = {
+    Seq(Byte.MinValue, Byte.MaxValue) ++
+      Range(0, n).map(_ => r.nextInt().toByte)
+  }
+
+  def generateShorts(n: Int): Seq[Short] = {
+    val r = new Random(0)
+    Seq(Short.MinValue, Short.MaxValue) ++
+      Range(0, n).map(_ => r.nextInt().toShort)
+  }
+
+  def generateInts(n: Int): Seq[Int] = {
+    Seq(Int.MinValue, Int.MaxValue) ++
+      Range(0, n).map(_ => r.nextInt())
+  }
+
+  def generateLongs(n: Int): Seq[Long] = {
+    Seq(Long.MinValue, Long.MaxValue) ++
+      Range(0, n).map(_ => r.nextLong())
+  }
+
 }

--- a/spark/src/test/scala/org/apache/comet/DataGenerator.scala
+++ b/spark/src/test/scala/org/apache/comet/DataGenerator.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet
+
+import scala.util.Random
+
+class DataGenerator(r: Random) {
+
+  /** Generate a random string using the specified characters */
+  def generateString(chars: String, maxLen: Int): String = {
+    val len = r.nextInt(maxLen)
+    Range(0, len).map(_ => chars.charAt(r.nextInt(chars.length))).mkString
+  }
+
+  /** Generate random strings */
+  def generateStrings(n: Int, maxLen: Int): Seq[String] = {
+    Range(0, n).map(_ => r.nextString(maxLen))
+  }
+
+  /** Generate random strings using the specified characters */
+  def generateStrings(n: Int, chars: String, maxLen: Int): Seq[String] = {
+    Range(0, n).map(_ => generateString(chars, maxLen))
+  }
+
+}

--- a/spark/src/test/scala/org/apache/comet/DataGenerator.scala
+++ b/spark/src/test/scala/org/apache/comet/DataGenerator.scala
@@ -21,6 +21,13 @@ package org.apache.comet
 
 import scala.util.Random
 
+object DataGenerator {
+  // note that we use `def` rather than `val` intentionally here so that
+  // each test suite starts with a fresh data generator to help ensure
+  // that tests are deterministic
+  def DEFAULT = new DataGenerator(new Random(42))
+}
+
 class DataGenerator(r: Random) {
 
   /** Generate a random string using the specified characters */


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Start moving random data generation out of `CometCastSuite` and into a class that can be used from other test suites.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Refactor data generator
- Mark CAST string -> integer as incompatible because the data gen changes exposed new issues

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests
