### PR TITLE
chore: print Comet native version to logs after Comet is initialized

### DIFF
--- a/native/core/src/lib.rs
+++ b/native/core/src/lib.rs
@@ -86,7 +86,8 @@ pub extern "system" fn Java_org_apache_comet_NativeBase_init(
         let java_vm = env.get_java_vm()?;
         JAVA_VM.get_or_init(|| java_vm);
 
-        info!("Comet native library initialized");
+        let comet_version = env!("CARGO_PKG_VERSION");
+        info!("Comet native library version {} initialized", comet_version);
         Ok(())
     })
 }


### PR DESCRIPTION
## Which issue does this PR close?
Closes #894

## Rationale for this change
More information for debugging

## What changes are included in this PR?
- `native/core/src/lib.rs`: added a call to `env!` to get a version and add this version to info message

## How are these changes tested?
I run it and it works:
![image](https://github.com/user-attachments/assets/f5d2f68b-4846-4831-aa77-b8ddd58e829a)

I googled a little how one can test logging and it looks like the only solution is to redirect logs to the file, to read the file and to check the content. To be honest, I do not fully understand how that approach could be introduced into the current test system... Should I try? Because it is the only one place at the moment where one needs to test logs output and I'm not sure that it worth it.
