### PR TITLE
fix: handle missing field correctly in native_iceberg_compat

### DIFF
--- a/common/src/main/java/org/apache/comet/parquet/BatchReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/BatchReader.java
@@ -282,6 +282,9 @@ public class BatchReader extends RecordReader<Void, ColumnarBatch> implements Cl
     // Initialize missing columns and use null vectors for them
     missingColumns = new boolean[columns.size()];
     List<String[]> paths = requestedSchema.getPaths();
+    // We do not need the column index of the row index; but this method has the
+    // side effect of throwing an exception if a column with the same name is
+    // found which we do want (spark unit tests explicitly test for that).
     ShimFileFormat.findRowIndexColumnIndexInSchema(sparkSchema);
     StructField[] nonPartitionFields = sparkSchema.fields();
     for (int i = 0; i < requestedSchema.getFieldCount(); i++) {


### PR DESCRIPTION
## 
Part of #1542 

## Rationale for this change

In some cases, the field that is being requested does not exist in the file being read. With primitive types, one has to check if the default value is defined and if so return the default value (otherwise return null). With complex types, we merely return null. Existing code was trying to treat complex types the same way as primitive types and failing an internal assertion.


## How are these changes tested?

Spark SQL tests 

(Note: I also added a comment that was requested in a previous PR, not related to this change).