### PR TITLE
fix: [native_iceberg_compat / native_datafusion] Fall back to Spark for maps containing structs

### DIFF
--- a/docs/source/user-guide/compatibility.md
+++ b/docs/source/user-guide/compatibility.md
@@ -70,6 +70,14 @@ information.
 [#1542]: https://github.com/apache/datafusion-comet/issues/1542
 [Comet Tuning Guide]: tuning.md
 
+## Complex Type Support
+
+Comet supports Structs, Maps, and Arrays, with some limitations.
+
+- Reading complex types from Parquet is only supported when using the `native_datafusion` or `native_iceberg_compat`
+scans (se previous section).
+- Comet does not currently maps that contain structs in either the key or value field
+
 ## ANSI mode
 
 Comet currently ignores ANSI mode in most cases, and therefore can produce different results than Spark. By default,

--- a/docs/source/user-guide/compatibility.md
+++ b/docs/source/user-guide/compatibility.md
@@ -75,8 +75,8 @@ information.
 Comet supports Structs, Maps, and Arrays, with some limitations.
 
 - Reading complex types from Parquet is only supported when using the `native_datafusion` or `native_iceberg_compat`
-scans (se previous section).
-- Comet does not currently maps that contain structs in either the key or value field
+scans (see previous section).
+- Comet does not currently support maps that contain structs.
 
 ## ANSI mode
 

--- a/docs/templates/compatibility-template.md
+++ b/docs/templates/compatibility-template.md
@@ -70,6 +70,14 @@ The new scans currently have the following limitations:
 [#1542]: https://github.com/apache/datafusion-comet/issues/1542
 [Comet Tuning Guide]: tuning.md
 
+## Complex Type Support
+
+Comet supports Structs, Maps, and Arrays, with some limitations.
+
+- Reading complex types from Parquet is only supported when using the `native_datafusion` or `native_iceberg_compat` 
+  scans (se previous section).
+- Comet does not currently maps that contain structs in either the key or value field
+
 ## ANSI mode
 
 Comet currently ignores ANSI mode in most cases, and therefore can produce different results than Spark. By default,

--- a/docs/templates/compatibility-template.md
+++ b/docs/templates/compatibility-template.md
@@ -75,8 +75,8 @@ The new scans currently have the following limitations:
 Comet supports Structs, Maps, and Arrays, with some limitations.
 
 - Reading complex types from Parquet is only supported when using the `native_datafusion` or `native_iceberg_compat` 
-  scans (se previous section).
-- Comet does not currently maps that contain structs in either the key or value field
+  scans (see previous section).
+- Comet does not currently support maps that contain structs.
 
 ## ANSI mode
 

--- a/spark/src/main/scala/org/apache/comet/DataTypeSupport.scala
+++ b/spark/src/main/scala/org/apache/comet/DataTypeSupport.scala
@@ -57,6 +57,9 @@ trait DataTypeSupport {
         fields.forall(f => isTypeSupported(f.dataType, f.name, fallbackReasons))
       case ArrayType(elementType, _) =>
         isTypeSupported(elementType, ARRAY_ELEMENT, fallbackReasons)
+      case MapType(keyType, valueType, _) if isComplexType(keyType) || isComplexType(valueType) =>
+        // https://github.com/apache/datafusion-comet/issues/1754
+        false
       case MapType(keyType, valueType, _) =>
         isTypeSupported(keyType, MAP_KEY, fallbackReasons) && isTypeSupported(
           valueType,
@@ -66,6 +69,11 @@ trait DataTypeSupport {
         fallbackReasons += s"Unsupported ${name} of type ${dt}"
         false
     }
+  }
+
+  def isComplexType(dt: DataType): Boolean = dt match {
+    case _: StructType | _: ArrayType | _: MapType => true
+    case _ => false
   }
 }
 

--- a/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
@@ -153,7 +153,8 @@ class CometNativeReaderSuite extends CometTestBase with AdaptiveSparkPlanHelper 
       "select c0 from tbl")
   }
 
-  test("native reader - read MAP of value STRUCT fields") {
+  // https://github.com/apache/datafusion-comet/issues/1754
+  ignore("native reader - read MAP of value STRUCT fields") {
     testSingleLineQuery(
       """
         |select map('a', named_struct('f0', 0, 'f1', 'foo'), 'b', named_struct('f0', 1, 'f1', 'bar')) as c0 union all
@@ -198,7 +199,8 @@ class CometNativeReaderSuite extends CometTestBase with AdaptiveSparkPlanHelper 
       "select c0 from tbl")
   }
 
-  test("native reader - read STRUCT of MAP of STRUCT value fields") {
+  // https://github.com/apache/datafusion-comet/issues/1754
+  ignore("native reader - read STRUCT of MAP of STRUCT value fields") {
     testSingleLineQuery(
       """
         |select named_struct('m0', map('a', named_struct('f0', 1)), 'm1', map('b', named_struct('f1', 1))) as c0 union all
@@ -216,7 +218,8 @@ class CometNativeReaderSuite extends CometTestBase with AdaptiveSparkPlanHelper 
       "select c0 from tbl")
   }
 
-  test("native reader - read MAP of STRUCT of MAP fields") {
+  // https://github.com/apache/datafusion-comet/issues/1754
+  ignore("native reader - read MAP of STRUCT of MAP fields") {
     testSingleLineQuery(
       """
         |select map('a', named_struct('f0', map(1, 'b')), 'b', named_struct('f0', map(1, 'b'))) as c0 union all
@@ -224,6 +227,7 @@ class CometNativeReaderSuite extends CometTestBase with AdaptiveSparkPlanHelper 
         |""".stripMargin,
       "select c0 from tbl")
   }
+
   test("native reader - read a STRUCT subfield from ARRAY of STRUCTS - second field") {
     testSingleLineQuery(
       """


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Workaround for https://github.com/apache/datafusion-comet/issues/1754

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Fix the following Spark SQL tests in `core-2`.

```
- Spark vectorized reader - without partition data column - select a single complex field from a map entry and in clause *** FAILED *** (290 milliseconds)
- Spark vectorized reader - with partition data column - select a single complex field from a map entry and in clause *** FAILED *** (269 milliseconds)
- Non-vectorized reader - without partition data column - select a single complex field from a map entry and in clause *** FAILED *** (263 milliseconds)
- Non-vectorized reader - with partition data column - select a single complex field from a map entry and in clause *** FAILED *** (322 milliseconds)
- Spark vectorized reader - without partition data column - select nested field from a complex map key using map_keys *** FAILED *** (315 milliseconds)
- Spark vectorized reader - with partition data column - select nested field from a complex map key using map_keys *** FAILED *** (278 milliseconds)
- Non-vectorized reader - without partition data column - select nested field from a complex map key using map_keys *** FAILED *** (261 milliseconds)
- Non-vectorized reader - with partition data column - select nested field from a complex map key using map_keys *** FAILED *** (312 milliseconds)
- Spark vectorized reader - without partition data column - select nested field from a complex map value using map_values *** FAILED *** (268 milliseconds)
- Spark vectorized reader - with partition data column - select nested field from a complex map value using map_values *** FAILED *** (262 milliseconds)
- Non-vectorized reader - without partition data column - select nested field from a complex map value using map_values *** FAILED *** (264 milliseconds)
- Non-vectorized reader - with partition data column - select nested field from a complex map value using map_values *** FAILED *** (308 milliseconds)
- Spark vectorized reader - without partition data column - SPARK-40033: Schema pruning support through element_at *** FAILED *** (554 milliseconds)
- Spark vectorized reader - with partition data column - SPARK-40033: Schema pruning support through element_at *** FAILED *** (510 milliseconds)
- Non-vectorized reader - without partition data column - SPARK-40033: Schema pruning support through element_at *** FAILED *** (525 milliseconds)
- Non-vectorized reader - with partition data column - SPARK-40033: Schema pruning support through element_at *** FAILED *** (488 milliseconds)
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
