### PR TITLE
fix: The spilled_bytes metric of CometSortExec should be size instead of time

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -523,7 +523,7 @@ case class CometSortExec(
     CometMetricNode.baselineMetrics(sparkContext) ++
       Map(
         "spill_count" -> SQLMetrics.createMetric(sparkContext, "number of spills"),
-        "spilled_bytes" -> SQLMetrics.createNanoTimingMetric(sparkContext, "total spilled bytes"))
+        "spilled_bytes" -> SQLMetrics.createSizeMetric(sparkContext, "total spilled bytes"))
 }
 
 case class CometLocalLimitExec(


### PR DESCRIPTION
## Which issue does this PR close?

Closes #983.

## Rationale for this change

Please refer to https://github.com/apache/datafusion-comet/issues/983 for details.

## What changes are included in this PR?

Fixed the metric creation code for the `spilled_bytes` metric of `CometSortExec`. I've also examined all other metrics to make sure that similar problem does not happen to other comet operators.

## How are these changes tested?

This fix is so obvious so it may not worth adding a test for it. I've verified the fix manually on Spark UI:

| Before | After |
|--|--|
| ![image](https://github.com/user-attachments/assets/48615afc-5f00-4734-a36b-0db703015724) | ![image](https://github.com/user-attachments/assets/5a27426a-9055-4fb0-a823-8c09b6818b98) |
