### PR TITLE
feat: track unified memory pool

### DIFF
--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -382,13 +382,19 @@ fn create_memory_pool(
         MemoryPoolType::Unified => {
             // Set Comet memory pool for native
             let memory_pool = CometMemoryPool::new(comet_task_memory_manager);
-            Arc::new(memory_pool)
+            Arc::new(TrackConsumersPool::new(
+                memory_pool,
+                NonZeroUsize::new(NUM_TRACKED_CONSUMERS).unwrap(),
+            ))
         }
         MemoryPoolType::FairUnified => {
             // Set Comet fair memory pool for native
             let memory_pool =
                 CometFairMemoryPool::new(comet_task_memory_manager, memory_pool_config.pool_size);
-            Arc::new(memory_pool)
+            Arc::new(TrackConsumersPool::new(
+                memory_pool,
+                NonZeroUsize::new(NUM_TRACKED_CONSUMERS).unwrap(),
+            ))
         }
         MemoryPoolType::Greedy => Arc::new(TrackConsumersPool::new(
             GreedyMemoryPool::new(memory_pool_config.pool_size),


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

track unified memory pool

## What changes are included in this PR?

Wrap unified memory pool with TrackConsumersPool

## How are these changes tested?

after this:

```
25/04/15 22:01:13 WARN TaskSetManager: Lost task 0.0 in stage 32.0 (TID 8219) (10.5.154.255 executor driver): org.apache.comet.CometNativeException: Resources exhausted: Additional allocation failed with top memory consumers (across reservations) as: HashJoinInput[0] consumed 16737056 bytes, GroupedHashAggregateStream[0] consumed 0 bytes. Error: Failed to acquire 106560 bytes, only got 40160. Reserved: 16737056
	at org.apache.comet.Native.executePlan(Native Method)
	at org.apache.comet.CometExecIterator.$anonfun$getNextBatch$1(CometExecIterator.scala:137)
	at org.apache.comet.CometExecIterator.$anonfun$getNextBatch$1$adapted(CometExecIterator.scala:135)

```