### PR TITLE
fix: skip negative scale checks for creating decimals

### DIFF
--- a/common/src/main/java/org/apache/comet/vector/CometDictionary.java
+++ b/common/src/main/java/org/apache/comet/vector/CometDictionary.java
@@ -30,7 +30,7 @@ public class CometDictionary implements AutoCloseable {
   private final int numValues;
 
   /** Decoded dictionary values. We only need to copy values for decimal type. */
-  private ByteArrayWrapper[] binaries;
+  private volatile ByteArrayWrapper[] binaries;
 
   public CometDictionary(CometPlainVector values) {
     this.values = values;

--- a/common/src/main/java/org/apache/comet/vector/CometVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometVector.java
@@ -73,9 +73,9 @@ public abstract class CometVector extends ColumnVector {
   @Override
   public Decimal getDecimal(int i, int precision, int scale) {
     if (!useDecimal128 && precision <= Decimal.MAX_INT_DIGITS() && type instanceof IntegerType) {
-      return Decimal.createUnsafe(getInt(i), precision, scale);
+      return createDecimal(getInt(i), precision, scale);
     } else if (!useDecimal128 && precision <= Decimal.MAX_LONG_DIGITS()) {
-      return Decimal.createUnsafe(getLong(i), precision, scale);
+      return createDecimal(getLong(i), precision, scale);
     } else {
       byte[] bytes = getBinaryDecimal(i);
       BigInteger bigInteger = new BigInteger(bytes);
@@ -96,6 +96,17 @@ public abstract class CometVector extends ColumnVector {
                 + scale);
       }
     }
+  }
+
+  /**
+   * This method skips the negative scale check, otherwise the same as Decimal.createUnsafe.
+   */
+  private Decimal createDecimal(long unscaled, int precision, int scale) {
+    Decimal dec = new Decimal();
+    dec.org$apache$spark$sql$types$Decimal$$longVal_$eq(unscaled);
+    dec.org$apache$spark$sql$types$Decimal$$_precision_$eq(precision);
+    dec.org$apache$spark$sql$types$Decimal$$_scale_$eq(scale);
+    return dec;
   }
 
   /**


### PR DESCRIPTION
## Which issue does this PR close?

Part of #679 and #670

## Rationale for this change

This PR improves the getDecimal performance

## What changes are included in this PR?

The new `createDecimal` method skips the negative scale check

## How are these changes tested?

Existing tests
