### PR TITLE
chore: Improve error handling when native lib fails to load

### DIFF
--- a/common/src/main/java/org/apache/comet/NativeBase.java
+++ b/common/src/main/java/org/apache/comet/NativeBase.java
@@ -46,15 +46,24 @@ public abstract class NativeBase {
 
   private static final String libraryToLoad = System.mapLibraryName(NATIVE_LIB_NAME);
   private static boolean loaded = false;
+  private static Throwable loadErr = null;
   private static final String searchPattern = "libcomet-";
 
   static {
-    if (!isLoaded()) {
+    try {
       load();
+    } catch (Throwable th) {
+      LOG.warn("Failed to load comet library", th);
+      // logging may not be initialized yet, so also write to stderr
+      System.err.println("Failed to load comet library: " + th.getMessage());
+      loadErr = th;
     }
   }
 
-  public static synchronized boolean isLoaded() {
+  public static synchronized boolean isLoaded() throws Throwable {
+    if (loadErr != null) {
+      throw loadErr;
+    }
     return loaded;
   }
 

--- a/common/src/main/java/org/apache/comet/NativeBase.java
+++ b/common/src/main/java/org/apache/comet/NativeBase.java
@@ -46,7 +46,7 @@ public abstract class NativeBase {
 
   private static final String libraryToLoad = System.mapLibraryName(NATIVE_LIB_NAME);
   private static boolean loaded = false;
-  private static Throwable loadErr = null;
+  private static volatile Throwable loadErr = null;
   private static final String searchPattern = "libcomet-";
 
   static {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/999

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

If the static initialization block failed to load the library then we did not see the reason why (in some cases).

Before:

```
│ 24/10/07 22:42:11 WARN CometSparkSessionExtensions: Comet extension is disabled because of error when loading native lib. Falling back to Spark                                                                                                   │
│ java.lang.NoClassDefFoundError: Could not initialize class org.apache.comet.NativeBase  
```

After:

```
│ 24/10/22 15:00:08 WARN CometSparkSessionExtensions: Comet extension is disabled because of error when loading native lib. Falling back to Spark                                                                                                          │
│ java.lang.UnsatisfiedLinkError: /tmp/libcomet-11952721851997920414.so: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.35' not found (required by /tmp/libcomet-11952721851997920414.so)      
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Improve error handling by consuming exceptions in the static init code and then rethrowing them when `isCometEnabled` calls` isLibraryLoaded`

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Manually.