### PR TITLE
chore: Enable CI checks for `native_datafusion` scan

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -76,6 +76,41 @@ jobs:
           # upload test reports only for java 17
           upload-test-reports: ${{ matrix.java_version == '17' }}
 
+  linux-test-native-datafusion-scan:
+    env:
+      COMET_PARQUET_SCAN_IMPL: "native_datafusion"
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        java_version: [17]
+        test-target: [rust, java]
+        spark-version: ['3.5']
+        scala-version: ['2.12']
+        is_push_event:
+          - ${{ github.event_name == 'push' }}
+      fail-fast: false
+    name: ${{ matrix.os }}/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}-scala-${{matrix.scala-version}}/${{ matrix.test-target }}-native-datafusion
+    runs-on: ${{ matrix.os }}
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust & Java toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: ${{env.RUST_VERSION}}
+          jdk-version: ${{ matrix.java_version }}
+      - if: matrix.test-target == 'rust'
+        name: Rust test steps
+        uses: ./.github/actions/rust-test
+      - if: matrix.test-target == 'java'
+        name: Java test steps
+        uses: ./.github/actions/java-test
+        with:
+          maven_opts: -Pspark-${{ matrix.spark-version }},scala-${{ matrix.scala-version }}
+          # upload test reports only for java 17
+          upload-test-reports: ${{ matrix.java_version == '17' }}
+
   linux-test-with-spark4_0:
     strategy:
       matrix:

--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -101,6 +101,11 @@ object CometConf extends ShimCometConf {
       .getOrElse("COMET_PARQUET_SCAN_IMPL", SCAN_NATIVE_COMET)
       .toLowerCase(Locale.ROOT))
 
+  val isExperimentalNativeScan: Boolean = COMET_NATIVE_SCAN_IMPL.get() match {
+    case SCAN_NATIVE_DATAFUSION | SCAN_NATIVE_ICEBERG_COMPAT => true
+    case SCAN_NATIVE_COMET => false
+  }
+
   val COMET_PARQUET_PARALLEL_IO_ENABLED: ConfigEntry[Boolean] =
     conf("spark.comet.parquet.read.parallel.io.enabled")
       .doc(

--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -101,7 +101,7 @@ object CometConf extends ShimCometConf {
       .getOrElse("COMET_PARQUET_SCAN_IMPL", SCAN_NATIVE_COMET)
       .toLowerCase(Locale.ROOT))
 
-  val isExperimentalNativeScan: Boolean = COMET_NATIVE_SCAN_IMPL.get() match {
+  def isExperimentalNativeScan: Boolean = COMET_NATIVE_SCAN_IMPL.get() match {
     case SCAN_NATIVE_DATAFUSION | SCAN_NATIVE_ICEBERG_COMPAT => true
     case SCAN_NATIVE_COMET => false
   }

--- a/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
@@ -234,6 +234,7 @@ class CometArrayExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelp
   }
 
   test("array_intersect") {
+    assume(!CometConf.isExperimentalNativeScan)
     withSQLConf(CometConf.COMET_EXPR_ALLOW_INCOMPATIBLE.key -> "true") {
       Seq(true, false).foreach { dictionaryEnabled =>
         withTempDir { dir =>

--- a/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
@@ -234,10 +234,10 @@ class CometArrayExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelp
   }
 
   test("array_intersect") {
-    assume(
-      !CometConf.isExperimentalNativeScan
-    ) // https://github.com/apache/datafusion-comet/issues/1441
+    // https://github.com/apache/datafusion-comet/issues/1441
+    assume(!CometConf.isExperimentalNativeScan)
     withSQLConf(CometConf.COMET_EXPR_ALLOW_INCOMPATIBLE.key -> "true") {
+
       Seq(true, false).foreach { dictionaryEnabled =>
         withTempDir { dir =>
           val path = new Path(dir.toURI.toString, "test.parquet")

--- a/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
@@ -234,7 +234,9 @@ class CometArrayExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelp
   }
 
   test("array_intersect") {
-    assume(!CometConf.isExperimentalNativeScan)
+    assume(
+      !CometConf.isExperimentalNativeScan
+    ) // https://github.com/apache/datafusion-comet/issues/1441
     withSQLConf(CometConf.COMET_EXPR_ALLOW_INCOMPATIBLE.key -> "true") {
       Seq(true, false).foreach { dictionaryEnabled =>
         withTempDir { dir =>

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -900,9 +900,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("cast TimestampType to LongType") {
-    assume(
-      !CometConf.isExperimentalNativeScan
-    ) // https://github.com/apache/datafusion-comet/issues/1441
+    // https://github.com/apache/datafusion-comet/issues/1441assume(!CometConf.isExperimentalNativeScan)
     assume(CometSparkSessionExtensions.isSpark33Plus)
     castTest(generateTimestampsExtended(), DataTypes.LongType)
   }
@@ -926,25 +924,22 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("cast TimestampType to StringType") {
-    assume(
-      !CometConf.isExperimentalNativeScan
-    ) // https://github.com/apache/datafusion-comet/issues/1441
+    // https://github.com/apache/datafusion-comet/issues/1441
+    assume(!CometConf.isExperimentalNativeScan)
     castTest(generateTimestamps(), DataTypes.StringType)
   }
 
   test("cast TimestampType to DateType") {
-    assume(
-      !CometConf.isExperimentalNativeScan
-    ) // https://github.com/apache/datafusion-comet/issues/1441
+    // https://github.com/apache/datafusion-comet/issues/1441
+    assume(!CometConf.isExperimentalNativeScan)
     castTest(generateTimestamps(), DataTypes.DateType)
   }
 
   // Complex Types
 
   test("cast StructType to StringType") {
-    assume(
-      !CometConf.isExperimentalNativeScan
-    ) // https://github.com/apache/datafusion-comet/issues/1441
+    // https://github.com/apache/datafusion-comet/issues/1441
+    assume(!CometConf.isExperimentalNativeScan)
     Seq(true, false).foreach { dictionaryEnabled =>
       withTempDir { dir =>
         val path = new Path(dir.toURI.toString, "test.parquet")

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -900,7 +900,8 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("cast TimestampType to LongType") {
-    // https://github.com/apache/datafusion-comet/issues/1441assume(!CometConf.isExperimentalNativeScan)
+    // https://github.com/apache/datafusion-comet/issues/1441
+    assume(!CometConf.isExperimentalNativeScan)
     assume(CometSparkSessionExtensions.isSpark33Plus)
     castTest(generateTimestampsExtended(), DataTypes.LongType)
   }

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -900,7 +900,9 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("cast TimestampType to LongType") {
-    assume(!CometConf.isExperimentalNativeScan)
+    assume(
+      !CometConf.isExperimentalNativeScan
+    ) // https://github.com/apache/datafusion-comet/issues/1441
     assume(CometSparkSessionExtensions.isSpark33Plus)
     castTest(generateTimestampsExtended(), DataTypes.LongType)
   }
@@ -924,19 +926,25 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("cast TimestampType to StringType") {
-    assume(!CometConf.isExperimentalNativeScan)
+    assume(
+      !CometConf.isExperimentalNativeScan
+    ) // https://github.com/apache/datafusion-comet/issues/1441
     castTest(generateTimestamps(), DataTypes.StringType)
   }
 
   test("cast TimestampType to DateType") {
-    assume(!CometConf.isExperimentalNativeScan)
+    assume(
+      !CometConf.isExperimentalNativeScan
+    ) // https://github.com/apache/datafusion-comet/issues/1441
     castTest(generateTimestamps(), DataTypes.DateType)
   }
 
   // Complex Types
 
   test("cast StructType to StringType") {
-    assume(!CometConf.isExperimentalNativeScan)
+    assume(
+      !CometConf.isExperimentalNativeScan
+    ) // https://github.com/apache/datafusion-comet/issues/1441
     Seq(true, false).foreach { dictionaryEnabled =>
       withTempDir { dir =>
         val path = new Path(dir.toURI.toString, "test.parquet")

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -900,6 +900,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("cast TimestampType to LongType") {
+    assume(!CometConf.isExperimentalNativeScan)
     assume(CometSparkSessionExtensions.isSpark33Plus)
     castTest(generateTimestampsExtended(), DataTypes.LongType)
   }
@@ -923,16 +924,19 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("cast TimestampType to StringType") {
+    assume(!CometConf.isExperimentalNativeScan)
     castTest(generateTimestamps(), DataTypes.StringType)
   }
 
   test("cast TimestampType to DateType") {
+    assume(!CometConf.isExperimentalNativeScan)
     castTest(generateTimestamps(), DataTypes.DateType)
   }
 
   // Complex Types
 
   test("cast StructType to StringType") {
+    assume(!CometConf.isExperimentalNativeScan)
     Seq(true, false).foreach { dictionaryEnabled =>
       withTempDir { dir =>
         val path = new Path(dir.toURI.toString, "test.parquet")

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1266,9 +1266,8 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("round") {
-    assume(
-      !CometConf.isExperimentalNativeScan
-    ) // https://github.com/apache/datafusion-comet/issues/1441
+    // https://github.com/apache/datafusion-comet/issues/1441
+    assume(!CometConf.isExperimentalNativeScan)
     Seq(true, false).foreach { dictionaryEnabled =>
       withTempDir { dir =>
         val path = new Path(dir.toURI.toString, "test.parquet")
@@ -1497,9 +1496,8 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("hex") {
-    assume(
-      !CometConf.isExperimentalNativeScan
-    ) // https://github.com/apache/datafusion-comet/issues/1441
+    // https://github.com/apache/datafusion-comet/issues/1441
+    assume(!CometConf.isExperimentalNativeScan)
     Seq(true, false).foreach { dictionaryEnabled =>
       withTempDir { dir =>
         val path = new Path(dir.toURI.toString, "hex.parquet")
@@ -2682,9 +2680,8 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("test integral divide") {
-    assume(
-      !CometConf.isExperimentalNativeScan
-    ) // https://github.com/apache/datafusion-comet/issues/1441
+    // https://github.com/apache/datafusion-comet/issues/1441
+    assume(!CometConf.isExperimentalNativeScan)
     Seq(true, false).foreach { dictionaryEnabled =>
       withTempDir { dir =>
         val path1 = new Path(dir.toURI.toString, "test1.parquet")

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1266,6 +1266,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("round") {
+    assume(!CometConf.isExperimentalNativeScan)
     Seq(true, false).foreach { dictionaryEnabled =>
       withTempDir { dir =>
         val path = new Path(dir.toURI.toString, "test.parquet")
@@ -1494,6 +1495,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("hex") {
+    assume(!CometConf.isExperimentalNativeScan)
     Seq(true, false).foreach { dictionaryEnabled =>
       withTempDir { dir =>
         val path = new Path(dir.toURI.toString, "hex.parquet")
@@ -2676,6 +2678,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("test integral divide") {
+    assume(!CometConf.isExperimentalNativeScan)
     Seq(true, false).foreach { dictionaryEnabled =>
       withTempDir { dir =>
         val path1 = new Path(dir.toURI.toString, "test1.parquet")

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1266,7 +1266,9 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("round") {
-    assume(!CometConf.isExperimentalNativeScan)
+    assume(
+      !CometConf.isExperimentalNativeScan
+    ) // https://github.com/apache/datafusion-comet/issues/1441
     Seq(true, false).foreach { dictionaryEnabled =>
       withTempDir { dir =>
         val path = new Path(dir.toURI.toString, "test.parquet")
@@ -1495,7 +1497,9 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("hex") {
-    assume(!CometConf.isExperimentalNativeScan)
+    assume(
+      !CometConf.isExperimentalNativeScan
+    ) // https://github.com/apache/datafusion-comet/issues/1441
     Seq(true, false).foreach { dictionaryEnabled =>
       withTempDir { dir =>
         val path = new Path(dir.toURI.toString, "hex.parquet")
@@ -2678,7 +2682,9 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("test integral divide") {
-    assume(!CometConf.isExperimentalNativeScan)
+    assume(
+      !CometConf.isExperimentalNativeScan
+    ) // https://github.com/apache/datafusion-comet/issues/1441
     Seq(true, false).foreach { dictionaryEnabled =>
       withTempDir { dir =>
         val path1 = new Path(dir.toURI.toString, "test1.parquet")

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -818,7 +818,9 @@ class CometExecSuite extends CometTestBase {
   }
 
   test("explain native plan") {
-    assume(!CometConf.isExperimentalNativeScan)
+    assume(
+      !CometConf.isExperimentalNativeScan
+    ) // https://github.com/apache/datafusion-comet/issues/1441
     // there are no assertions in this test to prove that the explain feature
     // wrote the expected output to stdout, but we at least test that enabling
     // the config does not cause any exceptions.

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -818,6 +818,7 @@ class CometExecSuite extends CometTestBase {
   }
 
   test("explain native plan") {
+    assume(!CometConf.isExperimentalNativeScan)
     // there are no assertions in this test to prove that the explain feature
     // wrote the expected output to stdout, but we at least test that enabling
     // the config does not cause any exceptions.

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -818,9 +818,8 @@ class CometExecSuite extends CometTestBase {
   }
 
   test("explain native plan") {
-    assume(
-      !CometConf.isExperimentalNativeScan
-    ) // https://github.com/apache/datafusion-comet/issues/1441
+    // https://github.com/apache/datafusion-comet/issues/1441
+    assume(!CometConf.isExperimentalNativeScan)
     // there are no assertions in this test to prove that the explain feature
     // wrote the expected output to stdout, but we at least test that enabling
     // the config does not cause any exceptions.

--- a/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
@@ -201,7 +201,9 @@ class CometJoinSuite extends CometTestBase {
   }
 
   test("HashJoin struct key") {
-    assume(!CometConf.isExperimentalNativeScan)
+    assume(
+      !CometConf.isExperimentalNativeScan
+    ) // https://github.com/apache/datafusion-comet/issues/1441
     withSQLConf(
       "spark.sql.join.forceApplyShuffledHashJoin" -> "true",
       SQLConf.PREFER_SORTMERGEJOIN.key -> "false",

--- a/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
@@ -201,9 +201,8 @@ class CometJoinSuite extends CometTestBase {
   }
 
   test("HashJoin struct key") {
-    assume(
-      !CometConf.isExperimentalNativeScan
-    ) // https://github.com/apache/datafusion-comet/issues/1441
+    // https://github.com/apache/datafusion-comet/issues/1441
+    assume(!CometConf.isExperimentalNativeScan)
     withSQLConf(
       "spark.sql.join.forceApplyShuffledHashJoin" -> "true",
       SQLConf.PREFER_SORTMERGEJOIN.key -> "false",

--- a/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
@@ -201,6 +201,7 @@ class CometJoinSuite extends CometTestBase {
   }
 
   test("HashJoin struct key") {
+    assume(!CometConf.isExperimentalNativeScan)
     withSQLConf(
       "spark.sql.join.forceApplyShuffledHashJoin" -> "true",
       SQLConf.PREFER_SORTMERGEJOIN.key -> "false",

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -337,7 +337,9 @@ abstract class ParquetReadSuite extends CometTestBase {
   }
 
   test("test multiple pages with different sizes and nulls") {
-    assume(!CometConf.isExperimentalNativeScan)
+    assume(
+      !CometConf.isExperimentalNativeScan
+    ) // https://github.com/apache/datafusion-comet/issues/1441
     def makeRawParquetFile(
         path: Path,
         dictionaryEnabled: Boolean,

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -337,6 +337,7 @@ abstract class ParquetReadSuite extends CometTestBase {
   }
 
   test("test multiple pages with different sizes and nulls") {
+    assume(!CometConf.isExperimentalNativeScan)
     def makeRawParquetFile(
         path: Path,
         dictionaryEnabled: Boolean,

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -337,9 +337,8 @@ abstract class ParquetReadSuite extends CometTestBase {
   }
 
   test("test multiple pages with different sizes and nulls") {
-    assume(
-      !CometConf.isExperimentalNativeScan
-    ) // https://github.com/apache/datafusion-comet/issues/1441
+    // https://github.com/apache/datafusion-comet/issues/1441
+    assume(!CometConf.isExperimentalNativeScan)
     def makeRawParquetFile(
         path: Path,
         dictionaryEnabled: Boolean,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/datafusion-comet/issues/1486

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

To prevent regressions and track progress with supporting `native_datafusion`, I would like to start enabling CI runs with this scan as the default.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- [x] Enable CI check with `native_datafusion` enabled
- [x] Skip 11 currently failing tests using `assume(!CometConf.isExperimentalNativeScan)` and link to https://github.com/apache/datafusion-comet/issues/1441


## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
