### PR TITLE
perf: Use DataFusion FilterExec for experimental native scans

### DIFF
--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -2885,6 +2885,7 @@ mod tests {
             children: vec![child_op],
             op_struct: Some(OpStruct::Filter(spark_operator::Filter {
                 predicate: Some(expr),
+                use_datafusion_filter: false,
             })),
         }
     }

--- a/native/proto/src/proto/operator.proto
+++ b/native/proto/src/proto/operator.proto
@@ -99,6 +99,7 @@ message Projection {
 
 message Filter {
   spark.spark_expression.Expr predicate = 1;
+  bool use_datafusion_filter = 2;
 }
 
 message Sort {

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -2725,12 +2725,8 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
             .newBuilder()
             .setPredicate(cond.get)
             .setUseDatafusionFilter(
-              CometConf.COMET_NATIVE_SCAN_IMPL
-                .get()
-                .equals(CometConf.SCAN_NATIVE_DATAFUSION) ||
-                CometConf.COMET_NATIVE_SCAN_IMPL
-                  .get()
-                  .equals(CometConf.SCAN_NATIVE_ICEBERG_COMPAT))
+              CometConf.COMET_NATIVE_SCAN_IMPL.get() == CometConf.SCAN_NATIVE_DATAFUSION ||
+                CometConf.COMET_NATIVE_SCAN_IMPL.get() == CometConf.SCAN_NATIVE_ICEBERG_COMPAT)
           Some(result.setFilter(filterBuilder).build())
         } else {
           withInfo(op, condition, child)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently Comet has a copy of DataFusion's FilterExec that is modified to do a deep copy of a batch, even if the entire batch passes the filter predicate. https://github.com/apache/datafusion-comet/blob/4fe4f57da6339a5d66114750aee915525e601d4d/native/core/src/execution/operators/filter.rs#L487

This behavior exists because the underlying Comet Scan behavior is to reuse buffers, so it is not safe to pass pointers to them into downstream operators.

However, the experimental native scans do not have this behavior (@parthchandra please confirm this optimization is safe for `native_iceberg_compat`) , so we can use DataFusion's FilterExec, and benefit from the zero-copy fast path.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->



- Added boolean field to Filter's proto, set in QueryPlanSerde based on Comet native scan implementation configuration
- planner.rs uses that field to construct the correct FilterExec implementation
- I also think my IDEs optimized the imports on the touched files. I ran `make format` so it should still be compliant, but let me know if you don't like the style.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Local tests since the native scans are still experimental and not tested in CI.

Old behavior with `native_datafusion` (note the CometFilterExec):
```
25/02/12 16:13:08 INFO core/src/execution/jni_api.rs: Comet native query plan:
ProjectionExec: expr=[_4@0 as col_0]
  CometFilterExec: _20@2 IS NOT NULL AND _18@1 IS NOT NULL AND _20@2 > 2020-01-01 AND _18@1 < 1577865600000000
    ParquetExec: file_groups={1 group: [[private/var/folders/12/4pf3d5zn72n7q2_0ks3bkh7c0000gn/T/spark-36572425-4cac-4e78-89f5-c93e48a1e020/test.parquet:0..525155]]}, projection=[_4, _18, _20], predicate=_20@2 IS NOT NULL AND _18@1 IS NOT NULL AND _20@2 > 2020-01-01 AND _18@1 < 1577865600000000, pruning_predicate=_20_null_count@1 != _20_row_count@0 AND _18_null_count@3 != _18_row_count@2 AND _20_null_count@1 != _20_row_count@0 AND _20_max@4 > 2020-01-01 AND _18_null_count@3 != _18_row_count@2 AND _18_min@5 < 1577865600000000, required_guarantees=[]
```

This PR with `native_datafusion`:
```
25/02/12 16:22:55 INFO core/src/execution/jni_api.rs: Comet native query plan:
ProjectionExec: expr=[_4@0 as col_0]
  FilterExec: _20@2 IS NOT NULL AND _18@1 IS NOT NULL AND _20@2 > 2020-01-01 AND _18@1 < 1577865600000000
    ParquetExec: file_groups={1 group: [[private/var/folders/12/4pf3d5zn72n7q2_0ks3bkh7c0000gn/T/spark-a48c760f-bed8-4b8b-94e9-33aae7e12f84/test.parquet:0..523985]]}, projection=[_4, _18, _20], predicate=_20@2 IS NOT NULL AND _18@1 IS NOT NULL AND _20@2 > 2020-01-01 AND _18@1 < 1577865600000000, pruning_predicate=_20_null_count@1 != _20_row_count@0 AND _18_null_count@3 != _18_row_count@2 AND _20_null_count@1 != _20_row_count@0 AND _20_max@4 > 2020-01-01 AND _18_null_count@3 != _18_row_count@2 AND _18_min@5 < 1577865600000000, required_guarantees=[]
```