### PR TITLE
perf: improve decimal read performance in CometVector

### DIFF
--- a/common/src/main/java/org/apache/comet/parquet/ColumnReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/ColumnReader.java
@@ -185,6 +185,7 @@ public class ColumnReader extends AbstractColumnReader {
         && currentVector.numValues() >= currentNumValues) {
       currentVector.setNumNulls(currentNumNulls);
       currentVector.setNumValues(currentNumValues);
+      currentVector.reset();
       return currentVector;
     }
 

--- a/common/src/main/java/org/apache/comet/vector/CometVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometVector.java
@@ -89,8 +89,8 @@ public abstract class CometVector extends ColumnVector {
   public Decimal getDecimal(int i, int precision, int scale) {
     if (!useDecimal128 && precision <= Decimal.MAX_INT_DIGITS() && type instanceof IntegerType) {
       return createDecimal(getInt(i), precision, scale);
-    } else if ( precision <= Decimal.MAX_LONG_DIGITS()) {
-      if(useDecimal128){
+    } else if (precision <= Decimal.MAX_LONG_DIGITS()) {
+      if (useDecimal128) {
         return createDecimal(getLongFromDecimalBytes(getBinaryDecimal(i)), precision, scale);
       } else {
         return createDecimal(getLong(i), precision, scale);
@@ -123,7 +123,7 @@ public abstract class CometVector extends ColumnVector {
 
   // bytes.length must be 16
   public long getLongFromDecimalBytes(byte[] bytes) {
-    assert(bytes.length == 16);
+    assert (bytes.length == 16);
     // get Long value from the last eight bytes
     // Use ByteBuffer's fast conversion to long
     long val = ByteBuffer.wrap(bytes).getLong(8);

--- a/common/src/main/java/org/apache/comet/vector/CometVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometVector.java
@@ -234,6 +234,7 @@ public abstract class CometVector extends ColumnVector {
 
   @Override
   public void close() {
+    DECIMAL_BYTES_ALL = null;
     getValueVector().close();
   }
 

--- a/common/src/main/java/org/apache/comet/vector/CometVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometVector.java
@@ -89,7 +89,7 @@ public abstract class CometVector extends ColumnVector {
     if (!useDecimal128 && precision <= Decimal.MAX_INT_DIGITS() && type instanceof IntegerType) {
       return createDecimal(getInt(i), precision, scale);
     } else if (!useDecimal128 && precision <= Decimal.MAX_LONG_DIGITS()) {
-        return createDecimal(getLong(i), precision, scale);
+      return createDecimal(getLong(i), precision, scale);
     } else if (useDecimal128 && precision <= Decimal.MAX_LONG_DIGITS()) {
       return createDecimal(getLongFromDecimalBytes(getBinaryDecimal(i)), precision, scale);
     } else {

--- a/common/src/main/java/org/apache/comet/vector/CometVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometVector.java
@@ -232,9 +232,12 @@ public abstract class CometVector extends ColumnVector {
     throw new UnsupportedOperationException("Not yet supported");
   }
 
+  public void reset() {
+    DECIMAL_BYTES_ALL = null;
+  }
+
   @Override
   public void close() {
-    DECIMAL_BYTES_ALL = null;
     getValueVector().close();
   }
 

--- a/common/src/main/java/org/apache/comet/vector/CometVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometVector.java
@@ -142,9 +142,7 @@ public abstract class CometVector extends ColumnVector {
   /** Reads a 16-byte byte array which are encoded big-endian for decimal128. */
   public byte[] copyBinaryDecimal(int i, byte[] dest) {
     ValueVector vector = getValueVector();
-    // If the index is zero and DECIMAL_BYTES_ALL already has data, we have a new
-    // batch of data in the vector's backing buffer. So read it again.
-    if (DECIMAL_BYTES_ALL == null || i == 0) {
+    if (DECIMAL_BYTES_ALL == null) {
       DECIMAL_BYTES_ALL = new byte[vector.getValueCount() * DECIMAL_BYTE_WIDTH];
       copyBuffer(vector, DECIMAL_BYTES_ALL);
     }

--- a/common/src/main/java/org/apache/comet/vector/CometVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometVector.java
@@ -19,7 +19,6 @@
 
 package org.apache.comet.vector;
 
-import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
@@ -121,7 +120,7 @@ public abstract class CometVector extends ColumnVector {
 
   // bytes.length must be 16
   public long getLongFromDecimalBytes(byte[] bytes) {
-    assert(bytes.length == 16);
+    assert (bytes.length == 16);
     // we assume only the last 8 bytes of the array are non-zero.
     int value;
     value = ((bytes[8]) & 0xFF);
@@ -145,13 +144,14 @@ public abstract class CometVector extends ColumnVector {
 
   /** Reads a 16-byte byte array which are encoded big-endian for decimal128. */
   public byte[] copyBinaryDecimal(int i, byte[] dest) {
-    if (DECIMAL_BYTES_ALL == null){
+    if (DECIMAL_BYTES_ALL == null) {
       ValueVector vector = getValueVector();
       DECIMAL_BYTES_ALL = new byte[vector.getBufferSize()];
       copyBuffer(vector, DECIMAL_BYTES_ALL);
     }
     // Decimal is stored little-endian in Arrow, so we need to reverse the bytes here
-    System.arraycopy(DECIMAL_BYTES_ALL, i*DECIMAL_BYTE_WIDTH, DECIMAL_BYTES, 0, DECIMAL_BYTE_WIDTH);
+    System.arraycopy(
+        DECIMAL_BYTES_ALL, i * DECIMAL_BYTE_WIDTH, DECIMAL_BYTES, 0, DECIMAL_BYTE_WIDTH);
     for (int j = 0, k = DECIMAL_BYTE_WIDTH - 1; j < DECIMAL_BYTE_WIDTH / 2; j++, k--) {
       byte tmp = dest[j];
       dest[j] = dest[k];
@@ -163,11 +163,7 @@ public abstract class CometVector extends ColumnVector {
   private void copyBuffer(ValueVector vector, byte[] dest) {
     long valueBufferAddress = vector.getDataBuffer().memoryAddress();
     Platform.copyMemory(
-            null,
-            valueBufferAddress,
-            dest,
-            Platform.BYTE_ARRAY_OFFSET,
-            vector.getBufferSize());
+        null, valueBufferAddress, dest, Platform.BYTE_ARRAY_OFFSET, vector.getBufferSize());
   }
 
   @Override


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion-comet/issues/679 and https://github.com/apache/datafusion-comet/issues/670

## Rationale for this change

Improves performance of reading decimals in Comet vector

## What changes are included in this PR?
There are two changes 

1. For values with precision less than `Decimal.MAX_LONG_DIGITS` we will read the values into a long rather than into a BigInteger/BigDecimal
2. While reading the decimal buffer from native to jvm, we now read the entire buffer at one time instead of one value at a time. We were incurring a bounds check in JVM code for every read from native that is now reduced  from once per value to once per vector. 
Caveat: the code now uses  `num_elements_in_vector * size of element = 4K * 4 = 16` bytes more than previously. 


## How are these changes tested?
Existing tests