### PR TITLE
fix: Fall back to Spark for unsupported partition or sort expressions in window aggregates

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -2632,7 +2632,6 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
 
         if (partitionSpec.nonEmpty && orderSpec.nonEmpty &&
           !validatePartitionAndSortSpecsForWindowFunc(partitionSpec, orderSpec, op)) {
-          withInfo(op, "Unsupported partition or sort expression(s)")
           return None
         }
 

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -2632,6 +2632,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
 
         if (partitionSpec.nonEmpty && orderSpec.nonEmpty &&
           !validatePartitionAndSortSpecsForWindowFunc(partitionSpec, orderSpec, op)) {
+          withInfo(op, "Unsupported partition or sort expression(s)")
           return None
         }
 
@@ -3152,13 +3153,15 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
       return false
     }
 
-    val partitionColumnNames = partitionSpec.collect { case a: AttributeReference =>
-      a.name
+    val partitionColumnNames = partitionSpec.collect {
+      case a: AttributeReference => a.name
+      case _ => return false
     }
 
     val orderColumnNames = orderSpec.collect { case s: SortOrder =>
       s.child match {
         case a: AttributeReference => a.name
+        case _ => return false
       }
     }
 

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -25,7 +25,6 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{CometTestBase, DataFrame, Row}
 import org.apache.spark.sql.catalyst.optimizer.EliminateSorts
 import org.apache.spark.sql.comet.CometHashAggregateExec
-import org.apache.spark.sql.execution.WindowData
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.{count_distinct, sum}
 import org.apache.spark.sql.internal.SQLConf
@@ -94,13 +93,11 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   test("window function: partition and order expressions") {
     for (shuffleMode <- Seq("auto", "native", "jvm")) {
       withSQLConf(CometConf.COMET_SHUFFLE_MODE.key -> shuffleMode) {
-        val df = Seq(
-          (1, "a", 5),
-          (2, "a", 6),
-          (3, "b", 7),
-          (4, "b", 8),
-          (5, "c", 9),
-          (6, "c", 10)).toDF("month", "area", "product")
+        val df =
+          Seq((1, "a", 5), (2, "a", 6), (3, "b", 7), (4, "b", 8), (5, "c", 9), (6, "c", 10)).toDF(
+            "month",
+            "area",
+            "product")
         df.createOrReplaceTempView("windowData")
         checkSparkAnswer(sql("""
              |select month, area, product, sum(product + 1) over (partition by 1 order by 2)

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -101,15 +101,11 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
           (4, "b", 8),
           (5, "c", 9),
           (6, "c", 10)).toDF("month", "area", "product")
-        withTempPath{ f =>
-          val path = f.getAbsolutePath
-          df.write.parquet(path)
-          spark.read.parquet(path).createOrReplaceTempView("windowData")
-          checkSparkAnswerAndOperator(sql("""
+        df.createOrReplaceTempView("windowData")
+        checkSparkAnswer(sql("""
              |select month, area, product, sum(product + 1) over (partition by 1 order by 2)
              |from windowData
           """.stripMargin))
-        }
       }
     }
   }

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -20,7 +20,6 @@
 package org.apache.comet.exec
 
 import scala.util.Random
-
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{CometTestBase, DataFrame, Row}
 import org.apache.spark.sql.catalyst.optimizer.EliminateSorts
@@ -28,9 +27,9 @@ import org.apache.spark.sql.comet.CometHashAggregateExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.{count_distinct, sum}
 import org.apache.spark.sql.internal.SQLConf
-
 import org.apache.comet.CometConf
 import org.apache.comet.CometSparkSessionExtensions.isSpark34Plus
+import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 
 /**
  * Test suite dedicated to Comet native aggregate operator
@@ -99,10 +98,24 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
             "area",
             "product")
         df.createOrReplaceTempView("windowData")
-        checkSparkAnswer(sql("""
-             |select month, area, product, sum(product + 1) over (partition by 1 order by 2)
-             |from windowData
-          """.stripMargin))
+        val df2 = sql(
+          """
+            |select month, area, product, sum(product + 1) over (partition by 1 order by 2)
+            |from windowData
+          """.stripMargin)
+        checkSparkAnswer(df2)
+        val cometShuffles = collect(df2.queryExecution.executedPlan) {
+          case _: CometShuffleExchangeExec => true
+        }
+        if (shuffleMode == "jvm") {
+          assert(cometShuffles.length == 1)
+        } else {
+          // we fall back to Spark for shuffle because we do not support
+          // native shuffle with a LocalTableScan input, and we do not fall
+          // back to Comet columnar shuffle due to
+          // https://github.com/apache/datafusion-comet/issues/1248
+          assert(cometShuffles.isEmpty)
+        }
       }
     }
   }

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -20,16 +20,18 @@
 package org.apache.comet.exec
 
 import scala.util.Random
+
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{CometTestBase, DataFrame, Row}
 import org.apache.spark.sql.catalyst.optimizer.EliminateSorts
 import org.apache.spark.sql.comet.CometHashAggregateExec
+import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.{count_distinct, sum}
 import org.apache.spark.sql.internal.SQLConf
+
 import org.apache.comet.CometConf
 import org.apache.comet.CometSparkSessionExtensions.isSpark34Plus
-import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 
 /**
  * Test suite dedicated to Comet native aggregate operator
@@ -98,8 +100,7 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
             "area",
             "product")
         df.createOrReplaceTempView("windowData")
-        val df2 = sql(
-          """
+        val df2 = sql("""
             |select month, area, product, sum(product + 1) over (partition by 1 order by 2)
             |from windowData
           """.stripMargin)

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{CometTestBase, DataFrame, Row}
 import org.apache.spark.sql.catalyst.optimizer.EliminateSorts
 import org.apache.spark.sql.comet.CometHashAggregateExec
+import org.apache.spark.sql.execution.WindowData
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.{count_distinct, sum}
 import org.apache.spark.sql.internal.SQLConf
@@ -86,6 +87,26 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
                              |  lead(123, 100, a) OVER (ORDER BY id) as lead
                              |FROM (SELECT 1 as id, 2 as a) tmp
       """.stripMargin))
+    }
+  }
+
+  // based on Spark's SQLWindowFunctionSuite test of the same name
+  test("window function: partition and order expressions") {
+    for (shuffleMode <- Seq("auto", "native", "jvm")) {
+      withSQLConf(CometConf.COMET_SHUFFLE_MODE.key -> shuffleMode) {
+        val df = Seq(
+          (1, "a", 5),
+          (2, "a", 6),
+          (3, "b", 7),
+          (4, "b", 8),
+          (5, "c", 9),
+          (6, "c", 10)).toDF("month", "area", "product")
+        df.createOrReplaceTempView("windowData")
+        checkSparkAnswer(sql("""
+              |select month, area, product, sum(product + 1) over (partition by 1 order by 2)
+              |from windowData
+          """.stripMargin))
+      }
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -101,11 +101,15 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
           (4, "b", 8),
           (5, "c", 9),
           (6, "c", 10)).toDF("month", "area", "product")
-        df.createOrReplaceTempView("windowData")
-        checkSparkAnswer(sql("""
-              |select month, area, product, sum(product + 1) over (partition by 1 order by 2)
-              |from windowData
+        withTempPath{ f =>
+          val path = f.getAbsolutePath
+          df.write.parquet(path)
+          spark.read.parquet(path).createOrReplaceTempView("windowData")
+          checkSparkAnswerAndOperator(sql("""
+             |select month, area, product, sum(product + 1) over (partition by 1 order by 2)
+             |from windowData
           """.stripMargin))
+        }
       }
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/1249

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Fix bug that causes Spark SQL tests to fail when we run with jvm shuffle mode.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
