### PR TITLE
feat: Add "Comet Fuzz" fuzz-testing utility

### DIFF
--- a/dev/scalastyle-config.xml
+++ b/dev/scalastyle-config.xml
@@ -242,7 +242,7 @@ This file is divided into 3 sections:
       <parameter name="groups">java,scala,org,apache,3rdParty,comet</parameter>
       <parameter name="group.java">javax?\..*</parameter>
       <parameter name="group.scala">scala\..*</parameter>
-      <parameter name="group.org">org\.(?!apache\.comet).*</parameter>
+      <parameter name="group.org">org\.(?!apache).*</parameter>
       <parameter name="group.apache">org\.apache\.(?!comet).*</parameter>
       <parameter name="group.3rdParty">(?!(javax?\.|scala\.|org\.apache\.comet\.)).*</parameter>
       <parameter name="group.comet">org\.apache\.comet\..*</parameter>

--- a/fuzz-testing/.gitignore
+++ b/fuzz-testing/.gitignore
@@ -2,5 +2,5 @@
 target
 spark-warehouse
 queries.sql
-results.md
+results*.md
 test*.parquet

--- a/fuzz-testing/.gitignore
+++ b/fuzz-testing/.gitignore
@@ -1,0 +1,6 @@
+.idea
+target
+spark-warehouse
+queries.sql
+results.md
+test*.parquet

--- a/fuzz-testing/README.md
+++ b/fuzz-testing/README.md
@@ -43,7 +43,7 @@ Set appropriate values for `SPARK_HOME`, `SPARK_MASTER`, and `COMET_JAR` environ
 $SPARK_HOME/bin/spark-submit \
     --master $SPARK_MASTER \
     --class org.apache.comet.fuzz.Main \
-    target/comet-fuzz-0.1.0-SNAPSHOT-jar-with-dependencies.jar \
+    target/comet-fuzz-spark3.4_2.12-0.1.0-SNAPSHOT-jar-with-dependencies.jar \
     data --num-files=2 --num-rows=200 --num-columns=100
 ```
 
@@ -55,7 +55,7 @@ Generate random queries that are based on the available test files.
 $SPARK_HOME/bin/spark-submit \
     --master $SPARK_MASTER \
     --class org.apache.comet.fuzz.Main \
-    target/cometfuzz-0.1.0-SNAPSHOT-jar-with-dependencies.jar \
+    target/comet-fuzz-spark3.4_2.12-0.1.0-SNAPSHOT-jar-with-dependencies.jar \
     queries --num-files=2 --num-queries=500
 ```
 
@@ -76,7 +76,7 @@ $SPARK_HOME/bin/spark-submit \
     --jars $COMET_JAR \
     --driver-class-path $COMET_JAR \
     --class org.apache.comet.fuzz.Main \
-    target/cometfuzz-0.1.0-SNAPSHOT-jar-with-dependencies.jar \
+    target/comet-fuzz-spark3.4_2.12-0.1.0-SNAPSHOT-jar-with-dependencies.jar \
     run --num-files=2 --filename=queries.sql
 ```
 

--- a/fuzz-testing/README.md
+++ b/fuzz-testing/README.md
@@ -43,7 +43,7 @@ Set appropriate values for `SPARK_HOME`, `SPARK_MASTER`, and `COMET_JAR` environ
 $SPARK_HOME/bin/spark-submit \
     --master $SPARK_MASTER \
     --class org.apache.comet.fuzz.Main \
-    target/cometfuzz-0.1.0-SNAPSHOT-jar-with-dependencies.jar \
+    target/comet-fuzz-0.1.0-SNAPSHOT-jar-with-dependencies.jar \
     data --num-files=2 --num-rows=200 --num-columns=100
 ```
 

--- a/fuzz-testing/README.md
+++ b/fuzz-testing/README.md
@@ -1,3 +1,22 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 # Comet Fuzz
 
 Comet Fuzz is a standalone project for generating random data and queries and executing queries against Spark 

--- a/fuzz-testing/README.md
+++ b/fuzz-testing/README.md
@@ -26,6 +26,23 @@ Although it is a simple tool it has already been useful in finding many bugs.
 
 Comet Fuzz is inspired by the [SparkFuzz](https://ir.cwi.nl/pub/30222) paper from Databricks and CWI.
 
+## Roadmap
+
+Planned areas of improvement:
+
+- Support for all data types, expressions, and operators supported by Comet
+- Explicit casts
+- Unary and binary arithmetic expressions
+- IF and CASE WHEN expressions
+- Complex (nested) expressions
+- Literal scalar values in queries
+- Add option to avoid grouping and sorting on floating-point columns
+- Improve join query support:
+  - Support joins without join keys
+  - Support composite join keys
+  - Support multiple join keys
+  - Support join conditions that use expressions
+
 ## Usage
 
 Build the jar file first.

--- a/fuzz-testing/README.md
+++ b/fuzz-testing/README.md
@@ -89,7 +89,7 @@ $SPARK_HOME/bin/spark-submit \
     --conf spark.comet.exec.all.enabled=true \
     --conf spark.shuffle.manager=org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager \
     --conf spark.comet.exec.shuffle.enabled=true \
-    --conf spark.comet.columnar.shuffle.enabled=true \
+    --conf spark.comet.exec.shuffle.mode=auto \
     --jars $COMET_JAR \
     --driver-class-path $COMET_JAR \
     --class org.apache.comet.fuzz.Main \
@@ -97,4 +97,4 @@ $SPARK_HOME/bin/spark-submit \
     run --num-files=2 --filename=queries.sql
 ```
 
-Note that the output filename is currently hard-coded as `results.md`
+Note that the output filename is currently hard-coded as `results-${System.currentTimeMillis()}.md`

--- a/fuzz-testing/pom.xml
+++ b/fuzz-testing/pom.xml
@@ -54,7 +54,7 @@ under the License.
         <dependency>
             <groupId>org.rogach</groupId>
             <artifactId>scallop_${scala.binary.version}</artifactId>
-            <version>3.5.1</version>
+            <version>5.1.0</version>
         </dependency>
     </dependencies>
 

--- a/fuzz-testing/pom.xml
+++ b/fuzz-testing/pom.xml
@@ -54,7 +54,6 @@ under the License.
         <dependency>
             <groupId>org.rogach</groupId>
             <artifactId>scallop_${scala.binary.version}</artifactId>
-            <version>5.1.0</version>
         </dependency>
     </dependencies>
 

--- a/fuzz-testing/pom.xml
+++ b/fuzz-testing/pom.xml
@@ -22,20 +22,20 @@ under the License.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.apache.comet.fuzz</groupId>
-    <artifactId>cometfuzz</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
+    <parent>
+        <groupId>org.apache.comet</groupId>
+        <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
+    <artifactId>comet-fuzz-spark${spark.version.short}_${scala.binary.version}</artifactId>
     <name>comet-fuzz</name>
     <url>http://maven.apache.org</url>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>11</java.version>
-        <scala.version>2.12.7</scala.version>
-        <scala.binary.version>2.12</scala.binary.version>
-        <spark.version>3.4.2</spark.version>
+        <!-- Reverse default (skip installation), and then enable only for child modules -->
+        <maven.deploy.skip>false</maven.deploy.skip>
     </properties>
 
     <dependencies>
@@ -48,7 +48,6 @@ under the License.
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.binary.version}</artifactId>
-            <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/fuzz-testing/pom.xml
+++ b/fuzz-testing/pom.xml
@@ -32,6 +32,7 @@ under the License.
     <artifactId>comet-fuzz-spark${spark.version.short}_${scala.binary.version}</artifactId>
     <name>comet-fuzz</name>
     <url>http://maven.apache.org</url>
+    <packaging>jar</packaging>
 
     <properties>
         <!-- Reverse default (skip installation), and then enable only for child modules -->

--- a/fuzz-testing/pom.xml
+++ b/fuzz-testing/pom.xml
@@ -1,0 +1,87 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.comet.fuzz</groupId>
+    <artifactId>cometfuzz</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>comet-fuzz</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>11</java.version>
+        <scala.version>2.12.7</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <spark.version>3.4.2</spark.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.rogach</groupId>
+            <artifactId>scallop_${scala.binary.version}</artifactId>
+            <version>3.5.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/scala</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>4.7.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/fuzz-testing/pom.xml
+++ b/fuzz-testing/pom.xml
@@ -1,3 +1,22 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/DataGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/DataGen.scala
@@ -142,7 +142,7 @@ object DataGen {
           }
       case DataTypes.DateType =>
         Range(0, numRows).map(_ => new java.sql.Date(1716645600011L + r.nextInt()))
-      case DataTypes.TimestampType | DataTypes.TimestampNTZType =>
+      case DataTypes.TimestampType | dataType.typeName == "timestamp_ntz" =>
         Range(0, numRows).map(_ => new Timestamp(1716645600011L + r.nextInt()))
       case _ => throw new IllegalStateException(s"Cannot generate data for $dataType yet")
     }

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/DataGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/DataGen.scala
@@ -26,33 +26,40 @@ import scala.util.Random
 import org.apache.spark.sql.{Row, SaveMode, SparkSession}
 import org.apache.spark.sql.types.{DataType, DataTypes, StructField, StructType}
 
-
 object DataGen {
 
-  def generateRandomFiles(r: Random, spark: SparkSession, numFiles: Int, numRows: Int,
+  def generateRandomFiles(
+      r: Random,
+      spark: SparkSession,
+      numFiles: Int,
+      numRows: Int,
       numColumns: Int): Unit = {
     for (i <- 0 until numFiles) {
       generateRandomParquetFile(r, spark, s"test$i.parquet", numRows, numColumns)
     }
   }
 
-  def generateRandomParquetFile(r: Random, spark: SparkSession, filename: String,
-      numRows: Int, numColumns: Int): Unit = {
+  def generateRandomParquetFile(
+      r: Random,
+      spark: SparkSession,
+      filename: String,
+      numRows: Int,
+      numColumns: Int): Unit = {
 
     // TODO add examples of all supported types, including complex types
     val dataTypes = Seq(
       (DataTypes.ByteType, 0.2),
-            (DataTypes.ShortType, 0.2),
-            (DataTypes.IntegerType, 0.2),
-            (DataTypes.LongType, 0.2),
-            (DataTypes.FloatType, 0.2),
-            (DataTypes.DoubleType, 0.2),
+      (DataTypes.ShortType, 0.2),
+      (DataTypes.IntegerType, 0.2),
+      (DataTypes.LongType, 0.2),
+      (DataTypes.FloatType, 0.2),
+      (DataTypes.DoubleType, 0.2),
       // TODO add support for all Comet supported types
 //            (DataTypes.createDecimalType(10,2), 0.2),
 //            (DataTypes.createDecimalType(10,0), 0.2),
 //            (DataTypes.createDecimalType(4,0), 0.2),
-            (DataTypes.DateType, 0.2),
-            (DataTypes.TimestampType, 0.2),
+      (DataTypes.DateType, 0.2),
+      (DataTypes.TimestampType, 0.2),
 //            (DataTypes.TimestampNTZType, 0.2),
       (DataTypes.StringType, 0.2))
 
@@ -142,6 +149,5 @@ object DataGen {
       case _ => throw new IllegalStateException(s"Cannot generate data for $dataType yet")
     }
   }
-
 
 }

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/DataGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/DataGen.scala
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.fuzz
+
+import org.apache.spark.sql.{Row, SaveMode, SparkSession}
+import org.apache.spark.sql.types.{DataType, DataTypes, StructField, StructType}
+
+import java.sql.Timestamp
+import scala.util.Random
+
+object DataGen {
+
+  def generateRandomFiles(r: Random, spark: SparkSession, numFiles: Int, numRows: Int, numColumns: Int): Unit = {
+    for (i <- 0 until numFiles) {
+      generateRandomParquetFile(r, spark, s"test$i.parquet", numRows, numColumns)
+    }
+  }
+
+  def generateRandomParquetFile(r: Random, spark: SparkSession, filename: String, numRows: Int, numColumns: Int): Unit = {
+
+    // TODO add examples of all supported types, including complex types
+    val dataTypes = Seq(
+      (DataTypes.ByteType, 0.2),
+            (DataTypes.ShortType, 0.2),
+            (DataTypes.IntegerType, 0.2),
+            (DataTypes.LongType, 0.2),
+            (DataTypes.FloatType, 0.2),
+            (DataTypes.DoubleType, 0.2),
+      // TODO add support for all Comet supported types
+//            (DataTypes.createDecimalType(10,2), 0.2),
+//            (DataTypes.createDecimalType(10,0), 0.2),
+//            (DataTypes.createDecimalType(4,0), 0.2),
+            (DataTypes.DateType, 0.2),
+            (DataTypes.TimestampType, 0.2),
+//            (DataTypes.TimestampNTZType, 0.2),
+      (DataTypes.StringType, 0.2))
+
+    // generate schema using random data types
+    val fields = Range(0, numColumns)
+      .map(i => StructField(s"c$i", Utils.randomWeightedChoice(dataTypes), nullable = true))
+    val schema = StructType(fields)
+
+    // generate columnar data
+    val cols: Seq[Seq[Any]] = fields.map(f => generateColumn(r, f.dataType, numRows))
+
+    // convert to rows
+    val rows = Range(0, numRows).map(rowIndex => {
+      Row.fromSeq(cols.map(_(rowIndex)))
+    })
+
+    // TODO random partitioning and bucketing
+    // TODO random parquet write options
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(rows), schema)
+    df.write.mode(SaveMode.Overwrite).parquet(filename)
+  }
+
+  def generateColumn(r: Random, dataType: DataType, numRows: Int): Seq[Any] = {
+    dataType match {
+      case DataTypes.ByteType =>
+        generateColumn(r, DataTypes.LongType, numRows).map(_.asInstanceOf[Long].toByte)
+      case DataTypes.ShortType =>
+        generateColumn(r, DataTypes.LongType, numRows).map(_.asInstanceOf[Long].toShort)
+      case DataTypes.IntegerType =>
+        generateColumn(r, DataTypes.LongType, numRows).map(_.asInstanceOf[Long].toInt)
+      case DataTypes.LongType =>
+        Range(0, numRows).map(_ => {
+          r.nextInt(50) match {
+            case 0 => null
+            case 1 => 0L
+            case 2 => Byte.MinValue.toLong
+            case 3 => Byte.MaxValue.toLong
+            case 4 => Short.MinValue.toLong
+            case 5 => Short.MaxValue.toLong
+            case 6 => Int.MinValue.toLong
+            case 7 => Int.MaxValue.toLong
+            case 8 => Long.MinValue
+            case 9 => Long.MaxValue
+            case _ => r.nextLong()
+          }
+        })
+      case DataTypes.FloatType =>
+        Range(0, numRows).map(_ => {
+          r.nextInt(20) match {
+            case 0 => null
+            case 1 => Float.NegativeInfinity
+            case 2 => Float.PositiveInfinity
+            case 3 => Float.MinValue
+            case 4 => Float.MaxValue
+            case 5 => 0.0f
+            case 6 => -0.0f
+            case _ => r.nextFloat()
+          }
+        })
+      case DataTypes.DoubleType =>
+        Range(0, numRows).map(_ => {
+          r.nextInt(20) match {
+            case 0 => null
+            case 1 => Double.NegativeInfinity
+            case 2 => Double.PositiveInfinity
+            case 3 => Double.MinValue
+            case 4 => Double.MaxValue
+            case 5 => 0.0
+            case 6 => -0.0
+            case _ => r.nextDouble()
+          }
+        })
+      case DataTypes.StringType =>
+        Range(0, numRows).map(_ => {
+          r.nextInt(10) match {
+            case 0 => null
+            case 1 => r.nextInt().toByte.toString
+            case 2 => r.nextLong().toString
+            case 3 => r.nextDouble().toString
+            case _ => r.nextString(8)
+          }
+        })
+      case DataTypes.DateType =>
+        Range(0, numRows).map(_ => new java.sql.Date(1716645600011L + r.nextInt()))
+      case DataTypes.TimestampType =>
+        Range(0, numRows).map(_ => new Timestamp(1716645600011L + r.nextInt()))
+      case _ => throw new IllegalStateException(s"Cannot generate data for $dataType yet")
+    }
+  }
+
+
+}

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/DataGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/DataGen.scala
@@ -134,8 +134,12 @@ object DataGen {
         })
       case DataTypes.BinaryType =>
         generateColumn(r, DataTypes.StringType, numRows)
-          .filterNot(_ == null)
-          .map(_.asInstanceOf[String].getBytes(Charset.defaultCharset()))
+          .map {
+            case x: String =>
+              x.getBytes(Charset.defaultCharset())
+            case _ =>
+              null
+          }
       case DataTypes.DateType =>
         Range(0, numRows).map(_ => new java.sql.Date(1716645600011L + r.nextInt()))
       case DataTypes.TimestampType | DataTypes.TimestampNTZType =>

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/DataGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/DataGen.scala
@@ -19,13 +19,14 @@
 
 package org.apache.comet.fuzz
 
+import java.math.BigDecimal
 import java.nio.charset.Charset
 import java.sql.Timestamp
 
 import scala.util.Random
 
 import org.apache.spark.sql.{Row, SaveMode, SparkSession}
-import org.apache.spark.sql.types.{DataType, DataTypes, StructField, StructType}
+import org.apache.spark.sql.types.{DataType, DataTypes, DecimalType, StructField, StructType}
 
 object DataGen {
 
@@ -118,6 +119,8 @@ object DataGen {
             case _ => r.nextDouble()
           }
         })
+      case dt: DecimalType =>
+        Range(0, numRows).map(_ => new BigDecimal(r.nextDouble()).setScale(dt.scale))
       case DataTypes.StringType =>
         Range(0, numRows).map(_ => {
           r.nextInt(10) match {

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/DataGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/DataGen.scala
@@ -47,25 +47,9 @@ object DataGen {
       numRows: Int,
       numColumns: Int): Unit = {
 
-    val dataTypes = Seq(
-      (DataTypes.BooleanType, 0.2),
-      (DataTypes.ByteType, 0.2),
-      (DataTypes.ShortType, 0.2),
-      (DataTypes.IntegerType, 0.2),
-      (DataTypes.LongType, 0.2),
-      (DataTypes.FloatType, 0.2),
-      (DataTypes.DoubleType, 0.2),
-      //TODO add Decimal support
-      //(DataTypes.createDecimalType(10,2), 0.2),
-      (DataTypes.DateType, 0.2),
-      (DataTypes.TimestampType, 0.2),
-      (DataTypes.TimestampNTZType, 0.2),
-      (DataTypes.StringType, 0.2),
-      (DataTypes.BinaryType, 0.2))
-
     // generate schema using random data types
     val fields = Range(0, numColumns)
-      .map(i => StructField(s"c$i", Utils.randomWeightedChoice(dataTypes), nullable = true))
+      .map(i => StructField(s"c$i", Utils.randomWeightedChoice(Meta.dataTypes), nullable = true))
     val schema = StructType(fields)
 
     // generate columnar data
@@ -83,7 +67,9 @@ object DataGen {
   def generateColumn(r: Random, dataType: DataType, numRows: Int): Seq[Any] = {
     dataType match {
       case DataTypes.BooleanType =>
-        generateColumn(r, DataTypes.LongType, numRows).map(_.asInstanceOf[Long].toShort).map(s => s%2 ==0)
+        generateColumn(r, DataTypes.LongType, numRows)
+          .map(_.asInstanceOf[Long].toShort)
+          .map(s => s % 2 == 0)
       case DataTypes.ByteType =>
         generateColumn(r, DataTypes.LongType, numRows).map(_.asInstanceOf[Long].toByte)
       case DataTypes.ShortType =>
@@ -143,7 +129,8 @@ object DataGen {
           }
         })
       case DataTypes.BinaryType =>
-        generateColumn(r, DataTypes.StringType, numRows).map(_.asInstanceOf[String].getBytes(Charset.defaultCharset()))
+        generateColumn(r, DataTypes.StringType, numRows)
+          .map(_.asInstanceOf[String].getBytes(Charset.defaultCharset()))
       case DataTypes.DateType =>
         Range(0, numRows).map(_ => new java.sql.Date(1716645600011L + r.nextInt()))
       case DataTypes.TimestampType | DataTypes.TimestampNTZType =>

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/DataGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/DataGen.scala
@@ -142,7 +142,7 @@ object DataGen {
           }
       case DataTypes.DateType =>
         Range(0, numRows).map(_ => new java.sql.Date(1716645600011L + r.nextInt()))
-      case DataTypes.TimestampType | dataType.typeName == "timestamp_ntz" =>
+      case DataTypes.TimestampType =>
         Range(0, numRows).map(_ => new Timestamp(1716645600011L + r.nextInt()))
       case _ => throw new IllegalStateException(s"Cannot generate data for $dataType yet")
     }

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/DataGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/DataGen.scala
@@ -19,7 +19,7 @@
 
 package org.apache.comet.fuzz
 
-import java.math.BigDecimal
+import java.math.{BigDecimal, RoundingMode}
 import java.nio.charset.Charset
 import java.sql.Timestamp
 
@@ -120,7 +120,8 @@ object DataGen {
           }
         })
       case dt: DecimalType =>
-        Range(0, numRows).map(_ => new BigDecimal(r.nextDouble()).setScale(dt.scale))
+        Range(0, numRows).map(_ =>
+          new BigDecimal(r.nextDouble()).setScale(dt.scale, RoundingMode.HALF_UP))
       case DataTypes.StringType =>
         Range(0, numRows).map(_ => {
           r.nextInt(10) match {
@@ -133,6 +134,7 @@ object DataGen {
         })
       case DataTypes.BinaryType =>
         generateColumn(r, DataTypes.StringType, numRows)
+          .filterNot(_ == null)
           .map(_.asInstanceOf[String].getBytes(Charset.defaultCharset()))
       case DataTypes.DateType =>
         Range(0, numRows).map(_ => new java.sql.Date(1716645600011L + r.nextInt()))

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/DataGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/DataGen.scala
@@ -19,21 +19,25 @@
 
 package org.apache.comet.fuzz
 
+import java.sql.Timestamp
+
+import scala.util.Random
+
 import org.apache.spark.sql.{Row, SaveMode, SparkSession}
 import org.apache.spark.sql.types.{DataType, DataTypes, StructField, StructType}
 
-import java.sql.Timestamp
-import scala.util.Random
 
 object DataGen {
 
-  def generateRandomFiles(r: Random, spark: SparkSession, numFiles: Int, numRows: Int, numColumns: Int): Unit = {
+  def generateRandomFiles(r: Random, spark: SparkSession, numFiles: Int, numRows: Int,
+      numColumns: Int): Unit = {
     for (i <- 0 until numFiles) {
       generateRandomParquetFile(r, spark, s"test$i.parquet", numRows, numColumns)
     }
   }
 
-  def generateRandomParquetFile(r: Random, spark: SparkSession, filename: String, numRows: Int, numColumns: Int): Unit = {
+  def generateRandomParquetFile(r: Random, spark: SparkSession, filename: String,
+      numRows: Int, numColumns: Int): Unit = {
 
     // TODO add examples of all supported types, including complex types
     val dataTypes = Seq(

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Main.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Main.scala
@@ -19,10 +19,10 @@
 
 package org.apache.comet.fuzz
 
+import scala.util.Random
+
 import org.apache.spark.sql.SparkSession
 import org.rogach.scallop.{ScallopConf, Subcommand}
-
-import scala.util.Random
 
 class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
   val generateData = new Subcommand("data") {
@@ -64,7 +64,9 @@ object Main {
       case Some(opt @ conf.runQueries) =>
         QueryRunner.runQueries(spark, opt.numFiles(), opt.filename(), opt.showMatchingResults())
       case _ =>
+        // scalastyle:off println
         println("Invalid subcommand")
+        // scalastyle:on println
         sys.exit(-1)
     }
   }

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Main.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Main.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.fuzz
+
+import org.apache.spark.sql.SparkSession
+import org.rogach.scallop.{ScallopConf, Subcommand}
+
+import scala.util.Random
+
+class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
+  val generateData = new Subcommand("data") {
+    val numFiles = opt[Int](required = true)
+    val numRows = opt[Int](required = true)
+    val numColumns = opt[Int](required = true)
+  }
+  val generateQueries = new Subcommand("queries") {
+    val numFiles = opt[Int](required = false)
+    val numQueries = opt[Int](required = true)
+  }
+  val runQueries = new Subcommand("run") {
+    val filename = opt[String](required = true)
+    val numFiles = opt[Int](required = false)
+    val showMatchingResults = opt[Boolean](required = false)
+  }
+  addSubcommand(generateData)
+  addSubcommand(generateQueries)
+  addSubcommand(runQueries)
+  verify()
+}
+
+object Main {
+
+  lazy val spark = SparkSession.builder()
+    .master("local[*]")
+    .getOrCreate()
+
+  def main(args: Array[String]): Unit = {
+    val r = new Random(42)
+
+    val conf = new Conf(args)
+    conf.subcommand match {
+      case Some(opt @ conf.generateData) =>
+        DataGen.generateRandomFiles(r, spark, numFiles = opt.numFiles(), numRows = opt.numRows(),
+          numColumns = opt.numColumns())
+      case Some(opt @ conf.generateQueries) =>
+        QueryGen.generateRandomQueries(r, spark, numFiles = opt.numFiles(), opt.numQueries())
+      case Some(opt @ conf.runQueries) =>
+        QueryRunner.runQueries(spark, opt.numFiles(), opt.filename(), opt.showMatchingResults())
+      case _ =>
+        println("Invalid subcommand")
+        sys.exit(-1)
+    }
+  }
+}

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Main.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Main.scala
@@ -51,7 +51,6 @@ object Main {
 
   lazy val spark: SparkSession = SparkSession
     .builder()
-    .master("local[*]")
     .getOrCreate()
 
   def main(args: Array[String]): Unit = {

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Main.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Main.scala
@@ -22,26 +22,27 @@ package org.apache.comet.fuzz
 import scala.util.Random
 
 import org.rogach.scallop.{ScallopConf, Subcommand}
+import org.rogach.scallop.ScallopOption
 
 import org.apache.spark.sql.SparkSession
 
 class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
   val generateData: generateData = new generateData
   class generateData extends Subcommand("data") {
-    val numFiles = opt[Int](required = true)
-    val numRows = opt[Int](required = true)
-    val numColumns = opt[Int](required = true)
+    val numFiles: ScallopOption[Int] = opt[Int](required = true)
+    val numRows: ScallopOption[Int] = opt[Int](required = true)
+    val numColumns: ScallopOption[Int] = opt[Int](required = true)
   }
   val generateQueries: generateQueries = new generateQueries
   class generateQueries extends Subcommand("queries") {
-    val numFiles = opt[Int](required = false)
-    val numQueries = opt[Int](required = true)
+    val numFiles: ScallopOption[Int] = opt[Int](required = false)
+    val numQueries: ScallopOption[Int] = opt[Int](required = true)
   }
   val runQueries: runQueries = new runQueries
   class runQueries extends Subcommand("run") {
-    val filename = opt[String](required = true)
-    val numFiles = opt[Int](required = false)
-    val showMatchingResults = opt[Boolean](required = false)
+    val filename: ScallopOption[String] = opt[String](required = true)
+    val numFiles: ScallopOption[Int] = opt[Int](required = false)
+    val showMatchingResults: ScallopOption[Boolean] = opt[Boolean](required = false)
   }
   addSubcommand(generateData)
   addSubcommand(generateQueries)

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Main.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Main.scala
@@ -21,20 +21,24 @@ package org.apache.comet.fuzz
 
 import scala.util.Random
 
-import org.apache.spark.sql.SparkSession
 import org.rogach.scallop.{ScallopConf, Subcommand}
 
+import org.apache.spark.sql.SparkSession
+
 class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
-  val generateData = new Subcommand("data") {
+  val generateData: generateData = new generateData
+  class generateData extends Subcommand("data") {
     val numFiles = opt[Int](required = true)
     val numRows = opt[Int](required = true)
     val numColumns = opt[Int](required = true)
   }
-  val generateQueries = new Subcommand("queries") {
+  val generateQueries: generateQueries = new generateQueries
+  class generateQueries extends Subcommand("queries") {
     val numFiles = opt[Int](required = false)
     val numQueries = opt[Int](required = true)
   }
-  val runQueries = new Subcommand("run") {
+  val runQueries: runQueries = new runQueries
+  class runQueries extends Subcommand("run") {
     val filename = opt[String](required = true)
     val numFiles = opt[Int](required = false)
     val showMatchingResults = opt[Boolean](required = false)
@@ -47,7 +51,8 @@ class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
 
 object Main {
 
-  lazy val spark = SparkSession.builder()
+  lazy val spark: SparkSession = SparkSession
+    .builder()
     .master("local[*]")
     .getOrCreate()
 
@@ -57,7 +62,11 @@ object Main {
     val conf = new Conf(args)
     conf.subcommand match {
       case Some(opt @ conf.generateData) =>
-        DataGen.generateRandomFiles(r, spark, numFiles = opt.numFiles(), numRows = opt.numRows(),
+        DataGen.generateRandomFiles(
+          r,
+          spark,
+          numFiles = opt.numFiles(),
+          numRows = opt.numRows(),
           numColumns = opt.numColumns())
       case Some(opt @ conf.generateQueries) =>
         QueryGen.generateRandomQueries(r, spark, numFiles = opt.numFiles(), opt.numQueries())

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Meta.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Meta.scala
@@ -25,19 +25,20 @@ import org.apache.spark.sql.types.DataTypes
 object Meta {
 
   val dataTypes: Seq[(DataType, Double)] = Seq(
-    (DataTypes.BooleanType, 0.2),
+    // (DataTypes.BooleanType, 0.2),
     (DataTypes.ByteType, 0.2),
     (DataTypes.ShortType, 0.2),
     (DataTypes.IntegerType, 0.2),
     (DataTypes.LongType, 0.2),
     (DataTypes.FloatType, 0.2),
     (DataTypes.DoubleType, 0.2),
-    (DataTypes.createDecimalType(10, 2), 0.2),
+    // (DataTypes.createDecimalType(10, 2), 0.2),
     (DataTypes.DateType, 0.2),
     (DataTypes.TimestampType, 0.2),
-    (DataTypes.TimestampNTZType, 0.2),
-    (DataTypes.StringType, 0.2),
-    (DataTypes.BinaryType, 0.2))
+    // (DataTypes.TimestampNTZType, 0.2),
+    (DataTypes.StringType, 0.2)
+    // (DataTypes.BinaryType, 0.2)
+  )
 
   val stringScalarFunc: Seq[Function] = Seq(
     Function("substring", 3),

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Meta.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Meta.scala
@@ -32,16 +32,14 @@ object Meta {
     (DataTypes.LongType, 0.2),
     (DataTypes.FloatType, 0.2),
     (DataTypes.DoubleType, 0.2),
-    // TODO add Decimal support
-    // (DataTypes.createDecimalType(10,2), 0.2),
+    (DataTypes.createDecimalType(10, 2), 0.2),
     (DataTypes.DateType, 0.2),
     (DataTypes.TimestampType, 0.2),
     (DataTypes.TimestampNTZType, 0.2),
     (DataTypes.StringType, 0.2),
     (DataTypes.BinaryType, 0.2))
 
-  val scalarFunc: Seq[Function] = Seq(
-    // string
+  val stringScalarFunc: Seq[Function] = Seq(
     Function("substring", 3),
     Function("coalesce", 1),
     Function("starts_with", 2),
@@ -64,13 +62,17 @@ object Meta {
     Function("reverse", 1),
     Function("in_str", 2),
     Function("replace", 2),
-    Function("translate", 2),
-    // date
+    Function("translate", 2)
+  )
+
+  val dateScalarFunc: Seq[Function] = Seq(
     Function("year", 1),
     Function("hour", 1),
     Function("minute", 1),
-    Function("second", 1),
-    // math
+    Function("second", 1)
+  )
+
+  val mathScalarFunc: Seq[Function] = Seq(
     Function("abs", 1),
     Function("acos", 1),
     Function("asin", 1),
@@ -88,7 +90,10 @@ object Meta {
     Function("Sqrt", 1),
     Function("Tan", 1),
     Function("Ceil", 1),
-    Function("Floor", 1))
+    Function("Floor", 1)
+  )
+
+  val scalarFunc: Seq[Function] = stringScalarFunc ++ dateScalarFunc ++ mathScalarFunc
 
   val aggFunc: Seq[Function] = Seq(
     Function("min", 1),

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Meta.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Meta.scala
@@ -25,20 +25,20 @@ import org.apache.spark.sql.types.DataTypes
 object Meta {
 
   val dataTypes: Seq[(DataType, Double)] = Seq(
-    (DataTypes.BooleanType, 0.2),
+    (DataTypes.BooleanType, 0.1),
     (DataTypes.ByteType, 0.2),
     (DataTypes.ShortType, 0.2),
     (DataTypes.IntegerType, 0.2),
     (DataTypes.LongType, 0.2),
     (DataTypes.FloatType, 0.2),
     (DataTypes.DoubleType, 0.2),
-    // (DataTypes.createDecimalType(10, 2), 0.2),
+    (DataTypes.createDecimalType(10, 2), 0.2),
     (DataTypes.DateType, 0.2),
     (DataTypes.TimestampType, 0.2),
     // TimestampNTZType only in Spark 3.4+
     // (DataTypes.TimestampNTZType, 0.2),
     (DataTypes.StringType, 0.2),
-    (DataTypes.BinaryType, 0.2))
+    (DataTypes.BinaryType, 0.1))
 
   val stringScalarFunc: Seq[Function] = Seq(
     Function("substring", 3),

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Meta.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Meta.scala
@@ -62,15 +62,10 @@ object Meta {
     Function("reverse", 1),
     Function("in_str", 2),
     Function("replace", 2),
-    Function("translate", 2)
-  )
+    Function("translate", 2))
 
-  val dateScalarFunc: Seq[Function] = Seq(
-    Function("year", 1),
-    Function("hour", 1),
-    Function("minute", 1),
-    Function("second", 1)
-  )
+  val dateScalarFunc: Seq[Function] =
+    Seq(Function("year", 1), Function("hour", 1), Function("minute", 1), Function("second", 1))
 
   val mathScalarFunc: Seq[Function] = Seq(
     Function("abs", 1),
@@ -90,8 +85,7 @@ object Meta {
     Function("Sqrt", 1),
     Function("Tan", 1),
     Function("Ceil", 1),
-    Function("Floor", 1)
-  )
+    Function("Floor", 1))
 
   val scalarFunc: Seq[Function] = stringScalarFunc ++ dateScalarFunc ++ mathScalarFunc
 

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Meta.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Meta.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.types.DataTypes
 object Meta {
 
   val dataTypes: Seq[(DataType, Double)] = Seq(
-    // (DataTypes.BooleanType, 0.2),
+    (DataTypes.BooleanType, 0.2),
     (DataTypes.ByteType, 0.2),
     (DataTypes.ShortType, 0.2),
     (DataTypes.IntegerType, 0.2),
@@ -37,9 +37,8 @@ object Meta {
     (DataTypes.TimestampType, 0.2),
     // TimestampNTZType only in Spark 3.4+
     // (DataTypes.TimestampNTZType, 0.2),
-    (DataTypes.StringType, 0.2)
-    // (DataTypes.BinaryType, 0.2)
-  )
+    (DataTypes.StringType, 0.2),
+    (DataTypes.BinaryType, 0.2))
 
   val stringScalarFunc: Seq[Function] = Seq(
     Function("substring", 3),

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Meta.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Meta.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.fuzz
+
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.DataTypes
+
+object Meta {
+
+  val dataTypes: Seq[(DataType, Double)] = Seq(
+    (DataTypes.BooleanType, 0.2),
+    (DataTypes.ByteType, 0.2),
+    (DataTypes.ShortType, 0.2),
+    (DataTypes.IntegerType, 0.2),
+    (DataTypes.LongType, 0.2),
+    (DataTypes.FloatType, 0.2),
+    (DataTypes.DoubleType, 0.2),
+    // TODO add Decimal support
+    // (DataTypes.createDecimalType(10,2), 0.2),
+    (DataTypes.DateType, 0.2),
+    (DataTypes.TimestampType, 0.2),
+    (DataTypes.TimestampNTZType, 0.2),
+    (DataTypes.StringType, 0.2),
+    (DataTypes.BinaryType, 0.2))
+
+  val scalarFunc: Seq[Function] = Seq(
+    // string
+    Function("substring", 3),
+    Function("coalesce", 1),
+    Function("starts_with", 2),
+    Function("ends_with", 2),
+    Function("contains", 2),
+    Function("ascii", 1),
+    Function("bit_length", 1),
+    Function("octet_length", 1),
+    Function("upper", 1),
+    Function("lower", 1),
+    Function("chr", 1),
+    Function("init_cap", 1),
+    Function("trim", 1),
+    Function("ltrim", 1),
+    Function("rtrim", 1),
+    Function("btrim", 1),
+    Function("concat_ws", 2),
+    Function("repeat", 2),
+    Function("length", 1),
+    Function("reverse", 1),
+    Function("in_str", 2),
+    Function("replace", 2),
+    Function("translate", 2),
+    // date
+    Function("year", 1),
+    Function("hour", 1),
+    Function("minute", 1),
+    Function("second", 1),
+    // math
+    Function("abs", 1),
+    Function("acos", 1),
+    Function("asin", 1),
+    Function("atan", 1),
+    Function("Atan2", 1),
+    Function("Cos", 1),
+    Function("Exp", 2),
+    Function("Ln", 1),
+    Function("Log10", 1),
+    Function("Log2", 1),
+    Function("Pow", 2),
+    Function("Round", 1),
+    Function("Signum", 1),
+    Function("Sin", 1),
+    Function("Sqrt", 1),
+    Function("Tan", 1),
+    Function("Ceil", 1),
+    Function("Floor", 1))
+
+  val aggFunc: Seq[Function] = Seq(
+    Function("min", 1),
+    Function("max", 1),
+    Function("count", 1),
+    Function("avg", 1),
+    Function("sum", 1),
+    Function("first", 1),
+    Function("last", 1),
+    Function("var_pop", 1),
+    Function("var_samp", 1),
+    Function("covar_pop", 1),
+    Function("covar_samp", 1),
+    Function("stddev_pop", 1),
+    Function("stddev_samp", 1),
+    Function("corr", 2))
+
+}

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Meta.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Meta.scala
@@ -35,6 +35,7 @@ object Meta {
     // (DataTypes.createDecimalType(10, 2), 0.2),
     (DataTypes.DateType, 0.2),
     (DataTypes.TimestampType, 0.2),
+    // TimestampNTZType only in Spark 3.4+
     // (DataTypes.TimestampNTZType, 0.2),
     (DataTypes.StringType, 0.2)
     // (DataTypes.BinaryType, 0.2)

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
@@ -68,12 +68,12 @@ object QueryGen {
     if (groupingCols.isEmpty) {
       s"SELECT ${args.mkString(", ")}, ${func.name}(${args.mkString(", ")}) AS x " +
         s"FROM $tableName " +
-        s"ORDER BY ${args.mkString(", ")}"
+        s"ORDER BY ${args.mkString(", ")};"
     } else {
       s"SELECT ${groupingCols.mkString(", ")}, ${func.name}(${args.mkString(", ")}) " +
         s"FROM $tableName " +
         s"GROUP BY ${groupingCols.mkString(",")} " +
-        s"ORDER BY ${groupingCols.mkString(", ")}"
+        s"ORDER BY ${groupingCols.mkString(", ")};"
     }
   }
 
@@ -88,7 +88,7 @@ object QueryGen {
     // Example SELECT c0, log(c0) as x FROM test0
     s"SELECT ${args.mkString(", ")}, ${func.name}(${args.mkString(", ")}) AS x " +
       s"FROM $tableName " +
-      s"ORDER BY ${args.mkString(", ")}"
+      s"ORDER BY ${args.mkString(", ")};"
   }
 
   private def generateJoin(r: Random, spark: SparkSession, numFiles: Int): String = {

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.fuzz
+
+import org.apache.spark.sql.SparkSession
+
+import java.io.{BufferedWriter, FileWriter}
+import scala.collection.mutable
+import scala.util.Random
+
+object QueryGen {
+
+  def generateRandomQueries(r: Random, spark: SparkSession, numFiles: Int,
+                            numQueries: Int): Unit = {
+    for (i <- 0 until numFiles) {
+      spark.read.parquet(s"test$i.parquet").createTempView(s"test$i")
+    }
+
+    val w = new BufferedWriter(new FileWriter("queries.sql"))
+
+    val uniqueQueries = mutable.HashSet[String]()
+
+    for (_ <- 0 until numQueries) {
+      val sql = r.nextInt().abs % 3 match {
+        case 0 => generateJoin(r, spark, numFiles)
+        case 1 => generateAggregate(r, spark, numFiles)
+        case 2 => generateScalar(r, spark, numFiles)
+        // TODO add explicit casts
+        // TODO add unary and binary arithmetic expressions
+        // TODO add IF and CASE WHEN expressions
+      }
+      if (!uniqueQueries.contains(sql)) {
+        uniqueQueries += sql
+        w.write(sql + "\n")
+      }
+    }
+    w.close()
+  }
+
+  val scalarFunc = Seq(
+    // string
+    Function("substring", 3),
+    Function("coalesce", 1),
+    Function("starts_with", 2),
+    Function("ends_with", 2),
+    Function("contains", 2),
+    Function("ascii", 1),
+    Function("bit_length", 1),
+    Function("octet_length", 1),
+    Function("upper", 1),
+    Function("lower", 1),
+    Function("chr", 1),
+    Function("init_cap", 1),
+    Function("trim", 1),
+    Function("ltrim", 1),
+    Function("rtrim", 1),
+    Function("btrim", 1),
+    Function("concat_ws", 2),
+    Function("repeat", 2),
+    Function("length", 1),
+    Function("reverse", 1),
+    Function("in_str", 2),
+    Function("replace", 2),
+    Function("translate", 2),
+    // date
+    Function("year", 1),
+    Function("hour", 1),
+    Function("minute", 1),
+    Function("second", 1),
+    // math
+    Function("abs", 1),
+    Function("acos", 1),
+    Function("asin", 1),
+    Function("atan", 1),
+    Function("Atan2", 1),
+    Function("Cos", 1),
+    Function("Exp", 2),
+    Function("Ln", 1),
+    Function("Log10", 1),
+    Function("Log2", 1),
+    Function("Pow", 2),
+    Function("Round", 1),
+    Function("Signum", 1),
+    Function("Sin", 1),
+    Function("Sqrt", 1),
+    Function("Tan", 1),
+    Function("Ceil", 1),
+    Function("Floor", 1),
+  )
+
+  val aggFunc = Seq(
+    Function("min", 1),
+    Function("max", 1),
+    Function("count", 1),
+    Function("avg", 1),
+    Function("sum", 1),
+    Function("first", 1),
+    Function("last", 1),
+    Function("var_pop", 1),
+    Function("var_samp", 1),
+    Function("covar_pop", 1),
+    Function("covar_samp", 1),
+    Function("stddev_pop", 1),
+    Function("stddev_samp", 1),
+    Function("corr", 2))
+
+  private def generateAggregate(r: Random, spark: SparkSession, numFiles: Int): String = {
+    val tableName = s"test${r.nextInt(numFiles)}"
+    val table = spark.table(tableName)
+
+    val func = Utils.randomChoice(aggFunc, r)
+    val args = Range(0, func.num_args)
+      // TODO support using literals as well as columns
+      .map(_ => Utils.randomChoice(table.columns, r))
+    val groupingCols = Range(0, 2).map(_ => Utils.randomChoice(table.columns, r))
+    if (groupingCols.isEmpty) {
+      s"SELECT ${func.name}(${args.mkString(", ")}) FROM $tableName"
+    } else {
+      s"SELECT ${groupingCols.mkString(", ")}, ${func.name}(${args.mkString(", ")}) " +
+        s"FROM $tableName GROUP BY ${groupingCols.mkString(",")}"
+    }
+  }
+
+  private def generateScalar(r: Random, spark: SparkSession, numFiles: Int): String = {
+    val tableName = s"test${r.nextInt(numFiles)}"
+    val table = spark.table(tableName)
+
+    val func = Utils.randomChoice(scalarFunc, r)
+    val args = Range(0, func.num_args)
+      // TODO support using literals as well as columns
+      .map(_ => Utils.randomChoice(table.columns, r))
+
+    s"SELECT ${func.name}(${args.mkString(", ")}) FROM $tableName"
+  }
+
+  private def generateJoin(r: Random, spark: SparkSession, numFiles: Int): String = {
+    val leftTableName = s"test${r.nextInt(numFiles)}"
+    val rightTableName = s"test${r.nextInt(numFiles)}"
+    val leftTable = spark.table(leftTableName)
+    val rightTable = spark.table(rightTableName)
+
+    // TODO support no join keys
+    // TODO support multiple join keys
+    // TODO support join conditions that use expressions
+    val leftCol = Utils.randomChoice(leftTable.columns, r)
+    val rightCol = Utils.randomChoice(rightTable.columns, r)
+
+    val joinTypes = Seq(
+      ("INNER", 0.4),
+      ("LEFT", 0.3),
+      ("RIGHT", 0.3),
+    )
+    val joinType = Utils.randomWeightedChoice(joinTypes)
+
+    s"SELECT * " +
+      s"FROM ${leftTableName} " +
+      s"${joinType} JOIN ${rightTableName} " +
+      s"ON ${leftTableName}.${leftCol} = ${rightTableName}.${rightCol};"
+  }
+
+}
+
+case class Function(name: String, num_args: Int)

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
@@ -28,8 +28,11 @@ import org.apache.spark.sql.SparkSession
 
 object QueryGen {
 
-  def generateRandomQueries(r: Random, spark: SparkSession, numFiles: Int,
-                            numQueries: Int): Unit = {
+  def generateRandomQueries(
+      r: Random,
+      spark: SparkSession,
+      numFiles: Int,
+      numQueries: Int): Unit = {
     for (i <- 0 until numFiles) {
       spark.read.parquet(s"test$i.parquet").createTempView(s"test$i")
     }
@@ -55,7 +58,7 @@ object QueryGen {
     w.close()
   }
 
-  val scalarFunc = Seq(
+  val scalarFunc: Seq[Function] = Seq(
     // string
     Function("substring", 3),
     Function("coalesce", 1),
@@ -103,10 +106,9 @@ object QueryGen {
     Function("Sqrt", 1),
     Function("Tan", 1),
     Function("Ceil", 1),
-    Function("Floor", 1)
-  )
+    Function("Floor", 1))
 
-  val aggFunc = Seq(
+  val aggFunc: Seq[Function] = Seq(
     Function("min", 1),
     Function("max", 1),
     Function("count", 1),
@@ -163,14 +165,10 @@ object QueryGen {
     val leftCol = Utils.randomChoice(leftTable.columns, r)
     val rightCol = Utils.randomChoice(rightTable.columns, r)
 
-    val joinTypes = Seq(
-      ("INNER", 0.4),
-      ("LEFT", 0.3),
-      ("RIGHT", 0.3)
-    )
+    val joinTypes = Seq(("INNER", 0.4), ("LEFT", 0.3), ("RIGHT", 0.3))
     val joinType = Utils.randomWeightedChoice(joinTypes)
 
-    s"SELECT * " +
+    "SELECT * " +
       s"FROM ${leftTableName} " +
       s"${joinType} JOIN ${rightTableName} " +
       s"ON ${leftTableName}.${leftCol} = ${rightTableName}.${rightCol};"

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
@@ -19,11 +19,12 @@
 
 package org.apache.comet.fuzz
 
-import org.apache.spark.sql.SparkSession
-
 import java.io.{BufferedWriter, FileWriter}
+
 import scala.collection.mutable
 import scala.util.Random
+
+import org.apache.spark.sql.SparkSession
 
 object QueryGen {
 
@@ -102,7 +103,7 @@ object QueryGen {
     Function("Sqrt", 1),
     Function("Tan", 1),
     Function("Ceil", 1),
-    Function("Floor", 1),
+    Function("Floor", 1)
   )
 
   val aggFunc = Seq(
@@ -165,7 +166,7 @@ object QueryGen {
     val joinTypes = Seq(
       ("INNER", 0.4),
       ("LEFT", 0.3),
-      ("RIGHT", 0.3),
+      ("RIGHT", 0.3)
     )
     val joinType = Utils.randomWeightedChoice(joinTypes)
 

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
@@ -85,6 +85,7 @@ object QueryGen {
     val args = Range(0, func.num_args)
       .map(_ => Utils.randomChoice(table.columns, r))
 
+    // Example SELECT c0, log(c0) as x FROM test0
     s"SELECT ${args.mkString(", ")}, ${func.name}(${args.mkString(", ")}) AS x " +
       s"FROM $tableName " +
       s"ORDER BY ${args.mkString(", ")}"

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
@@ -55,77 +55,11 @@ object QueryGen {
     w.close()
   }
 
-  val scalarFunc: Seq[Function] = Seq(
-    // string
-    Function("substring", 3),
-    Function("coalesce", 1),
-    Function("starts_with", 2),
-    Function("ends_with", 2),
-    Function("contains", 2),
-    Function("ascii", 1),
-    Function("bit_length", 1),
-    Function("octet_length", 1),
-    Function("upper", 1),
-    Function("lower", 1),
-    Function("chr", 1),
-    Function("init_cap", 1),
-    Function("trim", 1),
-    Function("ltrim", 1),
-    Function("rtrim", 1),
-    Function("btrim", 1),
-    Function("concat_ws", 2),
-    Function("repeat", 2),
-    Function("length", 1),
-    Function("reverse", 1),
-    Function("in_str", 2),
-    Function("replace", 2),
-    Function("translate", 2),
-    // date
-    Function("year", 1),
-    Function("hour", 1),
-    Function("minute", 1),
-    Function("second", 1),
-    // math
-    Function("abs", 1),
-    Function("acos", 1),
-    Function("asin", 1),
-    Function("atan", 1),
-    Function("Atan2", 1),
-    Function("Cos", 1),
-    Function("Exp", 2),
-    Function("Ln", 1),
-    Function("Log10", 1),
-    Function("Log2", 1),
-    Function("Pow", 2),
-    Function("Round", 1),
-    Function("Signum", 1),
-    Function("Sin", 1),
-    Function("Sqrt", 1),
-    Function("Tan", 1),
-    Function("Ceil", 1),
-    Function("Floor", 1))
-
-  val aggFunc: Seq[Function] = Seq(
-    Function("min", 1),
-    Function("max", 1),
-    Function("count", 1),
-    Function("avg", 1),
-    Function("sum", 1),
-    Function("first", 1),
-    Function("last", 1),
-    Function("var_pop", 1),
-    Function("var_samp", 1),
-    Function("covar_pop", 1),
-    Function("covar_samp", 1),
-    Function("stddev_pop", 1),
-    Function("stddev_samp", 1),
-    Function("corr", 2))
-
   private def generateAggregate(r: Random, spark: SparkSession, numFiles: Int): String = {
     val tableName = s"test${r.nextInt(numFiles)}"
     val table = spark.table(tableName)
 
-    val func = Utils.randomChoice(aggFunc, r)
+    val func = Utils.randomChoice(Meta.aggFunc, r)
     val args = Range(0, func.num_args)
       .map(_ => Utils.randomChoice(table.columns, r))
 
@@ -147,7 +81,7 @@ object QueryGen {
     val tableName = s"test${r.nextInt(numFiles)}"
     val table = spark.table(tableName)
 
-    val func = Utils.randomChoice(scalarFunc, r)
+    val func = Utils.randomChoice(Meta.scalarFunc, r)
     val args = Range(0, func.num_args)
       .map(_ => Utils.randomChoice(table.columns, r))
 

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
@@ -46,10 +46,6 @@ object QueryGen {
         case 0 => generateJoin(r, spark, numFiles)
         case 1 => generateAggregate(r, spark, numFiles)
         case 2 => generateScalar(r, spark, numFiles)
-        // TODO add explicit casts
-        // TODO add unary and binary arithmetic expressions
-        // TODO add IF and CASE WHEN expressions
-        // TODO support nested expressions
       }
       if (!uniqueQueries.contains(sql)) {
         uniqueQueries += sql
@@ -131,16 +127,13 @@ object QueryGen {
 
     val func = Utils.randomChoice(aggFunc, r)
     val args = Range(0, func.num_args)
-      // TODO support using literals as well as columns
       .map(_ => Utils.randomChoice(table.columns, r))
 
-    // TODO avoid grouping and sorting on floating-point columns
     val groupingCols = Range(0, 2).map(_ => Utils.randomChoice(table.columns, r))
 
     if (groupingCols.isEmpty) {
       s"SELECT ${args.mkString(", ")}, ${func.name}(${args.mkString(", ")}) AS x " +
         s"FROM $tableName " +
-        // TODO avoid sorting on floating-point columns
         s"ORDER BY ${args.mkString(", ")}"
     } else {
       s"SELECT ${groupingCols.mkString(", ")}, ${func.name}(${args.mkString(", ")}) " +
@@ -156,12 +149,10 @@ object QueryGen {
 
     val func = Utils.randomChoice(scalarFunc, r)
     val args = Range(0, func.num_args)
-      // TODO support using literals as well as columns
       .map(_ => Utils.randomChoice(table.columns, r))
 
     s"SELECT ${args.mkString(", ")}, ${func.name}(${args.mkString(", ")}) AS x " +
       s"FROM $tableName " +
-      // TODO avoid sorting on floating-point columns
       s"ORDER BY ${args.mkString(", ")}"
   }
 
@@ -171,16 +162,12 @@ object QueryGen {
     val leftTable = spark.table(leftTableName)
     val rightTable = spark.table(rightTableName)
 
-    // TODO support no join keys
-    // TODO support multiple join keys
-    // TODO support join conditions that use expressions
     val leftCol = Utils.randomChoice(leftTable.columns, r)
     val rightCol = Utils.randomChoice(rightTable.columns, r)
 
     val joinTypes = Seq(("INNER", 0.4), ("LEFT", 0.3), ("RIGHT", 0.3))
     val joinType = Utils.randomWeightedChoice(joinTypes)
 
-    // TODO avoid sorting on floating-point columns
     val leftColProjection = leftTable.columns.map(c => s"l.$c").mkString(", ")
     val rightColProjection = rightTable.columns.map(c => s"r.$c").mkString(", ")
     "SELECT " +

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
@@ -183,13 +183,13 @@ object QueryGen {
     // TODO avoid sorting on floating-point columns
     val leftColProjection = leftTable.columns.map(c => s"l.$c").mkString(", ")
     val rightColProjection = rightTable.columns.map(c => s"r.$c").mkString(", ")
-    s"SELECT " +
+    "SELECT " +
       s"$leftColProjection, " +
       s"$rightColProjection " +
       s"FROM $leftTableName l " +
       s"$joinType JOIN $rightTableName r " +
       s"ON l.$leftCol = r.$rightCol " +
-      s"ORDER BY " +
+      "ORDER BY " +
       s"$leftColProjection, " +
       s"$rightColProjection;"
   }

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryRunner.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryRunner.scala
@@ -28,11 +28,11 @@ import org.apache.spark.sql.SparkSession
 object QueryRunner {
 
   def runQueries(
-    spark: SparkSession,
-    numFiles: Int,
-    filename: String,
-    showMatchingResults: Boolean,
-    showFailedSparkQueries: Boolean = false): Unit = {
+      spark: SparkSession,
+      numFiles: Int,
+      filename: String,
+      showMatchingResults: Boolean,
+      showFailedSparkQueries: Boolean = false): Unit = {
 
     val outputFilename = s"results-${System.currentTimeMillis()}.md"
     // scalastyle:off println
@@ -46,98 +46,102 @@ object QueryRunner {
       val table = spark.read.parquet(s"test$i.parquet")
       val tableName = s"test$i"
       table.createTempView(tableName)
-      w.write(s"Created table $tableName with schema:\n\t" +
-        s"${table.schema.fields.map(f => s"${f.name}: ${f.dataType}").mkString("\n\t")}\n\n")
+      w.write(
+        s"Created table $tableName with schema:\n\t" +
+          s"${table.schema.fields.map(f => s"${f.name}: ${f.dataType}").mkString("\n\t")}\n\n")
     }
 
     val querySource = Source.fromFile(filename)
     try {
-      querySource.getLines().foreach(sql => {
-
-        try {
-          // execute with Spark
-          spark.conf.set("spark.comet.enabled", "false")
-          val df = spark.sql(sql)
-          val sparkRows = df.collect()
-
-          // TODO for now we sort the output to make this deterministic, but this means
-          // that we are never testing Comet's sort for correctness
-          val sparkRowsAsStrings = sparkRows.map(_.toString()).sorted
-          val sparkResult = sparkRowsAsStrings.mkString("\n")
-
-          val sparkPlan = df.queryExecution.executedPlan.toString
-
-          w.write(s"## $sql\n\n")
+      querySource
+        .getLines()
+        .foreach(sql => {
 
           try {
-            spark.conf.set("spark.comet.enabled", "true")
+            // execute with Spark
+            spark.conf.set("spark.comet.enabled", "false")
             val df = spark.sql(sql)
-            val cometRows = df.collect()
+            val sparkRows = df.collect()
+
             // TODO for now we sort the output to make this deterministic, but this means
             // that we are never testing Comet's sort for correctness
-            val cometRowsAsStrings = cometRows.map(_.toString()).sorted
-            val cometResult = cometRowsAsStrings.mkString("\n")
-            val cometPlan = df.queryExecution.executedPlan.toString
+            val sparkRowsAsStrings = sparkRows.map(_.toString()).sorted
+            val sparkResult = sparkRowsAsStrings.mkString("\n")
 
-            if (sparkResult == cometResult) {
-              w.write(s"Spark and Comet produce the same results (${cometRows.length} rows).\n")
-              if (showMatchingResults) {
+            val sparkPlan = df.queryExecution.executedPlan.toString
+
+            w.write(s"## $sql\n\n")
+
+            try {
+              spark.conf.set("spark.comet.enabled", "true")
+              val df = spark.sql(sql)
+              val cometRows = df.collect()
+              // TODO for now we sort the output to make this deterministic, but this means
+              // that we are never testing Comet's sort for correctness
+              val cometRowsAsStrings = cometRows.map(_.toString()).sorted
+              val cometResult = cometRowsAsStrings.mkString("\n")
+              val cometPlan = df.queryExecution.executedPlan.toString
+
+              if (sparkResult == cometResult) {
+                w.write(s"Spark and Comet produce the same results (${cometRows.length} rows).\n")
+                if (showMatchingResults) {
+                  w.write("### Spark Plan\n")
+                  w.write(s"```\n$sparkPlan\n```\n")
+
+                  w.write("### Comet Plan\n")
+                  w.write(s"```\n$cometPlan\n```\n")
+
+                  w.write("### Query Result\n")
+                  w.write("```\n")
+                  w.write(s"$cometResult\n")
+                  w.write("```\n\n")
+                }
+              } else {
+                w.write("[ERROR] Spark and Comet produced different results.\n")
+
                 w.write("### Spark Plan\n")
                 w.write(s"```\n$sparkPlan\n```\n")
 
                 w.write("### Comet Plan\n")
                 w.write(s"```\n$cometPlan\n```\n")
 
-                w.write("### Query Result\n")
-                w.write("```\n")
-                w.write(s"$cometResult\n")
-                w.write("```\n\n")
-              }
-            } else {
-              w.write("[ERROR] Spark and Comet produced different results.\n")
+                w.write("### Results \n")
 
-              w.write("### Spark Plan\n")
-              w.write(s"```\n$sparkPlan\n```\n")
+                w.write(
+                  s"Spark produced ${sparkRows.length} rows and " +
+                    s"Comet produced ${cometRows.length} rows.\n")
 
-              w.write("### Comet Plan\n")
-              w.write(s"```\n$cometPlan\n```\n")
-
-              w.write("### Results \n")
-
-              w.write(s"Spark produced ${sparkRows.length} rows and " +
-                s"Comet produced ${cometRows.length} rows.\n")
-
-              if (sparkRows.length == cometRows.length) {
-                var i = 0
-                while (i < sparkRows.length) {
-                  if (sparkRowsAsStrings(i) != cometRowsAsStrings(i)) {
-                    w.write(s"First difference at row $i:\n")
-                    w.write("Spark: `" + sparkRowsAsStrings(i) + "`\n")
-                    w.write("Comet: `" + cometRowsAsStrings(i) + "`\n")
-                    i = sparkRows.length
+                if (sparkRows.length == cometRows.length) {
+                  var i = 0
+                  while (i < sparkRows.length) {
+                    if (sparkRowsAsStrings(i) != cometRowsAsStrings(i)) {
+                      w.write(s"First difference at row $i:\n")
+                      w.write("Spark: `" + sparkRowsAsStrings(i) + "`\n")
+                      w.write("Comet: `" + cometRowsAsStrings(i) + "`\n")
+                      i = sparkRows.length
+                    }
+                    i += 1
                   }
-                  i += 1
                 }
               }
+            } catch {
+              case e: Exception =>
+                // the query worked in Spark but failed in Comet, so this is likely a bug in Comet
+                w.write(s"Query failed in Comet: ${e.getMessage}\n")
             }
+
+            // flush after every query so that results are saved in the event of the driver crashing
+            w.flush()
+
           } catch {
             case e: Exception =>
-              // the query worked in Spark but failed in Comet, so this is likely a bug in Comet
-              w.write(s"Query failed in Comet: ${e.getMessage}\n")
+              // we expect many generated queries to be invalid
+              if (showFailedSparkQueries) {
+                w.write(s"## $sql\n\n")
+                w.write(s"Query failed in Spark: ${e.getMessage}\n")
+              }
           }
-
-          // flush after every query so that results are saved in the event of the driver crashing
-          w.flush()
-
-        } catch {
-          case e: Exception =>
-            // we expect many generated queries to be invalid
-            if (showFailedSparkQueries) {
-              w.write(s"## $sql\n\n")
-              w.write(s"Query failed in Spark: ${e.getMessage}\n")
-            }
-        }
-      })
+        })
 
     } finally {
       w.close()

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryRunner.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryRunner.scala
@@ -19,10 +19,11 @@
 
 package org.apache.comet.fuzz
 
-import org.apache.spark.sql.SparkSession
-
 import java.io.{BufferedWriter, FileWriter}
+
 import scala.io.Source
+
+import org.apache.spark.sql.SparkSession
 
 object QueryRunner {
 
@@ -34,7 +35,9 @@ object QueryRunner {
     showFailedSparkQueries: Boolean = false): Unit = {
 
     val outputFilename = s"results-${System.currentTimeMillis()}.md"
+    // scalastyle:off println
     println(s"Writing results to $outputFilename")
+    // scalastyle:on println
 
     val w = new BufferedWriter(new FileWriter(outputFilename))
 
@@ -101,7 +104,8 @@ object QueryRunner {
 
               w.write("### Results \n")
 
-              w.write(s"Spark produced ${sparkRows.length} rows and Comet produced ${cometRows.length} rows.\n")
+              w.write(s"Spark produced ${sparkRows.length} rows and " +
+                s"Comet produced ${cometRows.length} rows.\n")
 
               if (sparkRows.length == cometRows.length) {
                 var i = 0
@@ -135,7 +139,7 @@ object QueryRunner {
         }
       })
 
-    } finally  {
+    } finally {
       w.close()
       querySource.close()
     }

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryRunner.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryRunner.scala
@@ -78,7 +78,11 @@ object QueryRunner {
                   assert(l.length == r.length)
                   for (j <- 0 until l.length) {
                     val same = (l(j), r(j)) match {
+                      case (a: Float, b: Float) if a.isInfinity => b.isInfinity
+                      case (a: Float, b: Float) if a.isNaN => b.isNaN
                       case (a: Float, b: Float) => (a - b).abs <= 0.000001f
+                      case (a: Double, b: Double) if a.isInfinity => b.isInfinity
+                      case (a: Double, b: Double) if a.isNaN => b.isNaN
                       case (a: Double, b: Double) => (a - b).abs <= 0.000001
                       case (a, b) => a == b
                     }
@@ -87,7 +91,7 @@ object QueryRunner {
                       showPlans(w, sparkPlan, cometPlan)
                       w.write(s"First difference at row $i:\n")
                       w.write("Spark: `" + l.mkString(",") + "`\n")
-                      w.write("Comet: `" + r.mkString(", ") + "`\n")
+                      w.write("Comet: `" + r.mkString(",") + "`\n")
                       i = sparkRows.length
                     }
                   }

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryRunner.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryRunner.scala
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.fuzz
+
+import org.apache.spark.sql.SparkSession
+
+import java.io.{BufferedWriter, FileWriter}
+import scala.io.Source
+
+object QueryRunner {
+
+  def runQueries(
+    spark: SparkSession,
+    numFiles: Int,
+    filename: String,
+    showMatchingResults: Boolean,
+    showFailedSparkQueries: Boolean = false): Unit = {
+
+    val outputFilename = s"results-${System.currentTimeMillis()}.md"
+    println(s"Writing results to $outputFilename")
+
+    val w = new BufferedWriter(new FileWriter(outputFilename))
+
+    // register input files
+    for (i <- 0 until numFiles) {
+      val table = spark.read.parquet(s"test$i.parquet")
+      val tableName = s"test$i"
+      table.createTempView(tableName)
+      w.write(s"Created table $tableName with schema:\n\t" +
+        s"${table.schema.fields.map(f => s"${f.name}: ${f.dataType}").mkString("\n\t")}\n\n")
+    }
+
+    val querySource = Source.fromFile(filename)
+    try {
+      querySource.getLines().foreach(sql => {
+
+        try {
+          // execute with Spark
+          spark.conf.set("spark.comet.enabled", "false")
+          val df = spark.sql(sql)
+          val sparkRows = df.collect()
+
+          // TODO for now we sort the output to make this deterministic, but this means
+          // that we are never testing Comet's sort for correctness
+          val sparkRowsAsStrings = sparkRows.map(_.toString()).sorted
+          val sparkResult = sparkRowsAsStrings.mkString("\n")
+
+          val sparkPlan = df.queryExecution.executedPlan.toString
+
+          w.write(s"## $sql\n\n")
+
+          try {
+            spark.conf.set("spark.comet.enabled", "true")
+            val df = spark.sql(sql)
+            val cometRows = df.collect()
+            // TODO for now we sort the output to make this deterministic, but this means
+            // that we are never testing Comet's sort for correctness
+            val cometRowsAsStrings = cometRows.map(_.toString()).sorted
+            val cometResult = cometRowsAsStrings.mkString("\n")
+            val cometPlan = df.queryExecution.executedPlan.toString
+
+            if (sparkResult == cometResult) {
+              w.write(s"Spark and Comet produce the same results (${cometRows.length} rows).\n")
+              if (showMatchingResults) {
+                w.write("### Spark Plan\n")
+                w.write(s"```\n$sparkPlan\n```\n")
+
+                w.write("### Comet Plan\n")
+                w.write(s"```\n$cometPlan\n```\n")
+
+                w.write("### Query Result\n")
+                w.write("```\n")
+                w.write(s"$cometResult\n")
+                w.write("```\n\n")
+              }
+            } else {
+              w.write("[ERROR] Spark and Comet produced different results.\n")
+
+              w.write("### Spark Plan\n")
+              w.write(s"```\n$sparkPlan\n```\n")
+
+              w.write("### Comet Plan\n")
+              w.write(s"```\n$cometPlan\n```\n")
+
+              w.write("### Results \n")
+
+              w.write(s"Spark produced ${sparkRows.length} rows and Comet produced ${cometRows.length} rows.\n")
+
+              if (sparkRows.length == cometRows.length) {
+                var i = 0
+                while (i < sparkRows.length) {
+                  if (sparkRowsAsStrings(i) != cometRowsAsStrings(i)) {
+                    w.write(s"First difference at row $i:\n")
+                    w.write("Spark: `" + sparkRowsAsStrings(i) + "`\n")
+                    w.write("Comet: `" + cometRowsAsStrings(i) + "`\n")
+                    i = sparkRows.length
+                  }
+                  i += 1
+                }
+              }
+            }
+          } catch {
+            case e: Exception =>
+              // the query worked in Spark but failed in Comet, so this is likely a bug in Comet
+              w.write(s"Query failed in Comet: ${e.getMessage}\n")
+          }
+
+          // flush after every query so that results are saved in the event of the driver crashing
+          w.flush()
+
+        } catch {
+          case e: Exception =>
+            // we expect many generated queries to be invalid
+            if (showFailedSparkQueries) {
+              w.write(s"## $sql\n\n")
+              w.write(s"Query failed in Spark: ${e.getMessage}\n")
+            }
+        }
+      })
+
+    } finally  {
+      w.close()
+      querySource.close()
+    }
+  }
+
+}

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Utils.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Utils.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.fuzz
+
+import scala.util.Random
+
+object Utils {
+
+  def randomChoice[T](list: Seq[T], r: Random): T = {
+    list(r.nextInt(list.length))
+  }
+
+  def randomWeightedChoice[T](valuesWithWeights: Seq[(T, Double)]): T = {
+    val totalWeight = valuesWithWeights.map(_._2).sum
+    val randomValue = Random.nextDouble() * totalWeight
+    var cumulativeWeight = 0.0
+
+    for ((value, weight) <- valuesWithWeights) {
+      cumulativeWeight += weight
+      if (cumulativeWeight >= randomValue) {
+        return value
+      }
+    }
+
+    // If for some reason the loop doesn't return, return the last value
+    valuesWithWeights.last._1
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -410,6 +410,12 @@ under the License.
         <scope>test</scope>
       </dependency>
 
+      <dependency>
+        <groupId>org.rogach</groupId>
+        <artifactId>scallop_${scala.binary.version}</artifactId>
+        <version>5.1.0</version>
+      </dependency>
+
     </dependencies>
 
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@ under the License.
     <module>common</module>
     <module>spark</module>
     <module>spark-integration</module>
+    <module>fuzz-testing</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Comet Fuzz is a standalone project for generating random data and queries and executing queries against Spark 
with Comet disabled and enabled and checking for incompatibilities.

Although it is a simple tool it has already been useful in finding many bugs, including:

- #479 
- #480 
- #481 
- #482 
- #483 
- #484 
- #485 
- #486 

Comet Fuzz is inspired by the [SparkFuzz](https://ir.cwi.nl/pub/30222) paper from Databricks and CWI.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

New standalone `comet-fuzz` project.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->


Manually tested.