### PR TITLE
build: force use of winnow 0.6.22 to fix build

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -58,6 +58,9 @@ rand = "0.8"
 regex = "1.9.6"
 thiserror = "1"
 
+# https://github.com/apache/datafusion-comet/issues/1263
+winnow = "=0.6.22"
+
 [profile.release]
 debug = true
 overflow-checks = false


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/1263

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Build is broken due to breaking change in transitive dependency.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Force use of previous version.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
