### PR TITLE
fix: Executor memory overhead overriding

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -1409,6 +1409,11 @@ object CometSparkSessionExtensions extends Logging {
     }
   }
 
+  /** Calculates Comet shuffle memory size in MB */
+  def getCometShuffleMemorySizeInMiB(sparkConf: SparkConf, conf: SQLConf = SQLConf.get): Long = {
+    ByteUnit.BYTE.toMiB(getCometShuffleMemorySize(sparkConf, conf))
+  }
+
   def cometUnifiedMemoryManagerEnabled(sparkConf: SparkConf): Boolean = {
     sparkConf.getBoolean("spark.memory.offHeap.enabled", false)
   }

--- a/spark/src/main/scala/org/apache/spark/Plugins.scala
+++ b/spark/src/main/scala/org/apache/spark/Plugins.scala
@@ -51,18 +51,17 @@ class CometDriverPlugin extends DriverPlugin with Logging with ShimCometDriverPl
     CometDriverPlugin.registerCometSessionExtension(sc.conf)
 
     if (shouldOverrideMemoryConf(sc.getConf)) {
-      val execMemOverhead =
-        if (sc.getConf.contains(EXECUTOR_MEMORY_OVERHEAD.key)) {
-          sc.getConf.getSizeAsMb(EXECUTOR_MEMORY_OVERHEAD.key)
-        } else {
-          // By default, executorMemory * spark.executor.memoryOverheadFactor, with minimum of 384MB
-          val executorMemory =
-            sc.getConf.getSizeAsMb(EXECUTOR_MEMORY.key, EXECUTOR_MEMORY_DEFAULT)
-          val memoryOverheadFactor = getMemoryOverheadFactor(sc.getConf)
-          val memoryOverheadMinMib = getMemoryOverheadMinMib(sc.getConf)
+      val execMemOverhead = if (sc.getConf.contains(EXECUTOR_MEMORY_OVERHEAD.key)) {
+        sc.getConf.getSizeAsMb(EXECUTOR_MEMORY_OVERHEAD.key)
+      } else {
+        // By default, executorMemory * spark.executor.memoryOverheadFactor, with minimum of 384MB
+        val executorMemory =
+          sc.getConf.getSizeAsMb(EXECUTOR_MEMORY.key, EXECUTOR_MEMORY_DEFAULT)
+        val memoryOverheadFactor = getMemoryOverheadFactor(sc.getConf)
+        val memoryOverheadMinMib = getMemoryOverheadMinMib(sc.getConf)
 
-          Math.max((executorMemory * memoryOverheadFactor).toLong, memoryOverheadMinMib)
-        }
+        Math.max((executorMemory * memoryOverheadFactor).toLong, memoryOverheadMinMib)
+      }
 
       val cometMemOverhead =
         if (!CometSparkSessionExtensions.cometUnifiedMemoryManagerEnabled(sc.getConf)) {
@@ -72,8 +71,7 @@ class CometDriverPlugin extends DriverPlugin with Logging with ShimCometDriverPl
           CometSparkSessionExtensions.getCometShuffleMemorySizeInMiB(sc.getConf)
         }
       sc.conf.set(EXECUTOR_MEMORY_OVERHEAD.key, s"${execMemOverhead + cometMemOverhead}M")
-      val newExecMemOverhead =
-        sc.getConf.getSizeAsMb(EXECUTOR_MEMORY_OVERHEAD.key)
+      val newExecMemOverhead = sc.getConf.getSizeAsMb(EXECUTOR_MEMORY_OVERHEAD.key)
 
       logInfo(s"""
          Overriding Spark memory configuration for Comet:
@@ -110,10 +108,8 @@ class CometDriverPlugin extends DriverPlugin with Logging with ShimCometDriverPl
         conf.getBoolean(
           CometConf.COMET_EXEC_ENABLED.key,
           CometConf.COMET_EXEC_ENABLED.defaultValue.get)
-    ) && (
-      !CometSparkSessionExtensions.cometUnifiedMemoryManagerEnabled(conf) ||
-        !CometSparkSessionExtensions.cometShuffleUnifiedMemoryManagerInTestEnabled(conf)
-    )
+    ) && (!CometSparkSessionExtensions.cometUnifiedMemoryManagerEnabled(conf) ||
+      !CometSparkSessionExtensions.cometShuffleUnifiedMemoryManagerInTestEnabled(conf))
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/Plugins.scala
+++ b/spark/src/main/scala/org/apache/spark/Plugins.scala
@@ -63,7 +63,8 @@ class CometDriverPlugin extends DriverPlugin with Logging with ShimCometDriverPl
       }
 
       // shouldOverrideMemoryConf guarantees that Comet is unified mode is disabled
-      val cometMemOverhead = CometSparkSessionExtensions.getCometShuffleMemorySizeInMiB(sc.getConf)
+      val cometMemOverhead =
+        CometSparkSessionExtensions.getCometShuffleMemorySizeInMiB(sc.getConf)
       sc.conf.set(EXECUTOR_MEMORY_OVERHEAD.key, s"${execMemOverhead + cometMemOverhead}M")
       val newExecMemOverhead = sc.getConf.getSizeAsMb(EXECUTOR_MEMORY_OVERHEAD.key)
 

--- a/spark/src/main/scala/org/apache/spark/Plugins.scala
+++ b/spark/src/main/scala/org/apache/spark/Plugins.scala
@@ -100,15 +100,19 @@ class CometDriverPlugin extends DriverPlugin with Logging with ShimCometDriverPl
    * unified memory manager.
    */
   private def shouldOverrideMemoryConf(conf: SparkConf): Boolean = {
-    conf.getBoolean(CometConf.COMET_ENABLED.key, true) && (
-      conf.getBoolean(
-        CometConf.COMET_EXEC_SHUFFLE_ENABLED.key,
-        CometConf.COMET_EXEC_SHUFFLE_ENABLED.defaultValue.get) ||
+    // short-circuit if InTestEnabled otherwise would always return true in production use
+    if (CometSparkSessionExtensions.cometShuffleUnifiedMemoryManagerInTestEnabled(conf)) {
+      false
+    } else {
+      conf.getBoolean(CometConf.COMET_ENABLED.key, true) && (
         conf.getBoolean(
-          CometConf.COMET_EXEC_ENABLED.key,
-          CometConf.COMET_EXEC_ENABLED.defaultValue.get)
-    ) && (!CometSparkSessionExtensions.cometUnifiedMemoryManagerEnabled(conf) ||
-      !CometSparkSessionExtensions.cometShuffleUnifiedMemoryManagerInTestEnabled(conf))
+          CometConf.COMET_EXEC_SHUFFLE_ENABLED.key,
+          CometConf.COMET_EXEC_SHUFFLE_ENABLED.defaultValue.get) ||
+          conf.getBoolean(
+            CometConf.COMET_EXEC_ENABLED.key,
+            CometConf.COMET_EXEC_ENABLED.defaultValue.get)
+      ) && (!CometSparkSessionExtensions.cometUnifiedMemoryManagerEnabled(conf))
+    }
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/Plugins.scala
+++ b/spark/src/main/scala/org/apache/spark/Plugins.scala
@@ -62,13 +62,8 @@ class CometDriverPlugin extends DriverPlugin with Logging with ShimCometDriverPl
         Math.max((executorMemory * memoryOverheadFactor).toLong, memoryOverheadMinMib)
       }
 
-      val cometMemOverhead =
-        if (CometSparkSessionExtensions.cometUnifiedMemoryManagerEnabled(sc.getConf)) {
-          CometSparkSessionExtensions.getCometMemoryOverheadInMiB(sc.getConf)
-        } else {
-          // comet shuffle unified memory manager is disabled, so we need to add overhead memory
-          CometSparkSessionExtensions.getCometShuffleMemorySizeInMiB(sc.getConf)
-        }
+      // shouldOverrideMemoryConf guarantees that Comet is unified mode is disabled
+      val cometMemOverhead = CometSparkSessionExtensions.getCometShuffleMemorySizeInMiB(sc.getConf)
       sc.conf.set(EXECUTOR_MEMORY_OVERHEAD.key, s"${execMemOverhead + cometMemOverhead}M")
       val newExecMemOverhead = sc.getConf.getSizeAsMb(EXECUTOR_MEMORY_OVERHEAD.key)
 

--- a/spark/src/main/scala/org/apache/spark/Plugins.scala
+++ b/spark/src/main/scala/org/apache/spark/Plugins.scala
@@ -63,11 +63,11 @@ class CometDriverPlugin extends DriverPlugin with Logging with ShimCometDriverPl
       }
 
       val cometMemOverhead =
-        if (!CometSparkSessionExtensions.cometUnifiedMemoryManagerEnabled(sc.getConf)) {
+        if (CometSparkSessionExtensions.cometUnifiedMemoryManagerEnabled(sc.getConf)) {
           CometSparkSessionExtensions.getCometMemoryOverheadInMiB(sc.getConf)
         } else {
           // comet shuffle unified memory manager is disabled, so we need to add overhead memory
-          CometSparkSessionExtensions.getCometShuffleMemorySize(sc.getConf)
+          CometSparkSessionExtensions.getCometShuffleMemorySizeInMiB(sc.getConf)
         }
       sc.conf.set(EXECUTOR_MEMORY_OVERHEAD.key, s"${execMemOverhead + cometMemOverhead}M")
       val newExecMemOverhead = sc.getConf.getSizeAsMb(EXECUTOR_MEMORY_OVERHEAD.key)

--- a/spark/src/test/scala/org/apache/spark/CometPluginsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/CometPluginsSuite.scala
@@ -143,3 +143,33 @@ class CometPluginsNonOverrideSuite extends CometTestBase {
     assert(execMemOverhead4 == "2G")
   }
 }
+
+class CometPluginsNonOverrideUnifiedModeSuite extends CometTestBase {
+  override protected def sparkConf: SparkConf = {
+    val conf = new SparkConf()
+    conf.set("spark.driver.memory", "1G")
+    conf.set("spark.executor.memory", "1G")
+    conf.set("spark.executor.memoryOverhead", "1G")
+    conf.set("spark.plugins", "org.apache.spark.CometPlugin")
+    conf.set("spark.comet.enabled", "true")
+    conf.set("spark.memory.offHeap.enabled", "true")
+    conf.set("spark.memory.offHeap.size", "2G")
+    conf.set("spark.comet.exec.shuffle.enabled", "true")
+    conf.set("spark.comet.exec.enabled", "true")
+    conf.set("spark.comet.memory.overhead.factor", "0.5")
+    conf
+  }
+
+  /** Since using unified memory, executor memory should not be overridden */
+  test("executor memory overhead is not overridden") {
+    val execMemOverhead1 = spark.conf.get("spark.executor.memoryOverhead")
+    val execMemOverhead2 = spark.sessionState.conf.getConfString("spark.executor.memoryOverhead")
+    val execMemOverhead3 = spark.sparkContext.getConf.get("spark.executor.memoryOverhead")
+    val execMemOverhead4 = spark.sparkContext.conf.get("spark.executor.memoryOverhead")
+
+    assert(execMemOverhead1 == "1G")
+    assert(execMemOverhead2 == "1G")
+    assert(execMemOverhead3 == "1G")
+    assert(execMemOverhead4 == "1G")
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/CometPluginsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/CometPluginsSuite.scala
@@ -144,7 +144,7 @@ class CometPluginsNonOverrideSuite extends CometTestBase {
   }
 }
 
-class CometPluginsNonOverrideUnifiedModeSuite extends CometTestBase {
+class CometPluginsUnifiedModeOverrideSuite extends CometTestBase {
   override protected def sparkConf: SparkConf = {
     val conf = new SparkConf()
     conf.set("spark.driver.memory", "1G")
@@ -161,15 +161,18 @@ class CometPluginsNonOverrideUnifiedModeSuite extends CometTestBase {
   }
 
   /** Since using unified memory, executor memory should not be overridden */
-  test("executor memory overhead is not overridden") {
+  test("executor memory overhead is correctly overridden") {
     val execMemOverhead1 = spark.conf.get("spark.executor.memoryOverhead")
     val execMemOverhead2 = spark.sessionState.conf.getConfString("spark.executor.memoryOverhead")
     val execMemOverhead3 = spark.sparkContext.getConf.get("spark.executor.memoryOverhead")
     val execMemOverhead4 = spark.sparkContext.conf.get("spark.executor.memoryOverhead")
 
-    assert(execMemOverhead1 == "1G")
-    assert(execMemOverhead2 == "1G")
-    assert(execMemOverhead3 == "1G")
-    assert(execMemOverhead4 == "1G")
+    // in unified memory mode, comet memory overhead is spark.memory.offHeap.size (2G) * spark.comet.memory.overhead.factor (0.5) = 1G
+    // so the total executor memory overhead is executor memory overhead (1G) + comet memory overhead (1G) = 2G
+    // and the overhead is overridden in MiB
+    assert(execMemOverhead1 == "2048M")
+    assert(execMemOverhead2 == "2048M")
+    assert(execMemOverhead3 == "2048M")
+    assert(execMemOverhead4 == "2048M")
   }
 }

--- a/spark/src/test/scala/org/apache/spark/CometPluginsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/CometPluginsSuite.scala
@@ -160,7 +160,10 @@ class CometPluginsUnifiedModeOverrideSuite extends CometTestBase {
     conf
   }
 
-  /** Since using unified memory, executor memory should not be overridden */
+  /*
+   * Since using unified memory, but not shuffle unified memory
+   * executor memory should be overridden by adding comet shuffle memory size
+   */
   test("executor memory overhead is correctly overridden") {
     val execMemOverhead1 = spark.conf.get("spark.executor.memoryOverhead")
     val execMemOverhead2 = spark.sessionState.conf.getConfString("spark.executor.memoryOverhead")


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1460 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Even when using unified memory, Comet would override `spark.executor.memoryOverhead` using inconsistent byte units.
This situation should not have happened in the first place.


## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fixes for
* `shouldOverrideMemoryConf`
* Adds result of `getCometShuffleMemorySizeInMiB` to executor memoryOverhead 

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Added `CometPluginsNonOverrideUnifiedModeSuite` to test that `spark.executor.memoryOverhead` is not overridden, which failed in previous versions.
