### PR TITLE
chore: Rename `scalarExprToProto` to `scalarFunctionExprToProto`

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -1018,13 +1018,15 @@ object QueryPlanSerde extends Logging with CometExprShim {
       case DateAdd(left, right) =>
         val leftExpr = exprToProtoInternal(left, inputs, binding)
         val rightExpr = exprToProtoInternal(right, inputs, binding)
-        val optExpr = scalarExprToProtoWithReturnType("date_add", DateType, leftExpr, rightExpr)
+        val optExpr =
+          scalarFunctionExprToProtoWithReturnType("date_add", DateType, leftExpr, rightExpr)
         optExprWithInfo(optExpr, expr, left, right)
 
       case DateSub(left, right) =>
         val leftExpr = exprToProtoInternal(left, inputs, binding)
         val rightExpr = exprToProtoInternal(right, inputs, binding)
-        val optExpr = scalarExprToProtoWithReturnType("date_sub", DateType, leftExpr, rightExpr)
+        val optExpr =
+          scalarFunctionExprToProtoWithReturnType("date_sub", DateType, leftExpr, rightExpr)
         optExprWithInfo(optExpr, expr, left, right)
 
       case TruncDate(child, format) =>
@@ -1091,7 +1093,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
       case Year(child) =>
         val periodType = exprToProtoInternal(Literal("year"), inputs, binding)
         val childExpr = exprToProtoInternal(child, inputs, binding)
-        val optExpr = scalarExprToProto("datepart", Seq(periodType, childExpr): _*)
+        val optExpr = scalarFunctionExprToProto("datepart", Seq(periodType, childExpr): _*)
           .map(e => {
             Expr
               .newBuilder()
@@ -1126,7 +1128,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
       case IsNaN(child) =>
         val childExpr = exprToProtoInternal(child, inputs, binding)
         val optExpr =
-          scalarExprToProtoWithReturnType("isnan", BooleanType, childExpr)
+          scalarFunctionExprToProtoWithReturnType("isnan", BooleanType, childExpr)
 
         optExprWithInfo(optExpr, expr, child)
 
@@ -1265,29 +1267,29 @@ object QueryPlanSerde extends Logging with CometExprShim {
 
       case Acos(child) =>
         val childExpr = exprToProtoInternal(child, inputs, binding)
-        val optExpr = scalarExprToProto("acos", childExpr)
+        val optExpr = scalarFunctionExprToProto("acos", childExpr)
         optExprWithInfo(optExpr, expr, child)
 
       case Asin(child) =>
         val childExpr = exprToProtoInternal(child, inputs, binding)
-        val optExpr = scalarExprToProto("asin", childExpr)
+        val optExpr = scalarFunctionExprToProto("asin", childExpr)
         optExprWithInfo(optExpr, expr, child)
 
       case Atan(child) =>
         val childExpr = exprToProtoInternal(child, inputs, binding)
-        val optExpr = scalarExprToProto("atan", childExpr)
+        val optExpr = scalarFunctionExprToProto("atan", childExpr)
         optExprWithInfo(optExpr, expr, child)
 
       case Atan2(left, right) =>
         val leftExpr = exprToProtoInternal(left, inputs, binding)
         val rightExpr = exprToProtoInternal(right, inputs, binding)
-        val optExpr = scalarExprToProto("atan2", leftExpr, rightExpr)
+        val optExpr = scalarFunctionExprToProto("atan2", leftExpr, rightExpr)
         optExprWithInfo(optExpr, expr, left, right)
 
       case Hex(child) =>
         val childExpr = exprToProtoInternal(child, inputs, binding)
         val optExpr =
-          scalarExprToProtoWithReturnType("hex", StringType, childExpr)
+          scalarFunctionExprToProtoWithReturnType("hex", StringType, childExpr)
 
         optExprWithInfo(optExpr, expr, child)
 
@@ -1298,7 +1300,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
         val failOnErrorExpr = exprToProtoInternal(unHex._2, inputs, binding)
 
         val optExpr =
-          scalarExprToProtoWithReturnType("unhex", e.dataType, childExpr, failOnErrorExpr)
+          scalarFunctionExprToProtoWithReturnType("unhex", e.dataType, childExpr, failOnErrorExpr)
         optExprWithInfo(optExpr, expr, unHex._1)
 
       case e @ Ceil(child) =>
@@ -1310,18 +1312,18 @@ object QueryPlanSerde extends Logging with CometExprShim {
             withInfo(e, s"Decimal type $t has negative scale")
             None
           case _ =>
-            val optExpr = scalarExprToProtoWithReturnType("ceil", e.dataType, childExpr)
+            val optExpr = scalarFunctionExprToProtoWithReturnType("ceil", e.dataType, childExpr)
             optExprWithInfo(optExpr, expr, child)
         }
 
       case Cos(child) =>
         val childExpr = exprToProtoInternal(child, inputs, binding)
-        val optExpr = scalarExprToProto("cos", childExpr)
+        val optExpr = scalarFunctionExprToProto("cos", childExpr)
         optExprWithInfo(optExpr, expr, child)
 
       case Exp(child) =>
         val childExpr = exprToProtoInternal(child, inputs, binding)
-        val optExpr = scalarExprToProto("exp", childExpr)
+        val optExpr = scalarFunctionExprToProto("exp", childExpr)
         optExprWithInfo(optExpr, expr, child)
 
       case e @ Floor(child) =>
@@ -1333,7 +1335,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
             withInfo(e, s"Decimal type $t has negative scale")
             None
           case _ =>
-            val optExpr = scalarExprToProtoWithReturnType("floor", e.dataType, childExpr)
+            val optExpr = scalarFunctionExprToProtoWithReturnType("floor", e.dataType, childExpr)
             optExprWithInfo(optExpr, expr, child)
         }
 
@@ -1342,23 +1344,23 @@ object QueryPlanSerde extends Logging with CometExprShim {
       // instead of NaN or -Infinity.
       case Log(child) =>
         val childExpr = exprToProtoInternal(nullIfNegative(child), inputs, binding)
-        val optExpr = scalarExprToProto("ln", childExpr)
+        val optExpr = scalarFunctionExprToProto("ln", childExpr)
         optExprWithInfo(optExpr, expr, child)
 
       case Log10(child) =>
         val childExpr = exprToProtoInternal(nullIfNegative(child), inputs, binding)
-        val optExpr = scalarExprToProto("log10", childExpr)
+        val optExpr = scalarFunctionExprToProto("log10", childExpr)
         optExprWithInfo(optExpr, expr, child)
 
       case Log2(child) =>
         val childExpr = exprToProtoInternal(nullIfNegative(child), inputs, binding)
-        val optExpr = scalarExprToProto("log2", childExpr)
+        val optExpr = scalarFunctionExprToProto("log2", childExpr)
         optExprWithInfo(optExpr, expr, child)
 
       case Pow(left, right) =>
         val leftExpr = exprToProtoInternal(left, inputs, binding)
         val rightExpr = exprToProtoInternal(right, inputs, binding)
-        val optExpr = scalarExprToProto("pow", leftExpr, rightExpr)
+        val optExpr = scalarFunctionExprToProto("pow", leftExpr, rightExpr)
         optExprWithInfo(optExpr, expr, left, right)
 
       case r: Round =>
@@ -1396,7 +1398,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
             // `scale` must be Int64 type in DataFusion
             val scaleExpr = exprToProtoInternal(Literal(_scale.toLong, LongType), inputs, binding)
             val optExpr =
-              scalarExprToProtoWithReturnType("round", r.dataType, childExpr, scaleExpr)
+              scalarFunctionExprToProtoWithReturnType("round", r.dataType, childExpr, scaleExpr)
             optExprWithInfo(optExpr, expr, r.child)
         }
 
@@ -1409,29 +1411,29 @@ object QueryPlanSerde extends Logging with CometExprShim {
 
       case Sin(child) =>
         val childExpr = exprToProtoInternal(child, inputs, binding)
-        val optExpr = scalarExprToProto("sin", childExpr)
+        val optExpr = scalarFunctionExprToProto("sin", childExpr)
         optExprWithInfo(optExpr, expr, child)
 
       case Sqrt(child) =>
         val childExpr = exprToProtoInternal(child, inputs, binding)
-        val optExpr = scalarExprToProto("sqrt", childExpr)
+        val optExpr = scalarFunctionExprToProto("sqrt", childExpr)
         optExprWithInfo(optExpr, expr, child)
 
       case Tan(child) =>
         val childExpr = exprToProtoInternal(child, inputs, binding)
-        val optExpr = scalarExprToProto("tan", childExpr)
+        val optExpr = scalarFunctionExprToProto("tan", childExpr)
         optExprWithInfo(optExpr, expr, child)
 
       case Ascii(child) =>
         val castExpr = Cast(child, StringType)
         val childExpr = exprToProtoInternal(castExpr, inputs, binding)
-        val optExpr = scalarExprToProto("ascii", childExpr)
+        val optExpr = scalarFunctionExprToProto("ascii", childExpr)
         optExprWithInfo(optExpr, expr, castExpr)
 
       case BitLength(child) =>
         val castExpr = Cast(child, StringType)
         val childExpr = exprToProtoInternal(castExpr, inputs, binding)
-        val optExpr = scalarExprToProto("bit_length", childExpr)
+        val optExpr = scalarFunctionExprToProto("bit_length", childExpr)
         optExprWithInfo(optExpr, expr, castExpr)
 
       case If(predicate, trueValue, falseValue) =>
@@ -1494,19 +1496,19 @@ object QueryPlanSerde extends Logging with CometExprShim {
           childExprs = childExprs :+ castExpr
           exprToProtoInternal(castExpr, inputs, binding)
         })
-        val optExpr = scalarExprToProto("concat_ws", exprs: _*)
+        val optExpr = scalarFunctionExprToProto("concat_ws", exprs: _*)
         optExprWithInfo(optExpr, expr, childExprs: _*)
 
       case Chr(child) =>
         val childExpr = exprToProtoInternal(child, inputs, binding)
-        val optExpr = scalarExprToProto("chr", childExpr)
+        val optExpr = scalarFunctionExprToProto("chr", childExpr)
         optExprWithInfo(optExpr, expr, child)
 
       case InitCap(child) =>
         if (CometConf.COMET_EXEC_INITCAP_ENABLED.get()) {
           val castExpr = Cast(child, StringType)
           val childExpr = exprToProtoInternal(castExpr, inputs, binding)
-          val optExpr = scalarExprToProto("initcap", childExpr)
+          val optExpr = scalarFunctionExprToProto("initcap", childExpr)
           optExprWithInfo(optExpr, expr, castExpr)
         } else {
           withInfo(
@@ -1520,24 +1522,24 @@ object QueryPlanSerde extends Logging with CometExprShim {
       case Length(child) =>
         val castExpr = Cast(child, StringType)
         val childExpr = exprToProtoInternal(castExpr, inputs, binding)
-        val optExpr = scalarExprToProto("length", childExpr)
+        val optExpr = scalarFunctionExprToProto("length", childExpr)
         optExprWithInfo(optExpr, expr, castExpr)
 
       case Md5(child) =>
         val childExpr = exprToProtoInternal(child, inputs, binding)
-        val optExpr = scalarExprToProto("md5", childExpr)
+        val optExpr = scalarFunctionExprToProto("md5", childExpr)
         optExprWithInfo(optExpr, expr, child)
 
       case OctetLength(child) =>
         val castExpr = Cast(child, StringType)
         val childExpr = exprToProtoInternal(castExpr, inputs, binding)
-        val optExpr = scalarExprToProto("octet_length", childExpr)
+        val optExpr = scalarFunctionExprToProto("octet_length", childExpr)
         optExprWithInfo(optExpr, expr, castExpr)
 
       case Reverse(child) =>
         val castExpr = Cast(child, StringType)
         val childExpr = exprToProtoInternal(castExpr, inputs, binding)
-        val optExpr = scalarExprToProto("reverse", childExpr)
+        val optExpr = scalarFunctionExprToProto("reverse", childExpr)
         optExprWithInfo(optExpr, expr, castExpr)
 
       case StringInstr(str, substr) =>
@@ -1545,7 +1547,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
         val rightCast = Cast(substr, StringType)
         val leftExpr = exprToProtoInternal(leftCast, inputs, binding)
         val rightExpr = exprToProtoInternal(rightCast, inputs, binding)
-        val optExpr = scalarExprToProto("strpos", leftExpr, rightExpr)
+        val optExpr = scalarFunctionExprToProto("strpos", leftExpr, rightExpr)
         optExprWithInfo(optExpr, expr, leftCast, rightCast)
 
       case StringRepeat(str, times) =>
@@ -1553,7 +1555,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
         val rightCast = Cast(times, LongType)
         val leftExpr = exprToProtoInternal(leftCast, inputs, binding)
         val rightExpr = exprToProtoInternal(rightCast, inputs, binding)
-        val optExpr = scalarExprToProto("repeat", leftExpr, rightExpr)
+        val optExpr = scalarFunctionExprToProto("repeat", leftExpr, rightExpr)
         optExprWithInfo(optExpr, expr, leftCast, rightCast)
 
       case StringReplace(src, search, replace) =>
@@ -1563,7 +1565,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
         val srcExpr = exprToProtoInternal(srcCast, inputs, binding)
         val searchExpr = exprToProtoInternal(searchCast, inputs, binding)
         val replaceExpr = exprToProtoInternal(replaceCast, inputs, binding)
-        val optExpr = scalarExprToProto("replace", srcExpr, searchExpr, replaceExpr)
+        val optExpr = scalarFunctionExprToProto("replace", srcExpr, searchExpr, replaceExpr)
         optExprWithInfo(optExpr, expr, srcCast, searchCast, replaceCast)
 
       case StringTranslate(src, matching, replace) =>
@@ -1573,7 +1575,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
         val srcExpr = exprToProtoInternal(srcCast, inputs, binding)
         val matchingExpr = exprToProtoInternal(matchingCast, inputs, binding)
         val replaceExpr = exprToProtoInternal(replaceCast, inputs, binding)
-        val optExpr = scalarExprToProto("translate", srcExpr, matchingExpr, replaceExpr)
+        val optExpr = scalarFunctionExprToProto("translate", srcExpr, matchingExpr, replaceExpr)
         optExprWithInfo(optExpr, expr, srcCast, matchingCast, replaceCast)
 
       case StringTrim(srcStr, trimStr) =>
@@ -1592,7 +1594,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
         if (CometConf.COMET_CASE_CONVERSION_ENABLED.get()) {
           val castExpr = Cast(child, StringType)
           val childExpr = exprToProtoInternal(castExpr, inputs, binding)
-          val optExpr = scalarExprToProto("upper", childExpr)
+          val optExpr = scalarFunctionExprToProto("upper", childExpr)
           optExprWithInfo(optExpr, expr, castExpr)
         } else {
           withInfo(
@@ -1607,7 +1609,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
         if (CometConf.COMET_CASE_CONVERSION_ENABLED.get()) {
           val castExpr = Cast(child, StringType)
           val childExpr = exprToProtoInternal(castExpr, inputs, binding)
-          val optExpr = scalarExprToProto("lower", childExpr)
+          val optExpr = scalarFunctionExprToProto("lower", childExpr)
           optExprWithInfo(optExpr, expr, castExpr)
         } else {
           withInfo(
@@ -1727,7 +1729,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
 
       case a @ Coalesce(_) =>
         val exprChildren = a.children.map(exprToProtoInternal(_, inputs, binding))
-        scalarExprToProto("coalesce", exprChildren: _*)
+        scalarFunctionExprToProto("coalesce", exprChildren: _*)
 
       // With Spark 3.4, CharVarcharCodegenUtils.readSidePadding gets called to pad spaces for
       // char types.
@@ -1747,7 +1749,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
           exprToProtoInternal(s.arguments(1), inputs, binding))
 
         if (argsExpr.forall(_.isDefined)) {
-          scalarExprToProto("read_side_padding", argsExpr: _*)
+          scalarFunctionExprToProto("read_side_padding", argsExpr: _*)
         } else {
           withInfo(expr, s.arguments: _*)
           None
@@ -1760,7 +1762,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
             val arg0 = exprToProtoInternal(srcStr, inputs, binding)
             val arg1 = exprToProtoInternal(size, inputs, binding)
             if (arg0.isDefined && arg1.isDefined) {
-              scalarExprToProto("rpad", arg0, arg1)
+              scalarFunctionExprToProto("rpad", arg0, arg1)
             } else {
               withInfo(expr, "rpad unsupported arguments", srcStr, size)
               None
@@ -1801,12 +1803,13 @@ object QueryPlanSerde extends Logging with CometExprShim {
 
       case UnscaledValue(child) =>
         val childExpr = exprToProtoInternal(child, inputs, binding)
-        val optExpr = scalarExprToProtoWithReturnType("unscaled_value", LongType, childExpr)
+        val optExpr =
+          scalarFunctionExprToProtoWithReturnType("unscaled_value", LongType, childExpr)
         optExprWithInfo(optExpr, expr, child)
 
       case MakeDecimal(child, precision, scale, true) =>
         val childExpr = exprToProtoInternal(child, inputs, binding)
-        val optExpr = scalarExprToProtoWithReturnType(
+        val optExpr = scalarFunctionExprToProtoWithReturnType(
           "make_decimal",
           DecimalType(precision, scale),
           childExpr)
@@ -1855,7 +1858,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
         if (algorithm == null) {
           exprToProtoInternal(Literal(null, StringType), inputs, binding)
         } else {
-          scalarExprToProtoWithReturnType(algorithm, StringType, childExpr)
+          scalarFunctionExprToProtoWithReturnType(algorithm, StringType, childExpr)
         }
 
       case struct @ CreateNamedStruct(_) =>
@@ -1898,7 +1901,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
         val childExprs = children.map(exprToProtoInternal(_, inputs, binding))
 
         if (childExprs.forall(_.isDefined)) {
-          scalarExprToProto("make_array", childExprs: _*)
+          scalarFunctionExprToProto("make_array", childExprs: _*)
         } else {
           withInfo(expr, "unsupported arguments for CreateArray", children: _*)
           None
@@ -2061,7 +2064,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
     }
   }
 
-  def createMathExpression(
+  private def createMathExpression(
       expr: Expression,
       left: Expression,
       right: Expression,
@@ -2109,10 +2112,10 @@ object QueryPlanSerde extends Logging with CometExprShim {
     if (trimStr.isDefined) {
       val trimCast = Cast(trimStr.get, StringType)
       val trimExpr = exprToProtoInternal(trimCast, inputs, binding)
-      val optExpr = scalarExprToProto(trimType, srcExpr, trimExpr)
+      val optExpr = scalarFunctionExprToProto(trimType, srcExpr, trimExpr)
       optExprWithInfo(optExpr, expr, srcCast, trimCast)
     } else {
-      val optExpr = scalarExprToProto(trimType, srcExpr)
+      val optExpr = scalarFunctionExprToProto(trimType, srcExpr)
       optExprWithInfo(optExpr, expr, srcCast)
     }
   }
@@ -2143,7 +2146,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
     }
   }
 
-  def scalarExprToProtoWithReturnType(
+  def scalarFunctionExprToProtoWithReturnType(
       funcName: String,
       returnType: DataType,
       args: Option[Expr]*): Option[Expr] = {
@@ -2151,17 +2154,17 @@ object QueryPlanSerde extends Logging with CometExprShim {
     builder.setFunc(funcName)
     serializeDataType(returnType).flatMap { t =>
       builder.setReturnType(t)
-      scalarExprToProto0(builder, args: _*)
+      scalarFunctionExprToProto0(builder, args: _*)
     }
   }
 
-  def scalarExprToProto(funcName: String, args: Option[Expr]*): Option[Expr] = {
+  def scalarFunctionExprToProto(funcName: String, args: Option[Expr]*): Option[Expr] = {
     val builder = ExprOuterClass.ScalarFunc.newBuilder()
     builder.setFunc(funcName)
-    scalarExprToProto0(builder, args: _*)
+    scalarFunctionExprToProto0(builder, args: _*)
   }
 
-  private def scalarExprToProto0(
+  private def scalarFunctionExprToProto0(
       builder: ScalarFunc.Builder,
       args: Option[Expr]*): Option[Expr] = {
     args.foreach {
@@ -2172,25 +2175,26 @@ object QueryPlanSerde extends Logging with CometExprShim {
     Some(ExprOuterClass.Expr.newBuilder().setScalarFunc(builder).build())
   }
 
-  def isPrimitive(expression: Expression): Boolean = expression.dataType match {
+  private def isPrimitive(expression: Expression): Boolean = expression.dataType match {
     case _: ByteType | _: ShortType | _: IntegerType | _: LongType | _: FloatType |
         _: DoubleType | _: TimestampType | _: DateType | _: BooleanType | _: DecimalType =>
       true
     case _ => false
   }
 
-  def nullIfWhenPrimitive(expression: Expression): Expression = if (isPrimitive(expression)) {
-    val zero = Literal.default(expression.dataType)
-    expression match {
-      case _: Literal if expression != zero => expression
-      case _ =>
-        If(EqualTo(expression, zero), Literal.create(null, expression.dataType), expression)
+  private def nullIfWhenPrimitive(expression: Expression): Expression =
+    if (isPrimitive(expression)) {
+      val zero = Literal.default(expression.dataType)
+      expression match {
+        case _: Literal if expression != zero => expression
+        case _ =>
+          If(EqualTo(expression, zero), Literal.create(null, expression.dataType), expression)
+      }
+    } else {
+      expression
     }
-  } else {
-    expression
-  }
 
-  def nullIfNegative(expression: Expression): Expression = {
+  private def nullIfNegative(expression: Expression): Expression = {
     val zero = Literal.default(expression.dataType)
     If(LessThanOrEqual(expression, zero), Literal.create(null, expression.dataType), expression)
   }
@@ -2198,7 +2202,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
   /**
    * Returns true if given datatype is supported as a key in DataFusion sort merge join.
    */
-  def supportedSortMergeJoinEqualType(dataType: DataType): Boolean = dataType match {
+  private def supportedSortMergeJoinEqualType(dataType: DataType): Boolean = dataType match {
     case _: ByteType | _: ShortType | _: IntegerType | _: LongType | _: FloatType |
         _: DoubleType | _: StringType | _: DateType | _: DecimalType | _: BooleanType =>
       true

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -63,7 +63,7 @@ object CometArrayRemove extends CometExpressionSerde with CometExprShim {
     val keyExprProto = exprToProto(ar.right, inputs, binding)
 
     val arrayRemoveScalarExpr =
-      scalarExprToProto("array_remove_all", arrayExprProto, keyExprProto)
+      scalarFunctionExprToProto("array_remove_all", arrayExprProto, keyExprProto)
 
     val isNotNullExpr = createUnaryExpr(
       expr,
@@ -104,7 +104,8 @@ object CometArrayAppend extends CometExpressionSerde with IncompatExpr {
     val arrayExprProto = exprToProto(expr.children(0), inputs, binding)
     val keyExprProto = exprToProto(expr.children(1), inputs, binding)
 
-    val arrayAppendScalarExpr = scalarExprToProto("array_append", arrayExprProto, keyExprProto)
+    val arrayAppendScalarExpr =
+      scalarFunctionExprToProto("array_append", arrayExprProto, keyExprProto)
 
     val isNotNullExpr = createUnaryExpr(
       expr,
@@ -143,7 +144,7 @@ object CometArrayContains extends CometExpressionSerde with IncompatExpr {
     val keyExprProto = exprToProto(expr.children(1), inputs, binding)
 
     val arrayContainsScalarExpr =
-      scalarExprToProto("array_has", arrayExprProto, keyExprProto)
+      scalarFunctionExprToProto("array_has", arrayExprProto, keyExprProto)
     optExprWithInfo(arrayContainsScalarExpr, expr, expr.children: _*)
   }
 }
@@ -157,7 +158,7 @@ object CometArrayIntersect extends CometExpressionSerde with IncompatExpr {
     val rightArrayExprProto = exprToProto(expr.children(1), inputs, binding)
 
     val arraysIntersectScalarExpr =
-      scalarExprToProto("array_intersect", leftArrayExprProto, rightArrayExprProto)
+      scalarFunctionExprToProto("array_intersect", leftArrayExprProto, rightArrayExprProto)
     optExprWithInfo(arraysIntersectScalarExpr, expr, expr.children: _*)
   }
 }
@@ -170,7 +171,7 @@ object CometArraysOverlap extends CometExpressionSerde with IncompatExpr {
     val leftArrayExprProto = exprToProto(expr.children(0), inputs, binding)
     val rightArrayExprProto = exprToProto(expr.children(1), inputs, binding)
 
-    val arraysOverlapScalarExpr = scalarExprToProtoWithReturnType(
+    val arraysOverlapScalarExpr = scalarFunctionExprToProtoWithReturnType(
       "array_has_any",
       BooleanType,
       leftArrayExprProto,
@@ -190,7 +191,7 @@ object CometArrayCompact extends CometExpressionSerde with IncompatExpr {
     val arrayExprProto = exprToProto(child, inputs, binding)
     val nullLiteralProto = exprToProto(Literal(null, elementType), Seq.empty)
 
-    val arrayCompactScalarExpr = scalarExprToProtoWithReturnType(
+    val arrayCompactScalarExpr = scalarFunctionExprToProtoWithReturnType(
       "array_remove_all",
       ArrayType(elementType = elementType),
       arrayExprProto,
@@ -232,7 +233,7 @@ object CometArrayExcept extends CometExpressionSerde with CometExprShim with Inc
     val rightArrayExprProto = exprToProto(arrayExceptExpr.right, inputs, binding)
 
     val arrayExceptScalarExpr =
-      scalarExprToProto("array_except", leftArrayExprProto, rightArrayExprProto)
+      scalarFunctionExprToProto("array_except", leftArrayExprProto, rightArrayExprProto)
     optExprWithInfo(arrayExceptScalarExpr, expr, expr.children: _*)
   }
 }
@@ -250,7 +251,7 @@ object CometArrayJoin extends CometExpressionSerde with IncompatExpr {
       case Some(nullReplacementExpr) =>
         val nullReplacementExprProto = exprToProto(nullReplacementExpr, inputs, binding)
 
-        val arrayJoinScalarExpr = scalarExprToProto(
+        val arrayJoinScalarExpr = scalarFunctionExprToProto(
           "array_to_string",
           arrayExprProto,
           delimiterExprProto,
@@ -264,7 +265,7 @@ object CometArrayJoin extends CometExpressionSerde with IncompatExpr {
           nullReplacementExpr)
       case None =>
         val arrayJoinScalarExpr =
-          scalarExprToProto("array_to_string", arrayExprProto, delimiterExprProto)
+          scalarFunctionExprToProto("array_to_string", arrayExprProto, delimiterExprProto)
 
         optExprWithInfo(arrayJoinScalarExpr, expr, arrayExpr, arrayExpr.delimiter)
     }

--- a/spark/src/main/scala/org/apache/comet/serde/hash.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/hash.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, Murmur3
 import org.apache.spark.sql.types.{DecimalType, IntegerType, LongType}
 
 import org.apache.comet.CometSparkSessionExtensions.withInfo
-import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, scalarExprToProtoWithReturnType, serializeDataType, supportedDataType}
+import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, scalarFunctionExprToProtoWithReturnType, serializeDataType, supportedDataType}
 
 object CometXxHash64 extends CometExpressionSerde {
   override def convert(
@@ -41,7 +41,7 @@ object CometXxHash64 extends CometExpressionSerde {
       .setLongVal(hash.seed)
     val seedExpr = Some(ExprOuterClass.Expr.newBuilder().setLiteral(seedBuilder).build())
     // the seed is put at the end of the arguments
-    scalarExprToProtoWithReturnType("xxhash64", LongType, exprs :+ seedExpr: _*)
+    scalarFunctionExprToProtoWithReturnType("xxhash64", LongType, exprs :+ seedExpr: _*)
   }
 }
 
@@ -61,7 +61,7 @@ object CometMurmur3Hash extends CometExpressionSerde {
       .setIntVal(hash.seed)
     val seedExpr = Some(ExprOuterClass.Expr.newBuilder().setLiteral(seedBuilder).build())
     // the seed is put at the end of the arguments
-    scalarExprToProtoWithReturnType("murmur3_hash", IntegerType, exprs :+ seedExpr: _*)
+    scalarFunctionExprToProtoWithReturnType("murmur3_hash", IntegerType, exprs :+ seedExpr: _*)
   }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

`scalarExprToProto` is actually a wrapper over scalar function, picking more precise name

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
