### PR TITLE
docs: Update percentage speedups in benchmarking guide

### DIFF
--- a/docs/source/contributor-guide/benchmarking.md
+++ b/docs/source/contributor-guide/benchmarking.md
@@ -87,7 +87,7 @@ you to run these benchmarks in your own environments.
 
 ### TPC-H
 
-Comet currently provides a 35% speedup for TPC-H @ SF=100GB.
+Comet currently provides a 54% speedup for TPC-H @ SF=100GB.
 
 ![](../../_static/images/benchmark-results/2024-07-19/tpch_allqueries.png)
 
@@ -107,7 +107,7 @@ The raw results of these benchmarks in JSON format is available here:
  
 ### TPC-DS
 
-Comet currently provides an 18% speedup for TPC-DS @ SF=100GB. Note that we used an optimized version of 
+Comet currently provides an 23% speedup for TPC-DS @ SF=100GB. Note that we used an optimized version of 
 query 72 with a better join order for these benchmarks since the focus of Spark (and Comet) is not on join 
 reordering algorithms but raw execution speed.
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I used the wrong formula for calculating the speedups when updating the benchmark results and they were inconsistent with how we previously stated them and how we calculate them in the charts.

This PR updates them based on the following math:

TPC-DS:
```
>>> round((1973/1608)-1, 2) * 100
23.0
```
TPC-H:
```
>>> round((626/407)-1, 2) * 100
54.0
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
