### PR TITLE
minor: Warn if memory pool is dropped with bytes still reserved

### DIFF
--- a/native/core/src/execution/memory_pools/unified_pool.rs
+++ b/native/core/src/execution/memory_pools/unified_pool.rs
@@ -76,6 +76,15 @@ impl CometMemoryPool {
     }
 }
 
+impl Drop for CometMemoryPool {
+    fn drop(&mut self) {
+        let used = self.used.load(Relaxed);
+        if used != 0 {
+            log::warn!("CometMemoryPool dropped with {} bytes still reserved", used);
+        }
+    }
+}
+
 unsafe impl Send for CometMemoryPool {}
 unsafe impl Sync for CometMemoryPool {}
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

If we drop memory pools before all bytes are freed, it could lead to a memory leak over time. I would like to know if/when this is happening.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add a check when dropping memory pools.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
