### PR TITLE
chore: Remove num partitions from repartitioner

### DIFF
--- a/native/core/src/execution/shuffle/shuffle_writer.rs
+++ b/native/core/src/execution/shuffle/shuffle_writer.rs
@@ -412,8 +412,6 @@ impl ShuffleRepartitioner {
                     .await?;
             }
             Partitioning::Hash(exprs, num_output_partitions) => {
-                let num_output_partitions = *num_output_partitions;
-
                 let (partition_starts, shuffled_partition_ids): (Vec<usize>, Vec<usize>) = {
                     let mut timer = self.metrics.repart_time.timer();
 
@@ -433,11 +431,11 @@ impl ShuffleRepartitioner {
                         .iter()
                         .enumerate()
                         .for_each(|(idx, hash)| {
-                            partition_ids[idx] = pmod(*hash, num_output_partitions) as u64
+                            partition_ids[idx] = pmod(*hash, *num_output_partitions) as u64
                         });
 
                     // count each partition size
-                    let mut partition_counters = vec![0usize; num_output_partitions];
+                    let mut partition_counters = vec![0usize; *num_output_partitions];
                     partition_ids
                         .iter()
                         .for_each(|partition_id| partition_counters[*partition_id as usize] += 1);


### PR DESCRIPTION
Also: 
* treat all single partition schemes the same way
* remove duplicate messaging by using assert_eq instead of assert

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
None really, but it can be seen as cleanup towards #1497 


## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

It was just an unneeded field in a file that is already a bit complex with too many structs.
this information is always accessible, from multiple places.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

With the normal testing scheme.