### PR TITLE
chore: Add custom metric for native shuffle fetching batches from JVM

### DIFF
--- a/docs/source/user-guide/tuning.md
+++ b/docs/source/user-guide/tuning.md
@@ -105,15 +105,16 @@ then any shuffle operations that cannot be supported in this mode will fall back
 
 ## Metrics
 
-Some Comet metrics are not directly comparable to Spark metrics in some cases.
+Some Comet metrics are not directly comparable to Spark metrics in some cases:
 
-`CometScanExec` uses nanoseconds for total scan time. Spark also measures scan time in nanoseconds but converts to
-milliseconds _per batch_ which can result in a large loss of precision.
+- `CometScanExec` uses nanoseconds for total scan time. Spark also measures scan time in nanoseconds but converts to
+  milliseconds _per batch_ which can result in a large loss of precision, making it difficult to compare scan times
+  between Spark and Comet.
 
 Comet also adds some custom metrics:
 
 ### ShuffleWriterExec
 
-| Metric           | Description                                                                                                                                                                               |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `jvm_fetch_time` | Measure the time it takes for `ShuffleWriterExec` to fetch an existing batch from the JVM. Note that this does not include the execution time of the query that produced the input batch. |
+| Metric           | Description                                                                                                                                                                       |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `jvm_fetch_time` | Measure the time it takes for `ShuffleWriterExec` to fetch batches from the JVM. Note that this does not include the execution time of the query that produced the input batches. |

--- a/docs/source/user-guide/tuning.md
+++ b/docs/source/user-guide/tuning.md
@@ -114,6 +114,6 @@ Comet also adds some custom metrics:
 
 ### ShuffleWriterExec
 
-| Metric      | Description                                                                                                                                                                             |
-| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `read_time` | Measure the time it takes for ShuffleWriterExec to fetch an existing batch from the JVM. Note that this does not include the execution time of the query that produced the input batch. |
+| Metric           | Description                                                                                                                                                                             |
+|------------------| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `jvm_fetch_time` | Measure the time it takes for ShuffleWriterExec to fetch an existing batch from the JVM. Note that this does not include the execution time of the query that produced the input batch. |

--- a/docs/source/user-guide/tuning.md
+++ b/docs/source/user-guide/tuning.md
@@ -23,7 +23,7 @@ Comet provides some tuning options to help you get the best performance from you
 
 ## Memory Tuning
 
-Comet shares an off-heap memory pool between Spark and Comet. This requires setting `spark.memory.offHeap.enabled=true`. 
+Comet shares an off-heap memory pool between Spark and Comet. This requires setting `spark.memory.offHeap.enabled=true`.
 If this setting is not enabled, Comet will not accelerate queries and will fall back to Spark.
 
 Each executor will have a single memory pool which will be shared by all native plans being executed within that
@@ -105,8 +105,15 @@ then any shuffle operations that cannot be supported in this mode will fall back
 
 ## Metrics
 
-Comet metrics are not directly comparable to Spark metrics in some cases.
+Some Comet metrics are not directly comparable to Spark metrics in some cases.
 
 `CometScanExec` uses nanoseconds for total scan time. Spark also measures scan time in nanoseconds but converts to
-milliseconds _per batch_ which can result in a large loss of precision. In one case we saw total scan time
-of 41 seconds reported as 23 seconds for example.
+milliseconds _per batch_ which can result in a large loss of precision.
+
+Comet also adds some custom metrics:
+
+### ShuffleWriterExec
+
+| Metric      | Description                                                                                                                                                                             |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `read_time` | Measure the time it takes for ShuffleWriterExec to fetch an existing batch from the JVM. Note that this does not include the execution time of the query that produced the input batch. |

--- a/docs/source/user-guide/tuning.md
+++ b/docs/source/user-guide/tuning.md
@@ -114,6 +114,6 @@ Comet also adds some custom metrics:
 
 ### ShuffleWriterExec
 
-| Metric           | Description                                                                                                                                                                             |
-|------------------| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `jvm_fetch_time` | Measure the time it takes for ShuffleWriterExec to fetch an existing batch from the JVM. Note that this does not include the execution time of the query that produced the input batch. |
+| Metric           | Description                                                                                                                                                                               |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `jvm_fetch_time` | Measure the time it takes for `ShuffleWriterExec` to fetch an existing batch from the JVM. Note that this does not include the execution time of the query that produced the input batch. |

--- a/native/core/src/execution/datafusion/shuffle_writer.rs
+++ b/native/core/src/execution/datafusion/shuffle_writer.rs
@@ -60,12 +60,12 @@ use futures::{lock::Mutex, Stream, StreamExt, TryFutureExt, TryStreamExt};
 use itertools::Itertools;
 use simd_adler32::Adler32;
 
+use crate::execution::operators::ScanExec;
 use crate::{
     common::bit::ceil,
     errors::{CometError, CometResult},
 };
 use datafusion_comet_spark_expr::spark_hash::create_murmur3_hashes;
-use crate::execution::operators::ScanExec;
 
 /// The status of appending rows to a partition buffer.
 enum AppendRowStatus {
@@ -160,7 +160,7 @@ impl ExecutionPlan for ShuffleWriterExec {
                     metrics,
                     context,
                     read_time,
-                    scan_time
+                    scan_time,
                 )
                 .map_err(|e| ArrowError::ExternalError(Box::new(e))),
             )
@@ -1102,7 +1102,7 @@ async fn external_shuffle(
     metrics: ShuffleRepartitionerMetrics,
     context: Arc<TaskContext>,
     read_time: Time,
-    scan_time: Option<Time>
+    scan_time: Option<Time>,
 ) -> Result<SendableRecordBatchStream> {
     let schema = input.schema();
     let mut repartitioner = ShuffleRepartitioner::new(

--- a/native/core/src/execution/operators/scan.rs
+++ b/native/core/src/execution/operators/scan.rs
@@ -72,8 +72,9 @@ pub struct ScanExec {
     /// Cache of expensive-to-compute plan properties
     cache: PlanProperties,
     /// Metrics collector
-    metrics: ExecutionPlanMetricsSet,
-    baseline_metrics: BaselineMetrics,
+    pub(crate) metrics: ExecutionPlanMetricsSet,
+    /// Baseline metrics
+    pub(crate) baseline_metrics: BaselineMetrics,
 }
 
 impl ScanExec {

--- a/native/core/src/execution/operators/scan.rs
+++ b/native/core/src/execution/operators/scan.rs
@@ -76,7 +76,7 @@ pub struct ScanExec {
     /// Metrics collector
     metrics: ExecutionPlanMetricsSet,
     /// Baseline metrics
-    pub(crate) baseline_metrics: BaselineMetrics,
+    baseline_metrics: BaselineMetrics,
 }
 
 impl ScanExec {

--- a/native/core/src/execution/operators/scan.rs
+++ b/native/core/src/execution/operators/scan.rs
@@ -52,7 +52,9 @@ use std::{
 };
 
 /// ScanExec reads batches of data from Spark via JNI. The source of the scan could be a file
-/// scan or the result of reading a broadcast or shuffle exchange.
+/// scan or the result of reading a broadcast or shuffle exchange. ScanExec isn't invoked
+/// until the data is already available in the JVM. When CometExecIterator invokes
+/// Native.executePlan, it passes in the memory addresses of the input batches.
 #[derive(Debug, Clone)]
 pub struct ScanExec {
     /// The ID of the execution context that owns this subquery. We use this ID to retrieve the JVM
@@ -72,7 +74,7 @@ pub struct ScanExec {
     /// Cache of expensive-to-compute plan properties
     cache: PlanProperties,
     /// Metrics collector
-    pub(crate) metrics: ExecutionPlanMetricsSet,
+    metrics: ExecutionPlanMetricsSet,
     /// Baseline metrics
     pub(crate) baseline_metrics: BaselineMetrics,
 }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -77,7 +77,9 @@ case class CometShuffleExchangeExec(
     SQLShuffleReadMetricsReporter.createShuffleReadMetrics(sparkContext)
   override lazy val metrics: Map[String, SQLMetric] = Map(
     "dataSize" -> SQLMetrics.createSizeMetric(sparkContext, "data size"),
-    "jvm_fetch_time" -> SQLMetrics.createNanoTimingMetric(sparkContext, "time fetching batches from JVM"),
+    "jvm_fetch_time" -> SQLMetrics.createNanoTimingMetric(
+      sparkContext,
+      "time fetching batches from JVM"),
     "numPartitions" -> SQLMetrics.createMetric(
       sparkContext,
       "number of partitions")) ++ readMetrics ++ writeMetrics
@@ -483,7 +485,9 @@ class CometShuffleWriteProcessor(
       "elapsed_compute" -> metrics(SQLShuffleWriteMetricsReporter.SHUFFLE_WRITE_TIME))
 
     val nativeMetrics = if (metrics.contains("jvm_fetch_time")) {
-      CometMetricNode(nativeSQLMetrics ++ Map("jvm_fetch_time" -> metrics("time to fetch batches from JVM")))
+      CometMetricNode(
+        nativeSQLMetrics ++ Map("jvm_fetch_time" ->
+          metrics("time to fetch batches from JVM")))
     } else {
       CometMetricNode(nativeSQLMetrics)
     }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -487,7 +487,7 @@ class CometShuffleWriteProcessor(
     val nativeMetrics = if (metrics.contains("jvm_fetch_time")) {
       CometMetricNode(
         nativeSQLMetrics ++ Map("jvm_fetch_time" ->
-          metrics("time to fetch batches from JVM")))
+          metrics("jvm_fetch_time")))
     } else {
       CometMetricNode(nativeSQLMetrics)
     }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -77,7 +77,7 @@ case class CometShuffleExchangeExec(
     SQLShuffleReadMetricsReporter.createShuffleReadMetrics(sparkContext)
   override lazy val metrics: Map[String, SQLMetric] = Map(
     "dataSize" -> SQLMetrics.createSizeMetric(sparkContext, "data size"),
-    "read_time" -> SQLMetrics.createNanoTimingMetric(sparkContext, "read time"),
+    "jvm_fetch_time" -> SQLMetrics.createNanoTimingMetric(sparkContext, "time fetching batches from JVM"),
     "numPartitions" -> SQLMetrics.createMetric(
       sparkContext,
       "number of partitions")) ++ readMetrics ++ writeMetrics
@@ -482,8 +482,8 @@ class CometShuffleWriteProcessor(
       "data_size" -> metrics("dataSize"),
       "elapsed_compute" -> metrics(SQLShuffleWriteMetricsReporter.SHUFFLE_WRITE_TIME))
 
-    val nativeMetrics = if (metrics.contains("read_time")) {
-      CometMetricNode(nativeSQLMetrics ++ Map("read_time" -> metrics("read_time")))
+    val nativeMetrics = if (metrics.contains("jvm_fetch_time")) {
+      CometMetricNode(nativeSQLMetrics ++ Map("jvm_fetch_time" -> metrics("time to fetch batches from JVM")))
     } else {
       CometMetricNode(nativeSQLMetrics)
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Provide more visibility into shuffle costs. We already report shuffle write time but we could not see how long it took to read the input data. This PR adds a new `jvm_fetch_time` metric.

![Screenshot from 2024-11-21 09-56-51](https://github.com/user-attachments/assets/2458a041-345e-45db-8b67-aeb0ba66eabf)

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add a new custom metric to show the time that it takes for native shuffle to read its input data (fetching batches from the JVM that already exist).

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Manually.