### PR TITLE
feat: Reenable tests for filtered SMJ anti join

### DIFF
--- a/docs/source/user-guide/kubernetes.md
+++ b/docs/source/user-guide/kubernetes.md
@@ -21,8 +21,8 @@
 
 ## Comet Docker Images
 
-Run the following command from the root of this repository to build the Comet Docker image, or use a published
-Docker image from https://github.com/orgs/apache/packages?repo_name=datafusion-comet
+Run the following command from the root of this repository to build the Comet Docker image, or use a [published
+Docker image](https://github.com/orgs/apache/packages?repo_name=datafusion-comet)
 
 ```shell
 docker build -t apache/datafusion-comet -f kube/Dockerfile .
@@ -78,7 +78,7 @@ spec:
     "spark.comet.cast.allowIncompatible": "true"
     "spark.comet.exec.shuffle.enabled": "true"
     "spark.comet.exec.shuffle.mode": "auto"
-    "conf spark.shuffle.manager": "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager"
+    "spark.shuffle.manager": "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager"
   sparkVersion: 3.4.3
   driver:
     labels:
@@ -106,4 +106,4 @@ Check application status
 ```bash
 kubectl describe sparkapplication --namespace=spark-operator
 ```
-More info on Kube Spark operator https://www.kubeflow.org/docs/components/spark-operator/getting-started/
+More info on [Kube Spark operator](https://www.kubeflow.org/docs/components/spark-operator/getting-started/)

--- a/docs/source/user-guide/kubernetes.md
+++ b/docs/source/user-guide/kubernetes.md
@@ -21,8 +21,8 @@
 
 ## Comet Docker Images
 
-Run the following command from the root of this repository to build the Comet Docker image, or use a [published
-Docker image](https://github.com/orgs/apache/packages?repo_name=datafusion-comet)
+Run the following command from the root of this repository to build the Comet Docker image, or use a published
+Docker image from https://github.com/orgs/apache/packages?repo_name=datafusion-comet
 
 ```shell
 docker build -t apache/datafusion-comet -f kube/Dockerfile .
@@ -78,7 +78,7 @@ spec:
     "spark.comet.cast.allowIncompatible": "true"
     "spark.comet.exec.shuffle.enabled": "true"
     "spark.comet.exec.shuffle.mode": "auto"
-    "spark.shuffle.manager": "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager"
+    "conf spark.shuffle.manager": "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager"
   sparkVersion: 3.4.3
   driver:
     labels:
@@ -106,4 +106,4 @@ Check application status
 ```bash
 kubectl describe sparkapplication --namespace=spark-operator
 ```
-More info on [Kube Spark operator](https://www.kubeflow.org/docs/components/spark-operator/getting-started/)
+More info on Kube Spark operator https://www.kubeflow.org/docs/components/spark-operator/getting-started/

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -70,6 +70,7 @@ use datafusion_physical_expr::aggregate::{AggregateExprBuilder, AggregateFunctio
 
 use crate::execution::shuffle::CompressionCodec;
 use crate::execution::spark_plan::SparkPlan;
+use datafusion::optimizer::OptimizerConfig;
 use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
 use datafusion_comet_proto::{
     spark_expression::{
@@ -1188,8 +1189,12 @@ impl PhysicalPlanner {
                     // SMJ with join filter produces lots of tiny batches
                     let coalesce_batches: Arc<dyn ExecutionPlan> =
                         Arc::new(CoalesceBatchesExec::new(
-                            Arc::clone(&join),
-                            self.session_ctx.state().config_options().batch_size(),
+                            Arc::<SortMergeJoinExec>::clone(&join),
+                            self.session_ctx
+                                .state()
+                                .config_options()
+                                .execution
+                                .batch_size,
                         ));
                     Ok((
                         scans,

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -70,7 +70,6 @@ use datafusion_physical_expr::aggregate::{AggregateExprBuilder, AggregateFunctio
 
 use crate::execution::shuffle::CompressionCodec;
 use crate::execution::spark_plan::SparkPlan;
-use datafusion::optimizer::OptimizerConfig;
 use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
 use datafusion_comet_proto::{
     spark_expression::{

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -1187,7 +1187,10 @@ impl PhysicalPlanner {
                 if join.filter.is_some() {
                     // SMJ with join filter produces lots of tiny batches
                     let coalesce_batches: Arc<dyn ExecutionPlan> =
-                        Arc::new(CoalesceBatchesExec::new(join.clone(), 8192));
+                        Arc::new(CoalesceBatchesExec::new(
+                            Arc::clone(&join),
+                            self.session_ctx.state().config_options().batch_size(),
+                        ));
                     Ok((
                         scans,
                         Arc::new(SparkPlan::new_with_additional(

--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -567,7 +567,7 @@ class CometSparkSessionExtensions
 
         case op: SortMergeJoinExec
             if CometConf.COMET_EXEC_SORT_MERGE_JOIN_ENABLED.get(conf) &&
-              op.children.forall(isCometNative(_)) =>
+              op.children.forall(isCometNative) =>
           val newOp = transform1(op)
           newOp match {
             case Some(nativeOp) =>

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -2859,11 +2859,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           case RightOuter => JoinType.RightOuter
           case FullOuter => JoinType.FullOuter
           case LeftSemi => JoinType.LeftSemi
-          // TODO: DF SMJ with join condition fails TPCH q21
-          case LeftAnti if condition.isEmpty => JoinType.LeftAnti
-          case LeftAnti =>
-            withInfo(join, "LeftAnti SMJ join with condition is not supported")
-            return None
+          case LeftAnti => JoinType.LeftAnti
           case _ =>
             // Spark doesn't support other join types
             withInfo(op, s"Unsupported join type ${join.joinType}")

--- a/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
@@ -30,7 +30,6 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.Decimal
 
 import org.apache.comet.CometConf
-import org.apache.comet.CometConf.COMET_EXEC_SORT_MERGE_JOIN_WITH_JOIN_FILTER_ENABLED
 import org.apache.comet.CometSparkSessionExtensions.isSpark34Plus
 
 class CometJoinSuite extends CometTestBase {
@@ -295,7 +294,7 @@ class CometJoinSuite extends CometTestBase {
 
   test("SortMergeJoin without join filter") {
     withSQLConf(
-      CometConf.COMET_EXEC_SORT_MERGE_JOIN_WITH_JOIN_FILTER_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_SORT_MERGE_JOIN_ENABLED.key -> "true",
       SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
       withParquetTable((0 until 10).map(i => (i, i % 5)), "tbl_a") {
@@ -342,6 +341,7 @@ class CometJoinSuite extends CometTestBase {
 
   test("SortMergeJoin with join filter") {
     withSQLConf(
+      CometConf.COMET_EXEC_SORT_MERGE_JOIN_ENABLED.key -> "true",
       CometConf.COMET_EXEC_SORT_MERGE_JOIN_WITH_JOIN_FILTER_ENABLED.key -> "true",
       SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {

--- a/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
@@ -216,7 +216,7 @@ class CometJoinSuite extends CometTestBase {
           v.toDouble,
           v.toString,
           v % 2 == 0,
-          v.toString().getBytes,
+          v.toString.getBytes,
           Decimal(v))
 
       withParquetTable((0 until 10).map(i => manyTypes(i, i % 5)), "tbl_a") {
@@ -391,19 +391,17 @@ class CometJoinSuite extends CometTestBase {
               "AND tbl_a._2 >= tbl_b._1")
           checkSparkAnswerAndOperator(df9)
 
-          // TODO: Enable these tests after fixing the issue:
-          // https://github.com/apache/datafusion-comet/issues/861
-          /*
           val df10 = sql(
             "SELECT * FROM tbl_a LEFT ANTI JOIN tbl_b ON tbl_a._2 = tbl_b._1 " +
               "AND tbl_a._2 >= tbl_b._1")
+
           checkSparkAnswerAndOperator(df10)
 
           val df11 = sql(
             "SELECT * FROM tbl_b LEFT ANTI JOIN tbl_a ON tbl_a._2 = tbl_b._1 " +
               "AND tbl_a._2 >= tbl_b._1")
+
           checkSparkAnswerAndOperator(df11)
-           */
         }
       }
     }

--- a/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
@@ -21,12 +21,14 @@ package org.apache.comet.exec
 
 import org.scalactic.source.Position
 import org.scalatest.Tag
+
 import org.apache.spark.sql.CometTestBase
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.comet.{CometBroadcastExchangeExec, CometBroadcastHashJoinExec}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.Decimal
+
 import org.apache.comet.CometConf
 import org.apache.comet.CometConf.COMET_EXEC_SORT_MERGE_JOIN_WITH_JOIN_FILTER_ENABLED
 import org.apache.comet.CometSparkSessionExtensions.isSpark34Plus
@@ -295,8 +297,7 @@ class CometJoinSuite extends CometTestBase {
     withSQLConf(
       CometConf.COMET_EXEC_SORT_MERGE_JOIN_WITH_JOIN_FILTER_ENABLED.key -> "true",
       SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1"
-      ) {
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
       withParquetTable((0 until 10).map(i => (i, i % 5)), "tbl_a") {
         withParquetTable((0 until 10).map(i => (i % 10, i + 2)), "tbl_b") {
           val df1 = sql("SELECT * FROM tbl_a JOIN tbl_b ON tbl_a._2 = tbl_b._1")

--- a/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
@@ -394,13 +394,11 @@ class CometJoinSuite extends CometTestBase {
           val df10 = sql(
             "SELECT * FROM tbl_a LEFT ANTI JOIN tbl_b ON tbl_a._2 = tbl_b._1 " +
               "AND tbl_a._2 >= tbl_b._1")
-
           checkSparkAnswerAndOperator(df10)
 
           val df11 = sql(
             "SELECT * FROM tbl_b LEFT ANTI JOIN tbl_a ON tbl_a._2 = tbl_b._1 " +
               "AND tbl_a._2 >= tbl_b._1")
-
           checkSparkAnswerAndOperator(df11)
         }
       }

--- a/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
@@ -21,15 +21,14 @@ package org.apache.comet.exec
 
 import org.scalactic.source.Position
 import org.scalatest.Tag
-
 import org.apache.spark.sql.CometTestBase
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.comet.{CometBroadcastExchangeExec, CometBroadcastHashJoinExec}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.Decimal
-
 import org.apache.comet.CometConf
+import org.apache.comet.CometConf.COMET_EXEC_SORT_MERGE_JOIN_WITH_JOIN_FILTER_ENABLED
 import org.apache.comet.CometSparkSessionExtensions.isSpark34Plus
 
 class CometJoinSuite extends CometTestBase {
@@ -294,8 +293,10 @@ class CometJoinSuite extends CometTestBase {
 
   test("SortMergeJoin without join filter") {
     withSQLConf(
+      CometConf.COMET_EXEC_SORT_MERGE_JOIN_WITH_JOIN_FILTER_ENABLED.key -> "true",
       SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1"
+      ) {
       withParquetTable((0 until 10).map(i => (i, i % 5)), "tbl_a") {
         withParquetTable((0 until 10).map(i => (i % 10, i + 2)), "tbl_b") {
           val df1 = sql("SELECT * FROM tbl_a JOIN tbl_b ON tbl_a._2 = tbl_b._1")
@@ -338,8 +339,7 @@ class CometJoinSuite extends CometTestBase {
     }
   }
 
-  // https://github.com/apache/datafusion-comet/issues/398
-  ignore("SortMergeJoin with join filter") {
+  test("SortMergeJoin with join filter") {
     withSQLConf(
       CometConf.COMET_EXEC_SORT_MERGE_JOIN_WITH_JOIN_FILTER_ENABLED.key -> "true",
       SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Checking that filtered SMJ antijoin works correctly in Comet after fixes in the DataFusion

Closes #398 #861 #891.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
