### PR TITLE
chore: Correct memory acquired size in unified memory pool

### DIFF
--- a/native/core/src/execution/memory_pools/unified_pool.rs
+++ b/native/core/src/execution/memory_pools/unified_pool.rs
@@ -115,7 +115,7 @@ impl MemoryPool for CometMemoryPool {
                     self.reserved()
                 ));
             }
-            self.used.fetch_add(additional, Relaxed);
+            self.used.fetch_add(acquired as usize, Relaxed);
         }
         Ok(())
     }


### PR DESCRIPTION
## Which issue does this PR close?


## Rationale for this change

Although the `acquired` is always equal to the `additional` due to the current implicit semantics, it’s still better to make this logic explicit for clarity and better maintainability.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
