### PR TITLE
fix: Fix metrics regressions

### DIFF
--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -2549,12 +2549,7 @@ mod tests {
 
         assert_eq!("FilterExec", filter_exec.native_plan.name());
         assert_eq!(1, filter_exec.children.len());
-        assert_eq!(1, filter_exec.additional_native_plans.len());
-        assert_eq!("ScanExec", filter_exec.additional_native_plans[0].name());
-
-        let scan_exec = &filter_exec.children()[0];
-        assert_eq!("ScanExec", scan_exec.native_plan.name());
-        assert_eq!(0, scan_exec.additional_native_plans.len());
+        assert_eq!(0, filter_exec.additional_native_plans.len());
     }
 
     #[test]
@@ -2580,10 +2575,6 @@ mod tests {
         assert_eq!(2, hash_join_exec.children.len());
         assert_eq!("ScanExec", hash_join_exec.children[0].native_plan.name());
         assert_eq!("ScanExec", hash_join_exec.children[1].native_plan.name());
-
-        assert_eq!(2, hash_join_exec.additional_native_plans.len());
-        assert_eq!("ScanExec", hash_join_exec.additional_native_plans[0].name());
-        assert_eq!("ScanExec", hash_join_exec.additional_native_plans[1].name());
     }
 
     fn create_bound_reference(index: i32) -> Expr {

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -1236,7 +1236,7 @@ impl PhysicalPlanner {
                     let mut additional_native_plans = vec![];
                     if swapped_hash_join.as_any().is::<ProjectionExec>() {
                         // a projection was added to the hash join
-                        additional_native_plans.push(Arc::clone(&swapped_hash_join.children()[0]));
+                        additional_native_plans.push(Arc::clone(swapped_hash_join.children()[0]));
                     }
 
                     Ok((

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -1230,21 +1230,20 @@ impl PhysicalPlanner {
                         )),
                     ))
                 } else {
-                    // we insert a projection around the hash join in this case
-                    let projection =
+                    let swapped_hash_join =
                         swap_hash_join(hash_join.as_ref(), PartitionMode::Partitioned)?;
-                    let swapped_hash_join = Arc::clone(projection.children()[0]);
-                    let mut additional_native_plans = swapped_hash_join
-                        .children()
-                        .iter()
-                        .map(|p| Arc::clone(p))
-                        .collect::<Vec<_>>();
-                    additional_native_plans.push(Arc::clone(&swapped_hash_join));
+
+                    let mut additional_native_plans = vec![];
+                    if swapped_hash_join.as_any().is::<ProjectionExec>() {
+                        // a projection was added to the hash join
+                        additional_native_plans.push(Arc::clone(&swapped_hash_join.children()[0]));
+                    }
+
                     Ok((
                         scans,
                         Arc::new(SparkPlan::new_with_additional(
                             spark_plan.plan_id,
-                            projection,
+                            swapped_hash_join,
                             vec![join_params.left, join_params.right],
                             additional_native_plans,
                         )),

--- a/native/core/src/execution/datafusion/spark_plan.rs
+++ b/native/core/src/execution/datafusion/spark_plan.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::execution::operators::{CopyExec, ScanExec};
+use crate::execution::operators::CopyExec;
 use arrow_schema::SchemaRef;
 use datafusion::physical_plan::ExecutionPlan;
 use std::sync::Arc;
@@ -32,7 +32,7 @@ pub(crate) struct SparkPlan {
     /// Child Spark plans
     pub(crate) children: Vec<Arc<SparkPlan>>,
     /// Additional native plans that were generated for this Spark plan that we need
-    /// to collect metrics for (such as CopyExec and ScanExec)
+    /// to collect metrics for
     pub(crate) additional_native_plans: Vec<Arc<dyn ExecutionPlan>>,
 }
 
@@ -93,10 +93,6 @@ fn collect_additional_plans(
     additional_native_plans: &mut Vec<Arc<dyn ExecutionPlan>>,
 ) {
     if child.as_any().is::<CopyExec>() {
-        additional_native_plans.push(Arc::clone(&child));
-        // CopyExec may be wrapping a ScanExec
-        collect_additional_plans(Arc::clone(child.children()[0]), additional_native_plans);
-    } else if child.as_any().is::<ScanExec>() {
         additional_native_plans.push(Arc::clone(&child));
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Follow up to https://github.com/apache/datafusion-comet/pull/1111

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We should not include `ScanExec` elapsed time in parent nodes because this is measuring the time to call `CometBatchIterator.next`, which is calling `next` on its input. In other words, `ScanExec` elapsed time is the time taken by the child query that generates the input batches for `ScanExec` so we should not count this time twice.

Also fixed an issue with swapped hash joins.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
