### PR TITLE
fix:  translate CometNativeException to SparkException in NativeUtil

### DIFF
--- a/common/src/main/scala/org/apache/comet/vector/NativeUtil.scala
+++ b/common/src/main/scala/org/apache/comet/vector/NativeUtil.scala
@@ -19,16 +19,19 @@
 
 package org.apache.comet.vector
 
-import scala.collection.mutable
+import java.io.FileNotFoundException
 
-import org.apache.arrow.c.{ArrowArray, ArrowImporter, ArrowSchema, CDataDictionaryProvider, Data}
+import scala.collection.mutable
+import scala.util.matching.Regex
+
+import org.apache.arrow.c._
 import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.dictionary.DictionaryProvider
 import org.apache.spark.SparkException
 import org.apache.spark.sql.comet.util.Utils
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-import org.apache.comet.CometArrowAllocator
+import org.apache.comet.{CometArrowAllocator, CometNativeException}
 
 /**
  * Provides functionality for importing Arrow vectors from native code and wrapping them as
@@ -42,6 +45,7 @@ import org.apache.comet.CometArrowAllocator
  * NativeUtil must be closed after use to release resources in the dictionary provider.
  */
 class NativeUtil {
+
   import Utils._
 
   /** Use the global allocator */
@@ -154,7 +158,25 @@ class NativeUtil {
     val arrayAddrs = arrays.map(_.memoryAddress())
     val schemaAddrs = schemas.map(_.memoryAddress())
 
-    val result = func(arrayAddrs, schemaAddrs)
+    val result: Long =
+      try {
+        func(arrayAddrs, schemaAddrs)
+      } catch {
+        case e: CometNativeException =>
+          val fileNotFoundPattern: Regex =
+            ("""^External: Object at location (.+?) not found: No such file or directory """ +
+              """\(os error \d+\)$""").r
+          e.getMessage match {
+            case fileNotFoundPattern(filePath) =>
+              // See org.apache.spark.sql.errors.QueryExecutionErrors.readCurrentFileNotFoundError
+              throw new SparkException(
+                errorClass = "_LEGACY_ERROR_TEMP_2055",
+                messageParameters = Map("message" -> e.getMessage),
+                cause = new FileNotFoundException(filePath)
+              ) // Can't use SparkFileNotFoundException
+          }
+        case e: Throwable => throw e
+      }
 
     result match {
       case -1 =>

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -133,7 +133,7 @@ class CometExecIterator(
     }
   }
 
-  def getNextBatch(): Option[ColumnarBatch] = {
+  private def getNextBatch: Option[ColumnarBatch] = {
     assert(partitionIndex >= 0 && partitionIndex < numParts)
 
     if (tracingEnabled) {
@@ -167,7 +167,7 @@ class CometExecIterator(
       prevBatch = null
     }
 
-    nextBatch = getNextBatch()
+    nextBatch = getNextBatch
 
     if (nextBatch.isEmpty) {
       close()


### PR DESCRIPTION
 Passes Spark SQL test "SPARK-16337 temporary view refresh" now. Draft as I am looking to fix more.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

A number of Spark SQL tests expect specific exceptions to be thrown (or not thrown) during query execution. The `native_datafusion` reader throws `CometNativeException`, so we ned to translate those in `NativeUtil`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Wrap native execution in a `try`-`catch` block and translate `CometNativeException` to `SparkException` using regular expressions.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing Spark SQL tests that are now passing with `native_datafusion`.
