### PR TITLE
fix: cast_struct_to_struct aligns to Spark behavior

### DIFF
--- a/native/core/src/parquet/parquet_support.rs
+++ b/native/core/src/parquet/parquet_support.rs
@@ -44,6 +44,10 @@ use url::Url;
 
 use super::objectstore;
 
+// This file originates from cast.rs. While developing native scan support and implementing
+// SparkSchemaAdapter we observed that Spark's type conversion logic on Parquet reads does not
+// always align to the CAST expression's logic, so it was duplicated here to adapt its behavior.
+
 static TIMESTAMP_FORMAT: Option<&str> = Some("%Y-%m-%d %H:%M:%S%.f");
 
 static PARQUET_OPTIONS: CastOptions = CastOptions {
@@ -53,7 +57,7 @@ static PARQUET_OPTIONS: CastOptions = CastOptions {
         .with_timestamp_format(TIMESTAMP_FORMAT),
 };
 
-/// Spark cast options
+/// Spark Parquet type conversion options
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct SparkParquetOptions {
     /// Spark evaluation mode
@@ -109,7 +113,7 @@ pub fn spark_parquet_convert(
     parquet_options: &SparkParquetOptions,
 ) -> DataFusionResult<ColumnarValue> {
     match arg {
-        ColumnarValue::Array(array) => Ok(ColumnarValue::Array(cast_array(
+        ColumnarValue::Array(array) => Ok(ColumnarValue::Array(parquet_convert_array(
             array,
             data_type,
             parquet_options,
@@ -119,14 +123,16 @@ pub fn spark_parquet_convert(
             // some cases e.g., scalar subquery, Spark will not fold it, so we need to handle it
             // here.
             let array = scalar.to_array()?;
-            let scalar =
-                ScalarValue::try_from_array(&cast_array(array, data_type, parquet_options)?, 0)?;
+            let scalar = ScalarValue::try_from_array(
+                &parquet_convert_array(array, data_type, parquet_options)?,
+                0,
+            )?;
             Ok(ColumnarValue::Scalar(scalar))
         }
     }
 }
 
-fn cast_array(
+fn parquet_convert_array(
     array: ArrayRef,
     to_type: &DataType,
     parquet_options: &SparkParquetOptions,
@@ -146,7 +152,7 @@ fn cast_array(
 
             let casted_dictionary = DictionaryArray::<Int32Type>::new(
                 dict_array.keys().clone(),
-                cast_array(Arc::clone(dict_array.values()), to_type, parquet_options)?,
+                parquet_convert_array(Arc::clone(dict_array.values()), to_type, parquet_options)?,
             );
 
             let casted_result = match to_type {
@@ -162,7 +168,7 @@ fn cast_array(
     // Try Comet specific handlers first, then arrow-rs cast if supported,
     // return uncasted data otherwise
     match (from_type, to_type) {
-        (Struct(_), Struct(_)) => Ok(cast_struct_to_struct(
+        (Struct(_), Struct(_)) => Ok(parquet_convert_struct_to_struct(
             array.as_struct(),
             from_type,
             to_type,
@@ -170,7 +176,7 @@ fn cast_array(
         )?),
         (List(_), List(to_inner_type)) => {
             let list_arr: &ListArray = array.as_list();
-            let cast_field = cast_array(
+            let cast_field = parquet_convert_array(
                 Arc::clone(list_arr.values()),
                 to_inner_type.data_type(),
                 parquet_options,
@@ -192,7 +198,7 @@ fn cast_array(
             ))
         }
         (Map(_, ordered_from), Map(_, ordered_to)) if ordered_from == ordered_to =>
-            cast_map_values(array.as_map(), to_type, parquet_options, *ordered_to)
+            parquet_convert_map_to_map(array.as_map(), to_type, parquet_options, *ordered_to)
             ,
         // If Arrow cast supports the cast, delegate the cast to Arrow
         _ if can_cast_types(from_type, to_type) => {
@@ -204,7 +210,7 @@ fn cast_array(
 
 /// Cast between struct types based on logic in
 /// `org.apache.spark.sql.catalyst.expressions.Cast#castStruct`.
-fn cast_struct_to_struct(
+fn parquet_convert_struct_to_struct(
     array: &StructArray,
     from_type: &DataType,
     to_type: &DataType,
@@ -236,7 +242,7 @@ fn cast_struct_to_struct(
                 };
                 if field_name_to_index_map.contains_key(&key) {
                     let from_index = field_name_to_index_map[&key];
-                    let cast_field = cast_array(
+                    let cast_field = parquet_convert_array(
                         Arc::clone(array.column(from_index)),
                         to_fields[i].data_type(),
                         parquet_options,
@@ -267,8 +273,8 @@ fn cast_struct_to_struct(
 }
 
 /// Cast a map type to another map type. The same as arrow-cast except we recursively call our own
-/// cast_array
-fn cast_map_values(
+/// parquet_convert_array
+fn parquet_convert_map_to_map(
     from: &MapArray,
     to_data_type: &DataType,
     parquet_options: &SparkParquetOptions,
@@ -283,12 +289,12 @@ fn cast_map_values(
                 "map is missing value field".to_string(),
             ))?;
 
-            let key_array = cast_array(
+            let key_array = parquet_convert_array(
                 Arc::clone(from.keys()),
                 key_field.data_type(),
                 parquet_options,
             )?;
-            let value_array = cast_array(
+            let value_array = parquet_convert_array(
                 Arc::clone(from.values()),
                 value_field.data_type(),
                 parquet_options,

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -983,7 +983,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
         checkSparkAnswerAndOperator(
           "SELECT CAST(s AS struct<field1:string, field2:string>) AS new_struct FROM tab1")
       } else {
-        // Should just fall back to Spark since non-DataSoruceExec scan does not support nested types.
+        // Should just fall back to Spark since non-DataSourceExec scan does not support nested types.
         checkSparkAnswer(
           "SELECT CAST(s AS struct<field1:string, field2:string>) AS new_struct FROM tab1")
       }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1875.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- `cast_struct_to_struct` was modified to support Parquet struct conversion before we split that logic off into parquet_support.rs. This brings the cast behavior back into alignment with Spark where field names don't matter.
- Renamed `cast_*` functions in parquet_support.rs and added some documentation to better differentiate those two files.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

- New test case.
