### PR TITLE
fix: Re-implement some Parquet decode methods without `copy_nonoverlapping`

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -878,6 +878,7 @@ dependencies = [
  "futures",
  "half",
  "hashbrown",
+ "hex",
  "itertools 0.11.0",
  "jni",
  "lazy_static",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -137,3 +137,7 @@ harness = false
 [[bench]]
 name = "shuffle_writer"
 harness = false
+
+[[bench]]
+name = "parquet_decode"
+harness = false

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -93,6 +93,7 @@ criterion = "0.5.1"
 jni = { version = "0.21", features = ["invocation"] }
 lazy_static = "1.4"
 assertables = "7"
+hex = "0.4.3"
 
 [features]
 default = []

--- a/core/benches/parquet_decode.rs
+++ b/core/benches/parquet_decode.rs
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow_buffer::ToByteSlice;
+use comet::parquet::read::values::{copy_i32_to_i16, copy_i32_to_u16};
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let num = 1000;
+    let source = vec![78_i8; num * 4];
+    let mut group = c.benchmark_group("parquet_decode");
+    group.bench_function("decode_i32_to_i16", |b| {
+        let mut dest: Vec<u8> = vec![b' '; num * 2];
+        b.iter(|| {
+            copy_i32_to_i16(source.to_byte_slice(), dest.as_mut_slice(), num);
+        });
+    });
+    group.bench_function("decode_i32_to_u16", |b| {
+        let mut dest: Vec<u8> = vec![b' '; num * 4];
+        b.iter(|| {
+            copy_i32_to_u16(source.to_byte_slice(), dest.as_mut_slice(), num);
+        });
+    });
+}
+
+// Create UTF8 batch with strings representing ints, floats, nulls
+fn config() -> Criterion {
+    Criterion::default()
+}
+
+criterion_group! {
+    name = benches;
+    config = config();
+    targets = criterion_benchmark
+}
+criterion_main!(benches);

--- a/core/src/parquet/read/values.rs
+++ b/core/src/parquet/read/values.rs
@@ -586,10 +586,10 @@ fn copy_i32_to_u32(src: &[u8], dst: &mut [u8], num: usize) {
         let u32_value = i32_value as u32;
         let u32_bytes = u32_value.to_le_bytes();
 
-        dst[i * 2] = u32_bytes[0];
-        dst[i * 2 + 1] = u32_bytes[1];
-        dst[i * 2 + 2] = u32_bytes[2];
-        dst[i * 2 + 3] = u32_bytes[3];
+        dst[i * 4] = u32_bytes[0];
+        dst[i * 4 + 1] = u32_bytes[1];
+        dst[i * 4 + 2] = u32_bytes[2];
+        dst[i * 4 + 3] = u32_bytes[3];
     }
 }
 

--- a/core/src/parquet/read/values.rs
+++ b/core/src/parquet/read/values.rs
@@ -419,7 +419,7 @@ impl PlainDictDecoding for BoolType {
     }
 }
 
-macro_rules! impl_plain_decoding_int {
+macro_rules! make_int_variant_impl {
     ($dst_type:ty, $copy_fn:ident, $type_width:expr) => {
         impl PlainDecoding for $dst_type {
             fn decode(src: &mut PlainDecoderInner, dst: &mut ParquetMutableVector, num: usize) {
@@ -436,15 +436,15 @@ macro_rules! impl_plain_decoding_int {
     };
 }
 
-impl_plain_decoding_int!(Int8Type, copy_i32_to_i8, 1);
-impl_plain_decoding_int!(Int16Type, copy_i32_to_i16, 2);
-impl_plain_decoding_int!(Int32To64Type, copy_i32_to_i64, 4);
+make_int_variant_impl!(Int8Type, copy_i32_to_i8, 1);
+make_int_variant_impl!(Int16Type, copy_i32_to_i16, 2);
+make_int_variant_impl!(Int32To64Type, copy_i32_to_i64, 4);
 
 // unsigned type require double the width and zeroes are written for the second half
 // perhaps because they are implemented as the next size up signed type?
-impl_plain_decoding_int!(UInt8Type, copy_i32_to_u8, 2);
-impl_plain_decoding_int!(UInt16Type, copy_i32_to_u16, 4);
-impl_plain_decoding_int!(UInt32Type, copy_i32_to_u32, 8);
+make_int_variant_impl!(UInt8Type, copy_i32_to_u8, 2);
+make_int_variant_impl!(UInt16Type, copy_i32_to_u16, 4);
+make_int_variant_impl!(UInt32Type, copy_i32_to_u32, 8);
 
 macro_rules! generate_cast_to_unsigned {
     ($name: ident, $src_type:ty, $dst_type:ty, $zero_value:expr) => {
@@ -478,7 +478,7 @@ generate_cast_to_unsigned!(copy_i32_to_u16, i32, u16, 0_u16);
 generate_cast_to_unsigned!(copy_i32_to_u32, i32, u32, 0_u32);
 
 macro_rules! generate_cast_to_signed {
-    ($name: ident, $src_type:ty, $dst_type:ty, $zero_value:expr) => {
+    ($name: ident, $src_type:ty, $dst_type:ty) => {
         pub fn $name(src: &[u8], dst: &mut [u8], num: usize) {
             debug_assert!(
                 src.len() >= num * std::mem::size_of::<$src_type>(),
@@ -502,9 +502,9 @@ macro_rules! generate_cast_to_signed {
     };
 }
 
-generate_cast_to_signed!(copy_i32_to_i8, i32, i8, 0_i8);
-generate_cast_to_signed!(copy_i32_to_i16, i32, i16, 0_i16);
-generate_cast_to_signed!(copy_i32_to_i64, i32, i64, 0_i64);
+generate_cast_to_signed!(copy_i32_to_i8, i32, i8);
+generate_cast_to_signed!(copy_i32_to_i16, i32, i16);
+generate_cast_to_signed!(copy_i32_to_i64, i32, i64);
 
 // Shared implementation for variants of Binary type
 macro_rules! make_plain_binary_impl {

--- a/core/src/parquet/read/values.rs
+++ b/core/src/parquet/read/values.rs
@@ -500,7 +500,7 @@ impl PlainDecoding for UInt32Type {
         let dst_slice = dst.value_buffer.as_slice_mut();
         let dst_offset = dst.num_values * 8;
         copy_i32_to_u32(&src_data[src.offset..], &mut dst_slice[dst_offset..], num);
-        src.offset += 8 * num;
+        src.offset += 4 * num;
     }
 
     fn skip(src: &mut PlainDecoderInner, num: usize) {
@@ -579,7 +579,7 @@ fn copy_i32_to_u16(src: &[u8], dst: &mut [u8], num: usize) {
 
 fn copy_i32_to_u32(src: &[u8], dst: &mut [u8], num: usize) {
     debug_assert!(src.len() >= num * 4, "Source slice is too small");
-    debug_assert!(dst.len() >= num * 4, "Destination slice is too small");
+    debug_assert!(dst.len() >= num * 8, "Destination slice is too small");
 
     for i in 0..num {
         let i32_value =

--- a/core/src/parquet/read/values.rs
+++ b/core/src/parquet/read/values.rs
@@ -510,7 +510,7 @@ impl PlainDecoding for UInt32Type {
 
 fn copy_i32_to_i8(src: &[u8], dst: &mut [u8], num: usize) {
     debug_assert!(src.len() >= num * 4, "Source slice is too small");
-    debug_assert!(dst.len() >= num * 1, "Destination slice is too small");
+    debug_assert!(dst.len() >= num, "Destination slice is too small");
 
     for i in 0..num {
         let i32_value =

--- a/core/src/parquet/read/values.rs
+++ b/core/src/parquet/read/values.rs
@@ -526,7 +526,7 @@ fn copy_i32_to_i8(src: &[u8], dst: &mut [u8], num: usize) {
 
 fn copy_i32_to_u8(src: &[u8], dst: &mut [u8], num: usize) {
     debug_assert!(src.len() >= num * 4, "Source slice is too small");
-    debug_assert!(dst.len() >= num * 1, "Destination slice is too small");
+    debug_assert!(dst.len() >= num * 2, "Destination slice is too small");
 
     for i in 0..num {
         let i32_value =
@@ -536,7 +536,8 @@ fn copy_i32_to_u8(src: &[u8], dst: &mut [u8], num: usize) {
         let u8_value = i32_value as u8;
         let u8_bytes = u8_value.to_le_bytes();
 
-        dst[i] = u8_bytes[0];
+        dst[i * 2] = u8_bytes[0];
+        dst[i * 2 + 1] = 0;
     }
 }
 
@@ -1121,17 +1122,17 @@ mod test {
         assert_eq!(expected.as_bytes(), dest.as_bytes());
     }
 
-    // #[test]
-    // fn test_i32_to_u8() {
-    //     let source =
-    //         hex::decode("8a000000dbffffff1800000034ffffff300000001d000000abffffff37fffffff1000000")
-    //             .unwrap();
-    //     let expected = hex::decode("8adb1834301dab37f1").unwrap();
-    //     let num = source.len() / 4;
-    //     let mut dest: Vec<u8> = vec![b' '; num * 2];
-    //     copy_i32_to_i8(&source.as_bytes(), dest.as_mut_slice(), num);
-    //     assert_eq!(expected.as_bytes(), dest.as_bytes());
-    // }
+    #[test]
+    fn test_i32_to_u8() {
+        let source =
+            hex::decode("8a000000dbffffff1800000034ffffff300000001d000000abffffff37fffffff1000000")
+                .unwrap();
+        let expected = hex::decode("8a00db001800340030001d00ab003700f100").unwrap();
+        let num = source.len() / 4;
+        let mut dest: Vec<u8> = vec![b' '; num * 2];
+        copy_i32_to_u8(&source.as_bytes(), dest.as_mut_slice(), num);
+        assert_eq!(expected.as_bytes(), dest.as_bytes());
+    }
 
     #[test]
     fn test_i32_to_i16() {

--- a/core/src/parquet/read/values.rs
+++ b/core/src/parquet/read/values.rs
@@ -528,7 +528,7 @@ fn copy_i32_to_u8(src: &[u8], dst: &mut [u8], num: usize) {
     debug_assert!(dst.len() >= num * 2, "Destination slice is too small");
 
     let src_ptr = src.as_ptr() as *const i32;
-    let dst_ptr = dst.as_mut_ptr() as *mut u8;
+    let dst_ptr = dst.as_mut_ptr();
     unsafe {
         for i in 0..num {
             dst_ptr

--- a/core/src/parquet/read/values.rs
+++ b/core/src/parquet/read/values.rs
@@ -182,25 +182,6 @@ make_plain_dict_impl! { Int8Type, UInt8Type, Int16Type, UInt16Type, Int32Type, U
 make_plain_dict_impl! { Int32DateType, Int64Type, FloatType, FLBAType }
 make_plain_dict_impl! { DoubleType, Int64TimestampMillisType, Int64TimestampMicrosType }
 
-impl PlainDecoding for Int32To64Type {
-    fn decode(src: &mut PlainDecoderInner, dst: &mut ParquetMutableVector, num: usize) {
-        let src_ptr = src.data.as_ptr() as *const i32;
-        let dst_ptr = dst.value_buffer.as_mut_ptr() as *mut i64;
-        unsafe {
-            for i in 0..num {
-                dst_ptr
-                    .add(dst.num_values + i)
-                    .write_unaligned(src_ptr.add(src.offset + i).read_unaligned() as i64);
-            }
-        }
-        src.offset += 4 * num;
-    }
-
-    fn skip(src: &mut PlainDecoderInner, num: usize) {
-        src.offset += 4 * num;
-    }
-}
-
 impl PlainDictDecoding for Int32To64Type {
     fn decode_dict_one(
         idx: usize,
@@ -461,6 +442,7 @@ macro_rules! impl_plain_decoding_int {
 
 impl_plain_decoding_int!(Int8Type, copy_i32_to_i8, true);
 impl_plain_decoding_int!(Int16Type, copy_i32_to_i16, true);
+impl_plain_decoding_int!(Int32To64Type, copy_i32_to_i64, true);
 impl_plain_decoding_int!(UInt8Type, copy_i32_to_u8, false);
 impl_plain_decoding_int!(UInt16Type, copy_i32_to_u16, false);
 impl_plain_decoding_int!(UInt32Type, copy_i32_to_u32, false);
@@ -523,6 +505,7 @@ macro_rules! generate_cast_to_signed {
 
 generate_cast_to_signed!(copy_i32_to_i8, i32, i8, 0_i8);
 generate_cast_to_signed!(copy_i32_to_i16, i32, i16, 0_i16);
+generate_cast_to_signed!(copy_i32_to_i64, i32, i64, 0_i64);
 
 // Shared implementation for variants of Binary type
 macro_rules! make_plain_binary_impl {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/datafusion-comet/issues/557

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Parquet decoding when converting between different integral types was using `copy_nonoverlapping` without meeting the precondition that both pointers were properly aligned.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Rewrite without using `copy_nonoverlapping`
- Added unit tests in Rust

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

- New tests in Rust
- Existing tests in Scala
