### PR TITLE
build: bump spark version to 3.3.4, 3.4.4, 3.5.4 for spark-3.3, spark-3.4 and spark-3.5

### DIFF
--- a/.github/actions/setup-spark-builder/action.yaml
+++ b/.github/actions/setup-spark-builder/action.yaml
@@ -23,9 +23,9 @@ inputs:
     required: true
     default: '3.4'
   spark-version:
-    description: 'The Apache Spark version (e.g., 3.4.3) to build'
+    description: 'The Apache Spark version (e.g., 3.4.4) to build'
     required: true
-    default: '3.4.3'
+    default: '3.4.4'
   comet-version:
     description: 'The Comet version to use for Spark'
     required: true

--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         java-version: [11]
-        spark-version: [{short: '3.4', full: '3.4.3'}, {short: '3.5', full: '3.5.1'}]
+        spark-version: [{short: '3.4', full: '3.4.4'}, {short: '3.5', full: '3.5.4'}]
         module:
           - {name: "catalyst", args1: "catalyst/test", args2: ""}
           - {name: "sql/core-1", args1: "", args2: sql/testOnly * -- -l org.apache.spark.tags.ExtendedSQLTest -l org.apache.spark.tags.SlowSQLTest}

--- a/kube/Dockerfile
+++ b/kube/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM apache/spark:3.4.3 AS builder
+FROM apache/spark:3.4.4 AS builder
 
 USER root
 
@@ -59,7 +59,7 @@ COPY pom.xml /comet/pom.xml
 RUN cd /comet \
     && JAVA_HOME=$(readlink -f $(which javac) | sed "s/\/bin\/javac//") make release-nogit PROFILES="-Pspark-$SPARK_VERSION -Pscala-$SCALA_VERSION"
 
-FROM apache/spark:3.4.3
+FROM apache/spark:3.4.4
 ENV SPARK_VERSION=3.4
 ENV SCALA_VERSION=2.12
 USER root

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@ under the License.
     <scala.plugin.version>4.7.2</scala.plugin.version>
     <scalatest.version>3.2.9</scalatest.version>
     <scalatest-maven-plugin.version>2.0.2</scalatest-maven-plugin.version>
-    <spark.version>3.4.3</spark.version>
+    <spark.version>3.4.4</spark.version>
     <spark.version.short>3.4</spark.version.short>
     <spark.maven.scope>provided</spark.maven.scope>
     <protobuf.version>3.21.12</protobuf.version>
@@ -537,7 +537,7 @@ under the License.
       <id>spark-3.3</id>
       <properties>
         <scala.version>2.12.15</scala.version>
-        <spark.version>3.3.2</spark.version>
+        <spark.version>3.3.4</spark.version>
         <spark.version.short>3.3</spark.version.short>
         <parquet.version>1.12.0</parquet.version>
         <slf4j.version>1.7.32</slf4j.version>
@@ -559,7 +559,7 @@ under the License.
       <id>spark-3.5</id>
       <properties>
         <scala.version>2.12.18</scala.version>
-        <spark.version>3.5.1</spark.version>
+        <spark.version>3.5.4</spark.version>
         <spark.version.short>3.5</spark.version.short>
         <parquet.version>1.13.1</parquet.version>
         <slf4j.version>2.0.7</slf4j.version>


### PR DESCRIPTION
## Which issue does this PR close?

Closes #1242.

## Rationale for this change

The latest versions of spark-3.3, spark-3.4 and spark-3.5 are 3.3.4, 3.4.4, 3.5.4.

## What changes are included in this PR?

Bump spark version to 3.3.4, 3.4.4, 3.5.4 for spark-3.3, spark-3.4 and spark-3.5

## How are these changes tested?

CI.