### PR TITLE
fix: Fall back to Spark when reading Parquet files with structs inside arrays

### DIFF
--- a/spark/src/main/scala/org/apache/comet/DataTypeSupport.scala
+++ b/spark/src/main/scala/org/apache/comet/DataTypeSupport.scala
@@ -67,7 +67,7 @@ trait DataTypeSupport {
         case StructType(fields) => fields.map(_.dataType).forall(isTypeSupported)
         case ArrayType(elementType, _) => isSupportedButNotStruct(elementType)
         case MapType(keyType, valueType, _) =>
-          isTypeSupported(keyType) && isSupportedButNotStruct(valueType)
+          isSupportedButNotStruct(keyType) && isSupportedButNotStruct(valueType)
         // Not a complex type
         case _ => true
       }
@@ -76,7 +76,7 @@ trait DataTypeSupport {
     }
   }
 
-  def isSupportedButNotStruct(dt: DataType): Boolean = {
+  private def isSupportedButNotStruct(dt: DataType): Boolean = {
     dt match {
       case StructType(_) => false
       case ArrayType(elementType, _) => isSupportedButNotStruct(elementType)

--- a/spark/src/main/scala/org/apache/comet/DataTypeSupport.scala
+++ b/spark/src/main/scala/org/apache/comet/DataTypeSupport.scala
@@ -65,14 +65,24 @@ trait DataTypeSupport {
       // If complex types are supported, we additionally want to recurse into their children
       dt match {
         case StructType(fields) => fields.map(_.dataType).forall(isTypeSupported)
-        case ArrayType(elementType, _) => isTypeSupported(elementType)
+        case ArrayType(elementType, _) => isSupportedButNotStruct(elementType)
         case MapType(keyType, valueType, _) =>
-          isTypeSupported(keyType) && isTypeSupported(valueType)
+          isTypeSupported(keyType) && isSupportedButNotStruct(valueType)
         // Not a complex type
         case _ => true
       }
     } else {
       false
+    }
+  }
+
+  def isSupportedButNotStruct(dt: DataType): Boolean = {
+    dt match {
+      case StructType(_) => false
+      case ArrayType(elementType, _) => isSupportedButNotStruct(elementType)
+      case MapType(keyType, valueType, _) =>
+        isSupportedButNotStruct(keyType) && isSupportedButNotStruct(valueType)
+      case _ => isTypeSupported(dt)
     }
   }
 }

--- a/spark/src/test/scala/org/apache/comet/CometComplexTypeSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometComplexTypeSuite.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet
+
+import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+
+class CometComplexTypeSuite extends CometTestBase with AdaptiveSparkPlanHelper {
+
+  // Adapted from Spark's ParquetQuerySuite
+  test("nested data - array of struct") {
+    val data = (1 to 10).map(i => Tuple1(Seq(i -> s"val_$i")))
+    withParquetTable(data, "t") {
+      withSQLConf(CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_ICEBERG_COMPAT) {
+        checkSparkAnswerAndOperator(sql("SELECT _1[0]._2 FROM t"))
+      }
+    }
+  }
+
+}

--- a/spark/src/test/scala/org/apache/comet/CometComplexTypeSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometComplexTypeSuite.scala
@@ -28,8 +28,13 @@ class CometComplexTypeSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   test("nested data - array of struct") {
     val data = (1 to 10).map(i => Tuple1(Seq(i -> s"val_$i")))
     withParquetTable(data, "t") {
-      withSQLConf(CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_ICEBERG_COMPAT) {
-        checkSparkAnswer/*AndOperator*/(sql("SELECT _1[0]._2 FROM t"))
+      Seq(CometConf.SCAN_NATIVE_DATAFUSION, CometConf.SCAN_NATIVE_ICEBERG_COMPAT).foreach {
+        scan =>
+          withSQLConf(CometConf.COMET_NATIVE_SCAN_IMPL.key -> scan) {
+            // TODO check for Comet operators once
+            // https://github.com/apache/datafusion-comet/issues/1681 is resolved
+            checkSparkAnswer /*AndOperator*/ (sql("SELECT _1[0]._2 FROM t"))
+          }
       }
     }
   }

--- a/spark/src/test/scala/org/apache/comet/CometComplexTypeSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometComplexTypeSuite.scala
@@ -29,7 +29,7 @@ class CometComplexTypeSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     val data = (1 to 10).map(i => Tuple1(Seq(i -> s"val_$i")))
     withParquetTable(data, "t") {
       withSQLConf(CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_ICEBERG_COMPAT) {
-        checkSparkAnswerAndOperator(sql("SELECT _1[0]._2 FROM t"))
+        checkSparkAnswer/*AndOperator*/(sql("SELECT _1[0]._2 FROM t"))
       }
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Workaround for https://github.com/apache/datafusion-comet/issues/1681

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We have a correctness issues when reading Parquet files with structs inside arrays when using the new experimental scans.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Test to demonstrate the issue
- Fall back to Spark for structs inside arrays or maps

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
