### PR TITLE
feat: Optimze CreateNamedStruct preserve dictionaries

### DIFF
--- a/common/src/main/java/org/apache/comet/vector/CometStructVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometStructVector.java
@@ -24,14 +24,17 @@ import java.util.List;
 
 import org.apache.arrow.vector.*;
 import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import org.apache.arrow.vector.util.TransferPair;
 import org.apache.spark.sql.vectorized.ColumnVector;
 
 /** A Comet column vector for struct type. */
 public class CometStructVector extends CometDecodedVector {
   final List<ColumnVector> children;
+  final DictionaryProvider dictionaryProvider;
 
-  public CometStructVector(ValueVector vector, boolean useDecimal128) {
+  public CometStructVector(
+      ValueVector vector, boolean useDecimal128, DictionaryProvider dictionaryProvider) {
     super(vector, vector.getField(), useDecimal128);
 
     StructVector structVector = ((StructVector) vector);
@@ -41,9 +44,10 @@ public class CometStructVector extends CometDecodedVector {
 
     for (int i = 0; i < size; ++i) {
       ValueVector value = structVector.getVectorById(i);
-      children.add(getVector(value, useDecimal128));
+      children.add(getVector(value, useDecimal128, dictionaryProvider));
     }
     this.children = children;
+    this.dictionaryProvider = dictionaryProvider;
   }
 
   @Override
@@ -56,6 +60,6 @@ public class CometStructVector extends CometDecodedVector {
     TransferPair tp = this.valueVector.getTransferPair(this.valueVector.getAllocator());
     tp.splitAndTransfer(offset, length);
 
-    return new CometStructVector(tp.getTo(), useDecimal128);
+    return new CometStructVector(tp.getTo(), useDecimal128, dictionaryProvider);
   }
 }

--- a/common/src/main/java/org/apache/comet/vector/CometVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometVector.java
@@ -235,9 +235,9 @@ public abstract class CometVector extends ColumnVector {
   protected static CometVector getVector(
       ValueVector vector, boolean useDecimal128, DictionaryProvider dictionaryProvider) {
     if (vector instanceof StructVector) {
-      return new CometStructVector(vector, useDecimal128);
+      return new CometStructVector(vector, useDecimal128, dictionaryProvider);
     } else if (vector instanceof MapVector) {
-      return new CometMapVector(vector, useDecimal128);
+      return new CometMapVector(vector, useDecimal128, dictionaryProvider);
     } else if (vector instanceof ListVector) {
       return new CometListVector(vector, useDecimal128);
     } else {

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -616,8 +616,8 @@ impl PhysicalPlanner {
                     .iter()
                     .map(|expr| self.create_expr(expr, input_schema.clone()))
                     .collect::<Result<Vec<_>, _>>()?;
-                let data_type = to_arrow_datatype(expr.datatype.as_ref().unwrap());
-                Ok(Arc::new(CreateNamedStruct::new(values, data_type)))
+                let names = expr.names.clone();
+                Ok(Arc::new(CreateNamedStruct::new(values, names)))
             }
             ExprStruct::GetStructField(expr) => {
                 let child = self.create_expr(expr.child.as_ref().unwrap(), input_schema.clone())?;

--- a/native/proto/src/proto/expr.proto
+++ b/native/proto/src/proto/expr.proto
@@ -490,7 +490,7 @@ message BloomFilterMightContain {
 
 message CreateNamedStruct {
   repeated Expr values = 1;
-  DataType datatype = 2;
+  repeated string names = 2;
 }
 
 message GetStructField {

--- a/native/spark-expr/src/structs.rs
+++ b/native/spark-expr/src/structs.rs
@@ -124,7 +124,9 @@ impl PartialEq<dyn Any> for CreateNamedStruct {
                     .iter()
                     .zip(x.values.iter())
                     .all(|(a, b)| a.eq(b))
+                    && self.values.len() == x.values.len()
                     && self.names.iter().zip(x.names.iter()).all(|(a, b)| a.eq(b))
+                    && self.names.len() == x.names.len()
             })
             .unwrap_or(false)
     }

--- a/native/spark-expr/src/structs.rs
+++ b/native/spark-expr/src/structs.rs
@@ -15,10 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::compute::take;
 use arrow::record_batch::RecordBatch;
-use arrow_array::types::Int32Type;
-use arrow_array::{Array, DictionaryArray, StructArray};
+use arrow_array::{Array, StructArray};
 use arrow_schema::{DataType, Field, Schema};
 use datafusion::logical_expr::ColumnarValue;
 use datafusion_common::{DataFusionError, Result as DataFusionResult, ScalarValue};
@@ -35,12 +33,24 @@ use crate::utils::down_cast_any_ref;
 #[derive(Debug, Hash)]
 pub struct CreateNamedStruct {
     values: Vec<Arc<dyn PhysicalExpr>>,
-    data_type: DataType,
+    names: Vec<String>,
 }
 
 impl CreateNamedStruct {
-    pub fn new(values: Vec<Arc<dyn PhysicalExpr>>, data_type: DataType) -> Self {
-        Self { values, data_type }
+    pub fn new(values: Vec<Arc<dyn PhysicalExpr>>, names: Vec<String>) -> Self {
+        Self { values, names }
+    }
+
+    fn fields(&self, schema: &Schema) -> DataFusionResult<Vec<Field>> {
+        self.values
+            .iter()
+            .zip(&self.names)
+            .map(|(expr, name)| {
+                let data_type = expr.data_type(schema)?;
+                let nullable = expr.nullable(schema)?;
+                Ok(Field::new(name, data_type, nullable))
+            })
+            .collect()
     }
 }
 
@@ -49,8 +59,9 @@ impl PhysicalExpr for CreateNamedStruct {
         self
     }
 
-    fn data_type(&self, _input_schema: &Schema) -> DataFusionResult<DataType> {
-        Ok(self.data_type.clone())
+    fn data_type(&self, input_schema: &Schema) -> DataFusionResult<DataType> {
+        let fields = self.fields(input_schema)?;
+        Ok(DataType::Struct(fields.into()))
     }
 
     fn nullable(&self, _input_schema: &Schema) -> DataFusionResult<bool> {
@@ -64,32 +75,9 @@ impl PhysicalExpr for CreateNamedStruct {
             .map(|expr| expr.evaluate(batch))
             .collect::<datafusion_common::Result<Vec<_>>>()?;
         let arrays = ColumnarValue::values_to_arrays(&values)?;
-        // TODO it would be more efficient if we could preserve dictionaries within the
-        // struct array but for now we unwrap them to avoid runtime errors
-        // https://github.com/apache/datafusion-comet/issues/755
-        let arrays = arrays
-            .iter()
-            .map(|array| {
-                if let Some(dict_array) =
-                    array.as_any().downcast_ref::<DictionaryArray<Int32Type>>()
-                {
-                    take(dict_array.values().as_ref(), dict_array.keys(), None)
-                } else {
-                    Ok(Arc::clone(array))
-                }
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        let fields = match &self.data_type {
-            DataType::Struct(fields) => fields,
-            _ => {
-                return Err(DataFusionError::Internal(format!(
-                    "Expected struct data type, got {:?}",
-                    self.data_type
-                )))
-            }
-        };
+        let fields = self.fields(&batch.schema())?;
         Ok(ColumnarValue::Array(Arc::new(StructArray::new(
-            fields.clone(),
+            fields.into(),
             arrays,
             None,
         ))))
@@ -105,14 +93,14 @@ impl PhysicalExpr for CreateNamedStruct {
     ) -> datafusion_common::Result<Arc<dyn PhysicalExpr>> {
         Ok(Arc::new(CreateNamedStruct::new(
             children.clone(),
-            self.data_type.clone(),
+            self.names.clone(),
         )))
     }
 
     fn dyn_hash(&self, state: &mut dyn Hasher) {
         let mut s = state;
         self.values.hash(&mut s);
-        self.data_type.hash(&mut s);
+        self.names.hash(&mut s);
         self.hash(&mut s);
     }
 }
@@ -121,8 +109,8 @@ impl Display for CreateNamedStruct {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "CreateNamedStruct [values: {:?}, data_type: {:?}]",
-            self.values, self.data_type
+            "CreateNamedStruct [values: {:?}, names: {:?}]",
+            self.values, self.names
         )
     }
 }
@@ -136,7 +124,7 @@ impl PartialEq<dyn Any> for CreateNamedStruct {
                     .iter()
                     .zip(x.values.iter())
                     .all(|(a, b)| a.eq(b))
-                    && self.data_type.eq(&x.data_type)
+                    && self.names.iter().zip(x.names.iter()).all(|(a, b)| a.eq(b))
             })
             .unwrap_or(false)
     }
@@ -246,7 +234,7 @@ impl PartialEq<dyn Any> for GetStructField {
 mod test {
     use super::CreateNamedStruct;
     use arrow_array::{Array, DictionaryArray, Int32Array, RecordBatch, StringArray};
-    use arrow_schema::{DataType, Field, Fields, Schema};
+    use arrow_schema::{DataType, Field, Schema};
     use datafusion_common::Result;
     use datafusion_expr::ColumnarValue;
     use datafusion_physical_expr_common::expressions::column::Column;
@@ -261,9 +249,8 @@ mod test {
         let data_type = DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Int32));
         let schema = Schema::new(vec![Field::new("a", data_type, false)]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(dict)])?;
-        let data_type =
-            DataType::Struct(Fields::from(vec![Field::new("a", DataType::Int32, false)]));
-        let x = CreateNamedStruct::new(vec![Arc::new(Column::new("a", 0))], data_type);
+        let field_names = vec!["a".to_string()];
+        let x = CreateNamedStruct::new(vec![Arc::new(Column::new("a", 0))], field_names);
         let ColumnarValue::Array(x) = x.evaluate(&batch)? else {
             unreachable!()
         };
@@ -279,9 +266,8 @@ mod test {
         let data_type = DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8));
         let schema = Schema::new(vec![Field::new("a", data_type, false)]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(dict)])?;
-        let data_type =
-            DataType::Struct(Fields::from(vec![Field::new("a", DataType::Utf8, false)]));
-        let x = CreateNamedStruct::new(vec![Arc::new(Column::new("a", 0))], data_type);
+        let field_names = vec!["a".to_string()];
+        let x = CreateNamedStruct::new(vec![Arc::new(Column::new("a", 0))], field_names);
         let ColumnarValue::Array(x) = x.evaluate(&batch)? else {
             unreachable!()
         };

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -2318,12 +2318,11 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
 
         case struct @ CreateNamedStruct(_) =>
           val valExprs = struct.valExprs.map(exprToProto(_, inputs, binding))
-          val dataType = serializeDataType(struct.dataType)
 
-          if (valExprs.forall(_.isDefined) && dataType.isDefined) {
+          if (valExprs.forall(_.isDefined)) {
             val structBuilder = ExprOuterClass.CreateNamedStruct.newBuilder()
             structBuilder.addAllValues(valExprs.map(_.get).asJava)
-            structBuilder.setDatatype(dataType.get)
+            structBuilder.addAllNames(struct.names.map(_.toString).asJava)
 
             Some(
               ExprOuterClass.Expr


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #755.

## Rationale for this change

Should improve performance as we avoid materializing arrays with dictionary encoding.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

This PR removes the workaround from #750 and makes changes needed to CreateNamedStruct to preserve dictionary types. This is achived by just serializing the field names instead of the full return type, this way we get a type that actually matches the expected physical type. The original implementation was done as it lead to a slightly simpler implementation, but it clear from #750 that this was the wrong choice and leads to issues with the physical data_type.

Secondly this includes some changes in the Comet*Vector classes in 2a55eb537720e9f3558d24746f123b7b463662b9 these are needed to make those classes support dictionary types inside CometStructVector.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

Existing tests.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
