### PR TITLE
fix: use inputRDD to get outputPartitions in CometScanExec

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
@@ -132,7 +132,7 @@ case class CometScanExec(
   lazy val bucketedScan: Boolean = wrapped.bucketedScan
 
   override lazy val (outputPartitioning, outputOrdering): (Partitioning, Seq[SortOrder]) =
-    (wrapped.outputPartitioning, wrapped.outputOrdering)
+    (UnknownPartitioning(wrapped.inputRDD.getNumPartitions), wrapped.outputOrdering)
 
   @transient
   private lazy val pushedDownFilters = getPushedDownFilters(relation, dataFilters)


### PR DESCRIPTION
outputPartitioning for CometScanExec was incorrectly returning 0 causing unit tests to fail
