### PR TITLE
minor: Fix clippy warnings

### DIFF
--- a/native/core/src/execution/shuffle/row.rs
+++ b/native/core/src/execution/shuffle/row.rs
@@ -225,7 +225,7 @@ impl SparkUnsafeRow {
     /// The logic is from Spark `UnsafeRow.calculateBitSetWidthInBytes`.
     #[inline]
     pub const fn get_row_bitset_width(num_fields: usize) -> usize {
-        ((num_fields + 63) / 64) * 8
+        num_fields.div_ceil(64) * 8
     }
 
     pub fn new_with_num_fields(num_fields: usize) -> Self {

--- a/native/spark-expr/src/agg_funcs/correlation.rs
+++ b/native/spark-expr/src/agg_funcs/correlation.rs
@@ -207,7 +207,7 @@ impl Accumulator for CorrelationAccumulator {
             Arc::clone(&states[5]),
         ];
 
-        if states[0].len() > 0 && states[1].len() > 0 && states[2].len() > 0 {
+        if !states[0].is_empty() && !states[1].is_empty() && !states[2].is_empty() {
             self.covar.merge_batch(&states_c)?;
             self.stddev1.merge_batch(&states_s1)?;
             self.stddev2.merge_batch(&states_s2)?;


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

Rust clippy check fails when I submit https://github.com/apache/datafusion-comet/pull/1605, this is one of the failed runs: https://github.com/apache/datafusion-comet/actions/runs/14241125683/job/39911060021. This could be caused latest updates of clippy.

## What changes are included in this PR?

Fix clippy to make CI pass

## How are these changes tested?

Passing the CI
