### PR TITLE
feat: Implement native version of ColumnarToRow

### DIFF
--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -196,6 +196,12 @@ object CometConf extends ShimCometConf {
       .booleanConf
       .createWithDefault(false)
 
+  val COMET_EXEC_NATIVE_COLUMNAR_TO_ROW_ENABLED: ConfigEntry[Boolean] =
+    conf("spark.comet.exec.nativeColumnarToRow.enabled")
+      .doc("Experimental support for native columnar to row for fixed width types")
+      .booleanConf
+      .createWithDefault(true)
+
   val COMET_EXPR_STDDEV_ENABLED: ConfigEntry[Boolean] =
     createExecEnabledConfig(
       "stddev",

--- a/docs/source/user-guide/configs.md
+++ b/docs/source/user-guide/configs.md
@@ -49,6 +49,7 @@ Comet provides the following configuration settings.
 | spark.comet.exec.hashJoin.enabled | Whether to enable hashJoin by default. | true |
 | spark.comet.exec.localLimit.enabled | Whether to enable localLimit by default. | true |
 | spark.comet.exec.memoryFraction | The fraction of memory from Comet memory overhead that the native memory manager can use for execution. The purpose of this config is to set aside memory for untracked data structures, as well as imprecise size estimation during memory acquisition. Default value is 0.7. | 0.7 |
+| spark.comet.exec.nativeColumnarToRow.enabled | Experimental support for native columnar to row for fixed width types | true |
 | spark.comet.exec.project.enabled | Whether to enable project by default. | true |
 | spark.comet.exec.replaceSortMergeJoin | Experimental feature to force Spark to replace SortMergeJoin with ShuffledHashJoin for improved performance. This feature is not stable yet. For more information, refer to the Comet Tuning Guide (https://datafusion.apache.org/comet/user-guide/tuning.html). | false |
 | spark.comet.exec.shuffle.codec | The codec of Comet native shuffle used to compress shuffle data. Only zstd is supported. | zstd |

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -572,7 +572,9 @@ pub extern "system" fn Java_org_apache_comet_Native_sortRowPartitionsNative(
 /// From a set of vectors and a block of native memory allocated by Spark, convert the vectors
 /// into a batch of SparkUnsafeRows. The unsafe rows are written to the memory block passed in
 /// Currently implemented only for boolean and numeric types.
-pub extern "system" fn Java_org_apache_comet_Native_getUnsafeRowsNative(
+/// # Safety
+/// This function is inherently unsafe since it deals with raw pointers passed from JNI.
+pub unsafe extern "system" fn Java_org_apache_comet_Native_getUnsafeRowsNative(
     e: JNIEnv,
     _class: JClass,
     _base_object: JObject,
@@ -582,9 +584,6 @@ pub extern "system" fn Java_org_apache_comet_Native_getUnsafeRowsNative(
     schema_addrs: jlongArray,
 ) -> jlong {
     try_unwrap_or_throw(&e, |mut env| {
-        // SAFETY: JVM unsafe memory allocation is aligned with long.
-        // let long_array = env.new_long_array(2)?;
-
         let array_address_array = unsafe { JLongArray::from_raw(array_addrs) };
         let num_cols = env.get_array_length(&array_address_array)? as usize;
 

--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -1103,6 +1103,7 @@ class CometSparkSessionExtensions
         case CometColumnarToRowExec(sparkToColumnar: CometSparkToColumnarExec)
             if !sparkToColumnar.child.supportsColumnar =>
           sparkToColumnar.child
+        case CometColumnarToRowExec(child: CometColumnarToRowExec) => child
         case ColumnarToRowExec(sparkToColumnar: CometSparkToColumnarExec)
             if !sparkToColumnar.child.supportsColumnar =>
           sparkToColumnar.child

--- a/spark/src/main/scala/org/apache/comet/Native.scala
+++ b/spark/src/main/scala/org/apache/comet/Native.scala
@@ -123,4 +123,17 @@ class Native extends NativeBase {
    *   the size of the array.
    */
   @native def sortRowPartitionsNative(addr: Long, size: Long): Unit
+
+  /**
+   * Given a set of value vectors from a record batch, return an array of corresponding UnsafeRows
+   * @param arrayAddrs
+   * @param schemaAddrs
+   * @return
+   */
+  @native def getUnsafeRowsNative(
+      baseObject: Object,
+      offset: Long,
+      length: Long,
+      arrayAddrs: Array[Long],
+      schemaAddrs: Array[Long]): Long
 }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometBatchScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometBatchScanExec.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, DynamicPruningExpre
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.connector.read._
-import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.datasources.v2._
 import org.apache.spark.sql.execution.metric._
 import org.apache.spark.sql.vectorized._
@@ -73,11 +72,11 @@ case class CometBatchScanExec(wrapped: BatchScanExec, runtimeFilters: Seq[Expres
 
   // `ReusedSubqueryExec` in Spark only call non-columnar execute.
   override def doExecute(): RDD[InternalRow] = {
-    ColumnarToRowExec(this).doExecute()
+    CometColumnarToRowExec(this).doExecute()
   }
 
   override def executeCollect(): Array[InternalRow] = {
-    ColumnarToRowExec(this).executeCollect()
+    CometColumnarToRowExec(this).executeCollect()
   }
 
   override def readerFactory: PartitionReaderFactory = wrappedScan.readerFactory

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometColumnarToRowExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometColumnarToRowExec.scala
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder, UnsafeProjection}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode, FalseLiteral, JavaCode}
+import org.apache.spark.sql.catalyst.expressions.codegen.Block._
+import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.execution.{CodegenSupport, ColumnarToRowTransition, SparkPlan}
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+import org.apache.spark.util.Utils
+
+/**
+ * This is currently an identical copy of Spark's ColumnarToRowExec except for removing the
+ * code-gen features.
+ *
+ * This is moved into the Comet repo as the first step towards refactoring this to make the
+ * interactions with CometVector more efficient to avoid some JNI overhead.
+ */
+case class CometColumnarToRowExec(child: SparkPlan)
+    extends CometExec
+    with ColumnarToRowTransition
+    with CodegenSupport {
+  // supportsColumnar requires to be only called on driver side, see also SPARK-37779.
+  assert(Utils.isInRunningSparkTask || child.supportsColumnar)
+
+  override def supportsColumnar: Boolean = false
+
+  override def originalPlan: SparkPlan = child
+
+  override def output: Seq[Attribute] = child.output
+
+  override def outputPartitioning: Partitioning = child.outputPartitioning
+
+  override def outputOrdering: Seq[SortOrder] = child.outputOrdering
+
+  // `ColumnarToRowExec` processes the input RDD directly, which is kind of a leaf node in the
+  // codegen stage and needs to do the limit check.
+  protected override def canCheckLimitNotReached: Boolean = true
+
+  private val prefetchTime: SQLMetric =
+    SQLMetrics.createNanoTimingMetric(sparkContext, "time to prefetch vectors")
+
+  override lazy val metrics: Map[String, SQLMetric] = Map(
+    "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
+    "numInputBatches" -> SQLMetrics.createMetric(sparkContext, "number of input batches"),
+    "prefetchTime" -> prefetchTime)
+
+  override def doExecute(): RDD[InternalRow] = {
+    val numOutputRows = longMetric("numOutputRows")
+    val numInputBatches = longMetric("numInputBatches")
+    // This avoids calling `output` in the RDD closure, so that we don't need to include the entire
+    // plan (this) in the closure.
+    val localOutput = this.output
+    child.executeColumnar().mapPartitionsInternal { batches =>
+      val toUnsafe = UnsafeProjection.create(localOutput, localOutput)
+      batches.flatMap { batch =>
+        numInputBatches += 1
+        numOutputRows += batch.numRows()
+
+        // This is the original Spark code that creates an iterator over `ColumnarBatch`
+        // to provide `Iterator[InternalRow]`. The implementation uses a `ColumnarBatchRow`
+        // instance that contains an array of `ColumnVector` which will be instances of
+        // `CometVector`, which in turn is a wrapper around Arrow's `ValueVector`.
+        batch.rowIterator().asScala.map(toUnsafe)
+      }
+    }
+  }
+
+  /**
+   * Generate [[ColumnVector]] expressions for our parent to consume as rows. This is called once
+   * per [[ColumnVector]] in the batch.
+   */
+  private def genCodeColumnVector(
+      ctx: CodegenContext,
+      columnVar: String,
+      ordinal: String,
+      dataType: DataType,
+      nullable: Boolean): ExprCode = {
+    val javaType = CodeGenerator.javaType(dataType)
+    val value = CodeGenerator.getValueFromVector(columnVar, dataType, ordinal)
+    val isNullVar = if (nullable) {
+      JavaCode.isNullVariable(ctx.freshName("isNull"))
+    } else {
+      FalseLiteral
+    }
+    val valueVar = ctx.freshName("value")
+    val str = s"columnVector[$columnVar, $ordinal, ${dataType.simpleString}]"
+    val code = code"${ctx.registerComment(str)}" + (if (nullable) {
+                                                      code"""
+        boolean $isNullVar = $columnVar.isNullAt($ordinal);
+        $javaType $valueVar = $isNullVar ? ${CodeGenerator.defaultValue(dataType)} : ($value);
+      """
+                                                    } else {
+                                                      code"$javaType $valueVar = $value;"
+                                                    })
+    ExprCode(code, isNullVar, JavaCode.variable(valueVar, dataType))
+  }
+
+  /**
+   * Produce code to process the input iterator as [[ColumnarBatch]]es. This produces an
+   * [[org.apache.spark.sql.catalyst.expressions.UnsafeRow]] for each row in each batch.
+   */
+  override protected def doProduce(ctx: CodegenContext): String = {
+    // PhysicalRDD always just has one input
+    val input = ctx.addMutableState("scala.collection.Iterator", "input", v => s"$v = inputs[0];")
+
+    // metrics
+    val numOutputRows = metricTerm(ctx, "numOutputRows")
+    val numInputBatches = metricTerm(ctx, "numInputBatches")
+
+    val columnarBatchClz = classOf[ColumnarBatch].getName
+    val batch = ctx.addMutableState(columnarBatchClz, "batch")
+
+    val idx = ctx.addMutableState(CodeGenerator.JAVA_INT, "batchIdx") // init as batchIdx = 0
+    val columnVectorClzs =
+      child.vectorTypes.getOrElse(Seq.fill(output.indices.size)(classOf[ColumnVector].getName))
+    val (colVars, columnAssigns) = columnVectorClzs.zipWithIndex.map {
+      case (columnVectorClz, i) =>
+        val colVarName = s"colInstance$i"
+        val name = ctx.addMutableState(columnVectorClz, colVarName)
+        (name, s"$name = ($columnVectorClz) $batch.column($i);")
+    }.unzip
+
+    val nextBatch = ctx.freshName("nextBatch")
+    val nextBatchFuncName = ctx.addNewFunction(
+      nextBatch,
+      s"""
+         |private void $nextBatch() throws java.io.IOException {
+         |  if ($input.hasNext()) {
+         |    $batch = ($columnarBatchClz)$input.next();
+         |    $numInputBatches.add(1);
+         |    $numOutputRows.add($batch.numRows());
+         |    $idx = 0;
+         |    ${columnAssigns.mkString("", "\n", "\n")}
+         |  }
+         |}""".stripMargin)
+
+    ctx.currentVars = null
+    val rowidx = ctx.freshName("rowIdx")
+    val columnsBatchInput = (output zip colVars).map { case (attr, colVar) =>
+      genCodeColumnVector(ctx, colVar, rowidx, attr.dataType, attr.nullable)
+    }
+    val localIdx = ctx.freshName("localIdx")
+    val localEnd = ctx.freshName("localEnd")
+    val numRows = ctx.freshName("numRows")
+    val shouldStop = if (parent.needStopCheck) {
+      s"if (shouldStop()) { $idx = $rowidx + 1; return; }"
+    } else {
+      "// shouldStop check is eliminated"
+    }
+    s"""
+       |if ($batch == null) {
+       |  $nextBatchFuncName();
+       |}
+       |while ($limitNotReachedCond $batch != null) {
+       |  int $numRows = $batch.numRows();
+       |  int $localEnd = $numRows - $idx;
+       |  for (int $localIdx = 0; $localIdx < $localEnd; $localIdx++) {
+       |    int $rowidx = $idx + $localIdx;
+       |    ${consume(ctx, columnsBatchInput).trim}
+       |    $shouldStop
+       |  }
+       |  $idx = $numRows;
+       |  $batch = null;
+       |  $nextBatchFuncName();
+       |}
+     """.stripMargin
+  }
+
+  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+    Seq(child.executeColumnar().asInstanceOf[RDD[InternalRow]]) // Hack because of type erasure
+  }
+
+  override protected def withNewChildInternal(newChild: SparkPlan): CometColumnarToRowExec =
+    copy(child = newChild)
+}

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometExecUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometExecUtils.scala
@@ -145,6 +145,7 @@ object CometExecUtils {
       None
     }
   }
+
 }
 
 /** A simple RDD with no data, but with the given number of partitions. */

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
@@ -235,7 +235,7 @@ case class CometScanExec(
   }
 
   protected override def doExecute(): RDD[InternalRow] = {
-    ColumnarToRowExec(this).doExecute()
+    CometColumnarToRowExec(this).doExecute()
   }
 
   protected override def doExecuteColumnar(): RDD[ColumnarBatch] = {
@@ -262,7 +262,7 @@ case class CometScanExec(
   }
 
   override def executeCollect(): Array[InternalRow] = {
-    ColumnarToRowExec(this).executeCollect()
+    CometColumnarToRowExec(this).executeCollect()
   }
 
   override val nodeName: String =

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometUnsafeRowIterators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometUnsafeRowIterators.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet
+
+import scala.collection.mutable
+
+import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow
+import org.apache.spark.sql.comet.util.Utils.getUnsafeRowBatchSize
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.unsafe.memory.{MemoryAllocator, MemoryBlock}
+
+import org.apache.comet.Native
+import org.apache.comet.vector.{CometVector, NativeUtil}
+
+object CometUnsafeRowIterators extends Logging {
+  val nativeUtil = new NativeUtil()
+
+  private[sql] class ColumnBatchToSparkRowIter(
+      conf: SparkConf,
+      batch: ColumnarBatch,
+      context: TaskContext)
+      extends Iterator[InternalRow]
+      with AutoCloseable {
+
+    protected var closed: Boolean = false
+
+    Option(context).foreach {
+      _.addTaskCompletionListener[Unit] { _ =>
+        close(true)
+      }
+    }
+
+    private val blockSize = {
+      val vectors = mutable.Buffer[CometVector]()
+      for (i <- 0 until batch.numCols()) {
+        vectors += batch.column(i).asInstanceOf[CometVector]
+      }
+      getUnsafeRowBatchSize(vectors.toArray)
+    }
+
+    // TODO: Make CometShuffleMemoryAllocator common code and use memory allocation
+    // thru the allocator instead of allocating directly.
+    //    private val allocator: CometShuffleMemoryAllocator =
+    //      CometShuffleMemoryAllocator.getInstance(conf, context.taskMemoryManager(), blockSize)
+    private val allocator: MemoryAllocator = MemoryAllocator.UNSAFE
+    private val block = allocator.allocate(blockSize)
+
+    private val unsafeRows = toUnsafeRows
+
+    private def toUnsafeRows: Array[InternalRow] = {
+      val numRows = batch.numRows()
+      val numCols = batch.numCols()
+      val rows = new Array[InternalRow](numRows)
+      val (arrayAddrs, schemaAddrs) = nativeUtil.exportColumnarBatch(batch)
+      val converted = getUnsafeRowsNative(block, arrayAddrs, schemaAddrs)
+      val rowWidth = UnsafeRow.calculateBitSetWidthInBytes(numCols) + 8 * numCols
+      var rowNum = 0;
+      while (rowNum < numRows) {
+        // TODO: Make UnsafeRow from the block for variable length types
+        // We need the row start offsets for each row.
+        val row = new UnsafeRow(batch.numCols())
+        row.pointTo(block.getBaseObject, block.getBaseOffset + rowNum * rowWidth, rowWidth)
+        rows(rowNum) = row
+        rowNum = rowNum + 1
+      }
+      rows
+    }
+
+    private val unsafeRowIter: Iterator[InternalRow] = unsafeRows.iterator
+
+    override def hasNext: Boolean = unsafeRowIter.hasNext || {
+      close(false)
+      false
+    }
+
+    override def next(): InternalRow = unsafeRowIter.next()
+
+    override def close(): Unit = {
+      close(false)
+    }
+
+    protected def close(freeBlock: Boolean): Unit = {
+      if (!closed) {
+        closed = true
+      }
+      if (freeBlock) {
+        allocator.free(block)
+      }
+    }
+
+    private def getUnsafeRowsNative(
+        block: MemoryBlock,
+        arrayAddrs: Array[Long],
+        schemaAddrs: Array[Long]): Long = {
+      val native = new Native()
+      native.getUnsafeRowsNative(
+        block.getBaseObject,
+        block.getBaseOffset,
+        block.size,
+        arrayAddrs,
+        schemaAddrs)
+    }
+
+  }
+
+  def columnarBatchToSparkRowIter(
+      conf: SparkConf,
+      batch: ColumnarBatch,
+      context: TaskContext): Iterator[InternalRow] = {
+
+    new ColumnBatchToSparkRowIter(conf, batch, context)
+  }
+
+  def hasDictionaryOrNullVector(batch: ColumnarBatch): Boolean = {
+    nativeUtil.hasDictionaryOrNullVector(batch)
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -67,9 +67,6 @@ abstract class CometExec extends CometPlan {
   override def doExecute(): RDD[InternalRow] =
     CometColumnarToRowExec(this).doExecute()
 
-  override def executeCollect(): Array[InternalRow] =
-    CometColumnarToRowExec(this).executeCollect()
-
   override def outputOrdering: Seq[SortOrder] = originalPlan.outputOrdering
 
   // `CometExec` reuses the outputPartitioning of the original SparkPlan.

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partition
 import org.apache.spark.sql.comet.execution.shuffle.{ArrowReaderIterator, CometShuffleExchangeExec}
 import org.apache.spark.sql.comet.plans.PartitioningPreservingUnaryExecNode
 import org.apache.spark.sql.comet.util.Utils
-import org.apache.spark.sql.execution.{BinaryExecNode, ColumnarToRowExec, ExecSubqueryExpression, ExplainUtils, LeafExecNode, ScalarSubquery, SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.{BinaryExecNode, ExecSubqueryExpression, ExplainUtils, LeafExecNode, ScalarSubquery, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.adaptive.{AQEShuffleReadExec, BroadcastQueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
@@ -65,10 +65,10 @@ abstract class CometExec extends CometPlan {
   override def output: Seq[Attribute] = originalPlan.output
 
   override def doExecute(): RDD[InternalRow] =
-    ColumnarToRowExec(this).doExecute()
+    CometColumnarToRowExec(this).doExecute()
 
   override def executeCollect(): Array[InternalRow] =
-    ColumnarToRowExec(this).executeCollect()
+    CometColumnarToRowExec(this).executeCollect()
 
   override def outputOrdering: Seq[SortOrder] = originalPlan.outputOrdering
 

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -28,8 +28,8 @@ import scala.util.Random
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{CometTestBase, DataFrame, Row}
 import org.apache.spark.sql.catalyst.optimizer.SimplifyExtractValueOps
-import org.apache.spark.sql.comet.CometProjectExec
-import org.apache.spark.sql.execution.{ColumnarToRowExec, InputAdapter, ProjectExec, WholeStageCodegenExec}
+import org.apache.spark.sql.comet.{CometColumnarToRowExec, CometProjectExec}
+import org.apache.spark.sql.execution.{InputAdapter, ProjectExec, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -752,7 +752,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       val project = cometPlan
         .asInstanceOf[WholeStageCodegenExec]
         .child
-        .asInstanceOf[ColumnarToRowExec]
+        .asInstanceOf[CometColumnarToRowExec]
         .child
         .asInstanceOf[InputAdapter]
         .child

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -36,7 +36,7 @@ import org.apache.parquet.hadoop.example.ExampleParquetWriter
 import org.apache.parquet.schema.{MessageType, MessageTypeParser}
 import org.apache.spark._
 import org.apache.spark.internal.config.{MEMORY_OFFHEAP_ENABLED, MEMORY_OFFHEAP_SIZE, SHUFFLE_MANAGER}
-import org.apache.spark.sql.comet.{CometBatchScanExec, CometBroadcastExchangeExec, CometExec, CometScanExec, CometScanWrapper, CometSinkPlaceHolder, CometSparkToColumnarExec}
+import org.apache.spark.sql.comet.{CometBatchScanExec, CometBroadcastExchangeExec, CometColumnarToRowExec, CometExec, CometScanExec, CometScanWrapper, CometSinkPlaceHolder, CometSparkToColumnarExec}
 import org.apache.spark.sql.comet.execution.shuffle.{CometColumnarShuffle, CometNativeShuffle, CometShuffleExchangeExec}
 import org.apache.spark.sql.execution.{ColumnarToRowExec, ExtendedMode, InputAdapter, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
@@ -174,6 +174,7 @@ abstract class CometTestBase
     wrapped.foreach {
       case _: CometScanExec | _: CometBatchScanExec =>
       case _: CometSinkPlaceHolder | _: CometScanWrapper =>
+      case _: CometColumnarToRowExec =>
       case _: CometSparkToColumnarExec =>
       case _: CometExec | _: CometShuffleExchangeExec =>
       case _: CometBroadcastExchangeExec =>


### PR DESCRIPTION
## Which issue does this PR close?

Closes #708 

## Rationale for this change

Columnar to row operation is really slow and this attempts to speed it up.

## What changes are included in this PR?

Implements a native columnar to row operation for integer and floating point types. Variable length types can be added later.
The implementation allocates an off-heap buffer large enough to hold an entire batch of `UnsafeRow`s, passes it in to the native layer which converts the Arrow vectors into `UnsafeRow`s and puts them into the allocated buffer. The JVM code then simply points its `UnsafeRow`s to the underlying buffer.  
The native conversion copies the data from the arrow vector into the UnsafeRows. This is currently the performance bottleneck.

## How are these changes tested?
Additional unit test.

