### PR TITLE
Minor: ScanExec code cleanup and additional documentation

### DIFF
--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -867,7 +867,7 @@ impl PhysicalPlanner {
                 ))
             }
             OpStruct::Scan(scan) => {
-                let fields = scan.fields.iter().map(to_arrow_datatype).collect_vec();
+                let data_types = scan.fields.iter().map(to_arrow_datatype).collect_vec();
 
                 // If it is not test execution context for unit test, we should have at least one
                 // input source
@@ -887,7 +887,8 @@ impl PhysicalPlanner {
                     };
 
                 // The `ScanExec` operator will take actual arrays from Spark during execution
-                let scan = ScanExec::new(self.exec_context_id, input_source, &scan.source, fields)?;
+                let scan =
+                    ScanExec::new(self.exec_context_id, input_source, &scan.source, data_types)?;
                 Ok((vec![scan.clone()], Arc::new(scan)))
             }
             OpStruct::ShuffleWriter(writer) => {

--- a/native/core/src/execution/operators/scan.rs
+++ b/native/core/src/execution/operators/scan.rs
@@ -126,7 +126,7 @@ impl ScanExec {
         if let DataType::Dictionary(_, vt) = dt {
             if !matches!(
                 vt.as_ref(),
-                DataType::Utf8 | DataType::LargeUtf8 | DataType::Binary
+                DataType::Utf8 | DataType::LargeUtf8 | DataType::Binary | DataType::LargeBinary
             ) {
                 // return the underlying data type
                 return vt.as_ref().clone();

--- a/native/core/src/execution/operators/scan.rs
+++ b/native/core/src/execution/operators/scan.rs
@@ -380,6 +380,7 @@ impl Stream for ScanStream {
         let input_batch = if let Some(batch) = input_batch {
             batch
         } else {
+            timer.stop();
             return Poll::Pending;
         };
 

--- a/native/core/src/execution/operators/scan.rs
+++ b/native/core/src/execution/operators/scan.rs
@@ -210,8 +210,7 @@ impl ScanExec {
         let array_elements = unsafe { addresses.as_ptr().add(1) };
         let mut inputs: Vec<ArrayRef> = Vec::with_capacity(num_arrays);
 
-        let mut i: usize = 0;
-        while i < num_arrays {
+        for i in 0..num_arrays {
             let array_ptr = unsafe { *(array_elements.add(i * 2)) };
             let schema_ptr = unsafe { *(array_elements.add(i * 2 + 1)) };
             let array_data = ArrayData::from_spark((array_ptr, schema_ptr))?;
@@ -219,7 +218,6 @@ impl ScanExec {
             // TODO: validate array input data
 
             inputs.push(make_array(array_data));
-            i += 1;
         }
 
         Ok(InputBatch::new(inputs, Some(num_rows as usize)))


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I recently learned more about how ScanExec works so I thought I would add some documentation to help other contributors.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- More documentation
- Some pedantic code cleanup changes
- Use a single metrics timer instead of two timers when fetching batches
- Create a vector with the correct capacity to avoid overhead of reallocation
- Re-use CastOptions across all batches instead of creating per-batch

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests
