### PR TITLE
chore: Stop running Comet tests with JDK 8 on pull requests

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -52,7 +52,9 @@ jobs:
         scala-version: ['2.12', '2.13']
         is_push_event:
           - ${{ github.event_name == 'push' }}
-        exclude: # exclude java 11 for pull_request event
+        exclude: # exclude java 8 and 11 for pull_request event
+          - java_version: 8
+            is_push_event: false
           - java_version: 11
             is_push_event: false
       fail-fast: false
@@ -209,6 +211,13 @@ jobs:
         test-target: [rust, java]
         spark-version: ['3.4', '3.5']
         scala-version: ['2.12', '2.13']
+        is_push_event:
+          - ${{ github.event_name == 'push' }}
+        exclude: # exclude java 8 and 11 for pull_request event
+          - java_version: 8
+            is_push_event: false
+          - java_version: 11
+            is_push_event: false
       fail-fast: false
     if: github.event_name == 'push'
     name: ${{ matrix.os }}/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}-scala-${{matrix.scala-version}}/${{ matrix.test-target }}
@@ -238,7 +247,9 @@ jobs:
         scala-version: ['2.12', '2.13']
         is_push_event:
           - ${{ github.event_name == 'push' }}
-        exclude: # exclude java 11 for pull_request event
+        exclude: # exclude java 8 and 11 for pull_request event
+          - java_version: 8
+            is_push_event: false
           - java_version: 11
             is_push_event: false
       fail-fast: false
@@ -292,11 +303,6 @@ jobs:
         java_version: [17]
         test-target: [java]
         spark-version: ['4.0']
-        is_push_event:
-          - ${{ github.event_name == 'push' }}
-        exclude: # exclude java 11 for pull_request event
-          - java_version: 11
-            is_push_event: false
       fail-fast: false
     name: macos-14(Silicon)/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}/${{ matrix.test-target }}
     runs-on: macos-14
@@ -324,6 +330,11 @@ jobs:
         scala-version: ['2.12', '2.13']
         exclude:
           - java_version: 8
+      is_push_event:
+        - ${{ github.event_name == 'push' }}
+      exclude: # exclude java 8 for pull_request event
+        - java_version: 8
+          is_push_event: false
       fail-fast: false
     name: macos-14(Silicon)/java ${{ matrix.java_version }}-spark-${{matrix.spark-version}}-scala-${{matrix.scala-version}}/${{ matrix.test-target }}
     runs-on: macos-14


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We have many PRs that we cannot merge due to workflows failing due to CI runs getting aborted. We suspect that we are running into some limit due to how many test permutations we are running.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Stop running Comet tests with JDK 8 on each PR. We can still run these workflows manually.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
