### PR TITLE
Chore: implement bit_count as ScalarUDFImpl

### DIFF
--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -64,7 +64,9 @@ use datafusion::{
     },
     prelude::SessionContext,
 };
-use datafusion_comet_spark_expr::{create_comet_physical_fun, create_negate_expr};
+use datafusion_comet_spark_expr::{
+    create_comet_physical_fun, create_negate_expr, SparkBitwiseCount,
+};
 
 use crate::execution::operators::ExecutionError::GeneralError;
 use crate::execution::shuffle::CompressionCodec;
@@ -150,6 +152,7 @@ impl Default for PhysicalPlanner {
 
         // register UDFs from datafusion-spark crate
         session_ctx.register_udf(ScalarUDF::new_from_impl(SparkExpm1::default()));
+        session_ctx.register_udf(ScalarUDF::new_from_impl(SparkBitwiseCount::default()));
 
         Self {
             exec_context_id: TEST_EXEC_CONTEXT_ID,
@@ -162,6 +165,7 @@ impl PhysicalPlanner {
     pub fn new(session_ctx: Arc<SessionContext>) -> Self {
         // register UDFs from datafusion-spark crate
         session_ctx.register_udf(ScalarUDF::new_from_impl(SparkExpm1::default()));
+        session_ctx.register_udf(ScalarUDF::new_from_impl(SparkBitwiseCount::default()));
         Self {
             exec_context_id: TEST_EXEC_CONTEXT_ID,
             session_ctx,

--- a/native/spark-expr/src/bitwise_funcs/mod.rs
+++ b/native/spark-expr/src/bitwise_funcs/mod.rs
@@ -18,5 +18,5 @@
 mod bitwise_count;
 mod bitwise_not;
 
-pub use bitwise_count::spark_bit_count;
+pub use bitwise_count::SparkBitwiseCount;
 pub use bitwise_not::{bitwise_not, BitwiseNotExpr};

--- a/native/spark-expr/src/comet_scalar_funcs.rs
+++ b/native/spark-expr/src/comet_scalar_funcs.rs
@@ -17,10 +17,10 @@
 
 use crate::hash_funcs::*;
 use crate::{
-    spark_array_repeat, spark_bit_count, spark_ceil, spark_date_add, spark_date_sub,
-    spark_decimal_div, spark_decimal_integral_div, spark_floor, spark_hex, spark_isnan,
-    spark_make_decimal, spark_read_side_padding, spark_round, spark_rpad, spark_unhex,
-    spark_unscaled_value, SparkChrFunc,
+    spark_array_repeat, spark_ceil, spark_date_add, spark_date_sub, spark_decimal_div,
+    spark_decimal_integral_div, spark_floor, spark_hex, spark_isnan, spark_make_decimal,
+    spark_read_side_padding, spark_round, spark_rpad, spark_unhex, spark_unscaled_value,
+    SparkChrFunc,
 };
 use arrow::datatypes::DataType;
 use datafusion::common::{DataFusionError, Result as DataFusionResult};
@@ -144,10 +144,6 @@ pub fn create_comet_physical_fun(
         "array_repeat" => {
             let func = Arc::new(spark_array_repeat);
             make_comet_scalar_udf!("array_repeat", func, without data_type)
-        }
-        "bit_count" => {
-            let func = Arc::new(spark_bit_count);
-            make_comet_scalar_udf!("bit_count", func, without data_type)
         }
         _ => registry.udf(fun_name).map_err(|e| {
             DataFusionError::Execution(format!(


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion-comet/issues/1819

## Rationale for this change

See https://github.com/apache/datafusion-comet/issues/1819 for rationale.

## What changes are included in this PR?

1. Implement bitwise_count as ScalarUDFImpl (bitwise_count.rs)

## How are these changes tested?

There are no functional changes, so rely on existing tests.
