### PR TITLE
chore: Revert "fix: change the not exists base image apache/spark:3.4.3 to 3.4.2"

### DIFF
--- a/kube/Dockerfile
+++ b/kube/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM apache/spark:3.4.2 AS builder
+FROM apache/spark:3.4.3 AS builder
 
 USER root
 
@@ -59,7 +59,7 @@ COPY pom.xml /comet/pom.xml
 RUN cd /comet \
     && JAVA_HOME=$(readlink -f $(which javac) | sed "s/\/bin\/javac//") make release-nogit PROFILES="-Pspark-$SPARK_VERSION -Pscala-$SCALA_VERSION"
 
-FROM apache/spark:3.4.2
+FROM apache/spark:3.4.3
 ENV SPARK_VERSION=3.4
 ENV SCALA_VERSION=2.12
 USER root


### PR DESCRIPTION
Reverts apache/datafusion-comet#686

See https://github.com/apache/spark-docker/pull/65, `3.4.3` is published