### PR TITLE
chore: Bump minimum rust version to 1.80.1

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -30,7 +30,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 # Comet uses the same minimum Rust version as DataFusion
-rust-version = "1.79"
+rust-version = "1.80.1"
 
 [workspace.dependencies]
 arrow = { version = "53.2.0", features = ["prettyprint", "ffi", "chrono-tz"] }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

In preparation for upgrading to DataFusion 44, we need to update rust-version. I saw some miri failures in the DF upgrade PR so wanted to see if this is related to the rust version.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
