### PR TITLE
chore: Comet + Iceberg (1.8.1) CI

### DIFF
--- a/.github/actions/setup-iceberg-builder/action.yaml
+++ b/.github/actions/setup-iceberg-builder/action.yaml
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Setup Iceberg Builder
+description: 'Setup Apache Iceberg to run Spark SQL tests'
+inputs:
+  iceberg-short-version:
+    description: 'The Apache Iceberg short version (e.g., 1.8) to build'
+    required: true
+  iceberg-version:
+    description: 'The Apache Iceberg version (e.g., 1.8.1) to build'
+    required: true
+  scala-version:
+    description: 'The Scala short version (e.g., 2.13) to build'
+    required: true
+  spark-short-version:
+    description: 'The Apache Spark short version (e.g., 3.5) to build'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Clone Iceberg repo
+      uses: actions/checkout@v4
+      with:
+        repository: apache/iceberg
+        path: apache-iceberg
+        ref: apache-iceberg-${{inputs.iceberg-version}}
+        fetch-depth: 1
+
+    - name: Setup Iceberg for Comet
+      shell: bash
+      run: |
+        cd apache-iceberg
+        git apply ../dev/diffs/iceberg/${{inputs.iceberg-version}}.diff
+
+    - name: Cache Maven dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.m2/repository
+          /root/.m2/repository
+        key: ${{ runner.os }}-iceberg-spark-sql-${{ hashFiles('spark/**/pom.xml', 'common/**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-iceberg-spark-sql-
+
+    - name: Build Comet
+      shell: bash
+      run: |
+        PROFILES="-Pspark-${{inputs.spark-short-version}} -Pscala-${{inputs.scala-version}}" make release

--- a/.github/workflows/iceberg_spark_test.yml
+++ b/.github/workflows/iceberg_spark_test.yml
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Iceberg Spark SQL Tests
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+on:
+  push:
+    paths-ignore:
+      - "doc/**"
+      - "docs/**"
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "doc/**"
+      - "docs/**"
+      - "**.md"
+  # manual trigger
+  # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+  workflow_dispatch:
+
+env:
+  RUST_VERSION: stable
+
+jobs:
+  iceberg-spark-sql:
+    strategy:
+      matrix:
+        os: [ubuntu-24.04]
+        java-version: [11, 17]
+        iceberg-version: [{short: '1.8', full: '1.8.1'}]
+        spark-version: [{short: '3.5', full: '3.5.4'}]
+        scala-version: [ '2.12', '2.13']
+      fail-fast: false
+    name: iceberg-spark-sql/${{ matrix.os }}/iceberg-${{ matrix.iceberg-version.full }}/spark-${{ matrix.spark-version.full }}/scala-${{ matrix.scala-version }}/java-${{ matrix.java-version }}
+    runs-on: ${{ matrix.os }}
+    container:
+      image: amd64/rust
+    env:
+      SPARK_LOCAL_IP: localhost
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust & Java toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: ${{env.RUST_VERSION}}
+          jdk-version: ${{ matrix.java-version }}
+      - name: Setup Iceberg
+        uses: ./.github/actions/setup-iceberg-builder
+        with:
+          iceberg-version: ${{ matrix.iceberg-version.full }}
+          iceberg-short-version: ${{ matrix.iceberg-version.short }}
+          scala-version: ${{ matrix.scala-version }}
+          spark-short-version: ${{ matrix.spark-version.short }}
+      - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+      - name: Run Iceberg Spark tests
+        run: |
+          cd apache-iceberg
+          rm -rf /root/.m2/repository/org/apache/parquet # somehow parquet cache requires cleanups
+          ENABLE_COMET=true ENABLE_COMET_SHUFFLE=true ../../gradlew -DsparkVersions=${{ matrix.spark-version.short }} -DscalaVersion=${{ matrix.scala-version }} -DflinkVersions= -DkafkaVersions= \
+            :iceberg-spark:iceberg-spark-${{ matrix.spark-version.short }}_${{ matrix.scala-version }}:check \
+            :iceberg-spark:iceberg-spark-extensions-${{ matrix.spark-version.short }}_${{ matrix.scala-version }}:check \
+            :iceberg-spark:iceberg-spark-runtime-${{ matrix.spark-version.short }}_${{ matrix.scala-version }}:check \
+            -Pquick=true -x javadoc

--- a/.github/workflows/iceberg_spark_test_native_datafusion.yml
+++ b/.github/workflows/iceberg_spark_test_native_datafusion.yml
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Iceberg Spark SQL Tests (native_datafusion)
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+on:
+  push:
+    paths-ignore:
+      - "doc/**"
+      - "docs/**"
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "doc/**"
+      - "docs/**"
+      - "**.md"
+  # manual trigger
+  # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+  workflow_dispatch:
+
+env:
+  RUST_VERSION: stable
+
+jobs:
+  iceberg-spark-sql-native-datafusion:
+    strategy:
+      matrix:
+        os: [ubuntu-24.04]
+        java-version: [11, 17]
+        iceberg-version: [{short: '1.8', full: '1.8.1'}]
+        spark-version: [{short: '3.5', full: '3.5.4'}]
+        scala-version: [ '2.12', '2.13']
+      fail-fast: false
+    name: iceberg-spark-sql-native-datafusion/${{ matrix.os }}/iceberg-${{ matrix.iceberg-version.full }}/spark-${{ matrix.spark-version.full }}/scala-${{ matrix.scala-version }}/java-${{ matrix.java-version }}
+    runs-on: ${{ matrix.os }}
+    container:
+      image: amd64/rust
+    env:
+      SPARK_LOCAL_IP: localhost
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust & Java toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: ${{env.RUST_VERSION}}
+          jdk-version: ${{ matrix.java-version }}
+      - name: Setup Iceberg
+        uses: ./.github/actions/setup-iceberg-builder
+        with:
+          iceberg-version: ${{ matrix.iceberg-version.full }}
+          iceberg-short-version: ${{ matrix.iceberg-version.short }}
+          scala-version: ${{ matrix.scala-version }}
+          spark-short-version: ${{ matrix.spark-version.short }}
+      - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+      - name: Run Iceberg Spark tests
+        run: |
+          cd apache-iceberg
+          rm -rf /root/.m2/repository/org/apache/parquet # somehow parquet cache requires cleanups
+          ENABLE_COMET=true ENABLE_COMET_SHUFFLE=true COMET_PARQUET_SCAN_IMPL=native_datafusion ../../gradlew -DsparkVersions=${{ matrix.spark-version.short }} -DscalaVersion=${{ matrix.scala-version }} -DflinkVersions= -DkafkaVersions= \
+            :iceberg-spark:iceberg-spark-${{ matrix.spark-version.short }}_${{ matrix.scala-version }}:check \
+            :iceberg-spark:iceberg-spark-extensions-${{ matrix.spark-version.short }}_${{ matrix.scala-version }}:check \
+            :iceberg-spark:iceberg-spark-runtime-${{ matrix.spark-version.short }}_${{ matrix.scala-version }}:check \
+            -Pquick=true -x javadoc

--- a/.github/workflows/iceberg_spark_test_native_iceberg_compat.yml
+++ b/.github/workflows/iceberg_spark_test_native_iceberg_compat.yml
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Iceberg Spark SQL Tests (native_iceberg_compat)
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+on:
+  push:
+    paths-ignore:
+      - "doc/**"
+      - "docs/**"
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "doc/**"
+      - "docs/**"
+      - "**.md"
+  # manual trigger
+  # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+  workflow_dispatch:
+
+env:
+  RUST_VERSION: stable
+
+jobs:
+  iceberg-spark-sql-native-iceberg-compat:
+    strategy:
+      matrix:
+        os: [ubuntu-24.04]
+        java-version: [11, 17]
+        iceberg-version: [{short: '1.8', full: '1.8.1'}]
+        spark-version: [{short: '3.5', full: '3.5.4'}]
+        scala-version: [ '2.12', '2.13']
+      fail-fast: false
+    name: iceberg-spark-sql-native-iceberg-compat/${{ matrix.os }}/iceberg-${{ matrix.iceberg-version.full }}/spark-${{ matrix.spark-version.full }}/scala-${{ matrix.scala-version }}/java-${{ matrix.java-version }}
+    runs-on: ${{ matrix.os }}
+    container:
+      image: amd64/rust
+    env:
+      SPARK_LOCAL_IP: localhost
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust & Java toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: ${{env.RUST_VERSION}}
+          jdk-version: ${{ matrix.java-version }}
+      - name: Setup Iceberg
+        uses: ./.github/actions/setup-iceberg-builder
+        with:
+          iceberg-version: ${{ matrix.iceberg-version.full }}
+          iceberg-short-version: ${{ matrix.iceberg-version.short }}
+          scala-version: ${{ matrix.scala-version }}
+          spark-short-version: ${{ matrix.spark-version.short }}
+      - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+      - name: Run Iceberg Spark tests
+        run: |
+          cd apache-iceberg
+          rm -rf /root/.m2/repository/org/apache/parquet # somehow parquet cache requires cleanups
+          ENABLE_COMET=true ENABLE_COMET_SHUFFLE=true COMET_PARQUET_SCAN_IMPL=native_iceberg_compat ../../gradlew -DsparkVersions=${{ matrix.spark-version.short }} -DscalaVersion=${{ matrix.scala-version }} -DflinkVersions= -DkafkaVersions= \
+            :iceberg-spark:iceberg-spark-${{ matrix.spark-version.short }}_${{ matrix.scala-version }}:check \
+            :iceberg-spark:iceberg-spark-extensions-${{ matrix.spark-version.short }}_${{ matrix.scala-version }}:check \
+            :iceberg-spark:iceberg-spark-runtime-${{ matrix.spark-version.short }}_${{ matrix.scala-version }}:check \
+            -Pquick=true -x javadoc

--- a/dev/diffs/iceberg/1.8.1.diff
+++ b/dev/diffs/iceberg/1.8.1.diff
@@ -1,0 +1,179 @@
+diff --git a/spark/v3.4/build.gradle b/spark/v3.4/build.gradle
+index 6eb26e8..90d848d 100644
+--- a/spark/v3.4/build.gradle
++++ b/spark/v3.4/build.gradle
+@@ -75,7 +75,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
+       exclude group: 'org.roaringbitmap'
+     }
+ 
+-    compileOnly "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.5.0"
++    compileOnly "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.9.0-SNAPSHOT"
+ 
+     implementation libs.parquet.column
+     implementation libs.parquet.hadoop
+@@ -185,7 +185,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
+     testImplementation libs.avro.avro
+     testImplementation libs.parquet.hadoop
+     testImplementation libs.junit.vintage.engine
+-    testImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.5.0"
++    testImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.9.0-SNAPSHOT"
+ 
+     // Required because we remove antlr plugin dependencies from the compile configuration, see note above
+     runtimeOnly libs.antlr.runtime
+@@ -260,6 +260,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
+     integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+     integrationImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+     integrationImplementation project(path: ":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
++    integrationImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.9.0-SNAPSHOT"
+ 
+     // runtime dependencies for running Hive Catalog based integration test
+     integrationRuntimeOnly project(':iceberg-hive-metastore')
+@@ -297,8 +298,8 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
+     relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
+     relocate 'avro.shaded', 'org.apache.iceberg.shaded.org.apache.avro.shaded'
+     relocate 'com.thoughtworks.paranamer', 'org.apache.iceberg.shaded.com.thoughtworks.paranamer'
+-    relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'
+-    relocate 'shaded.parquet', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
++//    relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'
++//    relocate 'shaded.parquet', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
+     relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
+     relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
+     relocate 'org.apache.hc.client5', 'org.apache.iceberg.shaded.org.apache.hc.client5'
+diff --git a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java
+index 4794863..8d02f02 100644
+--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java
++++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java
+@@ -20,11 +20,11 @@ package org.apache.iceberg.spark.data.vectorized;
+ 
+ import java.io.IOException;
+ import java.util.Map;
++import org.apache.comet.CometSchemaImporter;
+ import org.apache.comet.parquet.AbstractColumnReader;
+ import org.apache.comet.parquet.ColumnReader;
+ import org.apache.comet.parquet.TypeUtil;
+ import org.apache.comet.parquet.Utils;
+-import org.apache.comet.shaded.arrow.c.CometSchemaImporter;
+ import org.apache.comet.shaded.arrow.memory.RootAllocator;
+ import org.apache.iceberg.parquet.VectorizedReader;
+ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+diff --git a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+index a361a7f..9021cd5 100644
+--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
++++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+@@ -24,6 +24,7 @@ import java.util.Objects;
+ import java.util.Set;
+ import java.util.function.Supplier;
+ import java.util.stream.Collectors;
++import org.apache.comet.parquet.SupportsComet;
+ import org.apache.iceberg.DeleteFile;
+ import org.apache.iceberg.FileContent;
+ import org.apache.iceberg.FileScanTask;
+@@ -63,7 +64,7 @@ import org.slf4j.Logger;
+ import org.slf4j.LoggerFactory;
+ 
+ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
+-    implements SupportsRuntimeV2Filtering {
++    implements SupportsRuntimeV2Filtering, SupportsComet {
+ 
+   private static final Logger LOG = LoggerFactory.getLogger(SparkBatchQueryScan.class);
+ 
+@@ -290,4 +291,9 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
+         runtimeFilterExpressions,
+         caseSensitive());
+   }
++
++  @Override
++  public boolean isCometEnabled() {
++    return true;
++  }
+ }
+diff --git a/spark/v3.5/build.gradle b/spark/v3.5/build.gradle
+index e2d2c7a..8b5bff8 100644
+--- a/spark/v3.5/build.gradle
++++ b/spark/v3.5/build.gradle
+@@ -75,7 +75,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
+       exclude group: 'org.roaringbitmap'
+     }
+ 
+-    compileOnly "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.5.0"
++    compileOnly "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.9.0-SNAPSHOT"
+ 
+     implementation libs.parquet.column
+     implementation libs.parquet.hadoop
+@@ -182,8 +182,8 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
+ 
+     testImplementation libs.avro.avro
+     testImplementation libs.parquet.hadoop
++    testImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.9.0-SNAPSHOT"
+     testImplementation libs.awaitility
+-    testImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.5.0"
+ 
+     // Required because we remove antlr plugin dependencies from the compile configuration, see note above
+     runtimeOnly libs.antlr.runtime
+@@ -263,6 +263,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
+     integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+     integrationImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
+     integrationImplementation project(path: ":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
++    integrationImplementation "org.apache.datafusion:comet-spark-spark${sparkMajorVersion}_${scalaVersion}:0.9.0-SNAPSHOT"
+ 
+     // runtime dependencies for running Hive Catalog based integration test
+     integrationRuntimeOnly project(':iceberg-hive-metastore')
+@@ -300,8 +301,8 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
+     relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
+     relocate 'avro.shaded', 'org.apache.iceberg.shaded.org.apache.avro.shaded'
+     relocate 'com.thoughtworks.paranamer', 'org.apache.iceberg.shaded.com.thoughtworks.paranamer'
+-    relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'
+-    relocate 'shaded.parquet', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
++//    relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'
++//    relocate 'shaded.parquet', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
+     relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
+     relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
+     relocate 'org.apache.hc.client5', 'org.apache.iceberg.shaded.org.apache.hc.client5'
+diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java
+index 4794863..8d02f02 100644
+--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java
++++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/CometColumnReader.java
+@@ -20,11 +20,11 @@ package org.apache.iceberg.spark.data.vectorized;
+ 
+ import java.io.IOException;
+ import java.util.Map;
++import org.apache.comet.CometSchemaImporter;
+ import org.apache.comet.parquet.AbstractColumnReader;
+ import org.apache.comet.parquet.ColumnReader;
+ import org.apache.comet.parquet.TypeUtil;
+ import org.apache.comet.parquet.Utils;
+-import org.apache.comet.shaded.arrow.c.CometSchemaImporter;
+ import org.apache.comet.shaded.arrow.memory.RootAllocator;
+ import org.apache.iceberg.parquet.VectorizedReader;
+ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+index a361a7f..9021cd5 100644
+--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
++++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+@@ -24,6 +24,7 @@ import java.util.Objects;
+ import java.util.Set;
+ import java.util.function.Supplier;
+ import java.util.stream.Collectors;
++import org.apache.comet.parquet.SupportsComet;
+ import org.apache.iceberg.DeleteFile;
+ import org.apache.iceberg.FileContent;
+ import org.apache.iceberg.FileScanTask;
+@@ -63,7 +64,7 @@ import org.slf4j.Logger;
+ import org.slf4j.LoggerFactory;
+ 
+ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
+-    implements SupportsRuntimeV2Filtering {
++    implements SupportsRuntimeV2Filtering, SupportsComet {
+ 
+   private static final Logger LOG = LoggerFactory.getLogger(SparkBatchQueryScan.class);
+ 
+@@ -290,4 +291,9 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
+         runtimeFilterExpressions,
+         caseSensitive());
+   }
++
++  @Override
++  public boolean isCometEnabled() {
++    return true;
++  }
+ }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #. https://github.com/apache/datafusion-comet/issues/1685

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Run Iceberg Spark' tests as part of Comet CI

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

 - Produce a git diff bases on Iceberg version 1.8.1 (will work on other Iceberg versions (e.g. 1.9.x) later)
 - Run Iceberg Spark's tests, based on Iceberg's GitHub workflow: https://github.com/apache/iceberg/blob/main/.github/workflows/spark-ci.yml

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

At the moment, locally:

```shell
ENABLE_COMET=true ENABLE_COMET_SHUFFLE=true ./gradlew -DsparkVersions=3.5 -DscalaVersion=2.12 -DflinkVersions= -DkafkaVersions= :iceberg-spark:iceberg-spark-3.5_2.12:check -Pquick=true -x javadoc

BUILD SUCCESSFUL in 24m 36s
46 actionable tasks: 24 executed, 22 up-to-date

ENABLE_COMET=true ENABLE_COMET_SHUFFLE=true ./gradlew -DsparkVersions=3.5 -DscalaVersion=2.12 -DflinkVersions= -DkafkaVersions= :iceberg-spark:iceberg-spark-extensions-3.5_2.12:check -Pquick=true -x javadoc

BUILD SUCCESSFUL in 22m 28s
52 actionable tasks: 7 executed, 45 up-to-date

ENABLE_COMET=true ENABLE_COMET_SHUFFLE=true ./gradlew -DsparkVersions=3.5 -DscalaVersion=2.12 -DflinkVersions= -DkafkaVersions= :iceberg-spark:iceberg-spark-runtime-3.5_2.12:check -Pquick=true -x javadoc 

BUILD SUCCESSFUL in 14s
65 actionable tasks: 5 executed, 25 from cache, 35 up-to-date
```
