### PR TITLE
fix: Fix various memory leaks problems

### DIFF
--- a/common/src/main/scala/org/apache/comet/vector/ExportedBatch.scala
+++ b/common/src/main/scala/org/apache/comet/vector/ExportedBatch.scala
@@ -38,15 +38,7 @@ case class ExportedBatch(
     arrowSchemas: Array[ArrowSchema],
     arrowArrays: Array[ArrowArray]) {
   def close(): Unit = {
-    arrowSchemas.foreach { schema =>
-      val snapshot = schema.snapshot
-      if (snapshot.release != 0) schema.release()
-      schema.close()
-    }
-    arrowArrays.foreach { array =>
-      val snapshot = array.snapshot
-      if (snapshot.release != 0) array.release()
-      array.close()
-    }
+    arrowSchemas.foreach(_.close())
+    arrowArrays.foreach(_.close())
   }
 }

--- a/common/src/main/scala/org/apache/comet/vector/ExportedBatch.scala
+++ b/common/src/main/scala/org/apache/comet/vector/ExportedBatch.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.vector
+
+import org.apache.arrow.c.ArrowArray
+import org.apache.arrow.c.ArrowSchema
+
+/**
+ * A wrapper class to hold the exported Arrow arrays and schemas.
+ *
+ * @param batch
+ *   a list containing number of rows + pairs of memory addresses in the format of (address of
+ *   Arrow array, address of Arrow schema)
+ * @param arrowSchemas
+ *   the exported Arrow schemas, needs to be deallocated after being moved by the native executor
+ * @param arrowArrays
+ *   the exported Arrow arrays, needs to be deallocated after being moved by the native executor
+ */
+case class ExportedBatch(
+    batch: Array[Long],
+    arrowSchemas: Array[ArrowSchema],
+    arrowArrays: Array[ArrowArray]) {
+  def close(): Unit = {
+    arrowSchemas.foreach { schema =>
+      val snapshot = schema.snapshot
+      if (snapshot.release != 0) schema.release()
+      schema.close()
+    }
+    arrowArrays.foreach { array =>
+      val snapshot = array.snapshot
+      if (snapshot.release != 0) array.release()
+      array.close()
+    }
+  }
+}

--- a/common/src/main/scala/org/apache/comet/vector/NativeUtil.scala
+++ b/common/src/main/scala/org/apache/comet/vector/NativeUtil.scala
@@ -44,43 +44,53 @@ class NativeUtil {
    * @param batch
    *   the input Comet columnar batch
    * @return
-   *   a list containing number of rows + pairs of memory addresses in the format of (address of
-   *   Arrow array, address of Arrow schema)
+   *   an exported batches object containing an array containing number of rows + pairs of memory
+   *   addresses in the format of (address of Arrow array, address of Arrow schema)
    */
-  def exportBatch(batch: ColumnarBatch): Array[Long] = {
+  def exportBatch(batch: ColumnarBatch): ExportedBatch = {
     val exportedVectors = mutable.ArrayBuffer.empty[Long]
     exportedVectors += batch.numRows()
 
+    // Run checks prior to exporting the batch
     (0 until batch.numCols()).foreach { index =>
-      batch.column(index) match {
-        case a: CometVector =>
-          val valueVector = a.getValueVector
-
-          val provider = if (valueVector.getField.getDictionary != null) {
-            a.getDictionaryProvider
-          } else {
-            null
-          }
-
-          val arrowSchema = ArrowSchema.allocateNew(allocator)
-          val arrowArray = ArrowArray.allocateNew(allocator)
-          Data.exportVector(
-            allocator,
-            getFieldVector(valueVector, "export"),
-            provider,
-            arrowArray,
-            arrowSchema)
-
-          exportedVectors += arrowArray.memoryAddress()
-          exportedVectors += arrowSchema.memoryAddress()
-        case c =>
-          throw new SparkException(
-            "Comet execution only takes Arrow Arrays, but got " +
-              s"${c.getClass}")
+      val c = batch.column(index)
+      if (!c.isInstanceOf[CometVector]) {
+        batch.close()
+        throw new SparkException(
+          "Comet execution only takes Arrow Arrays, but got " +
+            s"${c.getClass}")
       }
     }
 
-    exportedVectors.toArray
+    val arrowSchemas = mutable.ArrayBuffer.empty[ArrowSchema]
+    val arrowArrays = mutable.ArrayBuffer.empty[ArrowArray]
+
+    (0 until batch.numCols()).foreach { index =>
+      val cometVector = batch.column(index).asInstanceOf[CometVector]
+      val valueVector = cometVector.getValueVector
+
+      val provider = if (valueVector.getField.getDictionary != null) {
+        cometVector.getDictionaryProvider
+      } else {
+        null
+      }
+
+      val arrowSchema = ArrowSchema.allocateNew(allocator)
+      val arrowArray = ArrowArray.allocateNew(allocator)
+      arrowSchemas += arrowSchema
+      arrowArrays += arrowArray
+      Data.exportVector(
+        allocator,
+        getFieldVector(valueVector, "export"),
+        provider,
+        arrowArray,
+        arrowSchema)
+
+      exportedVectors += arrowArray.memoryAddress()
+      exportedVectors += arrowSchema.memoryAddress()
+    }
+
+    ExportedBatch(exportedVectors.toArray, arrowSchemas.toArray, arrowArrays.toArray)
   }
 
   /**

--- a/common/src/main/scala/org/apache/spark/sql/comet/util/Utils.scala
+++ b/common/src/main/scala/org/apache/spark/sql/comet/util/Utils.scala
@@ -215,12 +215,8 @@ object Utils {
       val writer = new ArrowStreamWriter(root, provider, Channels.newChannel(out))
       writer.start()
       writer.writeBatch()
-
       root.clear()
-      writer.end()
-
-      out.flush()
-      out.close()
+      writer.close()
 
       if (out.size() > 0) {
         (batch.numRows(), cbbos.toChunkedByteBuffer)

--- a/spark/src/main/java/org/apache/comet/CometBatchIterator.java
+++ b/spark/src/main/java/org/apache/comet/CometBatchIterator.java
@@ -23,6 +23,7 @@ import scala.collection.Iterator;
 
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
+import org.apache.comet.vector.ExportedBatch;
 import org.apache.comet.vector.NativeUtil;
 
 /**
@@ -34,9 +35,12 @@ public class CometBatchIterator {
   final Iterator<ColumnarBatch> input;
   final NativeUtil nativeUtil;
 
+  private ExportedBatch lastBatch;
+
   CometBatchIterator(Iterator<ColumnarBatch> input, NativeUtil nativeUtil) {
     this.input = input;
     this.nativeUtil = nativeUtil;
+    this.lastBatch = null;
   }
 
   /**
@@ -45,12 +49,27 @@ public class CometBatchIterator {
    * indicating the end of the iterator.
    */
   public long[] next() {
+    // The native executor should have moved the previous batch, it is safe for us to deallocate
+    // the ArrowSchema and ArrowArray base structures.
+    if (lastBatch != null) {
+      lastBatch.close();
+      lastBatch = null;
+    }
+
     boolean hasBatch = input.hasNext();
 
     if (!hasBatch) {
       return new long[] {-1};
     }
 
-    return nativeUtil.exportBatch(input.next());
+    lastBatch = nativeUtil.exportBatch(input.next());
+    return lastBatch.batch();
+  }
+
+  public void close() {
+    if (lastBatch != null) {
+      lastBatch.close();
+      lastBatch = null;
+    }
   }
 }

--- a/spark/src/main/java/org/apache/comet/CometBatchIterator.java
+++ b/spark/src/main/java/org/apache/comet/CometBatchIterator.java
@@ -49,8 +49,8 @@ public class CometBatchIterator {
    * indicating the end of the iterator.
    */
   public long[] next() {
-    // The native executor should have moved the previous batch, it is safe for us to deallocate
-    // the ArrowSchema and ArrowArray base structures.
+    // Native side already copied the content of ArrowSchema and ArrowArray. We should deallocate
+    // the ArrowSchema and ArrowArray base structures allocated in JVM.
     if (lastBatch != null) {
       lastBatch.close();
       lastBatch = null;

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -159,6 +159,8 @@ class CometExecIterator(
       }
       nativeLib.releasePlan(plan)
 
+      cometBatchIterators.foreach(_.close())
+
       // The allocator thoughts the exported ArrowArray and ArrowSchema structs are not released,
       // so it will report:
       // Caused by: java.lang.IllegalStateException: Memory was leaked by query.


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #884.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Please refer to the comments in https://github.com/apache/datafusion-comet/issues/884 for details.

## What changes are included in this PR?

* Fixes `ArrowSchema` and `ArrowArray` base structure leaks in JVM
* Fixes AQE coalesce partition leaks by closing the ArrowStreamWriter

## How are these changes tested?

It is pretty hard to add tests for this fix, so we manually tested this and relying on existing tests to make sure that it does not break anything.
