### PR TITLE
fix: Passthrough condition in StaticInvoke case block

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -2129,7 +2129,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
       // See https://github.com/apache/spark/pull/38151
       case s: StaticInvoke
           // classOf gets ther runtime class of T, which lets us compare directly
-          // Otherwise isInstanceOf[Class[_]] will always evaluate to true
+          // Otherwise isInstanceOf[Class[T]] will always evaluate to true for Class[_]
           if s.staticObject == classOf[CharVarcharCodegenUtils] &&
             s.dataType.isInstanceOf[StringType] &&
             s.functionName == "readSidePadding" &&

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -2128,7 +2128,9 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
       // char types.
       // See https://github.com/apache/spark/pull/38151
       case s: StaticInvoke
-          if s.staticObject.isInstanceOf[Class[CharVarcharCodegenUtils]] &&
+          // classOf gets ther runtime class of T, which lets us compare directly
+          // Otherwise isInstanceOf[Class[_]] will always evaluate to true
+          if s.staticObject == classOf[CharVarcharCodegenUtils] &&
             s.dataType.isInstanceOf[StringType] &&
             s.functionName == "readSidePadding" &&
             s.arguments.size == 2 &&


### PR DESCRIPTION
## Which issue does this PR close?

Closes #1391 .

## Rationale for this change

It is a logic error.

## What changes are included in this PR?

Moved to a direct comparator instead of checking that Class isInstanceOf Class

## How are these changes tested?

I believe this is an inherent language feature, it does not need a TestSuite.