### PR TITLE
feat: add jemalloc as optional custom allocator

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -681,6 +681,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,8 +1026,11 @@ dependencies = [
  "serde",
  "simd-adler32",
  "snap",
+ "snmalloc-rs",
+ "tcmalloc",
  "tempfile",
  "thiserror 1.0.69",
+ "tikv-jemallocator",
  "tokio",
  "url",
  "zstd 0.11.2+zstd.1.5.2",
@@ -3694,6 +3706,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
+name = "snmalloc-rs"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb317153089fdfa4d8a2eec059d40a5a23c3bde43995ea23b19121c3f621e74a"
+dependencies = [
+ "snmalloc-sys",
+]
+
+[[package]]
+name = "snmalloc-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065fea53d32bb77bc36cca466cb191f2e5216ebfd0ed360b1d64889ee6e559ea"
+dependencies = [
+ "cmake",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3828,6 +3858,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tcmalloc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375205113d84a1c5eeed67beaa0ce08e41be1a9d5acc3425ad2381fddd9d819b"
+dependencies = [
+ "tcmalloc-sys",
+]
+
+[[package]]
+name = "tcmalloc-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7ad73e635dd232c2c2106d59269f59a61de421cc6b95252d2d932094ff1f40"
+
+[[package]]
 name = "tempfile"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3899,6 +3944,26 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "ordered-float",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -681,15 +681,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "cmake"
-version = "0.1.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,7 +1017,6 @@ dependencies = [
  "serde",
  "simd-adler32",
  "snap",
- "snmalloc-rs",
  "tempfile",
  "thiserror 1.0.69",
  "tikv-jemallocator",
@@ -3703,24 +3693,6 @@ name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
-
-[[package]]
-name = "snmalloc-rs"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb317153089fdfa4d8a2eec059d40a5a23c3bde43995ea23b19121c3f621e74a"
-dependencies = [
- "snmalloc-sys",
-]
-
-[[package]]
-name = "snmalloc-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065fea53d32bb77bc36cca466cb191f2e5216ebfd0ed360b1d64889ee6e559ea"
-dependencies = [
- "cmake",
-]
 
 [[package]]
 name = "socket2"

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1027,7 +1027,6 @@ dependencies = [
  "simd-adler32",
  "snap",
  "snmalloc-rs",
- "tcmalloc",
  "tempfile",
  "thiserror 1.0.69",
  "tikv-jemallocator",
@@ -3856,21 +3855,6 @@ dependencies = [
  "quote",
  "syn 2.0.100",
 ]
-
-[[package]]
-name = "tcmalloc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375205113d84a1c5eeed67beaa0ce08e41be1a9d5acc3425ad2381fddd9d819b"
-dependencies = [
- "tcmalloc-sys",
-]
-
-[[package]]
-name = "tcmalloc-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7ad73e635dd232c2c2106d59269f59a61de421cc6b95252d2d932094ff1f40"
 
 [[package]]
 name = "tempfile"

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -40,7 +40,6 @@ parquet = { workspace = true, default-features = false, features = ["experimenta
 futures = { workspace = true }
 mimalloc = { version = "*", default-features = false, optional = true }
 tikv-jemallocator = { version = "0.6.0", optional = true, features = ["disable_initial_exec_tls"] }
-snmalloc-rs = { version = "0.3.8", optional = true, features = ["native-cpu", "lto"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 async-trait = { workspace = true }
 log = "0.4"
@@ -85,7 +84,6 @@ datafusion-functions-nested = { git = "https://github.com/apache/datafusion", re
 default = []
 hdfs = ["datafusion-comet-objectstore-hdfs"]
 jemalloc = ["tikv-jemallocator"]
-snmalloc = ["snmalloc-rs"]
 
 # exclude optional packages from cargo machete verifications
 [package.metadata.cargo-machete]

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -39,6 +39,9 @@ arrow = { workspace = true }
 parquet = { workspace = true, default-features = false, features = ["experimental"] }
 futures = { workspace = true }
 mimalloc = { version = "*", default-features = false, optional = true }
+tikv-jemallocator = { version = "0.6.0", optional = true }
+tcmalloc = { version = "0.3.0", optional = true, features = ["bundled"] }
+snmalloc-rs = { version = "0.3.8", optional = true, features = ["native-cpu", "lto"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 async-trait = { workspace = true }
 log = "0.4"
@@ -52,13 +55,13 @@ snap = "1.1"
 # we disable default features in lz4_flex to force the use of the faster unsafe encoding and decoding implementation
 lz4_flex = { version = "0.11.3", default-features = false }
 zstd = "0.11"
-rand = { workspace = true}
+rand = { workspace = true }
 num = { workspace = true }
 bytes = { workspace = true }
 tempfile = "3.8.0"
 itertools = "0.14.0"
 paste = "1.0.14"
-datafusion = {  workspace = true }
+datafusion = { workspace = true }
 once_cell = "1.18.0"
 regex = { workspace = true }
 crc32fast = "1.3.2"
@@ -81,7 +84,9 @@ datafusion-functions-nested = { git = "https://github.com/apache/datafusion", re
 
 [features]
 default = []
-hdfs=["datafusion-comet-objectstore-hdfs"]
+hdfs = ["datafusion-comet-objectstore-hdfs"]
+jemalloc = ["tikv-jemallocator"]
+snmalloc = ["snmalloc-rs"]
 
 # exclude optional packages from cargo machete verifications
 [package.metadata.cargo-machete]

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -40,7 +40,6 @@ parquet = { workspace = true, default-features = false, features = ["experimenta
 futures = { workspace = true }
 mimalloc = { version = "*", default-features = false, optional = true }
 tikv-jemallocator = { version = "0.6.0", optional = true }
-tcmalloc = { version = "0.3.0", optional = true, features = ["bundled"] }
 snmalloc-rs = { version = "0.3.8", optional = true, features = ["native-cpu", "lto"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 async-trait = { workspace = true }

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -39,7 +39,7 @@ arrow = { workspace = true }
 parquet = { workspace = true, default-features = false, features = ["experimental"] }
 futures = { workspace = true }
 mimalloc = { version = "*", default-features = false, optional = true }
-tikv-jemallocator = { version = "0.6.0", optional = true }
+tikv-jemallocator = { version = "0.6.0", optional = true, features = ["disable_initial_exec_tls"] }
 snmalloc-rs = { version = "0.3.8", optional = true, features = ["native-cpu", "lto"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 async-trait = { workspace = true }

--- a/native/core/src/lib.rs
+++ b/native/core/src/lib.rs
@@ -62,10 +62,6 @@ static GLOBAL: Jemalloc = Jemalloc;
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
-#[cfg(feature = "snmalloc")]
-#[global_allocator]
-static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
-
 static JAVA_VM: OnceCell<JavaVM> = OnceCell::new();
 
 #[no_mangle]

--- a/native/core/src/lib.rs
+++ b/native/core/src/lib.rs
@@ -76,20 +76,6 @@ static GLOBAL: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 #[global_allocator]
 static GLOBAL: TCMalloc = TCMalloc;
 
-const _: () = {
-    let enabled_features = {
-        cfg!(feature = "jemalloc") as u32
-            + cfg!(feature = "mimalloc") as u32
-            + cfg!(feature = "snmalloc") as u32
-            + cfg!(feature = "tcmalloc") as u32
-    };
-
-    match enabled_features {
-        0 | 1=> {}
-        2.. => panic!("Invalid feature flags for custom allocators. Please enable at most one of [\"jemalloc\", \"mimalloc\", \"snmalloc\", \"tcmalloc\"]"),
-    }
-};
-
 static JAVA_VM: OnceCell<JavaVM> = OnceCell::new();
 
 #[no_mangle]

--- a/native/core/src/lib.rs
+++ b/native/core/src/lib.rs
@@ -44,9 +44,6 @@ use tikv_jemallocator::Jemalloc;
 #[cfg(feature = "mimalloc")]
 use mimalloc::MiMalloc;
 
-#[cfg(feature = "snmalloc")]
-use snmalloc_rs::SnMalloc;
-
 #[cfg(feature = "tcmalloc")]
 use tcmalloc::TCMalloc;
 
@@ -70,7 +67,7 @@ static GLOBAL: MiMalloc = MiMalloc;
 
 #[cfg(feature = "snmalloc")]
 #[global_allocator]
-static GLOBAL: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
+static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
 #[cfg(feature = "tcmalloc")]
 #[global_allocator]

--- a/native/core/src/lib.rs
+++ b/native/core/src/lib.rs
@@ -44,9 +44,6 @@ use tikv_jemallocator::Jemalloc;
 #[cfg(feature = "mimalloc")]
 use mimalloc::MiMalloc;
 
-#[cfg(feature = "tcmalloc")]
-use tcmalloc::TCMalloc;
-
 use errors::{try_unwrap_or_throw, CometError, CometResult};
 
 #[macro_use]
@@ -68,10 +65,6 @@ static GLOBAL: MiMalloc = MiMalloc;
 #[cfg(feature = "snmalloc")]
 #[global_allocator]
 static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
-
-#[cfg(feature = "tcmalloc")]
-#[global_allocator]
-static GLOBAL: TCMalloc = TCMalloc;
 
 static JAVA_VM: OnceCell<JavaVM> = OnceCell::new();
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1648.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Comet currently supports mimalloc to override the system memory allocator (`make release COMET_FEATURES=mimalloc` or `cargo build --features=mimalloc`). We want to explore jemalloc ([tikv-jemallocator](https://lib.rs/crates/jemallocator) crate) as an alternative to mimalloc for our custom allocator.  I will bring some discussion from #1648:

https://github.com/apache/datafusion-comet/issues/1648#issuecomment-2821590325
> FYI: We found mimalloc to be unstable for running long term (keeps memory allocated but seems doesn't release it over time => running into OOMs much more easily). Switching to jemalloc fixed this.

https://github.com/apache/datafusion-comet/issues/1648#issuecomment-2821819183
> We prefer to use jemalloc with Comet by setting LD_PRELOAD, as it returns freed memory to the operating system more aggressively than ptmalloc, resulting in a more predictable RSS for the Spark executor process. Additionally, jemalloc's memory profiler is helpful for diagnosing OOM issues.
> 
> However, I'm uncertain whether jemalloc can still be used with LD_PRELOAD when Comet is compiled with mimalloc. The last time I attempted to dynamically override malloc it didn't work.

https://github.com/apache/datafusion-comet/issues/1648#issuecomment-2821858616
> I've also only ever used jemalloc in the past. I'm not sure what the discussion was at the time to pursue mimalloc for Comet. [@mdcallag](https://github.com/mdcallag) has some recent writing on the topic, althrough RocksDB is a different workload than what we're doing:
> 
> https://smalldatum.blogspot.com/2025/04/battle-of-mallocators.html https://smalldatum.blogspot.com/2025/04/battle-of-mallocators-part-2.html
> 
> The Germans 🇩🇪 did a bake-off a few years ago and they chose jemalloc for Umbra (and likely CedarDB): https://www.adms-conf.org/2019-camera-ready/durner_adms19.pdf

Other relevant reading:
- https://github.com/jemalloc/jemalloc
- https://github.com/jemalloc/jemalloc/wiki/Background#adoption
- https://internals.rust-lang.org/t/jemalloc-was-just-removed-from-the-standard-library/8759 (Rust used to implicitly link jemalloc at compilation. Now it is still used in the toolchain like rustc)
- https://kerkour.com/rust-jemalloc
- https://magiroux.com/rust-jemalloc-profiling

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add jemalloc as a feature accessible through `make release COMET_FEATURES=jemalloc`. I had tcmalloc (Google) and snmalloc (Microsoft Research) as well, but the former failed to link at compilation time and the latter didn't like being loaded later as a dynamic library with Comet.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
