### PR TITLE
perf: add metrics to CopyExec and ScanExec

### DIFF
--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -363,8 +363,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
                     if exec_context.debug_native {
                         if let Some(plan) = &exec_context.root_op {
                             let formatted_plan_str =
-                                DisplayableExecutionPlan::with_metrics(plan.as_ref())
-                                    .indent(true);
+                                DisplayableExecutionPlan::with_metrics(plan.as_ref()).indent(true);
                             info!("Comet native query plan with metrics:\n {formatted_plan_str:}");
                         }
                     }

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -363,7 +363,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
                     if exec_context.debug_native {
                         if let Some(plan) = &exec_context.root_op {
                             let formatted_plan_str =
-                                DisplayableExecutionPlan::with_full_metrics(plan.as_ref())
+                                DisplayableExecutionPlan::with_metrics(plan.as_ref())
                                     .indent(true);
                             info!("Comet native query plan with metrics:\n {formatted_plan_str:}");
                         }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Add more metrics so that we can more easily see the overhead of each operator.

Example output:

```
ProjectionExec: ..., metrics=[elapsed_compute{partition=0}=3.467µs, output_rows{partition=0}=100]
  SortExec: ..., metrics=[elapsed_compute{partition=0}=128.029µs, output_rows{partition=0}=100, ...
    CopyExec, metrics=[..., elapsed_compute{partition=0}=88.506µs, output_rows{partition=0}=201]
      ScanExec: ..., metrics=[s..., elapsed_compute{partition=0}=5.461µs, output_rows{partition=0}=201]
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add more metrics

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
