### PR TITLE
fix: Compute murmur3 hash with dictionary input correctly

### DIFF
--- a/core/src/execution/datafusion/spark_hash.rs
+++ b/core/src/execution/datafusion/spark_hash.rs
@@ -368,78 +368,64 @@ mod tests {
     use crate::execution::datafusion::spark_hash::{create_hashes, pmod};
     use datafusion::arrow::array::{ArrayRef, Int32Array, Int64Array, Int8Array, StringArray};
 
-    macro_rules! test_hashes {
-        ($ty:ty, $values:expr, $expected:expr) => {
-            let i = Arc::new(<$ty>::from($values)) as ArrayRef;
-            let mut hashes = vec![42; $values.len()];
+    macro_rules! test_hashes_internal {
+        ($input: expr, $len: expr, $expected: expr) => {
+            let i = $input as ArrayRef;
+            let mut hashes = vec![42; $len];
             create_hashes(&[i], &mut hashes).unwrap();
             assert_eq!(hashes, $expected);
         };
     }
 
+    fn test_murmur3_hash<I: Clone, T: arrow_array::Array + From<Vec<Option<I>>> + 'static>(
+        values: Vec<Option<I>>,
+        expected: Vec<u32>,
+    ) {
+        // copied before inserting nulls
+        let mut input_with_nulls = values.clone();
+        let mut expected_with_nulls = expected.clone();
+        let len = values.len();
+        let i = Arc::new(T::from(values)) as ArrayRef;
+        test_hashes_internal!(i, len, expected);
+
+        // test with nulls
+        let median = len / 2;
+        input_with_nulls.insert(0, None);
+        input_with_nulls.insert(median, None);
+        expected_with_nulls.insert(0, 42);
+        expected_with_nulls.insert(median, 42);
+        let with_nulls_len = len + 2;
+        let nullable_input = Arc::new(T::from(input_with_nulls)) as ArrayRef;
+        test_hashes_internal!(nullable_input, with_nulls_len, expected_with_nulls);
+    }
+
     #[test]
     fn test_i8() {
-        test_hashes!(
-            Int8Array,
+        test_murmur3_hash::<i8, Int8Array>(
             vec![Some(1), Some(0), Some(-1), Some(i8::MAX), Some(i8::MIN)],
-            vec![0xdea578e3, 0x379fae8f, 0xa0590e3d, 0x43b4d8ed, 0x422a1365]
-        );
-        // with null input
-        test_hashes!(
-            Int8Array,
-            vec![Some(1), None, Some(-1), Some(i8::MAX), Some(i8::MIN)],
-            vec![0xdea578e3, 42, 0xa0590e3d, 0x43b4d8ed, 0x422a1365]
+            vec![0xdea578e3, 0x379fae8f, 0xa0590e3d, 0x43b4d8ed, 0x422a1365],
         );
     }
 
     #[test]
     fn test_i32() {
-        test_hashes!(
-            Int32Array,
+        test_murmur3_hash::<i32, Int32Array>(
             vec![Some(1), Some(0), Some(-1), Some(i32::MAX), Some(i32::MIN)],
-            vec![0xdea578e3, 0x379fae8f, 0xa0590e3d, 0x07fb67e7, 0x2b1f0fc6]
-        );
-        // with null input
-        test_hashes!(
-            Int32Array,
-            vec![
-                Some(1),
-                Some(0),
-                Some(-1),
-                None,
-                Some(i32::MAX),
-                Some(i32::MIN)
-            ],
-            vec![0xdea578e3, 0x379fae8f, 0xa0590e3d, 42, 0x07fb67e7, 0x2b1f0fc6]
+            vec![0xdea578e3, 0x379fae8f, 0xa0590e3d, 0x07fb67e7, 0x2b1f0fc6],
         );
     }
 
     #[test]
     fn test_i64() {
-        test_hashes!(
-            Int64Array,
+        test_murmur3_hash::<i64, Int64Array>(
             vec![Some(1), Some(0), Some(-1), Some(i64::MAX), Some(i64::MIN)],
-            vec![0x99f0149d, 0x9c67b85d, 0xc8008529, 0xa05b5d7b, 0xcd1e64fb]
-        );
-        // with null input
-        test_hashes!(
-            Int64Array,
-            vec![
-                Some(1),
-                Some(0),
-                Some(-1),
-                None,
-                Some(i64::MAX),
-                Some(i64::MIN)
-            ],
-            vec![0x99f0149d, 0x9c67b85d, 0xc8008529, 42, 0xa05b5d7b, 0xcd1e64fb]
+            vec![0x99f0149d, 0x9c67b85d, 0xc8008529, 0xa05b5d7b, 0xcd1e64fb],
         );
     }
 
     #[test]
     fn test_f32() {
-        test_hashes!(
-            Float32Array,
+        test_murmur3_hash::<f32, Float32Array>(
             vec![
                 Some(1.0),
                 Some(0.0),
@@ -448,28 +434,15 @@ mod tests {
                 Some(99999999999.99999999999),
                 Some(-99999999999.99999999999),
             ],
-            vec![0xe434cc39, 0x379fae8f, 0x379fae8f, 0xdc0da8eb, 0xcbdc340f, 0xc0361c86]
-        );
-        // with null input
-        test_hashes!(
-            Float32Array,
             vec![
-                Some(1.0),
-                Some(0.0),
-                Some(-0.0),
-                Some(-1.0),
-                None,
-                Some(99999999999.99999999999),
-                Some(-99999999999.99999999999)
+                0xe434cc39, 0x379fae8f, 0x379fae8f, 0xdc0da8eb, 0xcbdc340f, 0xc0361c86,
             ],
-            vec![0xe434cc39, 0x379fae8f, 0x379fae8f, 0xdc0da8eb, 42, 0xcbdc340f, 0xc0361c86]
         );
     }
 
     #[test]
     fn test_f64() {
-        test_hashes!(
-            Float64Array,
+        test_murmur3_hash::<f64, Float64Array>(
             vec![
                 Some(1.0),
                 Some(0.0),
@@ -478,58 +451,26 @@ mod tests {
                 Some(99999999999.99999999999),
                 Some(-99999999999.99999999999),
             ],
-            vec![0xe4876492, 0x9c67b85d, 0x9c67b85d, 0x13d81357, 0xb87e1595, 0xa0eef9f9]
-        );
-        // with null input
-        test_hashes!(
-            Float64Array,
             vec![
-                Some(1.0),
-                Some(0.0),
-                Some(-0.0),
-                Some(-1.0),
-                None,
-                Some(99999999999.99999999999),
-                Some(-99999999999.99999999999)
+                0xe4876492, 0x9c67b85d, 0x9c67b85d, 0x13d81357, 0xb87e1595, 0xa0eef9f9,
             ],
-            vec![0xe4876492, 0x9c67b85d, 0x9c67b85d, 0x13d81357, 42, 0xb87e1595, 0xa0eef9f9]
         );
     }
 
     #[test]
     fn test_str() {
+        let input = vec![
+            "hello", "bar", "", "😁", "天地", "a", "ab", "abc", "abcd", "abcde",
+        ]
+        .iter()
+        .map(|s| Some(s.to_string()))
+        .collect::<Vec<Option<String>>>();
         let expected: Vec<u32> = vec![
             3286402344, 2486176763, 142593372, 885025535, 2395000894, 1485273170, 0xfa37157b,
             1322437556, 0xe860e5cc, 814637928,
         ];
 
-        test_hashes!(
-            StringArray,
-            vec!["hello", "bar", "", "😁", "天地", "a", "ab", "abc", "abcd", "abcde"],
-            expected
-        );
-        // test with null input
-        let with_null_expected: Vec<u32> = vec![
-            3286402344, 2486176763, 42, 142593372, 885025535, 2395000894, 1485273170, 0xfa37157b,
-            1322437556, 0xe860e5cc, 814637928,
-        ];
-        test_hashes!(
-            StringArray,
-            vec![
-                Some("hello"),
-                Some("bar"),
-                None,
-                Some(""),
-                Some("😁"),
-                Some("天地"),
-                Some("a"),
-                Some("ab"),
-                Some("abc"),
-                Some("abcd"),
-                Some("abcde"),
-            ],
-            with_null_expected
-        );
+        test_murmur3_hash::<String, StringArray>(input, expected);
     }
 
     #[test]

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1493,7 +1493,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
             .mode("append")
             .insertInto(table)
           // with random generated data
-          // disable cast(b as string) for now, as it may produce incompatible result
+          // disable cast(b as string) for now, as the cast from float to string may produce incompatible result
           checkSparkAnswerAndOperator("""
               |select
               |md5(col), md5(cast(a as string)), --md5(cast(b as string)),

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1452,10 +1452,10 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
         withTable(table) {
           sql(s"create table $table(col string, a int, b float) using parquet")
           sql(s"""
-               |insert into $table values
-               |('Spark SQL  ', 10, 1.2), (NULL, NULL, NULL), ('', 0, 0.0), ('苹果手机', NULL, 3.999999)
-               |, ('Spark SQL  ', 10, 1.2), (NULL, NULL, NULL), ('', 0, 0.0), ('苹果手机', NULL, 3.999999)
-               |""".stripMargin)
+              |insert into $table values
+              |('Spark SQL  ', 10, 1.2), (NULL, NULL, NULL), ('', 0, 0.0), ('苹果手机', NULL, 3.999999)
+              |, ('Spark SQL  ', 10, 1.2), (NULL, NULL, NULL), ('', 0, 0.0), ('苹果手机', NULL, 3.999999)
+              |""".stripMargin)
           checkSparkAnswerAndOperator("""
               |select
               |md5(col), md5(cast(a as string)), md5(cast(b as string)),

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -19,10 +19,8 @@
 
 package org.apache.comet
 
-import java.io.File
-
 import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.{CometTestBase, DataFrame, Row, SaveMode}
+import org.apache.spark.sql.{CometTestBase, DataFrame, Row}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.expr
 import org.apache.spark.sql.internal.SQLConf


### PR DESCRIPTION
## Which issue does this PR close?
Closes #427 

## Rationale for this change
Bug fixes. When submitting #424, we found there's a bug in spark_hash, which doesn't handle dictionary array correctly.
This PR tries to fix this first.

## What changes are included in this PR?
1. refactor some part of spark_hash.rs and be ready for xxhash64 support
2. unpack dictionary when computing with hashes
3. updated test

This PR currently depends on #426, will rebase once that's merged.

## How are these changes tested?
Updated test with randomized input.
