### PR TITLE
fix: speed up ConcurrentHashMap#computeIfAbsent of JDK8

### DIFF
--- a/common/src/main/java/org/apache/comet/parquet/DictionaryPageReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/DictionaryPageReader.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.bytes.BytesInput;
@@ -44,6 +43,8 @@ import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.SeekableInputStream;
 
+import org.apache.comet.util.JavaUtils;
+
 public class DictionaryPageReader implements DictionaryPageReadStore {
   private final Map<String, Optional<DictionaryPage>> cache;
   private final InternalFileDecryptor fileDecryptor;
@@ -57,7 +58,7 @@ public class DictionaryPageReader implements DictionaryPageReadStore {
       SeekableInputStream inputStream,
       ParquetReadOptions options) {
     this.columns = new HashMap<>();
-    this.cache = new ConcurrentHashMap<>();
+    this.cache = JavaUtils.newConcurrentHashMap();
     this.fileDecryptor = fileDecryptor;
     this.inputStream = inputStream;
     this.options = options;

--- a/common/src/main/java/org/apache/comet/util/JavaUtils.java
+++ b/common/src/main/java/org/apache/comet/util/JavaUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.util;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+import org.apache.commons.lang3.JavaVersion;
+import org.apache.commons.lang3.SystemUtils;
+
+public class JavaUtils {
+
+  public static <K, V> ConcurrentHashMap<K, V> newConcurrentHashMap() {
+    if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
+      return new ConcurrentHashMap<>();
+    } else {
+      return new ConcurrentHashMapForJDK8<>();
+    }
+  }
+
+  /**
+   * For JDK8, there is a bug in {@code ConcurrentHashMap#computeIfAbsent}, checking the key
+   * existence to speed up. See details in JDK-8161372.
+   */
+  private static class ConcurrentHashMapForJDK8<K, V> extends ConcurrentHashMap<K, V> {
+
+    public ConcurrentHashMapForJDK8() {
+      super();
+    }
+
+    @Override
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+      V result;
+      if (null == (result = get(key))) {
+        result = super.computeIfAbsent(key, mappingFunction);
+      }
+      return result;
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleManager.scala
@@ -20,7 +20,6 @@
 package org.apache.spark.sql.comet.execution.shuffle
 
 import java.util.Collections
-import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.JavaConverters._
 
@@ -38,6 +37,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.collection.OpenHashSet
 
 import org.apache.comet.CometConf
+import org.apache.comet.util.JavaUtils
 
 /**
  * A [[ShuffleManager]] that uses Arrow format to shuffle data.
@@ -58,7 +58,8 @@ class CometShuffleManager(conf: SparkConf) extends ShuffleManager with Logging {
   /**
    * A mapping from shuffle ids to the task ids of mappers producing output for those shuffles.
    */
-  private[this] val taskIdMapsForShuffle = new ConcurrentHashMap[Int, OpenHashSet[Long]]()
+  private[this] val taskIdMapsForShuffle =
+    JavaUtils.newConcurrentHashMap[Int, OpenHashSet[Long]]()
 
   private lazy val shuffleExecutorComponents = loadShuffleExecutorComponents(conf)
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #1244.

## Rationale for this change

Comet supports JDK8, which could meet the bug mentioned in [JDK-8161372](https://bugs.openjdk.org/browse/JDK-8161372). Therefore, we could check the key existence before invoking `computeIfAbsent`.

## What changes are included in this PR?

Introduce `ConcurrentHashMapForJDK8` to check the key existence for speed up, which solves the bug [JDK-8161372](https://bugs.openjdk.org/browse/JDK-8161372) to speed up `ConcurrentHashMap#computeIfAbsent`.

Backport https://github.com/apache/incubator-uniffle/issues/519.

## How are these changes tested?

CI.