### PR TITLE
fix: cast map types correctly in schema adapter

### DIFF
--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -2557,7 +2557,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   // repro for https://github.com/apache/datafusion-comet/issues/1754
-  ignore("read map[struct, struct] from parquet") {
+  test("read map[struct, struct] from parquet") {
     assume(usingDataSourceExec(conf))
 
     withTempPath { dir =>


### PR DESCRIPTION
## Which issue does this PR close?

Closes #1754 



## Rationale for this change

In schema_adapter Map types are cast using arrow's cast which assumes that all nested fields within the map are also castable. However, the check to verify if the fields can be cast does not take into account nested struct fields with a different number of fields. 

## What changes are included in this PR?

The PR changes the cast method to a copy of the original that calls the schema adapter's struct cast method which can handle such structs

## How are these changes tested?

Unit test was already added. This PR enables the test