### PR TITLE
fix: Properly handle Java exceptions without error messages; fix loading of comet native library from java.library.path

### DIFF
--- a/common/src/main/java/org/apache/comet/NativeBase.java
+++ b/common/src/main/java/org/apache/comet/NativeBase.java
@@ -81,7 +81,7 @@ public abstract class NativeBase {
 
     // Try to load Comet library from the java.library.path.
     try {
-      System.loadLibrary(libraryToLoad);
+      System.loadLibrary(NATIVE_LIB_NAME);
       loaded = true;
     } catch (UnsatisfiedLinkError ex) {
       // Doesn't exist, so proceed to loading bundled library.

--- a/native/core/src/jvm_bridge/mod.rs
+++ b/native/core/src/jvm_bridge/mod.rs
@@ -339,7 +339,7 @@ fn get_throwable_message(
     throwable: &JThrowable,
 ) -> CometResult<String> {
     unsafe {
-        let message = env
+        let message: JString = env
             .call_method_unchecked(
                 throwable,
                 jvm_classes.throwable_get_message_method,
@@ -348,7 +348,11 @@ fn get_throwable_message(
             )?
             .l()?
             .into();
-        let message_str = env.get_string(&message)?.into();
+        let message_str = if !message.is_null() {
+            env.get_string(&message)?.into()
+        } else {
+            String::from("null")
+        };
 
         let cause: JThrowable = env
             .call_method_unchecked(

--- a/spark/src/test/scala/org/apache/comet/CometNativeSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometNativeSuite.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.catalyst.expressions.PrettyAttribute
+import org.apache.spark.sql.comet.{CometExec, CometExecUtils}
+import org.apache.spark.sql.types.LongType
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+class CometNativeSuite extends CometTestBase {
+  test("test handling NPE thrown by JVM") {
+    val rdd = spark.range(0, 1).rdd.map { value =>
+      val limitOp =
+        CometExecUtils.getLimitNativePlan(Seq(PrettyAttribute("test", LongType)), 100).get
+      val cometIter = CometExec.getCometIterator(
+        Seq(new Iterator[ColumnarBatch] {
+          override def hasNext: Boolean = true
+          override def next(): ColumnarBatch = throw new NullPointerException()
+        }),
+        1,
+        limitOp)
+      cometIter.next()
+      cometIter.close()
+      value
+    }
+
+    val exception = intercept[SparkException] {
+      rdd.collect()
+    }
+    assert(exception.getMessage contains "java.lang.NullPointerException")
+  }
+}


### PR DESCRIPTION
## Which issue does this PR close?

This is a minor, non-user-aware fix so I've not created a GtHub issue. A detailed explanation is provided in the next section.

## Rationale for this change

I had this small patch in my local workspace for a while, I think it is useful for other comet developers as well. The changes are as follows:

1. Fix the library name when not loading from the JAR bundle. The [documentation of `System.loadLibrary`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.html#loadLibrary(java.lang.String)) states that "The libname argument must not contain any platform specific prefix, file extension or path", so the library name should be `comet` instead of `libcomet.so` or `libcomet.dylib`. This fix makes it easier to load the newly built comet library in the `native/target` directory when running Java tests.
2. Handle exceptions without error messages properly in native code. When there's an NPE in Scala code, the NPE exception raised by JVM may not have an error message. The native code will panic with the following error message:

```
org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 0.0 failed 1 times, most recent failure: Lost task 0.0 in stage 0.0 (TID 0) (192.168.200.154 executor driver): org.apache.comet.CometNativeException: General execution error with reason: Null pointer in get_object_class.
	at org.apache.comet.Native.executePlan(Native Method)
	at org.apache.comet.CometExecIterator.$anonfun$getNextBatch$1(CometExecIterator.scala:107)
	at org.apache.comet.CometExecIterator.$anonfun$getNextBatch$1$adapted(CometExecIterator.scala:106)
	at org.apache.comet.vector.NativeUtil.getNextBatch(NativeUtil.scala:157)
	at org.apache.comet.CometExecIterator.getNextBatch(CometExecIterator.scala:106)
	at org.apache.comet.CometExecIterator.hasNext(CometExecIterator.scala:118)
	at org.apache.comet.CometExecIterator.next(CometExecIterator.scala:135)
```

It does not point to the source of the NPE, which makes troubleshooting difficult. This patch checks if the error message retrieved by the `.getMessage` JNI call is null and handles it specially. The error message becomes:

```
org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 0.0 failed 1 times, most recent failure: Lost task 0.0 in stage 0.0 (TID 0) (192.168.200.154 executor driver): java.lang.NullPointerException
	at org.apache.comet.CometNativeSuite$$anon$1.next(CometNativeSuite.scala:37)
	at org.apache.comet.CometNativeSuite$$anon$1.next(CometNativeSuite.scala:35)
	at org.apache.comet.CometBatchIterator.next(CometBatchIterator.java:56)
	at org.apache.comet.Native.executePlan(Native Method)
	at org.apache.comet.CometExecIterator.$anonfun$getNextBatch$1(CometExecIterator.scala:107)
	at org.apache.comet.CometExecIterator.$anonfun$getNextBatch$1$adapted(CometExecIterator.scala:106)
	at org.apache.comet.vector.NativeUtil.getNextBatch(NativeUtil.scala:157)
	at org.apache.comet.CometExecIterator.getNextBatch(CometExecIterator.scala:106)
	at org.apache.comet.CometExecIterator.hasNext(CometExecIterator.scala:118)
	at org.apache.comet.CometExecIterator.next(CometExecIterator.scala:135)
```

## What changes are included in this PR?

This PR includes fixes for the minor problems mentioned above.

## How are these changes tested?

Add a unit test for problem 2.
