### PR TITLE
chore: Use unique artifact names in Java test run

### DIFF
--- a/.github/actions/java-test/action.yaml
+++ b/.github/actions/java-test/action.yaml
@@ -18,8 +18,11 @@
 name: "Java Test"
 description: "Run Java tests"
 inputs:
+  artifact_name:
+    description: "Unique name for uploaded artifacts for this run"
+    required: true
   suites:
-    description: 'Which test suites to run'
+    description: 'Which Scalatest test suites to run'
     required: false
     default: ''
   maven_opts:
@@ -79,7 +82,7 @@ runs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
-        name: crash-logs-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+        name: crash-logs-${{ inputs.artifact_name }}
         path: "**/hs_err_pid*.log"
     - name: Debug listing
       if: failure()
@@ -93,13 +96,13 @@ runs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
-        name: unit-tests-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+        name: unit-tests-${{ inputs.artifact_name }}
         path: "**/target/unit-tests.log"
     - name: Upload test results
       if: ${{ inputs.upload-test-reports == 'true' }}
       uses: actions/upload-artifact@v4
       with:
-         name: java-test-reports-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+         name: java-test-reports-${{ inputs.artifact_name }}
          path: "**/target/surefire-reports/*.txt"
          retention-days: 7 # 1 week for test reports
          overwrite: true

--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -159,6 +159,7 @@ jobs:
       - name: Java test steps
         uses: ./.github/actions/java-test
         with:
+          artifact_name: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.suite.name }}
           suites: ${{ matrix.suite.value }}
           maven_opts: ${{ matrix.profile.maven_opts }}
           scan_impl: ${{ matrix.profile.scan_impl }}

--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Java test steps
         uses: ./.github/actions/java-test
         with:
-          artifact_name: Linux-${{ matrix.profile.name }}-${{ matrix.suite.name }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+          artifact_name: ${{ matrix.os }}-${{ matrix.profile.name }}-${{ matrix.suite.name }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           suites: ${{ matrix.suite.value }}
           maven_opts: ${{ matrix.profile.maven_opts }}
           scan_impl: ${{ matrix.profile.scan_impl }}

--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Java test steps
         uses: ./.github/actions/java-test
         with:
-          artifact_name: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.suite.name }}-${{ matrix.profile.maven_opts }}
+          artifact_name: ${{ matrix.profile.name }}-${{ matrix.suite.name }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           suites: ${{ matrix.suite.value }}
           maven_opts: ${{ matrix.profile.maven_opts }}
           scan_impl: ${{ matrix.profile.scan_impl }}

--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Java test steps
         uses: ./.github/actions/java-test
         with:
-          artifact_name: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.suite.name }}
+          artifact_name: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.suite.name }}-${{ matrix.profile.maven_opts }}
           suites: ${{ matrix.suite.value }}
           maven_opts: ${{ matrix.profile.maven_opts }}
           scan_impl: ${{ matrix.profile.scan_impl }}

--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Java test steps
         uses: ./.github/actions/java-test
         with:
-          artifact_name: ${{ matrix.profile.name }}-${{ matrix.suite.name }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+          artifact_name: Linux-${{ matrix.profile.name }}-${{ matrix.suite.name }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           suites: ${{ matrix.suite.value }}
           maven_opts: ${{ matrix.profile.maven_opts }}
           scan_impl: ${{ matrix.profile.scan_impl }}

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -108,6 +108,6 @@ jobs:
       - name: Java test steps
         uses: ./.github/actions/java-test
         with:
-          artifact_name: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.suite.name }}
+          artifact_name: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.suite.name }}-${{ matrix.profile.maven_opts }}
           suites: ${{ matrix.suite.value }}
           maven_opts: -Pspark-${{ matrix.spark-version }},scala-${{ matrix.scala-version }}

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -120,6 +120,6 @@ jobs:
       - name: Java test steps
         uses: ./.github/actions/java-test
         with:
-          artifact_name: ${{ matrix.profile.name }}-${{ matrix.suite.name }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+          artifact_name: macOS-${{ matrix.profile.name }}-${{ matrix.suite.name }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           suites: ${{ matrix.suite.value }}
           maven_opts: ${{ matrix.profile.maven_opts }}

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -108,5 +108,6 @@ jobs:
       - name: Java test steps
         uses: ./.github/actions/java-test
         with:
+          artifact_name: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.suite.name }}
           suites: ${{ matrix.suite.value }}
           maven_opts: -Pspark-${{ matrix.spark-version }},scala-${{ matrix.scala-version }}

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -44,9 +44,21 @@ jobs:
   macos-aarch64-test:
     strategy:
       matrix:
-        java_version: [17]
-        spark-version: ['3.4', '3.5', '4.0']
-        scala-version: ['2.13']
+        # the goal with these profiles is to get coverage of all Java, Scala, and Spark
+        # versions without testing all possible combinations, which would be overkill
+        profile:
+          - name: "Spark 3.4, JDK 11, Scala 2.12"
+            java_version: "11"
+            maven_opts: "-Pspark-3.4 -Pscala-2.12"
+
+          - name: "Spark 3.5, JDK 17, Scala 2.13"
+            java_version: "17"
+            maven_opts: "-Pspark-3.5 -Pscala-2.13"
+
+          - name: "Spark 4.0, JDK 17, Scala 2.13"
+            java_version: "17"
+            maven_opts: "-Pspark-4.0 -Pscala-2.13"
+
         suite:
           - name: "fuzz"
             value: |
@@ -108,6 +120,6 @@ jobs:
       - name: Java test steps
         uses: ./.github/actions/java-test
         with:
-          artifact_name: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.suite.name }}-${{ matrix.profile.maven_opts }}
+          artifact_name: ${{ matrix.profile.name }}-${{ matrix.suite.name }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           suites: ${{ matrix.suite.value }}
-          maven_opts: -Pspark-${{ matrix.spark-version }},scala-${{ matrix.scala-version }}
+          maven_opts: ${{ matrix.profile.maven_opts }}

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -114,7 +114,7 @@ jobs:
         uses: ./.github/actions/setup-macos-builder
         with:
           rust-version: ${{env.RUST_VERSION}}
-          jdk-version: ${{ matrix.java_version }}
+          jdk-version: ${{ matrix.profile.java_version }}
           jdk-architecture: aarch64
           protoc-architecture: aarch_64
       - name: Java test steps

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -44,6 +44,8 @@ jobs:
   macos-aarch64-test:
     strategy:
       matrix:
+        os: [macos-14]
+
         # the goal with these profiles is to get coverage of all Java, Scala, and Spark
         # versions without testing all possible combinations, which would be overkill
         profile:
@@ -107,7 +109,7 @@ jobs:
               org.apache.spark.sql.comet.CometTaskMetricsSuite
       fail-fast: false
     name: ${{ matrix.os }}/${{ matrix.profile.name }} [${{ matrix.suite.name }}]
-    runs-on: macos-14
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust & Java toolchain

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -106,7 +106,7 @@ jobs:
               org.apache.spark.sql.comet.CometTPCDSV2_7_PlanStabilitySuite
               org.apache.spark.sql.comet.CometTaskMetricsSuite
       fail-fast: false
-    name: macos-14(Silicon)/ ${{ matrix.java_version }}-spark-${{matrix.spark-version}}-scala-${{matrix.scala-version}} [${{matrix.suite.name}}]
+    name: ${{ matrix.os }}/${{ matrix.profile.name }} [${{ matrix.suite.name }}]
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -122,6 +122,6 @@ jobs:
       - name: Java test steps
         uses: ./.github/actions/java-test
         with:
-          artifact_name: macOS-${{ matrix.profile.name }}-${{ matrix.suite.name }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+          artifact_name: ${{ matrix.os }}-${{ matrix.profile.name }}-${{ matrix.suite.name }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           suites: ${{ matrix.suite.value }}
           maven_opts: ${{ matrix.profile.maven_opts }}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We frequently see CI runs fail due to artifact uploads failing due to duplicate names.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Make macOS workflow consistent with Linux workflow by specifying profiles
- Use profile name and suite name in artifact name

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
