### PR TITLE
feat: Support more types with BloomFilterAgg

### DIFF
--- a/native/core/src/execution/datafusion/expressions/bloom_filter_agg.rs
+++ b/native/core/src/execution/datafusion/expressions/bloom_filter_agg.rs
@@ -112,10 +112,22 @@ impl Accumulator for SparkBloomFilter {
         (0..arr.len()).try_for_each(|index| {
             let v = ScalarValue::try_from_array(arr, index)?;
 
-            if let ScalarValue::Int64(Some(value)) = v {
-                self.put_long(value);
-            } else {
-                unreachable!()
+            match v {
+                ScalarValue::Int8(Some(value)) => {
+                    self.put_long(value as i64);
+                }
+                ScalarValue::Int16(Some(value)) => {
+                    self.put_long(value as i64);
+                }
+                ScalarValue::Int32(Some(value)) => {
+                    self.put_long(value as i64);
+                }
+                ScalarValue::Int64(Some(value)) => {
+                    self.put_long(value);
+                }
+                _ => {
+                    unreachable!()
+                }
             }
             Ok(())
         })

--- a/native/core/src/execution/datafusion/expressions/bloom_filter_agg.rs
+++ b/native/core/src/execution/datafusion/expressions/bloom_filter_agg.rs
@@ -62,7 +62,17 @@ impl BloomFilterAgg {
         assert!(matches!(data_type, DataType::Binary));
         Self {
             name: name.into(),
-            signature: Signature::exact(vec![DataType::Int64], Volatility::Immutable),
+            signature: Signature::uniform(
+                1,
+                vec![
+                    DataType::Int8,
+                    DataType::Int16,
+                    DataType::Int32,
+                    DataType::Int64,
+                    DataType::Utf8,
+                ],
+                Volatility::Immutable,
+            ),
             expr,
             num_items: extract_i32_from_literal(num_items),
             num_bits: extract_i32_from_literal(num_bits),

--- a/native/core/src/execution/datafusion/expressions/bloom_filter_agg.rs
+++ b/native/core/src/execution/datafusion/expressions/bloom_filter_agg.rs
@@ -125,6 +125,9 @@ impl Accumulator for SparkBloomFilter {
                 ScalarValue::Int64(Some(value)) => {
                     self.put_long(value);
                 }
+                ScalarValue::Utf8(Some(value)) => {
+                    self.put_binary(value.as_bytes());
+                }
                 _ => {
                     unreachable!()
                 }

--- a/native/core/src/execution/datafusion/util/spark_bloom_filter.rs
+++ b/native/core/src/execution/datafusion/util/spark_bloom_filter.rs
@@ -115,6 +115,23 @@ impl SparkBloomFilter {
         bit_changed
     }
 
+    pub fn put_bgiinary(&mut self, item: &[u8]) -> bool {
+        // Here we first hash the input long element into 2 int hash values, h1 and h2, then produce
+        // n hash values by `h1 + i * h2` with 1 <= i <= num_hash_functions.
+        let h1 = spark_compatible_murmur3_hash(item, 0);
+        let h2 = spark_compatible_murmur3_hash(item, h1);
+        let bit_size = self.bits.bit_size() as i32;
+        let mut bit_changed = false;
+        for i in 1..=self.num_hash_functions {
+            let mut combined_hash = (h1 as i32).add_wrapping((i as i32).mul_wrapping(h2 as i32));
+            if combined_hash < 0 {
+                combined_hash = !combined_hash;
+            }
+            bit_changed |= self.bits.set((combined_hash % bit_size) as usize)
+        }
+        bit_changed
+    }
+
     pub fn might_contain_long(&self, item: i64) -> bool {
         let h1 = spark_compatible_murmur3_hash(item.to_le_bytes(), 0);
         let h2 = spark_compatible_murmur3_hash(item.to_le_bytes(), h1);

--- a/native/core/src/execution/datafusion/util/spark_bloom_filter.rs
+++ b/native/core/src/execution/datafusion/util/spark_bloom_filter.rs
@@ -115,7 +115,7 @@ impl SparkBloomFilter {
         bit_changed
     }
 
-    pub fn put_bgiinary(&mut self, item: &[u8]) -> bool {
+    pub fn put_binary(&mut self, item: &[u8]) -> bool {
         // Here we first hash the input long element into 2 int hash values, h1 and h2, then produce
         // n hash values by `h1 + i * h2` with 1 <= i <= num_hash_functions.
         let h1 = spark_compatible_murmur3_hash(item, 0);

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -770,6 +770,16 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
         val dataType = serializeDataType(bloom_filter.dataType)
 
         if (childExpr.isDefined &&
+          (child.dataType
+            .isInstanceOf[ByteType] ||
+            child.dataType
+              .isInstanceOf[ShortType] ||
+            child.dataType
+              .isInstanceOf[IntegerType] ||
+            child.dataType
+              .isInstanceOf[LongType] ||
+            child.dataType
+              .isInstanceOf[StringType]) &&
           numItemsExpr.isDefined &&
           numBitsExpr.isDefined &&
           dataType.isDefined) {

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -769,18 +769,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
         val numBitsExpr = exprToProto(numBits, inputs, binding)
         val dataType = serializeDataType(bloom_filter.dataType)
 
-        // TODO: Support more types
-        //  https://github.com/apache/datafusion-comet/issues/1023
         if (childExpr.isDefined &&
-          (child.dataType
-            .isInstanceOf[LongType] ||
-            child.dataType
-              .isInstanceOf[IntegerType] ||
-            child.dataType
-              .isInstanceOf[ByteType] ||
-            child.dataType
-              .isInstanceOf[ShortType])
-          &&
           numItemsExpr.isDefined &&
           numBitsExpr.isDefined &&
           dataType.isDefined) {

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -772,8 +772,15 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
         // TODO: Support more types
         //  https://github.com/apache/datafusion-comet/issues/1023
         if (childExpr.isDefined &&
-          child.dataType
-            .isInstanceOf[LongType] &&
+          (child.dataType
+            .isInstanceOf[LongType] ||
+            child.dataType
+              .isInstanceOf[IntegerType] ||
+            child.dataType
+              .isInstanceOf[ByteType] ||
+            child.dataType
+              .isInstanceOf[ShortType])
+          &&
           numItemsExpr.isDefined &&
           numBitsExpr.isDefined &&
           dataType.isDefined) {

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -947,15 +947,11 @@ class CometExecSuite extends CometTestBase {
         .map(_ => (Random.nextInt(), Random.nextInt() % 5)),
       "tbl") {
 
-      if (isSpark35Plus) {
-        Seq("tinyint", "short", "int", "long", "string").foreach { input_type =>
+      (if (isSpark35Plus) Seq("tinyint", "short", "int", "long", "string") else Seq("long"))
+        .foreach { input_type =>
           val df = sql(f"SELECT bloom_filter_agg(cast(_2 as $input_type)) FROM tbl")
           checkSparkAnswerAndOperator(df)
         }
-      } else {
-        val df = sql("SELECT bloom_filter_agg(cast(_2 as long)) FROM tbl")
-        checkSparkAnswerAndOperator(df)
-      }
     }
 
     spark.sessionState.functionRegistry.dropFunction(funcId_bloom_filter_agg)

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -946,6 +946,30 @@ class CometExecSuite extends CometTestBase {
       (0 until 100)
         .map(_ => (Random.nextInt(), Random.nextInt() % 5)),
       "tbl") {
+      val df = sql("SELECT bloom_filter_agg(cast(_2 as tinyint)) FROM tbl")
+      checkSparkAnswerAndOperator(df)
+    }
+
+    withParquetTable(
+      (0 until 100)
+        .map(_ => (Random.nextInt(), Random.nextInt() % 5)),
+      "tbl") {
+      val df = sql("SELECT bloom_filter_agg(cast(_2 as short)) FROM tbl")
+      checkSparkAnswerAndOperator(df)
+    }
+
+    withParquetTable(
+      (0 until 100)
+        .map(_ => (Random.nextInt(), Random.nextInt() % 5)),
+      "tbl") {
+      val df = sql("SELECT bloom_filter_agg(cast(_2 as int)) FROM tbl")
+      checkSparkAnswerAndOperator(df)
+    }
+
+    withParquetTable(
+      (0 until 100)
+        .map(_ => (Random.nextInt(), Random.nextInt() % 5)),
+      "tbl") {
       val df = sql("SELECT bloom_filter_agg(cast(_2 as long)) FROM tbl")
       checkSparkAnswerAndOperator(df)
     }

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -947,10 +947,14 @@ class CometExecSuite extends CometTestBase {
         .map(_ => (Random.nextInt(), Random.nextInt() % 5)),
       "tbl") {
 
-      Seq("tinyint", "short", "int", "long").foreach { input_type =>
-        val df = sql(f"SELECT bloom_filter_agg(cast(_2 as $input_type)) FROM tbl")
+      if (isSpark35Plus) {
+        Seq("tinyint", "short", "int", "long", "string").foreach { input_type =>
+          val df = sql(f"SELECT bloom_filter_agg(cast(_2 as $input_type)) FROM tbl")
+          checkSparkAnswerAndOperator(df)
+        }
+      } else {
+        val df = sql("SELECT bloom_filter_agg(cast(_2 as long)) FROM tbl")
         checkSparkAnswerAndOperator(df)
-
       }
     }
 

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -946,32 +946,12 @@ class CometExecSuite extends CometTestBase {
       (0 until 100)
         .map(_ => (Random.nextInt(), Random.nextInt() % 5)),
       "tbl") {
-      val df = sql("SELECT bloom_filter_agg(cast(_2 as tinyint)) FROM tbl")
-      checkSparkAnswerAndOperator(df)
-    }
 
-    withParquetTable(
-      (0 until 100)
-        .map(_ => (Random.nextInt(), Random.nextInt() % 5)),
-      "tbl") {
-      val df = sql("SELECT bloom_filter_agg(cast(_2 as short)) FROM tbl")
-      checkSparkAnswerAndOperator(df)
-    }
+      Seq("tinyint", "short", "int", "long").foreach { input_type =>
+        val df = sql(f"SELECT bloom_filter_agg(cast(_2 as $input_type)) FROM tbl")
+        checkSparkAnswerAndOperator(df)
 
-    withParquetTable(
-      (0 until 100)
-        .map(_ => (Random.nextInt(), Random.nextInt() % 5)),
-      "tbl") {
-      val df = sql("SELECT bloom_filter_agg(cast(_2 as int)) FROM tbl")
-      checkSparkAnswerAndOperator(df)
-    }
-
-    withParquetTable(
-      (0 until 100)
-        .map(_ => (Random.nextInt(), Random.nextInt() % 5)),
-      "tbl") {
-      val df = sql("SELECT bloom_filter_agg(cast(_2 as long)) FROM tbl")
-      checkSparkAnswerAndOperator(df)
+      }
     }
 
     spark.sessionState.functionRegistry.dropFunction(funcId_bloom_filter_agg)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1023.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

The other integer types just need a cast. For strings I had to add `put_binary` to `spark_bloom_filter`.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Added more types to test for Spark 3.5+.