### PR TITLE
perf: Remove one redundant CopyExec for SMJ

### DIFF
--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -918,7 +918,6 @@ impl PhysicalPlanner {
                 let fetch = sort.fetch.map(|num| num as usize);
 
                 let child: Arc<dyn ExecutionPlan> = if can_reuse_input_batch(&child) {
-                    // perform a deep copy but do not unpack dictionaries
                     Arc::new(CopyExec::new(child, CopyMode::UnpackOrDeepCopy))
                 } else {
                     child

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -1137,6 +1137,7 @@ impl PhysicalPlanner {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn parse_join_parameters(
         &self,
         inputs: &mut Vec<Arc<GlobalRef>>,

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -1284,7 +1284,10 @@ impl PhysicalPlanner {
         ))
     }
 
-    fn wrap_in_copy_exec(is_sort_merge: bool, plan: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+    fn wrap_in_copy_exec(
+        is_sort_merge: bool,
+        plan: Arc<dyn ExecutionPlan>,
+    ) -> Arc<dyn ExecutionPlan> {
         if is_sort_merge {
             // SortExec does not produce dictionary arrays and does not re-use batches,
             // so no need for a CopyExec in this case

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -919,7 +919,7 @@ impl PhysicalPlanner {
 
                 let child: Arc<dyn ExecutionPlan> = if can_reuse_input_batch(&child) {
                     // perform a deep copy but do not unpack dictionaries
-                    Arc::new(CopyExec::new(child, CopyMode::DeepCopy))
+                    Arc::new(CopyExec::new(child, CopyMode::UnpackOrDeepCopy))
                 } else {
                     child
                 };

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -916,16 +916,7 @@ impl PhysicalPlanner {
                     .collect();
 
                 let fetch = sort.fetch.map(|num| num as usize);
-
-                let child: Arc<dyn ExecutionPlan> = if can_reuse_input_batch(&child) {
-                    // perform a deep copy but do not unpack dictionaries
-                    Arc::new(CopyExec::new(child, CopyMode::DeepCopy))
-                } else {
-                    child
-                };
-
                 let sort_exec = Arc::new(SortExec::new(exprs?, child).with_fetch(fetch));
-
                 Ok((scans, sort_exec))
             }
             OpStruct::Scan(scan) => {
@@ -1269,8 +1260,8 @@ impl PhysicalPlanner {
         // DataFusion Join operators keep the input batch internally. We need
         // to copy the input batch to avoid the data corruption from reusing the input
         // batch.
-        let left = Self::wrap_in_copy_exec(is_sort_merge, left);
-        let right = Self::wrap_in_copy_exec(is_sort_merge, right);
+        let left = Self::wrap_join_input_in_copy_exec(is_sort_merge, left);
+        let right = Self::wrap_join_input_in_copy_exec(is_sort_merge, right);
 
         Ok((
             JoinParameters {
@@ -1284,10 +1275,14 @@ impl PhysicalPlanner {
         ))
     }
 
-    fn wrap_in_copy_exec(is_sort_merge: bool, plan: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+    fn wrap_join_input_in_copy_exec(
+        is_sort_merge: bool,
+        plan: Arc<dyn ExecutionPlan>,
+    ) -> Arc<dyn ExecutionPlan> {
         if is_sort_merge {
-            // SortExec does not produce dictionary arrays and does not re-use batches,
-            // so no need for a CopyExec in this case
+            // The input to a SortMergeJoin is always a SortExec, which does not produce
+            // dictionary-encoded arrays and does not re-use batches, so there is no need for
+            // a CopyExec in this case
             plan
         } else if can_reuse_input_batch(&plan) {
             Arc::new(CopyExec::new(plan, CopyMode::UnpackOrDeepCopy))

--- a/native/core/src/execution/mod.rs
+++ b/native/core/src/execution/mod.rs
@@ -26,11 +26,102 @@ pub mod operators;
 pub mod serde;
 pub mod shuffle;
 pub(crate) mod sort;
+
+use ::datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use arrow_array::RecordBatch;
+use arrow_schema::SchemaRef;
 pub use datafusion_comet_spark_expr::timezone;
+use datafusion_execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
+use futures::{Stream, StreamExt};
+use std::any::Any;
+use std::fmt::Formatter;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
 pub(crate) mod utils;
 
 mod memory_pool;
 pub use memory_pool::*;
+
+#[derive(Debug)]
+pub struct DebugExec {
+    child: Arc<dyn ExecutionPlan>,
+}
+
+impl DebugExec {
+    pub fn new(child: Arc<dyn ExecutionPlan>) -> Self {
+        Self { child }
+    }
+}
+
+impl DisplayAs for DebugExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "DebugExec")
+    }
+}
+
+impl ExecutionPlan for DebugExec {
+    fn name(&self) -> &str {
+        "DebugExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        self.child.properties()
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.child]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+        unreachable!()
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> datafusion_common::Result<SendableRecordBatchStream> {
+        let stream = self.child.execute(partition, context)?;
+        Ok(Box::pin(DebugStream {
+            name: self.child.name().to_owned(),
+            child_stream: stream,
+        }))
+    }
+}
+
+pub struct DebugStream {
+    name: String,
+    child_stream: SendableRecordBatchStream,
+}
+
+impl Stream for DebugStream {
+    type Item = datafusion_common::Result<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.child_stream.poll_next_unpin(cx).map(|x| match x {
+            Some(Err(e)) => {
+                println!("{}.poll_next() returned an error: {}", self.name, e);
+                panic!("{}.poll_next() returned an error: {}", self.name, e);
+                // Some(Err(e))
+            }
+            other => other,
+        })
+    }
+}
+
+impl RecordBatchStream for DebugStream {
+    fn schema(&self) -> SchemaRef {
+        self.child_stream.schema()
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/native/core/src/execution/mod.rs
+++ b/native/core/src/execution/mod.rs
@@ -26,102 +26,11 @@ pub mod operators;
 pub mod serde;
 pub mod shuffle;
 pub(crate) mod sort;
-
-use ::datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
-use arrow_array::RecordBatch;
-use arrow_schema::SchemaRef;
 pub use datafusion_comet_spark_expr::timezone;
-use datafusion_execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
-use futures::{Stream, StreamExt};
-use std::any::Any;
-use std::fmt::Formatter;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
 pub(crate) mod utils;
 
 mod memory_pool;
 pub use memory_pool::*;
-
-#[derive(Debug)]
-pub struct DebugExec {
-    child: Arc<dyn ExecutionPlan>,
-}
-
-impl DebugExec {
-    pub fn new(child: Arc<dyn ExecutionPlan>) -> Self {
-        Self { child }
-    }
-}
-
-impl DisplayAs for DebugExec {
-    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "DebugExec")
-    }
-}
-
-impl ExecutionPlan for DebugExec {
-    fn name(&self) -> &str {
-        "DebugExec"
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn properties(&self) -> &PlanProperties {
-        self.child.properties()
-    }
-
-    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        vec![&self.child]
-    }
-
-    fn with_new_children(
-        self: Arc<Self>,
-        _children: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
-        unreachable!()
-    }
-
-    fn execute(
-        &self,
-        partition: usize,
-        context: Arc<TaskContext>,
-    ) -> datafusion_common::Result<SendableRecordBatchStream> {
-        let stream = self.child.execute(partition, context)?;
-        Ok(Box::pin(DebugStream {
-            name: self.child.name().to_owned(),
-            child_stream: stream,
-        }))
-    }
-}
-
-pub struct DebugStream {
-    name: String,
-    child_stream: SendableRecordBatchStream,
-}
-
-impl Stream for DebugStream {
-    type Item = datafusion_common::Result<RecordBatch>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.child_stream.poll_next_unpin(cx).map(|x| match x {
-            Some(Err(e)) => {
-                println!("{}.poll_next() returned an error: {}", self.name, e);
-                panic!("{}.poll_next() returned an error: {}", self.name, e);
-                // Some(Err(e))
-            }
-            other => other,
-        })
-    }
-}
-
-impl RecordBatchStream for DebugStream {
-    fn schema(&self) -> SchemaRef {
-        self.child_stream.schema()
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/native/core/src/execution/operators/copy.rs
+++ b/native/core/src/execution/operators/copy.rs
@@ -50,6 +50,8 @@ pub struct CopyExec {
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum CopyMode {
+    /// Perform a deep copy but do not unpack dictionaries
+    DeepCopy,
     /// Perform a deep copy and also unpack dictionaries
     UnpackOrDeepCopy,
     /// Perform a clone and also unpack dictionaries
@@ -66,7 +68,7 @@ impl CopyExec {
             .fields
             .iter()
             .map(|f: &FieldRef| match f.data_type() {
-                DataType::Dictionary(_, value_type) => {
+                DataType::Dictionary(_, value_type) if mode != CopyMode::DeepCopy => {
                     Field::new(f.name(), value_type.as_ref().clone(), f.is_nullable())
                 }
                 _ => f.as_ref().clone(),
@@ -260,15 +262,15 @@ fn copy_array(array: &dyn Array) -> ArrayRef {
 /// array is a primitive array, we simply copy the array.
 fn copy_or_unpack_array(array: &Arc<dyn Array>, mode: &CopyMode) -> Result<ArrayRef, ArrowError> {
     match array.data_type() {
-        DataType::Dictionary(_, value_type) => {
+        DataType::Dictionary(_, value_type) if mode != &CopyMode::DeepCopy => {
             let options = CastOptions::default();
             cast_with_options(array, value_type.as_ref(), &options)
         }
         _ => {
-            if mode == &CopyMode::UnpackOrDeepCopy {
-                Ok(copy_array(array))
-            } else {
+            if mode == &CopyMode::UnpackOrClone {
                 Ok(Arc::clone(array))
+            } else {
+                Ok(copy_array(array))
             }
         }
     }

--- a/native/core/src/execution/operators/copy.rs
+++ b/native/core/src/execution/operators/copy.rs
@@ -50,7 +50,11 @@ pub struct CopyExec {
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum CopyMode {
+    /// Perform a deep copy but do not unpack dictionaries
+    DeepCopy,
+    /// Perform a deep copy and also unpack dictionaries
     UnpackOrDeepCopy,
+    /// Perform a clone and also unpack dictionaries
     UnpackOrClone,
 }
 
@@ -64,7 +68,7 @@ impl CopyExec {
             .fields
             .iter()
             .map(|f: &FieldRef| match f.data_type() {
-                DataType::Dictionary(_, value_type) => {
+                DataType::Dictionary(_, value_type) if mode != CopyMode::DeepCopy=> {
                     Field::new(f.name(), value_type.as_ref().clone(), f.is_nullable())
                 }
                 _ => f.as_ref().clone(),
@@ -258,15 +262,15 @@ fn copy_array(array: &dyn Array) -> ArrayRef {
 /// array is a primitive array, we simply copy the array.
 fn copy_or_unpack_array(array: &Arc<dyn Array>, mode: &CopyMode) -> Result<ArrayRef, ArrowError> {
     match array.data_type() {
-        DataType::Dictionary(_, value_type) => {
+        DataType::Dictionary(_, value_type) if mode != &CopyMode::DeepCopy => {
             let options = CastOptions::default();
             cast_with_options(array, value_type.as_ref(), &options)
         }
         _ => {
-            if mode == &CopyMode::UnpackOrDeepCopy {
-                Ok(copy_array(array))
-            } else {
+            if mode == &CopyMode::UnpackOrClone {
                 Ok(Arc::clone(array))
+            } else {
+                Ok(copy_array(array))
             }
         }
     }

--- a/native/core/src/execution/operators/copy.rs
+++ b/native/core/src/execution/operators/copy.rs
@@ -68,7 +68,7 @@ impl CopyExec {
             .fields
             .iter()
             .map(|f: &FieldRef| match f.data_type() {
-                DataType::Dictionary(_, value_type) if mode != CopyMode::DeepCopy=> {
+                DataType::Dictionary(_, value_type) if mode != CopyMode::DeepCopy => {
                     Field::new(f.name(), value_type.as_ref().clone(), f.is_nullable())
                 }
                 _ => f.as_ref().clone(),


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We were injecting too many CopyExecs for SMJ. Plans looked like this:

```
SortMergeJoin
  CopyExec [UnpackOrDeepClone]
    SortExec
      CopyExec [UnpackOrDeepClone]
        ...
  CopyExec [UnpackOrDeepClone]
    SortExec
      CopyExec [UnpackOrDeepClone]
        ...
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

With the changes in this PR, the plan now looks like:

```
SortMergeJoin
  SortExec
    CopyExec [UnpackOrDeepClone]
      ...
  SortExec
    CopyExec [UnpackOrDeepClone]
      ...
```

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests