### PR TITLE
fix: Make AQE capable of converting Comet shuffled joins to Comet broadcast hash joins

### DIFF
--- a/common/src/main/scala/org/apache/spark/sql/comet/execution/arrow/ArrowReaderIterator.scala
+++ b/common/src/main/scala/org/apache/spark/sql/comet/execution/arrow/ArrowReaderIterator.scala
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.spark.sql.comet.execution.shuffle
+package org.apache.spark.sql.comet.execution.arrow
 
 import java.nio.channels.ReadableByteChannel
 

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -2765,6 +2765,8 @@ object QueryPlanSerde extends Logging with ShimQueryPlanSerde with CometExprShim
       case ShuffleQueryStageExec(_, ReusedExchangeExec(_, _: CometShuffleExchangeExec), _) => true
       case _: TakeOrderedAndProjectExec => true
       case BroadcastQueryStageExec(_, _: CometBroadcastExchangeExec, _) => true
+      case BroadcastQueryStageExec(_, ReusedExchangeExec(_, _: CometBroadcastExchangeExec), _) =>
+        true
       case _: BroadcastExchangeExec => true
       case _: WindowExec => true
       case _ => false

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometBroadcastExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometBroadcastExchangeExec.scala
@@ -63,7 +63,8 @@ case class CometBroadcastExchangeExec(
     override val output: Seq[Attribute],
     mode: BroadcastMode,
     override val child: SparkPlan)
-    extends BroadcastExchangeLike {
+    extends BroadcastExchangeLike
+    with CometPlan {
   import CometBroadcastExchangeExec._
 
   override val runId: UUID = UUID.randomUUID

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometBroadcastExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometBroadcastExchangeExec.scala
@@ -252,7 +252,7 @@ case class CometBroadcastExchangeExec(
 
   override def hashCode(): Int = Objects.hashCode(child)
 
-  override def stringArgs: Iterator[Any] = Iterator(output, mode, child)
+  override def stringArgs: Iterator[Any] = Iterator(output, child)
 
   override protected def withNewChildInternal(newChild: SparkPlan): CometBroadcastExchangeExec =
     copy(child = newChild)

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometColumnarToRowExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometColumnarToRowExec.scala
@@ -19,20 +19,29 @@
 
 package org.apache.spark.sql.comet
 
-import scala.collection.JavaConverters._
+import java.util.UUID
+import java.util.concurrent.{Future, TimeoutException, TimeUnit}
 
+import scala.collection.JavaConverters._
+import scala.concurrent.Promise
+import scala.util.control.NonFatal
+
+import org.apache.spark.{broadcast, SparkException}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder, UnsafeProjection}
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
-import org.apache.spark.sql.execution.{CodegenSupport, ColumnarToRowTransition, SparkPlan}
+import org.apache.spark.sql.comet.util.{Utils => CometUtils}
+import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.execution.{CodegenSupport, ColumnarToRowTransition, SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.execution.vectorized.{ConstantColumnVector, WritableColumnVector}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{SparkFatalException, Utils}
+import org.apache.spark.util.io.ChunkedByteBuffer
 
 import org.apache.comet.vector.CometPlainVector
 
@@ -73,6 +82,86 @@ case class CometColumnarToRowExec(child: SparkPlan)
         numOutputRows += batch.numRows()
         batch.rowIterator().asScala.map(toUnsafe)
       }
+    }
+  }
+
+  @transient
+  private lazy val promise = Promise[broadcast.Broadcast[Any]]()
+
+  @transient
+  private val timeout: Long = conf.broadcastTimeout
+
+  private val runId: UUID = UUID.randomUUID
+
+  @transient
+  lazy val relationFuture: Future[broadcast.Broadcast[Any]] = {
+    SQLExecution.withThreadLocalCaptured[broadcast.Broadcast[Any]](
+      session,
+      CometBroadcastExchangeExec.executionContext) {
+      try {
+        // Setup a job group here so later it may get cancelled by groupId if necessary.
+        sparkContext.setJobGroup(
+          runId.toString,
+          s"ColumnarToRow broadcast exchange (runId $runId)",
+          interruptOnCancel = true)
+
+        val numOutputRows = longMetric("numOutputRows")
+        val numInputBatches = longMetric("numInputBatches")
+        val localOutput = this.output
+        val broadcastColumnar = child.executeBroadcast()
+        val serializedBatches = broadcastColumnar.value.asInstanceOf[Array[ChunkedByteBuffer]]
+        val toUnsafe = UnsafeProjection.create(localOutput, localOutput)
+        val rows = serializedBatches.iterator
+          .flatMap(CometUtils.decodeBatches(_, this.getClass.getSimpleName))
+          .flatMap { batch =>
+            numInputBatches += 1
+            numOutputRows += batch.numRows()
+            batch.rowIterator().asScala.map(toUnsafe)
+          }
+
+        val mode = child.asInstanceOf[CometBroadcastExchangeExec].mode
+        val relation = mode.transform(rows, Some(numOutputRows.value))
+        val broadcasted = sparkContext.broadcastInternal(relation, serializedOnly = true)
+        val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+        SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, metrics.values.toSeq)
+        promise.trySuccess(broadcasted)
+        broadcasted
+      } catch {
+        // SPARK-24294: To bypass scala bug: https://github.com/scala/bug/issues/9554, we throw
+        // SparkFatalException, which is a subclass of Exception. ThreadUtils.awaitResult
+        // will catch this exception and re-throw the wrapped fatal throwable.
+        case oe: OutOfMemoryError =>
+          val ex = new SparkFatalException(oe)
+          promise.tryFailure(ex)
+          throw ex
+        case e if !NonFatal(e) =>
+          val ex = new SparkFatalException(e)
+          promise.tryFailure(ex)
+          throw ex
+        case e: Throwable =>
+          promise.tryFailure(e)
+          throw e
+      }
+    }
+  }
+
+  override def doExecuteBroadcast[T](): broadcast.Broadcast[T] = {
+    if (!child.isInstanceOf[CometBroadcastExchangeExec]) {
+      throw new SparkException(
+        "ColumnarToRowExec only supports doExecuteBroadcast when child is " +
+          "CometBroadcastExchange, but got " + child.nodeName)
+    }
+
+    try {
+      relationFuture.get(timeout, TimeUnit.SECONDS).asInstanceOf[broadcast.Broadcast[T]]
+    } catch {
+      case ex: TimeoutException =>
+        logError(s"Could not execute broadcast in $timeout secs.", ex)
+        if (!relationFuture.isDone) {
+          sparkContext.cancelJobGroup(runId.toString)
+          relationFuture.cancel(true)
+        }
+        throw QueryExecutionErrors.executeBroadcastTimeoutError(timeout, Some(ex))
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateMode, Bloom
 import org.apache.spark.sql.comet._
 import org.apache.spark.sql.comet.execution.shuffle.{CometColumnarShuffle, CometShuffleExchangeExec}
 import org.apache.spark.sql.execution.{CollectLimitExec, ProjectExec, SQLExecution, UnionExec}
-import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, BroadcastQueryStageExec}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ReusedExchangeExec, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.joins.{BroadcastNestedLoopJoinExec, CartesianProductExec, SortMergeJoinExec}
@@ -746,6 +746,91 @@ class CometExecSuite extends CometTestBase {
             s
         }
         assert(exchanges.length == 4)
+      }
+    }
+  }
+
+  test("Comet Shuffled Join should be optimized to CometBroadcastHashJoin by AQE") {
+    withSQLConf(
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+      SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10485760",
+      CometConf.COMET_EXEC_SHUFFLE_ENABLED.key -> "true",
+      CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+      withParquetTable((0 until 100).map(i => (i, i + 1)), "tbl_a") {
+        withParquetTable((0 until 100).map(i => (i, i + 2)), "tbl_b") {
+          withParquetTable((0 until 100).map(i => (i, i + 3)), "tbl_c") {
+            val df = sql("""SELECT /*+ BROADCAST(c) */ a1, sum_b2, c._2 FROM (
+                |  SELECT a._1 a1, SUM(b._2) sum_b2 FROM tbl_a a
+                |  JOIN tbl_b b ON a._1 = b._1
+                |  GROUP BY a._1) t
+                |JOIN tbl_c c ON t.a1 = c._1
+                |""".stripMargin)
+            checkSparkAnswerAndOperator(df)
+
+            // Before AQE: 1 broadcast join
+            var broadcastHashJoinExec = stripAQEPlan(df.queryExecution.executedPlan).collect {
+              case s: CometBroadcastHashJoinExec => s
+            }
+            assert(broadcastHashJoinExec.length == 1)
+
+            // After AQE: shuffled join optimized to broadcast join
+            df.collect()
+            broadcastHashJoinExec = stripAQEPlan(df.queryExecution.executedPlan).collect {
+              case s: CometBroadcastHashJoinExec => s
+            }
+            assert(broadcastHashJoinExec.length == 2)
+          }
+        }
+      }
+    }
+  }
+
+  test("CometBroadcastExchange could be converted to rows using CometColumnarToRow") {
+    withSQLConf(
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+      SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10485760",
+      CometConf.COMET_EXEC_SHUFFLE_ENABLED.key -> "true",
+      CometConf.COMET_SHUFFLE_MODE.key -> "auto") {
+      withParquetTable((0 until 100).map(i => (i, i + 1)), "tbl_a") {
+        withParquetTable((0 until 100).map(i => (i, i + 2)), "tbl_b") {
+          withParquetTable((0 until 100).map(i => (i, i + 3)), "tbl_c") {
+            val df = sql("""SELECT /*+ BROADCAST(c) */ a1, sum_b2, c._2 FROM (
+                |  SELECT a._1 a1, SUM(b._2) sum_b2 FROM tbl_a a
+                |  JOIN tbl_b b ON a._1 = b._1
+                |  GROUP BY a._1) t
+                |JOIN tbl_c c ON t.a1 = c._1
+                |""".stripMargin)
+            checkSparkAnswer(df)
+
+            // Before AQE: one CometBroadcastExchange, no CometColumnarToRow
+            var columnarToRowExec = stripAQEPlan(df.queryExecution.executedPlan).collect {
+              case s: CometColumnarToRowExec => s
+            }
+            assert(columnarToRowExec.isEmpty)
+
+            // Disable CometExecRule after the initial plan is generated. The CometSortMergeJoin and
+            // CometBroadcastHashJoin nodes in the initial plan will be converted to Spark BroadcastHashJoin
+            // during AQE. This will make CometBroadcastExchangeExec being converted to rows to be used by
+            // Spark BroadcastHashJoin.
+            spark.conf.set(CometConf.COMET_EXEC_ENABLED.key, "false")
+            df.collect()
+
+            // After AQE: CometBroadcastExchange has to be converted to rows to conform to Spark
+            // BroadcastHashJoin.
+            columnarToRowExec = stripAQEPlan(df.queryExecution.executedPlan).collect {
+              case s: CometColumnarToRowExec => s
+            }
+            assert(columnarToRowExec.length == 1)
+            val broadcastQueryStage =
+              columnarToRowExec.head.find(_.isInstanceOf[BroadcastQueryStageExec])
+            assert(broadcastQueryStage.isDefined)
+            assert(
+              broadcastQueryStage.get
+                .asInstanceOf[BroadcastQueryStageExec]
+                .broadcast
+                .isInstanceOf[CometBroadcastExchangeExec])
+          }
+        }
       }
     }
   }

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.execution.{CollectLimitExec, ProjectExec, SQLExecuti
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, BroadcastQueryStageExec}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ReusedExchangeExec, ShuffleExchangeExec}
-import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec, CartesianProductExec, HashJoin, SortMergeJoinExec}
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec, CartesianProductExec, SortMergeJoinExec}
 import org.apache.spark.sql.execution.reuse.ReuseExchangeAndSubquery
 import org.apache.spark.sql.execution.window.WindowExec
 import org.apache.spark.sql.expressions.Window

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -812,8 +812,9 @@ class CometExecSuite extends CometTestBase {
             // CometBroadcastHashJoin nodes in the initial plan will be converted to Spark BroadcastHashJoin
             // during AQE. This will make CometBroadcastExchangeExec being converted to rows to be used by
             // Spark BroadcastHashJoin.
-            spark.conf.set(CometConf.COMET_EXEC_ENABLED.key, "false")
-            df.collect()
+            withSQLConf(CometConf.COMET_EXEC_ENABLED.key -> "false") {
+              df.collect()
+            }
 
             // After AQE: CometBroadcastExchange has to be converted to rows to conform to Spark
             // BroadcastHashJoin.


### PR DESCRIPTION
## Notice

This PR should be merged after https://github.com/apache/datafusion-comet/pull/1606

## Which issue does this PR close?

Closes #1589.

## Rationale for this change

`CometBroadcastExchangeExec` didn't implement `outputPartitioning` method, this prevents CometBroadcastExchangeExec from being correctly generated in AQE optimization. This patch fixes this problem to make shuffled equi-joins being able to be optimized to CometBroadcastHashJoin by AQE.

## What changes are included in this PR?

This PR contains 2 fixes to make AQE broadcast join optimization work correctly for Comet:

1. Implement `outputPartitioning` method of `CometBroadcastExchangeExec`, also fixes other places that prevents the AQE optimization from happening.
2. Implement `doExecuteBroadcast` method of `CometColumnarToRowExec`. The parent of `CometBroadcastExchangeExec` may change to Spark `BroadcastHashJoinExec` during AQE optimization, this requires inserting a `CometColumnarToRowExec` above `CometBroadcastExchangeExec` to broadcast the data as rows instead of column batches.

Example AQE plans:

| Query | main | PR |
|--|--|--|
| Q7 | <img width="877" alt="q7_aqe_main" src="https://github.com/user-attachments/assets/2e6738ed-1a63-4a38-b4b9-5225188cdf58" /> | <img width="777" alt="q7_aqe_pr" src="https://github.com/user-attachments/assets/0f3564b3-bc3e-4a5a-bbbb-43d93e219723" /> |

## How are these changes tested?

1. Added unit tests
2. Tested using TPC-H SF=100 locally
