### PR TITLE
chore: refactor v2 scan conversion

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -133,7 +133,7 @@ class CometSparkSessionExtensions
 
       if (COMET_DPP_FALLBACK_ENABLED.get() &&
         scanExec.partitionFilters.exists(isDynamicPruningFilter)) {
-        return withInfo(scanExec, "DPP not supported")
+        return withInfo(scanExec, "Dynamic Partition Pruning is not supported")
       }
 
       scanExec.relation match {

--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -231,7 +231,7 @@ class CometSparkSessionExtensions
         }
 
       case _ =>
-        withInfo(scanExec, "Comet Scan only supports Parquet and Iceberg")
+        withInfo(scanExec, "Comet Scan only supports Parquet and Iceberg Parquet file formats")
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -115,7 +115,7 @@ class CometExecSuite extends CometTestBase {
               "select * from dpp_fact join dpp_dim on fact_date = dim_date where dim_id > 7")
           val (_, cometPlan) = checkSparkAnswer(df)
           val infos = new ExtendedExplainInfo().generateExtendedInfo(cometPlan)
-          assert(infos.contains("DPP not supported"))
+          assert(infos.contains("Dynamic Partition Pruning not supported"))
         }
       }
     }

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -115,7 +115,7 @@ class CometExecSuite extends CometTestBase {
               "select * from dpp_fact join dpp_dim on fact_date = dim_date where dim_id > 7")
           val (_, cometPlan) = checkSparkAnswer(df)
           val infos = new ExtendedExplainInfo().generateExtendedInfo(cometPlan)
-          assert(infos.contains("Dynamic Partition Pruning not supported"))
+          assert(infos.contains("Dynamic Partition Pruning is not supported"))
         }
       }
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

In https://github.com/apache/datafusion-comet/pull/1483, we refactored the logic for translating v1 data source scans into Comet scans and reduced duplication and fixed some bugs.

This PR applies a similar refactoring to the v2 handling to make it consistent. In this case no bugs were found and there are no functional changes other than improving one fallback message to now mention Iceberg in addition to Parquet.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
