### PR TITLE
docs: Remove outdated param in macos bench guide

### DIFF
--- a/docs/source/contributor-guide/benchmarking_macos.md
+++ b/docs/source/contributor-guide/benchmarking_macos.md
@@ -89,7 +89,6 @@ $SPARK_HOME/bin/spark-submit \
     --conf spark.memory.offHeap.size=16g \
     --conf spark.eventLog.enabled=true \
     /path/to/datafusion-benchmarks/runners/datafusion-comet/tpcbench.py \
-    --name spark \
     --benchmark tpch \
     --data /Users/rusty/Data/tpch/sf100 \
     --queries /path/to/datafusion-benchmarks/tpch/queries \
@@ -136,7 +135,6 @@ $SPARK_HOME/bin/spark-submit \
     --conf spark.comet.exec.replaceSortMergeJoin=true \
     --conf spark.comet.cast.allowIncompatible=true \
     /path/to/datafusion-benchmarks/runners/datafusion-comet/tpcbench.py \
-    --name comet \
     --benchmark tpch \
     --data /path/to/tpch-data/ \
     --queries /path/to/datafusion-benchmarks//tpch/queries \


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
It seems like `tpcbench.py` in `datafusion-benchmarks` no longer take `name` as argument. This pr removes `--name` in `benchmarking_macos.md` 

See: https://github.com/apache/datafusion-benchmarks/blob/e82732f0f55998588ebe41cc49760575e82842db/runners/datafusion-comet/tpcbench.py#L113 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
