### PR TITLE
chore: Close dictionary provider when iterator is closed

### DIFF
--- a/common/src/main/java/org/apache/arrow/c/ArrowImporter.java
+++ b/common/src/main/java/org/apache/arrow/c/ArrowImporter.java
@@ -40,15 +40,12 @@ public class ArrowImporter {
   }
 
   Field importField(ArrowSchema schema, CDataDictionaryProvider provider) {
-    Field var4;
     try {
-      var4 = importer.importField(schema, provider);
+      return importer.importField(schema, provider);
     } finally {
       schema.release();
       schema.close();
     }
-
-    return var4;
   }
 
   public FieldVector importVector(

--- a/common/src/main/scala/org/apache/comet/vector/NativeUtil.scala
+++ b/common/src/main/scala/org/apache/comet/vector/NativeUtil.scala
@@ -30,12 +30,22 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import org.apache.comet.CometArrowAllocator
 
+/**
+ * Provides functionality for importing Arrow vectors from native code and wrapping them as
+ * CometVectors.
+ *
+ * Also provides functionality for exporting Comet columnar batches to native code.
+ *
+ * Each instance of NativeUtils creates an instance of CDataDictionaryProvider (a
+ * DictionaryProvider that is used in C Data Interface for imports).
+ */
 class NativeUtil {
   import Utils._
 
+  /** Use the global allocator */
   private val allocator = CometArrowAllocator
-  private val dictionaryProvider: CDataDictionaryProvider = new CDataDictionaryProvider
   private val importer = new ArrowImporter(allocator)
+  private val dictionaryProvider: CDataDictionaryProvider = new CDataDictionaryProvider
 
   /**
    * Exports a Comet `ColumnarBatch` into a list of memory addresses that can be consumed by the
@@ -132,6 +142,11 @@ class NativeUtil {
     }
 
     new ColumnarBatch(arrayVectors.toArray, maxNumRows)
+  }
+
+  def close(): Unit = {
+    // closing the dictionary provider also closes the dictionary arrays
+    dictionaryProvider.close()
   }
 }
 

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -48,7 +48,7 @@ class CometExecIterator(
     extends Iterator[ColumnarBatch] {
 
   private val nativeLib = new Native()
-  private val nativeUtil = new NativeUtil
+  private val nativeUtil = new NativeUtil()
   private val cometBatchIterators = inputs.map { iterator =>
     new CometBatchIterator(iterator, nativeUtil)
   }.toArray
@@ -157,6 +157,7 @@ class CometExecIterator(
         currentBatch.close()
         currentBatch = null
       }
+      nativeUtil.close()
       nativeLib.releasePlan(plan)
 
       // The allocator thoughts the exported ArrowArray and ArrowSchema structs are not released,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
