### PR TITLE
fix: fallback to Spark scan if encryption is enabled (native_datafusion/native_iceberg_compat)

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/comet/ParquetEncryptionITCase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/ParquetEncryptionITCase.scala
@@ -49,8 +49,7 @@ class ParquetEncryptionITCase extends CometTestBase with SQLTestUtils {
   private val key2 = encoder.encodeToString("1234567890123451".getBytes(StandardCharsets.UTF_8))
 
   test("SPARK-34990: Write and read an encrypted parquet") {
-    // https://github.com/apache/datafusion-comet/issues/1488
-    assume(CometConf.COMET_NATIVE_SCAN_IMPL.get() != CometConf.SCAN_NATIVE_ICEBERG_COMPAT)
+    assume(CometConf.COMET_NATIVE_SCAN_IMPL.get() == CometConf.SCAN_NATIVE_COMET)
 
     import testImplicits._
 
@@ -93,8 +92,7 @@ class ParquetEncryptionITCase extends CometTestBase with SQLTestUtils {
   }
 
   test("SPARK-37117: Can't read files in Parquet encryption external key material mode") {
-    // https://github.com/apache/datafusion-comet/issues/1488
-    assume(CometConf.COMET_NATIVE_SCAN_IMPL.get() != CometConf.SCAN_NATIVE_ICEBERG_COMPAT)
+    assume(CometConf.COMET_NATIVE_SCAN_IMPL.get() == CometConf.SCAN_NATIVE_COMET)
 
     import testImplicits._
 


### PR DESCRIPTION


## Which issue does this PR close?

Part of https://github.com/apache/datafusion-comet/issues/1542
Closes #.

## Rationale for this change

Encrypted files are not currently supported and cause failure

## What changes are included in this PR?

If encryption is enabled, fallback to Spark.

## How are these changes tested?

Existing Spark SQL ParquetEncryptionSuite