### PR TITLE
chore: converting ExtendedExplainInfo to object

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -857,13 +857,12 @@ class CometSparkSessionExtensions
         // if the plan cannot be run fully natively then explain why (when appropriate
         // config is enabled)
         if (CometConf.COMET_EXPLAIN_FALLBACK_ENABLED.get()) {
-          val info = new ExtendedExplainInfo()
-          if (info.extensionInfo(newPlan).nonEmpty) {
+          if (ExtendedExplainInfo.extensionInfo(newPlan).nonEmpty) {
             logWarning(
               "Comet cannot execute some parts of this plan natively " +
                 s"(set ${CometConf.COMET_EXPLAIN_FALLBACK_ENABLED.key}=false " +
                 "to disable this logging):\n" +
-                s"${info.generateVerboseExtendedInfo(newPlan)}")
+                s"${ExtendedExplainInfo.generateVerboseExtendedInfo(newPlan)}")
           }
         }
 

--- a/spark/src/main/scala/org/apache/comet/ExtendedExplainInfo.scala
+++ b/spark/src/main/scala/org/apache/comet/ExtendedExplainInfo.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, QueryStag
 
 import org.apache.comet.CometExplainInfo.getActualPlan
 
-class ExtendedExplainInfo extends ExtendedExplainGenerator {
+object ExtendedExplainInfo extends ExtendedExplainGenerator {
 
   override def title: String = "Comet"
 
@@ -161,5 +161,4 @@ object CometExplainInfo {
       case p => p
     }
   }
-
 }

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -940,7 +940,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
         val df = data.withColumn("converted", col("a").cast(toType))
         df.collect()
         val str =
-          new ExtendedExplainInfo().generateExtendedInfo(df.queryExecution.executedPlan)
+          ExtendedExplainInfo.generateExtendedInfo(df.queryExecution.executedPlan)
         assert(str.contains(expectedMessage))
       }
     }

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -661,7 +661,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       CometSparkSessionExtensions.withInfo(project, "reason 5", id)
       CometSparkSessionExtensions.withInfo(project, id)
       CometSparkSessionExtensions.withInfo(project, "reason 6")
-      val explain = new ExtendedExplainInfo().generateExtendedInfo(project)
+      val explain = ExtendedExplainInfo.generateExtendedInfo(project)
       for (i <- 1 until 7) {
         assert(explain.contains(s"reason $i"))
       }
@@ -676,7 +676,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       withSQLConf(CometConf.COMET_REGEXP_ALLOW_INCOMPATIBLE.key -> "true") {
         val query2 = sql(s"select id from $table where name rlike name")
         val (_, cometPlan) = checkSparkAnswer(query2)
-        val explain = new ExtendedExplainInfo().generateExtendedInfo(cometPlan)
+        val explain = ExtendedExplainInfo.generateExtendedInfo(cometPlan)
         assert(explain.contains("Only scalar regexp patterns are supported"))
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/CometTPCQueryListBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTPCQueryListBase.scala
@@ -109,7 +109,7 @@ trait CometTPCQueryListBase
         }
         out.println(
           s"Query: $name$nameSuffix: ExplainInfo:\n" +
-            s"${new ExtendedExplainInfo().generateExtendedInfo(executedPlan)}\n")
+            s"${ExtendedExplainInfo.generateExtendedInfo(executedPlan)}\n")
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -256,7 +256,7 @@ abstract class CometTestBase
       assert(expectedInfo.forall(s => diff.contains(s)))
     }
     val extendedInfo =
-      new ExtendedExplainInfo().generateExtendedInfo(dfComet.queryExecution.executedPlan)
+      ExtendedExplainInfo.generateExtendedInfo(dfComet.queryExecution.executedPlan)
     val expectedStr = expectedInfo.toSeq.sorted.mkString("\n")
     if (!extendedInfo.equalsIgnoreCase(expectedStr)) {
       fail(s"$extendedInfo != $expectedStr (case-insensitive comparison)")


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #452 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

ExtendedExplainInfo should be an object not a class.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

ExtendedExplainInfo converted to object.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
All tests pass