### PR TITLE
fix: Make comet-git-info.properties optional

### DIFF
--- a/common/src/main/scala/org/apache/comet/package.scala
+++ b/common/src/main/scala/org/apache/comet/package.scala
@@ -41,19 +41,20 @@ package object comet {
    * information is included to aid in future debugging efforts for releases.
    */
   private object CometBuildInfo extends Logging {
+    private val GIT_INFO_PROPS_FILENAME = "comet-git-info.properties"
 
     val props: Properties = {
       val props = new Properties()
       val resourceStream = Thread
         .currentThread()
         .getContextClassLoader
-        .getResourceAsStream("comet-git-info.properties")
+        .getResourceAsStream(GIT_INFO_PROPS_FILENAME)
       if (resourceStream != null) {
         try {
           props.load(resourceStream)
         } catch {
           case e: Exception =>
-            logError("Error loading properties from comet-git-info.properties", e)
+            logError(s"Error loading properties from $GIT_INFO_PROPS_FILENAME", e)
         } finally {
           if (resourceStream != null) {
             try {
@@ -65,7 +66,7 @@ package object comet {
           }
         }
       } else {
-        logWarning("Could not find comet-git-info.properties")
+        logWarning(s"Could not find $GIT_INFO_PROPS_FILENAME")
       }
       props
     }

--- a/common/src/main/scala/org/apache/comet/package.scala
+++ b/common/src/main/scala/org/apache/comet/package.scala
@@ -22,6 +22,7 @@ package org.apache
 import java.util.Properties
 
 import org.apache.arrow.memory.RootAllocator
+import org.apache.spark.internal.Logging
 
 package object comet {
 
@@ -39,60 +40,46 @@ package object comet {
    * benchmarking software to provide the source revision and repository. In addition, the build
    * information is included to aid in future debugging efforts for releases.
    */
-  private object CometBuildInfo {
+  private object CometBuildInfo extends Logging {
 
-    val (
-      cometVersion: String,
-      cometBranch: String,
-      cometRevision: String,
-      cometBuildUserName: String,
-      cometBuildUserEmail: String,
-      cometRepoUrl: String,
-      cometBuildTimestamp: String) = {
+    val props: Properties = {
+      val props = new Properties()
       val resourceStream = Thread
         .currentThread()
         .getContextClassLoader
         .getResourceAsStream("comet-git-info.properties")
-      if (resourceStream == null) {
-        throw new CometRuntimeException("Could not find comet-git-info.properties")
-      }
-
-      try {
-        val unknownProp = "<unknown>"
-        val props = new Properties()
-        props.load(resourceStream)
-        (
-          props.getProperty("git.build.version", unknownProp),
-          props.getProperty("git.branch", unknownProp),
-          props.getProperty("git.commit.id.full", unknownProp),
-          props.getProperty("git.build.user.name", unknownProp),
-          props.getProperty("git.build.user.email", unknownProp),
-          props.getProperty("git.remote.origin.url", unknownProp),
-          props.getProperty("git.build.time", unknownProp))
-      } catch {
-        case e: Exception =>
-          throw new CometRuntimeException(
-            "Error loading properties from comet-git-info.properties",
-            e)
-      } finally {
-        if (resourceStream != null) {
-          try {
-            resourceStream.close()
-          } catch {
-            case e: Exception =>
-              throw new CometRuntimeException("Error closing Comet build info resource stream", e)
+      if (resourceStream != null) {
+        try {
+          props.load(resourceStream)
+        } catch {
+          case e: Exception =>
+            logError("Error loading properties from comet-git-info.properties", e)
+        } finally {
+          if (resourceStream != null) {
+            try {
+              resourceStream.close()
+            } catch {
+              case e: Exception =>
+                logError("Error closing Comet build info resource stream", e)
+            }
           }
         }
+      } else {
+        logWarning("Could not find comet-git-info.properties")
       }
+      props
     }
   }
 
-  val COMET_VERSION = CometBuildInfo.cometVersion
-  val COMET_BRANCH = CometBuildInfo.cometBranch
-  val COMET_REVISION = CometBuildInfo.cometRevision
-  val COMET_BUILD_USER_EMAIL = CometBuildInfo.cometBuildUserEmail
-  val COMET_BUILD_USER_NAME = CometBuildInfo.cometBuildUserName
-  val COMET_REPO_URL = CometBuildInfo.cometRepoUrl
-  val COMET_BUILD_TIMESTAMP = CometBuildInfo.cometBuildTimestamp
+  private def getProp(name: String): String = {
+    CometBuildInfo.props.getProperty(name, "<unknown>")
+  }
 
+  val COMET_VERSION: String = getProp("git.build.version")
+  val COMET_BRANCH: String = getProp("git.branch")
+  val COMET_REVISION: String = getProp("git.commit.id.full")
+  val COMET_BUILD_USER_EMAIL: String = getProp("git.build.user.name")
+  val COMET_BUILD_USER_NAME: String = getProp("git.build.user.email")
+  val COMET_REPO_URL: String = getProp("git.remote.origin.url")
+  val COMET_BUILD_TIMESTAMP: String = getProp("git.build.time")
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/1026
Closes https://github.com/apache/datafusion-comet/issues/1012

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Our instructions for building from source produce a jar file that does not contain `comet-git-info.properties` and this results in an exception at runtime. 

We had the same issue with our Docker build because that also builds without git info.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Use default values in `CometBuildInfo` instead of throwing an exception if `comet-git-info.properties` does not exist.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

I tested manually using our Docker/k8s instructions. This was previously failing for me.
