### PR TITLE
chore: Use in_list func directly

### DIFF
--- a/core/src/execution/datafusion/planner.rs
+++ b/core/src/execution/datafusion/planner.rs
@@ -29,8 +29,8 @@ use datafusion::{
         execution_props::ExecutionProps,
         expressions::{
             in_list, BinaryExpr, BitAnd, BitOr, BitXor, CaseExpr, CastExpr, Column, Count,
-            FirstValue, InListExpr, IsNotNullExpr, IsNullExpr, LastValue,
-            Literal as DataFusionLiteral, Max, Min, NotExpr, Sum,
+            FirstValue, IsNotNullExpr, IsNullExpr, LastValue, Literal as DataFusionLiteral, Max,
+            Min, NotExpr, Sum,
         },
         AggregateExpr, PhysicalExpr, PhysicalSortExpr, ScalarFunctionExpr,
     },
@@ -544,18 +544,7 @@ impl PhysicalPlanner {
                     .map(|x| self.create_expr(x, input_schema.clone()))
                     .collect::<Result<Vec<_>, _>>()?;
 
-                // if schema contains any dictionary type, we should use InListExpr instead of
-                // in_list as it doesn't handle value being dictionary type correctly
-                let contains_dict_type = input_schema
-                    .fields()
-                    .iter()
-                    .any(|f| matches!(f.data_type(), DataType::Dictionary(_, _)));
-                if contains_dict_type {
-                    // TODO: remove the fallback when https://github.com/apache/arrow-datafusion/issues/9530 is fixed
-                    Ok(Arc::new(InListExpr::new(value, list, expr.negated, None)))
-                } else {
-                    in_list(value, list, &expr.negated, input_schema.as_ref()).map_err(|e| e.into())
-                }
+                in_list(value, list, &expr.negated, input_schema.as_ref()).map_err(|e| e.into())
             }
             ExprStruct::If(expr) => {
                 let if_expr =


### PR DESCRIPTION
## Which issue does this PR close?
Followup on #184.

## Rationale for this change
Since the [improvement](https://github.com/apache/arrow-datafusion/issues/9530) in DataFusion has been released, we can  remove the special check in Comet.

## What changes are included in this PR?
Remove special check for dictionary type in `in_list` expression 

## How are these changes tested?
Existing test.
