### PR TITLE
chore: Override node name for CometSparkToColumnar

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometSparkToColumnarExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometSparkToColumnarExec.scala
@@ -52,6 +52,12 @@ case class CometSparkToColumnarExec(child: SparkPlan)
 
   override def supportsColumnar: Boolean = true
 
+  override def nodeName: String = if (child.supportsColumnar) {
+    "CometSparkColumnarToColumnar"
+  } else {
+    "CometSparkRowToColumnar"
+  }
+
   override lazy val metrics: Map[String, SQLMetric] = Map(
     "numInputRows" -> SQLMetrics.createMetric(sparkContext, "number of input rows"),
     "numOutputBatches" -> SQLMetrics.createMetric(sparkContext, "number of output batches"),


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #936.

## Rationale for this change

Previous PR went stale so I wanted to move it forward.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

Added unit tests for row and columnar input.
