### PR TITLE
fix: CometTakeOrderedAndProjectExec native scan node should use child operator's output

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometTakeOrderedAndProjectExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometTakeOrderedAndProjectExec.scala
@@ -75,12 +75,12 @@ case class CometTakeOrderedAndProjectExec(
         childRDD
       } else {
         val localTopK = if (orderingSatisfies) {
-          CometExecUtils.getNativeLimitRDD(childRDD, output, limit)
+          CometExecUtils.getNativeLimitRDD(childRDD, child.output, limit)
         } else {
           childRDD.mapPartitionsInternal { iter =>
             val topK =
               CometExecUtils
-                .getTopKNativePlan(output, sortOrder, child, limit)
+                .getTopKNativePlan(child.output, sortOrder, child, limit)
                 .get
             CometExec.getCometIterator(Seq(iter), topK)
           }
@@ -100,7 +100,7 @@ case class CometTakeOrderedAndProjectExec(
 
       singlePartitionRDD.mapPartitionsInternal { iter =>
         val topKAndProjection = CometExecUtils
-          .getProjectionNativePlan(projectList, output, sortOrder, child, limit)
+          .getProjectionNativePlan(projectList, child.output, sortOrder, child, limit)
           .get
         val it = CometExec.getCometIterator(Seq(iter), topKAndProjection)
         setSubqueries(it.id, this)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This bug was found while debugging CI failure in #893. In `CometTakeOrderedAndProjectExec`, we create internal native plan to execute native limit + sort + project. The pseudo scan node created there was incorrectly using `CometTakeOrderedAndProjectExec`'s output attributes but it should be child node's output.

Currently it doesn't cause any error, although it will have incorrect schema in the scan node. Because sort/limit simply takes input so the incorrect schema doesn't make error. For project, we already bind attributes in Spark, as the input data is correct so it has no error too.

But in #893, we need to get the number of columns from the schema of scan node. If the schema is incorrect, the scan node will create incorrect number of array/schema structures which cause error later.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
