### PR TITLE
fix: partially fix consistency issue of hash functions with decimal input

### DIFF
--- a/native/spark-expr/src/hash_funcs/utils.rs
+++ b/native/spark-expr/src/hash_funcs/utils.rs
@@ -105,29 +105,38 @@ macro_rules! hash_array_primitive_float {
 }
 
 #[macro_export]
-macro_rules! hash_array_decimal {
-    ($array_type:ident, $column: ident, $hashes: ident, $hash_method: ident, $precision: ident) => {
+macro_rules! hash_array_small_decimal {
+    ($array_type:ident, $column: ident, $hashes: ident, $hash_method: ident) => {
         let array = $column.as_any().downcast_ref::<$array_type>().unwrap();
-        let precision = *$precision;
 
         if array.null_count() == 0 {
             for (i, hash) in $hashes.iter_mut().enumerate() {
-                // when precision is less than or equal to 18, spark use deimal long value to calculate hash.
-                // refer: org.apache.spark.sql.catalyst.expressions.InterpretedHashFunction.hash
-                if precision <= 18 {
-                    *hash = $hash_method(i64::try_from(array.value(i)).unwrap().to_le_bytes(), *hash);
-                } else {
-                    *hash = $hash_method(array.value(i).to_le_bytes(), *hash);
-                };
+                *hash = $hash_method(i64::try_from(array.value(i)).unwrap().to_le_bytes(), *hash);
             }
         } else {
             for (i, hash) in $hashes.iter_mut().enumerate() {
                 if !array.is_null(i) {
-                    if precision <= 18 {
-                        *hash = $hash_method(i64::try_from(array.value(i)).unwrap().to_le_bytes(), *hash);
-                    } else {
-                        *hash = $hash_method(array.value(i).to_le_bytes(), *hash);
-                    };
+                    *hash =
+                        $hash_method(i64::try_from(array.value(i)).unwrap().to_le_bytes(), *hash);
+                }
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! hash_array_decimal {
+    ($array_type:ident, $column: ident, $hashes: ident, $hash_method: ident) => {
+        let array = $column.as_any().downcast_ref::<$array_type>().unwrap();
+
+        if array.null_count() == 0 {
+            for (i, hash) in $hashes.iter_mut().enumerate() {
+                *hash = $hash_method(array.value(i).to_le_bytes(), *hash);
+            }
+        } else {
+            for (i, hash) in $hashes.iter_mut().enumerate() {
+                if !array.is_null(i) {
+                    *hash = $hash_method(array.value(i).to_le_bytes(), *hash);
                 }
             }
         }
@@ -285,14 +294,13 @@ macro_rules! create_hashes_internal {
                 DataType::FixedSizeBinary(_) => {
                     $crate::hash_array!(FixedSizeBinaryArray, col, $hashes_buffer, $hash_method);
                 }
-                DataType::Decimal128(precision, _) => {
-                    $crate::hash_array_decimal!(
-                        Decimal128Array,
-                        col,
-                        $hashes_buffer,
-                        $hash_method,
-                        precision
-                    );
+                // Apache Spark: if it's a small decimal, i.e. precision <= 18, turn it into long and hash it.
+                // Else, turn it into bytes and hash it.
+                DataType::Decimal128(precision, _) if *precision <= 18 => {
+                    $crate::hash_array_small_decimal!(Decimal128Array, col, $hashes_buffer, $hash_method);
+                }
+                DataType::Decimal128(_, _) => {
+                    $crate::hash_array_decimal!(Decimal128Array, col, $hashes_buffer, $hash_method);
                 }
                 DataType::Dictionary(index_type, _) => match **index_type {
                     DataType::Int8 => {

--- a/native/spark-expr/src/hash_funcs/utils.rs
+++ b/native/spark-expr/src/hash_funcs/utils.rs
@@ -286,7 +286,13 @@ macro_rules! create_hashes_internal {
                     $crate::hash_array!(FixedSizeBinaryArray, col, $hashes_buffer, $hash_method);
                 }
                 DataType::Decimal128(precision, _) => {
-                    $crate::hash_array_decimal!(Decimal128Array, col, $hashes_buffer, $hash_method, precision);
+                    $crate::hash_array_decimal!(
+                        Decimal128Array,
+                        col,
+                        $hashes_buffer,
+                        $hash_method,
+                        precision
+                    );
                 }
                 DataType::Dictionary(index_type, _) => match **index_type {
                     DataType::Int8 => {

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1928,6 +1928,23 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       }
     }
   }
+
+  test("hash functions with decimal input") {
+    withTable("t1", "t2") {
+      // when precision is less than or equal to 18, spark use decimal long value to calculate hash.
+      // refer: org.apache.spark.sql.catalyst.expressions.InterpretedHashFunction.hash
+      sql(s"create table t1(c1 decimal(18, 2)) using parquet")
+      sql(s"insert into t1 values(1.23), (-1.23), (0.0), (null)")
+      checkSparkAnswerAndOperator(s"select c1, hash(c1), xxhash64(c1) from t1 order by c1")
+
+      // TODO: comet hash function is not compatible with spark for decimal with precision greater than 18.
+      // https://github.com/apache/datafusion-comet/issues/1294
+//       sql(s"create table t2(c1 decimal(20, 2)) using parquet")
+//       sql(s"insert into t2 values(1.23), (-1.23), (0.0), (null)")
+//       checkSparkAnswerAndOperator(s"select c1, hash(c1), xxhash64(c1) from t2 order by c1")
+    }
+  }
+
   test("unary negative integer overflow test") {
     def withAnsiMode(enabled: Boolean)(f: => Unit): Unit = {
       withSQLConf(

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1931,8 +1931,8 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
 
   test("hash functions with decimal input") {
     withTable("t1", "t2") {
-      // when precision is less than or equal to 18, spark use decimal long value to calculate hash.
-      // refer: org.apache.spark.sql.catalyst.expressions.InterpretedHashFunction.hash
+      // Apache Spark: if it's a small decimal, i.e. precision <= 18, turn it into long and hash it.
+      // Else, turn it into bytes and hash it.
       sql("create table t1(c1 decimal(18, 2)) using parquet")
       sql("insert into t1 values(1.23), (-1.23), (0.0), (null)")
       checkSparkAnswerAndOperator("select c1, hash(c1), xxhash64(c1) from t1 order by c1")

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1933,15 +1933,15 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     withTable("t1", "t2") {
       // when precision is less than or equal to 18, spark use decimal long value to calculate hash.
       // refer: org.apache.spark.sql.catalyst.expressions.InterpretedHashFunction.hash
-      sql(s"create table t1(c1 decimal(18, 2)) using parquet")
-      sql(s"insert into t1 values(1.23), (-1.23), (0.0), (null)")
-      checkSparkAnswerAndOperator(s"select c1, hash(c1), xxhash64(c1) from t1 order by c1")
+      sql("create table t1(c1 decimal(18, 2)) using parquet")
+      sql("insert into t1 values(1.23), (-1.23), (0.0), (null)")
+      checkSparkAnswerAndOperator("select c1, hash(c1), xxhash64(c1) from t1 order by c1")
 
       // TODO: comet hash function is not compatible with spark for decimal with precision greater than 18.
       // https://github.com/apache/datafusion-comet/issues/1294
-//       sql(s"create table t2(c1 decimal(20, 2)) using parquet")
-//       sql(s"insert into t2 values(1.23), (-1.23), (0.0), (null)")
-//       checkSparkAnswerAndOperator(s"select c1, hash(c1), xxhash64(c1) from t2 order by c1")
+//       sql("create table t2(c1 decimal(20, 2)) using parquet")
+//       sql("insert into t2 values(1.23), (-1.23), (0.0), (null)")
+//       checkSparkAnswerAndOperator("select c1, hash(c1), xxhash64(c1) from t2 order by c1")
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

This is a partial fix for #1294, which fixes the consistency issue of hash functions for small decimal (precision <= 18).


## Rationale for this change

When precision is less than or equal to 18, spark use unscaled long value of decimal to calculate hash.

https://github.com/apache/spark/blob/d12bb23e49928ae36b57ac5fbeaa492dadf7d28f/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala#L560-L567

## What changes are included in this PR?

When precision is less than or equal to 18, convert i128 native value of decimal to i64 to calculate hash.

## How are these changes tested?

added unit test
