### PR TITLE
fix: Fallback to Spark for unsupported types for ArrayRemove

### DIFF
--- a/spark/src/main/scala/org/apache/comet/expressions/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/expressions/arrays.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.expressions
+
+import org.apache.spark.sql.catalyst.expressions.{ArrayRemove, Expression}
+import org.apache.spark.sql.types.{DataType, DataTypes}
+
+import org.apache.comet.CometSparkSessionExtensions.withInfo
+
+trait CometExpression {
+  def checkSupport(expr: Expression): Boolean
+}
+
+object CometArrayRemove extends CometExpression {
+
+  def isTypeSupported(dt: DataType): Boolean = {
+    // TODO we probably support many more types but we only
+    // have tests for integer so far, so we don't really know
+    dt == DataTypes.IntegerType
+  }
+
+  override def checkSupport(expr: Expression): Boolean = {
+    expr match {
+      case ArrayRemove(l, r) =>
+        if (!isTypeSupported(l.dataType)) {
+          withInfo(expr, s"data type not supported: ${l.dataType}")
+          return false
+        }
+        if (!isTypeSupported(r.dataType)) {
+          withInfo(expr, s"data type not supported: ${r.dataType}")
+          return false
+        }
+        true
+      case _ =>
+        false
+    }
+  }
+
+}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/1307

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This PR fixes a specific bug and provides an approach for solving a general problem where we are not checking for supported types when translating expressions to native.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
