### PR TITLE
[comet-parquet-exec] Simplify schema logic for CometNativeScan

### DIFF
--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -2327,15 +2327,20 @@ fn from_protobuf_eval_mode(value: i32) -> Result<EvalMode, prost::DecodeError> {
 }
 
 fn convert_spark_types_to_arrow_schema(
-    spark_types: &[datafusion_comet_proto::spark_expression::DataType],
+    spark_types: &[spark_operator::SparkStructField],
 ) -> SchemaRef {
-    let arrow_types = spark_types.iter().map(to_arrow_datatype).collect_vec();
-    let arrow_fields: Vec<_> = arrow_types
+    let thing = spark_types
         .iter()
-        .enumerate()
-        .map(|(idx, data_type)| Field::new(format!("req_{}", idx), data_type.clone(), true))
-        .collect();
-    let arrow_schema: SchemaRef = Arc::new(Schema::new(arrow_fields));
+        .map(|spark_type| {
+            Field::new(
+                String::clone(&spark_type.name),
+                to_arrow_datatype(spark_type.data_type.as_ref().unwrap()),
+                spark_type.nullable,
+            )
+        })
+        .collect_vec();
+    let arrow_schema: SchemaRef = Arc::new(Schema::new(thing));
+    println!["{}", arrow_schema];
     arrow_schema
 }
 

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -949,63 +949,23 @@ impl PhysicalPlanner {
                 ))
             }
             OpStruct::NativeScan(scan) => {
-                // let data_schema = parse_message_type(&scan.data_schema).unwrap();
-                // let required_schema = parse_message_type(&scan.required_schema).unwrap();
-                //
-                // let data_schema_descriptor =
-                //     parquet::schema::types::SchemaDescriptor::new(Arc::new(data_schema));
-                // let data_schema_arrow = Arc::new(
-                //     parquet::arrow::schema::parquet_to_arrow_schema(&data_schema_descriptor, None)
-                //         .unwrap(),
-                // );
-                //
-                // let required_schema_descriptor =
-                //     parquet::schema::types::SchemaDescriptor::new(Arc::new(required_schema));
-                // let required_schema_arrow = Arc::new(
-                //     parquet::arrow::schema::parquet_to_arrow_schema(
-                //         &required_schema_descriptor,
-                //         None,
-                //     )
-                //     .unwrap(),
-                // );
-                //
-                // println!["data_schema_arrow: {:?}", data_schema_arrow];
-                // println!["required_schema_arrow: {:?}", required_schema_arrow];
-
                 let data_schema_spark =
-                    convert_spark_types_to_arrow_schema(scan.data_schema_spark.as_slice());
-                let required_schema_spark: SchemaRef =
-                    convert_spark_types_to_arrow_schema(scan.required_schema_spark.as_slice());
-                let partition_schema_spark: SchemaRef =
-                    convert_spark_types_to_arrow_schema(scan.partition_schema_spark.as_slice());
-                let projection_vector_spark: Vec<usize> = scan
+                    convert_spark_types_to_arrow_schema(scan.data_schema.as_slice());
+                let required_schema: SchemaRef =
+                    convert_spark_types_to_arrow_schema(scan.required_schema.as_slice());
+                let partition_schema: SchemaRef =
+                    convert_spark_types_to_arrow_schema(scan.partition_schema.as_slice());
+                let projection_vector: Vec<usize> = scan
                     .projection_vector
                     .iter()
                     .map(|offset| *offset as usize)
                     .collect();
-                println!["data_schema_spark: {:?}", data_schema_spark];
-                println!["required_schema_spark: {:?}", required_schema_spark];
-                println!["partition_schema_spark: {:?}", partition_schema_spark];
-                println!["projection_vector_spark: {:?}", projection_vector_spark];
-
-                // let partition_schema_arrow = scan
-                //     .partition_schema
-                //     .iter()
-                //     .map(to_arrow_datatype)
-                //     .collect_vec();
-                // let partition_fields: Vec<_> = partition_schema_arrow
-                //     .iter()
-                //     .enumerate()
-                //     .map(|(idx, data_type)| {
-                //         Field::new(format!("part_{}", idx), data_type.clone(), true)
-                //     })
-                //     .collect();
 
                 // Convert the Spark expressions to Physical expressions
                 let data_filters: Result<Vec<Arc<dyn PhysicalExpr>>, ExecutionError> = scan
                     .data_filters
                     .iter()
-                    .map(|expr| self.create_expr(expr, Arc::clone(&required_schema_spark)))
+                    .map(|expr| self.create_expr(expr, Arc::clone(&required_schema)))
                     .collect();
 
                 // Create a conjunctive form of the vector because ParquetExecBuilder takes
@@ -1082,18 +1042,24 @@ impl PhysicalPlanner {
                 assert_eq!(file_groups.len(), partition_count);
 
                 let object_store_url = ObjectStoreUrl::local_filesystem();
-                let partition_fields:Vec<Field> = partition_schema_spark.fields().iter().map(|field| {Field::new(field.name(),field.data_type().clone(),field.is_nullable())}).collect_vec();
+                let partition_fields: Vec<Field> = partition_schema
+                    .fields()
+                    .iter()
+                    .map(|field| {
+                        Field::new(field.name(), field.data_type().clone(), field.is_nullable())
+                    })
+                    .collect_vec();
                 let mut file_scan_config =
                     FileScanConfig::new(object_store_url, Arc::clone(&data_schema_spark))
                         .with_file_groups(file_groups)
                         .with_table_partition_cols(partition_fields);
 
                 assert_eq!(
-                    projection_vector_spark.len(),
-                    required_schema_spark.fields.len() + partition_schema_spark.fields.len()
+                    projection_vector.len(),
+                    required_schema.fields.len() + partition_schema.fields.len()
                 );
                 // println!["projection_vector: {:?}", projection_vector];
-                file_scan_config = file_scan_config.with_projection(Some(projection_vector_spark));
+                file_scan_config = file_scan_config.with_projection(Some(projection_vector));
 
                 let mut table_parquet_options = TableParquetOptions::new();
                 // TODO: Maybe these are configs?

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -949,8 +949,7 @@ impl PhysicalPlanner {
                 ))
             }
             OpStruct::NativeScan(scan) => {
-                let data_schema_spark =
-                    convert_spark_types_to_arrow_schema(scan.data_schema.as_slice());
+                let data_schema = convert_spark_types_to_arrow_schema(scan.data_schema.as_slice());
                 let required_schema: SchemaRef =
                     convert_spark_types_to_arrow_schema(scan.required_schema.as_slice());
                 let partition_schema: SchemaRef =
@@ -1050,7 +1049,7 @@ impl PhysicalPlanner {
                     })
                     .collect_vec();
                 let mut file_scan_config =
-                    FileScanConfig::new(object_store_url, Arc::clone(&data_schema_spark))
+                    FileScanConfig::new(object_store_url, Arc::clone(&data_schema))
                         .with_file_groups(file_groups)
                         .with_table_partition_cols(partition_fields);
 

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -2294,7 +2294,6 @@ fn convert_spark_types_to_arrow_schema(
         })
         .collect_vec();
     let arrow_schema: SchemaRef = Arc::new(Schema::new(thing));
-    println!["{}", arrow_schema];
     arrow_schema
 }
 

--- a/native/core/src/execution/datafusion/planner.rs
+++ b/native/core/src/execution/datafusion/planner.rs
@@ -2279,7 +2279,7 @@ fn from_protobuf_eval_mode(value: i32) -> Result<EvalMode, prost::DecodeError> {
 fn convert_spark_types_to_arrow_schema(
     spark_types: &[spark_operator::SparkStructField],
 ) -> SchemaRef {
-    let thing = spark_types
+    let arrow_fields = spark_types
         .iter()
         .map(|spark_type| {
             Field::new(
@@ -2289,7 +2289,7 @@ fn convert_spark_types_to_arrow_schema(
             )
         })
         .collect_vec();
-    let arrow_schema: SchemaRef = Arc::new(Schema::new(thing));
+    let arrow_schema: SchemaRef = Arc::new(Schema::new(arrow_fields));
     arrow_schema
 }
 

--- a/native/core/src/execution/datafusion/schema_adapter.rs
+++ b/native/core/src/execution/datafusion/schema_adapter.rs
@@ -259,7 +259,8 @@ impl SchemaMapper for SchemaMapping {
                             EvalMode::Legacy,
                             "UTC",
                             false,
-                        )?.into_array(batch_col.len())
+                        )?
+                        .into_array(batch_col.len())
                         // and if that works, return the field and column.
                         .map(|new_col| (new_col, table_field.clone()))
                     })

--- a/native/proto/src/proto/operator.proto
+++ b/native/proto/src/proto/operator.proto
@@ -61,6 +61,12 @@ message SparkFilePartition {
   repeated SparkPartitionedFile partitioned_file = 1;
 }
 
+message SparkStructField {
+  string name = 1;
+  spark.spark_expression.DataType data_type = 2;
+  bool nullable = 3;
+}
+
 message Scan {
   repeated spark.spark_expression.DataType fields = 1;
   // The source of the scan (e.g. file scan, broadcast exchange, shuffle, etc). This
@@ -81,8 +87,9 @@ message NativeScan {
   repeated spark.spark_expression.Expr data_filters = 6;
   repeated SparkFilePartition file_partitions = 7;
   repeated int64 projection_vector = 8;
-  repeated spark.spark_expression.DataType required_schema_spark = 9;
-  repeated spark.spark_expression.DataType data_schema_spark = 10;
+  repeated SparkStructField required_schema_spark = 9;
+  repeated SparkStructField data_schema_spark = 10;
+  repeated SparkStructField partition_schema_spark = 11;
 }
 
 message Projection {

--- a/native/proto/src/proto/operator.proto
+++ b/native/proto/src/proto/operator.proto
@@ -80,6 +80,9 @@ message NativeScan {
   repeated spark.spark_expression.DataType partition_schema = 5;
   repeated spark.spark_expression.Expr data_filters = 6;
   repeated SparkFilePartition file_partitions = 7;
+  repeated int64 projection_vector = 8;
+  repeated spark.spark_expression.DataType required_schema_spark = 9;
+  repeated spark.spark_expression.DataType data_schema_spark = 10;
 }
 
 message Projection {

--- a/native/proto/src/proto/operator.proto
+++ b/native/proto/src/proto/operator.proto
@@ -81,15 +81,12 @@ message NativeScan {
   // is purely for informational purposes when viewing native query plans in
   // debug mode.
   string source = 2;
-  string required_schema = 3;
-  string data_schema = 4;
-  repeated spark.spark_expression.DataType partition_schema = 5;
+  repeated SparkStructField required_schema = 3;
+  repeated SparkStructField data_schema = 4;
+  repeated SparkStructField partition_schema = 5;
   repeated spark.spark_expression.Expr data_filters = 6;
   repeated SparkFilePartition file_partitions = 7;
   repeated int64 projection_vector = 8;
-  repeated SparkStructField required_schema_spark = 9;
-  repeated SparkStructField data_schema_spark = 10;
-  repeated SparkStructField partition_schema_spark = 11;
 }
 
 message Projection {


### PR DESCRIPTION
The current logic takes the data schema and the required schema from the Java side (in the scan node) and:
1. Converts back to a Parquet schema (Thrift encoded)
2. Serializes it to the native side
3. Parses it to a schema descriptor
4. Converts that to an Arrow schema

This process is introducing conversion errors that are difficult to recover from (e.g. Timestamp(milli) -> INT96 -> Timestamp(nano)). This PR simplifies the schema serialization and conversion to native side, building on what @viirya did with the partition schema (thank you for the inspiration!).

In this PR, data schema and required schema are now serialized as Spark types. On the native side they are converted to Arrow types. We also now serialize more schema info (column names, nullability) than we did for just partition schema.