### PR TITLE
chore: Enable tests in RemoveRedundantProjectsSuite.scala related to issue #242

### DIFF
--- a/dev/diffs/3.5.5.diff
+++ b/dev/diffs/3.5.5.diff
@@ -1189,7 +1189,7 @@ index 9e9d717db3b..c1a7caf56e0 100644
  package org.apache.spark.sql.execution
  
 -import org.apache.spark.sql.{DataFrame, QueryTest, Row}
-+import org.apache.spark.sql.{DataFrame, IgnoreComet, QueryTest, Row}
++import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 +import org.apache.spark.sql.comet.CometProjectExec
  import org.apache.spark.sql.connector.SimpleWritableDataSource
  import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
@@ -1206,13 +1206,12 @@ index 9e9d717db3b..c1a7caf56e0 100644
        assert(actual == expected)
      }
    }
-@@ -112,7 +116,8 @@ abstract class RemoveRedundantProjectsSuiteBase
+@@ -112,7 +116,7 @@ abstract class RemoveRedundantProjectsSuiteBase
      assertProjectExec(query, 1, 3)
    }
  
 -  test("join with ordering requirement") {
-+  test("join with ordering requirement",
-+    IgnoreComet("TODO: Support SubqueryBroadcastExec in Comet: #242")) {
++  test("join with ordering requirement") {
      val query = "select * from (select key, a, c, b from testView) as t1 join " +
        "(select key, a, b, c from testView) as t2 on t1.key = t2.key where t2.a > 50"
      assertProjectExec(query, 2, 2)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Addresses #1739 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Enables tests in `RemoveRedundantProjectsSuite.scala` related to #242. The Comet now falls back to Spark for Dynamic Partition Pruning. These tests can now be enabled.

The other ask to enable tests in `InjectRuntimeFilterSuite` were already addressed here: [#1837](https://github.com/apache/datafusion-comet/pull/1834)

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Updates the apache-spark `3.5.5.diff` to enable tests.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
1. Applied the updated `3.5.5.diff` to apache-spark-3.5
2. Ran the full `RemoveRedundantProjectsSuite` suite.