### PR TITLE
perf: Add memory profiling

### DIFF
--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -233,6 +233,12 @@ object CometConf extends ShimCometConf {
       defaultValue = true,
       notes = Some("stddev is slower than Spark's implementation"))
 
+  val COMET_MEMORY_PROFILING: ConfigEntry[Boolean] = conf("spark.comet.memory.profiling")
+    .doc("Enable logging of JVM and native memory statistics.")
+    .internal()
+    .booleanConf
+    .createWithDefault(false)
+
   val COMET_MEMORY_OVERHEAD: OptionalConfigEntry[Long] = conf("spark.comet.memoryOverhead")
     .doc(
       "The amount of additional memory to be allocated per executor process for Comet, in MiB, " +

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1000,6 +1000,7 @@ dependencies = [
  "snap",
  "tempfile",
  "thiserror 2.0.12",
+ "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
  "url",
@@ -3887,6 +3888,17 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "ordered-float",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21f216790c8df74ce3ab25b534e0718da5a1916719771d3fec23315c99e468b"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -992,6 +992,7 @@ dependencies = [
  "parquet",
  "paste",
  "pprof",
+ "procfs",
  "prost",
  "rand 0.9.1",
  "regex",
@@ -2996,6 +2997,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "procfs"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+dependencies = [
+ "bitflags 2.9.0",
+ "chrono",
+ "flate2",
+ "hex",
+ "procfs-core",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags 2.9.0",
+ "chrono",
+ "hex",
 ]
 
 [[package]]

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -68,6 +68,7 @@ datafusion-comet-proto = { workspace = true }
 object_store = { workspace = true }
 url = { workspace = true }
 parking_lot = "0.12.3"
+procfs = "0.17.0"
 datafusion-comet-objectstore-hdfs = { path = "../hdfs", optional = true, default-features = false, features = ["hdfs"] }
 
 [dev-dependencies]

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -68,8 +68,10 @@ datafusion-comet-proto = { workspace = true }
 object_store = { workspace = true }
 url = { workspace = true }
 parking_lot = "0.12.3"
-procfs = "0.17.0"
 datafusion-comet-objectstore-hdfs = { path = "../hdfs", optional = true, default-features = false, features = ["hdfs"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+procfs = "0.17.0"
 
 [dev-dependencies]
 pprof = { version = "0.14.0", features = ["flamegraph"] }

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -40,6 +40,7 @@ parquet = { workspace = true, default-features = false, features = ["experimenta
 futures = { workspace = true }
 mimalloc = { version = "*", default-features = false, optional = true }
 tikv-jemallocator = { version = "0.6.0", optional = true, features = ["disable_initial_exec_tls"] }
+tikv-jemalloc-ctl = { version = "0.6.0", optional = true, features = ["disable_initial_exec_tls", "stats"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 async-trait = { workspace = true }
 log = "0.4"
@@ -85,7 +86,7 @@ datafusion-functions-nested = { version = "47.0.0" }
 [features]
 default = []
 hdfs = ["datafusion-comet-objectstore-hdfs"]
-jemalloc = ["tikv-jemallocator"]
+jemalloc = ["tikv-jemallocator", "tikv-jemalloc-ctl"]
 
 # exclude optional packages from cargo machete verifications
 [package.metadata.cargo-machete]

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -366,16 +366,18 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
         let exec_context = get_execution_context(exec_context);
 
         // memory profiling is only available on linux
-        #[cfg(target_os = "linux")]
         if exec_context.memory_profiling_enabled {
-            let pid = std::process::id();
-            let process = Process::new(pid as i32).unwrap();
-            let statm = process.statm().unwrap();
-            let page_size = procfs::page_size();
-            println!(
-                "NATIVE_MEMORY: {{ resident: {:.2} }}",
-                (statm.resident * page_size) as f64 / (1024.0 * 1024.0)
-            );
+            #[cfg(target_os = "linux")]
+            {
+                let pid = std::process::id();
+                let process = Process::new(pid as i32).unwrap();
+                let statm = process.statm().unwrap();
+                let page_size = procfs::page_size();
+                println!(
+                    "NATIVE_MEMORY: {{ resident: {} }}",
+                    (statm.resident * page_size) as f64 / (1024.0 * 1024.0)
+                );
+            }
         }
 
         let exec_context_id = exec_context.id;

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -393,11 +393,10 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
                     e.advance().unwrap();
 
                     // Read statistics using MIB key:
-                    let allocated = allocated.read().unwrap() as f64 / 1024.0 / 1024.0;
-                    let resident = resident.read().unwrap() as f64 / 1024.0 / 1024.0;
+                    let allocated = allocated.read().unwrap() as f64 / (1024.0 * 1024.0);
+                    let resident = resident.read().unwrap() as f64 / (1024.0 * 1024.0);
                     println!(
-                        "NATIVE_MEMORY_JEMALLOC: {{ allocated: {}, resident: {} }}",
-                        allocated, resident
+                        "NATIVE_MEMORY_JEMALLOC: {{ allocated: {allocated:.0}, resident: {resident:.0} }}"
                     );
                 }
             }

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -393,10 +393,10 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
                     e.advance().unwrap();
 
                     // Read statistics using MIB key:
-                    let allocated = allocated.read().unwrap();
-                    let resident = resident.read().unwrap();
+                    let allocated = allocated.read().unwrap() as f64 / 1024.0 / 1024.0;
+                    let resident = resident.read().unwrap() as f64 / 1024.0 / 1024.0;
                     println!(
-                        "NATIVE_MEMORY_JEMALLOC: {{ allocated={}, resident={} }}",
+                        "NATIVE_MEMORY_JEMALLOC: {{ allocated: {}, resident: {} }}",
                         allocated, resident
                     );
                 }

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -364,6 +364,8 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
         // Retrieve the query
         let exec_context = get_execution_context(exec_context);
 
+        // memory profiling is only available on linux
+        #[cfg(target_os = "linux")]
         if exec_context.memory_profiling_enabled {
             let pid = std::process::id();
             let process = Process::new(pid as i32).unwrap();

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -68,6 +68,7 @@ use crate::execution::shuffle::{read_ipc_compressed, CompressionCodec};
 use crate::execution::spark_plan::SparkPlan;
 use log::info;
 use once_cell::sync::Lazy;
+use procfs::process::Process;
 
 static TOKIO_RUNTIME: Lazy<Runtime> = Lazy::new(|| {
     let mut builder = tokio::runtime::Builder::new_multi_thread();
@@ -126,6 +127,8 @@ struct ExecutionContext {
     pub explain_native: bool,
     /// Memory pool config
     pub memory_pool_config: MemoryPoolConfig,
+    /// Whether to log memory usage on each call to execute_plan
+    pub memory_profiling_enabled: bool,
 }
 
 /// Accept serialized query plan and return the address of the native query plan.
@@ -151,6 +154,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
     task_attempt_id: jlong,
     debug_native: jboolean,
     explain_native: jboolean,
+    memory_profiling_enabled: jboolean,
 ) -> jlong {
     try_unwrap_or_throw(&e, |mut env| {
         // Init JVM classes
@@ -231,6 +235,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
             debug_native: debug_native == 1,
             explain_native: explain_native == 1,
             memory_pool_config,
+            memory_profiling_enabled: memory_profiling_enabled != JNI_FALSE,
         });
 
         Ok(Box::into_raw(exec_context) as i64)
@@ -358,6 +363,17 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
     try_unwrap_or_throw(&e, |mut env| {
         // Retrieve the query
         let exec_context = get_execution_context(exec_context);
+
+        if exec_context.memory_profiling_enabled {
+            let pid = std::process::id();
+            let process = Process::new(pid as i32).unwrap();
+            let statm = process.statm().unwrap();
+            let page_size = procfs::page_size();
+            println!(
+                "NATIVE_MEMORY: {{ resident: {:.2} }}",
+                (statm.resident * page_size) as f64 / (1024.0 * 1024.0)
+            );
+        }
 
         let exec_context_id = exec_context.id;
 

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -68,6 +68,7 @@ use crate::execution::shuffle::{read_ipc_compressed, CompressionCodec};
 use crate::execution::spark_plan::SparkPlan;
 use log::info;
 use once_cell::sync::Lazy;
+#[cfg(target_os = "linux")]
 use procfs::process::Process;
 
 static TOKIO_RUNTIME: Lazy<Runtime> = Lazy::new(|| {

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -376,7 +376,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
                 let statm = process.statm().unwrap();
                 let page_size = procfs::page_size();
                 println!(
-                    "NATIVE_MEMORY: {{ resident: {} }}",
+                    "NATIVE_MEMORY: {{ resident: {:.0} }}",
                     (statm.resident * page_size) as f64 / (1024.0 * 1024.0)
                 );
 

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -19,6 +19,8 @@
 
 package org.apache.comet
 
+import java.lang.management.ManagementFactory
+
 import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.network.util.ByteUnit
@@ -57,6 +59,7 @@ class CometExecIterator(
     extends Iterator[ColumnarBatch]
     with Logging {
 
+  private val memoryProfilingEnabled = CometConf.COMET_MEMORY_PROFILING.get()
   private val nativeLib = new Native()
   private val nativeUtil = new NativeUtil()
   private val cometBatchIterators = inputs.map { iterator =>
@@ -92,7 +95,8 @@ class CometExecIterator(
       memoryLimitPerTask = getMemoryLimitPerTask(conf),
       taskAttemptId = TaskContext.get().taskAttemptId,
       debug = COMET_DEBUG_ENABLED.get(),
-      explain = COMET_EXPLAIN_NATIVE_ENABLED.get())
+      explain = COMET_EXPLAIN_NATIVE_ENABLED.get(),
+      memoryProfilingEnabled)
   }
 
   private var nextBatch: Option[ColumnarBatch] = None
@@ -129,6 +133,21 @@ class CometExecIterator(
 
   def getNextBatch(): Option[ColumnarBatch] = {
     assert(partitionIndex >= 0 && partitionIndex < numParts)
+
+    if (memoryProfilingEnabled) {
+      val memoryMXBean = ManagementFactory.getMemoryMXBean
+      val heap = memoryMXBean.getHeapMemoryUsage
+      val nonHeap = memoryMXBean.getNonHeapMemoryUsage
+
+      def mb(n: Long) = n / 1024 / 1024
+
+      // scalastyle:off println
+      println(
+        "JVM_MEMORY: { " +
+          s"heapUsed: ${mb(heap.getUsed)}, heapCommitted: ${mb(heap.getCommitted)}, " +
+          s"nonHeapUsed: ${mb(nonHeap.getUsed)}, nonHeapCommitted: ${mb(nonHeap.getCommitted)} " +
+          "}")
+    }
 
     nativeUtil.getNextBatch(
       numOutputCols,

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -147,6 +147,7 @@ class CometExecIterator(
           s"heapUsed: ${mb(heap.getUsed)}, heapCommitted: ${mb(heap.getCommitted)}, " +
           s"nonHeapUsed: ${mb(nonHeap.getUsed)}, nonHeapCommitted: ${mb(nonHeap.getCommitted)} " +
           "}")
+      // scalastyle:on println
     }
 
     nativeUtil.getNextBatch(

--- a/spark/src/main/scala/org/apache/comet/Native.scala
+++ b/spark/src/main/scala/org/apache/comet/Native.scala
@@ -66,7 +66,8 @@ class Native extends NativeBase {
       memoryLimitPerTask: Long,
       taskAttemptId: Long,
       debug: Boolean,
-      explain: Boolean): Long
+      explain: Boolean,
+      memoryProfilingEnabled: Boolean): Long
   // scalastyle:on
 
   /**


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/1701

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We need a way to profile memory.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Logging of JVM and native memory utilization on each call to `execute_plan`. After running TPC-H locally with 8GB executor memory and 8GB off-heap memory, I see these stats:

```
JVM_MEMORY: { heapUsed: 2696, heapCommitted: 4394, nonHeapUsed: 142, nonHeapCommitted: 160 }
NATIVE_MEMORY: { resident: 11531.53 }
```

When running with multiple iterations, I see overall memory exceeding 16GB. If this were running in a container environment then I would expect to see the executor be killed due to OOM.

```
JVM_MEMORY: { heapUsed: 4217, heapCommitted: 7440, nonHeapUsed: 145, nonHeapCommitted: 165 }
NATIVE_MEMORY: { resident: 18406.37 }
```

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
