### PR TITLE
fix: Enable scenarios accidentally commented out in CometExecBenchmark

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometExecBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometExecBenchmark.scala
@@ -274,23 +274,23 @@ object CometExecBenchmark extends CometBenchmarkBase {
   }
 
   override def runCometBenchmark(mainArgs: Array[String]): Unit = {
-//    runBenchmarkWithTable("Subquery", 1024 * 1024 * 10) { v =>
-//      subqueryExecBenchmark(v)
-//    }
-//
-//    runBenchmarkWithTable("Expand", 1024 * 1024 * 10) { v =>
-//      expandExecBenchmark(v)
-//    }
-//
-//    runBenchmarkWithTable("Project + Filter", 1024 * 1024 * 10) { v =>
-//      for (fractionOfZeros <- List(0.0, 0.50, 0.95)) {
-//        numericFilterExecBenchmark(v, fractionOfZeros)
-//      }
-//    }
-//
-//    runBenchmarkWithTable("Sort", 1024 * 1024 * 10) { v =>
-//      sortExecBenchmark(v)
-//    }
+    runBenchmarkWithTable("Subquery", 1024 * 1024 * 10) { v =>
+      subqueryExecBenchmark(v)
+    }
+
+    runBenchmarkWithTable("Expand", 1024 * 1024 * 10) { v =>
+      expandExecBenchmark(v)
+    }
+
+    runBenchmarkWithTable("Project + Filter", 1024 * 1024 * 10) { v =>
+      for (fractionOfZeros <- List(0.0, 0.50, 0.95)) {
+        numericFilterExecBenchmark(v, fractionOfZeros)
+      }
+    }
+
+    runBenchmarkWithTable("Sort", 1024 * 1024 * 10) { v =>
+      sortExecBenchmark(v)
+    }
 
     runBenchmarkWithTable("BloomFilterAggregate", 1024 * 1024 * 10) { v =>
       for (card <- List(100, 1024, 1024 * 1024)) {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

#987 accidentally commented out some scenarios in CometExecBenchmark.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Uncomment the scenarios in CometExecBenchmark.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->