### PR TITLE
Feat: Support array_intersect function

### DIFF
--- a/native/proto/src/proto/expr.proto
+++ b/native/proto/src/proto/expr.proto
@@ -86,6 +86,7 @@ message Expr {
     ArrayInsert array_insert = 59;
     BinaryExpr array_contains = 60;
     BinaryExpr array_remove = 61;
+    BinaryExpr array_intersect = 62;
   }
 }
 

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -2284,6 +2284,12 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
             expr.children(1),
             inputs,
             (builder, binaryExpr) => builder.setArrayAppend(binaryExpr))
+        case _ if expr.prettyName == "array_intersect" =>
+          createBinaryExpr(
+            expr.children(0),
+            expr.children(1),
+            inputs,
+            (builder, binaryExpr) => builder.setArrayIntersect(binaryExpr))
         case _ =>
           withInfo(expr, s"${expr.prettyName} is not supported", expr.children: _*)
           None

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -2553,7 +2553,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
         makeParquetFileAllTypes(path, dictionaryEnabled, 10000)
         spark.read.parquet(path.toString).createOrReplaceTempView("t1")
         checkSparkAnswerAndOperator(
-          sql("SELECT array_intersect(array(_2, _3, _4), array(_9, _10)) from t1"))
+          sql("SELECT array_intersect(array(_2, _3, _4), array(_3, _4)) from t1"))
         checkSparkAnswerAndOperator(
           sql("SELECT array_intersect(array(_2 * -1), array(_9, _10)) from t1"))
         checkSparkAnswerAndOperator(sql("SELECT array_intersect(array(_18), array(_19)) from t1"))

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -2545,4 +2545,20 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       }
     }
   }
+
+  test("array_intersect") {
+    Seq(true, false).foreach { dictionaryEnabled =>
+      withTempDir { dir =>
+        val path = new Path(dir.toURI.toString, "test.parquet")
+        makeParquetFileAllTypes(path, dictionaryEnabled, 10000)
+        spark.read.parquet(path.toString).createOrReplaceTempView("t1")
+        checkSparkAnswerAndOperator(
+          sql("SELECT array_intersect(array(_2, _3, _4), array(_9, _10)) from t1"))
+        checkSparkAnswerAndOperator(
+          sql("SELECT array_intersect(array(_2 * -1), array(_9, _10)) from t1"))
+        checkSparkAnswerAndOperator(sql("SELECT array_intersect(array(_18), array(_19)) from t1"))
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
## Which issue does this PR close?
Related to Epic: https://github.com/apache/datafusion-comet/issues/1042
array_intersect: `select array_intersect(array(1, 2, 3), array(2, 3, 4))` => `array(2, 3)`

## Rationale for this change
Defined under Epic: https://github.com/apache/datafusion-comet/issues/1042

## What changes are included in this PR?
`planner.rs:` Created DataFusion `array_intersect` physical expression from Spark physical expression,
`expr.proto:` `array_intersect` message has been added,
`QueryPlanSerde.scala:` `array_intersect` pattern matching case has been added,
`CometExpressionSuite.scala:` A new UT has been added for array_intersect function.

## How are these changes tested?
A new UT has been added.