### PR TITLE
perf: Report accurate total time for scans

### DIFF
--- a/docs/source/user-guide/tuning.md
+++ b/docs/source/user-guide/tuning.md
@@ -21,6 +21,14 @@ under the License.
 
 Comet provides some tuning options to help you get the best performance from your queries.
 
+## Metrics
+
+Comet metrics are not directly comparable to Spark metrics in some cases.
+
+`CometScanExec` uses nanoseconds for total scan time. Spark also measures scan time in nanoseconds but converts to
+milliseconds *per batch* which can result in a large loss of precision. In one case we saw total scan time
+of 41 seconds reported as 23 seconds for example.
+
 ## Memory Tuning
 
 Comet currently doesn't share the memory allocation from Spark but owns its own memory allocation.

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometBatchScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometBatchScanExec.scala
@@ -60,7 +60,7 @@ case class CometBatchScanExec(wrapped: BatchScanExec, runtimeFilters: Seq[Expres
           // The `FileScanRDD` returns an iterator which scans the file during the `hasNext` call.
           val startNs = System.nanoTime()
           val res = batches.hasNext
-          scanTime += NANOSECONDS.toMillis(System.nanoTime() - startNs)
+          scanTime += System.nanoTime() - startNs
           res
         }
 
@@ -139,7 +139,7 @@ case class CometBatchScanExec(wrapped: BatchScanExec, runtimeFilters: Seq[Expres
 
   override lazy val metrics: Map[String, SQLMetric] = Map(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
-    "scanTime" -> SQLMetrics.createTimingMetric(
+    "scanTime" -> SQLMetrics.createNanoTimingMetric(
       sparkContext,
       "scan time")) ++ wrapped.customMetrics ++ {
     wrapped.scan match {

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometBatchScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometBatchScanExec.scala
@@ -19,8 +19,6 @@
 
 package org.apache.spark.sql.comet
 
-import scala.concurrent.duration.NANOSECONDS
-
 import org.apache.spark.rdd._
 import org.apache.spark.sql.catalyst._
 import org.apache.spark.sql.catalyst.expressions.{Attribute, DynamicPruningExpression, Expression, Literal}

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
@@ -198,7 +198,7 @@ case class CometScanExec(
     // Tracking scan time has overhead, we can't afford to do it for each row, and can only do
     // it for each batch.
     if (supportsColumnar) {
-      Some("scanTime" -> SQLMetrics.createTimingMetric(sparkContext, "scan time"))
+      Some("scanTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "scan time"))
     } else {
       None
     }
@@ -223,7 +223,7 @@ case class CometScanExec(
           // The `FileScanRDD` returns an iterator which scans the file during the `hasNext` call.
           val startNs = System.nanoTime()
           val res = batches.hasNext
-          scanTime += NANOSECONDS.toMillis(System.nanoTime() - startNs)
+          scanTime += System.nanoTime() - startNs
           res
         }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/914

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The total scan time reported by Comet is often less than the reported time to decode Parquet data, which does not make sense.

The issue is that we convert nano time to milliseconds for each batch and this loses a lot of precision. In one example, the actual total scan time was 41 seconds but it was reported as 23 seconds, which is very misleading. Spark also suffers from this problem.

### Before

![Screenshot from 2024-09-05 09-56-51](https://github.com/user-attachments/assets/3a6206b8-afc7-4498-a708-e143095c7e54)

### After

![Screenshot from 2024-09-05 09-56-09](https://github.com/user-attachments/assets/56b4a34a-6ff5-43d2-8e35-fd03eb25cd09)

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Change scan time to be recorded in nanos.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Manual testing. See earlier screenshots.