### PR TITLE
chore: Add spilling metrics of SortMergeJoin

### DIFF
--- a/spark/src/main/scala/org/apache/spark/shuffle/sort/RowPartition.scala
+++ b/spark/src/main/scala/org/apache/spark/shuffle/sort/RowPartition.scala
@@ -30,7 +30,11 @@ class RowPartition(initialSize: Int) {
     rowSizes += size
   }
 
-  def getNumRows: Int = rowAddresses.size
+  def getNumRows: Int = if (rowAddresses == null) {
+    0
+  } else {
+    rowAddresses.size
+  }
 
   def getRowAddresses: Array[Long] = {
     val array = rowAddresses.toArray

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
@@ -102,6 +102,25 @@ object CometMetricNode {
   }
 
   /**
+   * SQL Metrics for DataFusion SortMergeJoin
+   */
+  def sortMergeJoinMetrics(sc: SparkContext): Map[String, SQLMetric] = {
+    Map(
+      "peak_mem_used" ->
+        SQLMetrics.createSizeMetric(sc, "Memory used by build-side"),
+      "input_batches" ->
+        SQLMetrics.createMetric(sc, "Number of batches consumed by probe-side"),
+      "input_rows" ->
+        SQLMetrics.createMetric(sc, "Number of rows consumed by probe-side"),
+      "output_batches" -> SQLMetrics.createMetric(sc, "Number of batches produced"),
+      "output_rows" -> SQLMetrics.createMetric(sc, "Number of rows produced"),
+      "join_time" -> SQLMetrics.createNanoTimingMetric(sc, "Total time for joining"),
+      "spill_count" -> SQLMetrics.createMetric(sc, "Count of spills"),
+      "spilled_bytes" -> SQLMetrics.createSizeMetric(sc, "Total spilled bytes"),
+      "spilled_rows" -> SQLMetrics.createMetric(sc, "Total spilled rows"))
+  }
+
+  /**
    * Creates a [[CometMetricNode]] from a [[CometPlan]].
    */
   def fromCometPlan(cometPlan: SparkPlan): CometMetricNode = {

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -933,14 +933,7 @@ case class CometSortMergeJoinExec(
     Objects.hashCode(leftKeys, rightKeys, condition, left, right)
 
   override lazy val metrics: Map[String, SQLMetric] =
-    Map(
-      "input_batches" -> SQLMetrics.createMetric(sparkContext, "Number of batches consumed"),
-      "input_rows" -> SQLMetrics.createMetric(sparkContext, "Number of rows consumed"),
-      "output_batches" -> SQLMetrics.createMetric(sparkContext, "Number of batches produced"),
-      "output_rows" -> SQLMetrics.createMetric(sparkContext, "Number of rows produced"),
-      "peak_mem_used" ->
-        SQLMetrics.createSizeMetric(sparkContext, "Peak memory used for buffered data"),
-      "join_time" -> SQLMetrics.createNanoTimingMetric(sparkContext, "Total time for joining"))
+    CometMetricNode.sortMergeJoinMetrics(sparkContext)
 }
 
 case class CometScanWrapper(override val nativeOp: Operator, override val originalPlan: SparkPlan)

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -519,6 +519,8 @@ class CometExecSuite extends CometTestBase {
           assert(metrics("peak_mem_used").value > 1L)
           assert(metrics.contains("join_time"))
           assert(metrics("join_time").value > 1L)
+          assert(metrics.contains("spill_count"))
+          assert(metrics("spill_count").value == 0)
         }
       }
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We don't propagate spilling metrics of SortMergeJoin from DataFusion to Comet yet. This patch adds spilling related metrics to Comet SortMergeJoin operator.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
