### PR TITLE
feat: make parquet native scan schema case insensitive

### DIFF
--- a/native/core/src/parquet/parquet_exec.rs
+++ b/native/core/src/parquet/parquet_exec.rs
@@ -110,6 +110,7 @@ fn get_options(session_timezone: &str) -> (TableParquetOptions, SparkParquetOpti
     let mut spark_parquet_options =
         SparkParquetOptions::new(EvalMode::Legacy, session_timezone, false);
     spark_parquet_options.allow_cast_unsigned_ints = true;
+    spark_parquet_options.case_sensitive = false;
     (table_parquet_options, spark_parquet_options)
 }
 

--- a/native/core/src/parquet/parquet_support.rs
+++ b/native/core/src/parquet/parquet_support.rs
@@ -64,6 +64,8 @@ pub struct SparkParquetOptions {
     pub use_decimal_128: bool,
     /// Whether to read dates/timestamps that were written in the legacy hybrid Julian + Gregorian calendar as it is. If false, throw exceptions instead. If the spark type is TimestampNTZ, this should be true.
     pub use_legacy_date_timestamp_or_ntz: bool,
+    // Whether schema field names are case sensitive
+    pub case_sensitive: bool,
 }
 
 impl SparkParquetOptions {
@@ -76,6 +78,7 @@ impl SparkParquetOptions {
             is_adapting_schema: false,
             use_decimal_128: false,
             use_legacy_date_timestamp_or_ntz: false,
+            case_sensitive: false,
         }
     }
 
@@ -88,6 +91,7 @@ impl SparkParquetOptions {
             is_adapting_schema: false,
             use_decimal_128: false,
             use_legacy_date_timestamp_or_ntz: false,
+            case_sensitive: false,
         }
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Part of #1574.

## Rationale for this change

The data schema of spark parquet datasource scan may not be consistent with the actual schema of file. This may cause the `projection/filter` to not behave as expected.

## What changes are included in this PR?

This PR makes `data schema` and `file schema` case insensitive in schema adapter, but it does not affect `pruning_predicate` and `page_pruning_predicate`.

## How are these changes tested?

added unit test
