### PR TITLE
perf: Reduce native shuffle memory overhead by 50%

### DIFF
--- a/native/core/src/execution/shuffle/shuffle_writer.rs
+++ b/native/core/src/execution/shuffle/shuffle_writer.rs
@@ -285,7 +285,6 @@ struct ShuffleRepartitioner {
     output_index_file: String,
     schema: SchemaRef,
     buffered_partitions: Vec<PartitionBuffer>,
-    /// Sort expressions
     /// Partitioning scheme to use
     partitioning: Partitioning,
     num_output_partitions: usize,
@@ -480,6 +479,9 @@ impl ShuffleRepartitioner {
                     buffered_partitions.len()
                 );
 
+                // TODO the single partition case could be optimized to avoid appending all
+                // rows from the batch into builders and then recreating the batch
+                // https://github.com/apache/datafusion-comet/issues/1453
                 let indices = (0..input.num_rows()).collect::<Vec<usize>>();
 
                 self.append_rows_to_partition(input.columns(), &indices, 0)

--- a/native/core/src/execution/shuffle/shuffle_writer.rs
+++ b/native/core/src/execution/shuffle/shuffle_writer.rs
@@ -1116,7 +1116,6 @@ mod test {
         assert!(repartitioner.buffered_partitions[1].spill_file.is_some());
 
         // after spill, all reservations should be freed
-        assert_eq!(0, repartitioner.reservation.size());
         assert_eq!(0, repartitioner.buffered_partitions[0].reservation.size());
         assert_eq!(0, repartitioner.buffered_partitions[1].reservation.size());
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/1448

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We were reserving memory twice in native shuffle, resulting in excessive shuffling.

Here are results for TPC-H q9 with 3GB off-heap memory allocated:

### Before (main branch)

```
        42.215020418167114,
        43.29415225982666,
        40.11583089828491,
        40.11201024055481,
        36.295708417892456
```

### After

```
        33.27595615386963,
        30.483699560165405,
        31.230262994766235,
        31.28650164604187,
        31.095990657806396
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Stop double reserving memory.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
