### PR TITLE
feat: CometNativeScan metrics from ParquetFileMetrics and FileStreamMetrics

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, UnknownPartitioning}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.collection._
 
@@ -59,6 +60,7 @@ case class CometNativeScanExec(
 
   override def outputPartitioning: Partitioning =
     UnknownPartitioning(originalPlan.inputRDD.getNumPartitions)
+
   override def outputOrdering: Seq[SortOrder] = originalPlan.outputOrdering
 
   override def stringArgs: Iterator[Any] = Iterator(output)
@@ -74,6 +76,85 @@ case class CometNativeScanExec(
   }
 
   override def hashCode(): Int = Objects.hashCode(output)
+
+  override lazy val metrics: Map[String, SQLMetric] = {
+    // We don't append CometMetricNode.baselineMetrics because
+    // elapsed_compute has no counterpart on the native side.
+    Map(
+      "output_rows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
+      "time_elapsed_opening" ->
+        SQLMetrics.createNanoTimingMetric(
+          sparkContext,
+          "Wall clock time elapsed for file opening"),
+      "time_elapsed_scanning_until_data" ->
+        SQLMetrics.createNanoTimingMetric(
+          sparkContext,
+          "Wall clock time elapsed for file scanning +" +
+            "first record batch of decompression + decoding"),
+      "time_elapsed_scanning_total" ->
+        SQLMetrics.createNanoTimingMetric(
+          sparkContext,
+          "Total elapsed wall clock time for for scanning " +
+            "+ record batch decompression / decoding"),
+      "time_elapsed_processing" ->
+        SQLMetrics.createNanoTimingMetric(
+          sparkContext,
+          "Wall clock time elapsed for data decompression + decoding"),
+      "file_open_errors" ->
+        SQLMetrics.createMetric(sparkContext, "Count of errors opening file"),
+      "file_scan_errors" ->
+        SQLMetrics.createMetric(sparkContext, "Count of errors scanning file"),
+      "predicate_evaluation_errors" ->
+        SQLMetrics.createMetric(
+          sparkContext,
+          "Number of times the predicate could not be evaluated"),
+      "row_groups_matched_bloom_filter" ->
+        SQLMetrics.createMetric(
+          sparkContext,
+          "Number of row groups whose bloom filters were checked and matched (not pruned)"),
+      "row_groups_pruned_bloom_filter" ->
+        SQLMetrics.createMetric(sparkContext, "Number of row groups pruned by bloom filters"),
+      "row_groups_matched_statistics" ->
+        SQLMetrics.createMetric(
+          sparkContext,
+          "Number of row groups whose statistics were checked and matched (not pruned)"),
+      "row_groups_pruned_statistics" ->
+        SQLMetrics.createMetric(sparkContext, "Number of row groups pruned by statistics"),
+      "bytes_scanned" ->
+        SQLMetrics.createSizeMetric(sparkContext, "Total number of bytes scanned"),
+      "pushdown_rows_pruned" ->
+        SQLMetrics.createMetric(
+          sparkContext,
+          "Total rows filtered out by predicates pushed into parquet scan"),
+      "pushdown_rows_matched" ->
+        SQLMetrics.createMetric(
+          sparkContext,
+          "Total rows passed predicates pushed into parquet scan"),
+      "row_pushdown_eval_time" ->
+        SQLMetrics.createNanoTimingMetric(
+          sparkContext,
+          "Total time spent evaluating row-level pushdown filters"),
+      "statistics_eval_time" ->
+        SQLMetrics.createNanoTimingMetric(
+          sparkContext,
+          "Total time spent evaluating row group-level statistics filters"),
+      "bloom_filter_eval_time" ->
+        SQLMetrics.createNanoTimingMetric(
+          sparkContext,
+          "Total time spent evaluating row group Bloom Filters"),
+      "page_index_rows_pruned" ->
+        SQLMetrics.createMetric(sparkContext, "Total rows filtered out by parquet page index"),
+      "page_index_rows_matched" ->
+        SQLMetrics.createMetric(sparkContext, "Total rows passed through the parquet page index"),
+      "page_index_eval_time" ->
+        SQLMetrics.createNanoTimingMetric(
+          sparkContext,
+          "Total time spent evaluating parquet page index filters"),
+      "metadata_load_time" ->
+        SQLMetrics.createNanoTimingMetric(
+          sparkContext,
+          "Total time spent reading and parsing metadata from the footer"))
+  }
 }
 
 object CometNativeScanExec extends DataTypeSupport {
@@ -102,6 +183,7 @@ object CometNativeScanExec extends DataTypeSupport {
       case other: AnyRef => other
       case null => null
     }
+
     val newArgs = mapProductIterator(scanExec, transform(_))
     val wrapped = scanExec.makeCopy(newArgs).asInstanceOf[FileSourceScanExec]
     val batchScanExec = CometNativeScanExec(

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
@@ -89,7 +89,7 @@ case class CometNativeScanExec(
       "time_elapsed_scanning_until_data" ->
         SQLMetrics.createNanoTimingMetric(
           sparkContext,
-          "Wall clock time elapsed for file scanning +" +
+          "Wall clock time elapsed for file scanning + " +
             "first record batch of decompression + decoding"),
       "time_elapsed_scanning_total" ->
         SQLMetrics.createNanoTimingMetric(

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
@@ -94,7 +94,7 @@ case class CometNativeScanExec(
       "time_elapsed_scanning_total" ->
         SQLMetrics.createNanoTimingMetric(
           sparkContext,
-          "Total elapsed wall clock time for for scanning " +
+          "Elapsed wall clock time for for scanning " +
             "+ record batch decompression / decoding"),
       "time_elapsed_processing" ->
         SQLMetrics.createNanoTimingMetric(
@@ -121,39 +121,37 @@ case class CometNativeScanExec(
       "row_groups_pruned_statistics" ->
         SQLMetrics.createMetric(sparkContext, "Number of row groups pruned by statistics"),
       "bytes_scanned" ->
-        SQLMetrics.createSizeMetric(sparkContext, "Total number of bytes scanned"),
+        SQLMetrics.createSizeMetric(sparkContext, "Number of bytes scanned"),
       "pushdown_rows_pruned" ->
         SQLMetrics.createMetric(
           sparkContext,
-          "Total rows filtered out by predicates pushed into parquet scan"),
+          "Rows filtered out by predicates pushed into parquet scan"),
       "pushdown_rows_matched" ->
-        SQLMetrics.createMetric(
-          sparkContext,
-          "Total rows passed predicates pushed into parquet scan"),
+        SQLMetrics.createMetric(sparkContext, "Rows passed predicates pushed into parquet scan"),
       "row_pushdown_eval_time" ->
         SQLMetrics.createNanoTimingMetric(
           sparkContext,
-          "Total time spent evaluating row-level pushdown filters"),
+          "Time spent evaluating row-level pushdown filters"),
       "statistics_eval_time" ->
         SQLMetrics.createNanoTimingMetric(
           sparkContext,
-          "Total time spent evaluating row group-level statistics filters"),
+          "Time spent evaluating row group-level statistics filters"),
       "bloom_filter_eval_time" ->
         SQLMetrics.createNanoTimingMetric(
           sparkContext,
-          "Total time spent evaluating row group Bloom Filters"),
+          "Time spent evaluating row group Bloom Filters"),
       "page_index_rows_pruned" ->
-        SQLMetrics.createMetric(sparkContext, "Total rows filtered out by parquet page index"),
+        SQLMetrics.createMetric(sparkContext, "Rows filtered out by parquet page index"),
       "page_index_rows_matched" ->
-        SQLMetrics.createMetric(sparkContext, "Total rows passed through the parquet page index"),
+        SQLMetrics.createMetric(sparkContext, "Rows passed through the parquet page index"),
       "page_index_eval_time" ->
         SQLMetrics.createNanoTimingMetric(
           sparkContext,
-          "Total time spent evaluating parquet page index filters"),
+          "Time spent evaluating parquet page index filters"),
       "metadata_load_time" ->
         SQLMetrics.createNanoTimingMetric(
           sparkContext,
-          "Total time spent reading and parsing metadata from the footer"))
+          "Time spent reading and parsing metadata from the footer"))
   }
 }
 


### PR DESCRIPTION
Still confirming if there's a unit mismatch wrt time between Spark elapsed time and native elapsed time. Once I confirm that, I'll mark this okay for review.