### PR TITLE
chore: Change maven group ID to `org.apache.datafusion`

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -24,7 +24,7 @@ under the License.
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.comet</groupId>
+    <groupId>org.apache.datafusion.comet</groupId>
     <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
     <version>0.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -24,7 +24,7 @@ under the License.
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.datafusion.comet</groupId>
+    <groupId>org.apache.datafusion</groupId>
     <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
     <version>0.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>

--- a/dev/diffs/3.4.3.diff
+++ b/dev/diffs/3.4.3.diff
@@ -16,7 +16,7 @@ index d3544881af1..bf0e2b53c70 100644
          <version>${netlib.ludovic.dev.version}</version>
        </dependency>
 +      <dependency>
-+        <groupId>org.apache.datafusion.comet</groupId>
++        <groupId>org.apache.datafusion</groupId>
 +        <artifactId>comet-spark-spark${spark.version.short}_${scala.binary.version}</artifactId>
 +        <version>${comet.version}</version>
 +        <exclusions>
@@ -46,7 +46,7 @@ index b386d135da1..854aec17c2d 100644
        <artifactId>spark-tags_${scala.binary.version}</artifactId>
      </dependency>
 +    <dependency>
-+      <groupId>org.apache.datafusion.comet</groupId>
++      <groupId>org.apache.datafusion</groupId>
 +      <artifactId>comet-spark-spark${spark.version.short}_${scala.binary.version}</artifactId>
 +    </dependency>
  

--- a/dev/diffs/3.4.3.diff
+++ b/dev/diffs/3.4.3.diff
@@ -16,7 +16,7 @@ index d3544881af1..bf0e2b53c70 100644
          <version>${netlib.ludovic.dev.version}</version>
        </dependency>
 +      <dependency>
-+        <groupId>org.apache.comet</groupId>
++        <groupId>org.apache.datafusion.comet</groupId>
 +        <artifactId>comet-spark-spark${spark.version.short}_${scala.binary.version}</artifactId>
 +        <version>${comet.version}</version>
 +        <exclusions>
@@ -46,7 +46,7 @@ index b386d135da1..854aec17c2d 100644
        <artifactId>spark-tags_${scala.binary.version}</artifactId>
      </dependency>
 +    <dependency>
-+      <groupId>org.apache.comet</groupId>
++      <groupId>org.apache.datafusion.comet</groupId>
 +      <artifactId>comet-spark-spark${spark.version.short}_${scala.binary.version}</artifactId>
 +    </dependency>
  

--- a/dev/diffs/3.5.1.diff
+++ b/dev/diffs/3.5.1.diff
@@ -16,7 +16,7 @@ index 0f504dbee85..f6019da888a 100644
          <version>${netlib.ludovic.dev.version}</version>
        </dependency>
 +      <dependency>
-+        <groupId>org.apache.comet</groupId>
++        <groupId>org.apache.datafusion.comet</groupId>
 +        <artifactId>comet-spark-spark${spark.version.short}_${scala.binary.version}</artifactId>
 +        <version>${comet.version}</version>
 +        <exclusions>
@@ -46,7 +46,7 @@ index c46ab7b8fce..d8b99c2c115 100644
        <artifactId>spark-tags_${scala.binary.version}</artifactId>
      </dependency>
 +    <dependency>
-+      <groupId>org.apache.comet</groupId>
++      <groupId>org.apache.datafusion.comet</groupId>
 +      <artifactId>comet-spark-spark${spark.version.short}_${scala.binary.version}</artifactId>
 +    </dependency>
  

--- a/dev/diffs/3.5.1.diff
+++ b/dev/diffs/3.5.1.diff
@@ -16,7 +16,7 @@ index 0f504dbee85..f6019da888a 100644
          <version>${netlib.ludovic.dev.version}</version>
        </dependency>
 +      <dependency>
-+        <groupId>org.apache.datafusion.comet</groupId>
++        <groupId>org.apache.datafusion</groupId>
 +        <artifactId>comet-spark-spark${spark.version.short}_${scala.binary.version}</artifactId>
 +        <version>${comet.version}</version>
 +        <exclusions>
@@ -46,7 +46,7 @@ index c46ab7b8fce..d8b99c2c115 100644
        <artifactId>spark-tags_${scala.binary.version}</artifactId>
      </dependency>
 +    <dependency>
-+      <groupId>org.apache.datafusion.comet</groupId>
++      <groupId>org.apache.datafusion</groupId>
 +      <artifactId>comet-spark-spark${spark.version.short}_${scala.binary.version}</artifactId>
 +    </dependency>
  

--- a/dev/diffs/4.0.0-preview1.diff
+++ b/dev/diffs/4.0.0-preview1.diff
@@ -16,7 +16,7 @@ index a4b1b2c3c9f..db50bdb0d3b 100644
          <version>${netlib.ludovic.dev.version}</version>
        </dependency>
 +      <dependency>
-+        <groupId>org.apache.datafusion.comet</groupId>
++        <groupId>org.apache.datafusion</groupId>
 +        <artifactId>comet-spark-spark${spark.version.short}_${scala.binary.version}</artifactId>
 +        <version>${comet.version}</version>
 +        <exclusions>
@@ -46,7 +46,7 @@ index 19f6303be36..31e1d27700f 100644
        <artifactId>spark-tags_${scala.binary.version}</artifactId>
      </dependency>
 +    <dependency>
-+      <groupId>org.apache.datafusion.comet</groupId>
++      <groupId>org.apache.datafusion</groupId>
 +      <artifactId>comet-spark-spark${spark.version.short}_${scala.binary.version}</artifactId>
 +    </dependency>
  

--- a/dev/diffs/4.0.0-preview1.diff
+++ b/dev/diffs/4.0.0-preview1.diff
@@ -16,7 +16,7 @@ index a4b1b2c3c9f..db50bdb0d3b 100644
          <version>${netlib.ludovic.dev.version}</version>
        </dependency>
 +      <dependency>
-+        <groupId>org.apache.comet</groupId>
++        <groupId>org.apache.datafusion.comet</groupId>
 +        <artifactId>comet-spark-spark${spark.version.short}_${scala.binary.version}</artifactId>
 +        <version>${comet.version}</version>
 +        <exclusions>
@@ -46,7 +46,7 @@ index 19f6303be36..31e1d27700f 100644
        <artifactId>spark-tags_${scala.binary.version}</artifactId>
      </dependency>
 +    <dependency>
-+      <groupId>org.apache.comet</groupId>
++      <groupId>org.apache.datafusion.comet</groupId>
 +      <artifactId>comet-spark-spark${spark.version.short}_${scala.binary.version}</artifactId>
 +    </dependency>
  

--- a/fuzz-testing/pom.xml
+++ b/fuzz-testing/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.apache.datafusion.comet</groupId>
+        <groupId>org.apache.datafusion</groupId>
         <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
         <version>0.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/fuzz-testing/pom.xml
+++ b/fuzz-testing/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.apache.comet</groupId>
+        <groupId>org.apache.datafusion.comet</groupId>
         <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
         <version>0.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@ under the License.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.apache.datafusion.comet</groupId>
+  <groupId>org.apache.datafusion</groupId>
   <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
   <version>0.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
@@ -267,7 +267,7 @@ under the License.
         <scope>test</scope>
         <exclusions>
           <exclusion>
-            <groupId>org.apache.datafusion.comet</groupId>
+            <groupId>org.apache.datafusion</groupId>
             <artifactId>*</artifactId>
           </exclusion>
 
@@ -331,7 +331,7 @@ under the License.
             <artifactId>parquet-column</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.apache.datafusion.comet</groupId>
+            <groupId>org.apache.datafusion</groupId>
             <artifactId>*</artifactId>
           </exclusion>
 
@@ -354,7 +354,7 @@ under the License.
         <scope>test</scope>
         <exclusions>
           <exclusion>
-            <groupId>org.apache.datafusion.comet</groupId>
+            <groupId>org.apache.datafusion</groupId>
             <artifactId>*</artifactId>
           </exclusion>
           <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@ under the License.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.apache.comet</groupId>
+  <groupId>org.apache.datafusion.comet</groupId>
   <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
   <version>0.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
@@ -267,7 +267,7 @@ under the License.
         <scope>test</scope>
         <exclusions>
           <exclusion>
-            <groupId>org.apache.comet</groupId>
+            <groupId>org.apache.datafusion.comet</groupId>
             <artifactId>*</artifactId>
           </exclusion>
 
@@ -331,7 +331,7 @@ under the License.
             <artifactId>parquet-column</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.apache.comet</groupId>
+            <groupId>org.apache.datafusion.comet</groupId>
             <artifactId>*</artifactId>
           </exclusion>
 
@@ -354,7 +354,7 @@ under the License.
         <scope>test</scope>
         <exclusions>
           <exclusion>
-            <groupId>org.apache.comet</groupId>
+            <groupId>org.apache.datafusion.comet</groupId>
             <artifactId>*</artifactId>
           </exclusion>
           <exclusion>

--- a/spark-integration/pom.xml
+++ b/spark-integration/pom.xml
@@ -24,7 +24,7 @@ under the License.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.apache.comet</groupId>
+        <groupId>org.apache.datafusion.comet</groupId>
         <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
         <version>0.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -41,13 +41,13 @@ under the License.
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.comet</groupId>
+            <groupId>org.apache.datafusion.comet</groupId>
             <artifactId>comet-spark-spark${spark.version.short}_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <exclusions>
               <!-- This is shaded into the jar -->
               <exclusion>
-                <groupId>org.apache.comet</groupId>
+                <groupId>org.apache.datafusion.comet</groupId>
                 <artifactId>comet-common-spark${spark.version.short}_${scala.binary.version}</artifactId>
               </exclusion>
             </exclusions>

--- a/spark-integration/pom.xml
+++ b/spark-integration/pom.xml
@@ -24,7 +24,7 @@ under the License.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.apache.datafusion.comet</groupId>
+        <groupId>org.apache.datafusion</groupId>
         <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
         <version>0.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -41,13 +41,13 @@ under the License.
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.datafusion.comet</groupId>
+            <groupId>org.apache.datafusion</groupId>
             <artifactId>comet-spark-spark${spark.version.short}_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <exclusions>
               <!-- This is shaded into the jar -->
               <exclusion>
-                <groupId>org.apache.datafusion.comet</groupId>
+                <groupId>org.apache.datafusion</groupId>
                 <artifactId>comet-common-spark${spark.version.short}_${scala.binary.version}</artifactId>
               </exclusion>
             </exclusions>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -24,7 +24,7 @@ under the License.
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.comet</groupId>
+    <groupId>org.apache.datafusion.comet</groupId>
     <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
     <version>0.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
@@ -40,7 +40,7 @@ under the License.
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.comet</groupId>
+      <groupId>org.apache.datafusion.comet</groupId>
       <artifactId>comet-common-spark${spark.version.short}_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <exclusions>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -24,7 +24,7 @@ under the License.
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.datafusion.comet</groupId>
+    <groupId>org.apache.datafusion</groupId>
     <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
     <version>0.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
@@ -40,7 +40,7 @@ under the License.
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.datafusion.comet</groupId>
+      <groupId>org.apache.datafusion</groupId>
       <artifactId>comet-common-spark${spark.version.short}_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <exclusions>


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/datafusion-comet/issues/721

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I am requesting that ASF INFRA sets up Nexus access for the DataFusion project so that we can publish Maven artifacts. The normal convention for maven group ids for Apache projects is `org.apache.TLPNAME`, so I think we need to revisit changing our Maven group ids (<groupId> in the pom.xml) from `org.apache.comet` to `org.apache.datafusion`. The DataFusion project could hypothetically want to publish Java bindings to Maven in the future as well. The artifact names would not change and there is no need to change package names in the code.

Note that we did previously discuss this back in https://github.com/apache/datafusion-comet/pull/278.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
