### PR TITLE
docs: Use a shallow clone for Spark SQL test instructions

### DIFF
--- a/docs/source/contributor-guide/spark-sql-tests.md
+++ b/docs/source/contributor-guide/spark-sql-tests.md
@@ -44,10 +44,10 @@ PROFILES="-Pspark-3.4" make release
 
 Clone Apache Spark locally and apply the diff file from Comet.
 
+Note: this is a shallow clone of a tagged Spark commit and is not suitable for general Spark development.
 ```shell
-git clone git@github.com:apache/spark.git apache-spark
+git clone -b 'v3.4.3' --single-branch --depth 1 git@github.com:apache/spark.git apache-spark
 cd apache-spark
-git checkout v3.4.3
 git apply ../datafusion-comet/dev/diffs/3.4.3.diff
 ```
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We don't need the whole Spark repository to run Spark SQL tests.

Current approach:
```
git clone git@github.com:apache/spark.git apache-spark
du -h apache-spark
...
680M	apache-spark
```

Proposed change:
```
git clone -b 'v3.4.3' --single-branch --depth 1 git@github.com:apache/spark.git apache-spark
du -h apache-spark
...
200M	apache-spark
```
## What changes are included in this PR?

Docs update to reflect this approach with a disclaimer that it's a shallow clone.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Ran Spark SQL tests locally using this approach. CI uses a different method that likely already has this optimization:
https://github.com/apache/datafusion-comet/blob/359b4b37a2bd3af1c462d443cf845758d64fb179/.github/actions/setup-spark-builder/action.yaml#L38