### PR TITLE
chore: Stop scanning batches during query planning in ScanExec

### DIFF
--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -2374,6 +2374,7 @@ mod tests {
     const STRING_TYPE_ID: i32 = 7;
 
     #[test]
+    #[ignore] // this test is no longer valid because ScanExec always unpacks dictionaries now
     fn test_unpack_dictionary_string() {
         let op_scan = Operator {
             plan_id: 0,

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -405,8 +405,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
                                 DisplayableExecutionPlan::with_metrics(plan.native_plan.as_ref())
                                     .indent(true);
                             info!(
-                                "Comet native query plan with metrics (Plan #{} Stage {} Partition {}):\
-                            \n plan creation (including CometScans fetching first batches) took {:?}:\
+                                "Comet native query plan with metrics (Plan #{} Stage {} Partition {}). Plan creation took {:?}:\
                             \n{formatted_plan_str:}",
                                 plan.plan_id, stage_id, partition, exec_context.plan_creation_time
                             );


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/1098

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

DataFusion `ExecutionPlan` instances should only start executing when the `execute` method is called. 

`ScanExec` was fetching its first batch during construction as part of query planning. The first batch was used to determine the schema.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR now creates the schema based on the Spark schema which is already serialized for the scan and avoids the need to fetch any data during construction.

As a result, `ScanExec` no longer produces dictionary-encoded arrays. It was already unpacking primitive arrays, but it will now also unpack string arrays. String arrays were previously unpacked in `CopyExec` in most cases, but now it happens directly in `ScanExec`.

There is a potential optimization where we could push filters down into the scan to get the benefit of filtering dictionary arrays rather than unpacking them first and then filtering.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

I ran TPC-H and saw no change in performance.
