### PR TITLE
feat: Support Type widening: byte → short/int/long, short → int/long

### DIFF
--- a/native/core/src/parquet/read/column.rs
+++ b/native/core/src/parquet/read/column.rs
@@ -125,7 +125,6 @@ impl ColumnReader {
             PhysicalType::BOOLEAN => typed_reader!(BoolColumnReader, Boolean),
             PhysicalType::INT32 => {
                 if let Some(ref logical_type) = desc.logical_type() {
-
                     match logical_type {
                         lt @ LogicalType::Integer {
                             bit_width,
@@ -156,14 +155,15 @@ impl ColumnReader {
                                     }
                                 }
                                 // promote byte to short
-                                PhysicalType::INT32 if promotion_info.bit_width == 16 =>
-                                    typed_reader!(Int16ColumnReader, Int16),
+                                PhysicalType::INT32 if promotion_info.bit_width == 16 => {
+                                    typed_reader!(Int16ColumnReader, Int16)
+                                }
                                 // promote byte to int
-                                PhysicalType::INT32 if promotion_info.bit_width == 32 =>
-                                    typed_reader!(Int32ColumnReader, Int32),
+                                PhysicalType::INT32 if promotion_info.bit_width == 32 => {
+                                    typed_reader!(Int32ColumnReader, Int32)
+                                }
                                 // promote byte to long
-                                PhysicalType::INT64 =>
-                                    typed_reader!(Int32To64ColumnReader, Int64),
+                                PhysicalType::INT64 => typed_reader!(Int32To64ColumnReader, Int64),
                                 _ => typed_reader!(Int8ColumnReader, Int8),
                             },
                             (8, false) => typed_reader!(UInt8ColumnReader, Int16),

--- a/native/core/src/parquet/read/column.rs
+++ b/native/core/src/parquet/read/column.rs
@@ -125,6 +125,7 @@ impl ColumnReader {
             PhysicalType::BOOLEAN => typed_reader!(BoolColumnReader, Boolean),
             PhysicalType::INT32 => {
                 if let Some(ref logical_type) = desc.logical_type() {
+
                     match logical_type {
                         lt @ LogicalType::Integer {
                             bit_width,
@@ -154,12 +155,25 @@ impl ColumnReader {
                                         )
                                     }
                                 }
+                                // promote byte to short
+                                PhysicalType::INT32 if promotion_info.bit_width == 16 =>
+                                    typed_reader!(Int16ColumnReader, Int16),
+                                // promote byte to int
+                                PhysicalType::INT32 if promotion_info.bit_width == 32 =>
+                                    typed_reader!(Int32ColumnReader, Int32),
+                                // promote byte to long
+                                PhysicalType::INT64 =>
+                                    typed_reader!(Int32To64ColumnReader, Int64),
                                 _ => typed_reader!(Int8ColumnReader, Int8),
                             },
                             (8, false) => typed_reader!(UInt8ColumnReader, Int16),
                             (16, true) => match promotion_info.physical_type {
                                 PhysicalType::DOUBLE => {
                                     typed_reader!(Int16ToDoubleColumnReader, Float64)
+                                }
+                                // promote short to long
+                                PhysicalType::INT64 => {
+                                    typed_reader!(Int32To64ColumnReader, Int64)
                                 }
                                 PhysicalType::INT32 if promotion_info.bit_width == 32 => {
                                     typed_reader!(Int32ColumnReader, Int32)

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -1256,15 +1256,13 @@ abstract class ParquetReadSuite extends CometTestBase {
         val inputDFs = Seq(
           "byte" -> values.map(_.toByte).toDF("col1"),
           "short" -> values.map(_.toShort).toDF("col1"),
-          "int" -> values.map(_.toInt).toDF("col1")
-        )
+          "int" -> values.map(_.toInt).toDF("col1"))
 
         // Target Spark read schemas for widening
         val widenTargets = Seq(
           "short" -> values.map(_.toShort).toDF("col1"),
           "int" -> values.map(_.toInt).toDF("col1"),
-          "long" -> values.map(_.toLong).toDF("col1")
-        )
+          "long" -> values.map(_.toLong).toDF("col1"))
 
         for ((inputType, inputDF) <- inputDFs) {
           val writePath = s"$path/$inputType"

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -1292,6 +1292,41 @@ abstract class ParquetReadSuite extends CometTestBase {
     }
   }
 
+  test("read byte, int, short, long together") {
+    withSQLConf(CometConf.COMET_SCHEMA_EVOLUTION_ENABLED.key -> "true") {
+      withTempPath { dir =>
+        val path = dir.getCanonicalPath
+
+        val byteDF = (Byte.MaxValue - 2 to Byte.MaxValue).map(_.toByte).toDF("col1")
+        val shortDF = (Short.MaxValue - 2 to Short.MaxValue).map(_.toShort).toDF("col1")
+        val intDF = (Int.MaxValue - 2 to Int.MaxValue).toDF("col1")
+        val longDF = (Long.MaxValue - 2 to Long.MaxValue).toDF("col1")
+        val unionDF = byteDF.union(shortDF).union(intDF).union(longDF)
+
+        val byteDir = s"$path${File.separator}part=byte"
+        val shortDir = s"$path${File.separator}part=short"
+        val intDir = s"$path${File.separator}part=int"
+        val longDir = s"$path${File.separator}part=long"
+
+        val options: Map[String, String] = Map.empty[String, String]
+
+        byteDF.write.format("parquet").options(options).save(byteDir)
+        shortDF.write.format("parquet").options(options).save(shortDir)
+        intDF.write.format("parquet").options(options).save(intDir)
+        longDF.write.format("parquet").options(options).save(longDir)
+
+        val df = spark.read
+          .schema(unionDF.schema)
+          .format("parquet")
+          .options(options)
+          .load(path)
+          .select("col1")
+
+        checkAnswer(df, unionDF)
+      }
+    }
+  }
+
   test("scan metrics") {
     // https://github.com/apache/datafusion-comet/issues/1441
     assume(CometConf.COMET_NATIVE_SCAN_IMPL.get() != CometConf.SCAN_NATIVE_ICEBERG_COMPAT)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Support type widening in Spark 4.0. This PR updates the code to pass the following test:
https://github.com/apache/spark/blob/master/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/ReadSchemaTest.scala#L340
```
/**
 * Change a column type (Case 4).
 * This suite assumes that a user gives a wider schema intentionally.
 */
trait IntegralTypeTest extends ReadSchemaTest {

  import testImplicits._

  private lazy val values = 1 to 10
  private lazy val byteDF = values.map(_.toByte).toDF("col1")
  private lazy val shortDF = values.map(_.toShort).toDF("col1")
  private lazy val intDF = values.toDF("col1")
  private lazy val longDF = values.map(_.toLong).toDF("col1")

  test("change column type from byte to short/int/long") {
    withTempPath { dir =>
      val path = dir.getCanonicalPath

      byteDF.write.format(format).options(options).save(path)

      Seq(
        ("col1 short", shortDF),
        ("col1 int", intDF),
        ("col1 long", longDF)).foreach { case (schema, answerDF) =>
        checkAnswer(spark.read.schema(schema).format(format).options(options).load(path), answerDF)
      }
    }
  }

  test("change column type from short to int/long") {
    withTempPath { dir =>
      val path = dir.getCanonicalPath

      shortDF.write.format(format).options(options).save(path)

      Seq(("col1 int", intDF), ("col1 long", longDF)).foreach { case (schema, answerDF) =>
        checkAnswer(spark.read.schema(schema).format(format).options(options).load(path), answerDF)
      }
    }
  }

  test("change column type from int to long") {
    withTempPath { dir =>
      val path = dir.getCanonicalPath

      intDF.write.format(format).options(options).save(path)

      Seq(("col1 long", longDF)).foreach { case (schema, answerDF) =>
        checkAnswer(spark.read.schema(schema).format(format).options(options).load(path), answerDF)
      }
    }
  }

  test("read byte, int, short, long together") {
    withTempPath { dir =>
      val path = dir.getCanonicalPath

      val byteDF = (Byte.MaxValue - 2 to Byte.MaxValue).map(_.toByte).toDF("col1")
      val shortDF = (Short.MaxValue - 2 to Short.MaxValue).map(_.toShort).toDF("col1")
      val intDF = (Int.MaxValue - 2 to Int.MaxValue).toDF("col1")
      val longDF = (Long.MaxValue - 2 to Long.MaxValue).toDF("col1")
      val unionDF = byteDF.union(shortDF).union(intDF).union(longDF)

      val byteDir = s"$path${File.separator}part=byte"
      val shortDir = s"$path${File.separator}part=short"
      val intDir = s"$path${File.separator}part=int"
      val longDir = s"$path${File.separator}part=long"

      byteDF.write.format(format).options(options).save(byteDir)
      shortDF.write.format(format).options(options).save(shortDir)
      intDF.write.format(format).options(options).save(intDir)
      longDF.write.format(format).options(options).save(longDir)

      val df = spark.read
        .schema(unionDF.schema)
        .format(format)
        .options(options)
        .load(path)
        .select("col1")

      checkAnswer(df, unionDF)
    }
  }
}
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
