### PR TITLE
chore: Revise array import to more follow C Data Interface semantics

### DIFF
--- a/common/src/main/scala/org/apache/comet/vector/NativeUtil.scala
+++ b/common/src/main/scala/org/apache/comet/vector/NativeUtil.scala
@@ -19,9 +19,13 @@
 
 package org.apache.comet.vector
 
+import java.nio.ByteOrder
+
 import scala.collection.mutable
 
 import org.apache.arrow.c.{ArrowArray, ArrowImporter, ArrowSchema, CDataDictionaryProvider, Data}
+import org.apache.arrow.c.NativeUtil.NULL
+import org.apache.arrow.memory.util.MemoryUtil
 import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.dictionary.DictionaryProvider
 import org.apache.spark.SparkException
@@ -70,6 +74,13 @@ class NativeUtil {
 
     (0 until numCols).foreach { index =>
       val arrowSchema = ArrowSchema.allocateNew(allocator)
+
+      // Manually fill NULL to `release` slot of ArrowSchema because ArrowSchema doesn't provide
+      // `markReleased`.
+      val buffer =
+        MemoryUtil.directBuffer(arrowSchema.memoryAddress(), 72).order(ByteOrder.nativeOrder)
+      buffer.putLong(56, NULL);
+
       val arrowArray = ArrowArray.allocateNew(allocator)
       arrays(index) = arrowArray
       schemas(index) = arrowSchema

--- a/common/src/main/scala/org/apache/comet/vector/NativeUtil.scala
+++ b/common/src/main/scala/org/apache/comet/vector/NativeUtil.scala
@@ -56,7 +56,7 @@ class NativeUtil {
    */
   private val dictionaryProvider: CDataDictionaryProvider = new CDataDictionaryProvider
 
- /**
+  /**
    * Allocates Arrow structs for the given number of columns.
    *
    * @param numCols

--- a/common/src/main/scala/org/apache/comet/vector/NativeUtil.scala
+++ b/common/src/main/scala/org/apache/comet/vector/NativeUtil.scala
@@ -77,6 +77,8 @@ class NativeUtil {
 
       // Manually fill NULL to `release` slot of ArrowSchema because ArrowSchema doesn't provide
       // `markReleased`.
+      // The total size of ArrowSchema is 72 bytes.
+      // The `release` slot is at offset 56 in the ArrowSchema struct.
       val buffer =
         MemoryUtil.directBuffer(arrowSchema.memoryAddress(), 72).order(ByteOrder.nativeOrder)
       buffer.putLong(56, NULL);

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -17,10 +17,7 @@
 
 //! Define JNI APIs which can be called from Java/Scala.
 
-use arrow::{
-    datatypes::DataType as ArrowDataType,
-    ffi::{FFI_ArrowArray, FFI_ArrowSchema},
-};
+use arrow::datatypes::DataType as ArrowDataType;
 use arrow_array::RecordBatch;
 use datafusion::{
     execution::{
@@ -78,8 +75,6 @@ struct ExecutionContext {
     pub input_sources: Vec<Arc<GlobalRef>>,
     /// The record batch stream to pull results from
     pub stream: Option<SendableRecordBatchStream>,
-    /// The FFI arrays. We need to keep them alive here.
-    pub ffi_arrays: Vec<(Arc<FFI_ArrowArray>, Arc<FFI_ArrowSchema>)>,
     /// Configurations for DF execution
     pub conf: HashMap<String, String>,
     /// The Tokio runtime used for async.
@@ -177,7 +172,6 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
             scans: vec![],
             input_sources,
             stream: None,
-            ffi_arrays: vec![],
             conf: configs,
             runtime,
             metrics,
@@ -265,13 +259,32 @@ fn parse_bool(conf: &HashMap<String, String>, name: &str) -> CometResult<bool> {
 }
 
 /// Prepares arrow arrays for output.
-fn prepare_output(
+unsafe fn prepare_output(
     env: &mut JNIEnv,
+    array_addrs: jlongArray,
+    schema_addrs: jlongArray,
     output_batch: RecordBatch,
     exec_context: &mut ExecutionContext,
-) -> CometResult<jlongArray> {
+) -> CometResult<jlong> {
+    let array_address_array = JLongArray::from_raw(array_addrs);
+    let num_cols = env.get_array_length(&array_address_array)? as usize;
+
+    let array_addrs = env.get_array_elements(&array_address_array, ReleaseMode::NoCopyBack)?;
+    let array_addrs = &*array_addrs;
+
+    let schema_address_array = JLongArray::from_raw(schema_addrs);
+    let schema_addrs = env.get_array_elements(&schema_address_array, ReleaseMode::NoCopyBack)?;
+    let schema_addrs = &*schema_addrs;
+
     let results = output_batch.columns();
     let num_rows = output_batch.num_rows();
+
+    if results.len() != num_cols {
+        return Err(CometError::Internal(format!(
+            "Output column count mismatch: expected {num_cols}, got {}",
+            results.len()
+        )));
+    }
 
     if exec_context.debug_native {
         // Validate the output arrays.
@@ -286,32 +299,22 @@ fn prepare_output(
     let return_flag = 1;
 
     let long_array = env.new_long_array((results.len() * 2) as i32 + 2)?;
-    env.set_long_array_region(&long_array, 0, &[return_flag, num_rows as jlong])?;
-
-    let mut arrays = vec![];
+    env.set_long_array_region(long_array, 0, &[return_flag, num_rows as jlong])?;
 
     let mut i = 0;
     while i < results.len() {
         let array_ref = results.get(i).ok_or(CometError::IndexOutOfBounds(i))?;
-        let (array, schema) = array_ref.to_data().to_spark()?;
+        array_ref
+            .to_data()
+            .move_to_spark(array_addrs[i], schema_addrs[i])?;
 
-        unsafe {
-            let arrow_array = Arc::from_raw(array as *const FFI_ArrowArray);
-            let arrow_schema = Arc::from_raw(schema as *const FFI_ArrowSchema);
-            arrays.push((arrow_array, arrow_schema));
-        }
-
-        env.set_long_array_region(&long_array, (i * 2) as i32 + 2, &[array, schema])?;
         i += 1;
     }
 
     // Update metrics
     update_metrics(env, exec_context)?;
 
-    // Record the pointer to allocated Arrow Arrays
-    exec_context.ffi_arrays = arrays;
-
-    Ok(long_array.into_raw())
+    Ok(num_rows as jlong)
 }
 
 /// Pull the next input from JVM. Note that we cannot pull input batches in
@@ -337,7 +340,9 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
     e: JNIEnv,
     _class: JClass,
     exec_context: jlong,
-) -> jlongArray {
+    array_addrs: jlongArray,
+    schema_addrs: jlongArray,
+) -> jlong {
     try_unwrap_or_throw(&e, |mut env| {
         // Retrieve the query
         let exec_context = get_execution_context(exec_context);
@@ -383,7 +388,13 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
 
             match poll_output {
                 Poll::Ready(Some(output)) => {
-                    return prepare_output(&mut env, output?, exec_context);
+                    return prepare_output(
+                        &mut env,
+                        array_addrs,
+                        schema_addrs,
+                        output?,
+                        exec_context,
+                    );
                 }
                 Poll::Ready(None) => {
                     // Reaches EOF of output.
@@ -399,10 +410,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
                         }
                     }
 
-                    let long_array = env.new_long_array(1)?;
-                    env.set_long_array_region(&long_array, 0, &[-1])?;
-
-                    return Ok(long_array.into_raw());
+                    return Ok(-1);
                 }
                 // A poll pending means there are more than one blocking operators,
                 // we don't need go back-forth between JVM/Native. Just keeping polling.

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -296,11 +296,6 @@ unsafe fn prepare_output(
         }
     }
 
-    let return_flag = 1;
-
-    let long_array = env.new_long_array((results.len() * 2) as i32 + 2)?;
-    env.set_long_array_region(long_array, 0, &[return_flag, num_rows as jlong])?;
-
     let mut i = 0;
     while i < results.len() {
         let array_ref = results.get(i).ok_or(CometError::IndexOutOfBounds(i))?;

--- a/native/core/src/execution/utils.rs
+++ b/native/core/src/execution/utils.rs
@@ -108,18 +108,15 @@ impl SparkArrowConvert for ArrayData {
         let array_align = std::mem::align_of::<FFI_ArrowArray>();
         let schema_align = std::mem::align_of::<FFI_ArrowSchema>();
 
+        // Check if the pointer alignment is correct for `replace`.
         if array_ptr.align_offset(array_align) != 0 || schema_ptr.align_offset(schema_align) != 0 {
             return Err(ExecutionError::ArrowError(
                 "Pointer alignment is not correct".to_string(),
             ));
         }
 
-        let jvm_array = unsafe { std::ptr::replace(array_ptr, FFI_ArrowArray::new(self)) };
-        let jvm_schema =
-            unsafe { std::ptr::replace(schema_ptr, FFI_ArrowSchema::try_from(self.data_type())?) };
-
-        std::mem::forget(jvm_array);
-        std::mem::forget(jvm_schema);
+        unsafe { std::ptr::replace(array_ptr, FFI_ArrowArray::new(self)) };
+        unsafe { std::ptr::replace(schema_ptr, FFI_ArrowSchema::try_from(self.data_type())?) };
 
         Ok(())
     }

--- a/native/core/src/execution/utils.rs
+++ b/native/core/src/execution/utils.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::mem::forget;
 use std::sync::Arc;
 
 use arrow::{
@@ -102,13 +103,19 @@ impl SparkArrowConvert for ArrayData {
 
     /// Move this ArrowData to pointers of Arrow C data interface.
     fn move_to_spark(&self, array: i64, schema: i64) -> Result<(), ExecutionError> {
-        unsafe { std::ptr::replace(array as *mut FFI_ArrowArray, FFI_ArrowArray::new(self)) };
-        unsafe {
+        let jvm_array =
+            unsafe { std::ptr::replace(array as *mut FFI_ArrowArray, FFI_ArrowArray::new(self)) };
+        let jvm_schema = unsafe {
             std::ptr::replace(
                 schema as *mut FFI_ArrowSchema,
                 FFI_ArrowSchema::try_from(self.data_type())?,
             )
         };
+
+        // Don't deallocate the memory of the ArrowArray and ArrowSchema since they are allocated in Java.
+        // They will be deallocated in JVM.
+        forget(jvm_array);
+        forget(jvm_schema);
 
         Ok(())
     }

--- a/native/core/src/execution/utils.rs
+++ b/native/core/src/execution/utils.rs
@@ -102,13 +102,16 @@ impl SparkArrowConvert for ArrayData {
 
     /// Move this ArrowData to pointers of Arrow C data interface.
     fn move_to_spark(&self, array: i64, schema: i64) -> Result<(), ExecutionError> {
-        unsafe { std::ptr::replace(array as *mut FFI_ArrowArray, FFI_ArrowArray::new(self)) };
-        unsafe {
+        let jvm_array = unsafe { std::ptr::replace(array as *mut FFI_ArrowArray, FFI_ArrowArray::new(self)) };
+        let jvm_schema = unsafe {
             std::ptr::replace(
                 schema as *mut FFI_ArrowSchema,
                 FFI_ArrowSchema::try_from(self.data_type())?,
             )
         };
+
+        std::mem::forget(jvm_array);
+        std::mem::forget(jvm_schema);
 
         Ok(())
     }

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -43,6 +43,7 @@ import org.apache.comet.vector.NativeUtil
 class CometExecIterator(
     val id: Long,
     inputs: Seq[Iterator[ColumnarBatch]],
+    numOutputCols: Int,
     protobufQueryPlan: Array[Byte],
     nativeMetrics: CometMetricNode)
     extends Iterator[ColumnarBatch] {
@@ -100,18 +101,18 @@ class CometExecIterator(
   }
 
   def getNextBatch(): Option[ColumnarBatch] = {
+    val (arrayAddrs, schemaAddrs) = nativeUtil.allocateArrowStructs(numOutputCols)
+
     // we execute the native plan each time we need another output batch and this could
     // result in multiple input batches being processed
-    val result = nativeLib.executePlan(plan)
+    val result = nativeLib.executePlan(plan, arrayAddrs, schemaAddrs)
 
-    result(0) match {
+    result match {
       case -1 =>
         // EOF
         None
-      case 1 =>
-        val numRows = result(1)
-        val addresses = result.slice(2, result.length)
-        val cometVectors = nativeUtil.importVector(addresses)
+      case numRows =>
+        val cometVectors = nativeUtil.importVector(arrayAddrs, schemaAddrs)
         Some(new ColumnarBatch(cometVectors.toArray, numRows.toInt))
       case flag =>
         throw new IllegalStateException(s"Invalid native flag: $flag")

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -101,22 +101,11 @@ class CometExecIterator(
   }
 
   def getNextBatch(): Option[ColumnarBatch] = {
-    val (arrayAddrs, schemaAddrs) = nativeUtil.allocateArrowStructs(numOutputCols)
-
-    // we execute the native plan each time we need another output batch and this could
-    // result in multiple input batches being processed
-    val result = nativeLib.executePlan(plan, arrayAddrs, schemaAddrs)
-
-    result match {
-      case -1 =>
-        // EOF
-        None
-      case numRows =>
-        val cometVectors = nativeUtil.importVector(arrayAddrs, schemaAddrs)
-        Some(new ColumnarBatch(cometVectors.toArray, numRows.toInt))
-      case flag =>
-        throw new IllegalStateException(s"Invalid native flag: $flag")
-    }
+    nativeUtil.getNextBatch(
+      numOutputCols,
+      (arrayAddrs, schemaAddrs) => {
+        nativeLib.executePlan(plan, arrayAddrs, schemaAddrs)
+      })
   }
 
   override def hasNext: Boolean = {

--- a/spark/src/main/scala/org/apache/comet/Native.scala
+++ b/spark/src/main/scala/org/apache/comet/Native.scala
@@ -58,12 +58,14 @@ class Native extends NativeBase {
    *
    * @param plan
    *   the address to native query plan.
+   * @param arrayAddrs
+   *   the addresses of Arrow Array structures
+   * @param schemaAddrs
+   *   the addresses of Arrow Schema structures
    * @return
-   *   an array containing: 1) the status flag (1 for normal returned arrays, -1 for end of
-   *   output) 2) (optional) the number of rows if returned flag is 1 3) the addresses of output
-   *   Arrow arrays
+   *   the number of rows, if -1, it means end of the output.
    */
-  @native def executePlan(plan: Long): Array[Long]
+  @native def executePlan(plan: Long, arrayAddrs: Array[Long], schemaAddrs: Array[Long]): Long
 
   /**
    * Release and drop the native query plan object and context object.

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometExecUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometExecUtils.scala
@@ -53,7 +53,7 @@ object CometExecUtils {
       limit: Int): RDD[ColumnarBatch] = {
     childPlan.mapPartitionsInternal { iter =>
       val limitOp = CometExecUtils.getLimitNativePlan(outputAttribute, limit).get
-      CometExec.getCometIterator(Seq(iter), limitOp)
+      CometExec.getCometIterator(Seq(iter), outputAttribute.length, limitOp)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometTakeOrderedAndProjectExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometTakeOrderedAndProjectExec.scala
@@ -82,7 +82,7 @@ case class CometTakeOrderedAndProjectExec(
               CometExecUtils
                 .getTopKNativePlan(child.output, sortOrder, child, limit)
                 .get
-            CometExec.getCometIterator(Seq(iter), topK)
+            CometExec.getCometIterator(Seq(iter), child.output.length, topK)
           }
         }
 
@@ -102,7 +102,7 @@ case class CometTakeOrderedAndProjectExec(
         val topKAndProjection = CometExecUtils
           .getProjectionNativePlan(projectList, child.output, sortOrder, child, limit)
           .get
-        val it = CometExec.getCometIterator(Seq(iter), topKAndProjection)
+        val it = CometExec.getCometIterator(Seq(iter), output.length, topKAndProjection)
         setSubqueries(it.id, this)
 
         Option(TaskContext.get()).foreach { context =>

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -487,6 +487,7 @@ class CometShuffleWriteProcessor(
 
     val cometIter = CometExec.getCometIterator(
       Seq(newInputs.asInstanceOf[Iterator[ColumnarBatch]]),
+      outputAttributes.length,
       nativePlan,
       nativeMetrics)
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -119,19 +119,21 @@ object CometExec {
 
   def getCometIterator(
       inputs: Seq[Iterator[ColumnarBatch]],
+      numOutputCols: Int,
       nativePlan: Operator): CometExecIterator = {
-    getCometIterator(inputs, nativePlan, CometMetricNode(Map.empty))
+    getCometIterator(inputs, numOutputCols, nativePlan, CometMetricNode(Map.empty))
   }
 
   def getCometIterator(
       inputs: Seq[Iterator[ColumnarBatch]],
+      numOutputCols: Int,
       nativePlan: Operator,
       nativeMetrics: CometMetricNode): CometExecIterator = {
     val outputStream = new ByteArrayOutputStream()
     nativePlan.writeTo(outputStream)
     outputStream.close()
     val bytes = outputStream.toByteArray
-    new CometExecIterator(newIterId, inputs, bytes, nativeMetrics)
+    new CometExecIterator(newIterId, inputs, numOutputCols, bytes, nativeMetrics)
   }
 
   /**
@@ -213,8 +215,12 @@ abstract class CometNativeExec extends CometExec {
         val nativeMetrics = CometMetricNode.fromCometPlan(this)
 
         def createCometExecIter(inputs: Seq[Iterator[ColumnarBatch]]): CometExecIterator = {
-          val it =
-            new CometExecIterator(CometExec.newIterId, inputs, serializedPlanCopy, nativeMetrics)
+          val it = new CometExecIterator(
+            CometExec.newIterId,
+            inputs,
+            output.length,
+            serializedPlanCopy,
+            nativeMetrics)
 
           setSubqueries(it.id, this)
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #885.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This is another part of #885. In #893, we already revised the way we export arrays to native side. We now allocate array/schema structures in native side when exporting arrays from JVM to native.

Similarly, this PR revises the way we import array from native side by allocating array/schema structures in JVM when importing arrays from native to JVM.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
