### PR TITLE
minor: replace .downcast_ref::<T>().is_some() with .is::<T>()

### DIFF
--- a/core/src/execution/datafusion/planner.rs
+++ b/core/src/execution/datafusion/planner.rs
@@ -907,7 +907,7 @@ impl PhysicalPlanner {
                 // the data corruption. Note that we only need to copy the input batch
                 // if the child operator is `ScanExec`, because other operators after `ScanExec`
                 // will create new arrays for the output batch.
-                let child = if child.as_any().downcast_ref::<ScanExec>().is_some() {
+                let child = if child.as_any().is::<ScanExec>() {
                     Arc::new(CopyExec::new(child))
                 } else {
                     child
@@ -1600,10 +1600,10 @@ impl From<ExpressionError> for DataFusionError {
 /// modification. This is used to determine if we need to copy the input batch to avoid
 /// data corruption from reusing the input batch.
 fn can_reuse_input_batch(op: &Arc<dyn ExecutionPlan>) -> bool {
-    op.as_any().downcast_ref::<ScanExec>().is_some()
-        || op.as_any().downcast_ref::<LocalLimitExec>().is_some()
-        || op.as_any().downcast_ref::<ProjectionExec>().is_some()
-        || op.as_any().downcast_ref::<FilterExec>().is_some()
+    op.as_any().is::<ScanExec>()
+        || op.as_any().is::<LocalLimitExec>()
+        || op.as_any().is::<ProjectionExec>()
+        || op.as_any().is::<FilterExec>()
 }
 
 /// Collects the indices of the columns in the input schema that are used in the expression


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Minor code cleanup. We can check the type of an `Any` using `is::<T>()` instead of actually attempting to perform the downcast first.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests.