### PR TITLE
chore: enable map_values testing since we fall back on nested types for defa…

### DIFF
--- a/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
@@ -334,7 +334,8 @@ class CometNativeReaderSuite extends CometTestBase with AdaptiveSparkPlanHelper 
 
 // Note: commented out for comet native result because of correctness issue https://github.com/apache/datafusion-comet/issues/1789
 // But now we fall back to Spark for this query in https://github.com/apache/datafusion-comet/pull/1799 , so it is not an issue currently.
-  test("native reader - select nested field from a complex map[struct, struct] using map_values") {
+  test(
+    "native reader - select nested field from a complex map[struct, struct] using map_values") {
     testSingleLineQuery(
       """
         | select map(str0, str1) c0 from

--- a/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
@@ -332,18 +332,19 @@ class CometNativeReaderSuite extends CometTestBase with AdaptiveSparkPlanHelper 
       "select map_keys(c0).b from tbl")
   }
 
-//  commented out because of correctness issue https://github.com/apache/datafusion-comet/issues/1789
-//  test("native reader - select nested field from a complex map[struct, struct] using map_values") {
-//    testSingleLineQuery(
-//      """
-//        | select map(str0, str1) c0 from
-//        | (
-//        |   select named_struct('a', cast(1 as long), 'b', cast(2 as long), 'c', cast(3 as long)) str0,
-//        |          named_struct('x', cast(8 as long), 'y', cast(9 as long), 'z', cast(0 as long)) str1 union all
-//        |   select named_struct('a', cast(3 as long), 'b', cast(4 as long), 'c', cast(5 as long)) str0,
-//        |          named_struct('x', cast(6 as long), 'y', cast(7 as long), 'z', cast(8 as long)) str1
-//        | )
-//        |""".stripMargin,
-//      "select map_values(c0).b from tbl")
-//  }
+// Note: commented out for comet native result because of correctness issue https://github.com/apache/datafusion-comet/issues/1789
+// But now we fall back to Spark for this query in https://github.com/apache/datafusion-comet/pull/1799 , so it is not an issue currently.
+  test("native reader - select nested field from a complex map[struct, struct] using map_values") {
+    testSingleLineQuery(
+      """
+        | select map(str0, str1) c0 from
+        | (
+        |   select named_struct('a', cast(1 as long), 'b', cast(2 as long), 'c', cast(3 as long)) str0,
+        |          named_struct('x', cast(8 as long), 'y', cast(9 as long), 'z', cast(0 as long)) str1 union all
+        |   select named_struct('a', cast(3 as long), 'b', cast(4 as long), 'c', cast(5 as long)) str0,
+        |          named_struct('x', cast(6 as long), 'y', cast(7 as long), 'z', cast(8 as long)) str1
+        | )
+        |""".stripMargin,
+      "select map_values(c0).b from tbl")
+  }
 }


### PR DESCRIPTION
…ult values

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
Part of 

Closes [#1789](https://github.com/apache/datafusion-comet/issues/1789)

We should fix map_values when we use native comet again.

## Rationale for this change
Now we fall back to Spark for this query in https://github.com/apache/datafusion-comet/pull/1799 , we can enable the map_values testing.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Now we fall back to Spark for this query in https://github.com/apache/datafusion-comet/pull/1799 , we can enable the map_values testing.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
