### PR TITLE
fix: Don't create CometScanExec for subclasses of ParquetFileFormat

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -190,7 +190,7 @@ class CometSparkSessionExtensions
 
           // data source V1
           case scanExec @ FileSourceScanExec(
-                HadoopFsRelation(_, partitionSchema, _, _, _: ParquetFileFormat, _),
+                HadoopFsRelation(_, partitionSchema, _, _, fileFormat, _),
                 _: Seq[_],
                 requiredSchema,
                 _,
@@ -199,14 +199,15 @@ class CometSparkSessionExtensions
                 _,
                 _,
                 _)
-              if CometScanExec.isSchemaSupported(requiredSchema)
+              if CometScanExec.isFileFormatSupported(fileFormat)
+                && CometScanExec.isSchemaSupported(requiredSchema)
                 && CometScanExec.isSchemaSupported(partitionSchema) =>
             logInfo("Comet extension enabled for v1 Scan")
             CometScanExec(scanExec, session)
 
           // data source v1 not supported case
           case scanExec @ FileSourceScanExec(
-                HadoopFsRelation(_, partitionSchema, _, _, _: ParquetFileFormat, _),
+                HadoopFsRelation(_, partitionSchema, _, _, fileFormat, _),
                 _: Seq[_],
                 requiredSchema,
                 _,
@@ -216,12 +217,15 @@ class CometSparkSessionExtensions
                 _,
                 _) =>
             val info1 = createMessage(
+              !CometScanExec.isFileFormatSupported(fileFormat),
+              s"File format $fileFormat is not supported")
+            val info2 = createMessage(
               !CometScanExec.isSchemaSupported(requiredSchema),
               s"Schema $requiredSchema is not supported")
-            val info2 = createMessage(
+            val info3 = createMessage(
               !CometScanExec.isSchemaSupported(partitionSchema),
               s"Partition schema $partitionSchema is not supported")
-            withInfo(scanExec, Seq(info1, info2).flatten.mkString(","))
+            withInfo(scanExec, Seq(info1, info2, info3).flatten.mkString(","))
             scanExec
         }
       }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.comet.shims.ShimCometScanExec
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.execution.datasources.parquet.ParquetOptions
+import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetOptions}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceRDD
 import org.apache.spark.sql.execution.metric._
 import org.apache.spark.sql.types._
@@ -502,5 +502,9 @@ object CometScanExec extends DataTypeSupport {
       wrapped)
     scanExec.logicalLink.foreach(batchScanExec.setLogicalLink)
     batchScanExec
+  }
+
+  def isFileFormatSupported(fileFormat: FileFormat): Boolean = {
+    fileFormat.getClass().equals(classOf[ParquetFileFormat])
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
@@ -505,6 +505,8 @@ object CometScanExec extends DataTypeSupport {
   }
 
   def isFileFormatSupported(fileFormat: FileFormat): Boolean = {
+    // Only support Spark's built-in Parquet scans, not others such as Delta which use a subclass
+    // of ParquetFileFormat.
     fileFormat.getClass().equals(classOf[ParquetFileFormat])
   }
 }

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -39,6 +39,7 @@ import org.apache.spark.sql.comet.{CometBroadcastExchangeExec, CometBroadcastHas
 import org.apache.spark.sql.comet.execution.shuffle.{CometColumnarShuffle, CometShuffleExchangeExec}
 import org.apache.spark.sql.execution.{CollectLimitExec, ProjectExec, SQLExecution, UnionExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ReusedExchangeExec, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.joins.{BroadcastNestedLoopJoinExec, CartesianProductExec, SortMergeJoinExec}
 import org.apache.spark.sql.execution.reuse.ReuseExchangeAndSubquery
@@ -1882,6 +1883,14 @@ class CometExecSuite extends CometTestBase {
         checkSparkAnswerAndOperator("SELECT a, b.c, b.d FROM tbl")
       }
     }
+  }
+
+  test("Supported file formats for CometScanExec") {
+    assert(CometScanExec.isFileFormatSupported(new ParquetFileFormat()))
+
+    class CustomParquetFileFormat extends ParquetFileFormat {}
+
+    assert(!CometScanExec.isFileFormatSupported(new CustomParquetFileFormat()))
   }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1121 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Currently Comet checks for replacing a Scan node with CometScanExec if the HadoopFsRelation's FileFormat is of type `ParquetFileFormat`. However, Comet then simply [replaces that file format with it's own custom CometParquetFileFormat](https://github.com/apache/datafusion-comet/blob/5400fd7c372d2f97ba607457f7d1098e36e2a6e8/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala#L486), discarding the original FileFormat which may have been a subclass of ParquetFileFormat with custom behaviors, which is how Delta currently creates scans. Throwing out the DeltaParquetFileFormat can end up with incorrect results for reading Delta tables. Instead, CometScanExec should only be supported if the file format is exactly ParquetFileFormat and not a subclass.

The alternative would be to try to delegate to the child ParquetFileFormat when possible to include these custom behaviors, but with some other changes such as the native Parquet scan going on right now, this could be investigated at a later time. For now just try to fix possible incorrect behaviors.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Updates the check for a supported CometScanExec to be only if the file format is exactly ParquetFileFormat, not a subclass.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
New UT testing the helper method.
