### PR TITLE
Feat: Support arrays_overlap function

### DIFF
--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -65,6 +65,7 @@ use datafusion::{
     prelude::SessionContext,
 };
 use datafusion_comet_spark_expr::{create_comet_physical_fun, create_negate_expr};
+use datafusion_functions_nested::array_has::array_has_any_udf;
 use datafusion_functions_nested::concat::ArrayAppend;
 use datafusion_functions_nested::remove::array_remove_all_udf;
 use datafusion_functions_nested::set_ops::array_intersect_udf;
@@ -817,6 +818,21 @@ impl PhysicalPlanner {
                     DataType::Utf8,
                 ));
                 Ok(array_join_expr)
+            }
+            ExprStruct::ArraysOverlap(expr) => {
+                let left_array_expr =
+                    self.create_expr(expr.left.as_ref().unwrap(), Arc::clone(&input_schema))?;
+                let right_array_expr =
+                    self.create_expr(expr.right.as_ref().unwrap(), Arc::clone(&input_schema))?;
+                let args = vec![Arc::clone(&left_array_expr), right_array_expr];
+                let datafusion_array_has_any = array_has_any_udf();
+                let array_has_any_expr = Arc::new(ScalarFunctionExpr::new(
+                    "array_has_any",
+                    datafusion_array_has_any,
+                    args,
+                    DataType::Boolean,
+                ));
+                Ok(array_has_any_expr)
             }
             expr => Err(ExecutionError::GeneralError(format!(
                 "Not implemented: {:?}",

--- a/native/proto/src/proto/expr.proto
+++ b/native/proto/src/proto/expr.proto
@@ -88,6 +88,7 @@ message Expr {
     BinaryExpr array_remove = 61;
     BinaryExpr array_intersect = 62;
     ArrayJoin array_join = 63;
+    BinaryExpr arrays_overlap = 64;
   }
 }
 

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -2428,6 +2428,22 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
           withInfo(expr, "unsupported arguments for ArrayJoin", exprs: _*)
           None
         }
+      case ArraysOverlap(leftArrayExpr, rightArrayExpr) =>
+        if (CometConf.COMET_CAST_ALLOW_INCOMPATIBLE.get()) {
+          createBinaryExpr(
+            expr,
+            leftArrayExpr,
+            rightArrayExpr,
+            inputs,
+            binding,
+            (builder, binaryExpr) => builder.setArraysOverlap(binaryExpr))
+        } else {
+          withInfo(
+            expr,
+            s"$expr is not supported yet. To enable all incompatible casts, set " +
+              s"${CometConf.COMET_CAST_ALLOW_INCOMPATIBLE.key}=true")
+          None
+        }
       case _ =>
         withInfo(expr, s"${expr.prettyName} is not supported", expr.children: _*)
         None


### PR DESCRIPTION
## Which issue does this PR close?
Related to Epic: https://github.com/apache/datafusion-comet/issues/1042
`arrays_overlap`: `select arrays_overlap(array('hello', '-', 'world'), array('hello'))` => `true`
DataFusion' s array_has_any has same behavior with Spark 's arrays_overlap function
`Spark:` https://docs.databricks.com/en/sql/language-manual/functions/arrays_overlap.html
`DataFusion:` https://datafusion.apache.org/user-guide/sql/scalar_functions.html#array-has-any

## Rationale for this change
Defined under Epic: https://github.com/apache/datafusion-comet/issues/1042

## What changes are included in this PR?
`planner.rs:` Maps Spark 's `arrays_overlap` function to DataFusion `array_has_any` physical expression from Spark physical expression with return type: DataType::Boolean,
`expr.proto:` arrays_overlap message has been added,
`QueryPlanSerde.scala:` arrays_overlap pattern matching case has been added,
`CometExpressionSuite.scala:` A new UT has been added for arrays_overlap function.

## How are these changes tested?
A new UT has been added.
