### PR TITLE
refactor: Remove method get_global_jclass

### DIFF
--- a/core/src/jvm_bridge/batch_iterator.rs
+++ b/core/src/jvm_bridge/batch_iterator.rs
@@ -33,7 +33,6 @@ impl<'a> CometBatchIterator<'a> {
     pub const JVM_CLASS: &'static str = "org/apache/comet/CometBatchIterator";
 
     pub fn new(env: &mut JNIEnv<'a>) -> JniResult<CometBatchIterator<'a>> {
-        // Get the global class reference
         let class = env.find_class(Self::JVM_CLASS)?;
 
         Ok(CometBatchIterator {

--- a/core/src/jvm_bridge/batch_iterator.rs
+++ b/core/src/jvm_bridge/batch_iterator.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use super::get_global_jclass;
 use jni::{
     errors::Result as JniResult,
     objects::{JClass, JMethodID},
@@ -35,7 +34,7 @@ impl<'a> CometBatchIterator<'a> {
 
     pub fn new(env: &mut JNIEnv<'a>) -> JniResult<CometBatchIterator<'a>> {
         // Get the global class reference
-        let class = get_global_jclass(env, Self::JVM_CLASS)?;
+        let class = env.find_class(Self::JVM_CLASS)?;
 
         Ok(CometBatchIterator {
             class,

--- a/core/src/jvm_bridge/comet_exec.rs
+++ b/core/src/jvm_bridge/comet_exec.rs
@@ -53,7 +53,6 @@ impl<'a> CometExec<'a> {
     pub const JVM_CLASS: &'static str = "org/apache/spark/sql/comet/CometScalarSubquery";
 
     pub fn new(env: &mut JNIEnv<'a>) -> JniResult<CometExec<'a>> {
-        // Get the global class reference
         let class = env.find_class(Self::JVM_CLASS)?;
 
         Ok(CometExec {

--- a/core/src/jvm_bridge/comet_exec.rs
+++ b/core/src/jvm_bridge/comet_exec.rs
@@ -22,8 +22,6 @@ use jni::{
     JNIEnv,
 };
 
-use super::get_global_jclass;
-
 /// A struct that holds all the JNI methods and fields for JVM CometExec object.
 pub struct CometExec<'a> {
     pub class: JClass<'a>,
@@ -56,7 +54,7 @@ impl<'a> CometExec<'a> {
 
     pub fn new(env: &mut JNIEnv<'a>) -> JniResult<CometExec<'a>> {
         // Get the global class reference
-        let class = get_global_jclass(env, Self::JVM_CLASS)?;
+        let class = env.find_class(Self::JVM_CLASS)?;
 
         Ok(CometExec {
             method_get_bool: env

--- a/core/src/jvm_bridge/comet_metric_node.rs
+++ b/core/src/jvm_bridge/comet_metric_node.rs
@@ -22,8 +22,6 @@ use jni::{
     JNIEnv,
 };
 
-use super::get_global_jclass;
-
 /// A struct that holds all the JNI methods and fields for JVM CometMetricNode class.
 pub struct CometMetricNode<'a> {
     pub class: JClass<'a>,
@@ -38,7 +36,7 @@ impl<'a> CometMetricNode<'a> {
 
     pub fn new(env: &mut JNIEnv<'a>) -> JniResult<CometMetricNode<'a>> {
         // Get the global class reference
-        let class = get_global_jclass(env, Self::JVM_CLASS)?;
+        let class = env.find_class(Self::JVM_CLASS)?;
 
         Ok(CometMetricNode {
             method_get_child_node: env

--- a/core/src/jvm_bridge/comet_metric_node.rs
+++ b/core/src/jvm_bridge/comet_metric_node.rs
@@ -35,7 +35,6 @@ impl<'a> CometMetricNode<'a> {
     pub const JVM_CLASS: &'static str = "org/apache/spark/sql/comet/CometMetricNode";
 
     pub fn new(env: &mut JNIEnv<'a>) -> JniResult<CometMetricNode<'a>> {
-        // Get the global class reference
         let class = env.find_class(Self::JVM_CLASS)?;
 
         Ok(CometMetricNode {

--- a/core/src/jvm_bridge/comet_task_memory_manager.rs
+++ b/core/src/jvm_bridge/comet_task_memory_manager.rs
@@ -22,8 +22,6 @@ use jni::{
     JNIEnv,
 };
 
-use crate::jvm_bridge::get_global_jclass;
-
 /// A wrapper which delegate acquire/release memory calls to the
 /// JVM side `CometTaskMemoryManager`.
 #[derive(Debug)]
@@ -40,7 +38,7 @@ impl<'a> CometTaskMemoryManager<'a> {
     pub const JVM_CLASS: &'static str = "org/apache/spark/CometTaskMemoryManager";
 
     pub fn new(env: &mut JNIEnv<'a>) -> JniResult<CometTaskMemoryManager<'a>> {
-        let class = get_global_jclass(env, Self::JVM_CLASS)?;
+        let class = env.find_class(Self::JVM_CLASS)?;
 
         let result = CometTaskMemoryManager {
             class,

--- a/core/src/jvm_bridge/mod.rs
+++ b/core/src/jvm_bridge/mod.rs
@@ -20,8 +20,8 @@
 use crate::errors::CometResult;
 
 use jni::{
-    errors::{Error, Result as JniResult},
-    objects::{JClass, JMethodID, JObject, JString, JThrowable, JValueGen, JValueOwned},
+    errors::Error,
+    objects::{JMethodID, JObject, JString, JThrowable, JValueGen, JValueOwned},
     signature::ReturnType,
     AttachGuard, JNIEnv,
 };
@@ -175,20 +175,6 @@ pub(crate) use jni_new_global_ref;
 pub(crate) use jni_new_string;
 pub(crate) use jni_static_call;
 pub(crate) use jvalues;
-
-/// Gets a global reference to a Java class.
-pub fn get_global_jclass(env: &mut JNIEnv, cls: &str) -> JniResult<JClass<'static>> {
-    let local_jclass = env.find_class(cls)?;
-    let global = env.new_global_ref::<JObject>(local_jclass.into())?;
-
-    // A hack to make the `JObject` static. This is safe because the global reference is never
-    // gc-ed by the JVM before dropping the global reference.
-    let global_obj = unsafe { std::mem::transmute::<_, JObject<'static>>(global.as_obj()) };
-    // Prevent the global reference from being dropped.
-    let _ = std::mem::ManuallyDrop::new(global);
-
-    Ok(JClass::from(global_obj))
-}
 
 mod comet_exec;
 pub use comet_exec::*;


### PR DESCRIPTION
The method uses unsafe code to cast a value to a static lifetime using `std::mem::transmute`. But none of users of the method actually seems to depend on this lifetime extention. So to me it seems better to just call the underlying `find_class` method and delete the unsafe code.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

We needed to change this code in https://github.com/apache/datafusion-comet/pull/570 when upgrading to rust 1.79 and that highlights that usage of transmute is fishy.

## Rationale for this change

Less code and less unsafe which makes it easier to check and understand that the code is correct.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

Removed the method `get_global_jclass`. All users could be changed to use the underlying method `find_class` without further changes.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?
Existing tests.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
