### PR TITLE
fix: Fix data race in memory profiling

### DIFF
--- a/spark/src/main/java/org/apache/spark/CometTaskMemoryManager.java
+++ b/spark/src/main/java/org/apache/spark/CometTaskMemoryManager.java
@@ -62,7 +62,7 @@ public class CometTaskMemoryManager {
   public void releaseMemory(long size) {
     long newUsed = used.addAndGet(-size);
     if (newUsed < 0) {
-      logger.warn("Used memory is negative: " + newUsed);
+      logger.error("Used memory is negative: " + newUsed);
     }
     internal.releaseExecutionMemory(size, nativeMemoryConsumer);
   }

--- a/spark/src/main/java/org/apache/spark/CometTaskMemoryManager.java
+++ b/spark/src/main/java/org/apache/spark/CometTaskMemoryManager.java
@@ -62,7 +62,8 @@ public class CometTaskMemoryManager {
   public void releaseMemory(long size) {
     long newUsed = used.addAndGet(-size);
     if (newUsed < 0) {
-      logger.error("Used memory is negative: " + newUsed + " after releasing memory chunk of: " + size);
+      logger.error(
+          "Used memory is negative: " + newUsed + " after releasing memory chunk of: " + size);
     }
     internal.releaseExecutionMemory(size, nativeMemoryConsumer);
   }

--- a/spark/src/main/java/org/apache/spark/CometTaskMemoryManager.java
+++ b/spark/src/main/java/org/apache/spark/CometTaskMemoryManager.java
@@ -62,7 +62,7 @@ public class CometTaskMemoryManager {
   public void releaseMemory(long size) {
     long newUsed = used.addAndGet(-size);
     if (newUsed < 0) {
-      logger.error("Used memory is negative: " + newUsed);
+      logger.error("Used memory is negative: " + newUsed + " after releasing memory chunk of: " + size);
     }
     internal.releaseExecutionMemory(size, nativeMemoryConsumer);
   }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/1726

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Fix a data race that caused negative memory use to be reported

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Use AtomicLong instead of long to track used memory.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Manually.
