### PR TITLE
fix: Fix shuffle writing rows containing null struct fields

### DIFF
--- a/native/core/src/execution/shuffle/row.rs
+++ b/native/core/src/execution/shuffle/row.rs
@@ -3319,6 +3319,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Unaligned memory access in SparkUnsafeRow
     fn test_append_null_struct_field_to_struct_builder() {
         let data_type = DataType::Struct(Fields::from(vec![
             Field::new("a", DataType::Boolean, true),


### PR DESCRIPTION
## Which issue does this PR close?

Closes #1844 and probably #1823.

## Rationale for this change

Loading data with custom schema may produce rows containing null struct fields. Shuffling such null struct fields throws exceptions mentioned in the linked issues.

## What changes are included in this PR?

Fixes appending null rows to `StructBuilder` by making children field builders always in sync with the parent struct builder.

## How are these changes tested?

1. Add unit tests for `append_field` in native code
2. Add a Scala unit test modified from the minimal repro of the bug
