### PR TITLE
perf: Add metric for time spent in CometSparkToColumnarExec

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometSparkToColumnarExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometSparkToColumnarExec.scala
@@ -91,14 +91,11 @@ case class CometSparkToColumnarExec(child: SparkPlan)
               val startNs = System.nanoTime()
               val batch = arrowBatches.next()
               conversionTime += System.nanoTime() - startNs
+              numInputRows += batch.numRows()
+              numOutputBatches += 1
               batch
             }
           }
-        }
-        .map { batch =>
-          numInputRows += batch.numRows()
-          numOutputBatches += 1
-          batch
         }
     } else {
       child
@@ -124,17 +121,13 @@ case class CometSparkToColumnarExec(child: SparkPlan)
               val startNs = System.nanoTime()
               val batch = arrowBatches.next()
               conversionTime += System.nanoTime() - startNs
+              numInputRows += batch.numRows()
+              numOutputBatches += 1
               batch
             }
           }
         }
-        .map { batch =>
-          numInputRows += batch.numRows()
-          numOutputBatches += 1
-          batch
-        }
     }
-
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): CometSparkToColumnarExec =

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometSparkToColumnarExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometSparkToColumnarExec.scala
@@ -59,7 +59,7 @@ case class CometSparkToColumnarExec(child: SparkPlan)
       sparkContext,
       "time converting Spark batches to Arrow batches"))
 
-  // The conversion from Spark to Arrow batches happens in next(), so wrap the call to measure time spent.
+  // The conversion happens in next(), so wrap the call to measure time spent.
   private def createTimingIter(
       iter: Iterator[ColumnarBatch],
       numInputRows: SQLMetric,

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -1650,6 +1650,7 @@ class CometExecSuite extends CometTestBase {
           spark.catalog.cacheTable("abc")
           val df = spark.sql("SELECT * FROM abc").groupBy("key").count()
           checkSparkAnswerAndOperator(df, includeClasses = Seq(classOf[CometSparkToColumnarExec]))
+          df.collect()
 
           val metrics = find(df.queryExecution.executedPlan) {
             case _: CometSparkToColumnarExec => true

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -1650,6 +1650,15 @@ class CometExecSuite extends CometTestBase {
           spark.catalog.cacheTable("abc")
           val df = spark.sql("SELECT * FROM abc").groupBy("key").count()
           checkSparkAnswerAndOperator(df, includeClasses = Seq(classOf[CometSparkToColumnarExec]))
+
+          val metrics = find(df.queryExecution.executedPlan) {
+            case _: CometSparkToColumnarExec => true
+            case _ => false
+          }.map(_.metrics).get
+
+          assert(metrics.contains("conversionTime"))
+          assert(metrics("conversionTime").value > 0)
+
         }
       })
     })

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -1635,33 +1635,31 @@ class CometExecSuite extends CometTestBase {
   }
 
   test("SparkToColumnar over InMemoryTableScanExec") {
-    Seq("true", "false").foreach(aqe => {
-      Seq("true", "false").foreach(cacheVectorized => {
-        withSQLConf(
-          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> aqe,
-          CometConf.COMET_SHUFFLE_MODE.key -> "jvm",
-          SQLConf.CACHE_VECTORIZED_READER_ENABLED.key -> cacheVectorized) {
-          spark
-            .range(1000)
-            .selectExpr("id as key", "id % 8 as value")
-            .toDF("key", "value")
-            .selectExpr("key", "value", "key+1")
-            .createOrReplaceTempView("abc")
-          spark.catalog.cacheTable("abc")
-          val df = spark.sql("SELECT * FROM abc").groupBy("key").count()
-          checkSparkAnswerAndOperator(df, includeClasses = Seq(classOf[CometSparkToColumnarExec]))
-          df.collect() // Without this collect we don't get an aggregation of the metrics.
+    Seq("true", "false").foreach(cacheVectorized => {
+      withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+        CometConf.COMET_SHUFFLE_MODE.key -> "jvm",
+        SQLConf.CACHE_VECTORIZED_READER_ENABLED.key -> cacheVectorized) {
+        spark
+          .range(1000)
+          .selectExpr("id as key", "id % 8 as value")
+          .toDF("key", "value")
+          .selectExpr("key", "value", "key+1")
+          .createOrReplaceTempView("abc")
+        spark.catalog.cacheTable("abc")
+        val df = spark.sql("SELECT * FROM abc").groupBy("key").count()
+        checkSparkAnswerAndOperator(df, includeClasses = Seq(classOf[CometSparkToColumnarExec]))
+        df.collect() // Without this collect we don't get an aggregation of the metrics.
 
-          val metrics = find(df.queryExecution.executedPlan) {
-            case _: CometSparkToColumnarExec => true
-            case _ => false
-          }.map(_.metrics).get
+        val metrics = find(df.queryExecution.executedPlan) {
+          case _: CometSparkToColumnarExec => true
+          case _ => false
+        }.map(_.metrics).get
 
-          assert(metrics.contains("conversionTime"))
-          assert(metrics("conversionTime").value > 0)
+        assert(metrics.contains("conversionTime"))
+        assert(metrics("conversionTime").value > 0)
 
-        }
-      })
+      }
     })
   }
 

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -1650,7 +1650,7 @@ class CometExecSuite extends CometTestBase {
           spark.catalog.cacheTable("abc")
           val df = spark.sql("SELECT * FROM abc").groupBy("key").count()
           checkSparkAnswerAndOperator(df, includeClasses = Seq(classOf[CometSparkToColumnarExec]))
-          df.collect()
+          df.collect() // Without this collect we don't get an aggregation of the metrics.
 
           val metrics = find(df.queryExecution.executedPlan) {
             case _: CometSparkToColumnarExec => true


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We want deeper insights to query performance when Spark to Arrow conversions occur.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Added a new metric to `CometSparkToColumnarExec` and wrapped the calls to the batch iterator's `next` function with timing functions.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Extended an existing test that exercises SparkToColumnar to check for metrics.
