### PR TITLE
perf: decimal decode improvements

### DIFF
--- a/native/core/src/common/bit.rs
+++ b/native/core/src/common/bit.rs
@@ -145,7 +145,14 @@ macro_rules! read_num_be_bytes {
 #[inline]
 pub fn memcpy(source: &[u8], target: &mut [u8]) {
     debug_assert!(target.len() >= source.len(), "Copying from source to target is not possible. Source has {} bytes but target has {} bytes", source.len(), target.len());
-    target[..source.len()].copy_from_slice(source)
+    // Originally `target[..source.len()].copy_from_slice(source)`
+    // We use the unsafe copy method to avoid some expensive bounds checking/
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            source.as_ptr(),
+            target.as_mut_ptr(),
+            source.len())
+    }
 }
 
 #[inline]

--- a/native/core/src/common/bit.rs
+++ b/native/core/src/common/bit.rs
@@ -147,12 +147,7 @@ pub fn memcpy(source: &[u8], target: &mut [u8]) {
     debug_assert!(target.len() >= source.len(), "Copying from source to target is not possible. Source has {} bytes but target has {} bytes", source.len(), target.len());
     // Originally `target[..source.len()].copy_from_slice(source)`
     // We use the unsafe copy method to avoid some expensive bounds checking/
-    unsafe {
-        std::ptr::copy_nonoverlapping(
-            source.as_ptr(),
-            target.as_mut_ptr(),
-            source.len())
-    }
+    unsafe { std::ptr::copy_nonoverlapping(source.as_ptr(), target.as_mut_ptr(), source.len()) }
 }
 
 #[inline]

--- a/native/core/src/parquet/read/column.rs
+++ b/native/core/src/parquet/read/column.rs
@@ -211,6 +211,8 @@ impl ColumnReader {
                                         promotion_info.scale as i8
                                     )
                                 )
+                            } else if promotion_info.precision < DECIMAL_MAX_INT_DIGITS {
+                                typed_reader!(Int32ColumnReader, Int32)
                             } else {
                                 typed_reader!(
                                     Int32ToDecimal64ColumnReader,

--- a/native/core/src/parquet/read/column.rs
+++ b/native/core/src/parquet/read/column.rs
@@ -211,8 +211,6 @@ impl ColumnReader {
                                         promotion_info.scale as i8
                                     )
                                 )
-                            } else if promotion_info.precision < DECIMAL_MAX_INT_DIGITS {
-                                typed_reader!(Int32ColumnReader, Int32)
                             } else {
                                 typed_reader!(
                                     Int32ToDecimal64ColumnReader,

--- a/native/core/src/parquet/util/jni.rs
+++ b/native/core/src/parquet/util/jni.rs
@@ -93,6 +93,7 @@ pub fn convert_encoding(ordinal: jint) -> Encoding {
     }
 }
 
+#[derive(Debug)]
 pub struct TypePromotionInfo {
     pub(crate) physical_type: PhysicalType,
     pub(crate) precision: i32,

--- a/spark/src/test/resources/tpcds-micro-benchmarks/scan_decimal.sql
+++ b/spark/src/test/resources/tpcds-micro-benchmarks/scan_decimal.sql
@@ -1,0 +1,20 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- This is testing the cost of reading a single decimal(7,2) column
+
+select ss_net_profit from store_sales;

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometTPCDSMicroBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometTPCDSMicroBenchmark.scala
@@ -53,6 +53,7 @@ import org.apache.comet.CometConf
 object CometTPCDSMicroBenchmark extends CometTPCQueryBenchmarkBase {
 
   val queries: Seq[String] = Seq(
+    "scan_decimal",
     "add_many_decimals",
     "add_many_integers",
     "agg_high_cardinality",


### PR DESCRIPTION
## Which issue does this PR close?

Part of [#679](https://github.com/apache/datafusion-comet/issues/679) and [#670](https://github.com/apache/datafusion-comet/issues/670)
.

## Rationale for this change

profiler output shows that with decimal128 enabled we have a bottleneck in `comet::common::bit::memcpy`. 

## What changes are included in this PR?
This PR changes the method to use `copy_nonoverlapped` for speed

## How are these changes tested?

Tested using existing tests. This is a draft PR partly to verify there are no regressions.