### PR TITLE
perf: Remove some redundant copying of batches

### DIFF
--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -860,8 +860,11 @@ impl PhysicalPlanner {
 
                 let fetch = sort.fetch.map(|num| num as usize);
 
-                // TODO choose mode based on whether input can cache batches
-                let copy_exec = Arc::new(CopyExec::new(child, CopyMode::UnpackOrDeepCopy));
+                let copy_exec = if can_reuse_input_batch(&child) {
+                    Arc::new(CopyExec::new(child, CopyMode::UnpackOrDeepCopy))
+                } else {
+                    Arc::new(CopyExec::new(child, CopyMode::UnpackOrClone))
+                };
 
                 Ok((
                     scans,

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -1778,7 +1778,7 @@ fn can_reuse_input_batch(op: &Arc<dyn ExecutionPlan>) -> bool {
         || op.as_any().is::<LocalLimitExec>()
         || op.as_any().is::<FilterExec>()
     {
-        can_reuse_input_batch(&op.children()[0])
+        can_reuse_input_batch(op.children()[0])
     } else {
         op.as_any().is::<ScanExec>()
     }

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -1774,10 +1774,14 @@ impl From<ExpressionError> for DataFusionError {
 /// modification. This is used to determine if we need to copy the input batch to avoid
 /// data corruption from reusing the input batch.
 fn can_reuse_input_batch(op: &Arc<dyn ExecutionPlan>) -> bool {
-    op.as_any().is::<ScanExec>()
+    if op.as_any().is::<ProjectionExec>()
         || op.as_any().is::<LocalLimitExec>()
-        || op.as_any().is::<ProjectionExec>()
         || op.as_any().is::<FilterExec>()
+    {
+        can_reuse_input_batch(&op.children()[0])
+    } else {
+        op.as_any().is::<ScanExec>()
+    }
 }
 
 /// Collects the indices of the columns in the input schema that are used in the expression

--- a/native/core/src/execution/operators/copy.rs
+++ b/native/core/src/execution/operators/copy.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use arrow::compute::{cast_with_options, CastOptions};
+use futures::{Stream, StreamExt};
 use std::{
     any::Any,
     pin::Pin,
@@ -22,16 +24,15 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::{Stream, StreamExt};
-
-use arrow_array::{ArrayRef, RecordBatch, RecordBatchOptions};
-use arrow_schema::{DataType, Field, FieldRef, Schema, SchemaRef};
+use arrow_array::{
+    downcast_dictionary_array, make_array, Array, ArrayRef, RecordBatch, RecordBatchOptions,
+};
+use arrow_data::transform::MutableArrayData;
+use arrow_schema::{ArrowError, DataType, Field, FieldRef, Schema, SchemaRef};
 
 use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::{execution::TaskContext, physical_expr::*, physical_plan::*};
 use datafusion_common::{arrow_datafusion_err, DataFusionError, Result as DataFusionResult};
-
-use super::copy_or_unpack_array;
 
 /// An utility execution node which makes deep copies of input batches.
 ///
@@ -92,7 +93,7 @@ impl DisplayAs for CopyExec {
     fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
-                write!(f, "CopyExec")
+                write!(f, "CopyExec [{:?}]", self.mode)
             }
         }
     }
@@ -214,5 +215,58 @@ impl Stream for CopyStream {
 impl RecordBatchStream for CopyStream {
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
+    }
+}
+
+/// Copy an Arrow Array
+fn copy_array(array: &dyn Array) -> ArrayRef {
+    let capacity = array.len();
+    let data = array.to_data();
+
+    let mut mutable = MutableArrayData::new(vec![&data], false, capacity);
+
+    mutable.extend(0, 0, capacity);
+
+    if matches!(array.data_type(), DataType::Dictionary(_, _)) {
+        let copied_dict = make_array(mutable.freeze());
+        let ref_copied_dict = &copied_dict;
+
+        downcast_dictionary_array!(
+            ref_copied_dict => {
+                // Copying dictionary value array
+                let values = ref_copied_dict.values();
+                let data = values.to_data();
+
+                let mut mutable = MutableArrayData::new(vec![&data], false, values.len());
+                mutable.extend(0, 0, values.len());
+
+                let copied_dict = ref_copied_dict.with_values(make_array(mutable.freeze()));
+                Arc::new(copied_dict)
+            }
+            t => unreachable!("Should not reach here: {}", t)
+        )
+    } else {
+        make_array(mutable.freeze())
+    }
+}
+
+/// Copy an Arrow Array or cast to primitive type if it is a dictionary array.
+/// This is used for `CopyExec` to copy/cast the input array. If the input array
+/// is a dictionary array, we will cast the dictionary array to primitive type
+/// (i.e., unpack the dictionary array) and copy the primitive array. If the input
+/// array is a primitive array, we simply copy the array.
+fn copy_or_unpack_array(array: &Arc<dyn Array>, mode: &CopyMode) -> Result<ArrayRef, ArrowError> {
+    match array.data_type() {
+        DataType::Dictionary(_, value_type) => {
+            let options = CastOptions::default();
+            cast_with_options(array, value_type.as_ref(), &options)
+        }
+        _ => {
+            if mode == &CopyMode::UnpackOrDeepCopy {
+                Ok(copy_array(array))
+            } else {
+                Ok(Arc::clone(array))
+            }
+        }
     }
 }

--- a/native/core/src/execution/operators/mod.rs
+++ b/native/core/src/execution/operators/mod.rs
@@ -106,15 +106,12 @@ pub fn copy_or_unpack_array(
     match array.data_type() {
         DataType::Dictionary(_, value_type) => {
             let options = CastOptions::default();
-            let casted = cast_with_options(array, value_type.as_ref(), &options);
-
-            casted.and_then(|a| {
-                if mode == &CopyMode::UnpackOrDeepCopy {
-                    Ok(copy_array(array))
-                } else {
-                    Ok(Arc::clone(array))
-                }
-            })
+            let a = cast_with_options(array, value_type.as_ref(), &options)?;
+            if mode == &CopyMode::UnpackOrDeepCopy {
+                Ok(copy_array(a.as_ref()))
+            } else {
+                Ok(a)
+            }
         }
         _ => {
             if mode == &CopyMode::UnpackOrDeepCopy {

--- a/native/core/src/execution/operators/mod.rs
+++ b/native/core/src/execution/operators/mod.rs
@@ -17,22 +17,15 @@
 
 //! Operators
 
-use arrow::{
-    array::{make_array, Array, ArrayRef, MutableArrayData},
-    datatypes::DataType,
-    downcast_dictionary_array,
-};
+use std::fmt::Debug;
 
-use arrow::compute::{cast_with_options, CastOptions};
-use arrow_schema::ArrowError;
 use jni::objects::GlobalRef;
-use std::{fmt::Debug, sync::Arc};
 
-mod scan;
+pub use copy::*;
 pub use scan::*;
 
 mod copy;
-pub use copy::*;
+mod scan;
 
 /// Error returned during executing operators.
 #[derive(thiserror::Error, Debug)]
@@ -60,65 +53,4 @@ pub enum ExecutionError {
         msg: String,
         throwable: GlobalRef,
     },
-}
-
-/// Copy an Arrow Array
-pub fn copy_array(array: &dyn Array) -> ArrayRef {
-    let capacity = array.len();
-    let data = array.to_data();
-
-    let mut mutable = MutableArrayData::new(vec![&data], false, capacity);
-
-    mutable.extend(0, 0, capacity);
-
-    if matches!(array.data_type(), DataType::Dictionary(_, _)) {
-        let copied_dict = make_array(mutable.freeze());
-        let ref_copied_dict = &copied_dict;
-
-        downcast_dictionary_array!(
-            ref_copied_dict => {
-                // Copying dictionary value array
-                let values = ref_copied_dict.values();
-                let data = values.to_data();
-
-                let mut mutable = MutableArrayData::new(vec![&data], false, values.len());
-                mutable.extend(0, 0, values.len());
-
-                let copied_dict = ref_copied_dict.with_values(make_array(mutable.freeze()));
-                Arc::new(copied_dict)
-            }
-            t => unreachable!("Should not reach here: {}", t)
-        )
-    } else {
-        make_array(mutable.freeze())
-    }
-}
-
-/// Copy an Arrow Array or cast to primitive type if it is a dictionary array.
-/// This is used for `CopyExec` to copy/cast the input array. If the input array
-/// is a dictionary array, we will cast the dictionary array to primitive type
-/// (i.e., unpack the dictionary array) and copy the primitive array. If the input
-/// array is a primitive array, we simply copy the array.
-pub fn copy_or_unpack_array(
-    array: &Arc<dyn Array>,
-    mode: &CopyMode,
-) -> Result<ArrayRef, ArrowError> {
-    match array.data_type() {
-        DataType::Dictionary(_, value_type) => {
-            let options = CastOptions::default();
-            let a = cast_with_options(array, value_type.as_ref(), &options)?;
-            if mode == &CopyMode::UnpackOrDeepCopy {
-                Ok(copy_array(a.as_ref()))
-            } else {
-                Ok(a)
-            }
-        }
-        _ => {
-            if mode == &CopyMode::UnpackOrDeepCopy {
-                Ok(copy_array(array))
-            } else {
-                Ok(Arc::clone(array))
-            }
-        }
-    }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We use `CopyExec` to wrap inputs to operators that can cache batches. This is to avoid corruption issues if the input batches come from a `ScanExec` where arrays are re-used, or from some other operators that may be wrapping `ScanExec` and that can pass through input batches unchanged (projection, limit, or filter).

`CopyExec` also unpacks dictionary arrays (not just primitives, but Utf8 as well).

When we have nested joins, I see that `CopyExec` is processing the output of the nested joins and this is redundant because joins do not re-use arrays.

This PR aims to avoid deep copies of arrays in some cases where it is not necessary.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests
