### PR TITLE
minor: Refactor binary expr serde to reduce code duplication

### DIFF
--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -2150,6 +2150,7 @@ mod tests {
     use crate::execution::{datafusion::planner::PhysicalPlanner, operators::InputBatch};
 
     use crate::execution::operators::ExecutionError;
+    use datafusion_comet_proto::spark_expression::expr::ExprStruct;
     use datafusion_comet_proto::{
         spark_expression::expr::ExprStruct::*,
         spark_expression::{self, literal},
@@ -2388,7 +2389,7 @@ mod tests {
         };
 
         let expr = spark_expression::Expr {
-            expr_struct: Some(Eq(Box::new(spark_expression::BinaryExpr {
+            expr_struct: Some(ExprStruct::Eq(Box::new(spark_expression::BinaryExpr {
                 left: Some(Box::new(left)),
                 right: Some(Box::new(right)),
             }))),

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -2388,7 +2388,7 @@ mod tests {
         };
 
         let expr = spark_expression::Expr {
-            expr_struct: Some(Eq(Box::new(spark_expression::Equal {
+            expr_struct: Some(Eq(Box::new(spark_expression::BinaryExpr {
                 left: Some(Box::new(left)),
                 right: Some(Box::new(right)),
             }))),

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -2150,7 +2150,6 @@ mod tests {
     use crate::execution::{datafusion::planner::PhysicalPlanner, operators::InputBatch};
 
     use crate::execution::operators::ExecutionError;
-    use datafusion_comet_proto::spark_expression::expr::ExprStruct;
     use datafusion_comet_proto::{
         spark_expression::expr::ExprStruct::*,
         spark_expression::{self, literal},
@@ -2389,7 +2388,7 @@ mod tests {
         };
 
         let expr = spark_expression::Expr {
-            expr_struct: Some(ExprStruct::Eq(Box::new(spark_expression::BinaryExpr {
+            expr_struct: Some(Eq(Box::new(spark_expression::BinaryExpr {
                 left: Some(Box::new(left)),
                 right: Some(Box::new(right)),
             }))),

--- a/native/proto/src/proto/expr.proto
+++ b/native/proto/src/proto/expr.proto
@@ -33,16 +33,16 @@ message Expr {
     Multiply multiply = 6;
     Divide divide = 7;
     Cast cast = 8;
-    Equal eq = 9;
-    NotEqual neq = 10;
-    GreaterThan gt = 11;
-    GreaterThanEqual gt_eq = 12;
-    LessThan lt = 13;
-    LessThanEqual lt_eq = 14;
+    BinaryExpr eq = 9;
+    BinaryExpr neq = 10;
+    BinaryExpr gt = 11;
+    BinaryExpr gt_eq = 12;
+    BinaryExpr lt = 13;
+    BinaryExpr lt_eq = 14;
     IsNull is_null = 15;
     IsNotNull is_not_null = 16;
-    And and = 17;
-    Or or = 18;
+    BinaryExpr and = 17;
+    BinaryExpr or = 18;
     SortOrder sort_order = 19;
     Substring substring = 20;
     StringSpace string_space = 21;
@@ -50,24 +50,24 @@ message Expr {
     Minute minute = 23;
     Second second = 24;
     CheckOverflow check_overflow = 25;
-    Like like = 26;
-    StartsWith startsWith = 27;
-    EndsWith endsWith = 28;
-    Contains contains = 29;
-    RLike rlike = 30;
+    BinaryExpr like = 26;
+    BinaryExpr startsWith = 27;
+    BinaryExpr endsWith = 28;
+    BinaryExpr contains = 29;
+    BinaryExpr rlike = 30;
     ScalarFunc scalarFunc = 31;
-    EqualNullSafe eqNullSafe = 32;
-    NotEqualNullSafe neqNullSafe = 33;
-    BitwiseAnd bitwiseAnd = 34;
-    BitwiseOr bitwiseOr = 35;
-    BitwiseXor bitwiseXor = 36;
+    BinaryExpr eqNullSafe = 32;
+    BinaryExpr neqNullSafe = 33;
+    BinaryExpr bitwiseAnd = 34;
+    BinaryExpr bitwiseOr = 35;
+    BinaryExpr bitwiseXor = 36;
     Remainder remainder = 37;
     CaseWhen caseWhen = 38;
     In in = 39;
     Not not = 40;
     UnaryMinus unary_minus = 41;
-    BitwiseShiftRight bitwiseShiftRight = 42;
-    BitwiseShiftLeft bitwiseShiftLeft = 43;
+    BinaryExpr bitwiseShiftRight = 42;
+    BinaryExpr bitwiseShiftLeft = 43;
     IfExpr if = 44;
     NormalizeNaNAndZero normalize_nan_and_zero = 45;
     TruncDate truncDate = 46;
@@ -269,52 +269,7 @@ message Cast {
   bool allow_incompat = 5;
 }
 
-message Equal {
-  Expr left = 1;
-  Expr right = 2;
-}
-
-message NotEqual {
-  Expr left = 1;
-  Expr right = 2;
-}
-
-message EqualNullSafe {
-  Expr left = 1;
-  Expr right = 2;
-}
-
-message NotEqualNullSafe {
-  Expr left = 1;
-  Expr right = 2;
-}
-
-message GreaterThan {
-  Expr left = 1;
-  Expr right = 2;
-}
-
-message GreaterThanEqual {
-  Expr left = 1;
-  Expr right = 2;
-}
-
-message LessThan {
-  Expr left = 1;
-  Expr right = 2;
-}
-
-message LessThanEqual {
-  Expr left = 1;
-  Expr right = 2;
-}
-
-message And {
-  Expr left = 1;
-  Expr right = 2;
-}
-
-message Or {
+message BinaryExpr {
   Expr left = 1;
   Expr right = 2;
 }
@@ -384,60 +339,10 @@ message CheckOverflow {
   bool fail_on_error = 3;
 }
 
-message Like {
-  Expr left = 1;
-  Expr right = 2;
-}
-
-message RLike {
-  Expr left = 1;
-  Expr right = 2;
-}
-
-message StartsWith {
-  Expr left = 1;
-  Expr right = 2;
-}
-
-message EndsWith {
-  Expr left = 1;
-  Expr right = 2;
-}
-
-message Contains {
-  Expr left = 1;
-  Expr right = 2;
-}
-
 message ScalarFunc {
   string func = 1;
   repeated Expr args = 2;
   DataType return_type = 3;
-}
-
-message BitwiseAnd {
-  Expr left = 1;
-  Expr right = 2;
-}
-
-message BitwiseOr {
-  Expr left = 1;
-  Expr right = 2;
-}
-
-message BitwiseXor {
-  Expr left = 1;
-  Expr right = 2;
-}
-
-message BitwiseShiftRight {
-  Expr left = 1;
-  Expr right = 2;
-}
-
-message BitwiseShiftLeft {
-  Expr left = 1;
-  Expr right = 2;
 }
 
 message CaseWhen {

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -1090,7 +1090,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(right, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.Equal.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 
@@ -1109,7 +1109,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(right, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.NotEqual.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 
@@ -1128,7 +1128,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(right, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.EqualNullSafe.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 
@@ -1147,7 +1147,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(right, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.NotEqualNullSafe.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 
@@ -1166,7 +1166,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(right, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.GreaterThan.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 
@@ -1185,7 +1185,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(right, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.GreaterThanEqual.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 
@@ -1204,7 +1204,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(right, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.LessThan.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 
@@ -1223,7 +1223,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(right, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.LessThanEqual.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 
@@ -1376,7 +1376,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
             val rightExpr = exprToProtoInternal(right, inputs)
 
             if (leftExpr.isDefined && rightExpr.isDefined) {
-              val builder = ExprOuterClass.Like.newBuilder()
+              val builder = ExprOuterClass.BinaryExpr.newBuilder()
               builder.setLeft(leftExpr.get)
               builder.setRight(rightExpr.get)
 
@@ -1417,7 +1417,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(right, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.RLike.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 
@@ -1435,7 +1435,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(right, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.StartsWith.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 
@@ -1454,7 +1454,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(right, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.EndsWith.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 
@@ -1473,7 +1473,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(right, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.Contains.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 
@@ -1709,7 +1709,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(right, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.And.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 
@@ -1728,7 +1728,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(right, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.Or.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 
@@ -2181,7 +2181,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(right, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BitwiseAnd.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 
@@ -2217,7 +2217,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(right, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BitwiseOr.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 
@@ -2236,7 +2236,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(right, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BitwiseXor.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 
@@ -2262,7 +2262,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(rightExpression, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BitwiseShiftRight.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 
@@ -2288,7 +2288,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           val rightExpr = exprToProtoInternal(rightExpression, inputs)
 
           if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BitwiseShiftLeft.newBuilder()
+            val builder = ExprOuterClass.BinaryExpr.newBuilder()
             builder.setLeft(leftExpr.get)
             builder.setRight(rightExpr.get)
 

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -1086,155 +1086,67 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           None
 
         case EqualTo(left, right) =>
-          val leftExpr = exprToProtoInternal(left, inputs)
-          val rightExpr = exprToProtoInternal(right, inputs)
-
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BinaryExpr.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
-
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setEq(builder)
-                .build())
-          } else {
-            withInfo(expr, left, right)
-            None
+          createBinaryExpr(left, right, inputs).map { builder =>
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setEq(builder)
+              .build()
           }
 
         case Not(EqualTo(left, right)) =>
-          val leftExpr = exprToProtoInternal(left, inputs)
-          val rightExpr = exprToProtoInternal(right, inputs)
-
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BinaryExpr.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
-
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setNeq(builder)
-                .build())
-          } else {
-            withInfo(expr, left, right)
-            None
+          createBinaryExpr(left, right, inputs).map { builder =>
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setNeq(builder)
+              .build()
           }
 
         case EqualNullSafe(left, right) =>
-          val leftExpr = exprToProtoInternal(left, inputs)
-          val rightExpr = exprToProtoInternal(right, inputs)
-
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BinaryExpr.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
-
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setEqNullSafe(builder)
-                .build())
-          } else {
-            withInfo(expr, left, right)
-            None
+          createBinaryExpr(left, right, inputs).map { builder =>
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setEqNullSafe(builder)
+              .build()
           }
 
         case Not(EqualNullSafe(left, right)) =>
-          val leftExpr = exprToProtoInternal(left, inputs)
-          val rightExpr = exprToProtoInternal(right, inputs)
-
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BinaryExpr.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
-
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setNeqNullSafe(builder)
-                .build())
-          } else {
-            withInfo(expr, left, right)
-            None
+          createBinaryExpr(left, right, inputs).map { builder =>
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setNeqNullSafe(builder)
+              .build()
           }
 
         case GreaterThan(left, right) =>
-          val leftExpr = exprToProtoInternal(left, inputs)
-          val rightExpr = exprToProtoInternal(right, inputs)
-
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BinaryExpr.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
-
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setGt(builder)
-                .build())
-          } else {
-            withInfo(expr, left, right)
-            None
+          createBinaryExpr(left, right, inputs).map { builder =>
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setGt(builder)
+              .build()
           }
 
         case GreaterThanOrEqual(left, right) =>
-          val leftExpr = exprToProtoInternal(left, inputs)
-          val rightExpr = exprToProtoInternal(right, inputs)
-
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BinaryExpr.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
-
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setGtEq(builder)
-                .build())
-          } else {
-            withInfo(expr, left, right)
-            None
+          createBinaryExpr(left, right, inputs).map { builder =>
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setGtEq(builder)
+              .build()
           }
 
         case LessThan(left, right) =>
-          val leftExpr = exprToProtoInternal(left, inputs)
-          val rightExpr = exprToProtoInternal(right, inputs)
-
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BinaryExpr.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
-
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setLt(builder)
-                .build())
-          } else {
-            withInfo(expr, left, right)
-            None
+          createBinaryExpr(left, right, inputs).map { builder =>
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setLt(builder)
+              .build()
           }
 
         case LessThanOrEqual(left, right) =>
-          val leftExpr = exprToProtoInternal(left, inputs)
-          val rightExpr = exprToProtoInternal(right, inputs)
-
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BinaryExpr.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
-
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setLtEq(builder)
-                .build())
-          } else {
-            withInfo(expr, left, right)
-            None
+          createBinaryExpr(left, right, inputs).map { builder =>
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setLtEq(builder)
+              .build()
           }
 
         case Literal(value, dataType)
@@ -1372,22 +1284,11 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
 
         case Like(left, right, escapeChar) =>
           if (escapeChar == '\\') {
-            val leftExpr = exprToProtoInternal(left, inputs)
-            val rightExpr = exprToProtoInternal(right, inputs)
-
-            if (leftExpr.isDefined && rightExpr.isDefined) {
-              val builder = ExprOuterClass.BinaryExpr.newBuilder()
-              builder.setLeft(leftExpr.get)
-              builder.setRight(rightExpr.get)
-
-              Some(
-                ExprOuterClass.Expr
-                  .newBuilder()
-                  .setLike(builder)
-                  .build())
-            } else {
-              withInfo(expr, left, right)
-              None
+            createBinaryExpr(left, right, inputs).map { builder =>
+              ExprOuterClass.Expr
+                .newBuilder()
+                .setLike(builder)
+                .build()
             }
           } else {
             // TODO custom escape char
@@ -1413,78 +1314,35 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
               return None
           }
 
-          val leftExpr = exprToProtoInternal(left, inputs)
-          val rightExpr = exprToProtoInternal(right, inputs)
-
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BinaryExpr.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
-
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setRlike(builder)
-                .build())
-          } else {
-            withInfo(expr, left, right)
-            None
+          createBinaryExpr(left, right, inputs).map { builder =>
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setRlike(builder)
+              .build()
           }
+
         case StartsWith(left, right) =>
-          val leftExpr = exprToProtoInternal(left, inputs)
-          val rightExpr = exprToProtoInternal(right, inputs)
-
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BinaryExpr.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
-
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setStartsWith(builder)
-                .build())
-          } else {
-            withInfo(expr, left, right)
-            None
+          createBinaryExpr(left, right, inputs).map { builder =>
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setStartsWith(builder)
+              .build()
           }
 
         case EndsWith(left, right) =>
-          val leftExpr = exprToProtoInternal(left, inputs)
-          val rightExpr = exprToProtoInternal(right, inputs)
-
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BinaryExpr.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
-
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setEndsWith(builder)
-                .build())
-          } else {
-            withInfo(expr, left, right)
-            None
+          createBinaryExpr(left, right, inputs).map { builder =>
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setEndsWith(builder)
+              .build()
           }
 
         case Contains(left, right) =>
-          val leftExpr = exprToProtoInternal(left, inputs)
-          val rightExpr = exprToProtoInternal(right, inputs)
-
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BinaryExpr.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
-
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setContains(builder)
-                .build())
-          } else {
-            withInfo(expr, left, right)
-            None
+          createBinaryExpr(left, right, inputs).map { builder =>
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setContains(builder)
+              .build()
           }
 
         case StringSpace(child) =>
@@ -1713,22 +1571,11 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           }
 
         case Or(left, right) =>
-          val leftExpr = exprToProtoInternal(left, inputs)
-          val rightExpr = exprToProtoInternal(right, inputs)
-
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BinaryExpr.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
-
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setOr(builder)
-                .build())
-          } else {
-            withInfo(expr, left, right)
-            None
+          createBinaryExpr(left, right, inputs).map { builder =>
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setOr(builder)
+              .build()
           }
 
         case UnaryExpression(child) if expr.prettyName == "promote_precision" =>
@@ -2166,22 +2013,11 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           }
 
         case BitwiseAnd(left, right) =>
-          val leftExpr = exprToProtoInternal(left, inputs)
-          val rightExpr = exprToProtoInternal(right, inputs)
-
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BinaryExpr.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
-
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setBitwiseAnd(builder)
-                .build())
-          } else {
-            withInfo(expr, left, right)
-            None
+          createBinaryExpr(left, right, inputs).map { builder =>
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setBitwiseAnd(builder)
+              .build()
           }
 
         case BitwiseNot(child) =>
@@ -2202,45 +2038,22 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           }
 
         case BitwiseOr(left, right) =>
-          val leftExpr = exprToProtoInternal(left, inputs)
-          val rightExpr = exprToProtoInternal(right, inputs)
-
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BinaryExpr.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
-
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setBitwiseOr(builder)
-                .build())
-          } else {
-            withInfo(expr, left, right)
-            None
+          createBinaryExpr(left, right, inputs).map { builder =>
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setBitwiseOr(builder)
+              .build()
           }
 
         case BitwiseXor(left, right) =>
-          val leftExpr = exprToProtoInternal(left, inputs)
-          val rightExpr = exprToProtoInternal(right, inputs)
-
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BinaryExpr.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
-
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setBitwiseXor(builder)
-                .build())
-          } else {
-            withInfo(expr, left, right)
-            None
+          createBinaryExpr(left, right, inputs).map { builder =>
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setBitwiseXor(builder)
+              .build()
           }
 
         case ShiftRight(left, right) =>
-          val leftExpr = exprToProtoInternal(left, inputs)
           // DataFusion bitwise shift right expression requires
           // same data type between left and right side
           val rightExpression = if (left.dataType == LongType) {
@@ -2248,25 +2061,15 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           } else {
             right
           }
-          val rightExpr = exprToProtoInternal(rightExpression, inputs)
 
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BinaryExpr.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
-
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setBitwiseShiftRight(builder)
-                .build())
-          } else {
-            withInfo(expr, left, rightExpression)
-            None
+          createBinaryExpr(left, rightExpression, inputs).map { builder =>
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setBitwiseShiftRight(builder)
+              .build()
           }
 
         case ShiftLeft(left, right) =>
-          val leftExpr = exprToProtoInternal(left, inputs)
           // DataFusion bitwise shift right expression requires
           // same data type between left and right side
           val rightExpression = if (left.dataType == LongType) {
@@ -2274,21 +2077,12 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           } else {
             right
           }
-          val rightExpr = exprToProtoInternal(rightExpression, inputs)
 
-          if (leftExpr.isDefined && rightExpr.isDefined) {
-            val builder = ExprOuterClass.BinaryExpr.newBuilder()
-            builder.setLeft(leftExpr.get)
-            builder.setRight(rightExpr.get)
-
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setBitwiseShiftLeft(builder)
-                .build())
-          } else {
-            withInfo(expr, left, rightExpression)
-            None
+          createBinaryExpr(left, rightExpression, inputs).map { builder =>
+            ExprOuterClass.Expr
+              .newBuilder()
+              .setBitwiseShiftLeft(builder)
+              .build()
           }
 
         case In(value, list) =>
@@ -2603,14 +2397,16 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
     def createBinaryExpr(
         left: Expression,
         right: Expression,
-        inputs: Seq[Attribute]): Option[ExprOuterClass.BinaryExpr.Builder] = {
+        inputs: Seq[Attribute]): Option[ExprOuterClass.BinaryExpr] = {
       val leftExpr = exprToProtoInternal(left, inputs)
       val rightExpr = exprToProtoInternal(right, inputs)
       if (leftExpr.isDefined && rightExpr.isDefined) {
-        val builder = ExprOuterClass.BinaryExpr.newBuilder()
-        builder.setLeft(leftExpr.get)
-        builder.setRight(rightExpr.get)
-        Some(builder)
+        Some(
+          ExprOuterClass.BinaryExpr
+            .newBuilder()
+            .setLeft(leftExpr.get)
+            .setRight(rightExpr.get)
+            .build())
       } else {
         withInfo(expr, left, right)
         None


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We currently have 20 duplicate structs defined in protobuf for binary expressions, such as:

```protobuf
message Equal {
  Expr left = 1;
  Expr right = 2;
}

message NotEqual {
  Expr left = 1;
  Expr right = 2;
}

message EqualNullSafe {
  Expr left = 1;
  Expr right = 2;
}
```

As a result, we have a lot of duplicate code in QueryPlanSerde for serializing binary expressions that cannot easily be refactored because each code block references a different (but identical) generated class.


## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Use a single definition of BinaryExpr
- Refactor  QueryPlanSerde to remove a lot of duplicate boilerplate code

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests
