### PR TITLE
fix: Fallback to Spark for LIKE with custom escape character

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -981,7 +981,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde {
             None
           }
 
-        case Like(left, right, _) =>
+        case Like(left, right, escapeChar) if escapeChar == '\\' =>
           // TODO escapeChar
           val leftExpr = exprToProtoInternal(left, inputs)
           val rightExpr = exprToProtoInternal(right, inputs)

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -981,23 +981,28 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde {
             None
           }
 
-        case Like(left, right, escapeChar) if escapeChar == '\\' =>
-          // TODO escapeChar
-          val leftExpr = exprToProtoInternal(left, inputs)
-          val rightExpr = exprToProtoInternal(right, inputs)
+        case Like(left, right, escapeChar) =>
+          if (escapeChar == '\\') {
+            val leftExpr = exprToProtoInternal(left, inputs)
+            val rightExpr = exprToProtoInternal(right, inputs)
 
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.Like.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
+            if (leftExpr.isDefined && rightExpr.isDefined) {
+              val builder = ExprOuterClass.Like.newBuilder()
+              builder.setLeft(leftExpr.get)
+              builder.setRight(rightExpr.get)
 
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setLike(builder)
-                .build())
+              Some(
+                ExprOuterClass.Expr
+                  .newBuilder()
+                  .setLike(builder)
+                  .build())
+            } else {
+              withInfo(expr, left, right)
+              None
+            }
           } else {
-            withInfo(expr, left, right)
+            // TODO custom escape char
+            withInfo(expr, s"custom escape character $escapeChar not supported in LIKE")
             None
           }
 

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -587,8 +587,12 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       sql(s"insert into $table values(3,'Robert_R_Williams')")
 
       // Filter column having values that include underscores
-      val query = sql("select id from names where name like '%$_%' escape '$'")
-      checkAnswer(query, Row(2) :: Row(3) :: Nil)
+      val queryDefaultEscape = sql("select id from names where name like '%\\_%'")
+      checkAnswer(queryDefaultEscape, Row(2) :: Row(3) :: Nil)
+
+      val queryCustomEscape = sql("select id from names where name like '%$_%' escape '$'")
+      checkAnswer(queryCustomEscape, Row(2) :: Row(3) :: Nil)
+
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -588,7 +588,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
 
       // Filter column having values that include underscores
       val queryDefaultEscape = sql("select id from names where name like '%\\_%'")
-      checkAnswer(queryDefaultEscape, Row(2) :: Row(3) :: Nil)
+      checkSparkAnswerAndOperator(queryDefaultEscape)
 
       val queryCustomEscape = sql("select id from names where name like '%$_%' escape '$'")
       checkAnswer(queryCustomEscape, Row(2) :: Row(3) :: Nil)

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -578,6 +578,20 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("like with custom escape") {
+    val table = "names"
+    withTable(table) {
+      sql(s"create table $table(id int, name varchar(20)) using parquet")
+      sql(s"insert into $table values(1,'James Smith')")
+      sql(s"insert into $table values(2,'Michael_Rose')")
+      sql(s"insert into $table values(3,'Robert_R_Williams')")
+
+      // Filter column having values that include underscores
+      val query = sql("select id from names where name like '%$_%' escape '$'")
+      checkAnswer(query, Row(2) :: Row(3) :: Nil)
+    }
+  }
+
   test("contains") {
     assume(!isSpark32)
 


### PR DESCRIPTION
Fallback to Spark for LIKE with custom escape character because currently, LIKE with custom escape character produces incorrect results.

## Which issue does this PR close?

Closes #462 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
An `if` clause is introduced for LIKE in `exprToProtoInternal` in `QueryPlanSerde.scala`. It ensures that we fallback to Spark in case LIKE has a custom escape character.

## How are these changes tested?
A test was added to `org.apache.comet.CometExpressionSuite`.
