### PR TITLE
chore: Update protobuf to 3.25.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@ under the License.
     <spark.version>3.4.3</spark.version>
     <spark.version.short>3.4</spark.version.short>
     <spark.maven.scope>provided</spark.maven.scope>
-    <protobuf.version>3.21.12</protobuf.version>
+    <protobuf.version>3.25.5</protobuf.version>
     <parquet.version>1.13.1</parquet.version>
     <parquet.maven.scope>provided</parquet.maven.scope>
     <arrow.version>16.0.0</arrow.version>


### PR DESCRIPTION
## Which issue does this PR close?

## Rationale for this change

To fix [CVE-2024-7254](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-7254)

## What changes are included in this PR?

Update protobuf to 3.25.5

## How are these changes tested?

CI