### PR TITLE
perf: Stop performing deep copies when CometScan source is an exchange

### DIFF
--- a/native/core/src/execution/operators/scan.rs
+++ b/native/core/src/execution/operators/scan.rs
@@ -64,6 +64,8 @@ pub struct ScanExec {
     pub input_source: Option<Arc<GlobalRef>>,
     /// A description of the input source for informational purposes
     pub input_source_description: String,
+    /// Some sources (currently only the native Parquet scan) re-use mutable buffers
+    pub reuses_buffers: bool,
     /// The data types of columns of the input batch. Converted from Spark schema.
     pub data_types: Vec<DataType>,
     /// Schema of first batch
@@ -85,6 +87,7 @@ impl ScanExec {
         input_source: Option<Arc<GlobalRef>>,
         input_source_description: &str,
         data_types: Vec<DataType>,
+        reuses_buffers: bool,
     ) -> Result<Self, CometError> {
         let metrics_set = ExecutionPlanMetricsSet::default();
         let baseline_metrics = BaselineMetrics::new(&metrics_set, 0);
@@ -119,6 +122,7 @@ impl ScanExec {
             exec_context_id,
             input_source,
             input_source_description: input_source_description.to_string(),
+            reuses_buffers,
             data_types,
             batch: Arc::new(Mutex::new(Some(first_batch))),
             cache,

--- a/native/proto/src/proto/operator.proto
+++ b/native/proto/src/proto/operator.proto
@@ -55,6 +55,7 @@ message Scan {
   // is purely for informational purposes when viewing native query plans in
   // debug mode.
   string source = 2;
+  bool reuses_buffers = 3;
 }
 
 message Projection {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Because our current Parquet decoding logic reuses mutable buffers, we have to be careful to perform a deep copy before calling operators that could cache data. We do this by wrapping ScanExec in a CopyExec.

However, we use ScanExec both for reading from Parquet scans and also for reading from exchanges (broadcast and shuffle). We only need to perform deep copies in the Parquet case.

Here are the before and after changes:

### Before

```
CopyExec [UnpackOrDeepCopy], metrics=[output_rows=510412, elapsed_compute=432.747µs]
  ScanExec: source=[ShuffleQueryStage (unknown), Statistics(sizeInBytes=223.2 MiB, ...
```

### After

```
CopyExec [UnpackOrClone], metrics=[output_rows=510412, elapsed_compute=9.006µs]
  ScanExec: source=[ShuffleQueryStage (unknown), Statistics(sizeInBytes=223.2 MiB, ...
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Use `CopyMode::UnpackOrClone` instead of `CopyMode::UnpackOrDeepCopy` when wrapping a `CometScan` that is reading from an exchange.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Manually.

