### PR TITLE
chore: Update guava to 33.2.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@ under the License.
     <jacoco.version>0.8.11</jacoco.version>
     <semanticdb.version>4.8.8</semanticdb.version>
     <slf4j.version>2.0.6</slf4j.version>
+    <guava.version>33.2.1-jre</guava.version>
     <jni.dir>${project.basedir}/../native/target/debug</jni.dir>
     <platform>darwin</platform>
     <arch>x86_64</arch>
@@ -259,7 +260,7 @@ under the License.
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>14.0.1</version>
+        <version>${guava.version}</version>
       </dependency>
       <!-- End of shaded deps -->
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -213,6 +213,10 @@ under the License.
                   <pattern>com.google.common</pattern>
                   <shadedPattern>${comet.shade.packageName}.guava</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>com.google.thirdparty</pattern>
+                  <shadedPattern>${comet.shade.packageName}.guava.thirdparty</shadedPattern>
+                </relocation>
               </relocations>
             </configuration>
           </execution>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -105,6 +105,12 @@ under the License.
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>


### PR DESCRIPTION
## Which issue does this PR close?

## Rationale for this change

To fix
[CVE-2023-2976](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2976)
[CVE-2020-8908](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908)
[CVE-2018-10237](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-10237)

## What changes are included in this PR?

Update guava to 33.2.1-jre

## How are these changes tested?

CI
