### PR TITLE
fix: need default value for getSizeAsMb(EXECUTOR_MEMORY.key)

### DIFF
--- a/spark/src/main/scala/org/apache/spark/Plugins.scala
+++ b/spark/src/main/scala/org/apache/spark/Plugins.scala
@@ -42,6 +42,8 @@ import org.apache.comet.{CometConf, CometSparkSessionExtensions}
  * To enable this plugin, set the config "spark.plugins" to `org.apache.spark.CometPlugin`.
  */
 class CometDriverPlugin extends DriverPlugin with Logging with ShimCometDriverPlugin {
+  private val EXECUTOR_MEMORY_DEFAULT = "1g"
+
   override def init(sc: SparkContext, pluginContext: PluginContext): ju.Map[String, String] = {
     logInfo("CometDriverPlugin init")
 
@@ -53,7 +55,7 @@ class CometDriverPlugin extends DriverPlugin with Logging with ShimCometDriverPl
         sc.getConf.getSizeAsMb(EXECUTOR_MEMORY_OVERHEAD.key)
       } else {
         // By default, executorMemory * spark.executor.memoryOverheadFactor, with minimum of 384MB
-        val executorMemory = sc.getConf.getSizeAsMb(EXECUTOR_MEMORY.key)
+        val executorMemory = sc.getConf.getSizeAsMb(EXECUTOR_MEMORY.key, EXECUTOR_MEMORY_DEFAULT)
         val memoryOverheadFactor = getMemoryOverheadFactor(sc.getConf)
         val memoryOverheadMinMib = getMemoryOverheadMinMib(sc.getConf)
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #1045 .

## Rationale for this change

Provide a default value `1g` to `getSizeAsMb(EXECUTOR_MEMORY.key)`, which is [the default value](https://spark.apache.org/docs/3.5.3/configuration.html#application-properties) of `spark.executor.memory` in Apache Spark 3.5.3.

## What changes are included in this PR?

+ Define `private val EXECUTOR_MEMORY_DEFAULT` in the class
+ Call `getSizeAsMb(EXECUTOR_MEMORY.key)` with `EXECUTOR_MEMORY_DEFAULT` 

## How are these changes tested?

Tested with the `datafusion-benchmarks` as described in the issue #1045  .