### PR TITLE
minor: stop warning that AQEShuffleRead cannot run natively

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -226,12 +226,7 @@ class CometSparkSessionExtensions
 
     private def isCometPlan(op: SparkPlan): Boolean = op.isInstanceOf[CometPlan]
 
-    private def isCometNative(op: SparkPlan): Boolean = op match {
-      case _: CometNativeExec => true
-      case AQEShuffleReadExec(q: ShuffleQueryStageExec, _) =>
-        isCometNative(q.plan)
-      case _ => false
-    }
+    private def isCometNative(op: SparkPlan): Boolean = op.isInstanceOf[CometNativeExec]
 
     private def explainChildNotNative(op: SparkPlan): String = {
       var nonNatives: Seq[String] = Seq()

--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -826,7 +826,7 @@ class CometSparkSessionExtensions
           op match {
             // Broadcast exchange exec is transformed by the parent node. We include
             // this case specially here so we do not add a misleading 'info' message
-            case _: BroadcastExchangeExec => op
+            case _: BroadcastExchangeExec | _: AQEShuffleReadExec => op
             case _: CometExec | _: CometBroadcastExchangeExec | _: CometShuffleExchangeExec => op
             case o =>
               withInfo(o, s"${o.nodeName} is not supported")

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1731,8 +1731,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
             Set(
               "HashAggregate is not native because the following children are not native (AQEShuffleRead)",
               "HashAggregate is not native because the following children are not native (Exchange)",
-              "Comet shuffle is not enabled: spark.comet.exec.shuffle.enabled is not enabled",
-              "AQEShuffleRead is not supported")),
+              "Comet shuffle is not enabled: spark.comet.exec.shuffle.enabled is not enabled")),
           (
             "SELECT A.c1, A.sum_c0, A.sum_c2, B.casted from "
               + s"(SELECT c1, sum(c0) as sum_c0, sum(c2) as sum_c2 from $table group by c1) as A, "
@@ -1740,7 +1739,6 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
               + "where A.c1 = B.c1 ",
             Set(
               "Comet shuffle is not enabled: spark.comet.exec.shuffle.enabled is not enabled",
-              "AQEShuffleRead is not supported",
               "make_interval is not supported",
               "HashAggregate is not native because the following children are not native (AQEShuffleRead)",
               "HashAggregate is not native because the following children are not native (Exchange)",


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

`AQEShuffleRead` will never have a native version so we should stop warning that we cannot run it natively

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
