### PR TITLE
chore: Remove unsafe use of from_raw_parts in Parquet decoder

### DIFF
--- a/core/src/parquet/read/values.rs
+++ b/core/src/parquet/read/values.rs
@@ -455,10 +455,8 @@ macro_rules! make_int_variant_impl {
 
                 while num - i >= 32 {
                     unsafe {
-                        //let in_slice = std::slice::from_raw_parts(in_ptr, 32);
                         for _ in 0..32 {
                             copy_nonoverlapping(
-                                //in_slice[n..].as_ptr() as *const $native_ty,
                                 &src_data[src_offset..] as *const [u8] as *const u8
                                     as *const $native_ty,
                                 &mut dst_slice[dst_offset] as *mut u8 as *mut $native_ty,

--- a/core/src/parquet/read/values.rs
+++ b/core/src/parquet/read/values.rs
@@ -443,11 +443,12 @@ macro_rules! make_int_variant_impl {
     ($ty: ident, $native_ty: ty, $type_size: expr) => {
         impl PlainDecoding for $ty {
             fn decode(src: &mut PlainDecoderInner, dst: &mut ParquetMutableVector, num: usize) {
-                let src_ptr = src.data.as_ptr() as *const u8;
+                assert!(src.offset % 4 == 0);
+                let src_ptr = src.data.as_ptr() as *const i32;
                 let dst_ptr = dst.value_buffer.as_mut_ptr() as *mut $native_ty;
                 unsafe {
                     for i in 0..num {
-                        let ptr = src_ptr.add(src.offset + i * 4) as *const u32;
+                        let ptr = src_ptr.add(src.offset/4 + i) as *const i32;
                         dst_ptr
                             .add(dst.num_values + i)
                             .write_unaligned(ptr.read_unaligned() as $native_ty);

--- a/core/src/parquet/read/values.rs
+++ b/core/src/parquet/read/values.rs
@@ -451,8 +451,6 @@ macro_rules! make_int_variant_impl {
                 let mut dst_offset = dst.num_values * $type_size;
 
                 let mut i = 0;
-                let mut in_ptr = &src_data[src_offset..] as *const [u8] as *const u8 as *const u32;
-
                 while num - i >= 32 {
                     unsafe {
                         for _ in 0..32 {
@@ -466,7 +464,6 @@ macro_rules! make_int_variant_impl {
                             src_offset += 4;
                             dst_offset += $type_size;
                         }
-                        in_ptr = in_ptr.offset(32);
                     }
                 }
 

--- a/core/src/parquet/read/values.rs
+++ b/core/src/parquet/read/values.rs
@@ -446,9 +446,10 @@ macro_rules! make_int_variant_impl {
                 assert!(src.offset % 4 == 0);
                 let src_ptr = src.data.as_ptr() as *const i32;
                 let dst_ptr = dst.value_buffer.as_mut_ptr() as *mut $native_ty;
+                let offset_i32 = src.offset / 4;
                 unsafe {
                     for i in 0..num {
-                        let ptr = src_ptr.add(src.offset/4 + i) as *const i32;
+                        let ptr = src_ptr.add(offset_i32 + i) as *const i32;
                         dst_ptr
                             .add(dst.num_values + i)
                             .write_unaligned(ptr.read_unaligned() as $native_ty);


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/datafusion-comet/issues/507

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The documentation for `from_raw_parts` states that the the memory must be "properly aligned" and Rust 1.78 added debug assertions that fail if the memory is not properly aligned. We are seeing those assertions fail when we run with Rust 1.78.

https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Refactor `make_int_variant_impl` to follow the same pattern as other decode methods and use `read_unaligned` and `write_unaligned` instead of incorrect use of `from_raw_parts`.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests.
