### PR TITLE
build: Use unique name for surefire artifacts

### DIFF
--- a/.github/actions/java-test/action.yaml
+++ b/.github/actions/java-test/action.yaml
@@ -60,7 +60,7 @@ runs:
       if: ${{ inputs.upload-test-reports == 'true' }}
       uses: actions/upload-artifact@v4
       with:
-         name: java-test-reports-${{ github.run_id }}
+         name: java-test-reports-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
          path: "**/target/surefire-reports/*.txt"
          retention-days: 7 # 1 week for test reports
          overwrite: true


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I have recently seen some build failures due to:

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

Example:

```

Run actions/upload-artifact@v4
  with:
    name: java-test-reports-13907435863
    path: **/target/surefire-reports/*.txt
    retention-days: 7
    overwrite: true
    if-no-files-found: warn
    compression-level: 6
    include-hidden-files: false
  env:
    RUST_VERSION: stable
    JAVA_HOME: /__t/Java_Zulu_jdk/17.0.14-7/x64
    JAVA_HOME_17_X64: /__t/Java_Zulu_jdk/17.0.14-7/x64
/usr/bin/docker exec  70ccce69d6cca5445b60eaedb1395aabda91e4f16400c4e06aef42fc0a773435 sh -c "cat /etc/*release | grep ^ID"
With the provided path, there will be 4 files uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
