### PR TITLE
fix: Only delegate to DataFusion cast when we know that it is compatible with Spark

### DIFF
--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -663,7 +663,10 @@ impl Cast {
             DataType::Timestamp(_, _) => {
                 // TODO need to add tests to see if we really do support all
                 // timestamp to timestamp conversions
-                matches!(to_type, DataType::Int64 | DataType::Date32 | DataType::Utf8 | DataType::Timestamp(_, _))
+                matches!(
+                    to_type,
+                    DataType::Int64 | DataType::Date32 | DataType::Utf8 | DataType::Timestamp(_, _)
+                )
             }
             DataType::Binary => {
                 // note that this is not completely Spark compatible because

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -647,7 +647,7 @@ impl Cast {
                     | DataType::Float32
                     | DataType::Float64
             ),
-            DataType::Decimal128(_, _) => matches!(
+            DataType::Decimal128(_, _) | DataType::Decimal256(_, _) => matches!(
                 to_type,
                 DataType::Int8
                     | DataType::Int16
@@ -655,6 +655,8 @@ impl Cast {
                     | DataType::Int64
                     | DataType::Float32
                     | DataType::Float64
+                    | DataType::Decimal128(_, _)
+                    | DataType::Decimal256(_, _)
             ),
             DataType::Utf8 => matches!(to_type, DataType::Binary),
             DataType::Date32 => matches!(to_type, DataType::Utf8),

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -663,6 +663,11 @@ impl Cast {
             DataType::Timestamp(_, _) => {
                 matches!(to_type, DataType::Int64 | DataType::Date32 | DataType::Utf8)
             }
+            DataType::Binary => {
+                // note that this is not completely Spark compatible because
+                // DataFusion only supports binary data containing valid UTF-8 strings
+                matches!(to_type, DataType::Utf8)
+            }
             _ => false,
         }
     }

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -605,51 +605,53 @@ impl Cast {
     /// Determines if DataFusion supports the given cast in a way that is
     /// compatible with Spark
     fn is_datafusion_spark_compatible(from_type: &DataType, to_type: &DataType) -> bool {
-        match (from_type, to_type) {
-            (
-                DataType::Boolean,
+        match from_type {
+            DataType::Boolean => matches!(
+                to_type,
                 DataType::Int8
-                | DataType::Int16
-                | DataType::Int32
-                | DataType::Int64
-                | DataType::Float32
-                | DataType::Float64
-                | DataType::Utf8,
-            ) => true,
-            (
-                DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64,
+                    | DataType::Int16
+                    | DataType::Int32
+                    | DataType::Int64
+                    | DataType::Float32
+                    | DataType::Float64
+                    | DataType::Utf8
+            ),
+            DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => matches!(
+                to_type,
                 DataType::Boolean
-                | DataType::Int8
-                | DataType::Int16
-                | DataType::Int32
-                | DataType::Int64
-                | DataType::Float32
-                | DataType::Float64
-                | DataType::Decimal128(_, _)
-                | DataType::Utf8,
-            ) => true,
-            (
-                DataType::Float32 | DataType::Float64,
+                    | DataType::Int8
+                    | DataType::Int16
+                    | DataType::Int32
+                    | DataType::Int64
+                    | DataType::Float32
+                    | DataType::Float64
+                    | DataType::Decimal128(_, _)
+                    | DataType::Utf8
+            ),
+            DataType::Float32 | DataType::Float64 => matches!(
+                to_type,
                 DataType::Boolean
-                | DataType::Int8
-                | DataType::Int16
-                | DataType::Int32
-                | DataType::Int64
-                | DataType::Float32
-                | DataType::Float64,
-            ) => true,
-            (
-                DataType::Decimal128(_, _),
+                    | DataType::Int8
+                    | DataType::Int16
+                    | DataType::Int32
+                    | DataType::Int64
+                    | DataType::Float32
+                    | DataType::Float64
+            ),
+            DataType::Decimal128(_, _) => matches!(
+                to_type,
                 DataType::Int8
-                | DataType::Int16
-                | DataType::Int32
-                | DataType::Int64
-                | DataType::Float32
-                | DataType::Float64,
-            ) => true,
-            (DataType::Utf8, DataType::Binary) => true,
-            (DataType::Date32 | DataType::Timestamp(_, _), DataType::Utf8) => true,
-            (DataType::Timestamp(_, _), DataType::Int64 | DataType::Date32) => true,
+                    | DataType::Int16
+                    | DataType::Int32
+                    | DataType::Int64
+                    | DataType::Float32
+                    | DataType::Float64
+            ),
+            DataType::Utf8 => matches!(to_type, DataType::Binary),
+            DataType::Date32 => matches!(to_type, DataType::Utf8),
+            DataType::Timestamp(_, _) => {
+                matches!(to_type, DataType::Int64 | DataType::Date32 | DataType::Utf8)
+            }
             _ => false,
         }
     }

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -625,7 +625,7 @@ impl Cast {
                     | DataType::Float64
                     | DataType::Utf8
             ),
-            DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => matches!(
+            DataType::Int8 | DataType::Int16 => matches!(
                 to_type,
                 DataType::Boolean
                     | DataType::Int8
@@ -635,6 +635,17 @@ impl Cast {
                     | DataType::Float32
                     | DataType::Float64
                     | DataType::Decimal128(_, _)
+                    | DataType::Utf8
+            ),
+            DataType::Int32 | DataType::Int64 => matches!(
+                to_type,
+                DataType::Boolean
+                    | DataType::Int8
+                    | DataType::Int16
+                    | DataType::Int32
+                    | DataType::Int64
+                    | DataType::Float32
+                    | DataType::Float64
                     | DataType::Utf8
             ),
             DataType::Float32 | DataType::Float64 => matches!(

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -661,8 +661,6 @@ impl Cast {
             DataType::Utf8 => matches!(to_type, DataType::Binary),
             DataType::Date32 => matches!(to_type, DataType::Utf8),
             DataType::Timestamp(_, _) => {
-                // TODO need to add tests to see if we really do support all
-                // timestamp to timestamp conversions
                 matches!(
                     to_type,
                     DataType::Int64 | DataType::Date32 | DataType::Utf8 | DataType::Timestamp(_, _)

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -625,18 +625,23 @@ impl Cast {
                     | DataType::Float64
                     | DataType::Utf8
             ),
-            DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => matches!(
-                to_type,
-                DataType::Boolean
-                    | DataType::Int8
-                    | DataType::Int16
-                    | DataType::Int32
-                    | DataType::Int64
-                    | DataType::Float32
-                    | DataType::Float64
-                    | DataType::Decimal128(_, _)
-                    | DataType::Utf8
-            ),
+            DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => {
+                // note that the cast from Int32/Int64 -> Decimal128 here is actually
+                // not compatible with Spark (no overflow checks) but we have tests that
+                // rely on this cast working so we have to leave it here for now
+                matches!(
+                    to_type,
+                    DataType::Boolean
+                        | DataType::Int8
+                        | DataType::Int16
+                        | DataType::Int32
+                        | DataType::Int64
+                        | DataType::Float32
+                        | DataType::Float64
+                        | DataType::Decimal128(_, _)
+                        | DataType::Utf8
+                )
+            }
             DataType::Float32 | DataType::Float64 => matches!(
                 to_type,
                 DataType::Boolean

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -533,29 +533,7 @@ impl Cast {
                 Self::cast_string_to_timestamp(&array, to_type, self.eval_mode)
             }
             (DataType::Utf8, DataType::Date32) => {
-                Self::cast_string_to_date(&array, to_type, self.eval_mode)?
-            }
-            (DataType::Dictionary(key_type, value_type), DataType::Date32)
-                if key_type.as_ref() == &DataType::Int32
-                    && (value_type.as_ref() == &DataType::Utf8
-                        || value_type.as_ref() == &DataType::LargeUtf8) =>
-            {
-                match value_type.as_ref() {
-                    DataType::Utf8 => {
-                        let unpacked_array =
-                            cast_with_options(&array, &DataType::Utf8, &CAST_OPTIONS)?;
-                        Self::cast_string_to_date(&unpacked_array, to_type, self.eval_mode)?
-                    }
-                    DataType::LargeUtf8 => {
-                        let unpacked_array =
-                            cast_with_options(&array, &DataType::LargeUtf8, &CAST_OPTIONS)?;
-                        Self::cast_string_to_date(&unpacked_array, to_type, self.eval_mode)?
-                    }
-                    dt => unreachable!(
-                        "{}",
-                        format!("invalid value type {dt} for dictionary-encoded string array")
-                    ),
-                }
+                Self::cast_string_to_date(&array, to_type, self.eval_mode)
             }
             (DataType::Int64, DataType::Int32)
             | (DataType::Int64, DataType::Int16)

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -661,7 +661,9 @@ impl Cast {
             DataType::Utf8 => matches!(to_type, DataType::Binary),
             DataType::Date32 => matches!(to_type, DataType::Utf8),
             DataType::Timestamp(_, _) => {
-                matches!(to_type, DataType::Int64 | DataType::Date32 | DataType::Utf8)
+                // TODO need to add tests to see if we really do support all
+                // timestamp to timestamp conversions
+                matches!(to_type, DataType::Int64 | DataType::Date32 | DataType::Utf8 | DataType::Timestamp(_, _))
             }
             DataType::Binary => {
                 // note that this is not completely Spark compatible because

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -625,7 +625,7 @@ impl Cast {
                     | DataType::Float64
                     | DataType::Utf8
             ),
-            DataType::Int8 | DataType::Int16 => matches!(
+            DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => matches!(
                 to_type,
                 DataType::Boolean
                     | DataType::Int8
@@ -635,17 +635,6 @@ impl Cast {
                     | DataType::Float32
                     | DataType::Float64
                     | DataType::Decimal128(_, _)
-                    | DataType::Utf8
-            ),
-            DataType::Int32 | DataType::Int64 => matches!(
-                to_type,
-                DataType::Boolean
-                    | DataType::Int8
-                    | DataType::Int16
-                    | DataType::Int32
-                    | DataType::Int64
-                    | DataType::Float32
-                    | DataType::Float64
                     | DataType::Utf8
             ),
             DataType::Float32 | DataType::Float64 => matches!(

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -644,7 +644,7 @@ impl Cast {
                     | DataType::Float32
                     | DataType::Float64
             ),
-            DataType::Decimal128(_, _) => matches!(
+            DataType::Decimal128(_, _) | DataType::Decimal256(_, _) => matches!(
                 to_type,
                 DataType::Int8
                     | DataType::Int16
@@ -652,6 +652,8 @@ impl Cast {
                     | DataType::Int64
                     | DataType::Float32
                     | DataType::Float64
+                    | DataType::Decimal128(_, _)
+                    | DataType::Decimal256(_, _)
             ),
             DataType::Utf8 => matches!(to_type, DataType::Binary),
             DataType::Date32 => matches!(to_type, DataType::Utf8),

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -611,6 +611,9 @@ impl Cast {
     /// Determines if DataFusion supports the given cast in a way that is
     /// compatible with Spark
     fn is_datafusion_spark_compatible(from_type: &DataType, to_type: &DataType) -> bool {
+        if from_type == to_type {
+            return true;
+        }
         match from_type {
             DataType::Boolean => matches!(
                 to_type,
@@ -644,7 +647,7 @@ impl Cast {
                     | DataType::Float32
                     | DataType::Float64
             ),
-            DataType::Decimal128(_, _) | DataType::Decimal256(_, _) => matches!(
+            DataType::Decimal128(_, _) => matches!(
                 to_type,
                 DataType::Int8
                     | DataType::Int16
@@ -652,8 +655,6 @@ impl Cast {
                     | DataType::Int64
                     | DataType::Float32
                     | DataType::Float64
-                    | DataType::Decimal128(_, _)
-                    | DataType::Decimal256(_, _)
             ),
             DataType::Utf8 => matches!(to_type, DataType::Binary),
             DataType::Date32 => matches!(to_type, DataType::Utf8),

--- a/core/src/execution/datafusion/expressions/cast.rs
+++ b/core/src/execution/datafusion/expressions/cast.rs
@@ -612,6 +612,8 @@ impl Cast {
         Ok(spark_cast(cast_result?, from_type, to_type))
     }
 
+    /// Determines if DataFusion supports the given cast in a way that is
+    /// compatible with Spark
     fn is_datafusion_spark_compatible(from_type: &DataType, to_type: &DataType) -> bool {
         match (from_type, to_type) {
             (
@@ -636,6 +638,28 @@ impl Cast {
                 | DataType::Decimal128(_, _)
                 | DataType::Utf8,
             ) => true,
+            (
+                DataType::Float32 | DataType::Float64,
+                DataType::Boolean
+                | DataType::Int8
+                | DataType::Int16
+                | DataType::Int32
+                | DataType::Int64
+                | DataType::Float32
+                | DataType::Float64,
+            ) => true,
+            (
+                DataType::Decimal128(_, _),
+                DataType::Int8
+                | DataType::Int16
+                | DataType::Int32
+                | DataType::Int64
+                | DataType::Float32
+                | DataType::Float64,
+            ) => true,
+            (DataType::Utf8, DataType::Binary) => true,
+            (DataType::Date32 | DataType::Timestamp(_, _), DataType::Utf8) => true,
+            (DataType::Timestamp(_, _), DataType::Int64 | DataType::Date32) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We have a catchall block in `cast.rs` that delegates to DataFusion for any cast that we don't have a specific match arm for. This is dangerous because it means we sometimes inadvertently delegate to DataFusion for casts where DataFusion is not compatible with Spark, which can lead to data corruption and hard-to-debug issues such as https://github.com/apache/datafusion-comet/pull/383#issuecomment-2127417428

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR introduces specific checks so that we only delegate to DataFusion for specific casts and changes the catchall to return an error.


I also improved handling of dictionary-encoded string arrays so that these are unpacked early on and this would have prevented the issue in https://github.com/apache/datafusion-comet/pull/383#issuecomment-2127417428

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests