### PR TITLE
perf: improve performance of update metrics

### DIFF
--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -622,6 +622,14 @@ object CometConf extends ShimCometConf {
       .booleanConf
       .createWithDefault(false)
 
+  val COMET_METRICS_UPDATE_INTERVAL: ConfigEntry[Long] =
+    conf("spark.comet.metrics.updateInterval")
+      .doc(
+        "The interval in milliseconds to update metrics. If interval is negative," +
+          " metrics will be updated upon task completion.")
+      .longConf
+      .createWithDefault(3000L)
+
   /** Create a config to enable a specific operator */
   private def createExecEnabledConfig(
       exec: String,

--- a/docs/source/user-guide/configs.md
+++ b/docs/source/user-guide/configs.md
@@ -66,6 +66,7 @@ Comet provides the following configuration settings.
 | spark.comet.explainFallback.enabled | When this setting is enabled, Comet will provide logging explaining the reason(s) why a query stage cannot be executed natively. Set this to false to reduce the amount of logging. | false |
 | spark.comet.memory.overhead.factor | Fraction of executor memory to be allocated as additional non-heap memory per executor process for Comet. | 0.2 |
 | spark.comet.memory.overhead.min | Minimum amount of additional memory to be allocated per executor process for Comet, in MiB. | 402653184b |
+| spark.comet.metrics.updateInterval | The interval in milliseconds to update metrics. If interval is negative, metrics will be updated upon task completion. | 3000 |
 | spark.comet.nativeLoadRequired | Whether to require Comet native library to load successfully when Comet is enabled. If not, Comet will silently fallback to Spark when it fails to load the native lib. Otherwise, an error will be thrown and the Spark job will be aborted. | false |
 | spark.comet.parquet.enable.directBuffer | Whether to use Java direct byte buffer when reading Parquet. | false |
 | spark.comet.parquet.read.io.adjust.readRange.skew | In the parallel reader, if the read ranges submitted are skewed in sizes, this option will cause the reader to break up larger read ranges into smaller ranges to reduce the skew. This will result in a slightly larger number of connections opened to the file system but may give improved performance. | false |

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -584,9 +584,13 @@ pub extern "system" fn Java_org_apache_comet_Native_releasePlan(
 
 /// Updates the metrics of the query plan.
 fn update_metrics(env: &mut JNIEnv, exec_context: &mut ExecutionContext) -> CometResult<()> {
-    let native_query = exec_context.root_op.as_ref().unwrap();
-    let metrics = exec_context.metrics.as_obj();
-    update_comet_metric(env, metrics, native_query)
+    if exec_context.root_op.is_some() {
+        let native_query = exec_context.root_op.as_ref().unwrap();
+        let metrics = exec_context.metrics.as_obj();
+        update_comet_metric(env, metrics, native_query)
+    } else {
+        Ok(())
+    }
 }
 
 fn convert_datatype_arrays(

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -519,15 +519,12 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
             let poll_output = exec_context.runtime.block_on(async { poll!(next_item) });
 
             // update metrics at interval
-            match exec_context.metrics_update_interval {
-                Some(interval) => {
-                    let now = Instant::now();
-                    if now - exec_context.metrics_last_update_time >= interval {
-                        update_metrics(&mut env, exec_context)?;
-                        exec_context.metrics_last_update_time = now;
-                    }
+            if let Some(interval) = exec_context.metrics_update_interval {
+                let now = Instant::now();
+                if now - exec_context.metrics_last_update_time >= interval {
+                    update_metrics(&mut env, exec_context)?;
+                    exec_context.metrics_last_update_time = now;
                 }
-                None => {}
             }
 
             match poll_output {

--- a/native/core/src/execution/metrics/utils.rs
+++ b/native/core/src/execution/metrics/utils.rs
@@ -16,16 +16,13 @@
 // under the License.
 
 use crate::execution::spark_plan::SparkPlan;
-use crate::{
-    errors::CometError,
-    jvm_bridge::jni_call,
-};
+use crate::{errors::CometError, jvm_bridge::jni_call};
 use datafusion::physical_plan::metrics::MetricValue;
 use datafusion_comet_proto::spark_metric::NativeMetricNode;
 use jni::{objects::JObject, JNIEnv};
+use prost::Message;
 use std::collections::HashMap;
 use std::sync::Arc;
-use prost::Message;
 
 /// Updates the metrics of a CometMetricNode. This function is called recursively to
 /// update the metrics of all the children nodes. The metrics are pulled from the
@@ -33,7 +30,7 @@ use prost::Message;
 pub fn update_comet_metric(
     env: &mut JNIEnv,
     metric_node: &JObject,
-    spark_plan: &Arc<SparkPlan>
+    spark_plan: &Arc<SparkPlan>,
 ) -> Result<(), CometError> {
     unsafe {
         let native_metric = to_native_metric_node(spark_plan);
@@ -76,7 +73,6 @@ pub fn to_native_metric_node(spark_plan: &Arc<SparkPlan>) -> Result<NativeMetric
         .for_each(|(name, value)| {
             native_metric_node.metrics.insert(name.to_string(), value);
         });
-
 
     // add children
     spark_plan.children().iter().for_each(|child_plan| {

--- a/native/core/src/execution/metrics/utils.rs
+++ b/native/core/src/execution/metrics/utils.rs
@@ -34,7 +34,7 @@ pub fn update_comet_metric(
 ) -> Result<(), CometError> {
     unsafe {
         let native_metric = to_native_metric_node(spark_plan);
-        let jbytes = env.byte_array_from_slice(&*native_metric?.encode_to_vec())?;
+        let jbytes = env.byte_array_from_slice(&native_metric?.encode_to_vec())?;
         jni_call!(env, comet_metric_node(metric_node).set_all_from_bytes(&jbytes) -> ())?;
     }
     Ok(())

--- a/native/core/src/execution/metrics/utils.rs
+++ b/native/core/src/execution/metrics/utils.rs
@@ -16,16 +16,16 @@
 // under the License.
 
 use crate::execution::spark_plan::SparkPlan;
-use crate::jvm_bridge::jni_new_global_ref;
 use crate::{
     errors::CometError,
-    jvm_bridge::{jni_call, jni_new_string},
+    jvm_bridge::jni_call,
 };
 use datafusion::physical_plan::metrics::MetricValue;
-use jni::objects::{GlobalRef, JString};
+use datafusion_comet_proto::spark_metric::NativeMetricNode;
 use jni::{objects::JObject, JNIEnv};
 use std::collections::HashMap;
 use std::sync::Arc;
+use prost::Message;
 
 /// Updates the metrics of a CometMetricNode. This function is called recursively to
 /// update the metrics of all the children nodes. The metrics are pulled from the
@@ -33,11 +33,23 @@ use std::sync::Arc;
 pub fn update_comet_metric(
     env: &mut JNIEnv,
     metric_node: &JObject,
-    spark_plan: &Arc<SparkPlan>,
-    metrics_jstrings: &mut HashMap<String, Arc<GlobalRef>>,
+    spark_plan: &Arc<SparkPlan>
 ) -> Result<(), CometError> {
-    // combine all metrics from all native plans for this SparkPlan
-    let metrics = if spark_plan.additional_native_plans.is_empty() {
+    unsafe {
+        let native_metric = to_native_metric_node(spark_plan);
+        let jbytes = env.byte_array_from_slice(&*native_metric?.encode_to_vec())?;
+        jni_call!(env, comet_metric_node(metric_node).set_all_from_bytes(&jbytes) -> ())?;
+    }
+    Ok(())
+}
+
+pub fn to_native_metric_node(spark_plan: &Arc<SparkPlan>) -> Result<NativeMetricNode, CometError> {
+    let mut native_metric_node = NativeMetricNode {
+        metrics: HashMap::new(),
+        children: Vec::new(),
+    };
+
+    let node_metrics = if spark_plan.additional_native_plans.is_empty() {
         spark_plan.native_plan.metrics()
     } else {
         let mut metrics = spark_plan.native_plan.metrics().unwrap_or_default();
@@ -55,60 +67,22 @@ pub fn update_comet_metric(
         Some(metrics.aggregate_by_name())
     };
 
-    update_metrics(
-        env,
-        metric_node,
-        &metrics
-            .unwrap_or_default()
-            .iter()
-            .map(|m| m.value())
-            .map(|m| (m.name(), m.as_usize() as i64))
-            .collect::<Vec<_>>(),
-        metrics_jstrings,
-    )?;
+    // add metrics
+    node_metrics
+        .unwrap_or_default()
+        .iter()
+        .map(|m| m.value())
+        .map(|m| (m.name(), m.as_usize() as i64))
+        .for_each(|(name, value)| {
+            native_metric_node.metrics.insert(name.to_string(), value);
+        });
 
-    unsafe {
-        for (i, child_plan) in spark_plan.children().iter().enumerate() {
-            let child_metric_node: JObject = jni_call!(env,
-                comet_metric_node(metric_node).get_child_node(i as i32) -> JObject
-            )?;
-            if child_metric_node.is_null() {
-                continue;
-            }
-            update_comet_metric(env, &child_metric_node, child_plan, metrics_jstrings)?;
-        }
-    }
-    Ok(())
-}
 
-#[inline]
-fn update_metrics(
-    env: &mut JNIEnv,
-    metric_node: &JObject,
-    metric_values: &[(&str, i64)],
-    metrics_jstrings: &mut HashMap<String, Arc<GlobalRef>>,
-) -> Result<(), CometError> {
-    unsafe {
-        for &(name, value) in metric_values {
-            // Perform a lookup in the jstrings cache.
-            if let Some(map_global_ref) = metrics_jstrings.get(name) {
-                // Cache hit. Extract the jstring from the global ref.
-                let jobject = map_global_ref.as_obj();
-                let jstring = JString::from_raw(**jobject);
-                // Update the metrics using the jstring as a key.
-                jni_call!(env, comet_metric_node(metric_node).set(&jstring, value) -> ())?;
-            } else {
-                // Cache miss. Allocate a new string, promote to global ref, and insert into cache.
-                let local_jstring = jni_new_string!(env, &name)?;
-                let global_ref = jni_new_global_ref!(env, local_jstring)?;
-                let arc_global_ref = Arc::new(global_ref);
-                metrics_jstrings.insert(name.to_string(), Arc::clone(&arc_global_ref));
-                let jobject = arc_global_ref.as_obj();
-                let jstring = JString::from_raw(**jobject);
-                // Update the metrics using the jstring as a key.
-                jni_call!(env, comet_metric_node(metric_node).set(&jstring, value) -> ())?;
-            }
-        }
-    }
-    Ok(())
+    // add children
+    spark_plan.children().iter().for_each(|child_plan| {
+        let child_node = to_native_metric_node(child_plan).unwrap();
+        native_metric_node.children.push(child_node);
+    });
+
+    Ok(native_metric_node)
 }

--- a/native/core/src/execution/metrics/utils.rs
+++ b/native/core/src/execution/metrics/utils.rs
@@ -75,10 +75,10 @@ pub fn to_native_metric_node(spark_plan: &Arc<SparkPlan>) -> Result<NativeMetric
         });
 
     // add children
-    spark_plan.children().iter().for_each(|child_plan| {
-        let child_node = to_native_metric_node(child_plan).unwrap();
+    for child_plan in spark_plan.children() {
+        let child_node = to_native_metric_node(child_plan)?;
         native_metric_node.children.push(child_node);
-    });
+    }
 
     Ok(native_metric_node)
 }

--- a/native/core/src/jvm_bridge/comet_metric_node.rs
+++ b/native/core/src/jvm_bridge/comet_metric_node.rs
@@ -49,7 +49,11 @@ impl<'a> CometMetricNode<'a> {
             method_get_child_node_ret: ReturnType::Object,
             method_set: env.get_method_id(Self::JVM_CLASS, "set", "(Ljava/lang/String;J)V")?,
             method_set_ret: ReturnType::Primitive(Primitive::Void),
-            method_set_all_from_bytes: env.get_method_id(Self::JVM_CLASS, "set_all_from_bytes", "([B)V")?,
+            method_set_all_from_bytes: env.get_method_id(
+                Self::JVM_CLASS,
+                "set_all_from_bytes",
+                "([B)V",
+            )?,
             method_set_all_from_bytes_ret: ReturnType::Primitive(Primitive::Void),
             class,
         })

--- a/native/core/src/jvm_bridge/comet_metric_node.rs
+++ b/native/core/src/jvm_bridge/comet_metric_node.rs
@@ -30,6 +30,8 @@ pub struct CometMetricNode<'a> {
     pub method_get_child_node_ret: ReturnType,
     pub method_set: JMethodID,
     pub method_set_ret: ReturnType,
+    pub method_set_all_from_bytes: JMethodID,
+    pub method_set_all_from_bytes_ret: ReturnType,
 }
 
 impl<'a> CometMetricNode<'a> {
@@ -47,6 +49,8 @@ impl<'a> CometMetricNode<'a> {
             method_get_child_node_ret: ReturnType::Object,
             method_set: env.get_method_id(Self::JVM_CLASS, "set", "(Ljava/lang/String;J)V")?,
             method_set_ret: ReturnType::Primitive(Primitive::Void),
+            method_set_all_from_bytes: env.get_method_id(Self::JVM_CLASS, "set_all_from_bytes", "([B)V")?,
+            method_set_all_from_bytes_ret: ReturnType::Primitive(Primitive::Void),
             class,
         })
     }

--- a/native/core/src/jvm_bridge/mod.rs
+++ b/native/core/src/jvm_bridge/mod.rs
@@ -46,13 +46,6 @@ macro_rules! jvalues {
     }}
 }
 
-/// Macro for create a new JNI string.
-macro_rules! jni_new_string {
-    ($env:expr, $value:expr) => {{
-        $crate::jvm_bridge::jni_map_error!($env, $env.new_string($value))
-    }};
-}
-
 /// Macro for calling a JNI method.
 /// The syntax is:
 /// jni_call!(env, comet_metric_node(metric_node).add(jname, value) -> ())?;
@@ -173,7 +166,6 @@ macro_rules! jni_new_global_ref {
 pub(crate) use jni_call;
 pub(crate) use jni_map_error;
 pub(crate) use jni_new_global_ref;
-pub(crate) use jni_new_string;
 pub(crate) use jni_static_call;
 pub(crate) use jvalues;
 

--- a/native/proto/src/lib.rs
+++ b/native/proto/src/lib.rs
@@ -36,3 +36,9 @@ pub mod spark_partitioning {
 pub mod spark_operator {
     include!(concat!("generated", "/spark.spark_operator.rs"));
 }
+
+// Include generated modules from .proto files.
+#[allow(missing_docs)]
+pub mod spark_metric {
+    include!(concat!("generated", "/spark.spark_metric.rs"));
+}

--- a/native/proto/src/proto/metric.proto
+++ b/native/proto/src/proto/metric.proto
@@ -15,26 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Build script for generating codes from .proto files.
 
-use std::{fs, io::Result, path::Path};
 
-fn main() -> Result<()> {
-    println!("cargo:rerun-if-changed=src/proto/");
+syntax = "proto3";
 
-    let out_dir = "src/generated";
-    if !Path::new(out_dir).is_dir() {
-        fs::create_dir(out_dir)?;
-    }
+package spark.spark_metric;
 
-    prost_build::Config::new().out_dir(out_dir).compile_protos(
-        &[
-            "src/proto/expr.proto",
-            "src/proto/metric.proto",
-            "src/proto/partitioning.proto",
-            "src/proto/operator.proto",
-        ],
-        &["src/proto"],
-    )?;
-    Ok(())
+option java_package = "org.apache.comet.serde";
+
+message NativeMetricNode {
+  map<string, int64> metrics = 1;
+  repeated NativeMetricNode children = 2;
 }

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -24,7 +24,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.comet.CometMetricNode
 import org.apache.spark.sql.vectorized._
 
-import org.apache.comet.CometConf.{COMET_BATCH_SIZE, COMET_BLOCKING_THREADS, COMET_DEBUG_ENABLED, COMET_EXEC_MEMORY_POOL_TYPE, COMET_EXPLAIN_NATIVE_ENABLED, COMET_WORKER_THREADS}
+import org.apache.comet.CometConf.{COMET_BATCH_SIZE, COMET_BLOCKING_THREADS, COMET_DEBUG_ENABLED, COMET_EXEC_MEMORY_POOL_TYPE, COMET_EXPLAIN_NATIVE_ENABLED, COMET_METRICS_UPDATE_INTERVAL, COMET_WORKER_THREADS}
 import org.apache.comet.vector.NativeUtil
 
 /**
@@ -72,6 +72,7 @@ class CometExecIterator(
       protobufQueryPlan,
       numParts,
       nativeMetrics,
+      metricsUpdateInterval = COMET_METRICS_UPDATE_INTERVAL.get(),
       new CometTaskMemoryManager(id),
       batchSize = COMET_BATCH_SIZE.get(),
       use_unified_memory_manager = conf.getBoolean("spark.memory.offHeap.enabled", false),

--- a/spark/src/main/scala/org/apache/comet/Native.scala
+++ b/spark/src/main/scala/org/apache/comet/Native.scala
@@ -40,6 +40,9 @@ class Native extends NativeBase {
    *   the bytes of serialized SparkPlan.
    * @param metrics
    *   the native metrics of SparkPlan.
+   * @param metricsUpdateInterval
+   *   the interval in milliseconds to update metrics, if interval is negative, metrics will be
+   *   updated upon task completion.
    * @param taskMemoryManager
    *   the task-level memory manager that is responsible for tracking memory usage across JVM and
    *   native side.
@@ -53,6 +56,7 @@ class Native extends NativeBase {
       plan: Array[Byte],
       partitionCount: Int,
       metrics: CometMetricNode,
+      metricsUpdateInterval: Long,
       taskMemoryManager: CometTaskMemoryManager,
       batchSize: Int,
       use_unified_memory_manager: Boolean,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1328.

## Rationale for this change

Improve performance of update metrics

## What changes are included in this PR?

+ Define a NativeMetricNode proto type to pass all metric nodes at once to avoid iterative jni calls.
+ Call update metrics when releasing plan to reduce the number of calls.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
### after this
sql metrics are displayed correctly:

<img src="https://github.com/user-attachments/assets/2e70d39f-ceff-4bf4-b51f-dc03bbe78942" height = "500" align=center />

cpu profile:
![image](https://github.com/user-attachments/assets/fbab1f59-c985-4f61-ba97-b008008f2d5e)

