### PR TITLE
fix: update row groups count in internal metrics accumulator

### DIFF
--- a/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
@@ -384,8 +384,7 @@ public class NativeBatchReader extends RecordReader<Void, ColumnarBatch> impleme
         if (accu.isDefined() && accu.get().getClass().getSimpleName().equals("NumRowGroupsAcc")) {
           @SuppressWarnings("unchecked")
           AccumulatorV2<Integer, Integer> intAccum = (AccumulatorV2<Integer, Integer>) accu.get();
-          // TODO: Get num_row_groups from native
-          // intAccum.add(fileReader.getRowGroups().size());
+          intAccum.add(blocks.size());
         }
       }
 


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion-comet/issues/1542

## Rationale for this change

Addresses more sql test failures

## What changes are included in this PR?

In BatchScan, the batch reader updates an internal metric directly for every row group that we read. in native_iceberg_compat this code was commented out because at that time the exact row group count was not available. With recent fixes, this count is now trivially available. This addresses sql test failures which were using this metics to verify that row group filtering was working correctly.

## How are these changes tested?

Spark sql tests