### PR TITLE
feat: respect `batchSize/workerThreads/blockingThreads` configurations for native_iceberg_compat scan

### DIFF
--- a/common/src/main/java/org/apache/comet/parquet/Native.java
+++ b/common/src/main/java/org/apache/comet/parquet/Native.java
@@ -256,7 +256,10 @@ public final class Native extends NativeBase {
       byte[] filter,
       byte[] requiredSchema,
       byte[] dataSchema,
-      String sessionTimezone);
+      String sessionTimezone,
+      int batchSize,
+      int workerThreads,
+      int blockingThreads);
 
   // arrow native version of read batch
   /**

--- a/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
@@ -353,6 +353,20 @@ public class NativeBatchReader extends RecordReader<Void, ColumnarBatch> impleme
       }
     }
 
+    int batchSize =
+        conf.getInt(
+            CometConf.COMET_BATCH_SIZE().key(),
+            (Integer) CometConf.COMET_BATCH_SIZE().defaultValue().get());
+    int workerThreads =
+        conf.getInt(
+            CometConf.COMET_WORKER_THREADS().key(),
+            (Integer) CometConf.COMET_WORKER_THREADS().defaultValue().get());
+    ;
+    int blockingThreads =
+        conf.getInt(
+            CometConf.COMET_BLOCKING_THREADS().key(),
+            (Integer) CometConf.COMET_BLOCKING_THREADS().defaultValue().get());
+    ;
     this.handle =
         Native.initRecordBatchReader(
             filePath,
@@ -362,7 +376,10 @@ public class NativeBatchReader extends RecordReader<Void, ColumnarBatch> impleme
             nativeFilter,
             serializedRequestedArrowSchema,
             serializedDataArrowSchema,
-            timeZoneId);
+            timeZoneId,
+            batchSize,
+            workerThreads,
+            blockingThreads);
     isInitialized = true;
   }
 

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -175,6 +175,11 @@ impl PhysicalPlanner {
         }
     }
 
+    /// Return session context of this planner.
+    pub fn session_ctx(&self) -> &Arc<SessionContext> {
+        &self.session_ctx
+    }
+
     /// get DataFusion PartitionedFiles from a Spark FilePartition
     fn get_partitioned_files(
         &self,

--- a/spark/src/main/scala/org/apache/comet/parquet/CometParquetFileFormat.scala
+++ b/spark/src/main/scala/org/apache/comet/parquet/CometParquetFileFormat.scala
@@ -232,6 +232,11 @@ object CometParquetFileFormat extends Logging with ShimSQLConf {
     hadoopConf.setBoolean(
       CometConf.COMET_EXCEPTION_ON_LEGACY_DATE_TIMESTAMP.key,
       CometConf.COMET_EXCEPTION_ON_LEGACY_DATE_TIMESTAMP.get())
+    hadoopConf.setInt(CometConf.COMET_BATCH_SIZE.key, CometConf.COMET_BATCH_SIZE.get())
+    hadoopConf.setInt(CometConf.COMET_WORKER_THREADS.key, CometConf.COMET_WORKER_THREADS.get())
+    hadoopConf.setInt(
+      CometConf.COMET_BLOCKING_THREADS.key,
+      CometConf.COMET_BLOCKING_THREADS.get())
   }
 
   def getDatetimeRebaseSpec(


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1571.

## Rationale for this change

Respect `batchSize/workerThreads/blockingThreads` configurations for native_iceberg_compat scan

## What changes are included in this PR?

+ Set `COMET_BATCH_SIZE/COMET_WORKER_THREADS/COMET_BLOCKING_THREADS` for NativeBatchReader
+ Use planer's session_ctx instead of new task_ctx

## How are these changes tested?

Successfully run `CometReadHdfsBenchmark` locally.
[CometReadHdfsBenchmark-results.txt](https://github.com/user-attachments/files/19545171/CometReadHdfsBenchmark-results.txt)

