### PR TITLE
build: pin machete to version 0.7.0

### DIFF
--- a/.github/actions/rust-test/action.yaml
+++ b/.github/actions/rust-test/action.yaml
@@ -41,7 +41,7 @@ runs:
       shell: bash
       run: |
         cd native
-        cargo install cargo-machete && cargo machete
+        cargo install cargo-machete --version 0.7.0 && cargo machete
 
     - name: Cache Maven dependencies
       uses: actions/cache@v4


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

CI fails with the recently released machete 0.8.0

```
  Downloaded cargo-machete v0.8.0
error: failed to parse manifest at `/Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-machete-0.8.0/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.81.0 (2dbb1af80 2024-08-20)).
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
