### PR TITLE
fix: corrected the logic of eliminating CometSparkToColumnarExec

### DIFF
--- a/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
@@ -106,12 +106,7 @@ class CometArrayExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelp
           sql(s"SELECT array($fieldName, $fieldName) as a, $fieldName as b FROM t1")
             .createOrReplaceTempView("t2")
           val df = sql("SELECT array_remove(a, b) FROM t2")
-          field.dataType match {
-            case _: StructType =>
-            // skip due to https://github.com/apache/datafusion-comet/issues/1314
-            case _ =>
-              checkSparkAnswer(df)
-          }
+          checkSparkAnswer(df)
         }
       }
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1314 and #1588.

## Rationale for this change

`EliminateRedundantTransitions` eliminates the required `ColumnarToRowExec`

## What changes are included in this PR?

+ For Spark Columnar to Comet Columnar of CometSparkToColumnarExec, we should keep the ColumnarToRowExec
+ For Spark Row to Comet Columnar of CometSparkToColumnarExec, we should remove ColumnarToRowExec and CometSparkToColumnarExec

## How are these changes tested?

unit test
