### PR TITLE
fix: Running cargo build always triggers rebuild

### DIFF
--- a/core/build.rs
+++ b/core/build.rs
@@ -20,7 +20,7 @@
 use std::{fs, io::Result, path::Path};
 
 fn main() -> Result<()> {
-    println!("cargo:rerun-if-changed=src/execution/proto/*.proto");
+    println!("cargo:rerun-if-changed=src/execution/proto/");
 
     let out_dir = "src/execution/generated";
     if !Path::new(out_dir).is_dir() {


### PR DESCRIPTION
I don't think rerun-if-changed supports globs https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed but according to the docs passing a directory should work.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #578.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Quicker build in many cases.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Fixes our build.rs build script to only rebuild when there is actual changes in the proto files.

## How are these changes tested?
Running `make core` manually.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
