### PR TITLE
build: Re-enable TPCDS q72 for broadcast and hash join configs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@ under the License.
       --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
       -Djdk.reflect.useDirectMethodHandle=false
     </extraJavaTestArgs>
-    <argLine>-ea -Xmx4g -Xss4m ${extraJavaTestArgs}</argLine>
+    <argLine>-ea -Xmx6g -Xss4m ${extraJavaTestArgs}</argLine>
     <additional.3_3.test.source>spark-3.3-plus</additional.3_3.test.source>
     <additional.3_4.test.source>spark-3.4-plus</additional.3_4.test.source>
     <additional.3_5.test.source>not-needed</additional.3_5.test.source>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@ under the License.
       --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
       -Djdk.reflect.useDirectMethodHandle=false
     </extraJavaTestArgs>
-    <argLine>-ea -Xmx6g -Xss4m ${extraJavaTestArgs}</argLine>
+    <argLine>-ea -Xmx4g -Xss4m ${extraJavaTestArgs}</argLine>
     <additional.3_3.test.source>spark-3.3-plus</additional.3_3.test.source>
     <additional.3_4.test.source>spark-3.4-plus</additional.3_4.test.source>
     <additional.3_5.test.source>not-needed</additional.3_5.test.source>

--- a/spark/src/test/scala/org/apache/spark/sql/CometTPCDSQuerySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTPCDSQuerySuite.scala
@@ -28,7 +28,6 @@ import org.apache.comet.CometConf
 class CometTPCDSQuerySuite
     extends {
       val tpcdsAllQueries: Seq[String] = Seq(
-        "q72",
         "q1",
         "q2",
         "q3",
@@ -109,6 +108,7 @@ class CometTPCDSQuerySuite
         "q69",
         "q70",
         "q71",
+        "q72",
         "q73",
         "q74",
         "q75",
@@ -138,7 +138,6 @@ class CometTPCDSQuerySuite
         "q99")
 
       val tpcdsAllQueriesV2_7_0: Seq[String] = Seq(
-        "q72",
         "q5a",
         "q6",
         "q10a",
@@ -163,6 +162,7 @@ class CometTPCDSQuerySuite
         "q64",
         "q67a",
         "q70a",
+        "q72",
         "q74",
         "q75",
         "q77a",

--- a/spark/src/test/scala/org/apache/spark/sql/CometTPCDSQuerySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTPCDSQuerySuite.scala
@@ -28,6 +28,7 @@ import org.apache.comet.CometConf
 class CometTPCDSQuerySuite
     extends {
       val tpcdsAllQueries: Seq[String] = Seq(
+        "q72",
         "q1",
         "q2",
         "q3",
@@ -108,7 +109,6 @@ class CometTPCDSQuerySuite
         "q69",
         "q70",
         "q71",
-        "q72",
         "q73",
         "q74",
         "q75",
@@ -138,6 +138,7 @@ class CometTPCDSQuerySuite
         "q99")
 
       val tpcdsAllQueriesV2_7_0: Seq[String] = Seq(
+        "q72",
         "q5a",
         "q6",
         "q10a",
@@ -162,7 +163,6 @@ class CometTPCDSQuerySuite
         "q64",
         "q67a",
         "q70a",
-        "q72",
         "q74",
         "q75",
         "q77a",

--- a/spark/src/test/scala/org/apache/spark/sql/CometTPCDSQuerySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTPCDSQuerySuite.scala
@@ -108,9 +108,7 @@ class CometTPCDSQuerySuite
         "q69",
         "q70",
         "q71",
-        // TODO: unknown failure (seems memory usage over Github action runner) in CI with q72 in
-        // https://github.com/apache/datafusion-comet/pull/613.
-        // "q72",
+        "q72",
         "q73",
         "q74",
         "q75",
@@ -164,9 +162,7 @@ class CometTPCDSQuerySuite
         "q64",
         "q67a",
         "q70a",
-        // TODO: unknown failure (seems memory usage over Github action runner) in CI with q72-v2.7
-        // in https://github.com/apache/datafusion-comet/pull/613.
-        // "q72",
+        "q72",
         "q74",
         "q75",
         "q77a",

--- a/spark/src/test/scala/org/apache/spark/sql/CometTPCDSQueryTestSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTPCDSQueryTestSuite.scala
@@ -208,8 +208,13 @@ class CometTPCDSQueryTestSuite extends QueryTest with TPCDSBase with CometSQLQue
       test(name) {
         val goldenFile = new File(s"$baseResourcePath/v1_4", s"$name.sql.out")
         joinConfs.foreach { conf =>
-          System.gc() // Workaround for GitHub Actions memory limitation, see also SPARK-37368
-          runQuery(queryString, goldenFile, conf)
+          val sortMergeJoin = sortMergeJoinConf == conf
+          // Skip q72 for sort-merge join because it uses too many resources
+          // that can cause OOM in GitHub Actions
+          if (!(sortMergeJoin && name == "q72")) {
+            System.gc() // Workaround for GitHub Actions memory limitation, see also SPARK-37368
+            runQuery(queryString, goldenFile, conf)
+          }
         }
       }
     }
@@ -221,8 +226,13 @@ class CometTPCDSQueryTestSuite extends QueryTest with TPCDSBase with CometSQLQue
       test(s"$name-v2.7") {
         val goldenFile = new File(s"$baseResourcePath/v2_7", s"$name.sql.out")
         joinConfs.foreach { conf =>
-          System.gc() // SPARK-37368
-          runQuery(queryString, goldenFile, conf)
+          val sortMergeJoin = sortMergeJoinConf == conf
+          // Skip q72 for sort-merge join because it uses too many resources
+          // that can cause OOM in GitHub Actions
+          if (!(sortMergeJoin && name == "q72")) {
+            System.gc() // SPARK-37368
+            runQuery(queryString, goldenFile, conf)
+          }
         }
       }
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I did memory profiling yesterday again locally, and didn't see the memory issue last time. Trying to re-enable q72.

In Github Action runner, it still cannot run q72 with sort merge join config. I only enabled q72 for other type join configs.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
