### PR TITLE
build: Skip installation of spark-integration  and fuzz testing modules

### DIFF
--- a/fuzz-testing/pom.xml
+++ b/fuzz-testing/pom.xml
@@ -100,6 +100,13 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/spark-integration/pom.xml
+++ b/spark-integration/pom.xml
@@ -100,6 +100,13 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION

## Rationale for this change

We do not need to publish these jars when we release Comet

## What changes are included in this PR?

