### PR TITLE
fix: Fix regression in choosing correct memory allocator in columnar shuffle

### DIFF
--- a/spark/src/main/java/org/apache/spark/shuffle/comet/CometShuffleMemoryAllocator.java
+++ b/spark/src/main/java/org/apache/spark/shuffle/comet/CometShuffleMemoryAllocator.java
@@ -48,9 +48,12 @@ public final class CometShuffleMemoryAllocator extends CometShuffleMemoryAllocat
   public static CometShuffleMemoryAllocatorTrait getInstance(
       SparkConf conf, TaskMemoryManager taskMemoryManager, long pageSize) {
     boolean isSparkTesting = Utils.isTesting();
-    boolean useUnifiedMemAllocator =
+    boolean useUnifiedMemInTests =
         (boolean)
             CometConf$.MODULE$.COMET_COLUMNAR_SHUFFLE_UNIFIED_MEMORY_ALLOCATOR_IN_TEST().get();
+    boolean useUnifiedMemAllocator =
+        taskMemoryManager.getTungstenMemoryMode() == MemoryMode.OFF_HEAP
+            || (isSparkTesting && useUnifiedMemInTests);
 
     if (!useUnifiedMemAllocator) {
       synchronized (CometShuffleMemoryAllocator.class) {

--- a/spark/src/main/scala/org/apache/spark/Plugins.scala
+++ b/spark/src/main/scala/org/apache/spark/Plugins.scala
@@ -101,7 +101,7 @@ class CometDriverPlugin extends DriverPlugin with Logging with ShimCometDriverPl
    * unified memory manager.
    */
   private def shouldOverrideMemoryConf(conf: SparkConf): Boolean = {
-    conf.getBoolean(CometConf.COMET_ENABLED.key, CometConf.COMET_ENABLED.defaultValue.get) && (
+    conf.getBoolean(CometConf.COMET_ENABLED.key, true) && (
       conf.getBoolean(
         CometConf.COMET_EXEC_SHUFFLE_ENABLED.key,
         CometConf.COMET_EXEC_SHUFFLE_ENABLED.defaultValue.get) ||

--- a/spark/src/main/scala/org/apache/spark/Plugins.scala
+++ b/spark/src/main/scala/org/apache/spark/Plugins.scala
@@ -101,7 +101,7 @@ class CometDriverPlugin extends DriverPlugin with Logging with ShimCometDriverPl
    * unified memory manager.
    */
   private def shouldOverrideMemoryConf(conf: SparkConf): Boolean = {
-    conf.getBoolean(CometConf.COMET_ENABLED.key, true) && (
+    conf.getBoolean(CometConf.COMET_ENABLED.key, CometConf.COMET_ENABLED.defaultValue.get) && (
       conf.getBoolean(
         CometConf.COMET_EXEC_SHUFFLE_ENABLED.key,
         CometConf.COMET_EXEC_SHUFFLE_ENABLED.defaultValue.get) ||


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Partial fix for https://github.com/apache/datafusion-comet/issues/1438

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This is the minimum change needed to fix the issue reported in https://github.com/apache/datafusion-comet/issues/1438 but it does not address renaming `CometTestShuffleMemoryAllocator` and updating configs and code comments to make clear that `CometTestShuffleMemoryAllocator` is not just used in testing but also in on-heap mode. These changes are being handled in https://github.com/apache/datafusion-comet/pull/1485.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
