### PR TITLE
fix: Fallback to Spark when PARQUET_FIELD_ID_READ_ENABLED=true for new native scans

### DIFF
--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -41,7 +41,6 @@ import org.apache.comet.parquet.{CometParquetScan, SupportsComet}
  * Spark physical optimizer rule for replacing Spark scans with Comet scans.
  */
 case class CometScanRule(session: SparkSession) extends Rule[SparkPlan] {
-  private val scanImpl: String = COMET_NATIVE_SCAN_IMPL.get()
 
   override def apply(plan: SparkPlan): SparkPlan = {
     if (!isCometLoaded(conf)) {
@@ -54,6 +53,7 @@ case class CometScanRule(session: SparkSession) extends Rule[SparkPlan] {
       return plan
     }
 
+    val scanImpl: String = COMET_NATIVE_SCAN_IMPL.get()
     if (SQLConf.get.getConf(
         SQLConf.PARQUET_FIELD_ID_READ_ENABLED) && scanImpl != CometConf.SCAN_NATIVE_COMET) {
       withInfo(plan, s"Comet $scanImpl scan does not support PARQUET_FIELD_ID_READ_ENABLED")
@@ -100,6 +100,7 @@ case class CometScanRule(session: SparkSession) extends Rule[SparkPlan] {
           return withInfos(scanExec, fallbackReasons.toSet)
         }
 
+        val scanImpl: String = COMET_NATIVE_SCAN_IMPL.get()
         if (scanImpl == CometConf.SCAN_NATIVE_DATAFUSION && !COMET_EXEC_ENABLED.get()) {
           fallbackReasons +=
             s"Full native scan disabled because ${COMET_EXEC_ENABLED.key} disabled"

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -41,6 +41,8 @@ import org.apache.comet.parquet.{CometParquetScan, SupportsComet}
  * Spark physical optimizer rule for replacing Spark scans with Comet scans.
  */
 case class CometScanRule(session: SparkSession) extends Rule[SparkPlan] {
+  private val scanImpl: String = COMET_NATIVE_SCAN_IMPL.get()
+
   override def apply(plan: SparkPlan): SparkPlan = {
     if (!isCometLoaded(conf)) {
       withInfo(plan, "Comet is not enabled")
@@ -52,8 +54,9 @@ case class CometScanRule(session: SparkSession) extends Rule[SparkPlan] {
       return plan
     }
 
-    if (SQLConf.get.getConf(SQLConf.PARQUET_FIELD_ID_READ_ENABLED)) {
-      withInfo(plan, "Comet does not support PARQUET_FIELD_ID_READ_ENABLED")
+    if (SQLConf.get.getConf(
+        SQLConf.PARQUET_FIELD_ID_READ_ENABLED) && scanImpl != CometConf.SCAN_NATIVE_COMET) {
+      withInfo(plan, s"Comet $scanImpl scan does not support PARQUET_FIELD_ID_READ_ENABLED")
       return plan
     }
 
@@ -97,7 +100,6 @@ case class CometScanRule(session: SparkSession) extends Rule[SparkPlan] {
           return withInfos(scanExec, fallbackReasons.toSet)
         }
 
-        val scanImpl = COMET_NATIVE_SCAN_IMPL.get()
         if (scanImpl == CometConf.SCAN_NATIVE_DATAFUSION && !COMET_EXEC_ENABLED.get()) {
           fallbackReasons +=
             s"Full native scan disabled because ${COMET_EXEC_ENABLED.key} disabled"


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/datafusion-comet/issues/1758

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Fix some Spark SQL test failures when the new native scans are enabled

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

I manually tested with the following test:

```
testOnly org.apache.spark.sql.execution.datasources.parquet.ParquetFieldIdIOSuite -- -z "read parquet file without ids"
```