### PR TITLE
chore: Refactor DataTypeSupport

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -242,12 +242,12 @@ object CometSparkSessionExtensions extends Logging {
     org.apache.spark.SPARK_VERSION >= "4.0"
   }
 
-  def usingDataFusionParquetExec(conf: SQLConf): Boolean =
+  def usingDataSourceExec(conf: SQLConf): Boolean =
     Seq(CometConf.SCAN_NATIVE_ICEBERG_COMPAT, CometConf.SCAN_NATIVE_DATAFUSION).contains(
       CometConf.COMET_NATIVE_SCAN_IMPL.get(conf))
 
-  def usingParquetExecWithIncompatTypes(conf: SQLConf): Boolean = {
-    usingDataFusionParquetExec(conf) &&
+  def usingDataSourceExecWithIncompatTypes(conf: SQLConf): Boolean = {
+    usingDataSourceExec(conf) &&
     !CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.get(conf)
   }
 

--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -246,6 +246,11 @@ object CometSparkSessionExtensions extends Logging {
     Seq(CometConf.SCAN_NATIVE_ICEBERG_COMPAT, CometConf.SCAN_NATIVE_DATAFUSION).contains(
       CometConf.COMET_NATIVE_SCAN_IMPL.get(conf))
 
+  def usingParquetExecWithIncompatTypes(conf: SQLConf): Boolean = {
+    usingDataFusionParquetExec(conf) &&
+    !CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.get(conf)
+  }
+
   /**
    * Whether we should override Spark memory configuration for Comet. This only returns true when
    * Comet native execution is enabled and/or Comet shuffle is enabled and Comet doesn't use

--- a/spark/src/main/scala/org/apache/comet/DataTypeSupport.scala
+++ b/spark/src/main/scala/org/apache/comet/DataTypeSupport.scala
@@ -35,10 +35,14 @@ trait DataTypeSupport {
    * @return
    *   true if all fields in the schema are supported
    */
-  def isSchemaSupported(struct: StructType, fallbackReasons: ListBuffer[String]): Boolean = {
-    struct.fields.forall(f => isTypeSupported(f.dataType, f.name, fallbackReasons))
+  def isSchemaSupported(schema: StructType, fallbackReasons: ListBuffer[String]): Boolean = {
+    schema.fields.forall(f => isTypeSupported(f.dataType, f.name, fallbackReasons))
   }
 
+  /**
+   * Determine if Comet supports a data type. This method can be overridden by specific operators
+   * as needed.
+   */
   def isTypeSupported(
       dt: DataType,
       name: String,

--- a/spark/src/main/scala/org/apache/comet/DataTypeSupport.scala
+++ b/spark/src/main/scala/org/apache/comet/DataTypeSupport.scala
@@ -21,7 +21,6 @@ package org.apache.comet
 
 import scala.collection.mutable.ListBuffer
 
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 import org.apache.comet.DataTypeSupport.{ARRAY_ELEMENT, MAP_KEY, MAP_VALUE}
@@ -70,9 +69,4 @@ object DataTypeSupport {
   val ARRAY_ELEMENT = "array element"
   val MAP_KEY = "map key"
   val MAP_VALUE = "map value"
-
-  def usingParquetExecWithIncompatTypes(conf: SQLConf): Boolean = {
-    CometSparkSessionExtensions.usingDataFusionParquetExec(conf) &&
-    !CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.get(conf)
-  }
 }

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -48,7 +48,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
 import org.apache.comet.CometConf
-import org.apache.comet.CometSparkSessionExtensions.{isCometScan, usingDataFusionParquetExec, withInfo}
+import org.apache.comet.CometSparkSessionExtensions.{isCometScan, usingDataSourceExec, withInfo}
 import org.apache.comet.expressions._
 import org.apache.comet.serde.ExprOuterClass.{AggExpr, DataType => ProtoDataType, Expr, ScalarFunc}
 import org.apache.comet.serde.ExprOuterClass.DataType._
@@ -2766,7 +2766,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
               // - Native datafusion reader enabled (experimental) OR
               // - conversion from Parquet/JSON enabled
               allowComplex =
-                usingDataFusionParquetExec(conf) || CometConf.COMET_CONVERT_FROM_PARQUET_ENABLED
+                usingDataSourceExec(conf) || CometConf.COMET_CONVERT_FROM_PARQUET_ENABLED
                   .get(conf) || CometConf.COMET_CONVERT_FROM_JSON_ENABLED.get(conf))) =>
         // These operators are source of Comet native execution chain
         val scanBuilder = OperatorOuterClass.Scan.newBuilder()

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometBatchScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometBatchScanExec.scala
@@ -19,6 +19,8 @@
 
 package org.apache.spark.sql.comet
 
+import scala.collection.mutable.ListBuffer
+
 import org.apache.spark.rdd._
 import org.apache.spark.sql.catalyst._
 import org.apache.spark.sql.catalyst.expressions.{Attribute, DynamicPruningExpression, Expression, Literal, SortOrder}
@@ -28,6 +30,7 @@ import org.apache.spark.sql.connector.read._
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.datasources.v2._
 import org.apache.spark.sql.execution.metric._
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructType}
 import org.apache.spark.sql.vectorized._
 
 import com.google.common.base.Objects
@@ -150,4 +153,12 @@ case class CometBatchScanExec(wrapped: BatchScanExec, runtimeFilters: Seq[Expres
   override def supportsColumnar: Boolean = true
 }
 
-object CometBatchScanExec extends DataTypeSupport
+object CometBatchScanExec extends DataTypeSupport {
+  override def isTypeSupported(
+      dt: DataType,
+      name: String,
+      fallbackReasons: ListBuffer[String]): Boolean = dt match {
+    case _: StructType | _: ArrayType | _: MapType => false
+    case _ => super.isTypeSupported(dt, name, fallbackReasons)
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
@@ -236,7 +236,6 @@ object CometNativeScanExec extends DataTypeSupport {
       dt: DataType,
       name: String,
       fallbackReasons: ListBuffer[String]): Boolean = {
-    // TODO we could consider adding checks here for deeply nested types, which are not fully supported yet
     dt match {
       case ByteType | ShortType if usingParquetExecWithIncompatTypes(SQLConf.get) =>
         fallbackReasons += s"${CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.key} is false"

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
@@ -38,7 +38,7 @@ import org.apache.spark.util.collection._
 import com.google.common.base.Objects
 
 import org.apache.comet.{CometConf, DataTypeSupport}
-import org.apache.comet.DataTypeSupport.usingParquetExecWithIncompatTypes
+import org.apache.comet.CometSparkSessionExtensions.usingParquetExecWithIncompatTypes
 import org.apache.comet.parquet.CometParquetFileFormat
 import org.apache.comet.serde.OperatorOuterClass.Operator
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
@@ -38,7 +38,7 @@ import org.apache.spark.util.collection._
 import com.google.common.base.Objects
 
 import org.apache.comet.{CometConf, DataTypeSupport}
-import org.apache.comet.CometSparkSessionExtensions.usingParquetExecWithIncompatTypes
+import org.apache.comet.CometSparkSessionExtensions.usingDataSourceExecWithIncompatTypes
 import org.apache.comet.parquet.CometParquetFileFormat
 import org.apache.comet.serde.OperatorOuterClass.Operator
 
@@ -237,7 +237,7 @@ object CometNativeScanExec extends DataTypeSupport {
       name: String,
       fallbackReasons: ListBuffer[String]): Boolean = {
     dt match {
-      case ByteType | ShortType if usingParquetExecWithIncompatTypes(SQLConf.get) =>
+      case ByteType | ShortType if usingDataSourceExecWithIncompatTypes(SQLConf.get) =>
         fallbackReasons += s"${CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.key} is false"
         false
       case _ =>

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
@@ -528,7 +528,8 @@ object CometScanExec extends DataTypeSupport {
       name: String,
       fallbackReasons: ListBuffer[String]): Boolean = {
     dt match {
-      case _: StructType | _: ArrayType | _: MapType =>
+      case _: StructType | _: ArrayType | _: MapType
+          if CometConf.COMET_NATIVE_SCAN_IMPL.get() != CometConf.SCAN_NATIVE_ICEBERG_COMPAT =>
         false
       case _ =>
         super.isTypeSupported(dt, name, fallbackReasons)

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
@@ -52,7 +52,7 @@ import org.apache.spark.sql.internal.SQLConf
  * Comet physical scan node for DataSource V1. Most of the code here follow Spark's
  * [[FileSourceScanExec]],
  */
-case class 7CometScanExec(
+case class CometScanExec(
     @transient relation: HadoopFsRelation,
     output: Seq[Attribute],
     requiredSchema: StructType,

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
@@ -46,7 +46,7 @@ import org.apache.spark.util.SerializableConfiguration
 import org.apache.spark.util.collection._
 
 import org.apache.comet.{CometConf, DataTypeSupport, MetricsSupport}
-import org.apache.comet.CometSparkSessionExtensions.usingParquetExecWithIncompatTypes
+import org.apache.comet.CometSparkSessionExtensions.usingDataSourceExecWithIncompatTypes
 import org.apache.comet.parquet.{CometParquetFileFormat, CometParquetPartitionReaderFactory}
 
 /**
@@ -530,7 +530,7 @@ object CometScanExec extends DataTypeSupport {
       name: String,
       fallbackReasons: ListBuffer[String]): Boolean = {
     dt match {
-      case ByteType | ShortType if usingParquetExecWithIncompatTypes(SQLConf.get) =>
+      case ByteType | ShortType if usingDataSourceExecWithIncompatTypes(SQLConf.get) =>
         fallbackReasons += s"${CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.key} is false"
         false
       case _: StructType | _: ArrayType | _: MapType

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
@@ -19,11 +19,10 @@
 
 package org.apache.spark.sql.comet
 
-import org.apache.comet.CometSparkSessionExtensions.usingParquetExecWithIncompatTypes
-
 import scala.collection.mutable.{HashMap, ListBuffer}
 import scala.concurrent.duration.NANOSECONDS
 import scala.reflect.ClassTag
+
 import org.apache.hadoop.fs.Path
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
@@ -40,13 +39,15 @@ import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetOptions}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceRDD
 import org.apache.spark.sql.execution.metric._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.SerializableConfiguration
 import org.apache.spark.util.collection._
+
 import org.apache.comet.{CometConf, DataTypeSupport, MetricsSupport}
+import org.apache.comet.CometSparkSessionExtensions.usingParquetExecWithIncompatTypes
 import org.apache.comet.parquet.{CometParquetFileFormat, CometParquetPartitionReaderFactory}
-import org.apache.spark.sql.internal.SQLConf
 
 /**
  * Comet physical scan node for DataSource V1. Most of the code here follow Spark's

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometSparkToColumnarExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometSparkToColumnarExec.scala
@@ -137,11 +137,11 @@ case class CometSparkToColumnarExec(child: SparkPlan)
 }
 
 object CometSparkToColumnarExec extends DataTypeSupport {
-  override def isAdditionallySupported(
+  override def isTypeSupported(
       dt: DataType,
       name: String,
       fallbackReasons: ListBuffer[String]): Boolean = dt match {
     case _: StructType => true
-    case _ => false
+    case _ => super.isTypeSupported(dt, name, fallbackReasons)
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometSparkToColumnarExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometSparkToColumnarExec.scala
@@ -141,7 +141,7 @@ object CometSparkToColumnarExec extends DataTypeSupport {
       dt: DataType,
       name: String,
       fallbackReasons: ListBuffer[String]): Boolean = dt match {
-    case _: StructType => true
+    case _: ArrayType | _: MapType => false
     case _ => super.isTypeSupported(dt, name, fallbackReasons)
   }
 }

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -60,7 +60,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   private val timestampPattern = "0123456789/:T" + whitespaceChars
 
   lazy val usingParquetExecWithIncompatTypes: Boolean =
-    CometSparkSessionExtensions.usingParquetExecWithIncompatTypes(conf)
+    CometSparkSessionExtensions.usingDataSourceExecWithIncompatTypes(conf)
 
   test("all valid cast combinations covered") {
     val names = testNames

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -60,7 +60,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   private val timestampPattern = "0123456789/:T" + whitespaceChars
 
   lazy val usingParquetExecWithIncompatTypes: Boolean =
-    DataTypeSupport.usingParquetExecWithIncompatTypes(conf)
+    CometSparkSessionExtensions.usingParquetExecWithIncompatTypes(conf)
 
   test("all valid cast combinations covered") {
     val names = testNames

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -140,7 +140,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
                 Byte.MaxValue)
               withParquetTable(path.toString, "tbl") {
                 val qry = "select _9 from tbl order by _11"
-                if (CometSparkSessionExtensions.usingDataFusionParquetExec(conf)) {
+                if (CometSparkSessionExtensions.usingDataSourceExec(conf)) {
                   if (!allowIncompatible) {
                     checkSparkAnswer(qry)
                   } else {

--- a/spark/src/test/scala/org/apache/comet/exec/CometColumnarShuffleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometColumnarShuffleSuite.scala
@@ -758,7 +758,7 @@ abstract class CometColumnarShuffleSuite extends CometTestBase with AdaptiveSpar
         // TODO: revisit this when we have resolution of https://github.com/apache/arrow-rs/issues/7040
         // and https://github.com/apache/arrow-rs/issues/7097
         val fieldsToTest =
-          if (CometSparkSessionExtensions.usingDataFusionParquetExec(conf)) {
+          if (CometSparkSessionExtensions.usingDataSourceExec(conf)) {
             Seq(
               $"_1",
               $"_4",

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -47,7 +47,7 @@ import org.apache.spark.unsafe.types.UTF8String
 
 import com.google.common.primitives.UnsignedLong
 
-import org.apache.comet.{CometConf, DataTypeSupport}
+import org.apache.comet.{CometConf, CometSparkSessionExtensions}
 import org.apache.comet.CometConf.SCAN_NATIVE_ICEBERG_COMPAT
 import org.apache.comet.CometSparkSessionExtensions.{isSpark40Plus, usingDataFusionParquetExec}
 
@@ -169,7 +169,7 @@ abstract class ParquetReadSuite extends CometTestBase {
             i.toDouble,
             DateTimeUtils.toJavaDate(i))
         }
-        if (!DataTypeSupport.usingParquetExecWithIncompatTypes(conf)) {
+        if (!CometSparkSessionExtensions.usingParquetExecWithIncompatTypes(conf)) {
           checkParquetScan(data)
         }
         checkParquetFile(data)
@@ -191,7 +191,7 @@ abstract class ParquetReadSuite extends CometTestBase {
             i.toDouble,
             DateTimeUtils.toJavaDate(i))
         }
-        if (!DataTypeSupport.usingParquetExecWithIncompatTypes(conf)) {
+        if (!CometSparkSessionExtensions.usingParquetExecWithIncompatTypes(conf)) {
           checkParquetScan(data)
         }
         checkParquetFile(data)
@@ -212,7 +212,7 @@ abstract class ParquetReadSuite extends CometTestBase {
         DateTimeUtils.toJavaDate(i))
     }
     val filter = (row: Row) => row.getBoolean(0)
-    if (!DataTypeSupport.usingParquetExecWithIncompatTypes(conf)) {
+    if (!CometSparkSessionExtensions.usingParquetExecWithIncompatTypes(conf)) {
       checkParquetScan(data, filter)
     }
     checkParquetFile(data, filter)

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -49,7 +49,7 @@ import com.google.common.primitives.UnsignedLong
 
 import org.apache.comet.{CometConf, CometSparkSessionExtensions}
 import org.apache.comet.CometConf.SCAN_NATIVE_ICEBERG_COMPAT
-import org.apache.comet.CometSparkSessionExtensions.{isSpark40Plus, usingDataFusionParquetExec}
+import org.apache.comet.CometSparkSessionExtensions.{isSpark40Plus, usingDataSourceExec}
 
 abstract class ParquetReadSuite extends CometTestBase {
   import testImplicits._
@@ -118,7 +118,7 @@ abstract class ParquetReadSuite extends CometTestBase {
         val fallbackReasons = new ListBuffer[String]()
         assert(CometScanExec.isTypeSupported(dt, "", fallbackReasons) == expected)
         // usingDataFusionParquetExec does not support CometBatchScanExec yet
-        if (!usingDataFusionParquetExec(conf)) {
+        if (!usingDataSourceExec(conf)) {
           assert(CometBatchScanExec.isTypeSupported(dt, "", fallbackReasons) == expected)
         }
       }
@@ -169,7 +169,7 @@ abstract class ParquetReadSuite extends CometTestBase {
             i.toDouble,
             DateTimeUtils.toJavaDate(i))
         }
-        if (!CometSparkSessionExtensions.usingParquetExecWithIncompatTypes(conf)) {
+        if (!CometSparkSessionExtensions.usingDataSourceExecWithIncompatTypes(conf)) {
           checkParquetScan(data)
         }
         checkParquetFile(data)
@@ -191,7 +191,7 @@ abstract class ParquetReadSuite extends CometTestBase {
             i.toDouble,
             DateTimeUtils.toJavaDate(i))
         }
-        if (!CometSparkSessionExtensions.usingParquetExecWithIncompatTypes(conf)) {
+        if (!CometSparkSessionExtensions.usingDataSourceExecWithIncompatTypes(conf)) {
           checkParquetScan(data)
         }
         checkParquetFile(data)
@@ -212,7 +212,7 @@ abstract class ParquetReadSuite extends CometTestBase {
         DateTimeUtils.toJavaDate(i))
     }
     val filter = (row: Row) => row.getBoolean(0)
-    if (!CometSparkSessionExtensions.usingParquetExecWithIncompatTypes(conf)) {
+    if (!CometSparkSessionExtensions.usingDataSourceExecWithIncompatTypes(conf)) {
       checkParquetScan(data, filter)
     }
     checkParquetFile(data, filter)
@@ -1233,7 +1233,7 @@ abstract class ParquetReadSuite extends CometTestBase {
 
             withParquetDataFrame(data, schema = Some(readSchema)) { df =>
               // TODO: validate with Spark 3.x and 'usingDataFusionParquetExec=true'
-              if (enableSchemaEvolution || usingDataFusionParquetExec(conf)) {
+              if (enableSchemaEvolution || usingDataSourceExec(conf)) {
                 checkAnswer(df, data.map(Row.fromTuple))
               } else {
                 assertThrows[SparkException](df.collect())
@@ -1412,7 +1412,7 @@ abstract class ParquetReadSuite extends CometTestBase {
   test("row group skipping doesn't overflow when reading into larger type") {
     // Spark 4.0 no longer fails for widening types SPARK-40876
     // https://github.com/apache/spark/commit/3361f25dc0ff6e5233903c26ee105711b79ba967
-    assume(!isSpark40Plus && !usingDataFusionParquetExec(conf))
+    assume(!isSpark40Plus && !usingDataSourceExec(conf))
     withTempPath { path =>
       Seq(0).toDF("a").write.parquet(path.toString)
       // Reading integer 'a' as a long isn't supported. Check that an exception is raised instead

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -432,7 +432,7 @@ abstract class CometTestBase
   }
 
   def getPrimitiveTypesParquetSchema: String = {
-    if (DataTypeSupport.usingParquetExecWithIncompatTypes(conf)) {
+    if (CometSparkSessionExtensions.usingParquetExecWithIncompatTypes(conf)) {
       // Comet complex type reader has different behavior for uint_8, uint_16 types.
       // The issue stems from undefined behavior in the parquet spec and is tracked
       // here: https://github.com/apache/parquet-java/issues/3142

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -432,7 +432,7 @@ abstract class CometTestBase
   }
 
   def getPrimitiveTypesParquetSchema: String = {
-    if (CometSparkSessionExtensions.usingParquetExecWithIncompatTypes(conf)) {
+    if (CometSparkSessionExtensions.usingDataSourceExecWithIncompatTypes(conf)) {
       // Comet complex type reader has different behavior for uint_8, uint_16 types.
       // The issue stems from undefined behavior in the parquet spec and is tracked
       // here: https://github.com/apache/parquet-java/issues/3142

--- a/spark/src/test/scala/org/apache/spark/sql/comet/ParquetDatetimeRebaseSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/ParquetDatetimeRebaseSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.{CometTestBase, DataFrame, Dataset, Row}
 import org.apache.spark.sql.internal.SQLConf
 
 import org.apache.comet.{CometConf, CometSparkSessionExtensions}
-import org.apache.comet.CometSparkSessionExtensions.{isSpark40Plus, usingDataFusionParquetExec}
+import org.apache.comet.CometSparkSessionExtensions.{isSpark40Plus, usingDataSourceExec}
 
 // This test checks if Comet reads ancient dates & timestamps that are before 1582, as if they are
 // read according to the `LegacyBehaviorPolicy.CORRECTED` mode (i.e., no rebase) in Spark.
@@ -51,7 +51,7 @@ abstract class ParquetDatetimeRebaseSuite extends CometTestBase {
           // Parquet file written by 2.4.5 should throw exception for both Spark and Comet
           // For Spark 4.0+, Parquet file written by 2.4.5 should not throw exception
           if ((exceptionOnRebase || sparkVersion == "2_4_5") && (!isSpark40Plus || sparkVersion != "2_4_5") && !CometSparkSessionExtensions
-              .usingDataFusionParquetExec(conf)) {
+              .usingDataSourceExec(conf)) {
             intercept[SparkException](df.collect())
           } else {
             checkSparkNoRebaseAnswer(df)
@@ -62,7 +62,7 @@ abstract class ParquetDatetimeRebaseSuite extends CometTestBase {
   }
 
   test("reading ancient timestamps before 1582") {
-    assume(!usingDataFusionParquetExec(conf))
+    assume(!usingDataSourceExec(conf))
     Seq(true, false).foreach { exceptionOnRebase =>
       withSQLConf(
         CometConf.COMET_EXCEPTION_ON_LEGACY_DATE_TIMESTAMP.key ->
@@ -76,7 +76,7 @@ abstract class ParquetDatetimeRebaseSuite extends CometTestBase {
             // Parquet file written by 2.4.5 should throw exception for both Spark and Comet
             // For Spark 4.0+, Parquet file written by 2.4.5 should not throw exception
             if ((exceptionOnRebase || sparkVersion == "2_4_5") && (!isSpark40Plus || sparkVersion != "2_4_5") && !CometSparkSessionExtensions
-                .usingDataFusionParquetExec(conf)) {
+                .usingDataSourceExec(conf)) {
               intercept[SparkException](df.collect())
             } else {
               checkSparkNoRebaseAnswer(df)
@@ -88,7 +88,7 @@ abstract class ParquetDatetimeRebaseSuite extends CometTestBase {
   }
 
   test("reading ancient int96 timestamps before 1582") {
-    assume(!usingDataFusionParquetExec(conf))
+    assume(!usingDataSourceExec(conf))
     Seq(true, false).foreach { exceptionOnRebase =>
       withSQLConf(
         CometConf.COMET_EXCEPTION_ON_LEGACY_DATE_TIMESTAMP.key ->
@@ -102,7 +102,7 @@ abstract class ParquetDatetimeRebaseSuite extends CometTestBase {
             // Parquet file written by 2.4.5 should throw exception for both Spark and Comet
             // For Spark 4.0+, Parquet file written by 2.4.5 should not throw exception
             if ((exceptionOnRebase || sparkVersion == "2_4_5") && (!isSpark40Plus || sparkVersion != "2_4_5") && !CometSparkSessionExtensions
-                .usingDataFusionParquetExec(conf)) {
+                .usingDataSourceExec(conf)) {
               intercept[SparkException](df.collect())
             } else {
               checkSparkNoRebaseAnswer(df)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This is a step towards some other changes that I am trying to make related to native scans.

The current implementation of DataTypeSupport has an `isGloballySupported` method, but it contains rules that are specific to one type of native scan, which I found confusing.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Remove `isGloballySupported` and `isAdditionallySupported`. Now we just have `isTypeSupported`, which can be overridden as needed.

`DataTypeSupport` is currently implemented by the following classes, which are all updated in this PR.

- CometScanExec
- CometNativeScanExec
- CometBatchScanExec
- CometSparkToColumnarExec

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests