### PR TITLE
fix: making is_nullable ansi aware for sum_decimal and avg_decimal

### DIFF
--- a/native/core/benches/aggregate.rs
+++ b/native/core/benches/aggregate.rs
@@ -69,7 +69,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             Arc::clone(&c1),
             DataType::Decimal128(38, 10),
             DataType::Decimal128(38, 10),
-            false
+            false,
         )));
         b.to_async(&rt).iter(|| {
             black_box(agg_test(

--- a/native/core/benches/aggregate.rs
+++ b/native/core/benches/aggregate.rs
@@ -69,6 +69,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             Arc::clone(&c1),
             DataType::Decimal128(38, 10),
             DataType::Decimal128(38, 10),
+            false
         )));
         b.to_async(&rt).iter(|| {
             black_box(agg_test(
@@ -96,7 +97,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     group.bench_function("sum_decimal_comet", |b| {
         let comet_sum_decimal = Arc::new(AggregateUDF::new_from_impl(
-            SumDecimal::try_new(Arc::clone(&c1), DataType::Decimal128(38, 10)).unwrap(),
+            SumDecimal::try_new(Arc::clone(&c1), DataType::Decimal128(38, 10), false).unwrap(),
         ));
         b.to_async(&rt).iter(|| {
             black_box(agg_test(

--- a/native/core/src/execution/datafusion/expressions/avg_decimal.rs
+++ b/native/core/src/execution/datafusion/expressions/avg_decimal.rs
@@ -51,7 +51,12 @@ pub struct AvgDecimal {
 
 impl AvgDecimal {
     /// Create a new AVG aggregate function
-    pub fn new(expr: Arc<dyn PhysicalExpr>, result_type: DataType, sum_type: DataType, ansi_mode: bool) -> Self {
+    pub fn new(
+        expr: Arc<dyn PhysicalExpr>,
+        result_type: DataType,
+        sum_type: DataType,
+        ansi_mode: bool,
+    ) -> Self {
         Self {
             signature: Signature::user_defined(Immutable),
             expr,

--- a/native/core/src/execution/datafusion/expressions/avg_decimal.rs
+++ b/native/core/src/execution/datafusion/expressions/avg_decimal.rs
@@ -110,12 +110,7 @@ impl AggregateUDFImpl for AvgDecimal {
     }
 
     fn is_nullable(&self) -> bool {
-        // SumDecimal is always nullable because overflows can cause null values
-        if self.ansi_mode {
-            false
-        } else {
-            true
-        }
+        !self.ansi_mode
     }
 
     fn groups_accumulator_supported(&self, _args: AccumulatorArgs) -> bool {

--- a/native/core/src/execution/datafusion/expressions/sum_decimal.rs
+++ b/native/core/src/execution/datafusion/expressions/sum_decimal.rs
@@ -52,7 +52,11 @@ pub struct SumDecimal {
 }
 
 impl SumDecimal {
-    pub fn try_new(expr: Arc<dyn PhysicalExpr>, data_type: DataType, ansi_mode: bool) -> DFResult<Self> {
+    pub fn try_new(
+        expr: Arc<dyn PhysicalExpr>,
+        data_type: DataType,
+        ansi_mode: bool,
+    ) -> DFResult<Self> {
         // The `data_type` is the SUM result type passed from Spark side
         let (precision, scale) = match data_type {
             DataType::Decimal128(p, s) => (p, s),
@@ -132,10 +136,8 @@ impl AggregateUDFImpl for SumDecimal {
     }
 
     fn is_nullable(&self) -> bool {
-        // SumDecimal is always nullable because overflows can cause null values
         !self.ansi_mode
     }
-
 }
 
 impl PartialEq<dyn Any> for SumDecimal {
@@ -528,7 +530,7 @@ mod tests {
         let aggregate_udf = Arc::new(AggregateUDF::new_from_impl(SumDecimal::try_new(
             Arc::clone(&c1),
             data_type.clone(),
-            false
+            false,
         )?));
 
         let aggr_expr = AggregateExprBuilder::new(aggregate_udf, vec![c1])

--- a/native/core/src/execution/datafusion/expressions/sum_decimal.rs
+++ b/native/core/src/execution/datafusion/expressions/sum_decimal.rs
@@ -133,12 +133,9 @@ impl AggregateUDFImpl for SumDecimal {
 
     fn is_nullable(&self) -> bool {
         // SumDecimal is always nullable because overflows can cause null values
-        if self.ansi_mode {
-            false
-        } else {
-            true
-        }
+        !self.ansi_mode
     }
+
 }
 
 impl PartialEq<dyn Any> for SumDecimal {

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -1374,6 +1374,7 @@ impl PhysicalPlanner {
                         let func = AggregateUDF::new_from_impl(SumDecimal::try_new(
                             Arc::clone(&child),
                             datatype,
+                            expr.fail_on_error,
                         )?);
                         AggregateExprBuilder::new(Arc::new(func), vec![child])
                     }
@@ -1403,6 +1404,7 @@ impl PhysicalPlanner {
                             Arc::clone(&child),
                             datatype,
                             input_datatype,
+                            expr.fail_on_error,
                         ));
                         AggregateExprBuilder::new(Arc::new(func), vec![child])
                     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #961 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

making is_nullable ansi aware for sum_decimal and avg_decimal

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Updated `planner.rs`, `sum_decimal.rs` and `avg_decimal.rs`

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

CI tests pass