### PR TITLE
build: re-enable upload-test-reports for macos-13 runner

### DIFF
--- a/.github/actions/java-test/action.yaml
+++ b/.github/actions/java-test/action.yaml
@@ -67,4 +67,4 @@ runs:
 
     - name: Upload coverage results
       if: ${{ inputs.upload-test-reports == 'true' }}
-      uses: codecov/codecov-action@v3 # uses v3 as it allows tokenless uploading
+      uses: codecov/codecov-action@v5

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -197,7 +197,7 @@ jobs:
         test-target: [java]
         spark-version: ['4.0']
       fail-fast: false
-    # if: github.event_name == 'push'
+    if: github.event_name == 'push'
     name: ${{ matrix.os }}/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}/${{ matrix.test-target }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -197,7 +197,7 @@ jobs:
         test-target: [java]
         spark-version: ['4.0']
       fail-fast: false
-    if: github.event_name == 'push'
+    # if: github.event_name == 'push'
     name: ${{ matrix.os }}/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}/${{ matrix.test-target }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -211,8 +211,7 @@ jobs:
         uses: ./.github/actions/java-test
         with:
           maven_opts: -Pspark-${{ matrix.spark-version }}
-          # https://github.com/codecov/codecov-action/issues/1549
-          # upload-test-reports: true
+          upload-test-reports: true
 
   macos-aarch64-test-with-spark4_0:
     strategy:


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The feature `upload-test-reports` for macos-13 runner was disabled (https://github.com/apache/datafusion-comet/pull/933) previously due to https://github.com/codecov/codecov-action/issues/1549. Trying to re-enable it with upgrading to `v5`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
