### PR TITLE
fix: Check acquired memory when CometMemoryPool grows

### DIFF
--- a/native/core/src/execution/memory_pools/unified_pool.rs
+++ b/native/core/src/execution/memory_pools/unified_pool.rs
@@ -89,10 +89,8 @@ unsafe impl Send for CometMemoryPool {}
 unsafe impl Sync for CometMemoryPool {}
 
 impl MemoryPool for CometMemoryPool {
-    fn grow(&self, _: &MemoryReservation, additional: usize) {
-        self.acquire(additional)
-            .unwrap_or_else(|_| panic!("Failed to acquire {} bytes", additional));
-        self.used.fetch_add(additional, Relaxed);
+    fn grow(&self, reservation: &MemoryReservation, additional: usize) {
+        self.try_grow(reservation, additional).unwrap();
     }
 
     fn shrink(&self, _: &MemoryReservation, size: usize) {

--- a/spark/src/main/java/org/apache/spark/CometTaskMemoryManager.java
+++ b/spark/src/main/java/org/apache/spark/CometTaskMemoryManager.java
@@ -48,6 +48,10 @@ public class CometTaskMemoryManager {
   // Returns the actual amount of memory (in bytes) granted.
   public long acquireMemory(long size) {
     long acquired = internal.acquireExecutionMemory(size, nativeMemoryConsumer);
+    if (acquired < size) {
+      // If memory manager is not able to acquire the requested size, log memory usage
+      internal.showMemoryUsage();
+    }
     used += acquired;
     return acquired;
   }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1733.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

+ Check acquired memory when CometMemoryPool grows
+ Log memory usage

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
