### PR TITLE
feat: Support IntegralDivide function

### DIFF
--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -136,16 +136,9 @@ struct JoinParameters {
     pub join_type: DFJoinType,
 }
 
+#[derive(Default)]
 struct BinaryExprOptions {
     pub is_integral_div: bool,
-}
-
-impl Default for BinaryExprOptions {
-    fn default() -> Self {
-        Self {
-            is_integral_div: false,
-        }
-    }
 }
 
 pub const TEST_EXEC_CONTEXT_ID: i64 = -1;

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -136,6 +136,18 @@ struct JoinParameters {
     pub join_type: DFJoinType,
 }
 
+struct BinaryExprOptions {
+    pub is_integral_div: bool,
+}
+
+impl Default for BinaryExprOptions {
+    fn default() -> Self {
+        Self {
+            is_integral_div: false,
+        }
+    }
+}
+
 pub const TEST_EXEC_CONTEXT_ID: i64 = -1;
 
 /// The query planner for converting Spark query plans to DataFusion query plans.
@@ -210,6 +222,16 @@ impl PhysicalPlanner {
                 expr.return_type.as_ref(),
                 DataFusionOperator::Divide,
                 input_schema,
+            ),
+            ExprStruct::IntegralDivide(expr) => self.create_binary_expr_with_options(
+                expr.left.as_ref().unwrap(),
+                expr.right.as_ref().unwrap(),
+                expr.return_type.as_ref(),
+                DataFusionOperator::Divide,
+                input_schema,
+                BinaryExprOptions {
+                    is_integral_div: true,
+                },
             ),
             ExprStruct::Remainder(expr) => self.create_binary_expr(
                 expr.left.as_ref().unwrap(),
@@ -874,6 +896,25 @@ impl PhysicalPlanner {
         op: DataFusionOperator,
         input_schema: SchemaRef,
     ) -> Result<Arc<dyn PhysicalExpr>, ExecutionError> {
+        self.create_binary_expr_with_options(
+            left,
+            right,
+            return_type,
+            op,
+            input_schema,
+            BinaryExprOptions::default(),
+        )
+    }
+
+    fn create_binary_expr_with_options(
+        &self,
+        left: &Expr,
+        right: &Expr,
+        return_type: Option<&spark_expression::DataType>,
+        op: DataFusionOperator,
+        input_schema: SchemaRef,
+        options: BinaryExprOptions,
+    ) -> Result<Arc<dyn PhysicalExpr>, ExecutionError> {
         let left = self.create_expr(left, Arc::clone(&input_schema))?;
         let right = self.create_expr(right, Arc::clone(&input_schema))?;
         match (
@@ -922,13 +963,18 @@ impl PhysicalPlanner {
                 Ok(DataType::Decimal128(_p2, _s2)),
             ) => {
                 let data_type = return_type.map(to_arrow_datatype).unwrap();
+                let func_name = if options.is_integral_div {
+                    "decimal_integral_div"
+                } else {
+                    "decimal_div"
+                };
                 let fun_expr = create_comet_physical_fun(
-                    "decimal_div",
+                    func_name,
                     data_type.clone(),
                     &self.session_ctx.state(),
                 )?;
                 Ok(Arc::new(ScalarFunctionExpr::new(
-                    "decimal_div",
+                    func_name,
                     fun_expr,
                     vec![left, right],
                     data_type,

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -957,6 +957,9 @@ impl PhysicalPlanner {
             ) => {
                 let data_type = return_type.map(to_arrow_datatype).unwrap();
                 let func_name = if options.is_integral_div {
+                    // Decimal256 division in Arrow may overflow, so we still need this variant of decimal_div.
+                    // Otherwise, we may be able to reuse the previous case-match instead of here,
+                    // see more: https://github.com/apache/datafusion-comet/pull/1428#discussion_r1972648463
                     "decimal_integral_div"
                 } else {
                     "decimal_div"

--- a/native/proto/src/proto/expr.proto
+++ b/native/proto/src/proto/expr.proto
@@ -89,6 +89,7 @@ message Expr {
     BinaryExpr array_intersect = 62;
     ArrayJoin array_join = 63;
     BinaryExpr arrays_overlap = 64;
+    MathExpr integral_divide = 65;
   }
 }
 

--- a/native/spark-expr/benches/decimal_div.rs
+++ b/native/spark-expr/benches/decimal_div.rs
@@ -19,7 +19,7 @@ use arrow::compute::cast;
 use arrow_array::builder::Decimal128Builder;
 use arrow_schema::DataType;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use datafusion_comet_spark_expr::spark_decimal_div;
+use datafusion_comet_spark_expr::{spark_decimal_div, spark_decimal_integral_div};
 use datafusion_expr::ColumnarValue;
 use std::sync::Arc;
 
@@ -40,9 +40,20 @@ fn criterion_benchmark(c: &mut Criterion) {
     let c2 = cast(c2.as_ref(), &c2_type).unwrap();
 
     let args = [ColumnarValue::Array(c1), ColumnarValue::Array(c2)];
-    c.bench_function("decimal_div", |b| {
+
+    let mut group = c.benchmark_group("decimal div");
+    group.bench_function("decimal_div", |b| {
         b.iter(|| {
             black_box(spark_decimal_div(
+                black_box(&args),
+                black_box(&DataType::Decimal128(10, 4)),
+            ))
+        })
+    });
+
+    group.bench_function("decimal_integral_div", |b| {
+        b.iter(|| {
+            black_box(spark_decimal_integral_div(
                 black_box(&args),
                 black_box(&DataType::Decimal128(10, 4)),
             ))

--- a/native/spark-expr/src/comet_scalar_funcs.rs
+++ b/native/spark-expr/src/comet_scalar_funcs.rs
@@ -17,9 +17,9 @@
 
 use crate::hash_funcs::*;
 use crate::{
-    spark_ceil, spark_date_add, spark_date_sub, spark_decimal_div, spark_floor, spark_hex,
-    spark_isnan, spark_make_decimal, spark_read_side_padding, spark_round, spark_unhex,
-    spark_unscaled_value, SparkChrFunc,
+    spark_ceil, spark_date_add, spark_date_sub, spark_decimal_div, spark_decimal_integral_div,
+    spark_floor, spark_hex, spark_isnan, spark_make_decimal, spark_read_side_padding, spark_round,
+    spark_unhex, spark_unscaled_value, SparkChrFunc,
 };
 use arrow_schema::DataType;
 use datafusion_common::{DataFusionError, Result as DataFusionResult};
@@ -89,6 +89,13 @@ pub fn create_comet_physical_fun(
         }
         "decimal_div" => {
             make_comet_scalar_udf!("decimal_div", spark_decimal_div, data_type)
+        }
+        "decimal_integral_div" => {
+            make_comet_scalar_udf!(
+                "decimal_integral_div",
+                spark_decimal_integral_div,
+                data_type
+            )
         }
         "murmur3_hash" => {
             let func = Arc::new(spark_murmur3_hash);

--- a/native/spark-expr/src/lib.rs
+++ b/native/spark-expr/src/lib.rs
@@ -67,9 +67,9 @@ pub use error::{SparkError, SparkResult};
 pub use hash_funcs::*;
 pub use json_funcs::ToJson;
 pub use math_funcs::{
-    create_negate_expr, spark_ceil, spark_decimal_div, spark_floor, spark_hex, spark_make_decimal,
-    spark_round, spark_unhex, spark_unscaled_value, CheckOverflow, NegativeExpr,
-    NormalizeNaNAndZero,
+    create_negate_expr, spark_ceil, spark_decimal_div, spark_decimal_integral_div, spark_floor,
+    spark_hex, spark_make_decimal, spark_round, spark_unhex, spark_unscaled_value, CheckOverflow,
+    NegativeExpr, NormalizeNaNAndZero,
 };
 pub use string_funcs::*;
 

--- a/native/spark-expr/src/math_funcs/div.rs
+++ b/native/spark-expr/src/math_funcs/div.rs
@@ -86,12 +86,10 @@ fn spark_decimal_div_internal(
             let div = if r.eq(&zero) { zero.clone() } else { &l / &r };
             let res = if is_integral_div {
                 div
+            } else if div.is_negative() {
+                div - &five
             } else {
-                if div.is_negative() {
-                    div - &five
-                } else {
-                    div + &five
-                }
+                div + &five
             } / &ten;
             res.to_i128().unwrap_or(i128::MAX)
         })?
@@ -104,12 +102,10 @@ fn spark_decimal_div_internal(
             let div = if r == 0 { 0 } else { l / r };
             let res = if is_integral_div {
                 div
+            } else if div.is_negative() {
+                div - 5
             } else {
-                if div.is_negative() {
-                    div - 5
-                } else {
-                    div + 5
-                }
+                div + 5
             } / 10;
             res.to_i128().unwrap_or(i128::MAX)
         })?

--- a/native/spark-expr/src/math_funcs/mod.rs
+++ b/native/spark-expr/src/math_funcs/mod.rs
@@ -27,6 +27,7 @@ mod utils;
 
 pub use ceil::spark_ceil;
 pub use div::spark_decimal_div;
+pub use div::spark_decimal_integral_div;
 pub use floor::spark_floor;
 pub use hex::spark_hex;
 pub use internal::*;

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -632,7 +632,7 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
         None
 
       case IntegralDivide(left, right, evalMode)
-        if supportedDataType(left.dataType) && !decimalBeforeSpark34(left.dataType) =>
+          if supportedDataType(left.dataType) && !decimalBeforeSpark34(left.dataType) =>
         // convert IntegralDivide(...) to Cast(Divide(...), LongType)
         exprToProtoInternal(Cast(Divide(left, right, evalMode), LongType), inputs, binding)
 

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -20,6 +20,7 @@
 package org.apache.comet.serde
 
 import scala.collection.JavaConverters._
+import scala.math.min
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
@@ -637,7 +638,9 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
 
         val dataType = (left.dataType, right.dataType) match {
           case (l: DecimalType, r: DecimalType) =>
-            div.resultDecimalType(l.precision, l.scale, r.precision, r.scale)
+            // copy from IntegralDivide.resultDecimalType
+            val intDig = l.precision - l.scale + r.scale
+            DecimalType(min(if (intDig == 0) 1 else intDig, DecimalType.MAX_PRECISION), 0)
           case _ => left.dataType
         }
 

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -2648,9 +2648,12 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       sql("insert into t1 values(10, 0), (52, 10)")
       checkSparkAnswerAndOperator("select c1 div c2, div(c1, c2) from t1 order by c1")
 
-      sql("create table t2(c1 decimal(10, 2), c2 decimal(10, 2)) using parquet")
-      sql("insert into t2 values(15.09, 5.0), (13.2, 2), (18.66, 0)")
-      checkSparkAnswerAndOperator("select c1 div c2, div(c1, c2) from t2 order by c1")
+      if (isSpark34Plus) {
+        // Decimal support requires Spark 3.4 or later
+        sql("create table t2(c1 decimal(10, 2), c2 decimal(10, 2)) using parquet")
+        sql("insert into t2 values(15.09, 5.0), (13.2, 2), (18.66, 0)")
+        checkSparkAnswerAndOperator("select c1 div c2, div(c1, c2) from t2 order by c1")
+      }
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -2641,4 +2641,17 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("test integral divide") {
+    withTable("t1", "t2") {
+      sql(s"create table t1(c1 long, c2 int) using parquet")
+      // TODO: COMET-1412: Support warping div on overflow for Long.MinValue / -1
+      sql(s"insert into t1 values(10, 0), (52, 10)")
+      checkSparkAnswerAndOperator("select c1 div c2, div(c1, c2) from t1 order by c1")
+
+      sql(s"create table t2(c1 decimal(10, 2), c2 decimal(10, 2)) using parquet")
+      sql(s"insert into t2 values(15.09, 5.0), (13.2, 2), (18.66, 0)")
+      checkSparkAnswerAndOperator("select c1 div c2, div(c1, c2) from t2 order by c1")
+    }
+  }
+
 }

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1811,7 +1811,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
             "spark.sql.decimalOperations.allowPrecisionLoss" -> allowPrecisionLoss.toString) {
             val a = makeNum(p1, s1)
             val b = makeNum(p2, s2)
-            var ops = Seq("+", "-", "*", "/", "%")
+            val ops = Seq("+", "-", "*", "/", "%", "div")
             for (op <- ops) {
               checkSparkAnswerAndOperator(s"select a, b, a $op b from $table")
               checkSparkAnswerAndOperator(s"select $a, b, $a $op b from $table")

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -2643,13 +2643,13 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
 
   test("test integral divide") {
     withTable("t1", "t2") {
-      sql(s"create table t1(c1 long, c2 int) using parquet")
+      sql("create table t1(c1 long, c2 int) using parquet")
       // TODO: COMET-1412: Support warping div on overflow for Long.MinValue / -1
-      sql(s"insert into t1 values(10, 0), (52, 10)")
+      sql("insert into t1 values(10, 0), (52, 10)")
       checkSparkAnswerAndOperator("select c1 div c2, div(c1, c2) from t1 order by c1")
 
-      sql(s"create table t2(c1 decimal(10, 2), c2 decimal(10, 2)) using parquet")
-      sql(s"insert into t2 values(15.09, 5.0), (13.2, 2), (18.66, 0)")
+      sql("create table t2(c1 decimal(10, 2), c2 decimal(10, 2)) using parquet")
+      sql("insert into t2 values(15.09, 5.0), (13.2, 2), (18.66, 0)")
       checkSparkAnswerAndOperator("select c1 div c2, div(c1, c2) from t2 order by c1")
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -19,6 +19,8 @@
 
 package org.apache.spark.sql
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
@@ -461,6 +463,7 @@ abstract class CometTestBase
          |  optional INT64                    _18(TIMESTAMP(MILLIS,true));
          |  optional INT64                    _19(TIMESTAMP(MICROS,true));
          |  optional INT32                    _20(DATE);
+         |  optional INT32                    _id;
          |}
         """.stripMargin
       } else {
@@ -486,6 +489,7 @@ abstract class CometTestBase
          |  optional INT64                    _18(TIMESTAMP(MILLIS,true));
          |  optional INT64                    _19(TIMESTAMP(MICROS,true));
          |  optional INT32                    _20(DATE);
+         |  optional INT32                    _id;
          |}
         """.stripMargin
       }
@@ -514,6 +518,7 @@ abstract class CometTestBase
          |  optional INT64                    _18(TIMESTAMP(MILLIS,true));
          |  optional INT64                    _19(TIMESTAMP(MICROS,true));
          |  optional INT32                    _20(DATE);
+         |  optional INT32                    _id;
          |}
         """.stripMargin
       } else {
@@ -539,6 +544,7 @@ abstract class CometTestBase
          |  optional INT64                    _18(TIMESTAMP(MILLIS,true));
          |  optional INT64                    _19(TIMESTAMP(MICROS,true));
          |  optional INT32                    _20(DATE);
+         |  optional INT32                    _id;
          |}
         """.stripMargin
       }
@@ -563,6 +569,8 @@ abstract class CometTestBase
       dictionaryEnabled = dictionaryEnabled,
       pageSize = pageSize,
       dictionaryPageSize = pageSize)
+
+    val idGenerator = new AtomicInteger(0)
 
     val rand = scala.util.Random
     val data = (begin until end).map { i =>
@@ -596,6 +604,7 @@ abstract class CometTestBase
           record.add(17, i.toLong)
           record.add(18, i.toLong)
           record.add(19, i)
+          record.add(20, idGenerator.getAndIncrement())
         case _ =>
       }
       writer.write(record)
@@ -623,6 +632,7 @@ abstract class CometTestBase
       record.add(17, i)
       record.add(18, i)
       record.add(19, i.toInt)
+      record.add(20, idGenerator.getAndIncrement())
       writer.write(record)
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1422.

## Rationale for this change

Support IntegralDivide function

## What changes are included in this PR?

Since datafusion div operator conforms to the logic of intergal div, we only need to convert `IntegralDivide(...)` to `Cast(Divide(...), LongType)` and then convert it to native.

## How are these changes tested?

added unit test
