### PR TITLE
fix: memory pool error type

### DIFF
--- a/native/core/src/execution/memory_pool.rs
+++ b/native/core/src/execution/memory_pool.rs
@@ -26,7 +26,7 @@ use std::{
 use jni::objects::GlobalRef;
 
 use datafusion::{
-    common::DataFusionError,
+    common::{resources_datafusion_err, DataFusionError},
     execution::memory_pool::{MemoryPool, MemoryReservation},
 };
 
@@ -101,12 +101,12 @@ impl MemoryPool for CometMemoryPool {
                 // Release the acquired bytes before throwing error
                 self.release(acquired as usize)?;
 
-                return Err(DataFusionError::Execution(format!(
+                return Err(resources_datafusion_err!(
                     "Failed to acquire {} bytes, only got {}. Reserved: {}",
                     additional,
                     acquired,
-                    self.reserved(),
-                )));
+                    self.reserved()
+                ));
             }
             self.used.fetch_add(additional, Relaxed);
         }


### PR DESCRIPTION
## Which issue does this PR close?

## Rationale for this change

## What changes are included in this PR?

Datafusion memory pool throws `insufficient_capacity_err` https://github.com/apache/datafusion/blob/main/datafusion/execution/src/memory_pool/pool.rs#L91
and aggregation expects to see it https://github.com/apache/datafusion/blob/main/datafusion/physical-plan/src/aggregates/row_hash.rs#L913

However comet memory pool was throwing an execution error that causes false OOM

## How are these changes tested?

existing tests
