### PR TITLE
feat: Implement basic version of string to float/double/decimal

### DIFF
--- a/docs/source/user-guide/compatibility.md
+++ b/docs/source/user-guide/compatibility.md
@@ -136,8 +136,9 @@ The following cast operations are not compatible with Spark for all inputs and a
 |-|-|-|
 | integer | decimal  | No overflow check |
 | long | decimal  | No overflow check |
-| string | float  | Does not support inputs ending with 'd' or 'f'. Does not support 'inf'. |
-| string | double  | Does not support inputs ending with 'd' or 'f'. Does not support 'inf'. |
+| string | float  | Does not support inputs ending with 'd' or 'f'. Does not support 'inf'. Does not support ANSI mode. |
+| string | double  | Does not support inputs ending with 'd' or 'f'. Does not support 'inf'. Does not support ANSI mode. |
+| string | decimal  | Does not support inputs ending with 'd' or 'f'. Does not support 'inf'. Does not support ANSI mode. Returns 0.0 instead of null if input contains no digits |
 | string | timestamp  | Not all valid formats are supported |
 | binary | string  | Only works for binary data representing valid UTF-8 strings |
 

--- a/docs/source/user-guide/compatibility.md
+++ b/docs/source/user-guide/compatibility.md
@@ -136,6 +136,8 @@ The following cast operations are not compatible with Spark for all inputs and a
 |-|-|-|
 | integer | decimal  | No overflow check |
 | long | decimal  | No overflow check |
+| string | float  | Does not support inputs ending with 'd' or 'f'. Does not support 'inf'. |
+| string | double  | Does not support inputs ending with 'd' or 'f'. Does not support 'inf'. |
 | string | timestamp  | Not all valid formats are supported |
 | binary | string  | Only works for binary data representing valid UTF-8 strings |
 

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -382,8 +382,13 @@ impl PhysicalPlanner {
                 let datatype = to_arrow_datatype(expr.datatype.as_ref().unwrap());
                 let timezone = expr.timezone.clone();
                 let eval_mode = from_protobuf_eval_mode(expr.eval_mode)?;
-
-                Ok(Arc::new(Cast::new(child, datatype, eval_mode, timezone)))
+                Ok(Arc::new(Cast::new(
+                    child,
+                    datatype,
+                    eval_mode,
+                    timezone,
+                    expr.allow_incompat,
+                )))
             }
             ExprStruct::Hour(expr) => {
                 let child = self.create_expr(expr.child.as_ref().unwrap(), input_schema)?;
@@ -723,17 +728,20 @@ impl PhysicalPlanner {
                     left,
                     DataType::Decimal256(p1, s1),
                     EvalMode::Legacy,
+                    false,
                 ));
                 let right = Arc::new(Cast::new_without_timezone(
                     right,
                     DataType::Decimal256(p2, s2),
                     EvalMode::Legacy,
+                    false,
                 ));
                 let child = Arc::new(BinaryExpr::new(left, op, right));
                 Ok(Arc::new(Cast::new_without_timezone(
                     child,
                     data_type,
                     EvalMode::Legacy,
+                    false,
                 )))
             }
             (

--- a/native/proto/src/proto/expr.proto
+++ b/native/proto/src/proto/expr.proto
@@ -254,8 +254,8 @@ message Cast {
   Expr child = 1;
   DataType datatype = 2;
   string timezone = 3;
-  EvalMode eval_mode = 4; 
-  
+  EvalMode eval_mode = 4;
+  bool allow_incompat = 5;
 }
 
 message Equal {

--- a/native/spark-expr/benches/cast_from_string.rs
+++ b/native/spark-expr/benches/cast_from_string.rs
@@ -31,20 +31,23 @@ fn criterion_benchmark(c: &mut Criterion) {
         DataType::Int8,
         EvalMode::Legacy,
         timezone.clone(),
+        false,
     );
     let cast_string_to_i16 = Cast::new(
         expr.clone(),
         DataType::Int16,
         EvalMode::Legacy,
         timezone.clone(),
+        false,
     );
     let cast_string_to_i32 = Cast::new(
         expr.clone(),
         DataType::Int32,
         EvalMode::Legacy,
         timezone.clone(),
+        false,
     );
-    let cast_string_to_i64 = Cast::new(expr, DataType::Int64, EvalMode::Legacy, timezone);
+    let cast_string_to_i64 = Cast::new(expr, DataType::Int64, EvalMode::Legacy, timezone, false);
 
     let mut group = c.benchmark_group("cast_string_to_int");
     group.bench_function("cast_string_to_i8", |b| {

--- a/native/spark-expr/benches/cast_numeric.rs
+++ b/native/spark-expr/benches/cast_numeric.rs
@@ -31,14 +31,16 @@ fn criterion_benchmark(c: &mut Criterion) {
         DataType::Int8,
         EvalMode::Legacy,
         timezone.clone(),
+        false,
     );
     let cast_i32_to_i16 = Cast::new(
         expr.clone(),
         DataType::Int16,
         EvalMode::Legacy,
         timezone.clone(),
+        false,
     );
-    let cast_i32_to_i64 = Cast::new(expr, DataType::Int64, EvalMode::Legacy, timezone);
+    let cast_i32_to_i64 = Cast::new(expr, DataType::Int64, EvalMode::Legacy, timezone, false);
 
     let mut group = c.benchmark_group("cast_int_to_int");
     group.bench_function("cast_i32_to_i8", |b| {

--- a/native/spark-expr/src/cast.rs
+++ b/native/spark-expr/src/cast.rs
@@ -143,6 +143,7 @@ pub struct Cast {
     /// session local timezone by an analyzer in Spark.
     pub timezone: String,
 
+    /// Whether to allow casts that are known to be incompatible with Spark
     pub allow_incompat: bool,
 }
 

--- a/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
+++ b/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
@@ -113,10 +113,12 @@ object CometCast {
         Compatible()
       case DataTypes.FloatType | DataTypes.DoubleType =>
         // https://github.com/apache/datafusion-comet/issues/326
-        Unsupported
+        Incompatible(Some(
+          "Does not support inputs ending with 'd' or 'f'. Does not support 'inf'. Does not support ANSI mode."))
       case _: DecimalType =>
         // https://github.com/apache/datafusion-comet/issues/325
-        Unsupported
+        Incompatible(Some(
+          "Does not support inputs ending with 'd' or 'f'. Does not support 'inf'. Does not support ANSI mode. Returns 0.0 instead of null if input contains no digits"))
       case DataTypes.DateType =>
         // https://github.com/apache/datafusion-comet/issues/327
         Compatible(Some("Only supports years between 262143 BC and 262142 AD"))

--- a/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
+++ b/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
@@ -113,12 +113,15 @@ object CometCast {
         Compatible()
       case DataTypes.FloatType | DataTypes.DoubleType =>
         // https://github.com/apache/datafusion-comet/issues/326
-        Incompatible(Some(
-          "Does not support inputs ending with 'd' or 'f'. Does not support 'inf'. Does not support ANSI mode."))
+        Incompatible(
+          Some(
+            "Does not support inputs ending with 'd' or 'f'. Does not support 'inf'. " +
+              "Does not support ANSI mode."))
       case _: DecimalType =>
         // https://github.com/apache/datafusion-comet/issues/325
-        Incompatible(Some(
-          "Does not support inputs ending with 'd' or 'f'. Does not support 'inf'. Does not support ANSI mode. Returns 0.0 instead of null if input contains no digits"))
+        Incompatible(
+          Some("Does not support inputs ending with 'd' or 'f'. Does not support 'inf'. " +
+            "Does not support ANSI mode. Returns 0.0 instead of null if input contains no digits"))
       case DataTypes.DateType =>
         // https://github.com/apache/datafusion-comet/issues/327
         Compatible(Some("Only supports years between 262143 BC and 262142 AD"))

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -792,7 +792,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
         castBuilder.setChild(childExpr.get)
         castBuilder.setDatatype(dataType.get)
         castBuilder.setEvalMode(evalModeToProto(evalMode))
-
+        castBuilder.setAllowIncompat(CometConf.COMET_CAST_ALLOW_INCOMPATIBLE.get())
         val timeZone = timeZoneId.getOrElse("UTC")
         castBuilder.setTimezone(timeZone)
 
@@ -1506,6 +1506,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
                     .setChild(e)
                     .setDatatype(serializeDataType(IntegerType).get)
                     .setEvalMode(ExprOuterClass.EvalMode.LEGACY)
+                    .setAllowIncompat(false)
                     .build())
                 .build()
             })


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/apache/datafusion-comet/issues/326 and https://github.com/apache/datafusion-comet/issues/325

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When running aggregate queries against schemas where numbers are in string format (csv files, parquet files generated from csv files, etc), Spark will add casts from string to floating point or decimal. We fall back to Spark because we did not have these casts implemented.

This is frustrating for casual users who just want to try Comet out on some text inputs.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR adds a basic implementation of these casts by delegating to DataFusion. These are not compatible with Spark and are documented as such and are only enabled if `spark.comet.cast.allowIncompatible` is enabled.

I recommend viewing the diff without whitespace changes (https://github.com/apache/datafusion-comet/pull/870/files?diff=split&w=1)

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

New tests
