### PR TITLE
fix: enable full decimal to decimal support

### DIFF
--- a/docs/source/user-guide/compatibility.md
+++ b/docs/source/user-guide/compatibility.md
@@ -104,76 +104,77 @@ Spark.
 The following cast operations are generally compatible with Spark except for the differences noted here.
 
 | From Type | To Type | Notes |
-|-|-|-|
-| boolean | byte |  |
-| boolean | short |  |
+|-|---------|-|
+| boolean | byte    |  |
+| boolean | short   |  |
 | boolean | integer |  |
-| boolean | long |  |
-| boolean | float |  |
-| boolean | double |  |
-| boolean | string |  |
+| boolean | long    |  |
+| boolean | float   |  |
+| boolean | double  |  |
+| boolean | string  |  |
 | byte | boolean |  |
-| byte | short |  |
+| byte | short   |  |
 | byte | integer |  |
-| byte | long |  |
-| byte | float |  |
-| byte | double |  |
+| byte | long    |  |
+| byte | float   |  |
+| byte | double  |  |
 | byte | decimal |  |
-| byte | string |  |
+| byte | string  |  |
 | short | boolean |  |
-| short | byte |  |
+| short | byte    |  |
 | short | integer |  |
-| short | long |  |
-| short | float |  |
-| short | double |  |
+| short | long    |  |
+| short | float   |  |
+| short | double  |  |
 | short | decimal |  |
-| short | string |  |
+| short | string  |  |
 | integer | boolean |  |
-| integer | byte |  |
-| integer | short |  |
-| integer | long |  |
-| integer | float |  |
-| integer | double |  |
-| integer | string |  |
+| integer | byte    |  |
+| integer | short   |  |
+| integer | long    |  |
+| integer | float   |  |
+| integer | double  |  |
+| integer | string  |  |
 | long | boolean |  |
-| long | byte |  |
-| long | short |  |
+| long | byte    |  |
+| long | short   |  |
 | long | integer |  |
-| long | float |  |
-| long | double |  |
-| long | string |  |
+| long | float   |  |
+| long | double  |  |
+| long | string  |  |
 | float | boolean |  |
-| float | byte |  |
-| float | short |  |
+| float | byte    |  |
+| float | short   |  |
 | float | integer |  |
-| float | long |  |
-| float | double |  |
-| float | string | There can be differences in precision. For example, the input "1.4E-45" will produce 1.0E-45 instead of 1.4E-45 |
+| float | long    |  |
+| float | double  |  |
+| float | string  | There can be differences in precision. For example, the input "1.4E-45" will produce 1.0E-45 instead of 1.4E-45 |
 | double | boolean |  |
-| double | byte |  |
-| double | short |  |
+| double | byte    |  |
+| double | short   |  |
 | double | integer |  |
-| double | long |  |
-| double | float |  |
-| double | string | There can be differences in precision. For example, the input "1.4E-45" will produce 1.0E-45 instead of 1.4E-45 |
-| decimal | byte |  |
-| decimal | short |  |
+| double | long    |  |
+| double | float   |  |
+| double | string  | There can be differences in precision. For example, the input "1.4E-45" will produce 1.0E-45 instead of 1.4E-45 |
+| decimal | byte    |  |
+| decimal | short   |  |
 | decimal | integer |  |
-| decimal | long |  |
-| decimal | float |  |
-| decimal | double |  |
-| decimal | string | There can be formatting differences in some case due to Spark using scientific notation where Comet does not |
+| decimal | long    |  |
+| decimal | float   |  |
+| decimal | double  |  |
+| decimal | string  | There can be formatting differences in some case due to Spark using scientific notation where Comet does not |
+| decimal | decimal |  |
 | string | boolean |  |
-| string | byte |  |
-| string | short |  |
+| string | byte    |  |
+| string | short   |  |
 | string | integer |  |
-| string | long |  |
-| string | binary |  |
-| string | date | Only supports years between 262143 BC and 262142 AD |
-| date | string |  |
-| timestamp | long |  |
-| timestamp | string |  |
-| timestamp | date |  |
+| string | long    |  |
+| string | binary  |  |
+| string | date    | Only supports years between 262143 BC and 262142 AD |
+| date | string  |  |
+| timestamp | long    |  |
+| timestamp | string  |  |
+| timestamp | date    |  |
 
 ### Incompatible Casts
 

--- a/docs/source/user-guide/compatibility.md
+++ b/docs/source/user-guide/compatibility.md
@@ -162,6 +162,7 @@ The following cast operations are generally compatible with Spark except for the
 | decimal | long |  |
 | decimal | float |  |
 | decimal | double |  |
+| decimal | decimal |  |
 | decimal | string | There can be formatting differences in some case due to Spark using scientific notation where Comet does not |
 | string | boolean |  |
 | string | byte |  |

--- a/docs/source/user-guide/compatibility.md
+++ b/docs/source/user-guide/compatibility.md
@@ -104,77 +104,76 @@ Spark.
 The following cast operations are generally compatible with Spark except for the differences noted here.
 
 | From Type | To Type | Notes |
-|-|---------|-|
-| boolean | byte    |  |
-| boolean | short   |  |
+|-|-|-|
+| boolean | byte |  |
+| boolean | short |  |
 | boolean | integer |  |
-| boolean | long    |  |
-| boolean | float   |  |
-| boolean | double  |  |
-| boolean | string  |  |
+| boolean | long |  |
+| boolean | float |  |
+| boolean | double |  |
+| boolean | string |  |
 | byte | boolean |  |
-| byte | short   |  |
+| byte | short |  |
 | byte | integer |  |
-| byte | long    |  |
-| byte | float   |  |
-| byte | double  |  |
+| byte | long |  |
+| byte | float |  |
+| byte | double |  |
 | byte | decimal |  |
-| byte | string  |  |
+| byte | string |  |
 | short | boolean |  |
-| short | byte    |  |
+| short | byte |  |
 | short | integer |  |
-| short | long    |  |
-| short | float   |  |
-| short | double  |  |
+| short | long |  |
+| short | float |  |
+| short | double |  |
 | short | decimal |  |
-| short | string  |  |
+| short | string |  |
 | integer | boolean |  |
-| integer | byte    |  |
-| integer | short   |  |
-| integer | long    |  |
-| integer | float   |  |
-| integer | double  |  |
-| integer | string  |  |
+| integer | byte |  |
+| integer | short |  |
+| integer | long |  |
+| integer | float |  |
+| integer | double |  |
+| integer | string |  |
 | long | boolean |  |
-| long | byte    |  |
-| long | short   |  |
+| long | byte |  |
+| long | short |  |
 | long | integer |  |
-| long | float   |  |
-| long | double  |  |
-| long | string  |  |
+| long | float |  |
+| long | double |  |
+| long | string |  |
 | float | boolean |  |
-| float | byte    |  |
-| float | short   |  |
+| float | byte |  |
+| float | short |  |
 | float | integer |  |
-| float | long    |  |
-| float | double  |  |
-| float | string  | There can be differences in precision. For example, the input "1.4E-45" will produce 1.0E-45 instead of 1.4E-45 |
+| float | long |  |
+| float | double |  |
+| float | string | There can be differences in precision. For example, the input "1.4E-45" will produce 1.0E-45 instead of 1.4E-45 |
 | double | boolean |  |
-| double | byte    |  |
-| double | short   |  |
+| double | byte |  |
+| double | short |  |
 | double | integer |  |
-| double | long    |  |
-| double | float   |  |
-| double | string  | There can be differences in precision. For example, the input "1.4E-45" will produce 1.0E-45 instead of 1.4E-45 |
-| decimal | byte    |  |
-| decimal | short   |  |
+| double | long |  |
+| double | float |  |
+| double | string | There can be differences in precision. For example, the input "1.4E-45" will produce 1.0E-45 instead of 1.4E-45 |
+| decimal | byte |  |
+| decimal | short |  |
 | decimal | integer |  |
-| decimal | long    |  |
-| decimal | float   |  |
-| decimal | double  |  |
-| decimal | string  | There can be formatting differences in some case due to Spark using scientific notation where Comet does not |
-| decimal | decimal |  |
+| decimal | long |  |
+| decimal | float |  |
+| decimal | double |  |
+| decimal | string | There can be formatting differences in some case due to Spark using scientific notation where Comet does not |
 | string | boolean |  |
-| string | byte    |  |
-| string | short   |  |
+| string | byte |  |
+| string | short |  |
 | string | integer |  |
-| string | long    |  |
-| string | binary  |  |
-| string | date    | Only supports years between 262143 BC and 262142 AD |
-| date | string  |  |
-| timestamp | long    |  |
-| timestamp | string  |  |
-| timestamp | date    |  |
+| string | long |  |
+| string | binary |  |
+| string | date | Only supports years between 262143 BC and 262142 AD |
+| date | string |  |
+| timestamp | long |  |
+| timestamp | string |  |
+| timestamp | date |  |
 
 ### Incompatible Casts
 

--- a/spark/src/main/scala/org/apache/comet/GenerateDocs.scala
+++ b/spark/src/main/scala/org/apache/comet/GenerateDocs.scala
@@ -69,7 +69,8 @@ object GenerateDocs {
         w.write("|-|-|-|\n".getBytes)
         for (fromType <- CometCast.supportedTypes) {
           for (toType <- CometCast.supportedTypes) {
-            if (Cast.canCast(fromType, toType) && fromType != toType) {
+            if (Cast.canCast(fromType, toType) && (fromType != toType || fromType.typeName
+                .contains("decimal"))) {
               val fromTypeName = fromType.typeName.replace("(10,2)", "")
               val toTypeName = toType.typeName.replace("(10,2)", "")
               CometCast.isSupported(fromType, toType, None, CometEvalMode.LEGACY) match {

--- a/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
+++ b/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
@@ -70,13 +70,8 @@ object CometCast {
           case _ =>
             Unsupported
         }
-      case (from: DecimalType, to: DecimalType) =>
-        if (to.precision < from.precision) {
-          // https://github.com/apache/datafusion/issues/13492
-          Incompatible(Some("Casting to smaller precision is not supported"))
-        } else {
-          Compatible()
-        }
+      case (_: DecimalType, _: DecimalType) =>
+        Compatible()
       case (DataTypes.StringType, _) =>
         canCastFromString(toType, timeZoneId, evalMode)
       case (_, DataTypes.StringType) =>

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -1214,10 +1214,13 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
                 if (cometException.getCause != null) cometException.getCause.getMessage
                 else cometException.getMessage
               // for comet decimal conversion throws ArrowError(string) from arrow - across spark versions the message dont match.
-              if (sparkMessage.contains("cannot be represented as")) {
-                cometMessage.contains("cannot be represented as") || cometMessage.contains(
-                  "too large to store")
+              if (df.schema("a").dataType.typeName.contains("decimal") && toType.typeName
+                  .contains("decimal")) {
+                assert(
+                  cometMessage.contains("too large to store"),
+                  sparkMessage.contains("cannot be represented as"))
               } else {
+
                 if (CometSparkSessionExtensions.isSpark40Plus) {
                   // for Spark 4 we expect to sparkException carries the message
                   assert(
@@ -1236,7 +1239,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
                     .replace("[NUMERIC_VALUE_OUT_OF_RANGE] ", "")
 
                   if (sparkMessage.contains("cannot be represented as")) {
-                    assert(cometMessage.contains("too large to store"))
+                    assert(cometMessage.contains("cannot be represented as"))
                   } else {
                     assert(cometMessageModified == sparkMessage)
                   }

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -1215,9 +1215,8 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
                 else cometException.getMessage
               // for comet decimal conversion throws ArrowError(string) from arrow - across spark versions the message dont match.
               if (sparkMessage.contains("cannot be represented as")) {
-                assert(
-                  cometMessage.contains("cannot be represented as") || cometMessage.contains(
-                    "too large to store"))
+                cometMessage.contains("cannot be represented as") || cometMessage.contains(
+                  "too large to store")
               } else {
                 if (CometSparkSessionExtensions.isSpark40Plus) {
                   // for Spark 4 we expect to sparkException carries the message

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -1213,14 +1213,11 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
               val cometMessage =
                 if (cometException.getCause != null) cometException.getCause.getMessage
                 else cometException.getMessage
-              // for comet decimal conversion throws ArrowError(string) from arrow - across spark versions the message dont match.
+              // this if branch should only check decimal to decimal cast and errors when output precision, scale causes overflow.
               if (df.schema("a").dataType.typeName.contains("decimal") && toType.typeName
-                  .contains("decimal")) {
-                assert(
-                  cometMessage.contains("too large to store") ==
-                    sparkMessage.contains("cannot be represented as"))
+                  .contains("decimal") && sparkMessage.contains("cannot be represented as")) {
+                assert(cometMessage.contains("too large to store"))
               } else {
-
                 if (CometSparkSessionExtensions.isSpark40Plus) {
                   // for Spark 4 we expect to sparkException carries the message
                   assert(

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -1237,9 +1237,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
                     .replace("[NUMERIC_VALUE_OUT_OF_RANGE] ", "")
 
                   if (sparkMessage.contains("cannot be represented as")) {
-                    assert(
-                      cometMessage.contains("cannot be represented as") || cometMessage.contains(
-                        "too large to store"))
+                    assert(cometMessage.contains("too large to store"))
                   } else {
                     assert(cometMessageModified == sparkMessage)
                   }

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -1217,8 +1217,8 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
               if (df.schema("a").dataType.typeName.contains("decimal") && toType.typeName
                   .contains("decimal")) {
                 assert(
-                  cometMessage.contains("too large to store"),
-                  sparkMessage.contains("cannot be represented as"))
+                  cometMessage.contains("too large to store") ==
+                    sparkMessage.contains("cannot be represented as"))
               } else {
 
                 if (CometSparkSessionExtensions.isSpark40Plus) {


### PR DESCRIPTION
Closes #375 

- enable decimal to decimal
-  remove hard coded  castoptions to pass to native execution
- fixed castTest to match arrow invalid argument error with spark's Number out of range error.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
