### PR TITLE
fix: Overflow when reading Timestamp from parquet file

### DIFF
--- a/core/src/parquet/read/values.rs
+++ b/core/src/parquet/read/values.rs
@@ -742,9 +742,9 @@ impl PlainDecoding for Int96TimestampMicrosType {
 
                 // TODO: optimize this further as checking value one by one is not very efficient
                 unsafe {
-                    let micros = (day.read_unaligned() - JULIAN_DAY_OF_EPOCH) as i64
-                        * MICROS_PER_DAY
-                        + nanos.read_unaligned() / 1000;
+                    let micros = ((day.read_unaligned() - JULIAN_DAY_OF_EPOCH) as i64)
+                        .wrapping_mul(MICROS_PER_DAY)
+                        .wrapping_add(nanos.read_unaligned() / 1000);
 
                     if unlikely(micros < JULIAN_GREGORIAN_SWITCH_OFF_TS) {
                         panic!(
@@ -769,8 +769,9 @@ impl PlainDecoding for Int96TimestampMicrosType {
                 let nanos = &v[..INT96_DST_BYTE_WIDTH] as *const [u8] as *const u8 as *const i64;
                 let day = &v[INT96_DST_BYTE_WIDTH..] as *const [u8] as *const u8 as *const i32;
 
-                let micros = (day.read_unaligned() - JULIAN_DAY_OF_EPOCH) as i64 * MICROS_PER_DAY
-                    + nanos.read_unaligned() / 1000;
+                let micros = ((day.read_unaligned() - JULIAN_DAY_OF_EPOCH) as i64)
+                    .wrapping_mul(MICROS_PER_DAY)
+                    .wrapping_add(nanos.read_unaligned() / 1000);
 
                 bit::memcpy_value(
                     &micros,

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -780,7 +780,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
 
   test("cast TimestampType to LongType") {
     assume(CometSparkSessionExtensions.isSpark33Plus)
-    castTest(generateTimestamps(), DataTypes.LongType)
+    castTest(generateTimestampsExtended(), DataTypes.LongType)
   }
 
   ignore("cast TimestampType to FloatType") {
@@ -882,6 +882,14 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   private def generateDates(): DataFrame = {
     val values = Seq("2024-01-01", "999-01-01", "12345-01-01")
     withNulls(values).toDF("b").withColumn("a", col("b").cast(DataTypes.DateType)).drop("b")
+  }
+
+  // Extended values are Timestamps that are outside dates supported chrono::DateTime and
+  // therefore not supported by operations using it.
+  private def generateTimestampsExtended(): DataFrame = {
+    val values = Seq("290000-12-31T01:00:00+02:00")
+    generateTimestamps().unionByName(
+      values.toDF("str").select(col("str").cast(DataTypes.TimestampType).as("a")))
   }
 
   private def generateTimestamps(): DataFrame = {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #481.

## Rationale for this change

When spark reads and writes timestamps in parquet file it using the following code: https://github.com/apache/spark/blob/v3.5.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala#L48-L66 to convert from the Long microsecond timestamp into the julian date + nano second format used in parquet. Because of the logic is implement dates like `290000-12-31T01:00:00+02:00` will lead to overflow both when encoding and decoding the value. Since it for both the reading and writing it "cancels out" and still gives the expected results.  This means the date in year 290000 is stored with a negative day offset, which to me is a bit unexpected. 

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

This changes the comet code to use wrapping_mul/add to make it explicit that wrapping overflow is expected and needed to match Spark behavior.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

Existing and new unit test in CometCastSuite.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
