### PR TITLE
fix: support literal null list and map

### DIFF
--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -378,6 +378,7 @@ impl PhysicalPlanner {
                         DataType::Binary => ScalarValue::Binary(None),
                         DataType::Decimal128(p, s) => ScalarValue::Decimal128(None, p, s),
                         DataType::Struct(fields) => ScalarStructBuilder::new_null(fields),
+                        DataType::Map(f, s) => DataType::Map(f.into(), s).try_into()?,
                         DataType::Null => ScalarValue::Null,
                         dt => {
                             return Err(GeneralError(format!("{:?} is not supported in Comet", dt)))

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -378,7 +378,8 @@ impl PhysicalPlanner {
                         DataType::Binary => ScalarValue::Binary(None),
                         DataType::Decimal128(p, s) => ScalarValue::Decimal128(None, p, s),
                         DataType::Struct(fields) => ScalarStructBuilder::new_null(fields),
-                        DataType::Map(f, s) => DataType::Map(f.into(), s).try_into()?,
+                        DataType::Map(f, s) => DataType::Map(f, s).try_into()?,
+                        DataType::List(f) => DataType::List(f).try_into()?,
                         DataType::Null => ScalarValue::Null,
                         dt => {
                             return Err(GeneralError(format!("{:?} is not supported in Comet", dt)))

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -171,11 +171,18 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
         makeParquetFileAllTypes(path, dictionaryEnabled = dictionaryEnabled, batchSize)
         withParquetTable(path.toString, "tbl") {
           val sqlString =
-            "SELECT _4 + null, _15 - null, _16 * null, cast(null as struct<_1:int>) FROM tbl"
+            """SELECT
+              |_4 + null,
+              |_15 - null,
+              |_16 * null,
+              |cast(null as struct<_1:int>),
+              |cast(null as map<int, int>),
+              |cast(null as list<int>),
+              |FROM tbl""".stripMargin
           val df2 = sql(sqlString)
           val rows = df2.collect()
           assert(rows.length == batchSize)
-          assert(rows.forall(_ == Row(null, null, null, null)))
+          assert(rows.forall(_ == Row(null, null, null, null, null, null)))
 
           checkSparkAnswerAndOperator(sqlString)
         }

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -177,7 +177,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
               |_16 * null,
               |cast(null as struct<_1:int>),
               |cast(null as map<int, int>),
-              |cast(null as list<int>),
+              |cast(null as array<int>)
               |FROM tbl""".stripMargin
           val df2 = sql(sqlString)
           val rows = df2.collect()


### PR DESCRIPTION
## Which issue does this PR close?

## Rationale for this change

Currently native execution for null literal creation for map and list will fail

## What changes are included in this PR?

Added null literal map and list support

## How are these changes tested?

Added a test