### PR TITLE
chore: Remove fallback reason "because the children were not native"

### DIFF
--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1877,10 +1877,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
               "extractintervalmonths is not supported")),
           (
             s"SELECT sum(c0), sum(c2) from $table group by c1",
-            Set(
-              "HashAggregate is not native because the following children are not native (AQEShuffleRead)",
-              "HashAggregate is not native because the following children are not native (Exchange)",
-              "Comet shuffle is not enabled: spark.comet.exec.shuffle.enabled is not enabled")),
+            Set("Comet shuffle is not enabled: spark.comet.exec.shuffle.enabled is not enabled")),
           (
             "SELECT A.c1, A.sum_c0, A.sum_c2, B.casted from "
               + s"(SELECT c1, sum(c0) as sum_c0, sum(c2) as sum_c2 from $table group by c1) as A, "
@@ -1888,12 +1885,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
               + "where A.c1 = B.c1 ",
             Set(
               "Comet shuffle is not enabled: spark.comet.exec.shuffle.enabled is not enabled",
-              "make_interval is not supported",
-              "HashAggregate is not native because the following children are not native (AQEShuffleRead)",
-              "HashAggregate is not native because the following children are not native (Exchange)",
-              "Project is not native because the following children are not native (BroadcastHashJoin)",
-              "BroadcastHashJoin is not enabled because the following children are not native" +
-                " (BroadcastExchange, Project)")))
+              "make_interval is not supported")))
           .foreach(test => {
             val qry = test._1
             val expected = test._2


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The message "OPERATOR is not native because the following children are not native: ..." is not very helpful. I originally asked for this feature, but I think we should remove it. We really just want to know why the first operator falls back to Spark.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
