### PR TITLE
chore: Log warning for tests that are not really testing dictionary-encoded Parquet files

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -403,8 +403,13 @@ abstract class CometTestBase
         }
         reader.close()
         if (!hasDict) {
-          logWarning(
-            "withParquetFile was called with withDictionary=true but did not write any dictionary-encoded columns")
+          // unit test logging goes to file (see log4j.properties under src/test/resources) but
+          // we want this warning to be visible when running tests from IDE and command line so
+          // we write directly to stdout
+          // scalastyle:off println
+          println(
+            "WARN: withParquetFile was called with withDictionary=true but did not write any dictionary-encoded columns")
+          // scalastyle:on println
         }
       }
       f(file.getCanonicalPath)

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -21,6 +21,7 @@ package org.apache.spark.sql
 
 import java.io.{File, FilenameFilter}
 
+import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
@@ -392,12 +393,10 @@ abstract class CometTestBase
           HadoopInputFile.fromPath(new Path(files.head.getCanonicalPath()), new Configuration()))
         val blocks = reader.getFooter.getBlocks
         var hasDict = false
-        import scala.collection.JavaConversions._
-        for (block <- blocks) {
-          for (column <- block.getColumns) {
+        for (block <- blocks.asScala) {
+          for (column <- block.getColumns.asScala) {
             val encodings = column.getEncodings
-            if (encodings.contains(Encoding.PLAIN_DICTIONARY) || encodings.contains(
-                Encoding.RLE_DICTIONARY)) {
+            if (encodings.contains(Encoding.RLE_DICTIONARY)) {
               hasDict = true
             }
           }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Many tests use the following pattern to cover testing with dictionary-encoded data.

```scala
    Seq("true", "false").foreach { dictionary =>
        withParquetTable(
          (-5 until 5).map(i => (i.toDouble + 0.3, i.toDouble + 0.8)),
          "tbl",
          withDictionary = dictionary.toBoolean) {
```

However, in many cases, including this example, the data does not contain repeated values and therefore does not cause any dictionary-encoded arrays to be created. 

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Log a warning when `withParquetTable` is called with `withDictionary=true` and when the parquet file does not actually contain dictionary-encoded data.

I was originally going to add an assertion instead of a log message but it was too disruptive.

Example output from running tests:

```
- test multiple pages with mixed PLAIN_DICTIONARY and PLAIN encoding (prefetch enabled) (709 milliseconds)
- test multiple pages with mixed PLAIN_DICTIONARY and PLAIN encoding (524 milliseconds)
WARN: withParquetFile was called with withDictionary=true but did not write any dictionary-encoded columns
- skip vector re-loading (prefetch enabled) (669 milliseconds)
WARN: withParquetFile was called with withDictionary=true but did not write any dictionary-encoded columns
```

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

No functional change to test. Manually tested that logging appears.