### PR TITLE
chore: Refactoring of CometError/SparkError

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -914,6 +914,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-functions",
  "datafusion-physical-expr",
+ "thiserror",
 ]
 
 [[package]]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -48,6 +48,7 @@ datafusion-physical-expr-common = { git = "https://github.com/apache/datafusion.
 datafusion-physical-expr = { git = "https://github.com/apache/datafusion.git", rev = "40.0.0-rc1", default-features = false }
 datafusion-comet-spark-expr = { path = "spark-expr", version = "0.1.0" }
 datafusion-comet-utils = { path = "utils", version = "0.1.0" }
+thiserror = "1"
 
 [profile.release]
 debug = true

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -48,7 +48,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 async-trait = "0.1"
 log = "0.4"
 log4rs = "1.2.0"
-thiserror = "1"
+thiserror = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 lazy_static = "1.4.0"
 prost = "0.12.1"

--- a/native/core/src/execution/datafusion/expressions/mod.rs
+++ b/native/core/src/execution/datafusion/expressions/mod.rs
@@ -43,10 +43,10 @@ mod utils;
 pub mod variance;
 pub mod xxhash64;
 
-pub use datafusion_comet_spark_expr::EvalMode;
+pub use datafusion_comet_spark_expr::{EvalMode, SparkError};
 
 fn arithmetic_overflow_error(from_type: &str) -> CometError {
-    CometError::ArithmeticOverflow {
+    CometError::Spark(SparkError::ArithmeticOverflow {
         from_type: from_type.to_string(),
-    }
+    })
 }

--- a/native/core/src/execution/datafusion/expressions/negative.rs
+++ b/native/core/src/execution/datafusion/expressions/negative.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use super::arithmetic_overflow_error;
 use crate::errors::CometError;
 use arrow::{compute::kernels::numeric::neg_wrapping, datatypes::IntervalDayTimeType};
 use arrow_array::RecordBatch;
@@ -24,6 +25,7 @@ use datafusion::{
     logical_expr::{interval_arithmetic::Interval, ColumnarValue},
     physical_expr::PhysicalExpr,
 };
+use datafusion_comet_spark_expr::SparkError;
 use datafusion_common::{Result, ScalarValue};
 use datafusion_expr::sort_properties::ExprProperties;
 use datafusion_physical_expr::aggregate::utils::down_cast_any_ref;
@@ -32,8 +34,6 @@ use std::{
     hash::{Hash, Hasher},
     sync::Arc,
 };
-
-use super::arithmetic_overflow_error;
 
 pub fn create_negate_expr(
     expr: Arc<dyn PhysicalExpr>,
@@ -234,7 +234,7 @@ impl PhysicalExpr for NegativeExpr {
             || child_interval.lower() == &ScalarValue::Int64(Some(i64::MIN))
             || child_interval.upper() == &ScalarValue::Int64(Some(i64::MIN))
         {
-            return Err(CometError::ArithmeticOverflow {
+            return Err(SparkError::ArithmeticOverflow {
                 from_type: "long".to_string(),
             }
             .into());

--- a/native/spark-expr/Cargo.toml
+++ b/native/spark-expr/Cargo.toml
@@ -34,6 +34,7 @@ datafusion-common = { workspace = true }
 datafusion-functions = { workspace = true }
 datafusion-physical-expr = { workspace = true }
 datafusion-comet-utils = { workspace = true }
+thiserror = { workspace = true }
 
 [lib]
 name = "datafusion_comet_spark_expr"

--- a/native/spark-expr/src/abs.rs
+++ b/native/spark-expr/src/abs.rs
@@ -77,11 +77,10 @@ impl ScalarUDFImpl for Abs {
                 if self.eval_mode == EvalMode::Legacy {
                     Ok(args[0].clone())
                 } else {
-                    Err(DataFusionError::External(Box::new(
-                        SparkError::ArithmeticOverflow {
-                            from_type: self.data_type_name.clone(),
-                        },
-                    )))
+                    Err(SparkError::ArithmeticOverflow {
+                        from_type: self.data_type_name.clone(),
+                    }
+                    .into())
                 }
             }
             other => other,

--- a/native/spark-expr/src/abs.rs
+++ b/native/spark-expr/src/abs.rs
@@ -78,7 +78,9 @@ impl ScalarUDFImpl for Abs {
                     Ok(args[0].clone())
                 } else {
                     Err(DataFusionError::External(Box::new(
-                        SparkError::ArithmeticOverflow(self.data_type_name.clone()),
+                        SparkError::ArithmeticOverflow {
+                            from_type: self.data_type_name.clone(),
+                        },
                     )))
                 }
             }

--- a/native/spark-expr/src/error.rs
+++ b/native/spark-expr/src/error.rs
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use arrow_schema::ArrowError;
+use datafusion_common::DataFusionError;
+
+#[derive(Debug)]
+pub enum SparkError {
+    ArithmeticOverflow(String),
+    CastInvalidValue {
+        value: String,
+        from_type: String,
+        to_type: String,
+    },
+    CastOverFlow {
+        value: String,
+        from_type: String,
+        to_type: String,
+    },
+    NumericValueOutOfRange {
+        value: String,
+        precision: u8,
+        scale: i8,
+    },
+    Arrow(ArrowError),
+    Internal(String)
+}
+
+pub type SparkResult<T> = Result<T, SparkError>;
+
+impl From<ArrowError> for SparkError {
+    fn from(value: ArrowError) -> Self {
+        SparkError::Arrow(value)
+    }
+}
+
+impl From<SparkError> for DataFusionError    {
+    fn from(value: SparkError) -> Self {
+        DataFusionError::External(Box::new(value))
+    }
+}
+
+impl Error for SparkError {}
+
+impl Display for SparkError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ArithmeticOverflow(data_type) =>
+                write!(f, "[ARITHMETIC_OVERFLOW] {} overflow. If necessary set \"spark.sql.ansi.enabled\" to \"false\" to bypass this error.", data_type),
+            Self::CastOverFlow { value, from_type, to_type } => write!(f, "[CAST_OVERFLOW] The value {value} of the type \"{from_type}\" cannot be cast to \"{to_type}\" \
+       due to an overflow. Use `try_cast` to tolerate overflow and return NULL instead. If necessary \
+       set \"spark.sql.ansi.enabled\" to \"false\" to bypass this error."),
+            Self::CastInvalidValue { value, from_type, to_type } => write!(f, "[CAST_INVALID_INPUT] The value '{value}' of the type \"{from_type}\" cannot be cast to \"{to_type}\" \
+       because it is malformed. Correct the value as per the syntax, or change its target type. \
+       Use `try_cast` to tolerate malformed input and return NULL instead. If necessary \
+       set \"spark.sql.ansi.enabled\" to \"false\" to bypass this error."),
+            Self::NumericValueOutOfRange { value, precision, scale } => write!(f, "[NUMERIC_VALUE_OUT_OF_RANGE] {value} cannot be represented as Decimal({precision}, {scale}). If necessary set \"spark.sql.ansi.enabled\" to \"false\" to bypass this error, and return NULL instead."),
+            Self::Arrow(e) => write!(f, "ArrowError: {e}"),
+            Self::Internal(e) => write!(f, "{e}"),
+        }
+    }
+}

--- a/native/spark-expr/src/lib.rs
+++ b/native/spark-expr/src/lib.rs
@@ -15,14 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::error::Error;
-use std::fmt::{Display, Formatter};
-
 mod abs;
+mod error;
 mod if_expr;
 
 pub use abs::Abs;
 pub use if_expr::IfExpr;
+pub use error::{SparkError, SparkResult};
 
 /// Spark supports three evaluation modes when evaluating expressions, which affect
 /// the behavior when processing input values that are invalid or would result in an
@@ -43,18 +42,3 @@ pub enum EvalMode {
     Try,
 }
 
-#[derive(Debug)]
-pub enum SparkError {
-    ArithmeticOverflow(String),
-}
-
-impl Error for SparkError {}
-
-impl Display for SparkError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::ArithmeticOverflow(data_type) =>
-                write!(f, "[ARITHMETIC_OVERFLOW] {} overflow. If necessary set \"spark.sql.ansi.enabled\" to \"false\" to bypass this error.", data_type)
-        }
-    }
-}

--- a/native/spark-expr/src/lib.rs
+++ b/native/spark-expr/src/lib.rs
@@ -20,8 +20,8 @@ mod error;
 mod if_expr;
 
 pub use abs::Abs;
-pub use if_expr::IfExpr;
 pub use error::{SparkError, SparkResult};
+pub use if_expr::IfExpr;
 
 /// Spark supports three evaluation modes when evaluating expressions, which affect
 /// the behavior when processing input values that are invalid or would result in an
@@ -41,4 +41,3 @@ pub enum EvalMode {
     /// failing the entire query.
     Try,
 }
-


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/datafusion-comet/issues/630

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

These changes are extracted from the larger WIP PR https://github.com/apache/datafusion-comet/pull/654 and are a first step to being able to move the `cast` expression to the new `spark-expr` crate.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Move `SparkError` into its own source file
- Move variants `ArithmeticOverflow`, `CastInvalidValue`, `CastOverFlow`, and `NumericValueOutOfRange` from `CometError` to `SparkError`
- Add new `CometError::Spark(SparkError)` variant

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests
