### PR TITLE
chore: Making comet native operators write spill files to spark local dir

### DIFF
--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -38,6 +38,7 @@ use jni::{
     sys::{jbyteArray, jint, jlong, jlongArray},
     JNIEnv,
 };
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use std::{collections::HashMap, sync::Arc, task::Poll};
 
@@ -167,6 +168,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
     metrics_node: JObject,
     metrics_update_interval: jlong,
     comet_task_memory_manager_obj: JObject,
+    local_dirs: jobjectArray,
     batch_size: jint,
     off_heap_mode: jboolean,
     memory_pool_type: jstring,
@@ -208,6 +210,8 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
             let input_source = Arc::new(jni_new_global_ref!(env, input_source)?);
             input_sources.push(input_source);
         }
+
+        // Create DataFusion memory pool
         let task_memory_manager =
             Arc::new(jni_new_global_ref!(env, comet_task_memory_manager_obj)?);
 
@@ -221,10 +225,21 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
         let memory_pool =
             create_memory_pool(&memory_pool_config, task_memory_manager, task_attempt_id);
 
+        // Get local directories for storing spill files
+        let local_dirs_array = JObjectArray::from_raw(local_dirs);
+        let num_local_dirs = env.get_array_length(&local_dirs_array)?;
+        let mut local_dirs = vec![];
+        for i in 0..num_local_dirs {
+            let local_dir: JString = env.get_object_array_element(&local_dirs_array, i)?.into();
+            let local_dir = env.get_string(&local_dir)?;
+            local_dirs.push(local_dir.into());
+        }
+
         // We need to keep the session context alive. Some session state like temporary
         // dictionaries are stored in session context. If it is dropped, the temporary
         // dictionaries will be dropped as well.
-        let session = prepare_datafusion_session_context(batch_size as usize, memory_pool)?;
+        let session =
+            prepare_datafusion_session_context(batch_size as usize, memory_pool, local_dirs)?;
 
         let plan_creation_time = start.elapsed();
 
@@ -262,8 +277,11 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
 fn prepare_datafusion_session_context(
     batch_size: usize,
     memory_pool: Arc<dyn MemoryPool>,
+    local_dirs: Vec<String>,
 ) -> CometResult<SessionContext> {
-    let mut rt_config = RuntimeEnvBuilder::new().with_disk_manager(DiskManagerConfig::NewOs);
+    let disk_manager_config =
+        DiskManagerConfig::NewSpecified(local_dirs.into_iter().map(PathBuf::from).collect());
+    let mut rt_config = RuntimeEnvBuilder::new().with_disk_manager(disk_manager_config);
     rt_config = rt_config.with_memory_pool(memory_pool);
 
     // Get Datafusion configuration from Spark Execution context

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -64,6 +64,7 @@ class CometExecIterator(
   }.toArray
   private val plan = {
     val conf = SparkEnv.get.conf
+    val localDiskDirs = SparkEnv.get.blockManager.getLocalDiskDirs
 
     val offHeapMode = CometSparkSessionExtensions.isOffHeapEnabled(conf)
     val memoryLimit = if (offHeapMode) {
@@ -83,6 +84,7 @@ class CometExecIterator(
       nativeMetrics,
       metricsUpdateInterval = COMET_METRICS_UPDATE_INTERVAL.get(),
       new CometTaskMemoryManager(id),
+      localDiskDirs,
       batchSize = COMET_BATCH_SIZE.get(),
       offHeapMode,
       memoryPoolType = COMET_EXEC_MEMORY_POOL_TYPE.get(),

--- a/spark/src/main/scala/org/apache/comet/Native.scala
+++ b/spark/src/main/scala/org/apache/comet/Native.scala
@@ -58,6 +58,7 @@ class Native extends NativeBase {
       metrics: CometMetricNode,
       metricsUpdateInterval: Long,
       taskMemoryManager: CometTaskMemoryManager,
+      localDirs: Array[String],
       batchSize: Int,
       offHeapMode: Boolean,
       memoryPoolType: String,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1607.

## Rationale for this change

Comet native operators always write spill files into the default tmp directory, this is not always the desired behavior. There are cases where we want to write spill files into Spark local directories:

1. The default tmp directory is too small to hold spill files, a special volume is configured for Spark to write temporary files and shuffle data/index files.
2. Multiple directories are configured as Spark local directories. These directories could be backed by multiple physical devices to have a larger overall disk read/write throughput. Spark will spread spill files and shuffle data/index files evenly onto these local directories by default, comet should also do that when writing spill files.

All the above mentioned cases are quite common for running Spark jobs on Kubernetes. Users usually specify 
persistent volume claims prefixed by `spark-local-dir-` to use allocated volumes as Spark local directories. https://spark.apache.org/docs/latest/running-on-kubernetes.html#local-storage

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Create DataFusion DiskManager using spark local directories, this will make spill files being created on spark local directories instead of the default tmp directory.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

* Added a unit test
* Manually tested locally and on Kubernetes
