### PR TITLE
[comet-parquet-exec] Use Parquet schema for scan instead of Spark schema

### DIFF
--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -1023,13 +1023,13 @@ impl PhysicalPlanner {
                 // TODO: I think we can remove partition_count in the future, but leave for testing.
                 assert_eq!(file_groups.len(), partition_count);
 
+                assert_eq!(projection_vector.len(), required_schema_arrow.fields.len());
+
                 let object_store_url = ObjectStoreUrl::local_filesystem();
                 let file_scan_config =
                     FileScanConfig::new(object_store_url, Arc::clone(&data_schema_arrow))
                         .with_file_groups(file_groups)
                         .with_projection(Some(projection_vector));
-
-                assert_eq!(projection_vector.len(), required_schema_arrow.fields.len());
 
                 let mut table_parquet_options = TableParquetOptions::new();
                 // TODO: Maybe these are configs?

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -985,7 +985,7 @@ impl PhysicalPlanner {
                 // Create a conjunctive form of the vector because ParquetExecBuilder takes
                 // a single expression
                 let data_filters = data_filters?;
-                let test_data_filters = data_filters.clone().into_iter().reduce(|left, right| {
+                let cnf_data_filters = data_filters.into_iter().reduce(|left, right| {
                     Arc::new(BinaryExpr::new(
                         left,
                         datafusion::logical_expr::Operator::And,
@@ -1039,7 +1039,7 @@ impl PhysicalPlanner {
                 let mut builder = ParquetExecBuilder::new(file_scan_config)
                     .with_table_parquet_options(table_parquet_options);
 
-                if let Some(filter) = test_data_filters {
+                if let Some(filter) = cnf_data_filters {
                     builder = builder.with_predicate(filter);
                 }
 

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -966,8 +966,6 @@ impl PhysicalPlanner {
                     .map(|offset| *offset as usize)
                     .collect();
 
-                println!("projection_vector: {:?}", projection_vector);
-
                 let required_schema_arrow = Arc::new(
                     parquet::arrow::schema::parquet_to_arrow_schema_by_columns(
                         &data_schema_descriptor,
@@ -976,10 +974,6 @@ impl PhysicalPlanner {
                     )
                     .unwrap(),
                 );
-
-                println!("data_schema_arrow: {}", data_schema_arrow);
-                println!("required_schema_arrow: {}", required_schema_arrow);
-                // projection_vector.iter().for_each(|offset|)
 
                 // Convert the Spark expressions to Physical expressions
                 let data_filters: Result<Vec<Arc<dyn PhysicalExpr>>, ExecutionError> = scan

--- a/native/proto/src/proto/operator.proto
+++ b/native/proto/src/proto/operator.proto
@@ -74,8 +74,8 @@ message NativeScan {
   // is purely for informational purposes when viewing native query plans in
   // debug mode.
   string source = 2;
-  string required_schema = 3;
-  string data_schema = 4;
+  string data_schema = 3;
+  repeated int64 projection_vector = 4;
   repeated spark.spark_expression.Expr data_filters = 5;
   repeated SparkFilePartition file_partitions = 6;
 }

--- a/spark/src/main/scala/org/apache/comet/parquet/CometParquetFileFormat.scala
+++ b/spark/src/main/scala/org/apache/comet/parquet/CometParquetFileFormat.scala
@@ -25,6 +25,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.filter2.predicate.FilterApi
 import org.apache.parquet.hadoop.ParquetInputFormat
 import org.apache.parquet.hadoop.metadata.FileMetaData
+import org.apache.parquet.schema.MessageType
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
@@ -61,6 +62,7 @@ class CometParquetFileFormat extends ParquetFileFormat with MetricsSupport with 
   override def toString: String = "CometParquet"
   override def hashCode(): Int = getClass.hashCode()
   override def equals(other: Any): Boolean = other.isInstanceOf[CometParquetFileFormat]
+  var schema: Option[MessageType] = None
 
   override def vectorTypes(
       requiredSchema: StructType,
@@ -104,7 +106,13 @@ class CometParquetFileFormat extends ParquetFileFormat with MetricsSupport with 
     (file: PartitionedFile) => {
       val sharedConf = broadcastedHadoopConf.value.value
       val footer = FooterReader.readFooter(sharedConf, file)
+      // scalastyle:off println
+      System.out.println(f"footer: $footer")
       val footerFileMetaData = footer.getFileMetaData
+      System.out.println(f"footerFileMetaData: $footerFileMetaData")
+      schema = Some(footerFileMetaData.getSchema)
+      System.out.println(f"schema: $schema")
+      // scalastyle:on println
       val datetimeRebaseSpec = CometParquetFileFormat.getDatetimeRebaseSpec(
         file,
         requiredSchema,

--- a/spark/src/main/scala/org/apache/comet/parquet/CometParquetFileFormat.scala
+++ b/spark/src/main/scala/org/apache/comet/parquet/CometParquetFileFormat.scala
@@ -25,7 +25,6 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.filter2.predicate.FilterApi
 import org.apache.parquet.hadoop.ParquetInputFormat
 import org.apache.parquet.hadoop.metadata.FileMetaData
-import org.apache.parquet.schema.MessageType
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
@@ -62,7 +61,6 @@ class CometParquetFileFormat extends ParquetFileFormat with MetricsSupport with 
   override def toString: String = "CometParquet"
   override def hashCode(): Int = getClass.hashCode()
   override def equals(other: Any): Boolean = other.isInstanceOf[CometParquetFileFormat]
-  var schema: Option[MessageType] = None
 
   override def vectorTypes(
       requiredSchema: StructType,
@@ -106,13 +104,7 @@ class CometParquetFileFormat extends ParquetFileFormat with MetricsSupport with 
     (file: PartitionedFile) => {
       val sharedConf = broadcastedHadoopConf.value.value
       val footer = FooterReader.readFooter(sharedConf, file)
-      // scalastyle:off println
-      System.out.println(f"footer: $footer")
       val footerFileMetaData = footer.getFileMetaData
-      System.out.println(f"footerFileMetaData: $footerFileMetaData")
-      schema = Some(footerFileMetaData.getSchema)
-      System.out.println(f"schema: $schema")
-      // scalastyle:on println
       val datetimeRebaseSpec = CometParquetFileFormat.getDatetimeRebaseSpec(
         file,
         requiredSchema,

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -3191,7 +3191,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
   private def partition2Proto(
       partition: FilePartition,
       nativeScanBuilder: OperatorOuterClass.NativeScan.Builder,
-      scan: CometNativeScanExec): Unit = {
+      scan: CometScanExec): Unit = {
     val partitionBuilder = OperatorOuterClass.SparkFilePartition.newBuilder()
     val sparkContext = scan.session.sparkContext
     var schema_saved: Boolean = false;

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, Normalize
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, RangePartitioning, RoundRobinPartitioning, SinglePartition}
 import org.apache.spark.sql.catalyst.util.CharVarcharCodegenUtils
-import org.apache.spark.sql.comet.{CometBroadcastExchangeExec, CometNativeScanExec, CometScanExec, CometSinkPlaceHolder, CometSparkToColumnarExec, DecimalPrecision}
+import org.apache.spark.sql.comet.{CometBroadcastExchangeExec, CometScanExec, CometSinkPlaceHolder, CometSparkToColumnarExec, DecimalPrecision}
 import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 import org.apache.spark.sql.execution
 import org.apache.spark.sql.execution._
@@ -3207,7 +3207,16 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
         val sharedConf = broadcastedHadoopConf.value.value
         val footer = FooterReader.readFooter(sharedConf, file)
         val footerFileMetaData = footer.getFileMetaData
-        nativeScanBuilder.setDataSchema(footerFileMetaData.getSchema.toString)
+        val schema = footerFileMetaData.getSchema
+        nativeScanBuilder.setDataSchema(schema.toString)
+
+//        val clippedSchema = CometParquetReadSupport.clipParquetSchema(
+//          schema,
+//          scan.requiredSchema,
+//          scan.session.sessionState.conf.caseSensitiveAnalysis,
+//          CometParquetUtils.readFieldId(scan.session.sessionState.conf),
+//          CometParquetUtils.ignoreMissingIds(scan.session.sessionState.conf))
+
         schema_saved = true
       }
       val fileBuilder = OperatorOuterClass.SparkPartitionedFile.newBuilder()

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -2520,8 +2520,9 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           }
 
           val projection_vector: Array[java.lang.Long] = scan.requiredSchema.fields.map(field => {
-            scan.relation.dataSchema.fields.indexOf(field).toLong.asInstanceOf[java.lang.Long]
+            scan.relation.dataSchema.fieldIndex(field.name).toLong.asInstanceOf[java.lang.Long]
           })
+
           nativeScanBuilder.addAllProjectionVector(projection_vector.toIterable.asJava)
 
           Some(result.setNativeScan(nativeScanBuilder).build())


### PR DESCRIPTION
Currently we get the scan schema from the plan nodes scan schema, and then serialize that back to a Parquet schema, then parse that on the native side. This is lossy, particularly with timestamps. For example:

```
schema: message root {
  optional int64 _0 (TIMESTAMP(MILLIS,true));
  optional int64 _1 (TIMESTAMP(MICROS,true));
  optional int64 _2 (TIMESTAMP(MILLIS,true));
  optional int64 _3 (TIMESTAMP(MILLIS,false));
  optional int64 _4 (TIMESTAMP(MICROS,true));
  optional int64 _5 (TIMESTAMP(MICROS,false));
  optional int64 _6 (INTEGER(64,true));
}

dataSchema: message spark_schema {
  optional int96 _0;
  optional int96 _1;
  optional int96 _2;
  optional int64 _3 (TIMESTAMP(MICROS,false));
  optional int96 _4;
  optional int64 _5 (TIMESTAMP(MICROS,false));
  optional int64 _6;
}
```
The former is the original Parquet footer, the latter is what we get after going through Spark. We need the original to handle timestamps correctly in ParquetExec.

This PR extracts some code from elsewhere (CometParquetFileFormat, CometNativeScanExec) to read the footer from the Parquet file, and serialize the original metadata. We also now generate the projection vector on the Spark side because the required columns is in Spark schema format, so will not match the Parquet schema 1:1. On the native side, we now have to regenerate the required schema from the Parquet schema using the projection vector (converted to a DF ProjectionMask).