### PR TITLE
fix: Optimize getDecimal for small precision

### DIFF
--- a/common/src/main/java/org/apache/comet/vector/CometDelegateVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometDelegateVector.java
@@ -108,6 +108,11 @@ public class CometDelegateVector extends CometVector {
   }
 
   @Override
+  public long getLongDecimal(int rowId) {
+    return delegate.getLongDecimal(rowId);
+  }
+
+  @Override
   public float getFloat(int rowId) {
     return delegate.getFloat(rowId);
   }

--- a/common/src/main/java/org/apache/comet/vector/CometDictionary.java
+++ b/common/src/main/java/org/apache/comet/vector/CometDictionary.java
@@ -68,6 +68,10 @@ public class CometDictionary implements AutoCloseable {
     return values.getLong(index);
   }
 
+  public long decodeToLongDecimal(int index) {
+    return values.getLongDecimal(index);
+  }
+
   public float decodeToFloat(int index) {
     return values.getFloat(index);
   }

--- a/common/src/main/java/org/apache/comet/vector/CometDictionaryVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometDictionaryVector.java
@@ -98,6 +98,11 @@ public class CometDictionaryVector extends CometDecodedVector {
   }
 
   @Override
+  public long getLongDecimal(int i) {
+    return values.decodeToLongDecimal(indices.getInt(i));
+  }
+
+  @Override
   public float getFloat(int i) {
     return values.decodeToFloat(indices.getInt(i));
   }

--- a/common/src/main/java/org/apache/comet/vector/CometPlainVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometPlainVector.java
@@ -91,6 +91,11 @@ public class CometPlainVector extends CometDecodedVector {
   }
 
   @Override
+  public long getLongDecimal(int rowId) {
+    return Platform.getLong(null, valueBufferAddress + rowId * 16L);
+  }
+
+  @Override
   public float getFloat(int rowId) {
     return Platform.getFloat(null, valueBufferAddress + rowId * 4L);
   }

--- a/common/src/main/java/org/apache/comet/vector/CometVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometVector.java
@@ -87,8 +87,8 @@ public abstract class CometVector extends ColumnVector {
   public Decimal getDecimal(int i, int precision, int scale) {
     if (!useDecimal128 && precision <= Decimal.MAX_INT_DIGITS() && type instanceof IntegerType) {
       return createDecimal(getInt(i), precision, scale);
-    } else if (!useDecimal128 && precision <= Decimal.MAX_LONG_DIGITS()) {
-      return createDecimal(getLong(i), precision, scale);
+    } else if (precision <= Decimal.MAX_LONG_DIGITS()) {
+      return createDecimal(useDecimal128 ? getLongDecimal(i) : getLong(i), precision, scale);
     } else {
       byte[] bytes = getBinaryDecimal(i);
       BigInteger bigInteger = new BigInteger(bytes);
@@ -163,6 +163,10 @@ public abstract class CometVector extends ColumnVector {
 
   @Override
   public long getLong(int rowId) {
+    throw new UnsupportedOperationException("Not yet supported");
+  }
+
+  public long getLongDecimal(int rowId) {
     throw new UnsupportedOperationException("Not yet supported");
   }
 

--- a/spark/src/test/resources/tpcds-micro-benchmarks/add_decimals.sql
+++ b/spark/src/test/resources/tpcds-micro-benchmarks/add_decimals.sql
@@ -1,0 +1,2 @@
+SELECT ss_net_profit + ss_net_profit
+FROM store_sales

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometTPCDSMicroBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometTPCDSMicroBenchmark.scala
@@ -54,6 +54,7 @@ object CometTPCDSMicroBenchmark extends CometTPCQueryBenchmarkBase {
 
   val queries: Seq[String] = Seq(
     "scan_decimal",
+    "add_decimals",
     "add_many_decimals",
     "add_many_integers",
     "agg_high_cardinality",


### PR DESCRIPTION
## Which issue does this PR close?

Part of #679 and #670

## Rationale for this change

This PR improves `getDecimal` read on decimals with a small precision

## What changes are included in this PR?

Implemented getLongDecimal that reads a long out of 16-byte Decimal data.

## How are these changes tested?

Existing tests