### PR TITLE
feat: show executed native plan with metrics when in debug mode

### DIFF
--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -361,9 +361,9 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
                     update_metrics(&mut env, exec_context)?;
 
                     if exec_context.debug_native {
-                        if let Some(x) = &exec_context.root_op {
+                        if let Some(plan) = &exec_context.root_op {
                             let formatted_plan_str =
-                                DisplayableExecutionPlan::with_full_metrics(x.as_ref())
+                                DisplayableExecutionPlan::with_full_metrics(plan.as_ref())
                                     .indent(true);
                             info!("Comet native query plan with metrics:\n {formatted_plan_str:}");
                         }

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -360,6 +360,15 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
                     // Update metrics
                     update_metrics(&mut env, exec_context)?;
 
+                    if exec_context.debug_native {
+                        if let Some(x) = &exec_context.root_op {
+                            let formatted_plan_str =
+                                DisplayableExecutionPlan::with_full_metrics(x.as_ref())
+                                    .indent(true);
+                            info!("Comet native query plan with metrics:\n {formatted_plan_str:}");
+                        }
+                    }
+
                     let long_array = env.new_long_array(1)?;
                     env.set_long_array_region(&long_array, 0, &[-1])?;
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

To help debug performance issues, I would like to see the executed DataFusion plan with native metrics.

Example output (goes to executor logs):

```
Comet native query plan with metrics:
 ProjectionExec: expr=[col_0@0 as col_0, count@1 as col_1], metrics=[start_timestamp{partition=0}=2024-07-31 19:33:43.785691143 UTC, end_timestamp{partition=0}=2024-07-31 19:33:43.883594710 UTC, elapsed_compute{partition=0}=551ns, output_rows{partition=0}=7]
  AggregateExec: mode=Final, gby=[col_0@0 as col_0], aggr=[count], metrics=[start_timestamp{partition=0}=2024-07-31 19:33:43.785670424 UTC, end_timestamp{partition=0}=NONE, elapsed_compute{partition=0}=5.799264ms, output_rows{partition=0}=7]
    ScanExec: schema=[col_0: Utf8, col_1: Int64], metrics=[]
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
