### PR TITLE
perf: Cache jstrings during metrics collection

### DIFF
--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -347,6 +347,8 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
 
         let exec_context_id = exec_context.id;
 
+        // We maintain a map of metrics name -> jstring object to reduce the overhead of calling
+        // jni_NewStringUTF repeatedly.
         let mut metrics_jstrings: HashMap<String, Arc<GlobalRef>> = HashMap::new();
 
         // Initialize the execution stream.

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -17,7 +17,6 @@
 
 //! Define JNI APIs which can be called from Java/Scala.
 
-use super::{serde, utils::SparkArrowConvert, CometMemoryPool};
 use arrow::datatypes::DataType as ArrowDataType;
 use arrow_array::RecordBatch;
 use datafusion::{
@@ -39,6 +38,8 @@ use jni::{
     JNIEnv,
 };
 use std::{collections::HashMap, sync::Arc, task::Poll};
+
+use super::{serde, utils::SparkArrowConvert, CometMemoryPool};
 
 use crate::{
     errors::{try_unwrap_or_throw, CometError, CometResult},

--- a/native/core/src/execution/metrics/utils.rs
+++ b/native/core/src/execution/metrics/utils.rs
@@ -71,8 +71,7 @@ fn update_metrics(
 ) -> Result<(), CometError> {
     unsafe {
         for &(name, value) in metric_values {
-            // We maintain a map of metrics name -> jstring object to reduce the
-            // overhead of calling jni_NewStringUTF repeatedly.
+            // Perform a lookup in the jstrings cache.
             if let Some(map_global_ref) = metrics_jstrings.get(name) {
                 // Cache hit. Extract the jstring from the global ref.
                 let jobject = map_global_ref.as_obj();

--- a/native/core/src/execution/metrics/utils.rs
+++ b/native/core/src/execution/metrics/utils.rs
@@ -82,11 +82,9 @@ fn update_metrics(
                 // Cache miss. Allocate a new string, promote to global ref, and insert into cache.
                 let local_jstring = jni_new_string!(env, &name)?;
                 let global_ref = jni_new_global_ref!(env, local_jstring)?;
-                metrics_jstrings.insert(name.to_string(), Arc::new(global_ref));
-                // try_insert returns a reference to the inserted value to avoid the subsequent
-                // get on the kv pair that we just inserted, but it's still experimental.
-                let map_global_ref = metrics_jstrings.get(name).unwrap();
-                let jobject = map_global_ref.as_obj();
+                let arc_global_ref = Arc::new(global_ref);
+                metrics_jstrings.insert(name.to_string(), Arc::clone(&arc_global_ref));
+                let jobject = arc_global_ref.as_obj();
                 let jstring = JString::from_raw(**jobject);
                 // Update the metrics using the jstring as a key.
                 jni_call!(env, comet_metric_node(metric_node).set(&jstring, value) -> ())?;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Partially addresses #1024.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Comet uses JNI jstrings as the keys to updating metrics values on the Spark side during execution. As described in #1024, currently Comet allocates a jstring for every metric for every invocation of metrics updating. The calls to `jni_NewStringUTF` account for over 1% of the on-CPU time in TPC-H SF10 for me.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Added a HashMap that maps the native string to a jstring to use in JNI calls. This has the benefit of being many-to-one, whereby multiple nodes with the same metric name will benefit from the cached jstring. This cache is populated on demand: if the entry isn't present, we allocate a jstring and insert it into the cache.

I have some thoughts about this approach that I would love for reviewers to comment on:

1. I wanted to populate the cache in advance, maybe do a plan traversal when it's generated in `ExecutePlan`. However, DF's metrics are Options and don't actually appear to be there until the plan starts executing.
2. What is the thread safety of this approach? It's unclear to me if multiple threads could be sharing this call stack and trying to write new values into the cache at the same time. I could wrap the HashMap in a latch in exchange for a performance hit, but would like to understand if this is even possible.
3. I think I understood the [jni crate's docs with respect to GlobalRef](https://docs.rs/jni/latest/jni/objects/struct.GlobalRef.html), but a sanity check on if this approach could hold references longer than we want (and leak) would be helpful. 

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests on the Java side that exercise metrics.