### PR TITLE
fix: expressions doc for ArrayRemove

### DIFF
--- a/docs/source/user-guide/expressions.md
+++ b/docs/source/user-guide/expressions.md
@@ -190,7 +190,7 @@ The following Spark expressions are currently available. Any known compatibility
 | ArrayContains     | Experimental |
 | ArrayIntersect    | Experimental |
 | ArrayJoin         | Experimental |
-| ArrayRemove       | Experimental |
+| ArrayRemove       |              |
 | ArraysOverlap     | Experimental |
 | ElementAt         | Arrays only  |
 | GetArrayItem      |              |

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -26,7 +26,7 @@ import org.apache.comet.CometSparkSessionExtensions.withInfo
 import org.apache.comet.serde.QueryPlanSerde.{createBinaryExpr, exprToProto}
 import org.apache.comet.shims.CometExprShim
 
-object CometArrayRemove extends CometExpressionSerde with CometExprShim with IncompatExpr {
+object CometArrayRemove extends CometExpressionSerde with CometExprShim {
 
   /** Exposed for unit testing */
   def isTypeSupported(dt: DataType): Boolean = {

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -26,7 +26,7 @@ import org.apache.comet.CometSparkSessionExtensions.withInfo
 import org.apache.comet.serde.QueryPlanSerde.{createBinaryExpr, exprToProto}
 import org.apache.comet.shims.CometExprShim
 
-object CometArrayRemove extends CometExpressionSerde with CometExprShim {
+object CometArrayRemove extends CometExpressionSerde with CometExprShim with IncompatExpr {
 
   /** Exposed for unit testing */
   def isTypeSupported(dt: DataType): Boolean = {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

The doc says ArrayRemove is experimental https://github.com/apache/datafusion-comet/blob/ea6d9508800f4fd50341dd33425a08a62b549aae/docs/source/user-guide/expressions.md?plain=1#L193
although array remove is compatible (and tested) for the types that it currently supports

## What changes are included in this PR?

Updated the doc

## How are these changes tested?

existing test
