### PR TITLE
fix: correct the logic of transform shuffle exchange

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -862,7 +862,7 @@ class CometSparkSessionExtensions
               newOp match {
                 case Some(nativeOp) =>
                   s.child match {
-                    case n if n.isInstanceOf[CometNativeExec] || !n.supportsColumnar =>
+                    case n if n.isInstanceOf[CometNativeExec] || n.supportsColumnar =>
                       val cometOp =
                         CometShuffleExchangeExec(s, shuffleType = CometColumnarShuffle)
                       Some(CometSinkPlaceHolder(nativeOp, s, cometOp))


### PR DESCRIPTION
## Which issue does this PR close?

minor fix

## Rationale for this change

The child of CometShuffleExchangeExec should be columnar

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
