### PR TITLE
fix: Remove `skip.surefire.tests` mvn property

### DIFF
--- a/docs/source/contributor-guide/development.md
+++ b/docs/source/contributor-guide/development.md
@@ -80,7 +80,7 @@ argument, for example if you only want to execute the test cases that contains *
 in their name in `org.apache.comet.CometCastSuite` you can use
 
 ```sh
-./mvnw test -Dsuites="org.apache.comet.CometCastSuite valid" -Dskip.surefire.tests=true
+./mvnw test -Dtest=none -Dsuites="org.apache.comet.CometCastSuite valid"
 ```
 
 Other options for selecting specific suites are described in the [ScalaTest Maven Plugin documentation](https://www.scalatest.org/user_guide/using_the_scalatest_maven_plugin)

--- a/pom.xml
+++ b/pom.xml
@@ -788,7 +788,7 @@ under the License.
             <systemPropertyVariables>
               <log4j.configurationFile>file:src/test/resources/log4j2.properties</log4j.configurationFile>
             </systemPropertyVariables>
-            <skipTests>${skip.surefire.tests}</skipTests>
+            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
## Which issue does this PR close?

Follow-up to #404

Closes #.

## Rationale for this change

The `skip.surefire.tests` property introduced in #404 causes `-DskipTests` to not work for `maven-surefire-plugin`.

To skip only java tests we just add `-Dtest=none`.


## What changes are included in this PR?

+ Remove `skip.surefire.tests` and set failIfNoSpecifiedTests to false for `maven-surefire-plugin`.
+ Update doc

## How are these changes tested?

1. test ` ./mvnw install -DskipTests -pl common`

    before this pr (`-DskipTests` does not take effect):

    ```
    [INFO] --- surefire:3.1.0:test (default-test) @ comet-common-spark3.4_2.12 ---
    [INFO] Using auto detected provider org.apache.maven.surefire.junit4.JUnit4Provider
    [INFO] 
    [INFO] -------------------------------------------------------
    [INFO]  T E S T S
    [INFO] -------------------------------------------------------
    [INFO] Running org.apache.comet.parquet.TestColumnReader
    24/07/31 10:04:11 INFO core/src/lib.rs: Comet native library initialized
    [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.298 s - in org.apache.comet.parquet.TestColumnReader
    [INFO] Running org.apache.comet.parquet.TestFileReader
    [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.347 s - in org.apache.comet.parquet.TestFileReader
    [INFO] Running org.apache.comet.parquet.TestCometInputFile
    [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.apache.comet.parquet.TestCometInputFile
    [INFO] 
    [INFO] Results:
    [INFO] 
    [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
    ```

    after this pr (`-DskipTests` takes effect):
    ```
    [INFO] --- surefire:3.1.0:test (default-test) @ comet-common-spark3.4_2.12 ---
    [INFO] Tests are skipped.
    ```

2. test `./mvnw test -Dtest=none -Dsuites="org.apache.comet.CometCastSuite valid"`

   after this pr (works well and only executes the specified suites):
    ```
    [INFO] --- surefire:3.1.0:test (default-test) @ comet-common-spark3.4_2.12 ---
    [INFO] 
    [INFO] --- jacoco:0.8.11:report (report) @ comet-common-spark3.4_2.12 ---
    ......
    [INFO] --- scalatest:2.0.2:test (test) @ comet-spark-spark3.4_2.12 ---
    Run starting. Expected test count is: 2
    CometCastSuite:
    - all valid cast combinations covered (127 milliseconds)
    24/07/31 10:12:19 INFO core/src/lib.rs: Comet native library initialized
    - cast BinaryType to StringType - valid UTF-8 inputs (12 seconds, 452 milliseconds)
    Run completed in 17 seconds, 535 milliseconds.
    Total number of tests run: 2
    Suites: completed 1, aborted 0
    Tests: succeeded 2, failed 0, canceled 0, ignored 0, pending 0
    All tests passed.
    ```