### PR TITLE
feat: Add array reading support to native_datafusion scan

### DIFF
--- a/native/core/src/execution/serde.rs
+++ b/native/core/src/execution/serde.rs
@@ -111,7 +111,7 @@ pub fn to_arrow_datatype(dt_value: &DataType) -> ArrowDataType {
         {
             DatatypeStruct::List(info) => {
                 let field = Field::new(
-                    "item",
+                    "element",
                     to_arrow_datatype(info.element_type.as_ref().unwrap()),
                     info.contains_null,
                 );

--- a/spark/src/main/scala/org/apache/comet/testing/ParquetGenerator.scala
+++ b/spark/src/main/scala/org/apache/comet/testing/ParquetGenerator.scala
@@ -42,9 +42,6 @@ object ParquetGenerator {
     DataTypes.createDecimalType(10, 2),
     DataTypes.createDecimalType(36, 18),
     DataTypes.DateType,
-    DataTypes.TimestampType,
-    // TimestampNTZType only in Spark 3.4+
-    // DataTypes.TimestampNTZType,
     DataTypes.StringType,
     DataTypes.BinaryType)
 
@@ -57,6 +54,12 @@ object ParquetGenerator {
 
     val dataTypes = ListBuffer[DataType]()
     dataTypes.appendAll(primitiveTypes)
+
+    if (options.generateTimestamps) {
+      dataTypes += DataTypes.TimestampType
+      // TimestampNTZType only in Spark 3.4+
+      // dataTypes += DataTypes.TimestampNTZType,
+    }
 
     if (options.generateStruct) {
       dataTypes += StructType(
@@ -212,8 +215,9 @@ object ParquetGenerator {
 }
 
 case class DataGenOptions(
-    allowNull: Boolean,
-    generateNegativeZero: Boolean,
-    generateArray: Boolean,
-    generateStruct: Boolean,
-    generateMap: Boolean)
+    allowNull: Boolean = true,
+    generateNegativeZero: Boolean = true,
+    generateTimestamps: Boolean = true,
+    generateArray: Boolean = false,
+    generateStruct: Boolean = false,
+    generateMap: Boolean = false)

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
@@ -122,8 +122,9 @@ object CometNativeScanExec extends DataTypeSupport {
   }
 
   override def isAdditionallySupported(dt: DataType): Boolean = {
-    // TODO add array and map
+    // TODO add map support
     dt match {
+      case s: ArrayType => isTypeSupported(s.elementType)
       case s: StructType => s.fields.map(_.dataType).forall(isTypeSupported)
       case _ => false
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/1322

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Add support for reading arrays from Parquet

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Enable array support in `native_datafusion` scan
- Add new test to exercise this support

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
