### PR TITLE
chore: See which Spark SQL tests fail if we set default shuffle mode to jvm

### DIFF
--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -252,7 +252,7 @@ object CometConf extends ShimCometConf {
     .stringConf
     .transform(_.toLowerCase(Locale.ROOT))
     .checkValues(Set("native", "jvm", "auto"))
-    .createWithDefault("auto")
+    .createWithDefault("jvm")
 
   val COMET_EXEC_BROADCAST_FORCE_ENABLED: ConfigEntry[Boolean] =
     conf(s"$COMET_EXEC_CONFIG_PREFIX.broadcast.enabled")


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We currently fall back to Spark for shuffle in some cases if shuffle mode is `auto` or `native` and a shuffle is not supported, rather than trying to fall back to Comet columner shuffle. Fixing this limitation in https://github.com/apache/datafusion-comet/pull/1209 caused a number of Spark SQL tests to start failing because we are now running more queries in Comet.

The goal of this PR is simply to demonstrate that changing our default shuffle mode will cause some Spark SQL tests to fail.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
