### PR TITLE
build: Exclude protobug generated codes from apache-rat check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -961,6 +961,7 @@ under the License.
             <exclude>docs/*.txt</exclude>
             <exclude>dev/release/rat_exclude_files.txt</exclude>
             <exclude>dev/release/requirements.txt</exclude>
+            <exclude>native/core/src/execution/generated/**</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

After we changed native code path, I got this warning when building Comet locally:

```
[WARNING] Files with unapproved licenses:
  native/core/src/execution/generated/spark.spark_operator.rs
  native/core/src/execution/generated/spark.spark_partitioning.rs
  native/core/src/execution/generated/spark.spark_expression.rs
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
