### PR TITLE
fix: correct schema type checking in native_iceberg_compat

### DIFF
--- a/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
@@ -346,7 +346,7 @@ public class NativeBatchReader extends RecordReader<Void, ColumnarBatch> impleme
         } else if (optFileField.isPresent()) {
           // The column we are reading may be a complex type in which case we check if each field in
           // the requested type is in the file type (and the same data type)
-          // This makes the same check as Spark's VectorzedParquetReader
+          // This makes the same check as Spark's VectorizedParquetReader
           checkColumn(parquetFields[i]);
           missingColumns[i] = false;
         } else {

--- a/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
@@ -275,9 +275,6 @@ public class NativeBatchReader extends RecordReader<Void, ColumnarBatch> impleme
         requestedSchema =
             CometParquetReadSupport.clipParquetSchema(
                 requestedSchema, sparkSchema, isCaseSensitive, useFieldId, ignoreMissingIds);
-        //        requestedSchema =
-        //            ParquetReadSupport.clipParquetSchema(
-        //                requestedSchema, sparkSchema, isCaseSensitive, useFieldId);
         if (requestedSchema.getFieldCount() != sparkSchema.size()) {
           throw new IllegalArgumentException(
               String.format(
@@ -446,8 +443,9 @@ public class NativeBatchReader extends RecordReader<Void, ColumnarBatch> impleme
 
   /**
    * Checks whether the given 'path' exists in 'parquetType'. The difference between this and {@link
-   * MessageType#containsPath(String[])} is that the latter only support paths to leaf /** From
-   * Spark: VectorizedParquetRecordReader Check whether a column from requested schema is missing
+   * MessageType#containsPath(String[])} is that the latter only support paths to leaf
+   * From Spark: VectorizedParquetRecordReader
+   * Check whether a column from requested schema is missing
    * from the file schema, or whether it conforms to the type of the file schema.
    */
   private void checkColumn(ParquetColumn column) throws IOException {
@@ -470,7 +468,6 @@ public class NativeBatchReader extends RecordReader<Void, ColumnarBatch> impleme
         throw new IOException(
             "Required column is missing in data file. Col: " + Arrays.toString(path));
       }
-      //      missingColumns.add(column);
     }
   }
 

--- a/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
@@ -443,10 +443,9 @@ public class NativeBatchReader extends RecordReader<Void, ColumnarBatch> impleme
 
   /**
    * Checks whether the given 'path' exists in 'parquetType'. The difference between this and {@link
-   * MessageType#containsPath(String[])} is that the latter only support paths to leaf
-   * From Spark: VectorizedParquetRecordReader
-   * Check whether a column from requested schema is missing
-   * from the file schema, or whether it conforms to the type of the file schema.
+   * MessageType#containsPath(String[])} is that the latter only support paths to leaf From Spark:
+   * VectorizedParquetRecordReader Check whether a column from requested schema is missing from the
+   * file schema, or whether it conforms to the type of the file schema.
    */
   private void checkColumn(ParquetColumn column) throws IOException {
     String[] path = JavaConverters.seqAsJavaList(column.path()).toArray(new String[0]);

--- a/common/src/main/java/org/apache/comet/parquet/TypeUtil.java
+++ b/common/src/main/java/org/apache/comet/parquet/TypeUtil.java
@@ -20,8 +20,6 @@
 package org.apache.comet.parquet;
 
 import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
 
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.schema.*;
@@ -318,61 +316,5 @@ public class TypeUtil {
 
   private static boolean isSpark40Plus() {
     return package$.MODULE$.SPARK_VERSION().compareTo("4.0") >= 0;
-  }
-
-  public static boolean isComplexType(Type t) {
-    return !t.isPrimitive() || t.isRepetition(Type.Repetition.REPEATED);
-  }
-
-  // From Parquet Type.java
-  public static boolean eqOrBothNull(Object o1, Object o2) {
-    return (o1 == null && o2 == null) || (o1 != null && o1.equals(o2));
-  }
-
-  // From Parquet Type.java
-  public static boolean equals(Type one, Type other) {
-    return one.getName().equals(other.getName())
-        && one.getRepetition() == other.getRepetition()
-        && eqOrBothNull(one.getRepetition(), other.getRepetition())
-        && eqOrBothNull(one.getId(), other.getId())
-        && eqOrBothNull(one.getLogicalTypeAnnotation(), other.getLogicalTypeAnnotation());
-  }
-
-  //
-  // Compare a field with another field and return true if they are the same. Unlike
-  // the equals method for Type (and derived classes), allows requested to have fields
-  // that are not in actual.
-  //
-  public static boolean isEqual(Type requested, Type actual) {
-    if (requested == null && actual == null) {
-      return true;
-    }
-    if (requested == null || actual == null) {
-      return false;
-    }
-    if (requested.isPrimitive() && actual.isPrimitive()) {
-      return requested.asPrimitiveType().equals(actual.asPrimitiveType());
-    } else if (!requested.isPrimitive() && !actual.isPrimitive()) {
-      if (equals(requested, actual)) {
-        // GroupType.equals also checks if LogicalTypeAnnotation is the same.
-        // But it really is not necessary here.
-        List<Type> requestedFields = requested.asGroupType().getFields();
-        List<Type> actualFields = requested.asGroupType().getFields();
-        for (Type field : requestedFields) {
-          Optional<Type> optActualField =
-              actualFields.stream().filter(f -> f.getName().equals(field.getName())).findFirst();
-          if (optActualField.isPresent()) {
-            if (!isEqual(field, optActualField.get())) {
-              return false;
-            }
-          }
-        }
-      } else {
-        return false;
-      }
-    } else {
-      return false; // one is a primitive type and the other is not.
-    }
-    return true;
   }
 }

--- a/common/src/main/scala/org/apache/spark/sql/comet/parquet/CometParquetReadSupport.scala
+++ b/common/src/main/scala/org/apache/spark/sql/comet/parquet/CometParquetReadSupport.scala
@@ -194,8 +194,6 @@ object CometParquetReadSupport {
           .addField(clipParquetType(repeatedGroup, elementType, caseSensitive, useFieldId))
           .named(parquetList.getName)
       } else {
-        // Otherwise, the repeated field's type is the element type with the repeated field's
-        // repetition.
         val newRepeatedGroup = Types
           .repeatedGroup()
           .addField(
@@ -208,15 +206,11 @@ object CometParquetReadSupport {
           newRepeatedGroup
         }
 
+        // Otherwise, the repeated field's type is the element type with the repeated field's
+        // repetition.
         Types
           .buildGroup(parquetList.getRepetition)
           .as(LogicalTypeAnnotation.listType())
-          .addField(
-            Types
-              .repeatedGroup()
-              .addField(
-                clipParquetType(repeatedGroup.getType(0), elementType, caseSensitive, useFieldId))
-              .named(repeatedGroup.getName))
           .addField(newElementType)
           .named(parquetList.getName)
       }
@@ -369,7 +363,7 @@ object CometParquetReadSupport {
   /**
    * Whether the parquet schema contains any field IDs.
    */
-  private def containsFieldIds(schema: Type): Boolean = schema match {
+  def containsFieldIds(schema: Type): Boolean = schema match {
     case p: PrimitiveType => p.getId != null
     // We don't require all fields to have IDs, so we use `exists` here.
     case g: GroupType => g.getId != null || g.getFields.asScala.exists(containsFieldIds)

--- a/common/src/main/scala/org/apache/spark/sql/comet/parquet/CometParquetReadSupport.scala
+++ b/common/src/main/scala/org/apache/spark/sql/comet/parquet/CometParquetReadSupport.scala
@@ -363,7 +363,7 @@ object CometParquetReadSupport {
   /**
    * Whether the parquet schema contains any field IDs.
    */
-  def containsFieldIds(schema: Type): Boolean = schema match {
+  private def containsFieldIds(schema: Type): Boolean = schema match {
     case p: PrimitiveType => p.getId != null
     // We don't require all fields to have IDs, so we use `exists` here.
     case g: GroupType => g.getId != null || g.getFields.asScala.exists(containsFieldIds)

--- a/conf/log4rs.yaml
+++ b/conf/log4rs.yaml
@@ -21,6 +21,6 @@ appenders:
     path: "target/unit-tests.log"
 
 root:
-  level: info
+  level: debug
   appenders:
     - unittest

--- a/conf/log4rs.yaml
+++ b/conf/log4rs.yaml
@@ -21,6 +21,6 @@ appenders:
     path: "target/unit-tests.log"
 
 root:
-  level: debug
+  level: info
   appenders:
     - unittest

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -1233,7 +1233,9 @@ abstract class ParquetReadSuite extends CometTestBase {
 
             withParquetDataFrame(data, schema = Some(readSchema)) { df =>
               // TODO: validate with Spark 3.x and 'usingDataFusionParquetExec=true'
-              if (enableSchemaEvolution || usingDataSourceExec(conf)) {
+              if (enableSchemaEvolution || CometConf.COMET_NATIVE_SCAN_IMPL
+                  .get(conf)
+                  .equals(CometConf.SCAN_NATIVE_DATAFUSION)) {
                 checkAnswer(df, data.map(Row.fromTuple))
               } else {
                 assertThrows[SparkException](df.collect())

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -1234,8 +1234,7 @@ abstract class ParquetReadSuite extends CometTestBase {
             withParquetDataFrame(data, schema = Some(readSchema)) { df =>
               // TODO: validate with Spark 3.x and 'usingDataFusionParquetExec=true'
               if (enableSchemaEvolution || CometConf.COMET_NATIVE_SCAN_IMPL
-                  .get(conf)
-                  .equals(CometConf.SCAN_NATIVE_DATAFUSION)) {
+                  .get(conf) == CometConf.SCAN_NATIVE_DATAFUSION) {
                 checkAnswer(df, data.map(Row.fromTuple))
               } else {
                 assertThrows[SparkException](df.collect())


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion-comet/issues/1542

Closes #.

## Rationale for this change

This addresses test failures due to incompatibilities in schema conversion and validation between Spark and the native_iceberg_compat Scan
The implementation now does nearly identical conversion and checking to Spark. Keeping with the original native_comet implementation, the changes duplicates some code from Spark.
