### PR TITLE
build: Use stable channel in rust-toolchain

### DIFF
--- a/native/core/benches/perf.rs
+++ b/native/core/benches/perf.rs
@@ -30,7 +30,7 @@ pub struct FlamegraphProfiler<'a> {
     active_profiler: Option<ProfilerGuard<'a>>,
 }
 
-impl<'a> FlamegraphProfiler<'a> {
+impl FlamegraphProfiler<'_> {
     pub fn new(frequency: c_int) -> Self {
         FlamegraphProfiler {
             frequency,
@@ -39,7 +39,7 @@ impl<'a> FlamegraphProfiler<'a> {
     }
 }
 
-impl<'a> Profiler for FlamegraphProfiler<'a> {
+impl Profiler for FlamegraphProfiler<'_> {
     fn start_profiling(&mut self, _benchmark_id: &str, _benchmark_dir: &Path) {
         self.active_profiler = Some(ProfilerGuard::new(self.frequency).unwrap());
     }

--- a/native/core/src/common/bit.rs
+++ b/native/core/src/common/bit.rs
@@ -901,7 +901,6 @@ impl BitReader {
     /// `T` needs to be a little-endian native type. The value is assumed to be byte
     /// aligned so the bit reader will be advanced to the start of the next byte before
     /// reading the value.
-
     /// Returns `Some` if there's enough bytes left to form a value of `T`.
     /// Otherwise `None`.
     pub fn get_aligned<T: FromBytes>(&mut self, num_bytes: usize) -> Option<T> {

--- a/native/core/src/errors.rs
+++ b/native/core/src/errors.rs
@@ -551,11 +551,13 @@ mod tests {
 
             let jvm = JavaVM::new(jvm_args).unwrap_or_else(|e| panic!("{:#?}", e));
 
+            #[allow(static_mut_refs)]
             unsafe {
                 JVM = Some(Arc::new(jvm));
             }
         });
 
+        #[allow(static_mut_refs)]
         unsafe { JVM.as_ref().unwrap() }
     }
 

--- a/native/core/src/errors.rs
+++ b/native/core/src/errors.rs
@@ -558,7 +558,9 @@ mod tests {
         });
 
         #[allow(static_mut_refs)]
-        unsafe { JVM.as_ref().unwrap() }
+        unsafe {
+            JVM.as_ref().unwrap()
+        }
     }
 
     fn attach_current_thread() -> AttachGuard<'static> {

--- a/native/core/src/execution/operators/scan.rs
+++ b/native/core/src/execution/operators/scan.rs
@@ -404,7 +404,7 @@ struct ScanStream<'a> {
     cast_time: Time,
 }
 
-impl<'a> ScanStream<'a> {
+impl ScanStream<'_> {
     pub fn new(
         scan: ScanExec,
         schema: SchemaRef,
@@ -453,7 +453,7 @@ impl<'a> ScanStream<'a> {
     }
 }
 
-impl<'a> Stream for ScanStream<'a> {
+impl Stream for ScanStream<'_> {
     type Item = DataFusionResult<RecordBatch>;
 
     fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -485,7 +485,7 @@ impl<'a> Stream for ScanStream<'a> {
     }
 }
 
-impl<'a> RecordBatchStream for ScanStream<'a> {
+impl RecordBatchStream for ScanStream<'_> {
     /// Get the schema
     fn schema(&self) -> SchemaRef {
         Arc::clone(&self.schema)

--- a/native/core/src/execution/sort.rs
+++ b/native/core/src/execution/sort.rs
@@ -20,7 +20,6 @@ use std::{cmp, mem, ptr};
 /// This is a copy of the `rdxsort-rs` crate, with the following changes:
 /// - removed `Rdx` implementations for all types except for i64 which is the packed representation
 ///   of row addresses and partition ids from Spark.
-
 pub trait Rdx {
     /// Sets the number of buckets used by the generic implementation.
     fn cfg_nbuckets() -> usize;

--- a/native/core/src/jvm_bridge/mod.rs
+++ b/native/core/src/jvm_bridge/mod.rs
@@ -209,9 +209,9 @@ pub struct JVMClasses<'a> {
     pub comet_task_memory_manager: CometTaskMemoryManager<'a>,
 }
 
-unsafe impl<'a> Send for JVMClasses<'a> {}
+unsafe impl Send for JVMClasses<'_> {}
 
-unsafe impl<'a> Sync for JVMClasses<'a> {}
+unsafe impl Sync for JVMClasses<'_> {}
 
 /// Keeps global references to JVM classes. Used for JNI calls to JVM.
 static JVM_CLASSES: OnceCell<JVMClasses> = OnceCell::new();

--- a/native/core/src/parquet/data_type.rs
+++ b/native/core/src/parquet/data_type.rs
@@ -68,7 +68,7 @@ impl AsBytes for Vec<u8> {
     }
 }
 
-impl<'a> AsBytes for &'a str {
+impl AsBytes for &str {
     fn as_bytes(&self) -> &[u8] {
         (self as &str).as_bytes()
     }

--- a/native/spark-expr/src/agg_funcs/variance.rs
+++ b/native/spark-expr/src/agg_funcs/variance.rs
@@ -229,7 +229,7 @@ impl Accumulator for VarianceAccumulator {
         };
 
         Ok(ScalarValue::Float64(match self.count {
-            count if count == 0.0 => None,
+            0.0 => None,
             count if count == 1.0 && StatsType::Sample == self.stats_type => {
                 if self.null_on_divide_by_zero {
                     None

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,5 +16,5 @@
 # under the License.
 
 [toolchain]
-channel = "1.81"
+channel = "stable"
 components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/1466

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

There is a new version of `rustup` and it causing builds to fail.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Use "stable" channel instead of pinning to a Rust version in the `rust-toolchain` file. We already pin the Rust version in `Cargo.toml`.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
