### PR TITLE
perf: Update RewriteJoin logic to choose optimal build side

### DIFF
--- a/spark/src/main/scala/org/apache/comet/rules/RewriteJoin.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/RewriteJoin.scala
@@ -20,6 +20,7 @@
 package org.apache.comet.rules
 
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide, JoinSelectionHelper}
+import org.apache.spark.sql.catalyst.plans.LeftSemi
 import org.apache.spark.sql.catalyst.plans.logical.Join
 import org.apache.spark.sql.execution.{SortExec, SparkPlan}
 import org.apache.spark.sql.execution.joins.{ShuffledHashJoinExec, SortMergeJoinExec}
@@ -64,6 +65,10 @@ object RewriteJoin extends JoinSelectionHelper {
   def rewrite(plan: SparkPlan): SparkPlan = plan match {
     case smj: SortMergeJoinExec =>
       getSmjBuildSide(smj) match {
+        case Some(BuildRight) if smj.joinType == LeftSemi =>
+          // TODO this was added as a workaround for TPC-DS q14 hanging and needs
+          // further investigation
+          plan
         case Some(buildSide) =>
           ShuffledHashJoinExec(
             smj.leftKeys,
@@ -90,7 +95,7 @@ object RewriteJoin extends JoinSelectionHelper {
       }
       return BuildLeft
     }
-    if (rightSize <= leftSize) {
+    if (rightRowCount <= leftRowCount) {
       return BuildRight
     }
     BuildLeft

--- a/spark/src/main/scala/org/apache/comet/rules/RewriteJoin.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/RewriteJoin.scala
@@ -20,8 +20,8 @@
 package org.apache.comet.rules
 
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide, JoinSelectionHelper}
-import org.apache.spark.sql.catalyst.plans.{JoinType, LeftSemi}
-import org.apache.spark.sql.execution.{SortExec, SparkPlan}
+import org.apache.spark.sql.catalyst.plans.logical.Join
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.joins.{ShuffledHashJoinExec, SortMergeJoinExec}
 
 /**
@@ -31,28 +31,34 @@ import org.apache.spark.sql.execution.joins.{ShuffledHashJoinExec, SortMergeJoin
  */
 object RewriteJoin extends JoinSelectionHelper {
 
-  private def getBuildSide(joinType: JoinType): Option[BuildSide] = {
-    if (canBuildShuffledHashJoinRight(joinType)) {
-      Some(BuildRight)
-    } else if (canBuildShuffledHashJoinLeft(joinType)) {
-      Some(BuildLeft)
-    } else {
-      None
+  private def getSmjBuildSide(join: SortMergeJoinExec): Option[BuildSide] = {
+    val leftBuildable = canBuildShuffledHashJoinLeft(join.joinType)
+    val rightBuildable = canBuildShuffledHashJoinRight(join.joinType)
+    if (!leftBuildable && !rightBuildable) {
+      return None
     }
-  }
-
-  private def removeSort(plan: SparkPlan) = plan match {
-    case _: SortExec => plan.children.head
-    case _ => plan
+    if (!leftBuildable) {
+      return Some(BuildRight)
+    }
+    if (!rightBuildable) {
+      return Some(BuildLeft)
+    }
+    val side = join.logicalLink
+      .flatMap {
+        case join: Join => Some(getOptimalBuildSide(join))
+        case _ => None
+      }
+      .getOrElse {
+        // If smj has no logical link, or its logical link is not a join,
+        // then we always choose left as build side.
+        BuildLeft
+      }
+    Some(side)
   }
 
   def rewrite(plan: SparkPlan): SparkPlan = plan match {
     case smj: SortMergeJoinExec =>
-      getBuildSide(smj.joinType) match {
-        case Some(BuildRight) if smj.joinType == LeftSemi =>
-          // TODO this was added as a workaround for TPC-DS q14 hanging and needs
-          // further investigation
-          plan
+      getSmjBuildSide(smj) match {
         case Some(buildSide) =>
           ShuffledHashJoinExec(
             smj.leftKeys,
@@ -60,11 +66,28 @@ object RewriteJoin extends JoinSelectionHelper {
             smj.joinType,
             buildSide,
             smj.condition,
-            removeSort(smj.left),
-            removeSort(smj.right),
+            smj.left,
+            smj.right,
             smj.isSkewJoin)
         case _ => plan
       }
     case _ => plan
+  }
+
+  def getOptimalBuildSide(join: Join): BuildSide = {
+    val leftSize = join.left.stats.sizeInBytes
+    val rightSize = join.right.stats.sizeInBytes
+    val leftRowCount = join.left.stats.rowCount
+    val rightRowCount = join.right.stats.rowCount
+    if (leftSize == rightSize && rightRowCount.isDefined && leftRowCount.isDefined) {
+      if (rightRowCount.get <= leftRowCount.get) {
+        return BuildRight
+      }
+      return BuildLeft
+    }
+    if (rightSize <= leftSize) {
+      return BuildRight
+    }
+    BuildLeft
   }
 }

--- a/spark/src/main/scala/org/apache/comet/rules/RewriteJoin.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/RewriteJoin.scala
@@ -95,7 +95,7 @@ object RewriteJoin extends JoinSelectionHelper {
       }
       return BuildLeft
     }
-    if (rightRowCount <= leftRowCount) {
+    if (rightSize <= leftSize) {
       return BuildRight
     }
     BuildLeft


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/apache/datafusion-comet/issues/1382

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The main goal of this PR is to try and choose smaller side of join for build-side.

With this PR, many queries are now faster when compared to the 0.6.0 release.

![tpch_queries_speedup_rel](https://github.com/user-attachments/assets/20798a59-a4f3-466c-a16b-0672d092b8e2)

Total time for TPC-H is 285 seconds, down from 330 seconds.

### Query 9 Before 
![2025-02-19_18-28](https://github.com/user-attachments/assets/b9d3b01c-3d2a-4638-90c1-3f0c22b3dff1)

### Query 9 After 
![2025-02-19_18-28_1](https://github.com/user-attachments/assets/764d4dab-486a-4e42-b25b-b1b0e1c446e6)

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Update RewreiteJoin to match latest version from Apache Gluten

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
