### PR TITLE
perf: Add criterion benchmark for xxhash64 function

### DIFF
--- a/core/benches/hash.rs
+++ b/core/benches/hash.rs
@@ -112,7 +112,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.bench_function(BenchmarkId::new("murmur3", BATCH_SIZE), |b| {
         let inputs = &[
             ColumnarValue::Array(a3.clone()),
-            ColumnarValue::Array(a3.clone()),
+            ColumnarValue::Array(a4.clone()),
             ColumnarValue::Scalar(ScalarValue::Int32(Some(42))),
         ];
         b.iter(|| {

--- a/core/benches/hash.rs
+++ b/core/benches/hash.rs
@@ -24,6 +24,9 @@ use comet::execution::kernels::hash;
 use common::*;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use std::sync::Arc;
+use datafusion_common::ScalarValue;
+use datafusion_expr::ColumnarValue;
+use comet::execution::datafusion::expressions::scalar_funcs::spark_murmur3_hash;
 
 const BATCH_SIZE: usize = 1024 * 8;
 const NUM_ITER: usize = 10;
@@ -103,6 +106,14 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             for _ in 0..NUM_ITER {
                 create_xxhash64_hashes(&input, &mut dst).unwrap();
+            }
+        });
+    });
+    group.bench_function(BenchmarkId::new("murmur3", BATCH_SIZE), |b| {
+        let inputs = &[ColumnarValue::Array(a3.clone()), ColumnarValue::Array(a3.clone()), ColumnarValue::Scalar(ScalarValue::Int32(Some(42)))];
+        b.iter(|| {
+            for _ in 0..NUM_ITER {
+                spark_murmur3_hash(inputs).unwrap();
             }
         });
     });

--- a/core/benches/hash.rs
+++ b/core/benches/hash.rs
@@ -19,6 +19,7 @@
 mod common;
 
 use arrow_array::ArrayRef;
+use comet::execution::datafusion::spark_hash::create_xxhash64_hashes;
 use comet::execution::kernels::hash;
 use common::*;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
@@ -95,6 +96,16 @@ fn criterion_benchmark(c: &mut Criterion) {
             });
         },
     );
+    group.bench_function(BenchmarkId::new("xxhash64", BATCH_SIZE), |b| {
+        let input = vec![a3.clone(), a4.clone()];
+        let mut dst = vec![0; BATCH_SIZE];
+
+        b.iter(|| {
+            for _ in 0..NUM_ITER {
+                create_xxhash64_hashes(&input, &mut dst).unwrap();
+            }
+        });
+    });
 }
 
 fn config() -> Criterion {

--- a/core/benches/hash.rs
+++ b/core/benches/hash.rs
@@ -19,14 +19,14 @@
 mod common;
 
 use arrow_array::ArrayRef;
+use comet::execution::datafusion::expressions::scalar_funcs::spark_murmur3_hash;
 use comet::execution::datafusion::spark_hash::create_xxhash64_hashes;
 use comet::execution::kernels::hash;
 use common::*;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use std::sync::Arc;
 use datafusion_common::ScalarValue;
 use datafusion_expr::ColumnarValue;
-use comet::execution::datafusion::expressions::scalar_funcs::spark_murmur3_hash;
+use std::sync::Arc;
 
 const BATCH_SIZE: usize = 1024 * 8;
 const NUM_ITER: usize = 10;
@@ -110,7 +110,11 @@ fn criterion_benchmark(c: &mut Criterion) {
         });
     });
     group.bench_function(BenchmarkId::new("murmur3", BATCH_SIZE), |b| {
-        let inputs = &[ColumnarValue::Array(a3.clone()), ColumnarValue::Array(a3.clone()), ColumnarValue::Scalar(ScalarValue::Int32(Some(42)))];
+        let inputs = &[
+            ColumnarValue::Array(a3.clone()),
+            ColumnarValue::Array(a3.clone()),
+            ColumnarValue::Scalar(ScalarValue::Int32(Some(42))),
+        ];
         b.iter(|| {
             for _ in 0..NUM_ITER {
                 spark_murmur3_hash(inputs).unwrap();

--- a/core/src/execution/datafusion/expressions/scalar_funcs.rs
+++ b/core/src/execution/datafusion/expressions/scalar_funcs.rs
@@ -636,7 +636,7 @@ fn spark_decimal_div(
     Ok(ColumnarValue::Array(Arc::new(result)))
 }
 
-fn spark_murmur3_hash(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
+pub fn spark_murmur3_hash(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
     let length = args.len();
     let seed = &args[length - 1];
     match seed {

--- a/core/src/execution/datafusion/mod.rs
+++ b/core/src/execution/datafusion/mod.rs
@@ -21,5 +21,5 @@ pub mod expressions;
 mod operators;
 pub mod planner;
 pub mod shuffle_writer;
-mod spark_hash;
+pub mod spark_hash;
 mod util;

--- a/core/src/execution/datafusion/spark_hash.rs
+++ b/core/src/execution/datafusion/spark_hash.rs
@@ -35,12 +35,6 @@ use datafusion::{
     error::{DataFusionError, Result},
 };
 
-const PRIME64_1: u64 = 0x9E3779B185EBCA87;
-const PRIME64_2: u64 = 0xC2B2AE3D27D4EB4F;
-const PRIME64_3: u64 = 0x165667B19E3779F9;
-const PRIME64_4: u64 = 0x85EBCA77C2B2AE63;
-const PRIME64_5: u64 = 0x27D4EB2F165667C5;
-
 #[inline]
 pub(crate) fn spark_compatible_murmur3_hash<T: AsRef<[u8]>>(data: T, seed: u32) -> u32 {
     #[inline]

--- a/core/src/execution/datafusion/spark_hash.rs
+++ b/core/src/execution/datafusion/spark_hash.rs
@@ -35,6 +35,12 @@ use datafusion::{
     error::{DataFusionError, Result},
 };
 
+const PRIME64_1: u64 = 0x9E3779B185EBCA87;
+const PRIME64_2: u64 = 0xC2B2AE3D27D4EB4F;
+const PRIME64_3: u64 = 0x165667B19E3779F9;
+const PRIME64_4: u64 = 0x85EBCA77C2B2AE63;
+const PRIME64_5: u64 = 0x27D4EB2F165667C5;
+
 #[inline]
 pub(crate) fn spark_compatible_murmur3_hash<T: AsRef<[u8]>>(data: T, seed: u32) -> u32 {
     #[inline]
@@ -481,7 +487,7 @@ pub(crate) fn create_murmur3_hashes<'a>(
 ///
 /// The number of rows to hash is determined by `hashes_buffer.len()`.
 /// `hashes_buffer` should be pre-sized appropriately
-pub(crate) fn create_xxhash64_hashes<'a>(
+pub fn create_xxhash64_hashes<'a>(
     arrays: &[ArrayRef],
     hashes_buffer: &'a mut [u64],
 ) -> Result<&'a mut [u64]> {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/apache/datafusion-comet/issues/547

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We suspect that we may have a performance issue in xxhash64, so the first step is to add a benchmark to evaluate current performance.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

New criterion benchmark

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->


Here are the results from Apple M3 Max.

```
hash/xxhash64/8192      time:   [891.80 µs 893.20 µs 895.25 µs]
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  6 (6.00%) high severe
```