### PR TITLE
chore: Enable CometFuzzTestSuite int96 test for experimental native scans (without complex types)

### DIFF
--- a/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
@@ -189,12 +189,12 @@ class CometFuzzTestSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("Parquet temporal types written as INT96") {
-
-    // there are known issues with INT96 support in the new experimental scans
-    // https://github.com/apache/datafusion-comet/issues/1441
-    assume(!CometConf.isExperimentalNativeScan)
-
-    testParquetTemporalTypes(ParquetOutputTimestampType.INT96)
+    // int96 coercion in DF does not work with nested types yet
+    // https://github.com/apache/datafusion/issues/15763
+    testParquetTemporalTypes(
+      ParquetOutputTimestampType.INT96,
+      generateArray = false,
+      generateStruct = false)
   }
 
   test("Parquet temporal types written as TIMESTAMP_MICROS") {
@@ -206,10 +206,15 @@ class CometFuzzTestSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   private def testParquetTemporalTypes(
-      outputTimestampType: ParquetOutputTimestampType.Value): Unit = {
+      outputTimestampType: ParquetOutputTimestampType.Value,
+      generateArray: Boolean = true,
+      generateStruct: Boolean = true): Unit = {
 
     val options =
-      DataGenOptions(generateArray = true, generateStruct = true, generateNegativeZero = false)
+      DataGenOptions(
+        generateArray = generateArray,
+        generateStruct = generateStruct,
+        generateNegativeZero = false)
 
     withTempPath { filename =>
       val random = new Random(42)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

#1652 added better int96 support for experimental native scans (relying on CometCastSuite and other Parquet tests) but did not enable CometFuzzTestSuite because it uses complex types by default. There's an [issue](https://github.com/apache/datafusion/issues/15763) in DF's schema coercion for complex types.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR modifies the test to get coverage with the int96 data type without complex types.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

New test coverage.
