### PR TITLE
fix: handle loading of complex types into CometVector correctly in iceberg_compat scans

### DIFF
--- a/common/src/main/java/org/apache/comet/parquet/AbstractColumnReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/AbstractColumnReader.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.Type;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.TimestampNTZType$;
 
@@ -35,6 +36,9 @@ public abstract class AbstractColumnReader implements AutoCloseable {
 
   /** The Spark data type. */
   protected final DataType type;
+
+  /** The Spark data type. */
+  protected final Type fieldType;
 
   /** Parquet column descriptor. */
   protected final ColumnDescriptor descriptor;
@@ -61,13 +65,23 @@ public abstract class AbstractColumnReader implements AutoCloseable {
 
   public AbstractColumnReader(
       DataType type,
+      Type fieldType,
       ColumnDescriptor descriptor,
       boolean useDecimal128,
       boolean useLegacyDateTimestamp) {
     this.type = type;
+    this.fieldType = fieldType;
     this.descriptor = descriptor;
     this.useDecimal128 = useDecimal128;
     this.useLegacyDateTimestamp = useLegacyDateTimestamp;
+  }
+
+  public AbstractColumnReader(
+      DataType type,
+      ColumnDescriptor descriptor,
+      boolean useDecimal128,
+      boolean useLegacyDateTimestamp) {
+    this(type, null, descriptor, useDecimal128, useLegacyDateTimestamp);
     TypeUtil.checkParquetType(descriptor, type);
   }
 

--- a/common/src/main/java/org/apache/comet/vector/CometVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometVector.java
@@ -232,7 +232,7 @@ public abstract class CometVector extends ColumnVector {
    * @param useDecimal128 Whether to use Decimal128 for decimal column
    * @return `CometVector` implementation
    */
-  protected static CometVector getVector(
+  public static CometVector getVector(
       ValueVector vector, boolean useDecimal128, DictionaryProvider dictionaryProvider) {
     if (vector instanceof StructVector) {
       return new CometStructVector(vector, useDecimal128, dictionaryProvider);


### PR DESCRIPTION
NativeColumnReader was reading all types into a CometPlainVector which is  correct only for primitive types. The PR updates the code to use NativeUtil and follow the same logic as CometExecIterator.
This addresses 12 unit test failures involving ColumnarShuffle on struct types.