### PR TITLE
perf: Add metric for time spent casting in native scan

### DIFF
--- a/native/core/src/execution/operators/scan.rs
+++ b/native/core/src/execution/operators/scan.rs
@@ -347,7 +347,7 @@ struct ScanStream<'a> {
     baseline_metrics: BaselineMetrics,
     /// Cast options
     cast_options: CastOptions<'a>,
-    /// Timer for cast operations
+    /// elapsed time for casting columns to different data types during scan
     cast_time: Time,
 }
 

--- a/native/core/src/execution/operators/scan.rs
+++ b/native/core/src/execution/operators/scan.rs
@@ -39,7 +39,9 @@ use arrow_data::ffi::FFI_ArrowArray;
 use arrow_data::ArrayData;
 use arrow_schema::ffi::FFI_ArrowSchema;
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
-use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::metrics::{
+    BaselineMetrics, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet, Time,
+};
 use datafusion::{
     execution::TaskContext,
     physical_expr::*,
@@ -345,16 +347,20 @@ struct ScanStream<'a> {
     baseline_metrics: BaselineMetrics,
     /// Cast options
     cast_options: CastOptions<'a>,
+    /// Timer for cast operations
+    cast_time: Time,
 }
 
 impl<'a> ScanStream<'a> {
     pub fn new(scan: ScanExec, schema: SchemaRef, partition: usize) -> Self {
         let baseline_metrics = BaselineMetrics::new(&scan.metrics, partition);
+        let cast_time = MetricBuilder::new(&scan.metrics).subset_time("cast_time", partition);
         Self {
             scan,
             schema,
             baseline_metrics,
             cast_options: CastOptions::default(),
+            cast_time,
         }
     }
 
@@ -375,7 +381,10 @@ impl<'a> ScanStream<'a> {
             .zip(schema_fields.iter())
             .map(|(column, f)| {
                 if column.data_type() != f.data_type() {
-                    cast_with_options(column, f.data_type(), &self.cast_options)
+                    let mut timer = self.cast_time.timer();
+                    let cast_array = cast_with_options(column, f.data_type(), &self.cast_options);
+                    timer.stop();
+                    cast_array
                 } else {
                     Ok(Arc::clone(column))
                 }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
@@ -80,6 +80,15 @@ object CometMetricNode {
   }
 
   /**
+   * SQL Metrics for Comet native ScanExec
+   */
+  def scanMetrics(sc: SparkContext): Map[String, SQLMetric] = {
+    Map(
+      "cast_time" ->
+        SQLMetrics.createNanoTimingMetric(sc, "Total time for casting arrays"))
+  }
+
+  /**
    * SQL Metrics for DataFusion HashJoin
    */
   def hashJoinMetrics(sc: SparkContext): Map[String, SQLMetric] = {

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
@@ -85,7 +85,7 @@ object CometMetricNode {
   def scanMetrics(sc: SparkContext): Map[String, SQLMetric] = {
     Map(
       "cast_time" ->
-        SQLMetrics.createNanoTimingMetric(sc, "Total time for casting arrays"))
+        SQLMetrics.createNanoTimingMetric(sc, "Total time for casting columns"))
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
@@ -198,9 +198,12 @@ case class CometScanExec(
     // Tracking scan time has overhead, we can't afford to do it for each row, and can only do
     // it for each batch.
     if (supportsColumnar) {
-      Some("scanTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "scan time"))
+      Seq(
+        "scanTime" -> SQLMetrics.createNanoTimingMetric(
+          sparkContext,
+          "scan time")) ++ CometMetricNode.scanMetrics(sparkContext)
     } else {
-      None
+      Seq.empty
     }
   } ++ {
     relation.fileFormat match {

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
@@ -198,12 +198,12 @@ case class CometScanExec(
     // Tracking scan time has overhead, we can't afford to do it for each row, and can only do
     // it for each batch.
     if (supportsColumnar) {
-      Seq(
+      Map(
         "scanTime" -> SQLMetrics.createNanoTimingMetric(
           sparkContext,
           "scan time")) ++ CometMetricNode.scanMetrics(sparkContext)
     } else {
-      Seq.empty
+      Map.empty
     }
   } ++ {
     relation.fileFormat match {

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -523,7 +523,7 @@ class CometExecSuite extends CometTestBase {
         val path = new Path(dir.toURI.toString, "native-scan.parquet")
         makeParquetFileAllTypes(path, dictionaryEnabled = true, 10000)
         withParquetTable(path.toString, "tbl") {
-          val df = sql("SELECT * FROM tbl")
+          val df = sql("SELECT * FROM tbl WHERE _2 > _3")
           df.collect()
 
           val metrics = find(df.queryExecution.executedPlan)(_.isInstanceOf[CometScanExec])
@@ -532,9 +532,8 @@ class CometExecSuite extends CometTestBase {
 
           assert(metrics.contains("scanTime"))
           assert(metrics.contains("cast_time"))
-
-          // TODO this assertion fails
-//            assert(metrics("cast_time").value > 0)
+          assert(metrics("scanTime").value > 0)
+          assert(metrics("cast_time").value > 0)
         }
       }
     }

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -517,6 +517,25 @@ class CometExecSuite extends CometTestBase {
     }
   }
 
+  test("Comet native metrics: scan") {
+    withSQLConf(CometConf.COMET_EXEC_ENABLED.key -> "true") {
+      withPar
+        val df = sql("SELECT cast(_1 as decimal(7,2)), cast(_2 as decimal(7,2)) FROM tbl")
+        df.collect()
+
+        val metrics = find(df.queryExecution.executedPlan)(_.isInstanceOf[CometScanExec])
+          .map(_.metrics)
+          .get
+
+        assert(metrics.contains("scanTime"))
+        assert(metrics.contains("cast_time"))
+
+        // TODO this assertion currently fails
+        //assert(metrics("cast_time").value > 0)
+      }
+    }
+  }
+
   test("Comet native metrics: project and filter") {
     withSQLConf(CometConf.COMET_EXEC_ENABLED.key -> "true") {
       withParquetTable((0 until 5).map(i => (i, i + 1)), "tbl") {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Make it easy to see how much of the native `ScanExec` time is spent casting columns to different types (this usually means unpacking dictionaries). 

Example from TPC-DS q9:


![Screenshot from 2024-09-06 11-57-48](https://github.com/user-attachments/assets/3fd75839-077f-41f7-8182-f74e82b5c74f)

DataFusion metrics in native explain output:


```
metrics=[
  output_rows=2097152, 
  elapsed_compute=21.847892ms, 
  cast_time=21.631731ms]
```

Full plan:

```
AggregateExec: mode=Partial, gby=[], aggr=[count, avg, avg], metrics=[output_rows=1, elapsed_compute=9.481194ms]
  ProjectionExec: expr=[col_1@1 as col_0, col_2@2 as col_1], metrics=[output_rows=400519, elapsed_compute=50.596µs]
    FilterExec: col_0@0 IS NOT NULL AND col_0@0 >= 81 AND col_0@0 <= 100, metrics=[output_rows=400519, elapsed_compute=4.753725ms]
      ScanExec: source=[CometScan parquet  (unknown)], schema=[col_0: Int32, col_1: Decimal128(7, 2), col_2: Decimal128(7, 2)], metrics=[output_rows=2097152, elapsed_compute=21.847892ms, cast_time=21.631731ms]
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
