### PR TITLE
Chore: implement bit_not as ScalarUDFImpl

### DIFF
--- a/native/proto/src/proto/expr.proto
+++ b/native/proto/src/proto/expr.proto
@@ -72,18 +72,17 @@ message Expr {
     NormalizeNaNAndZero normalize_nan_and_zero = 45;
     TruncDate truncDate = 46;
     TruncTimestamp truncTimestamp = 47;
-    UnaryExpr bitwiseNot = 48;
-    Abs abs = 49;
-    Subquery subquery = 50;
-    UnboundReference unbound = 51;
-    BloomFilterMightContain bloom_filter_might_contain = 52;
-    CreateNamedStruct create_named_struct = 53;
-    GetStructField get_struct_field = 54;
-    ToJson to_json = 55;
-    ListExtract list_extract = 56;
-    GetArrayStructFields get_array_struct_fields = 57;
-    ArrayInsert array_insert = 58;
-    MathExpr integral_divide = 59;
+    Abs abs = 48;
+    Subquery subquery = 49;
+    UnboundReference unbound = 50;
+    BloomFilterMightContain bloom_filter_might_contain = 51;
+    CreateNamedStruct create_named_struct = 52;
+    GetStructField get_struct_field = 53;
+    ToJson to_json = 54;
+    ListExtract list_extract = 55;
+    GetArrayStructFields get_array_struct_fields = 56;
+    ArrayInsert array_insert = 57;
+    MathExpr integral_divide = 58;
   }
 }
 

--- a/native/spark-expr/src/bitwise_funcs/bitwise_not.rs
+++ b/native/spark-expr/src/bitwise_funcs/bitwise_not.rs
@@ -15,138 +15,110 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::{
-    array::*,
-    datatypes::{DataType, Schema},
-    record_batch::RecordBatch,
+use arrow::{array::*, datatypes::DataType};
+use datafusion::common::{
+    exec_err, internal_datafusion_err, internal_err, DataFusionError, Result,
 };
-use datafusion::common::Result;
-use datafusion::physical_expr::PhysicalExpr;
-use datafusion::{error::DataFusionError, logical_expr::ColumnarValue};
-use std::fmt::Formatter;
-use std::hash::Hash;
+use datafusion::logical_expr::{ColumnarValue, Volatility};
+use datafusion::logical_expr::{ScalarFunctionArgs, ScalarUDFImpl, Signature};
 use std::{any::Any, sync::Arc};
+
+#[derive(Debug)]
+pub struct SparkBitwiseNot {
+    signature: Signature,
+    aliases: Vec<String>,
+}
+
+impl Default for SparkBitwiseNot {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SparkBitwiseNot {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::user_defined(Volatility::Immutable),
+            aliases: vec![],
+        }
+    }
+}
+
+impl ScalarUDFImpl for SparkBitwiseNot {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "bit_not"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        Ok(match arg_types[0] {
+            DataType::Int8 => DataType::Int8,
+            DataType::Int16 => DataType::Int16,
+            DataType::Int32 => DataType::Int32,
+            DataType::Int64 => DataType::Int64,
+            DataType::Null => DataType::Null,
+            _ => return exec_err!("{} function can only accept integral arrays", self.name()),
+        })
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let args: [ColumnarValue; 1] = args
+            .args
+            .try_into()
+            .map_err(|_| internal_datafusion_err!("bit_not expects exactly one argument"))?;
+        bitwise_not(args)
+    }
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
+    }
+}
 
 macro_rules! compute_op {
     ($OPERAND:expr, $DT:ident) => {{
-        let operand = $OPERAND
-            .as_any()
-            .downcast_ref::<$DT>()
-            .expect("compute_op failed to downcast array");
+        let operand = $OPERAND.as_any().downcast_ref::<$DT>().ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "compute_op failed to downcast array to: {:?}",
+                stringify!($DT)
+            ))
+        })?;
         let result: $DT = operand.iter().map(|x| x.map(|y| !y)).collect();
         Ok(Arc::new(result))
     }};
 }
 
-/// BitwiseNot expression
-#[derive(Debug, Eq)]
-pub struct BitwiseNotExpr {
-    /// Input expression
-    arg: Arc<dyn PhysicalExpr>,
-}
-
-impl Hash for BitwiseNotExpr {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.arg.hash(state);
-    }
-}
-
-impl PartialEq for BitwiseNotExpr {
-    fn eq(&self, other: &Self) -> bool {
-        self.arg.eq(&other.arg)
-    }
-}
-
-impl BitwiseNotExpr {
-    /// Create new bitwise not expression
-    pub fn new(arg: Arc<dyn PhysicalExpr>) -> Self {
-        Self { arg }
-    }
-
-    /// Get the input expression
-    pub fn arg(&self) -> &Arc<dyn PhysicalExpr> {
-        &self.arg
-    }
-}
-
-impl std::fmt::Display for BitwiseNotExpr {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "(~ {})", self.arg)
-    }
-}
-
-impl PhysicalExpr for BitwiseNotExpr {
-    /// Return a reference to Any that can be used for downcasting
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
-        self.arg.data_type(input_schema)
-    }
-
-    fn nullable(&self, input_schema: &Schema) -> Result<bool> {
-        self.arg.nullable(input_schema)
-    }
-
-    fn evaluate(&self, batch: &RecordBatch) -> Result<ColumnarValue> {
-        let arg = self.arg.evaluate(batch)?;
-        match arg {
-            ColumnarValue::Array(array) => {
-                let result: Result<ArrayRef> = match array.data_type() {
-                    DataType::Int8 => compute_op!(array, Int8Array),
-                    DataType::Int16 => compute_op!(array, Int16Array),
-                    DataType::Int32 => compute_op!(array, Int32Array),
-                    DataType::Int64 => compute_op!(array, Int64Array),
-                    _ => Err(DataFusionError::Execution(format!(
-                        "(- '{:?}') can't be evaluated because the expression's type is {:?}, not signed int",
-                        self,
-                        array.data_type(),
-                    ))),
-                };
-                result.map(ColumnarValue::Array)
-            }
-            ColumnarValue::Scalar(_) => Err(DataFusionError::Internal(
-                "shouldn't go to bitwise not scalar path".to_string(),
-            )),
+pub fn bitwise_not(args: [ColumnarValue; 1]) -> Result<ColumnarValue> {
+    match args {
+        [ColumnarValue::Array(array)] => {
+            let result: Result<ArrayRef> = match array.data_type() {
+                DataType::Int8 => compute_op!(array, Int8Array),
+                DataType::Int16 => compute_op!(array, Int16Array),
+                DataType::Int32 => compute_op!(array, Int32Array),
+                DataType::Int64 => compute_op!(array, Int64Array),
+                _ => exec_err!("bit_not can't be evaluated because the expression's type is {:?}, not signed int", array.data_type()),
+            };
+            result.map(ColumnarValue::Array)
         }
+        [ColumnarValue::Scalar(_)] => internal_err!("shouldn't go to bitwise not scalar path"),
     }
-
-    fn children(&self) -> Vec<&Arc<dyn PhysicalExpr>> {
-        vec![&self.arg]
-    }
-
-    fn with_new_children(
-        self: Arc<Self>,
-        children: Vec<Arc<dyn PhysicalExpr>>,
-    ) -> Result<Arc<dyn PhysicalExpr>> {
-        Ok(Arc::new(BitwiseNotExpr::new(Arc::clone(&children[0]))))
-    }
-
-    fn fmt_sql(&self, _: &mut Formatter<'_>) -> std::fmt::Result {
-        unimplemented!()
-    }
-}
-
-pub fn bitwise_not(arg: Arc<dyn PhysicalExpr>) -> Result<Arc<dyn PhysicalExpr>> {
-    Ok(Arc::new(BitwiseNotExpr::new(arg)))
 }
 
 #[cfg(test)]
 mod tests {
-    use arrow::datatypes::*;
     use datafusion::common::{cast::as_int32_array, Result};
-    use datafusion::physical_expr::expressions::col;
 
     use super::*;
 
     #[test]
     fn bitwise_not_op() -> Result<()> {
-        let schema = Schema::new(vec![Field::new("a", DataType::Int32, true)]);
-
-        let expr = bitwise_not(col("a", &schema)?)?;
-
-        let input = Int32Array::from(vec![
+        let int_array = Int32Array::from(vec![
             Some(1),
             Some(2),
             None,
@@ -163,9 +135,13 @@ mod tests {
             Some(3455),
         ]);
 
-        let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(input)])?;
+        let columnar_value = ColumnarValue::Array(Arc::new(int_array));
 
-        let result = expr.evaluate(&batch)?.into_array(batch.num_rows())?;
+        let result = bitwise_not([columnar_value])?;
+        let result = match result {
+            ColumnarValue::Array(array) => array,
+            _ => panic!("Expected array"),
+        };
         let result = as_int32_array(&result).expect("failed to downcast to In32Array");
         assert_eq!(result, expected);
 

--- a/native/spark-expr/src/bitwise_funcs/mod.rs
+++ b/native/spark-expr/src/bitwise_funcs/mod.rs
@@ -19,4 +19,4 @@ mod bitwise_count;
 mod bitwise_not;
 
 pub use bitwise_count::spark_bit_count;
-pub use bitwise_not::{bitwise_not, BitwiseNotExpr};
+pub use bitwise_not::SparkBitwiseNot;

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -1609,12 +1609,10 @@ object QueryPlanSerde extends Logging with CometExprShim {
           (builder, binaryExpr) => builder.setBitwiseAnd(binaryExpr))
 
       case BitwiseNot(child) =>
-        createUnaryExpr(
-          expr,
-          child,
-          inputs,
-          binding,
-          (builder, unaryExpr) => builder.setBitwiseNot(unaryExpr))
+        val childProto = exprToProto(child, inputs, binding)
+        val bitNotScalarExpr =
+          scalarFunctionExprToProto("bit_not", childProto)
+        optExprWithInfo(bitNotScalarExpr, expr, expr.children: _*)
 
       case BitwiseOr(left, right) =>
         createBinaryExpr(


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion-comet/issues/1819

Closes #.

See https://github.com/apache/datafusion-comet/issues/1819 for rationale.

## What changes are included in this PR?

1. Implement bitwise_not as ScalarUDFImpl (bitwise_not.rs)
2. Refactor QueryPlanSerde.scala
3. Remove bit_not unary expr from expr.proto

## How are these changes tested?

There are no functional changes, so rely on existing tests.
