### PR TITLE
fix: PartitionBuffers should not have their own MemoryConsumer

### DIFF
--- a/native/core/src/execution/shuffle/shuffle_writer.rs
+++ b/native/core/src/execution/shuffle/shuffle_writer.rs
@@ -481,7 +481,12 @@ impl ShuffleRepartitioner {
             Partitioning::UnknownPartitioning(n) if *n == 1 => {
                 let buffered_partitions = &mut self.buffered_partitions;
 
-                assert_eq!(buffered_partitions.len(), 1, "Expected 1 partition but got {}", buffered_partitions.len());
+                assert_eq!(
+                    buffered_partitions.len(),
+                    1,
+                    "Expected 1 partition but got {}",
+                    buffered_partitions.len()
+                );
 
                 // TODO the single partition case could be optimized to avoid appending all
                 // rows from the batch into builders and then recreating the batch


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1495 .

## Rationale for this change

It lets MemoryPools have a better grasp of the amount of operators actually running and requiring memory, as many of them use that count to determine the memory needs and allowances of each consumer.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Created a single MemoryConsumer in the ShuffleRepartitioner, and split it off into a reservation for each PartitionBuffer, instead of having them create their own.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
