### PR TITLE
chore: Show reason for falling back to Spark when SMJ with join condition is not enabled

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -2976,7 +2976,10 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
         if (join.condition.isDefined &&
           !CometConf.COMET_EXEC_SORT_MERGE_JOIN_WITH_JOIN_FILTER_ENABLED
             .get(conf)) {
-          withInfo(join, join.condition.get)
+          withInfo(
+            join,
+            s"${CometConf.COMET_EXEC_SORT_MERGE_JOIN_WITH_JOIN_FILTER_ENABLED.key} is not enabled",
+            join.condition.get)
           return None
         }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The fallback message in the plan was not very helpful.

Before:

```
SortMergeJoin [COMET: ]
```

After:

```
SortMergeJoin [COMET: spark.comet.exec.sortMergeJoinWithJoinFilter.enabled is not enabled]
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
