### PR TITLE
chore: Update viable crates

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -38,6 +38,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Install Build Dependencies
+        shell: bash
+        run: |
+          apt-get update
+          apt-get install -y protobuf-compiler
+          apt-get install -y clang
       - name: Install Miri
         run: |
           rustup toolchain install nightly --component miri

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Install Build Dependencies
         shell: bash
         run: |
-          apt-get update
-          apt-get install -y protobuf-compiler
-          apt-get install -y clang
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+          sudo apt-get install -y clang
       - name: Install Miri
         run: |
           rustup toolchain install nightly --component miri

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-comet"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "arrow",
  "assertables",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-comet-objectstore-hdfs"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-comet-proto"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-comet-spark-expr"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "arrow",
  "chrono",

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
  "zerocopy 0.7.35",
@@ -167,7 +167,7 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "chrono",
- "chrono-tz 0.10.3",
+ "chrono-tz",
  "half",
  "hashbrown 0.15.2",
  "num",
@@ -337,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "assertables"
-version = "7.0.1"
+version = "9.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c24e9d990669fbd16806bff449e4ac644fd9b1fca014760087732fe4102f131"
+checksum = "218459a1ca1459c9fbfedc0dc14febf22d0b809708d496b2368e407da91ff5a8"
 
 [[package]]
 name = "async-trait"
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389a099b34312839e16420d499a9cad9650541715937ffbdd40d36f49e77eeb3"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -485,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
+checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -576,35 +576,13 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
-dependencies = [
- "chrono",
- "chrono-tz-build 0.2.1",
- "phf",
-]
-
-[[package]]
-name = "chrono-tz"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efdce149c370f133a071ca8ef6ea340b7b88748ab0810097a9e2976eaa34b4f3"
 dependencies = [
  "chrono",
- "chrono-tz-build 0.4.1",
+ "chrono-tz-build",
  "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
-dependencies = [
- "parse-zoneinfo",
- "phf",
- "phf_codegen",
 ]
 
 [[package]]
@@ -657,18 +635,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -715,7 +693,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "tiny-keccak",
 ]
@@ -886,7 +864,8 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe060b978f74ab446be722adb8a274e052e005bf6dfd171caadc3abaad10080"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -936,7 +915,8 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61fe34f401bd03724a1f96d12108144f8cd495a3cdda2bf5e091822fb80b7e66"
 dependencies = [
  "arrow",
  "async-trait",
@@ -961,7 +941,8 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4411b8e3bce5e0fc7521e44f201def2e2d5d1b5f176fb56e8cdc9942c890f00"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1011,17 +992,16 @@ dependencies = [
  "parquet",
  "paste",
  "pprof",
- "prost 0.12.6",
- "rand 0.8.5",
+ "prost",
+ "rand 0.9.1",
  "regex",
- "serde",
  "simd-adler32",
  "snap",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "url",
- "zstd 0.11.2+zstd.1.5.2",
+ "zstd",
 ]
 
 [[package]]
@@ -1042,7 +1022,7 @@ dependencies = [
 name = "datafusion-comet-proto"
 version = "0.8.0"
 dependencies = [
- "prost 0.12.6",
+ "prost",
  "prost-build",
 ]
 
@@ -1052,15 +1032,14 @@ version = "0.8.0"
 dependencies = [
  "arrow",
  "chrono",
- "chrono-tz 0.8.6",
+ "chrono-tz",
  "criterion",
  "datafusion",
  "futures",
  "num",
- "parquet",
- "rand 0.8.5",
+ "rand 0.9.1",
  "regex",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "twox-hash 2.1.0",
 ]
@@ -1068,7 +1047,8 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0734015d81c8375eb5d4869b7f7ecccc2ee8d6cb81948ef737cd0e7b743bd69c"
 dependencies = [
  "ahash",
  "arrow",
@@ -1090,7 +1070,8 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5167bb1d2ccbb87c6bc36c295274d7a0519b14afcfdaf401d53cbcaa4ef4968b"
 dependencies = [
  "futures",
  "log",
@@ -1100,7 +1081,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e602dcdf2f50c2abf297cc2203c73531e6f48b29516af7695d338cf2a778b1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1129,7 +1111,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bb2253952dc32296ed5b84077cb2e0257fea4be6373e1c376426e17ead4ef6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1153,7 +1136,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8c7f47a5d2fe03bfa521ec9bafdb8a5c82de8377f60967c3663f00c8790352"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1177,7 +1161,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d15868ea39ed2dc266728b554f6304acd473de2142281ecfa1294bb7415923"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1207,12 +1192,14 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a91f8c2c5788ef32f48ff56c68e5b545527b744822a284373ac79bba1ba47292"
 
 [[package]]
 name = "datafusion-execution"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06f004d100f49a3658c9da6fb0c3a9b760062d96cd4ad82ccc3b7b69a9fb2f84"
 dependencies = [
  "arrow",
  "dashmap",
@@ -1230,7 +1217,8 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4e4ce3802609be38eeb607ee72f6fe86c3091460de9dbfae9e18db423b3964"
 dependencies = [
  "arrow",
  "chrono",
@@ -1249,7 +1237,8 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422ac9cf3b22bbbae8cdf8ceb33039107fde1b5492693168f13bd566b1bcc839"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1261,7 +1250,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ddf0a0a2db5d2918349c978d42d80926c6aa2459cd8a3c533a84ec4bb63479e"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1289,7 +1279,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "408a05dafdc70d05a38a29005b8b15e21b0238734dab1e98483fcb58038c5aba"
 dependencies = [
  "ahash",
  "arrow",
@@ -1309,7 +1300,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756d21da2dd6c9bef97af1504970ff56cbf35d03fbd4ffd62827f02f4d2279d4"
 dependencies = [
  "ahash",
  "arrow",
@@ -1321,7 +1313,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d8d50f6334b378930d992d801a10ac5b3e93b846b39e4a05085742572844537"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -1341,7 +1334,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9a97220736c8fff1446e936be90d57216c06f28969f9ffd3b72ac93c958c8a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1356,7 +1350,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cefc2d77646e1aadd1d6a9c40088937aedec04e68c5f0465939912e1291f8193"
 dependencies = [
  "datafusion-common",
  "datafusion-doc",
@@ -1372,7 +1367,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4aff082c42fa6da99ce0698c85addd5252928c908eb087ca3cfa64ff16b313"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1381,7 +1377,8 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df6f88d7ee27daf8b108ba910f9015176b36fbc72902b1ca5c2a5f1d1717e1a1"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -1391,7 +1388,8 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084d9f979c4b155346d3c34b18f4256e6904ded508e9554d90fed416415c3515"
 dependencies = [
  "arrow",
  "chrono",
@@ -1408,7 +1406,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c536062b0076f4e30084065d805f389f9fe38af0ca75bcbac86bc5e9fbab65"
 dependencies = [
  "ahash",
  "arrow",
@@ -1423,13 +1422,14 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "paste",
- "petgraph 0.7.1",
+ "petgraph",
 ]
 
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a92b53b3193fac1916a1c5b8e3f4347c526f6822e56b71faa5fb372327a863"
 dependencies = [
  "ahash",
  "arrow",
@@ -1442,7 +1442,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fa0a5ac94c7cf3da97bedabd69d6bbca12aef84b9b37e6e9e8c25286511b5e2"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1459,7 +1460,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "690c615db468c2e5fe5085b232d8b1c088299a6c63d87fd960a354a71f7acb55"
 dependencies = [
  "ahash",
  "arrow",
@@ -1488,7 +1490,8 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad229a134c7406c057ece00c8743c0c34b97f4e72f78b475fe17b66c5e14fa4f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1511,7 +1514,8 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "47.0.0"
-source = "git+https://github.com/apache/datafusion?rev=47.0.0#e4433049b04ca2c1e2031eb05d1a0990210f11d6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f6ab28b72b664c21a27b22a2ff815fd390ed224c26e89a93b5a8154a4e8607"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -1630,12 +1634,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixedbitset"
@@ -1808,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1893,12 +1891,9 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2250,15 +2245,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2429,9 +2415,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -2600,9 +2586,9 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.8.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "nix"
@@ -2837,7 +2823,7 @@ dependencies = [
  "thrift",
  "tokio",
  "twox-hash 2.1.0",
- "zstd 0.13.3",
+ "zstd",
 ]
 
 [[package]]
@@ -2869,21 +2855,11 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset 0.4.2",
- "indexmap",
-]
-
-[[package]]
-name = "petgraph"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
- "fixedbitset 0.5.7",
+ "fixedbitset",
  "indexmap",
 ]
 
@@ -3003,6 +2979,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,65 +2999,42 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.9.0"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive 0.9.0",
-]
-
-[[package]]
-name = "prost"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
-dependencies = [
- "bytes",
- "prost-derive 0.12.6",
+ "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.9.0"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "bytes",
  "heck",
- "itertools 0.10.5",
- "lazy_static",
+ "itertools 0.14.0",
  "log",
  "multimap",
- "petgraph 0.6.5",
- "prost 0.9.0",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
  "prost-types",
  "regex",
+ "syn 2.0.100",
  "tempfile",
- "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.9.0"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
-dependencies = [
- "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -3079,12 +3042,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.9.0"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "bytes",
- "prost 0.9.0",
+ "prost",
 ]
 
 [[package]]
@@ -3137,13 +3099,13 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
+checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
 dependencies = [
  "bytes",
  "getrandom 0.3.2",
- "rand 0.9.0",
+ "rand 0.9.1",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -3197,13 +3159,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3232,7 +3193,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -3385,7 +3346,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -3764,9 +3725,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"
-version = "12.15.3"
+version = "12.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb426702a1ee7c1d2ebf3b6fac2e67fde84f6d6396e581826e3f055d1bffb2a4"
+checksum = "23eae23242dffa2e8e66c0e20f4ca1e28391f64e361db1e921a209c9bc70ec3a"
 dependencies = [
  "debugid",
  "memmap2",
@@ -3776,9 +3737,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.15.3"
+version = "12.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4671b7ae11875cb9c34348d2df6c5d1edd51f4c98ec45f591acb593ac8af8e0"
+checksum = "153faacda0d58dc1eb3e8bbd5dab998041e95bd7f4ab2caeeadc89410617f144"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -4787,30 +4748,11 @@ checksum = "868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8"
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe 5.0.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "zstd"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
- "zstd-safe 7.2.4",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
+ "zstd-safe",
 ]
 
 [[package]]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -38,16 +38,16 @@ arrow = { version = "55.0.0", features = ["prettyprint", "ffi", "chrono-tz"] }
 async-trait = { version = "0.1" }
 bytes = { version = "1.10.0" }
 parquet = { version = "55.0.0", default-features = false, features = ["experimental"] }
-datafusion = { git = "https://github.com/apache/datafusion", rev = "47.0.0", default-features = false, features = ["unicode_expressions", "crypto_expressions", "nested_expressions", "parquet"] }
-datafusion-comet-spark-expr = { path = "spark-expr", version = "0.9.0" }
-datafusion-comet-proto = { path = "proto", version = "0.9.0" }
+datafusion = { version = "47.0.0", default-features = false, features = ["unicode_expressions", "crypto_expressions", "nested_expressions", "parquet"] }
+datafusion-comet-spark-expr = { path = "spark-expr" }
+datafusion-comet-proto = { path = "proto" }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-chrono-tz = { version = "0.8" }
+chrono-tz = { version = "0.10" }
 futures = "0.3.28"
 num = "0.4"
-rand = "0.8"
+rand = "0.9"
 regex = "1.9.6"
-thiserror = "1"
+thiserror = "2"
 object_store = { version = "0.12.0", features = ["gcp", "azure", "aws", "http"] }
 url = "2.2"
 

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -44,14 +44,13 @@ async-trait = { workspace = true }
 log = "0.4"
 log4rs = "1.2.0"
 thiserror = { workspace = true }
-serde = { version = "1", features = ["derive"] }
 lazy_static = "1.4.0"
-prost = "0.12.1"
+prost = "0.13.5"
 jni = "0.21"
 snap = "1.1"
 # we disable default features in lz4_flex to force the use of the faster unsafe encoding and decoding implementation
 lz4_flex = { version = "0.11.3", default-features = false }
-zstd = "0.11"
+zstd = "0.13.3"
 rand = { workspace = true}
 num = { workspace = true }
 bytes = { workspace = true }
@@ -75,9 +74,9 @@ pprof = { version = "0.14.0", features = ["flamegraph"] }
 criterion = { version = "0.5.1", features = ["async_tokio"] }
 jni = { version = "0.21", features = ["invocation"] }
 lazy_static = "1.4"
-assertables = "7"
+assertables = "9"
 hex = "0.4.3"
-datafusion-functions-nested = { git = "https://github.com/apache/datafusion", rev = "47.0.0" }
+datafusion-functions-nested = { version = "47.0.0" }
 
 [features]
 default = []

--- a/native/core/benches/bit_util.rs
+++ b/native/core/benches/bit_util.rs
@@ -17,7 +17,7 @@
 
 use std::{mem::size_of, time::Duration};
 
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 
 use arrow::buffer::Buffer;
 use comet::common::bit::{
@@ -36,7 +36,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     const N: usize = 1024 * 1024;
     let mut writer: BitWriter = BitWriter::new(N * 10);
     for _ in 0..N {
-        if !writer.put_vlq_int(thread_rng().gen::<u64>()) {
+        if !writer.put_vlq_int(rng().random::<u64>()) {
             break;
         }
     }

--- a/native/core/benches/common.rs
+++ b/native/core/benches/common.rs
@@ -21,7 +21,7 @@ use arrow::{
     datatypes::{ArrowPrimitiveType, Int32Type},
 };
 use rand::{
-    distributions::{Distribution, Standard},
+    distr::{Distribution, StandardUniform},
     rngs::StdRng,
     Rng, SeedableRng,
 };
@@ -36,10 +36,10 @@ pub fn create_int64_array(size: usize, null_density: f32, min: i64, max: i64) ->
     let mut rng = seedable_rng();
     (0..size)
         .map(|_| {
-            if rng.gen::<f32>() < null_density {
+            if rng.random::<f32>() < null_density {
                 None
             } else {
-                Some(rng.gen_range(min..max))
+                Some(rng.random_range(min..max))
             }
         })
         .collect()
@@ -49,15 +49,15 @@ pub fn create_int64_array(size: usize, null_density: f32, min: i64, max: i64) ->
 pub fn create_primitive_array<T>(size: usize, null_density: f32) -> PrimitiveArray<T>
 where
     T: ArrowPrimitiveType,
-    Standard: Distribution<T::Native>,
+    StandardUniform: Distribution<T::Native>,
 {
     let mut rng = seedable_rng();
     (0..size)
         .map(|_| {
-            if rng.gen::<f32>() < null_density {
+            if rng.random::<f32>() < null_density {
                 None
             } else {
-                Some(rng.gen())
+                Some(rng.random())
             }
         })
         .collect()
@@ -73,7 +73,7 @@ pub fn create_dictionary_array<T>(
 ) -> Result<DictionaryArray<Int32Type>, ArrowError>
 where
     T: ArrowPrimitiveType,
-    Standard: Distribution<T::Native>,
+    StandardUniform: Distribution<T::Native>,
 {
     // values are not null
     let values = create_primitive_array::<T>(value_size, 0.0);

--- a/native/core/benches/parquet_read.rs
+++ b/native/core/benches/parquet_read.rs
@@ -121,7 +121,7 @@ fn build_plain_int32_pages(
         let mut values = Vec::with_capacity(VALUES_PER_PAGE);
         let mut def_levels = Vec::with_capacity(VALUES_PER_PAGE);
         for _ in 0..VALUES_PER_PAGE {
-            let def_level = if rng.gen::<f32>() < null_density {
+            let def_level = if rng.random::<f32>() < null_density {
                 max_def_level - 1
             } else {
                 max_def_level

--- a/native/core/src/common/bit.rs
+++ b/native/core/src/common/bit.rs
@@ -1014,7 +1014,7 @@ mod tests {
     use crate::parquet::util::test_common::*;
 
     use rand::{
-        distributions::{Distribution, Standard},
+        distr::{Distribution, StandardUniform},
         Rng,
     };
     use std::fmt::Debug;
@@ -1378,16 +1378,16 @@ mod tests {
         // test reading consecutively from a buffer
         let mut reader = BitReader::from(vec);
         let mut buffer = vec![0; NUM_BYTES];
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut bits_read = 0;
 
         loop {
             if bits_read >= total_num_bits {
                 break;
             }
-            let n: usize = rng.gen();
+            let n: u64 = rng.random();
             let num_bits = n % 20;
-            bits_read += reader.get_bits(&mut buffer, bits_read, num_bits);
+            bits_read += reader.get_bits(&mut buffer, bits_read, num_bits as usize);
         }
 
         assert_eq!(total_num_bits, bits_read);
@@ -1424,14 +1424,14 @@ mod tests {
         }
 
         // test skipping consecutively
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         loop {
             if bits_read >= total_num_bits {
                 break;
             }
-            let n: usize = rng.gen();
+            let n: u64 = rng.random();
             let num_bits = n % 20;
-            bits_read += reader.skip_bits(num_bits);
+            bits_read += reader.skip_bits(num_bits as usize);
         }
 
         assert_eq!(total_num_bits, bits_read);
@@ -1534,10 +1534,10 @@ mod tests {
     fn test_put_aligned_rand_numbers<T>(total: usize, num_bits: usize)
     where
         T: Copy + FromBytes + AsBytes + Debug + PartialEq,
-        Standard: Distribution<T>,
+        StandardUniform: Distribution<T>,
     {
         assert!(num_bits <= 32);
-        assert!(total % 2 == 0);
+        assert_eq!(total % 2, 0);
 
         let aligned_value_byte_width = std::mem::size_of::<T>();
         let value_byte_width = ceil(num_bits, 8);

--- a/native/core/src/errors.rs
+++ b/native/core/src/errors.rs
@@ -517,7 +517,7 @@ mod tests {
         AttachGuard, InitArgsBuilder, JNIEnv, JNIVersion, JavaVM,
     };
 
-    use assertables::{assert_starts_with, assert_starts_with_as_result};
+    use assertables::assert_starts_with;
 
     pub fn jvm() -> &'static Arc<JavaVM> {
         static mut JVM: Option<Arc<JavaVM>> = None;

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -2423,7 +2423,7 @@ fn rewrite_physical_expr(
     Ok(expr.rewrite(&mut rewriter).data()?)
 }
 
-fn from_protobuf_eval_mode(value: i32) -> Result<EvalMode, prost::DecodeError> {
+fn from_protobuf_eval_mode(value: i32) -> Result<EvalMode, prost::UnknownEnumValue> {
     match spark_expression::EvalMode::try_from(value)? {
         spark_expression::EvalMode::Legacy => Ok(EvalMode::Legacy),
         spark_expression::EvalMode::Try => Ok(EvalMode::Try),

--- a/native/core/src/execution/serde.rs
+++ b/native/core/src/execution/serde.rs
@@ -40,8 +40,20 @@ impl From<prost::DecodeError> for ExpressionError {
     }
 }
 
+impl From<prost::UnknownEnumValue> for ExpressionError {
+    fn from(error: prost::UnknownEnumValue) -> ExpressionError {
+        ExpressionError::Deserialize(error.to_string())
+    }
+}
+
 impl From<prost::DecodeError> for ExecutionError {
     fn from(error: prost::DecodeError) -> ExecutionError {
+        ExecutionError::DeserializeError(error.to_string())
+    }
+}
+
+impl From<prost::UnknownEnumValue> for ExecutionError {
+    fn from(error: prost::UnknownEnumValue) -> ExecutionError {
         ExecutionError::DeserializeError(error.to_string())
     }
 }

--- a/native/core/src/parquet/util/test_common/page_util.rs
+++ b/native/core/src/parquet/util/test_common/page_util.rs
@@ -17,7 +17,7 @@
 
 use std::{collections::VecDeque, mem, sync::Arc};
 
-use rand::distributions::uniform::SampleUniform;
+use rand::distr::uniform::SampleUniform;
 
 use parquet::{
     basic::Encoding,

--- a/native/core/src/parquet/util/test_common/rand_gen.rs
+++ b/native/core/src/parquet/util/test_common/rand_gen.rs
@@ -16,42 +16,42 @@
 // under the License.
 
 use rand::{
-    distributions::{uniform::SampleUniform, Distribution, Standard},
-    thread_rng, Rng,
+    distr::{uniform::SampleUniform, Distribution, StandardUniform},
+    rng, Rng,
 };
 
 pub fn random_bytes(n: usize) -> Vec<u8> {
     let mut result = vec![];
-    let mut rng = thread_rng();
+    let mut rng = rng();
     for _ in 0..n {
-        result.push(rng.gen_range(0..255));
+        result.push(rng.random_range(0..255));
     }
     result
 }
 
 pub fn random_bools(n: usize) -> Vec<bool> {
     let mut result = vec![];
-    let mut rng = thread_rng();
+    let mut rng = rng();
     for _ in 0..n {
-        result.push(rng.gen::<bool>());
+        result.push(rng.random::<bool>());
     }
     result
 }
 
 pub fn random_numbers<T>(n: usize) -> Vec<T>
 where
-    Standard: Distribution<T>,
+    StandardUniform: Distribution<T>,
 {
-    let mut rng = thread_rng();
-    Standard.sample_iter(&mut rng).take(n).collect()
+    let mut rng = rng();
+    StandardUniform.sample_iter(&mut rng).take(n).collect()
 }
 
 pub fn random_numbers_range<T>(n: usize, low: T, high: T, result: &mut Vec<T>)
 where
     T: PartialOrd + SampleUniform + Copy,
 {
-    let mut rng = thread_rng();
+    let mut rng = rng();
     for _ in 0..n {
-        result.push(rng.gen_range(low..high));
+        result.push(rng.random_range(low..high));
     }
 }

--- a/native/proto/Cargo.toml
+++ b/native/proto/Cargo.toml
@@ -27,18 +27,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-prost = "0.12.1"
+prost = "0.13.5"
 
 [build-dependencies]
-prost-build = "0.9.0"
-
-[features]
-default = []
-
-[lib]
-name = "datafusion_comet_proto"
-path = "src/lib.rs"
-
-
-
-
+prost-build = "0.13.5"

--- a/native/spark-expr/Cargo.toml
+++ b/native/spark-expr/Cargo.toml
@@ -40,7 +40,6 @@ rand = { workspace = true }
 
 [dev-dependencies]
 arrow = {workspace = true}
-parquet = { workspace = true, features = ["arrow"] }
 criterion = "0.5.1"
 rand = { workspace = true}
 tokio = { version = "1", features = ["rt-multi-thread"] }


### PR DESCRIPTION
## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Reduce the amount of duplicate crates due to crates that use outdated versions, thereby improving compile times and reducing binary size.
Some of the crates(such as rand) have also made changes due to upcoming Rust Compiler changes that would give them compilation errors(reserved keywords, in this case, I believe)

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Update crate versions, removed some unused crates, removed crate versions when using "path"(for less maintenance), and moved to use the crates.io version of datafusion now that its released(it was left on the git version)
For the rand crate, updated the usage based on the deprecation warnings. 

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Firstly by compilation, then all the tests passing normally should be enough.
As for timing and crate count:

branch `main`
Binary size - 75MBs (release build)

![image](https://github.com/user-attachments/assets/2aae8844-2044-4037-b66f-3bd47576bb48)

branch `update-crates`
Binary size - 73MBs(release build)

![image](https://github.com/user-attachments/assets/8c2c1a72-b32d-4f23-ac4c-88eedee7ab73)
