### PR TITLE
chore: More refactoring of type checking logic

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -240,15 +240,6 @@ object CometSparkSessionExtensions extends Logging {
     org.apache.spark.SPARK_VERSION >= "4.0"
   }
 
-  def usingDataSourceExec(conf: SQLConf): Boolean =
-    Seq(CometConf.SCAN_NATIVE_ICEBERG_COMPAT, CometConf.SCAN_NATIVE_DATAFUSION).contains(
-      CometConf.COMET_NATIVE_SCAN_IMPL.get(conf))
-
-  def usingDataSourceExecWithIncompatTypes(conf: SQLConf): Boolean = {
-    usingDataSourceExec(conf) &&
-    !CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.get(conf)
-  }
-
   /**
    * Whether we should override Spark memory configuration for Comet. This only returns true when
    * Comet native execution is enabled and/or Comet shuffle is enabled and Comet doesn't use

--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -47,11 +47,9 @@ import org.apache.comet.rules.{CometExecRule, CometScanRule, EliminateRedundantT
 import org.apache.comet.shims.ShimCometSparkSessionExtensions
 
 /**
- * The entry point of Comet extension to Spark. This class is responsible for injecting Comet
- * rules and extensions into Spark.
+ * CometDriverPlugin will register an instance of this class with Spark.
  *
- * CometScanRule: A rule to transform a Spark scan plan into a Comet scan plan. CometExecRule: A
- * rule to transform a Spark execution plan into a Comet execution plan.
+ * This class is responsible for injecting Comet rules and extensions into Spark.
  */
 class CometSparkSessionExtensions
     extends (SparkSessionExtensions => Unit)

--- a/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
@@ -40,6 +40,9 @@ import org.apache.comet.CometSparkSessionExtensions.{createMessage, getCometBroa
 import org.apache.comet.serde.OperatorOuterClass.Operator
 import org.apache.comet.serde.QueryPlanSerde
 
+/**
+ * Spark physical optimizer rule for replacing Spark operators with Comet operators.
+ */
 case class CometExecRule(session: SparkSession) extends Rule[SparkPlan] {
   private def applyCometShuffle(plan: SparkPlan): SparkPlan = {
     plan.transformUp {

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -37,6 +37,9 @@ import org.apache.comet.CometConf._
 import org.apache.comet.CometSparkSessionExtensions.{isCometLoaded, isCometScanEnabled, withInfo, withInfos}
 import org.apache.comet.parquet.{CometParquetScan, SupportsComet}
 
+/**
+ * Spark physical optimizer rule for replacing Spark scans with Comet scans.
+ */
 case class CometScanRule(session: SparkSession) extends Rule[SparkPlan] {
   override def apply(plan: SparkPlan): SparkPlan = {
     if (!isCometLoaded(conf) || !isCometScanEnabled(conf)) {

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -22,7 +22,6 @@ package org.apache.comet.serde
 import java.util.Locale
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.ListBuffer
 import scala.math.min
 
 import org.apache.spark.internal.Logging
@@ -48,8 +47,8 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
-import org.apache.comet.{CometConf, DataTypeSupport}
-import org.apache.comet.CometSparkSessionExtensions.{isCometScan, withInfo, withInfos}
+import org.apache.comet.CometConf
+import org.apache.comet.CometSparkSessionExtensions.{isCometScan, withInfo}
 import org.apache.comet.expressions._
 import org.apache.comet.serde.ExprOuterClass.{AggExpr, DataType => ProtoDataType, Expr, ScalarFunc}
 import org.apache.comet.serde.ExprOuterClass.DataType._
@@ -2760,11 +2759,8 @@ object QueryPlanSerde extends Logging with CometExprShim {
         None
 
       case op if isCometSink(op) =>
-
-        val supportedTypes = op.output.forall(a =>
-            supportedDataType(
-              a.dataType,
-              allowComplex = true))
+        val supportedTypes =
+          op.output.forall(a => supportedDataType(a.dataType, allowComplex = true))
 
         if (!supportedTypes) {
           return None

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -2518,10 +2518,10 @@ object QueryPlanSerde extends Logging with CometExprShim {
           return None
         }
 
-        if (groupingExpressions.exists {
+        if (groupingExpressions.exists(expr => expr.dataType match {
             case _: StructType | _: ArrayType | _: MapType => true
             case _ => false
-          }) {
+          })) {
           withInfo(op, "Grouping on complex types is not supported")
           return None
         }

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -2520,10 +2520,10 @@ object QueryPlanSerde extends Logging with CometExprShim {
 
         if (groupingExpressions.exists(expr =>
             expr.dataType match {
-              case _: StructType | _: ArrayType | _: MapType => true
+              case _: MapType => true
               case _ => false
             })) {
-          withInfo(op, "Grouping on complex types is not supported")
+          withInfo(op, "Grouping on map types is not supported")
           return None
         }
 

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -2518,10 +2518,11 @@ object QueryPlanSerde extends Logging with CometExprShim {
           return None
         }
 
-        if (groupingExpressions.exists(expr => expr.dataType match {
-            case _: StructType | _: ArrayType | _: MapType => true
-            case _ => false
-          })) {
+        if (groupingExpressions.exists(expr =>
+            expr.dataType match {
+              case _: StructType | _: ArrayType | _: MapType => true
+              case _ => false
+            })) {
           withInfo(op, "Grouping on complex types is not supported")
           return None
         }

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -2518,6 +2518,14 @@ object QueryPlanSerde extends Logging with CometExprShim {
           return None
         }
 
+        if (groupingExpressions.exists {
+            case _: StructType | _: ArrayType | _: MapType => true
+            case _ => false
+          }) {
+          withInfo(op, "Grouping on complex types is not supported")
+          return None
+        }
+
         val groupingExprs = groupingExpressions.map(exprToProto(_, child.output))
         if (groupingExprs.exists(_.isEmpty)) {
           withInfo(op, "Not all grouping expressions are supported")

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
@@ -31,14 +31,12 @@ import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, UnknownPartit
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.util.collection._
 
 import com.google.common.base.Objects
 
 import org.apache.comet.{CometConf, DataTypeSupport}
-import org.apache.comet.CometSparkSessionExtensions.usingDataSourceExecWithIncompatTypes
 import org.apache.comet.parquet.CometParquetFileFormat
 import org.apache.comet.serde.OperatorOuterClass.Operator
 
@@ -237,8 +235,8 @@ object CometNativeScanExec extends DataTypeSupport {
       name: String,
       fallbackReasons: ListBuffer[String]): Boolean = {
     dt match {
-      case ByteType | ShortType if usingDataSourceExecWithIncompatTypes(SQLConf.get) =>
-        fallbackReasons += s"${CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.key} is false"
+      case ByteType | ShortType if !CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.get() =>
+        fallbackReasons += s"${CometConf.SCAN_NATIVE_DATAFUSION} scan cannot read $dt when ${CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.key} is false. ${CometConf.COMPAT_GUIDE}."
         false
       case _ =>
         super.isTypeSupported(dt, name, fallbackReasons)

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
@@ -236,7 +236,8 @@ object CometNativeScanExec extends DataTypeSupport {
       fallbackReasons: ListBuffer[String]): Boolean = {
     dt match {
       case ByteType | ShortType if !CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.get() =>
-        fallbackReasons += s"${CometConf.SCAN_NATIVE_DATAFUSION} scan cannot read $dt when ${CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.key} is false. ${CometConf.COMPAT_GUIDE}."
+        fallbackReasons += s"${CometConf.SCAN_NATIVE_DATAFUSION} scan cannot read $dt when " +
+          s"${CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.key} is false. ${CometConf.COMPAT_GUIDE}."
         false
       case _ =>
         super.isTypeSupported(dt, name, fallbackReasons)

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
@@ -529,9 +529,8 @@ object CometScanExec extends DataTypeSupport {
       fallbackReasons: ListBuffer[String]): Boolean = {
     dt match {
       case ByteType | ShortType
-          if CometConf.COMET_NATIVE_SCAN_IMPL
-            .get() == CometConf.SCAN_NATIVE_ICEBERG_COMPAT && CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE
-            .get() =>
+          if CometConf.COMET_NATIVE_SCAN_IMPL.get() == CometConf.SCAN_NATIVE_ICEBERG_COMPAT &&
+            CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.get() =>
         fallbackReasons += s"${CometConf.SCAN_NATIVE_ICEBERG_COMPAT} scan cannot read $dt when " +
           s"${CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.key} is false. ${CometConf.COMPAT_GUIDE}."
         false

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
@@ -530,7 +530,7 @@ object CometScanExec extends DataTypeSupport {
     dt match {
       case ByteType | ShortType
           if CometConf.COMET_NATIVE_SCAN_IMPL.get() == CometConf.SCAN_NATIVE_ICEBERG_COMPAT &&
-            CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.get() =>
+            !CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.get() =>
         fallbackReasons += s"${CometConf.SCAN_NATIVE_ICEBERG_COMPAT} scan cannot read $dt when " +
           s"${CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.key} is false. ${CometConf.COMPAT_GUIDE}."
         false

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
@@ -532,7 +532,8 @@ object CometScanExec extends DataTypeSupport {
           if CometConf.COMET_NATIVE_SCAN_IMPL
             .get() == CometConf.SCAN_NATIVE_ICEBERG_COMPAT && CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE
             .get() =>
-        fallbackReasons += s"${CometConf.SCAN_NATIVE_ICEBERG_COMPAT} scan cannot read $dt when ${CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.key} is false. ${CometConf.COMPAT_GUIDE}."
+        fallbackReasons += s"${CometConf.SCAN_NATIVE_ICEBERG_COMPAT} scan cannot read $dt when " +
+          s"${CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.key} is false. ${CometConf.COMPAT_GUIDE}."
         false
       case _: StructType | _: ArrayType | _: MapType
           if CometConf.COMET_NATIVE_SCAN_IMPL.get() != CometConf.SCAN_NATIVE_ICEBERG_COMPAT =>

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -60,7 +60,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   private val timestampPattern = "0123456789/:T" + whitespaceChars
 
   lazy val usingParquetExecWithIncompatTypes: Boolean =
-    CometSparkSessionExtensions.usingDataSourceExecWithIncompatTypes(conf)
+    usingDataSourceExecWithIncompatTypes(conf)
 
   test("all valid cast combinations covered") {
     val names = testNames

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -140,7 +140,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
                 Byte.MaxValue)
               withParquetTable(path.toString, "tbl") {
                 val qry = "select _9 from tbl order by _11"
-                if (CometSparkSessionExtensions.usingDataSourceExec(conf)) {
+                if (usingDataSourceExec(conf)) {
                   if (!allowIncompatible) {
                     checkSparkAnswer(qry)
                   } else {

--- a/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
@@ -141,14 +141,12 @@ class CometFuzzTestSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
-  test("shuffle") {
+  test("shuffle supports all types") {
     val df = spark.read.parquet(filename)
     val df2 = df.repartition(8, df.col("c0")).sort("c1")
     df2.collect()
     if (CometConf.isExperimentalNativeScan) {
-      val cometShuffles = collect(df2.queryExecution.executedPlan) {
-        case exec: CometShuffleExchangeExec => exec
-      }
+      val cometShuffles = collectCometShuffleExchanges(df2.queryExecution.executedPlan)
       assert(1 == cometShuffles.length)
     }
   }

--- a/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
@@ -117,7 +117,7 @@ class CometFuzzTestSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     df.createOrReplaceTempView("t1")
     val columns = df.schema.fields.filter(f => isComplexType(f.dataType)).map(_.name)
     for (col <- columns) {
-      // DISTRIBUTE BY is equivalent to df.repartition($col)
+      // DISTRIBUTE BY is equivalent to df.repartition($col) and uses
       val sql = s"SELECT $col FROM t1 DISTRIBUTE BY $col"
       val df = spark.sql(sql)
       df.collect()
@@ -296,8 +296,8 @@ class CometFuzzTestSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   private def collectCometShuffleExchanges(plan: SparkPlan): Seq[SparkPlan] = {
-    collect(plan) {
-      case exchange: CometShuffleExchangeExec => exchange
+    collect(plan) { case exchange: CometShuffleExchangeExec =>
+      exchange
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/exec/CometColumnarShuffleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometColumnarShuffleSuite.scala
@@ -758,7 +758,7 @@ abstract class CometColumnarShuffleSuite extends CometTestBase with AdaptiveSpar
         // TODO: revisit this when we have resolution of https://github.com/apache/arrow-rs/issues/7040
         // and https://github.com/apache/arrow-rs/issues/7097
         val fieldsToTest =
-          if (CometSparkSessionExtensions.usingDataSourceExec(conf)) {
+          if (usingDataSourceExec(conf)) {
             Seq(
               $"_1",
               $"_4",

--- a/spark/src/test/scala/org/apache/comet/exec/CometColumnarShuffleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometColumnarShuffleSuite.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
-import org.apache.comet.{CometConf, CometSparkSessionExtensions}
+import org.apache.comet.CometConf
 
 abstract class CometColumnarShuffleSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   protected val adaptiveExecutionEnabled: Boolean

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -49,7 +49,7 @@ import com.google.common.primitives.UnsignedLong
 
 import org.apache.comet.{CometConf, CometSparkSessionExtensions}
 import org.apache.comet.CometConf.SCAN_NATIVE_ICEBERG_COMPAT
-import org.apache.comet.CometSparkSessionExtensions.{isSpark40Plus, usingDataSourceExec}
+import org.apache.comet.CometSparkSessionExtensions.{isSpark40Plus}
 
 abstract class ParquetReadSuite extends CometTestBase {
   import testImplicits._
@@ -169,7 +169,7 @@ abstract class ParquetReadSuite extends CometTestBase {
             i.toDouble,
             DateTimeUtils.toJavaDate(i))
         }
-        if (!CometSparkSessionExtensions.usingDataSourceExecWithIncompatTypes(conf)) {
+        if (!usingDataSourceExecWithIncompatTypes(conf)) {
           checkParquetScan(data)
         }
         checkParquetFile(data)
@@ -191,7 +191,7 @@ abstract class ParquetReadSuite extends CometTestBase {
             i.toDouble,
             DateTimeUtils.toJavaDate(i))
         }
-        if (!CometSparkSessionExtensions.usingDataSourceExecWithIncompatTypes(conf)) {
+        if (!usingDataSourceExecWithIncompatTypes(conf)) {
           checkParquetScan(data)
         }
         checkParquetFile(data)
@@ -212,7 +212,7 @@ abstract class ParquetReadSuite extends CometTestBase {
         DateTimeUtils.toJavaDate(i))
     }
     val filter = (row: Row) => row.getBoolean(0)
-    if (!CometSparkSessionExtensions.usingDataSourceExecWithIncompatTypes(conf)) {
+    if (!usingDataSourceExecWithIncompatTypes(conf)) {
       checkParquetScan(data, filter)
     }
     checkParquetFile(data, filter)

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -47,9 +47,9 @@ import org.apache.spark.unsafe.types.UTF8String
 
 import com.google.common.primitives.UnsignedLong
 
-import org.apache.comet.{CometConf, CometSparkSessionExtensions}
+import org.apache.comet.CometConf
 import org.apache.comet.CometConf.SCAN_NATIVE_ICEBERG_COMPAT
-import org.apache.comet.CometSparkSessionExtensions.{isSpark40Plus}
+import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
 
 abstract class ParquetReadSuite extends CometTestBase {
   import testImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -20,11 +20,14 @@
 package org.apache.spark.sql
 
 import java.util.concurrent.atomic.AtomicInteger
+
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.Try
+
 import org.scalatest.BeforeAndAfterEach
+
 import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.column.ParquetProperties
@@ -42,6 +45,7 @@ import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.internal._
 import org.apache.spark.sql.test._
 import org.apache.spark.sql.types.{ArrayType, DataType, DecimalType, MapType, StructType}
+
 import org.apache.comet._
 import org.apache.comet.shims.ShimCometSparkSessionExtensions
 

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -432,7 +432,7 @@ abstract class CometTestBase
   }
 
   def getPrimitiveTypesParquetSchema: String = {
-    if (CometSparkSessionExtensions.usingDataSourceExecWithIncompatTypes(conf)) {
+    if (usingDataSourceExecWithIncompatTypes(conf)) {
       // Comet complex type reader has different behavior for uint_8, uint_16 types.
       // The issue stems from undefined behavior in the parquet spec and is tracked
       // here: https://github.com/apache/parquet-java/issues/3142
@@ -978,4 +978,14 @@ abstract class CometTestBase
 
     writer.close()
   }
+
+  def usingDataSourceExec(conf: SQLConf): Boolean =
+    Seq(CometConf.SCAN_NATIVE_ICEBERG_COMPAT, CometConf.SCAN_NATIVE_DATAFUSION).contains(
+      CometConf.COMET_NATIVE_SCAN_IMPL.get(conf))
+
+  def usingDataSourceExecWithIncompatTypes(conf: SQLConf): Boolean = {
+    usingDataSourceExec(conf) &&
+      !CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.get(conf)
+  }
+
 }

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -20,14 +20,11 @@
 package org.apache.spark.sql
 
 import java.util.concurrent.atomic.AtomicInteger
-
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.Try
-
 import org.scalatest.BeforeAndAfterEach
-
 import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.column.ParquetProperties
@@ -44,8 +41,7 @@ import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.internal._
 import org.apache.spark.sql.test._
-import org.apache.spark.sql.types.{DecimalType, StructType}
-
+import org.apache.spark.sql.types.{ArrayType, DataType, DecimalType, MapType, StructType}
 import org.apache.comet._
 import org.apache.comet.shims.ShimCometSparkSessionExtensions
 
@@ -988,4 +984,8 @@ abstract class CometTestBase
     !CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.get(conf)
   }
 
+  def isComplexType(dt: DataType): Boolean = dt match {
+    case _: StructType | _: ArrayType | _: MapType => true
+    case _ => false
+  }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -985,7 +985,7 @@ abstract class CometTestBase
 
   def usingDataSourceExecWithIncompatTypes(conf: SQLConf): Boolean = {
     usingDataSourceExec(conf) &&
-      !CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.get(conf)
+    !CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.get(conf)
   }
 
 }

--- a/spark/src/test/scala/org/apache/spark/sql/comet/ParquetDatetimeRebaseSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/ParquetDatetimeRebaseSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.{CometTestBase, DataFrame, Dataset, Row}
 import org.apache.spark.sql.internal.SQLConf
 
 import org.apache.comet.{CometConf, CometSparkSessionExtensions}
-import org.apache.comet.CometSparkSessionExtensions.{isSpark40Plus, usingDataSourceExec}
+import org.apache.comet.CometSparkSessionExtensions.{isSpark40Plus}
 
 // This test checks if Comet reads ancient dates & timestamps that are before 1582, as if they are
 // read according to the `LegacyBehaviorPolicy.CORRECTED` mode (i.e., no rebase) in Spark.
@@ -50,8 +50,8 @@ abstract class ParquetDatetimeRebaseSuite extends CometTestBase {
 
           // Parquet file written by 2.4.5 should throw exception for both Spark and Comet
           // For Spark 4.0+, Parquet file written by 2.4.5 should not throw exception
-          if ((exceptionOnRebase || sparkVersion == "2_4_5") && (!isSpark40Plus || sparkVersion != "2_4_5") && !CometSparkSessionExtensions
-              .usingDataSourceExec(conf)) {
+          if ((exceptionOnRebase || sparkVersion == "2_4_5") && (!isSpark40Plus || sparkVersion != "2_4_5") &&
+            !usingDataSourceExec(conf)) {
             intercept[SparkException](df.collect())
           } else {
             checkSparkNoRebaseAnswer(df)
@@ -75,8 +75,8 @@ abstract class ParquetDatetimeRebaseSuite extends CometTestBase {
 
             // Parquet file written by 2.4.5 should throw exception for both Spark and Comet
             // For Spark 4.0+, Parquet file written by 2.4.5 should not throw exception
-            if ((exceptionOnRebase || sparkVersion == "2_4_5") && (!isSpark40Plus || sparkVersion != "2_4_5") && !CometSparkSessionExtensions
-                .usingDataSourceExec(conf)) {
+            if ((exceptionOnRebase || sparkVersion == "2_4_5") && (!isSpark40Plus || sparkVersion != "2_4_5")
+              && !usingDataSourceExec(conf)) {
               intercept[SparkException](df.collect())
             } else {
               checkSparkNoRebaseAnswer(df)
@@ -101,8 +101,8 @@ abstract class ParquetDatetimeRebaseSuite extends CometTestBase {
 
             // Parquet file written by 2.4.5 should throw exception for both Spark and Comet
             // For Spark 4.0+, Parquet file written by 2.4.5 should not throw exception
-            if ((exceptionOnRebase || sparkVersion == "2_4_5") && (!isSpark40Plus || sparkVersion != "2_4_5") && !CometSparkSessionExtensions
-                .usingDataSourceExec(conf)) {
+            if ((exceptionOnRebase || sparkVersion == "2_4_5") && (!isSpark40Plus || sparkVersion != "2_4_5")
+              && !usingDataSourceExec(conf)) {
               intercept[SparkException](df.collect())
             } else {
               checkSparkNoRebaseAnswer(df)

--- a/spark/src/test/scala/org/apache/spark/sql/comet/ParquetDatetimeRebaseSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/ParquetDatetimeRebaseSuite.scala
@@ -26,8 +26,8 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.{CometTestBase, DataFrame, Dataset, Row}
 import org.apache.spark.sql.internal.SQLConf
 
-import org.apache.comet.{CometConf, CometSparkSessionExtensions}
-import org.apache.comet.CometSparkSessionExtensions.{isSpark40Plus}
+import org.apache.comet.CometConf
+import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
 
 // This test checks if Comet reads ancient dates & timestamps that are before 1582, as if they are
 // read according to the `LegacyBehaviorPolicy.CORRECTED` mode (i.e., no rebase) in Spark.


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Fixing technical debt in preparation for other improvements for native scans and complex type support

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Move some type checking logic into the native scan execs
- Improve fallback message for native scans reading byte/short
- Move `usingDataSourceExec` and `usingDataSourceExecWithIncompatTypes` into `CometTestBase`
- Reimplement type-checking logic when determining if a Comet sink is supported
- Add one more fuzz test for shuffle, for more coverage
- Add a check that we were missing for falling back to Spark for GROUP BY on complex types

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
