### PR TITLE
fix: Support per-task shuffle write rows and shuffle write time metrics

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
@@ -80,10 +80,12 @@ class CometNativeShuffleWriter[K, V](
       "spilled_bytes")
 
     // Maps native metrics to SQL metrics
+    val metricsOutputRows = metrics(SQLShuffleWriteMetricsReporter.SHUFFLE_RECORDS_WRITTEN)
+    val metricsWriteTime = metrics(SQLShuffleWriteMetricsReporter.SHUFFLE_WRITE_TIME)
     val nativeSQLMetrics = Map(
-      "output_rows" -> metrics(SQLShuffleWriteMetricsReporter.SHUFFLE_RECORDS_WRITTEN),
+      "output_rows" -> metricsOutputRows,
       "data_size" -> metrics("dataSize"),
-      "write_time" -> metrics(SQLShuffleWriteMetricsReporter.SHUFFLE_WRITE_TIME)) ++
+      "write_time" -> metricsWriteTime) ++
       metrics.filterKeys(detailedMetrics.contains)
     val nativeMetrics = CometMetricNode(nativeSQLMetrics)
 
@@ -121,6 +123,8 @@ class CometNativeShuffleWriter[K, V](
 
     // Total written bytes at native
     metricsReporter.incBytesWritten(Files.size(tempDataFilePath))
+    metricsReporter.incRecordsWritten(metricsOutputRows.value)
+    metricsReporter.incWriteTime(metricsWriteTime.value)
 
     // commit
     shuffleBlockResolver.writeMetadataFileAndCommit(

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
@@ -30,7 +30,7 @@ import org.apache.spark.shuffle.{IndexShuffleBlockResolver, ShuffleWriteMetricsR
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, SinglePartition}
 import org.apache.spark.sql.comet.{CometExec, CometMetricNode}
-import org.apache.spark.sql.execution.metric.{SQLMetric, SQLShuffleWriteMetricsReporter}
+import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import org.apache.comet.CometConf
@@ -80,8 +80,8 @@ class CometNativeShuffleWriter[K, V](
       "spilled_bytes")
 
     // Maps native metrics to SQL metrics
-    val metricsOutputRows = metrics(SQLShuffleWriteMetricsReporter.SHUFFLE_RECORDS_WRITTEN)
-    val metricsWriteTime = metrics(SQLShuffleWriteMetricsReporter.SHUFFLE_WRITE_TIME)
+    val metricsOutputRows = new SQLMetric("outputRows")
+    val metricsWriteTime = new SQLMetric("writeTime")
     val nativeSQLMetrics = Map(
       "output_rows" -> metricsOutputRows,
       "data_size" -> metrics("dataSize"),

--- a/spark/src/test/scala/org/apache/spark/sql/comet/CometTaskMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/CometTaskMetricsSuite.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet
+
+import scala.collection.mutable
+
+import org.apache.spark.executor.ShuffleReadMetrics
+import org.apache.spark.executor.ShuffleWriteMetrics
+import org.apache.spark.scheduler.SparkListener
+import org.apache.spark.scheduler.SparkListenerTaskEnd
+import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.comet.execution.shuffle.CometNativeShuffle
+import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+
+class CometTaskMetricsSuite extends CometTestBase with AdaptiveSparkPlanHelper {
+
+  import testImplicits._
+
+  test("per-task native shuffle metrics") {
+    withParquetTable((0 until 10000).map(i => (i, (i + 1).toLong)), "tbl") {
+      val df = sql("SELECT * FROM tbl").sortWithinPartitions($"_1".desc)
+      val shuffled = df.repartition(1, $"_1")
+
+      val cometShuffle = find(shuffled.queryExecution.executedPlan) {
+        case _: CometShuffleExchangeExec => true
+        case _ => false
+      }
+      assert(cometShuffle.isDefined, "CometShuffleExchangeExec not found in the plan")
+      assert(
+        cometShuffle.get.asInstanceOf[CometShuffleExchangeExec].shuffleType == CometNativeShuffle)
+
+      val shuffleWriteMetricsList = mutable.ArrayBuffer.empty[ShuffleWriteMetrics]
+      val shuffleReadMetricsList = mutable.ArrayBuffer.empty[ShuffleReadMetrics]
+
+      spark.sparkContext.addSparkListener(new SparkListener {
+        override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
+          val taskMetrics = taskEnd.taskMetrics
+
+          if (taskEnd.taskType.contains("ShuffleMapTask")) {
+            val shuffleWriteMetrics = taskMetrics.shuffleWriteMetrics
+            shuffleWriteMetricsList.synchronized {
+              shuffleWriteMetricsList += shuffleWriteMetrics
+            }
+          } else {
+            val shuffleReadMetrics = taskMetrics.shuffleReadMetrics
+            shuffleReadMetricsList.synchronized {
+              shuffleReadMetricsList += shuffleReadMetrics
+            }
+          }
+        }
+      })
+
+      // Avoid receiving earlier taskEnd events
+      spark.sparkContext.listenerBus.waitUntilEmpty()
+
+      // Run the action to trigger the shuffle
+      shuffled.collect()
+
+      spark.sparkContext.listenerBus.waitUntilEmpty()
+
+      // Check the shuffle write and read metrics
+      assert(shuffleWriteMetricsList.nonEmpty, "No shuffle write metrics found")
+      shuffleWriteMetricsList.foreach { metrics =>
+        assert(metrics.writeTime > 0)
+        assert(metrics.bytesWritten > 0)
+        assert(metrics.recordsWritten > 0)
+      }
+
+      assert(shuffleReadMetricsList.nonEmpty, "No shuffle read metrics found")
+      shuffleReadMetricsList.foreach { metrics =>
+        assert(metrics.recordsRead > 0)
+        assert(metrics.totalBytesRead > 0)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Which issue does this PR close?

Closes #1616 .

## Rationale for this change

Shuffle write records and shuffle write time are missing in per-task metrics, which makes it inconvenient to troubleshoot query performance problems.

## What changes are included in this PR?

Expose shuffle write rows and shuffle write time to task metrics.

Before:
<img width="1791" alt="missing_shuffle_write_metrics" src="https://github.com/user-attachments/assets/6a49d51a-1b78-4f8b-8ace-81497192e5dd" />

After:
<img width="1790" alt="having_shuffle_write_metrics" src="https://github.com/user-attachments/assets/4fa450f2-eb8f-46c8-8867-756f23a6107f" />


## How are these changes tested?

1. Added unit test
2. Tested manually in local environment
