### PR TITLE
fix: Document enabling comet explain plan usage in Spark (4.0)

### DIFF
--- a/docs/source/user-guide/tuning.md
+++ b/docs/source/user-guide/tuning.md
@@ -127,3 +127,13 @@ Here is a guide to some of the native metrics.
 | `elapsed_compute` | Total time spent in this operator, fetching batches from a JVM iterator.                            |
 | `jvm_fetch_time`  | Time spent in the JVM fetching input batches to be read by this `ScanExec` instance.                |
 | `arrow_ffi_time`  | Time spent using Arrow FFI to create Arrow batches from the memory addresses returned from the JVM. |
+
+## Explain Plan
+### Extended Explain
+With Spark 4.0.0 and newer, Comet can provide extended explain plan information in the Spark UI. Currently this lists
+reasons why Comet may not have been enabled for specific operations.
+To enable this, in the Spark configuration, set the following:
+```shell
+-c spark.sql.extendedExplainProviders=org.apache.comet.ExtendedExplainInfo
+```
+This will add a section to the detailed plan displayed in the Spark SQL UI page.


### PR DESCRIPTION
## Which issue does this PR close?

Closes #1166 

## Rationale for this change

Documenting an existing feature

## What changes are included in this PR?

Adds documentation to the tuning guide to enable extended explain plan in Spark

