### PR TITLE
minor: Improve testing of math scalar functions

### DIFF
--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1217,7 +1217,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
-  val doubleValues = Seq(
+  private val doubleValues: Seq[Double] = Seq(
     -1.0,
     // TODO we should eventually enable negative zero but there are known issues still
     // -0.0,

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -219,14 +219,14 @@ abstract class CometTestBase
   /**
    * Check the answer of a Comet SQL query with Spark result using absolute tolerance.
    */
-  protected def checkSparkAnswerWithTol(query: String, absTol: Double = 1e-6): Unit = {
+  protected def checkSparkAnswerWithTol(query: String, absTol: Double = 1e-6): DataFrame = {
     checkSparkAnswerWithTol(sql(query), absTol)
   }
 
   /**
    * Check the answer of a Comet DataFrame with Spark result using absolute tolerance.
    */
-  protected def checkSparkAnswerWithTol(df: => DataFrame, absTol: Double): Unit = {
+  protected def checkSparkAnswerWithTol(df: => DataFrame, absTol: Double): DataFrame = {
     var expected: Array[Row] = Array.empty
     withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
       val dfSpark = Dataset.ofRows(spark, df.logicalPlan)
@@ -234,6 +234,7 @@ abstract class CometTestBase
     }
     val dfComet = Dataset.ofRows(spark, df.logicalPlan)
     checkAnswerWithTol(dfComet, expected, absTol: Double)
+    dfComet
   }
 
   protected def checkSparkMaybeThrows(


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

There were multiple issues with the `various math scalar functions` test:

- It was testing multiple expressions in one query, including `abs`, which is not supported, so the entire query fell back to Spark and did not test Comet
- The input data did not include boundary values
- The test ran with and without dictionary encoding enabled but did not have any duplicate values so was not actually using dictionary encoding
- There were no assertions that anything actually ran in Comet

I discovered a new bug during this work - https://github.com/apache/datafusion-comet/issues/1897

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Rewrite the test to run one expression at a time and ensure that the query ran in Comet

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
