### PR TITLE
chore: Simplify code in CometExecIterator and avoid some small overhead

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -67,20 +67,6 @@ class CometExecIterator(
   private var currentBatch: ColumnarBatch = null
   private var closed: Boolean = false
 
-  private def executeNative(): ExecutionState = {
-    val result = nativeLib.executePlan(plan)
-
-    val flag = result(0)
-    if (flag == -1) EOF
-    else if (flag == 1) {
-      val numRows = result(1)
-      val addresses = result.slice(2, result.length)
-      Batch(numRows = numRows.toInt, addresses = addresses)
-    } else {
-      throw new IllegalStateException(s"Invalid native flag: $flag")
-    }
-  }
-
   /**
    * Creates a new configuration map to be passed to the native side.
    */
@@ -110,21 +96,22 @@ class CometExecIterator(
     result
   }
 
-  /** Execution result from Comet native */
-  trait ExecutionState
-
-  /** A new batch is available */
-  case class Batch(numRows: Int, addresses: Array[Long]) extends ExecutionState
-
-  /** The execution is finished - no more batch */
-  case object EOF extends ExecutionState
-
   def getNextBatch(): Option[ColumnarBatch] = {
-    executeNative() match {
-      case EOF => None
-      case Batch(numRows, addresses) =>
+    // we execute the native plan each time we need another output batch and this could
+    // result in multiple input batches being processed
+    val result = nativeLib.executePlan(plan)
+
+    result(0) match {
+      case -1 =>
+        // EOF
+        None
+      case 1 =>
+        val numRows = result(1)
+        val addresses = result.slice(2, result.length)
         val cometVectors = nativeUtil.importVector(addresses)
-        Some(new ColumnarBatch(cometVectors.toArray, numRows))
+        Some(new ColumnarBatch(cometVectors.toArray, numRows.toInt))
+      case flag =>
+        throw new IllegalStateException(s"Invalid native flag: $flag")
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

In the original code, `getNextBatch` called `executeNative` which would create a `Batch` object which is then discarded in `getNextBatch`. This seems like unnecessary overhead even though it is small.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Remove the interim `Batch` structure. Combine the two methods.
- Add some comments

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests.