### PR TITLE
feat: decode() expression when using 'utf-8' encoding

### DIFF
--- a/native/spark-expr/src/conversion_funcs/cast.rs
+++ b/native/spark-expr/src/conversion_funcs/cast.rs
@@ -882,7 +882,10 @@ fn cast_array(
     let array = match &from_type {
         Dictionary(key_type, value_type)
             if key_type.as_ref() == &Int32
-                && (value_type.as_ref() == &Utf8 || value_type.as_ref() == &LargeUtf8) =>
+                && (value_type.as_ref() == &Utf8
+                    || value_type.as_ref() == &LargeUtf8
+                    || value_type.as_ref() == &Binary
+                    || value_type.as_ref() == &LargeBinary) =>
         {
             let dict_array = array
                 .as_any()

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -19,6 +19,8 @@
 
 package org.apache.comet.serde
 
+import java.util.Locale
+
 import scala.collection.JavaConverters._
 import scala.math.min
 
@@ -1432,7 +1434,8 @@ object QueryPlanSerde extends Logging with CometExprShim {
 
       case StringDecode(binary, encoding) =>
         encoding match {
-          case Literal(str, DataTypes.StringType) if str.toString == "utf-8" =>
+          case Literal(str, DataTypes.StringType)
+              if str.toString.toLowerCase(Locale.ROOT) == "utf-8" =>
             // decode(col, 'utf-8') can be treated as a cast with "try" eval mode that puts nulls
             // for invalid strings.
             castToProto(

--- a/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
@@ -196,7 +196,8 @@ class CometFuzzTestSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     var tested_binary = false
     for (field <- df.schema.fields if field.dataType == BinaryType) {
       tested_binary = true
-      val sql = s"SELECT decode(${field.name}, 'utf-8') FROM t1"
+      // Intentionally use odd capitalization of 'utf-8' to test normalization.
+      val sql = s"SELECT decode(${field.name}, 'utF-8') FROM t1"
       checkSparkAnswerAndOperator(sql)
     }
     assert(tested_binary)

--- a/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
@@ -197,11 +197,7 @@ class CometFuzzTestSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     for (field <- df.schema.fields if field.dataType == BinaryType) {
       tested_binary = true
       val sql = s"SELECT decode(${field.name}, 'utf-8') FROM t1"
-      if (CometConf.isExperimentalNativeScan) {
-        checkSparkAnswerAndOperator(sql)
-      } else {
-        checkSparkAnswer(sql)
-      }
+      checkSparkAnswerAndOperator(sql)
     }
     assert(tested_binary)
   }

--- a/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
@@ -193,14 +193,14 @@ class CometFuzzTestSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     df.createOrReplaceTempView("t1")
     // We want to make sure that the schema generator wasn't modified to accidentally omit
     // BinaryType, since then this test would not run any queries and silently pass.
-    var tested_binary = false
+    var testedBinary = false
     for (field <- df.schema.fields if field.dataType == BinaryType) {
-      tested_binary = true
+      testedBinary = true
       // Intentionally use odd capitalization of 'utf-8' to test normalization.
       val sql = s"SELECT decode(${field.name}, 'utF-8') FROM t1"
       checkSparkAnswerAndOperator(sql)
     }
-    assert(tested_binary)
+    assert(testedBinary)
   }
 
   test("Parquet temporal types written as INT96") {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Spark SQL's `decode` with two arguments converts a binary column to a string given an encoding from one of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16'. 

https://github.com/apache/spark/blob/ef336ad51ba62e64a77896b9da12791051fa92cb/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala#L3028.

Comet currently has no support for this expression, and this PR adds 'UTF-8' support.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Convert a `StringDecode` expression to a `Cast` but only for the 'UTF-8' case. This scenario maps nicely to an Arrow cast with the safe option to replace invalid values with nulls:

https://github.com/apache/arrow-rs/blob/07093a49eface9be9208dd427b810abba8d0a755/arrow-cast/src/cast/string.rs#L342

Other encodings are currently unsupported, however 'US-ASCII' might be easy to convert into the `ascii` scalar function. That can be a future PR.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

New fuzz test and existing Spark SQL tests.