### PR TITLE
feat: add hex scalar function

### DIFF
--- a/core/src/execution/datafusion/expressions/scalar_funcs.rs
+++ b/core/src/execution/datafusion/expressions/scalar_funcs.rs
@@ -55,6 +55,9 @@ use unicode_segmentation::UnicodeSegmentation;
 mod unhex;
 use unhex::spark_unhex;
 
+mod hex;
+use hex::spark_hex;
+
 macro_rules! make_comet_scalar_udf {
     ($name:expr, $func:ident, $data_type:ident) => {{
         let scalar_func = CometScalarFunction::new(
@@ -107,6 +110,10 @@ pub fn create_comet_physical_fun(
         }
         "make_decimal" => {
             make_comet_scalar_udf!("make_decimal", spark_make_decimal, data_type)
+        }
+        "hex" => {
+            let func = Arc::new(spark_hex);
+            make_comet_scalar_udf!("hex", func, without data_type)
         }
         "unhex" => {
             let func = Arc::new(spark_unhex);

--- a/core/src/execution/datafusion/expressions/scalar_funcs/hex.rs
+++ b/core/src/execution/datafusion/expressions/scalar_funcs/hex.rs
@@ -34,28 +34,20 @@ fn hex_int64(num: i64) -> String {
     format!("{:X}", num)
 }
 
-fn hex_bytes(bytes: &[u8]) -> Vec<u8> {
+fn hex_bytes(bytes: &[u8]) -> Result<String, std::fmt::Error> {
     let length = bytes.len();
-    let mut value = vec![0; length * 2];
+    let mut hex_string = String::with_capacity(bytes.len() * 2);
     let mut i = 0;
     while i < length {
-        value[i * 2] = (bytes[i] & 0xF0) >> 4;
-        value[i * 2 + 1] = bytes[i] & 0x0F;
+        write!(&mut hex_string, "{:X}", (bytes[i] & 0xF0) >> 4)?;
+        write!(&mut hex_string, "{:X}", bytes[i] & 0x0F)?;
         i += 1;
     }
-    value
-}
-
-fn hex_string(s: &str) -> Vec<u8> {
-    hex_bytes(s.as_bytes())
-}
-
-fn hex_bytes_to_string(bytes: &[u8]) -> Result<String, std::fmt::Error> {
-    let mut hex_string = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        write!(&mut hex_string, "{:X}", byte)?;
-    }
     Ok(hex_string)
+}
+
+fn hex_string(s: &str) -> Result<String, std::fmt::Error> {
+    hex_bytes(s.as_bytes())
 }
 
 pub(super) fn spark_hex(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
@@ -80,7 +72,7 @@ pub(super) fn spark_hex(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFus
 
                 let hexed: Vec<Option<String>> = array
                     .iter()
-                    .map(|v| v.map(|v| hex_bytes_to_string(&hex_string(v))).transpose())
+                    .map(|v| v.map(|v| hex_string(v)).transpose())
                     .collect::<Result<_, _>>()?;
 
                 let string_array = StringArray::from(hexed);
@@ -92,7 +84,7 @@ pub(super) fn spark_hex(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFus
 
                 let hexed: Vec<Option<String>> = array
                     .iter()
-                    .map(|v| v.map(|v| hex_bytes_to_string(&hex_bytes(v))).transpose())
+                    .map(|v| v.map(|v| hex_bytes(v)).transpose())
                     .collect::<Result<_, _>>()?;
 
                 let string_array = StringArray::from(hexed);
@@ -104,7 +96,7 @@ pub(super) fn spark_hex(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFus
 
                 let hexed: Vec<Option<String>> = array
                     .iter()
-                    .map(|v| v.map(|v| hex_bytes_to_string(&hex_bytes(v))).transpose())
+                    .map(|v| v.map(|v| hex_bytes(v)).transpose())
                     .collect::<Result<_, _>>()?;
 
                 let string_array = StringArray::from(hexed);
@@ -137,7 +129,7 @@ pub(super) fn spark_hex(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFus
                 let hexed_values = as_string_array(dict.values());
                 let values: Vec<Option<String>> = hexed_values
                     .iter()
-                    .map(|v| v.map(|v| hex_bytes_to_string(&hex_string(v))).transpose())
+                    .map(|v| v.map(|v| hex_string(v)).transpose())
                     .collect::<Result<_, _>>()?;
 
                 let keys = dict.keys().clone();
@@ -158,7 +150,7 @@ pub(super) fn spark_hex(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFus
                 let hexed_values = as_binary_array(dict.values())?;
                 let values: Vec<Option<String>> = hexed_values
                     .iter()
-                    .map(|v| v.map(|v| hex_bytes_to_string(&hex_bytes(v))).transpose())
+                    .map(|v| v.map(|v| hex_bytes(v)).transpose())
                     .collect::<Result<_, _>>()?;
 
                 let keys = dict.keys().clone();
@@ -186,14 +178,12 @@ pub(super) fn spark_hex(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFus
             ScalarValue::Binary(Some(v))
             | ScalarValue::LargeBinary(Some(v))
             | ScalarValue::FixedSizeBinary(_, Some(v)) => {
-                let hex_bytes = hex_bytes(v);
-                let hex_string = hex_bytes_to_string(&hex_bytes)?;
+                let hex_string = hex_bytes(v)?;
 
                 Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(hex_string))))
             }
             ScalarValue::Utf8(Some(v)) | ScalarValue::LargeUtf8(Some(v)) => {
-                let hex_bytes = hex_string(v);
-                let hex_string = hex_bytes_to_string(&hex_bytes)?;
+                let hex_string = hex_string(v)?;
 
                 Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(hex_string))))
             }
@@ -310,26 +300,6 @@ mod test {
         let result = as_string_array(&result);
 
         assert_eq!(result, &expected);
-    }
-
-    #[test]
-    fn test_hex_bytes() {
-        let bytes = [0x01, 0x02, 0x03, 0x04];
-        let hexed = super::hex_bytes(&bytes);
-        assert_eq!(hexed, vec![0, 1, 0, 2, 0, 3, 0, 4]);
-    }
-
-    #[test]
-    fn test_hex_bytes_to_string() -> Result<(), std::fmt::Error> {
-        let bytes = [0x01, 0x02, 0x03, 0x04];
-        let hexed = super::hex_bytes_to_string(&bytes)?;
-        assert_eq!(hexed, "1234".to_string());
-
-        let large_bytes = [0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0];
-        let hexed = super::hex_bytes_to_string(&large_bytes)?;
-        assert_eq!(hexed, "123456789ABCDEF0".to_string());
-
-        Ok(())
     }
 
     #[test]

--- a/core/src/execution/datafusion/expressions/scalar_funcs/hex.rs
+++ b/core/src/execution/datafusion/expressions/scalar_funcs/hex.rs
@@ -26,7 +26,7 @@ use arrow_schema::DataType;
 use datafusion::logical_expr::ColumnarValue;
 use datafusion_common::{
     cast::{as_binary_array, as_fixed_size_binary_array, as_int64_array},
-    exec_err, DataFusionError, ScalarValue,
+    exec_err, DataFusionError,
 };
 use std::fmt::Write;
 
@@ -156,35 +156,7 @@ pub(super) fn spark_hex(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFus
                 array.data_type()
             ),
         },
-        ColumnarValue::Scalar(scalar) => match scalar {
-            ScalarValue::Int64(Some(v)) => {
-                let hex_string = hex_int64(*v);
-
-                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(hex_string))))
-            }
-            ScalarValue::Binary(Some(v))
-            | ScalarValue::LargeBinary(Some(v))
-            | ScalarValue::FixedSizeBinary(_, Some(v)) => {
-                let hex_string = hex_bytes(v)?;
-
-                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(hex_string))))
-            }
-            ScalarValue::Utf8(Some(v)) | ScalarValue::LargeUtf8(Some(v)) => {
-                let hex_string = hex_bytes(v)?;
-
-                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(hex_string))))
-            }
-            ScalarValue::Int64(None)
-            | ScalarValue::Utf8(None)
-            | ScalarValue::Binary(None)
-            | ScalarValue::FixedSizeBinary(_, None) => {
-                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(None)))
-            }
-            _ => exec_err!(
-                "hex got an unexpected argument type: {:?}",
-                scalar.data_type()
-            ),
-        },
+        _ => exec_err!("native hex does not support scalar values at this time"),
     }
 }
 

--- a/core/src/execution/datafusion/expressions/scalar_funcs/hex.rs
+++ b/core/src/execution/datafusion/expressions/scalar_funcs/hex.rs
@@ -1,0 +1,191 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use arrow::array::as_string_array;
+use arrow_array::StringArray;
+use arrow_schema::DataType;
+use datafusion::logical_expr::ColumnarValue;
+use datafusion_common::{
+    cast::{as_binary_array, as_int64_array},
+    exec_err, DataFusionError, ScalarValue,
+};
+use std::fmt::Write;
+
+fn hex_bytes(bytes: &[u8]) -> Vec<u8> {
+    let length = bytes.len();
+    let mut value = vec![0; length * 2];
+    let mut i = 0;
+    while i < length {
+        value[i * 2] = (bytes[i] & 0xF0) >> 4;
+        value[i * 2 + 1] = bytes[i] & 0x0F;
+        i += 1;
+    }
+    value
+}
+
+fn hex_int64(num: i64) -> String {
+    if num >= 0 {
+        format!("{:X}", num)
+    } else {
+        format!("{:016X}", num as u64)
+    }
+}
+
+fn hex_string(s: &str) -> Vec<u8> {
+    hex_bytes(s.as_bytes())
+}
+
+fn hex_bytes_to_string(bytes: &[u8]) -> Result<String, std::fmt::Error> {
+    let mut hex_string = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(&mut hex_string, "{:01X}", byte)?;
+    }
+    Ok(hex_string)
+}
+
+pub(super) fn spark_hex(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
+    if args.len() != 1 {
+        return Err(DataFusionError::Internal(
+            "hex expects exactly one argument".to_string(),
+        ));
+    }
+
+    match &args[0] {
+        ColumnarValue::Array(array) => match array.data_type() {
+            DataType::Int64 => {
+                let array = as_int64_array(array)?;
+
+                let hexed: Vec<Option<String>> = array.iter().map(|v| v.map(hex_int64)).collect();
+
+                let string_array = StringArray::from(hexed);
+                Ok(ColumnarValue::Array(Arc::new(string_array)))
+            }
+            DataType::Utf8 => {
+                let array = as_string_array(array);
+
+                let hexed: Vec<Option<String>> = array
+                    .iter()
+                    .map(|v| v.map(|v| hex_bytes_to_string(&hex_string(v))).transpose())
+                    .collect::<Result<_, _>>()?;
+
+                let string_array = StringArray::from(hexed);
+
+                Ok(ColumnarValue::Array(Arc::new(string_array)))
+            }
+            DataType::Binary => {
+                let array = as_binary_array(array)?;
+
+                let hexed: Vec<Option<String>> = array
+                    .iter()
+                    .map(|v| v.map(|v| hex_bytes_to_string(&hex_bytes(v))).transpose())
+                    .collect::<Result<_, _>>()?;
+
+                let string_array = StringArray::from(hexed);
+
+                Ok(ColumnarValue::Array(Arc::new(string_array)))
+            }
+            _ => exec_err!("hex expects a string, binary or integer argument"),
+        },
+        ColumnarValue::Scalar(scalar) => match scalar {
+            ScalarValue::Int64(Some(v)) => {
+                let hex_string = hex_int64(*v);
+
+                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(hex_string))))
+            }
+            ScalarValue::Binary(Some(v)) | ScalarValue::LargeBinary(Some(v)) => {
+                let hex_bytes = hex_bytes(v);
+                let hex_string = hex_bytes_to_string(&hex_bytes)?;
+
+                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(hex_string))))
+            }
+            ScalarValue::Utf8(Some(v)) | ScalarValue::LargeUtf8(Some(v)) => {
+                let hex_bytes = hex_string(v);
+                let hex_string = hex_bytes_to_string(&hex_bytes)?;
+
+                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(hex_string))))
+            }
+            ScalarValue::Int64(None) | ScalarValue::Utf8(None) | ScalarValue::Binary(None) => {
+                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(None)))
+            }
+            _ => exec_err!("hex expects a string, binary or integer argument"),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use arrow::array::as_string_array;
+    use arrow_array::{Int64Array, StringArray};
+    use datafusion::logical_expr::ColumnarValue;
+
+    #[test]
+    fn test_hex_bytes() {
+        let bytes = [0x01, 0x02, 0x03, 0x04];
+        let hexed = super::hex_bytes(&bytes);
+        assert_eq!(hexed, vec![0, 1, 0, 2, 0, 3, 0, 4]);
+    }
+
+    #[test]
+    fn test_hex_bytes_to_string() -> Result<(), std::fmt::Error> {
+        let bytes = [0x01, 0x02, 0x03, 0x04];
+        let hexed = super::hex_bytes_to_string(&bytes)?;
+        assert_eq!(hexed, "1234".to_string());
+
+        let large_bytes = [0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0];
+        let hexed = super::hex_bytes_to_string(&large_bytes)?;
+        assert_eq!(hexed, "123456789ABCDEF0".to_string());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_hex_int64() {
+        let num = 1234;
+        let hexed = super::hex_int64(num);
+        assert_eq!(hexed, "4D2".to_string());
+
+        let num = -1;
+        let hexed = super::hex_int64(num);
+        assert_eq!(hexed, "FFFFFFFFFFFFFFFF".to_string());
+    }
+
+    #[test]
+    fn test_spark_hex_int64() {
+        let int_array = Int64Array::from(vec![Some(1), Some(2), None, Some(3)]);
+        let columnar_value = ColumnarValue::Array(Arc::new(int_array));
+
+        let result = super::spark_hex(&[columnar_value]).unwrap();
+        let result = match result {
+            ColumnarValue::Array(array) => array,
+            _ => panic!("Expected array"),
+        };
+
+        let string_array = as_string_array(&result);
+        let expected_array = StringArray::from(vec![
+            Some("1".to_string()),
+            Some("2".to_string()),
+            None,
+            Some("3".to_string()),
+        ]);
+
+        assert_eq!(string_array, &expected_array);
+    }
+}

--- a/core/src/execution/datafusion/expressions/scalar_funcs/hex.rs
+++ b/core/src/execution/datafusion/expressions/scalar_funcs/hex.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 
 use arrow::{
-    array::{as_dictionary_array, as_string_array},
+    array::{as_dictionary_array, as_largestring_array, as_string_array},
     datatypes::Int32Type,
 };
 use arrow_array::StringArray;
@@ -60,8 +60,18 @@ pub(super) fn spark_hex(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFus
 
                 Ok(ColumnarValue::Array(Arc::new(hexed_array)))
             }
-            DataType::Utf8 | DataType::LargeUtf8 => {
+            DataType::Utf8 => {
                 let array = as_string_array(array);
+
+                let hexed: StringArray = array
+                    .iter()
+                    .map(|v| v.map(hex_bytes).transpose())
+                    .collect::<Result<_, _>>()?;
+
+                Ok(ColumnarValue::Array(Arc::new(hexed)))
+            }
+            DataType::LargeUtf8 => {
+                let array = as_largestring_array(array);
 
                 let hexed: StringArray = array
                     .iter()

--- a/core/src/execution/datafusion/expressions/scalar_funcs/hex.rs
+++ b/core/src/execution/datafusion/expressions/scalar_funcs/hex.rs
@@ -56,8 +56,7 @@ pub(super) fn spark_hex(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFus
             DataType::Int64 => {
                 let array = as_int64_array(array)?;
 
-                let hexed_array: StringArray =
-                    array.iter().map(|v| v.map(|v| hex_int64(v))).collect();
+                let hexed_array: StringArray = array.iter().map(|v| v.map(hex_int64)).collect();
 
                 Ok(ColumnarValue::Array(Arc::new(hexed_array)))
             }
@@ -66,7 +65,7 @@ pub(super) fn spark_hex(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFus
 
                 let hexed: StringArray = array
                     .iter()
-                    .map(|v| v.map(|v| hex_bytes(v)).transpose())
+                    .map(|v| v.map(hex_bytes).transpose())
                     .collect::<Result<_, _>>()?;
 
                 Ok(ColumnarValue::Array(Arc::new(hexed)))
@@ -76,7 +75,7 @@ pub(super) fn spark_hex(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFus
 
                 let hexed: StringArray = array
                     .iter()
-                    .map(|v| v.map(|v| hex_bytes(v)).transpose())
+                    .map(|v| v.map(hex_bytes).transpose())
                     .collect::<Result<_, _>>()?;
 
                 Ok(ColumnarValue::Array(Arc::new(hexed)))
@@ -86,7 +85,7 @@ pub(super) fn spark_hex(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFus
 
                 let hexed: StringArray = array
                     .iter()
-                    .map(|v| v.map(|v| hex_bytes(v)).transpose())
+                    .map(|v| v.map(hex_bytes).transpose())
                     .collect::<Result<_, _>>()?;
 
                 Ok(ColumnarValue::Array(Arc::new(hexed)))
@@ -117,7 +116,7 @@ pub(super) fn spark_hex(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFus
                 let hexed_values = as_string_array(dict.values());
                 let values: Vec<Option<String>> = hexed_values
                     .iter()
-                    .map(|v| v.map(|v| hex_bytes(v)).transpose())
+                    .map(|v| v.map(hex_bytes).transpose())
                     .collect::<Result<_, _>>()?;
 
                 let keys = dict.keys().clone();
@@ -138,7 +137,7 @@ pub(super) fn spark_hex(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFus
                 let hexed_values = as_binary_array(dict.values())?;
                 let values: Vec<Option<String>> = hexed_values
                     .iter()
-                    .map(|v| v.map(|v| hex_bytes(v)).transpose())
+                    .map(|v| v.map(hex_bytes).transpose())
                     .collect::<Result<_, _>>()?;
 
                 let keys = dict.keys().clone();

--- a/core/src/execution/datafusion/expressions/scalar_funcs/hex.rs
+++ b/core/src/execution/datafusion/expressions/scalar_funcs/hex.rs
@@ -27,18 +27,6 @@ use datafusion_common::{
 };
 use std::fmt::Write;
 
-fn hex_bytes(bytes: &[u8]) -> Vec<u8> {
-    let length = bytes.len();
-    let mut value = vec![0; length * 2];
-    let mut i = 0;
-    while i < length {
-        value[i * 2] = (bytes[i] & 0xF0) >> 4;
-        value[i * 2 + 1] = bytes[i] & 0x0F;
-        i += 1;
-    }
-    value
-}
-
 fn hex_int64(num: i64) -> String {
     if num >= 0 {
         format!("{:X}", num)
@@ -69,6 +57,18 @@ fn hex_int8(num: i8) -> String {
     } else {
         format!("{:02X}", num as u8)
     }
+}
+
+fn hex_bytes(bytes: &[u8]) -> Vec<u8> {
+    let length = bytes.len();
+    let mut value = vec![0; length * 2];
+    let mut i = 0;
+    while i < length {
+        value[i * 2] = (bytes[i] & 0xF0) >> 4;
+        value[i * 2 + 1] = bytes[i] & 0x0F;
+        i += 1;
+    }
+    value
 }
 
 fn hex_string(s: &str) -> Vec<u8> {
@@ -228,6 +228,16 @@ mod test {
         let bytes = [0x01, 0x02, 0x03, 0x04];
         let hexed = super::hex_bytes(&bytes);
         assert_eq!(hexed, vec![0, 1, 0, 2, 0, 3, 0, 4]);
+    }
+
+    #[test]
+    fn test_hex_string() {
+        let s = "1234";
+        let hexed = super::hex_string(s);
+        assert_eq!(hexed, vec![0x31, 0x32, 0x33, 0x34]);
+
+        let hexed_string = super::hex_bytes_to_string(&hexed).unwrap();
+        assert_eq!(hexed_string, "31323334".to_string());
     }
 
     #[test]

--- a/core/src/execution/datafusion/expressions/scalar_funcs/hex.rs
+++ b/core/src/execution/datafusion/expressions/scalar_funcs/hex.rs
@@ -62,46 +62,40 @@ pub(super) fn spark_hex(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFus
             DataType::Int64 => {
                 let array = as_int64_array(array)?;
 
-                let hexed: Vec<Option<String>> = array.iter().map(|v| v.map(hex_int64)).collect();
+                let hexed_array: StringArray =
+                    array.iter().map(|v| v.map(|v| hex_int64(v))).collect();
 
-                let string_array = StringArray::from(hexed);
-                Ok(ColumnarValue::Array(Arc::new(string_array)))
+                Ok(ColumnarValue::Array(Arc::new(hexed_array)))
             }
             DataType::Utf8 | DataType::LargeUtf8 => {
                 let array = as_string_array(array);
 
-                let hexed: Vec<Option<String>> = array
+                let hexed: StringArray = array
                     .iter()
                     .map(|v| v.map(|v| hex_string(v)).transpose())
                     .collect::<Result<_, _>>()?;
 
-                let string_array = StringArray::from(hexed);
-
-                Ok(ColumnarValue::Array(Arc::new(string_array)))
+                Ok(ColumnarValue::Array(Arc::new(hexed)))
             }
             DataType::Binary => {
                 let array = as_binary_array(array)?;
 
-                let hexed: Vec<Option<String>> = array
+                let hexed: StringArray = array
                     .iter()
                     .map(|v| v.map(|v| hex_bytes(v)).transpose())
                     .collect::<Result<_, _>>()?;
 
-                let string_array = StringArray::from(hexed);
-
-                Ok(ColumnarValue::Array(Arc::new(string_array)))
+                Ok(ColumnarValue::Array(Arc::new(hexed)))
             }
             DataType::FixedSizeBinary(_) => {
                 let array = as_fixed_size_binary_array(array)?;
 
-                let hexed: Vec<Option<String>> = array
+                let hexed: StringArray = array
                     .iter()
                     .map(|v| v.map(|v| hex_bytes(v)).transpose())
                     .collect::<Result<_, _>>()?;
 
-                let string_array = StringArray::from(hexed);
-
-                Ok(ColumnarValue::Array(Arc::new(string_array)))
+                Ok(ColumnarValue::Array(Arc::new(hexed)))
             }
             DataType::Dictionary(_, value_type) if matches!(**value_type, DataType::Int64) => {
                 let dict = as_dictionary_array::<Int32Type>(&array);

--- a/core/src/execution/datafusion/expressions/scalar_funcs/hex.rs
+++ b/core/src/execution/datafusion/expressions/scalar_funcs/hex.rs
@@ -31,11 +31,7 @@ use datafusion_common::{
 use std::fmt::Write;
 
 fn hex_int64(num: i64) -> String {
-    if num >= 0 {
-        format!("{:X}", num)
-    } else {
-        format!("{:016X}", num as u64)
-    }
+    format!("{:X}", num)
 }
 
 fn hex_bytes(bytes: &[u8]) -> Vec<u8> {

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -1483,6 +1483,13 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val optExpr = scalarExprToProto("atan2", leftExpr, rightExpr)
           optExprWithInfo(optExpr, expr, left, right)
 
+        case Hex(child) =>
+          val childExpr = exprToProtoInternal(child, inputs)
+          val optExpr =
+            scalarExprToProtoWithReturnType("hex", StringType, childExpr)
+
+          optExprWithInfo(optExpr, expr, child)
+
         case e: Unhex if !isSpark32 =>
           val unHex = unhexSerde(e)
 

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1038,6 +1038,46 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       }
     }
   }
+  test("hex") {
+    val str_table = "string_hex_table"
+    withTable(str_table) {
+      sql(s"create table $str_table(col string) using parquet")
+
+      sql(s"""INSERT INTO $str_table VALUES
+        |('Spark SQL'),
+        |('string'),
+        |(''),
+        |('###'),
+        |('G123'),
+        |(NULL),
+        |('hello'),
+        |('A1B'),
+        |('0A1B')""".stripMargin)
+
+      checkSparkAnswerAndOperator(s"SELECT hex(col) FROM $str_table")
+      checkSparkAnswerAndOperator(s"SELECT hex(CAST(col AS BINARY)) FROM $str_table")
+    }
+
+    val int_table = "int_hex_table"
+    withTable(int_table) {
+      sql(s"create table $int_table(col int) using parquet")
+
+      sql(s"""INSERT INTO $int_table VALUES
+        |(-1),
+        |(0),
+        |(1),
+        |(2),
+        |(3),
+        |(4),
+        |(NULL),
+        |(5),
+        |(6),
+        |(7),
+        |(8)""".stripMargin)
+
+      checkSparkAnswerAndOperator(s"SELECT hex(col) FROM $int_table")
+    }
+  }
   test("unhex") {
     // When running against Spark 3.2, we include a bug fix for https://issues.apache.org/jira/browse/SPARK-40924 that
     // was added in Spark 3.3, so although Comet's behavior is more correct when running against Spark 3.2, it is not

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1045,9 +1045,9 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
         makeParquetFileAllTypes(path, dictionaryEnabled = dictionaryEnabled, 10000)
 
         withParquetTable(path.toString, "tbl") {
-          // _9 and _10 (uint8 and uint16), and _13 (Dictionary(Int32, Utf8)) are not supported
+          // _9 and _10 (uint8 and uint16) not supported
           checkSparkAnswerAndOperator(
-            "SELECT hex(_1), hex(_2), hex(_3), hex(_4), hex(_5), hex(_6), hex(_7), hex(_8), hex(_11), hex(_12), hex(_14), hex(_15), hex(_16), hex(_17), hex(_18), hex(_19), hex(_20) FROM tbl")
+            "SELECT hex(_1), hex(_2), hex(_3), hex(_4), hex(_5), hex(_6), hex(_7), hex(_8), hex(_11), hex(_12), hex(_13), hex(_14), hex(_15), hex(_16), hex(_17), hex(_18), hex(_19), hex(_20) FROM tbl")
         }
       }
     }

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1038,6 +1038,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       }
     }
   }
+
   test("hex") {
     Seq(true, false).foreach { dictionaryEnabled =>
       withTempDir { dir =>
@@ -1052,6 +1053,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       }
     }
   }
+
   test("unhex") {
     // When running against Spark 3.2, we include a bug fix for https://issues.apache.org/jira/browse/SPARK-40924 that
     // was added in Spark 3.3, so although Comet's behavior is more correct when running against Spark 3.2, it is not

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1045,15 +1045,9 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
         makeParquetFileAllTypes(path, dictionaryEnabled = dictionaryEnabled, 10000)
 
         withParquetTable(path.toString, "tbl") {
-          // ints
-          checkSparkAnswerAndOperator("SELECT hex(_2), hex(_3), hex(_4), hex(_5) FROM tbl")
-
-          // uints, uint8 and uint16 not working yet
-          // checkSparkAnswerAndOperator("SELECT hex(_9), hex(_10), hex(_11), hex(_12) FROM tbl")
-          checkSparkAnswerAndOperator("SELECT hex(_11), hex(_12) FROM tbl")
-
-          // strings, binary
-          checkSparkAnswerAndOperator("SELECT hex(_8), hex(_14) FROM tbl")
+          // _9 and _10 (uint8 and uint16), and _13 (Dictionary(Int32, Utf8)) are not supported
+          checkSparkAnswerAndOperator(
+            "SELECT hex(_1), hex(_2), hex(_3), hex(_4), hex(_5), hex(_6), hex(_7), hex(_8), hex(_11), hex(_12), hex(_14), hex(_15), hex(_16), hex(_17), hex(_18), hex(_19), hex(_20) FROM tbl")
         }
       }
     }


### PR DESCRIPTION
## Which issue does this PR close?

Related to https://github.com/apache/datafusion-comet/issues/341.

## Rationale for this change

I recently added `unhex` so this PR adds `hex`. It's another scalar function that isn't yet implemented in Comet.

I decided to do a native version here because datafusion has an `to_hex`, but it has different functionality. E.g. `to_hex(-1)` returns `ffffffffffffffff` in datafusion vs `hex(-1)` returning `FFFFFFFFFFFFFFFF` in spark. Spark `hex` also supports strings, but datafusion and postgres do not. I'm happy to start the discussion if it seems it could be merged upstream.

## What changes are included in this PR?

I added the `hex` scalar function.

## How are these changes tested?

Yes, I've added tests to the rust side as well as spark sql based tests in scala.
