### PR TITLE
fix: correctly handle schemas with nested array of struct (native_iceberg_compat)

### DIFF
--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -50,7 +50,6 @@ import com.google.common.primitives.UnsignedLong
 
 import org.apache.comet.CometConf
 import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
-import org.apache.comet.parquet.CometParquetUtils.PARQUET_FIELD_ID_READ_ENABLED
 import org.apache.comet.rules.CometScanTypeChecker
 
 abstract class ParquetReadSuite extends CometTestBase {

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -1800,7 +1800,7 @@ abstract class ParquetReadSuite extends CometTestBase {
         Row(null) ::
         Nil
 
-    withSQLConf(SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key  -> "true") {
+    withSQLConf(SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key -> "true") {
       val df = spark.createDataFrame(spark.sparkContext.parallelize(data), nestedSchema)
       withTempPath { path =>
         df.write.parquet(path.getCanonicalPath)

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -1800,7 +1800,7 @@ abstract class ParquetReadSuite extends CometTestBase {
         Row(null) ::
         Nil
 
-    withSQLConf("spark.sql.parquet.fieldId.read.enabled" -> "true") {
+    withSQLConf(SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key  -> "true") {
       val df = spark.createDataFrame(spark.sparkContext.parallelize(data), nestedSchema)
       withTempPath { path =>
         df.write.parquet(path.getCanonicalPath)


### PR DESCRIPTION
## Which issue does this PR close?

The mapping between Spark and Parquet for schemas with field ids did not correctly handle the schemas with nested arrays of structs. 

## Rationale for this change

The added unit test fails without the fix. 


## How are these changes tested?

New unit test