### PR TITLE
fix: check if handle has been initialized before closing

### DIFF
--- a/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
@@ -459,8 +459,9 @@ public class NativeBatchReader extends RecordReader<Void, ColumnarBatch> impleme
       importer = null;
     }
     nativeUtil.close();
-    if (handle > 0) {
+    if (this.handle > 0) {
       Native.closeRecordBatchReader(this.handle);
+      this.handle = 0;
     }
   }
 

--- a/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
@@ -459,7 +459,9 @@ public class NativeBatchReader extends RecordReader<Void, ColumnarBatch> impleme
       importer = null;
     }
     nativeUtil.close();
-    Native.closeRecordBatchReader(this.handle);
+    if (handle > 0) {
+      Native.closeRecordBatchReader(this.handle);
+    }
   }
 
   @SuppressWarnings("deprecation")


### PR DESCRIPTION
## Which issue does this PR close?


Part of #1553


## Rationale for this change

Check that the handle is initialized before closing to avoid native thread panic.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

before this:
![image](https://github.com/user-attachments/assets/1daf70ee-0af6-452e-adf2-d5183a33bdb7)

after this:
![image](https://github.com/user-attachments/assets/f8f50ab4-043e-4e75-9fa4-88c7f218f5e0)
