### PR TITLE
chore: Drop support for Java 8

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java_version: [8, 11, 17]
+        java_version: [11, 17]
         test-target: [rust, java]
         spark-version: ['3.5']
         scala-version: ['2.12', '2.13']
@@ -180,7 +180,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java_version: [8, 11, 17]
+        java_version: [11, 17]
         test-target: [java]
         spark-version: ['3.4']
         scala-version: ['2.12', '2.13']
@@ -205,7 +205,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13]
-        java_version: [8, 11, 17]
+        java_version: [11, 17]
         test-target: [rust, java]
         spark-version: ['3.4', '3.5']
         scala-version: ['2.12', '2.13']
@@ -232,7 +232,7 @@ jobs:
   macos-aarch64-test:
     strategy:
       matrix:
-        java_version: [8, 11, 17]
+        java_version: [11, 17]
         test-target: [rust, java]
         spark-version: ['3.4', '3.5']
         scala-version: ['2.12', '2.13']
@@ -318,7 +318,7 @@ jobs:
   macos-aarch64-test-with-old-spark:
     strategy:
       matrix:
-        java_version: [8, 17]
+        java_version: [17]
         test-target: [java]
         spark-version: ['3.4']
         scala-version: ['2.12', '2.13']

--- a/docs/source/contributor-guide/development.md
+++ b/docs/source/contributor-guide/development.md
@@ -30,7 +30,7 @@ under the License.
 
 ## Development Setup
 
-1. Make sure `JAVA_HOME` is set and point to JDK 8/11/17 installation.
+1. Make sure `JAVA_HOME` is set and point to JDK 11/17 installation.
 2. Install Rust toolchain. The easiest way is to use
    [rustup](https://rustup.rs).
 

--- a/docs/source/contributor-guide/development.md
+++ b/docs/source/contributor-guide/development.md
@@ -30,7 +30,7 @@ under the License.
 
 ## Development Setup
 
-1. Make sure `JAVA_HOME` is set and point to JDK 11/17 installation.
+1. Make sure `JAVA_HOME` is set and point to JDK using (support matrix)[docs/source/user-guide/installation.md]
 2. Install Rust toolchain. The easiest way is to use
    [rustup](https://rustup.rs).
 

--- a/docs/source/user-guide/installation.md
+++ b/docs/source/user-guide/installation.md
@@ -38,12 +38,12 @@ We recommend only using Comet with Spark versions where we currently have both C
 Other versions may work well enough for development and evaluation purposes.
 
 | Spark Version | Java Version | Scala Version | Comet Tests in CI | Spark Tests in CI |
-| ------------- | ------------ | ------------- |-------------------| ----------------- |
-| 3.4.3         | 8/11/17      | 2.12/2.13     | Yes               | Yes               |
-| 3.5.2         | 8/11/17      | 2.12/2.13     | Partial\*         | No                |
-| 3.5.3         | 8/11/17      | 2.12/2.13     | Partial\*         | No                |
-| 3.5.4         | 8/11/17      | 2.12/2.13     | Partial\*         | Yes               |
-| 3.5.5         | 8/11/17      | 2.12/2.13     | Yes               | Yes               |
+| ------------- | ------------ | ------------- | ----------------- | ----------------- |
+| 3.4.3         | 11/17        | 2.12/2.13     | Yes               | Yes               |
+| 3.5.2         | 11/17        | 2.12/2.13     | Partial\*         | No                |
+| 3.5.3         | 11/17        | 2.12/2.13     | Partial\*         | No                |
+| 3.5.4         | 11/17        | 2.12/2.13     | Partial\*         | Yes               |
+| 3.5.5         | 11/17        | 2.12/2.13     | Yes               | Yes               |
 
 \* For older Spark 3.5.x releases, we do not test the full matrix of supported Java and Scala versions in CI.
 

--- a/pom.xml
+++ b/pom.xml
@@ -628,19 +628,6 @@ under the License.
     </profile>
 
     <profile>
-      <id>jdk1.8</id>
-      <activation>
-        <jdk>1.8</jdk>
-      </activation>
-      <properties>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
-        <spotless.version>2.29.0</spotless.version>
-      </properties>
-    </profile>
-
-    <profile>
       <id>jdk11</id>
       <activation>
         <jdk>11</jdk>


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/1775

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We want to upgrade to arrow-java 18.3.0 to pick up an important bug fix, but arrow-java no longer supports Java 8.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
