### PR TITLE
fix: skip negative scale checks for creating decimals

### DIFF
--- a/common/src/main/java/org/apache/comet/vector/CometDictionary.java
+++ b/common/src/main/java/org/apache/comet/vector/CometDictionary.java
@@ -30,7 +30,7 @@ public class CometDictionary implements AutoCloseable {
   private final int numValues;
 
   /** Decoded dictionary values. We only need to copy values for decimal type. */
-  private ByteArrayWrapper[] binaries;
+  private volatile ByteArrayWrapper[] binaries;
 
   public CometDictionary(CometPlainVector values) {
     this.values = values;

--- a/common/src/main/java/org/apache/comet/vector/CometVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometVector.java
@@ -98,9 +98,7 @@ public abstract class CometVector extends ColumnVector {
     }
   }
 
-  /**
-   * This method skips the negative scale check, otherwise the same as Decimal.createUnsafe.
-   */
+  /** This method skips the negative scale check, otherwise the same as Decimal.createUnsafe. */
   private Decimal createDecimal(long unscaled, int precision, int scale) {
     Decimal dec = new Decimal();
     dec.org$apache$spark$sql$types$Decimal$$longVal_$eq(unscaled);

--- a/common/src/main/java/org/apache/comet/vector/CometVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometVector.java
@@ -73,9 +73,9 @@ public abstract class CometVector extends ColumnVector {
   @Override
   public Decimal getDecimal(int i, int precision, int scale) {
     if (!useDecimal128 && precision <= Decimal.MAX_INT_DIGITS() && type instanceof IntegerType) {
-      return Decimal.createUnsafe(getInt(i), precision, scale);
+      return createDecimal(getInt(i), precision, scale);
     } else if (!useDecimal128 && precision <= Decimal.MAX_LONG_DIGITS()) {
-      return Decimal.createUnsafe(getLong(i), precision, scale);
+      return createDecimal(getLong(i), precision, scale);
     } else {
       byte[] bytes = getBinaryDecimal(i);
       BigInteger bigInteger = new BigInteger(bytes);
@@ -96,6 +96,17 @@ public abstract class CometVector extends ColumnVector {
                 + scale);
       }
     }
+  }
+
+  /**
+   * This method skips the negative scale check, otherwise the same as Decimal.createUnsafe.
+   */
+  private Decimal createDecimal(long unscaled, int precision, int scale) {
+    Decimal dec = new Decimal();
+    dec.org$apache$spark$sql$types$Decimal$$longVal_$eq(unscaled);
+    dec.org$apache$spark$sql$types$Decimal$$_precision_$eq(precision);
+    dec.org$apache$spark$sql$types$Decimal$$_scale_$eq(scale);
+    return dec;
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,6 @@ under the License.
       --add-opens=java.base/sun.security.action=ALL-UNNAMED
       --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
       -Djdk.reflect.useDirectMethodHandle=false
-      --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED
     </extraJavaTestArgs>
     <argLine>-ea -Xmx4g -Xss4m ${extraJavaTestArgs}</argLine>
     <additional.3_3.test.source>spark-3.3-plus</additional.3_3.test.source>
@@ -733,7 +732,6 @@ under the License.
               <javacArg>-target</javacArg>
               <javacArg>${maven.compiler.target}</javacArg>
               <javacArg>-Xlint:all,-serial,-path,-try</javacArg>
-              <javacArg>--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED</javacArg>
             </javacArgs>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@ under the License.
       --add-opens=java.base/sun.security.action=ALL-UNNAMED
       --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
       -Djdk.reflect.useDirectMethodHandle=false
+      --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED
     </extraJavaTestArgs>
     <argLine>-ea -Xmx4g -Xss4m ${extraJavaTestArgs}</argLine>
     <additional.3_3.test.source>spark-3.3-plus</additional.3_3.test.source>
@@ -711,7 +712,6 @@ under the License.
             </execution>
           </executions>
           <configuration>
-            -->
             <scalaVersion>${scala.version}</scalaVersion>
             <checkMultipleScalaVersions>true</checkMultipleScalaVersions>
             <failOnMultipleScalaVersions>true</failOnMultipleScalaVersions>
@@ -733,6 +733,7 @@ under the License.
               <javacArg>-target</javacArg>
               <javacArg>${maven.compiler.target}</javacArg>
               <javacArg>-Xlint:all,-serial,-path,-try</javacArg>
+              <javacArg>--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED</javacArg>
             </javacArgs>
           </configuration>
         </plugin>


### PR DESCRIPTION
## Which issue does this PR close?

Part of #679 and #670

## Rationale for this change

This PR improves the getDecimal performance

## What changes are included in this PR?

The new `createDecimal` method skips the negative scale check

## How are these changes tested?

Existing tests
