### PR TITLE
fix: Bucketed scan fallback for native_datafusion Parquet scan

### DIFF
--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -96,6 +96,13 @@ case class CometScanRule(session: SparkSession) extends Rule[SparkPlan] {
           return withInfo(scanExec, fallbackReasons.mkString(", "))
         }
 
+        if (scanImpl == CometConf.SCAN_NATIVE_DATAFUSION && scanExec.bucketedScan) {
+          // https://github.com/apache/datafusion-comet/issues/1719
+          fallbackReasons +=
+            "Full native scan disabled because bucketed scan is not supported"
+          return withInfo(scanExec, fallbackReasons.mkString(", "))
+        }
+
         val (schemaSupported, partitionSchemaSupported) = scanImpl match {
           case CometConf.SCAN_NATIVE_DATAFUSION =>
             (

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -1470,6 +1470,10 @@ class CometExecSuite extends CometTestBase {
   }
 
   test("bucketed table") {
+    // native_datafusion actually passes this test, but in the case where buckets are pruned it fails, so we're
+    // falling back for bucketed scans entirely as a workaround.
+    // https://github.com/apache/datafusion-comet/issues/1719
+    assume(CometConf.COMET_NATIVE_SCAN_IMPL.get() != CometConf.SCAN_NATIVE_DATAFUSION)
     val bucketSpec = Some(BucketSpec(8, Seq("i", "j"), Nil))
     val bucketedTableTestSpecLeft = BucketedTableTestSpec(bucketSpec, expectedShuffle = false)
     val bucketedTableTestSpecRight = BucketedTableTestSpec(bucketSpec, expectedShuffle = false)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

See https://github.com/apache/datafusion-comet/issues/1719

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fallback for bucketed scan when using native_datafusion.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing Spark SQL tests.
