### PR TITLE
bug fix: Fix fuzz testcase for cast string to integer 

### DIFF
--- a/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
+++ b/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
@@ -104,10 +104,9 @@ object CometCast {
       timeZoneId: Option[String],
       evalMode: String): SupportLevel = {
     toType match {
-      case DataTypes.BooleanType =>
+      case DataTypes.BooleanType | DataTypes.IntegerType =>
         Compatible()
-      case DataTypes.ByteType | DataTypes.ShortType | DataTypes.IntegerType |
-          DataTypes.LongType =>
+      case DataTypes.ByteType | DataTypes.ShortType | DataTypes.LongType =>
         Incompatible(Some("Not all invalid inputs are detected"))
       case DataTypes.BinaryType =>
         Compatible()

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -23,7 +23,7 @@ import java.io.File
 
 import scala.util.Random
 
-import org.apache.spark.sql.{CometTestBase, DataFrame, SaveMode}
+import org.apache.spark.sql.{functions, CometTestBase, DataFrame, SaveMode}
 import org.apache.spark.sql.catalyst.expressions.Cast
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.col
@@ -533,11 +533,16 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     castTest(gen.generateStrings(dataSize, numericPattern, 5).toDF("a"), DataTypes.ShortType)
   }
 
-  ignore("cast StringType to IntegerType") {
+  test("cast StringType to IntegerType") {
     // test with hand-picked values
     castTest(castStringToIntegralInputs.toDF("a"), DataTypes.IntegerType)
     // fuzz test
-    castTest(gen.generateStrings(dataSize, numericPattern, 8).toDF("a"), DataTypes.IntegerType)
+    castTest(
+      gen
+        .generateStrings(dataSize, numericPattern, 8)
+        .toDF("a")
+        .withColumn("a", functions.trim($"a")),
+      DataTypes.IntegerType)
   }
 
   ignore("cast StringType to LongType") {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #431  .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Removing leading whitespaces: In some inputs, Spark's error messages contain leading whitespaces while Comet's do not, causing the tests to fail. By removing the leading whitespaces from the input, this issue is resolved.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

removing the leading whitespaces from input df. 

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Fuzz tests pass.