### PR TITLE
fix: Fall back to Spark for `RANGE BETWEEN` window expressions

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -276,7 +276,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
                   .build())
               .build()
           case _ =>
-            // TODO add support for numeric and temporal range offsets
+            // TODO add support for numeric and temporal RANGE BETWEEN expressions
             // see https://github.com/apache/datafusion-comet/issues/1246
             return None
         }
@@ -307,7 +307,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
                   .build())
               .build()
           case _ =>
-            // TODO add support for numeric and temporal range offsets
+            // TODO add support for numeric and temporal RANGE BETWEEN expressions
             // see https://github.com/apache/datafusion-comet/issues/1246
             return None
         }

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -288,21 +288,11 @@ object QueryPlanSerde extends Logging with CometExprShim {
               .newBuilder()
               .setCurrentRow(OperatorOuterClass.CurrentRow.newBuilder().build())
               .build()
-          case e =>
-            val offset = e.eval() match {
-              case i: Integer => i.toLong
-              case l: Long => l
-              case _ => return None
-            }
 
-            OperatorOuterClass.UpperWindowFrameBound
-              .newBuilder()
-              .setFollowing(
-                OperatorOuterClass.Following
-                  .newBuilder()
-                  .setOffset(offset)
-                  .build())
-              .build()
+          case _ =>
+            // TODO add support for numeric and temporal offsets
+            // see https://github.com/apache/datafusion-comet/issues/1246
+            return None
         }
 
         (frameProto, lBoundProto, uBoundProto)

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -2707,7 +2707,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       }
   }
 
-  test("type coercion with window range") {
+  test("window query with rangeBetween") {
 
     // values are int
     val df = Seq(1, 2, 4, 3, 2, 1).toDF("value")

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -1979,12 +1979,7 @@ class CometExecSuite extends CometTestBase {
               s"SELECT $function OVER(order by _2 rows between current row and 1 following) FROM t1")
 
             queries.foreach { query =>
-              if (query.contains("rows between 1 preceding and 1 following")) {
-                // https://github.com/apache/datafusion-comet/issues/1246
-                checkSparkAnswer(query)
-              } else {
-                checkSparkAnswerAndOperator(query)
-              }
+              checkSparkAnswerAndOperator(query)
             }
           }
         }

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -1979,7 +1979,12 @@ class CometExecSuite extends CometTestBase {
               s"SELECT $function OVER(order by _2 rows between current row and 1 following) FROM t1")
 
             queries.foreach { query =>
-              checkSparkAnswerAndOperator(query)
+              if (query.contains("rows between 1 preceding and 1 following")) {
+                // https://github.com/apache/datafusion-comet/issues/1246
+                checkSparkAnswerAndOperator(query)
+              } else {
+                checkSparkAnswer(query)
+              }
             }
           }
         }

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -1981,9 +1981,9 @@ class CometExecSuite extends CometTestBase {
             queries.foreach { query =>
               if (query.contains("rows between 1 preceding and 1 following")) {
                 // https://github.com/apache/datafusion-comet/issues/1246
-                checkSparkAnswerAndOperator(query)
-              } else {
                 checkSparkAnswer(query)
+              } else {
+                checkSparkAnswerAndOperator(query)
               }
             }
           }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Workaround for https://github.com/apache/datafusion-comet/issues/1246

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We do not currently have any type coercion for `RANGE BETWEEN` window expressions and queries fail if the types do not match. We also have very limited testing and only have support for int/long and not the other types that Spark supports, such as float/double and date/timestamp.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fall back to Spark for now until we have time to implement with type coercion and adequate testing.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

New test added in this PR.