### PR TITLE
feat: Add HasRowIdMapping interface

### DIFF
--- a/common/src/main/java/org/apache/comet/vector/HasRowIdMapping.java
+++ b/common/src/main/java/org/apache/comet/vector/HasRowIdMapping.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.vector;
+
+/**
+ * An interface could be implemented by vectors that have row id mapping.
+ *
+ * <p>For example, Iceberg's DeleteFile has a row id mapping to map row id to position. This
+ * interface is used to set and get the row id mapping. The row id mapping is an array of integers,
+ * where the index is the row id and the value is the position. Here is an example:
+ * [0,1,2,3,4,5,6,7] -- Original status of the row id mapping array Position delete 2, 6
+ * [0,1,3,4,5,7,-,-] -- After applying position deletes [Set Num records to 6]
+ */
+public interface HasRowIdMapping {
+  default void setRowIdMapping(int[] rowIdMapping) {
+    throw new UnsupportedOperationException("setRowIdMapping is not supported");
+  }
+
+  default int[] getRowIdMapping() {
+    throw new UnsupportedOperationException("getRowIdMapping is not supported");
+  }
+}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Iceberg's CometVector has delete support which has an internal row id mapping to skip some rows in a batch. We need an API in Comet to get the row id mapping from third-party CometVector implementation like that.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
