### PR TITLE
fix: avoid panic caused by close null handle of parquet reader

### DIFF
--- a/native/core/src/parquet/mod.rs
+++ b/native/core/src/parquet/mod.rs
@@ -586,7 +586,7 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_closeColumnReader(
 ) {
     try_unwrap_or_throw(&env, |_| {
         unsafe {
-            let ctx = handle as *mut Context;
+            let ctx = get_context(handle)?;
             let _ = Box::from_raw(ctx);
         };
         Ok(())
@@ -805,7 +805,7 @@ pub extern "system" fn Java_org_apache_comet_parquet_Native_closeRecordBatchRead
 ) {
     try_unwrap_or_throw(&env, |_| {
         unsafe {
-            let ctx = handle as *mut BatchContext;
+            let ctx = get_batch_context(handle)?;
             let _ = Box::from_raw(ctx);
         };
         Ok(())

--- a/spark/src/test/scala/org/apache/comet/CometNativeSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometNativeSuite.scala
@@ -50,4 +50,17 @@ class CometNativeSuite extends CometTestBase {
     }
     assert(exception.getMessage contains "java.lang.NullPointerException")
   }
+
+  test("handling NPE when closing null handle of parquet reader") {
+    assert(NativeBase.isLoaded)
+    val exception1 = intercept[NullPointerException] {
+      parquet.Native.closeRecordBatchReader(0)
+    }
+    assert(exception1.getMessage contains "null batch context handle")
+
+    val exception2 = intercept[NullPointerException] {
+      parquet.Native.closeColumnReader(0)
+    }
+    assert(exception2.getMessage contains "null context handle")
+  }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1553.

## Rationale for this change

avoid panic caused by close null handle of parquet reader

## What changes are included in this PR?

`get_context/get_batch_context` wraps the null check, so I use `get_context/get_batch_context` to get the context to be released to avoid panic.

## How are these changes tested?

added unit test
