### PR TITLE
chore: Change suffix on some expressions from Exec to Expr

### DIFF
--- a/native/core/src/execution/datafusion/expressions/strings.rs
+++ b/native/core/src/execution/datafusion/expressions/strings.rs
@@ -146,30 +146,30 @@ make_predicate_function!(Contains, contains_dyn, contains_utf8_scalar_dyn);
 // make_predicate_function!(RLike, rlike_dyn, rlike_utf8_scalar_dyn);
 
 #[derive(Debug, Hash)]
-pub struct SubstringExec {
+pub struct SubstringExpr {
     pub child: Arc<dyn PhysicalExpr>,
     pub start: i64,
     pub len: u64,
 }
 
 #[derive(Debug, Hash)]
-pub struct StringSpaceExec {
+pub struct StringSpaceExpr {
     pub child: Arc<dyn PhysicalExpr>,
 }
 
-impl SubstringExec {
+impl SubstringExpr {
     pub fn new(child: Arc<dyn PhysicalExpr>, start: i64, len: u64) -> Self {
         Self { child, start, len }
     }
 }
 
-impl StringSpaceExec {
+impl StringSpaceExpr {
     pub fn new(child: Arc<dyn PhysicalExpr>) -> Self {
         Self { child }
     }
 }
 
-impl Display for SubstringExec {
+impl Display for SubstringExpr {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -179,13 +179,13 @@ impl Display for SubstringExec {
     }
 }
 
-impl Display for StringSpaceExec {
+impl Display for StringSpaceExpr {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "StringSpace [child: {}] ", self.child)
     }
 }
 
-impl PartialEq<dyn Any> for SubstringExec {
+impl PartialEq<dyn Any> for SubstringExpr {
     fn eq(&self, other: &dyn Any) -> bool {
         down_cast_any_ref(other)
             .downcast_ref::<Self>()
@@ -194,7 +194,7 @@ impl PartialEq<dyn Any> for SubstringExec {
     }
 }
 
-impl PhysicalExpr for SubstringExec {
+impl PhysicalExpr for SubstringExpr {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -229,7 +229,7 @@ impl PhysicalExpr for SubstringExec {
         self: Arc<Self>,
         children: Vec<Arc<dyn PhysicalExpr>>,
     ) -> datafusion_common::Result<Arc<dyn PhysicalExpr>> {
-        Ok(Arc::new(SubstringExec::new(
+        Ok(Arc::new(SubstringExpr::new(
             children[0].clone(),
             self.start,
             self.len,
@@ -245,7 +245,7 @@ impl PhysicalExpr for SubstringExec {
     }
 }
 
-impl PartialEq<dyn Any> for StringSpaceExec {
+impl PartialEq<dyn Any> for StringSpaceExpr {
     fn eq(&self, other: &dyn Any) -> bool {
         down_cast_any_ref(other)
             .downcast_ref::<Self>()
@@ -254,7 +254,7 @@ impl PartialEq<dyn Any> for StringSpaceExec {
     }
 }
 
-impl PhysicalExpr for StringSpaceExec {
+impl PhysicalExpr for StringSpaceExpr {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -294,7 +294,7 @@ impl PhysicalExpr for StringSpaceExec {
         self: Arc<Self>,
         children: Vec<Arc<dyn PhysicalExpr>>,
     ) -> datafusion_common::Result<Arc<dyn PhysicalExpr>> {
-        Ok(Arc::new(StringSpaceExec::new(children[0].clone())))
+        Ok(Arc::new(StringSpaceExpr::new(children[0].clone())))
     }
 
     fn dyn_hash(&self, state: &mut dyn Hasher) {

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -79,7 +79,7 @@ use crate::{
                 scalar_funcs::create_comet_physical_fun,
                 stats::StatsType,
                 stddev::Stddev,
-                strings::{Contains, EndsWith, Like, StartsWith, StringSpaceExec, SubstringExec},
+                strings::{Contains, EndsWith, Like, StartsWith, StringSpaceExpr, SubstringExpr},
                 subquery::Subquery,
                 sum_decimal::SumDecimal,
                 unbound::UnboundColumn,
@@ -108,7 +108,7 @@ use datafusion_comet_proto::{
     spark_partitioning::{partitioning::PartitioningStruct, Partitioning as SparkPartitioning},
 };
 use datafusion_comet_spark_expr::{
-    Abs, Cast, DateTruncExec, HourExec, IfExpr, MinuteExec, SecondExec, TimestampTruncExec,
+    Abs, Cast, DateTruncExpr, HourExpr, IfExpr, MinuteExpr, SecondExpr, TimestampTruncExpr,
 };
 
 // For clippy error on type_complexity.
@@ -378,32 +378,32 @@ impl PhysicalPlanner {
                 let child = self.create_expr(expr.child.as_ref().unwrap(), input_schema)?;
                 let timezone = expr.timezone.clone();
 
-                Ok(Arc::new(HourExec::new(child, timezone)))
+                Ok(Arc::new(HourExpr::new(child, timezone)))
             }
             ExprStruct::Minute(expr) => {
                 let child = self.create_expr(expr.child.as_ref().unwrap(), input_schema)?;
                 let timezone = expr.timezone.clone();
 
-                Ok(Arc::new(MinuteExec::new(child, timezone)))
+                Ok(Arc::new(MinuteExpr::new(child, timezone)))
             }
             ExprStruct::Second(expr) => {
                 let child = self.create_expr(expr.child.as_ref().unwrap(), input_schema)?;
                 let timezone = expr.timezone.clone();
 
-                Ok(Arc::new(SecondExec::new(child, timezone)))
+                Ok(Arc::new(SecondExpr::new(child, timezone)))
             }
             ExprStruct::TruncDate(expr) => {
                 let child = self.create_expr(expr.child.as_ref().unwrap(), input_schema.clone())?;
                 let format = self.create_expr(expr.format.as_ref().unwrap(), input_schema)?;
 
-                Ok(Arc::new(DateTruncExec::new(child, format)))
+                Ok(Arc::new(DateTruncExpr::new(child, format)))
             }
             ExprStruct::TruncTimestamp(expr) => {
                 let child = self.create_expr(expr.child.as_ref().unwrap(), input_schema.clone())?;
                 let format = self.create_expr(expr.format.as_ref().unwrap(), input_schema)?;
                 let timezone = expr.timezone.clone();
 
-                Ok(Arc::new(TimestampTruncExec::new(child, format, timezone)))
+                Ok(Arc::new(TimestampTruncExpr::new(child, format, timezone)))
             }
             ExprStruct::Substring(expr) => {
                 let child = self.create_expr(expr.child.as_ref().unwrap(), input_schema)?;
@@ -412,7 +412,7 @@ impl PhysicalPlanner {
                 // substring negative len is treated as 0 in Spark
                 let len = std::cmp::max(expr.len, 0);
 
-                Ok(Arc::new(SubstringExec::new(
+                Ok(Arc::new(SubstringExpr::new(
                     child,
                     start as i64,
                     len as u64,
@@ -421,7 +421,7 @@ impl PhysicalPlanner {
             ExprStruct::StringSpace(expr) => {
                 let child = self.create_expr(expr.child.as_ref().unwrap(), input_schema)?;
 
-                Ok(Arc::new(StringSpaceExec::new(child)))
+                Ok(Arc::new(StringSpaceExpr::new(child)))
             }
             ExprStruct::Contains(expr) => {
                 let left = self.create_expr(expr.left.as_ref().unwrap(), input_schema.clone())?;

--- a/native/spark-expr/src/lib.rs
+++ b/native/spark-expr/src/lib.rs
@@ -29,7 +29,7 @@ pub use abs::Abs;
 pub use cast::Cast;
 pub use error::{SparkError, SparkResult};
 pub use if_expr::IfExpr;
-pub use temporal::{DateTruncExec, HourExec, MinuteExec, SecondExec, TimestampTruncExec};
+pub use temporal::{DateTruncExpr, HourExpr, MinuteExpr, SecondExpr, TimestampTruncExpr};
 
 /// Spark supports three evaluation modes when evaluating expressions, which affect
 /// the behavior when processing input values that are invalid or would result in an

--- a/native/spark-expr/src/temporal.rs
+++ b/native/spark-expr/src/temporal.rs
@@ -38,19 +38,19 @@ use crate::kernels::temporal::{
 };
 
 #[derive(Debug, Hash)]
-pub struct HourExec {
+pub struct HourExpr {
     /// An array with DataType::Timestamp(TimeUnit::Microsecond, None)
     child: Arc<dyn PhysicalExpr>,
     timezone: String,
 }
 
-impl HourExec {
+impl HourExpr {
     pub fn new(child: Arc<dyn PhysicalExpr>, timezone: String) -> Self {
-        HourExec { child, timezone }
+        HourExpr { child, timezone }
     }
 }
 
-impl Display for HourExec {
+impl Display for HourExpr {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -60,7 +60,7 @@ impl Display for HourExec {
     }
 }
 
-impl PartialEq<dyn Any> for HourExec {
+impl PartialEq<dyn Any> for HourExpr {
     fn eq(&self, other: &dyn Any) -> bool {
         down_cast_any_ref(other)
             .downcast_ref::<Self>()
@@ -69,7 +69,7 @@ impl PartialEq<dyn Any> for HourExec {
     }
 }
 
-impl PhysicalExpr for HourExec {
+impl PhysicalExpr for HourExpr {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -117,7 +117,7 @@ impl PhysicalExpr for HourExec {
         self: Arc<Self>,
         children: Vec<Arc<dyn PhysicalExpr>>,
     ) -> Result<Arc<dyn PhysicalExpr>, DataFusionError> {
-        Ok(Arc::new(HourExec::new(
+        Ok(Arc::new(HourExpr::new(
             children[0].clone(),
             self.timezone.clone(),
         )))
@@ -132,19 +132,19 @@ impl PhysicalExpr for HourExec {
 }
 
 #[derive(Debug, Hash)]
-pub struct MinuteExec {
+pub struct MinuteExpr {
     /// An array with DataType::Timestamp(TimeUnit::Microsecond, None)
     child: Arc<dyn PhysicalExpr>,
     timezone: String,
 }
 
-impl MinuteExec {
+impl MinuteExpr {
     pub fn new(child: Arc<dyn PhysicalExpr>, timezone: String) -> Self {
-        MinuteExec { child, timezone }
+        MinuteExpr { child, timezone }
     }
 }
 
-impl Display for MinuteExec {
+impl Display for MinuteExpr {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -154,7 +154,7 @@ impl Display for MinuteExec {
     }
 }
 
-impl PartialEq<dyn Any> for MinuteExec {
+impl PartialEq<dyn Any> for MinuteExpr {
     fn eq(&self, other: &dyn Any) -> bool {
         down_cast_any_ref(other)
             .downcast_ref::<Self>()
@@ -163,7 +163,7 @@ impl PartialEq<dyn Any> for MinuteExec {
     }
 }
 
-impl PhysicalExpr for MinuteExec {
+impl PhysicalExpr for MinuteExpr {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -211,7 +211,7 @@ impl PhysicalExpr for MinuteExec {
         self: Arc<Self>,
         children: Vec<Arc<dyn PhysicalExpr>>,
     ) -> Result<Arc<dyn PhysicalExpr>, DataFusionError> {
-        Ok(Arc::new(MinuteExec::new(
+        Ok(Arc::new(MinuteExpr::new(
             children[0].clone(),
             self.timezone.clone(),
         )))
@@ -226,19 +226,19 @@ impl PhysicalExpr for MinuteExec {
 }
 
 #[derive(Debug, Hash)]
-pub struct SecondExec {
+pub struct SecondExpr {
     /// An array with DataType::Timestamp(TimeUnit::Microsecond, None)
     child: Arc<dyn PhysicalExpr>,
     timezone: String,
 }
 
-impl SecondExec {
+impl SecondExpr {
     pub fn new(child: Arc<dyn PhysicalExpr>, timezone: String) -> Self {
-        SecondExec { child, timezone }
+        SecondExpr { child, timezone }
     }
 }
 
-impl Display for SecondExec {
+impl Display for SecondExpr {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -248,7 +248,7 @@ impl Display for SecondExec {
     }
 }
 
-impl PartialEq<dyn Any> for SecondExec {
+impl PartialEq<dyn Any> for SecondExpr {
     fn eq(&self, other: &dyn Any) -> bool {
         down_cast_any_ref(other)
             .downcast_ref::<Self>()
@@ -257,7 +257,7 @@ impl PartialEq<dyn Any> for SecondExec {
     }
 }
 
-impl PhysicalExpr for SecondExec {
+impl PhysicalExpr for SecondExpr {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -305,7 +305,7 @@ impl PhysicalExpr for SecondExec {
         self: Arc<Self>,
         children: Vec<Arc<dyn PhysicalExpr>>,
     ) -> Result<Arc<dyn PhysicalExpr>, DataFusionError> {
-        Ok(Arc::new(SecondExec::new(
+        Ok(Arc::new(SecondExpr::new(
             children[0].clone(),
             self.timezone.clone(),
         )))
@@ -320,20 +320,20 @@ impl PhysicalExpr for SecondExec {
 }
 
 #[derive(Debug, Hash)]
-pub struct DateTruncExec {
+pub struct DateTruncExpr {
     /// An array with DataType::Date32
     child: Arc<dyn PhysicalExpr>,
     /// Scalar UTF8 string matching the valid values in Spark SQL: https://spark.apache.org/docs/latest/api/sql/index.html#trunc
     format: Arc<dyn PhysicalExpr>,
 }
 
-impl DateTruncExec {
+impl DateTruncExpr {
     pub fn new(child: Arc<dyn PhysicalExpr>, format: Arc<dyn PhysicalExpr>) -> Self {
-        DateTruncExec { child, format }
+        DateTruncExpr { child, format }
     }
 }
 
-impl Display for DateTruncExec {
+impl Display for DateTruncExpr {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -343,7 +343,7 @@ impl Display for DateTruncExec {
     }
 }
 
-impl PartialEq<dyn Any> for DateTruncExec {
+impl PartialEq<dyn Any> for DateTruncExpr {
     fn eq(&self, other: &dyn Any) -> bool {
         down_cast_any_ref(other)
             .downcast_ref::<Self>()
@@ -352,7 +352,7 @@ impl PartialEq<dyn Any> for DateTruncExec {
     }
 }
 
-impl PhysicalExpr for DateTruncExec {
+impl PhysicalExpr for DateTruncExpr {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -392,7 +392,7 @@ impl PhysicalExpr for DateTruncExec {
         self: Arc<Self>,
         children: Vec<Arc<dyn PhysicalExpr>>,
     ) -> Result<Arc<dyn PhysicalExpr>, DataFusionError> {
-        Ok(Arc::new(DateTruncExec::new(
+        Ok(Arc::new(DateTruncExpr::new(
             children[0].clone(),
             self.format.clone(),
         )))
@@ -407,7 +407,7 @@ impl PhysicalExpr for DateTruncExec {
 }
 
 #[derive(Debug, Hash)]
-pub struct TimestampTruncExec {
+pub struct TimestampTruncExpr {
     /// An array with DataType::Timestamp(TimeUnit::Microsecond, None)
     child: Arc<dyn PhysicalExpr>,
     /// Scalar UTF8 string matching the valid values in Spark SQL: https://spark.apache.org/docs/latest/api/sql/index.html#date_trunc
@@ -421,13 +421,13 @@ pub struct TimestampTruncExec {
     timezone: String,
 }
 
-impl TimestampTruncExec {
+impl TimestampTruncExpr {
     pub fn new(
         child: Arc<dyn PhysicalExpr>,
         format: Arc<dyn PhysicalExpr>,
         timezone: String,
     ) -> Self {
-        TimestampTruncExec {
+        TimestampTruncExpr {
             child,
             format,
             timezone,
@@ -435,7 +435,7 @@ impl TimestampTruncExec {
     }
 }
 
-impl Display for TimestampTruncExec {
+impl Display for TimestampTruncExpr {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -445,7 +445,7 @@ impl Display for TimestampTruncExec {
     }
 }
 
-impl PartialEq<dyn Any> for TimestampTruncExec {
+impl PartialEq<dyn Any> for TimestampTruncExpr {
     fn eq(&self, other: &dyn Any) -> bool {
         down_cast_any_ref(other)
             .downcast_ref::<Self>()
@@ -458,7 +458,7 @@ impl PartialEq<dyn Any> for TimestampTruncExec {
     }
 }
 
-impl PhysicalExpr for TimestampTruncExec {
+impl PhysicalExpr for TimestampTruncExpr {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -517,7 +517,7 @@ impl PhysicalExpr for TimestampTruncExec {
         self: Arc<Self>,
         children: Vec<Arc<dyn PhysicalExpr>>,
     ) -> Result<Arc<dyn PhysicalExpr>, DataFusionError> {
-        Ok(Arc::new(TimestampTruncExec::new(
+        Ok(Arc::new(TimestampTruncExpr::new(
             children[0].clone(),
             self.format.clone(),
             self.timezone.clone(),


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

By convention, DataFusion uses a suffix of `Expr` for implementations of `PhysicalExpr`, and `Exec` for implementations of `ExecutionPlan`.

We currently have some expressions with a suffix of `Exec`, which may cause some confusion. I propose that we rename these before the 0.1.0 release, especially since we are providing a public API in the new `datafusion-comet-spark-expr` crate.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Just renaming some expressions.


## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
