### PR TITLE
fix: [comet-parquet-exec] Use filePath instead of pathUri

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -3222,7 +3222,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
       val fileBuilder = OperatorOuterClass.SparkPartitionedFile.newBuilder()
       partitionVals.foreach(fileBuilder.addPartitionValues)
       fileBuilder
-        .setFilePath(file.pathUri.toString)
+        .setFilePath(file.filePath.toUri.toString)
         .setStart(file.start)
         .setLength(file.length)
         .setFileSize(file.fileSize)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

Fix compilation error on Spark 3.3:

```
Error:  /__w/datafusion-comet/datafusion-comet/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala:3225:
value pathUri is not a member of org.apache.spark.sql.execution.datasources.PartitionedFile
```

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
