### PR TITLE
fix: Fix Spark SQL AQE exchange reuse test failures

### DIFF
--- a/dev/diffs/3.5.5.diff
+++ b/dev/diffs/3.5.5.diff
@@ -355,7 +355,7 @@ index f32b32ffc5a..447d7c6416e 100644
      assert(exchanges.size == 2)
    }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
-index f33432ddb6f..bd2e5ef267e 100644
+index f33432ddb6f..fe9f74ff8f1 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
 @@ -22,6 +22,7 @@ import org.scalatest.GivenWhenThen
@@ -376,37 +376,7 @@ index f33432ddb6f..bd2e5ef267e 100644
        case _ => Nil
      }
    }
-@@ -755,7 +759,8 @@ abstract class DynamicPartitionPruningSuiteBase
-     }
-   }
- 
--  test("partition pruning in broadcast hash joins") {
-+  test("partition pruning in broadcast hash joins",
-+    IgnoreComet("TODO: Support SubqueryBroadcastExec in Comet: #1737")) {
-     Given("disable broadcast pruning and disable subquery duplication")
-     withSQLConf(
-       SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "true",
-@@ -1215,7 +1220,8 @@ abstract class DynamicPartitionPruningSuiteBase
-   }
- 
-   test("SPARK-32509: Unused Dynamic Pruning filter shouldn't affect " +
--    "canonicalization and exchange reuse") {
-+    "canonicalization and exchange reuse",
-+    IgnoreComet("TODO: Support SubqueryBroadcastExec in Comet: #1737")) {
-     withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "true") {
-       withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
-         val df = sql(
-@@ -1454,7 +1460,8 @@ abstract class DynamicPartitionPruningSuiteBase
-     }
-   }
- 
--  test("SPARK-35568: Fix UnsupportedOperationException when enabling both AQE and DPP") {
-+  test("SPARK-35568: Fix UnsupportedOperationException when enabling both AQE and DPP",
-+    IgnoreComet("TODO: Support SubqueryBroadcastExec in Comet: #1737")) {
-     val df = sql(
-       """
-         |SELECT s.store_id, f.product_id
-@@ -1729,6 +1736,8 @@ abstract class DynamicPartitionPruningV1Suite extends DynamicPartitionPruningDat
+@@ -1729,6 +1733,8 @@ abstract class DynamicPartitionPruningV1Suite extends DynamicPartitionPruningDat
                case s: BatchScanExec =>
                  // we use f1 col for v2 tables due to schema pruning
                  s.output.exists(_.exists(_.argString(maxFields = 100).contains("f1")))

--- a/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
@@ -87,8 +87,7 @@ case class EliminateRedundantTransitions(session: SparkSession) extends Rule[Spa
         }
         op
 
-      case CometColumnarToRowExec(sparkToColumnar: CometSparkToColumnarExec) =>
-        sparkToColumnar.child
+      case CometColumnarToRowExec(sparkToColumnar: CometSparkToColumnarExec) => sparkToColumnar.child
       case CometSparkToColumnarExec(child: CometSparkToColumnarExec) =>
         child
       // Spark adds `RowToColumnar` under Comet columnar shuffle. But it's redundant as the

--- a/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
@@ -64,7 +64,7 @@ case class EliminateRedundantTransitions(session: SparkSession) extends Rule[Spa
   private def _apply(plan: SparkPlan): SparkPlan = {
     val eliminatedPlan = plan transformUp {
       case ColumnarToRowExec(shuffleExchangeExec: CometShuffleExchangeExec)
-          if (conf.adaptiveExecutionEnabled) =>
+          if (plan.conf.adaptiveExecutionEnabled) =>
         shuffleExchangeExec
       case ColumnarToRowExec(sparkToColumnar: CometSparkToColumnarExec) =>
         if (sparkToColumnar.child.supportsColumnar) {

--- a/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
@@ -19,8 +19,6 @@
 
 package org.apache.comet.rules
 
-import scala.util.{Failure, Success, Try}
-
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.comet.{CometCollectLimitExec, CometColumnarToRowExec, CometPlan, CometSparkToColumnarExec}
@@ -86,10 +84,9 @@ case class EliminateRedundantTransitions(session: SparkSession) extends Rule[Spa
           c.logicalLink.foreach(op.setLogicalLink)
         }
         op
-
-      case CometColumnarToRowExec(sparkToColumnar: CometSparkToColumnarExec) => sparkToColumnar.child
-      case CometSparkToColumnarExec(child: CometSparkToColumnarExec) =>
-        child
+      case CometColumnarToRowExec(sparkToColumnar: CometSparkToColumnarExec) =>
+        sparkToColumnar.child
+      case CometSparkToColumnarExec(child: CometSparkToColumnarExec) => child
       // Spark adds `RowToColumnar` under Comet columnar shuffle. But it's redundant as the
       // shuffle takes row-based input.
       case s @ CometShuffleExchangeExec(

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -164,8 +164,7 @@ case class CometShuffleExchangeExec(
     }
 
   protected override def doExecute(): RDD[InternalRow] = {
-    throw new UnsupportedOperationException(
-      "CometShuffleExchangeExec.doExecute should not be executed.")
+    ColumnarToRowExec(this).doExecute()
   }
 
   /**


### PR DESCRIPTION
## Which issue does this PR close?

Closes #1737 

## Rationale for this change


The AQE feature in spark relies on a cache (where key is canonicalized version of a plan and value is the actual SparkPlan object itself) to avoid recomputation of stages and improve stage efficiency. However, with comet and spark plans' canonicalized version being the same, the AQE incorrectly fetches Comet Plan instead of native Spark ones causing Class type exceptions as mentioned in the related github issue. The goal of this change is to prevent that by handling AQE use case between the final handoff between Comet and Spark systems. Although this change solves the AQE usecase, the goal of the PR is to come up with a better suited strategy which includes but not limited to changing the canonicalization logic of Comet plans so that Spark can differentiate them

## What changes are included in this PR?

Changes to return the right object in `EliminateRedundantTransitions.scala` and also make sure that `doExecute` method inovkes Comet's method directly.

## How are these changes tested?

Local testing - Running all AQE unit tests 
Integration testing. - Workflow to run Spark , OS level and TPCH tests
