### PR TITLE
chore: move udf registration to better place

### DIFF
--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -65,8 +65,7 @@ use datafusion::{
     prelude::SessionContext,
 };
 use datafusion_comet_spark_expr::{
-    create_comet_physical_fun, create_negate_expr, SparkBitwiseCount, SparkBitwiseNot,
-    SparkDateTrunc, SparkHour, SparkMinute, SparkSecond,
+    create_comet_physical_fun, create_negate_expr, SparkHour, SparkMinute, SparkSecond,
 };
 
 use crate::execution::operators::ExecutionError::GeneralError;
@@ -110,7 +109,6 @@ use datafusion_comet_spark_expr::{
     NormalizeNaNAndZero, RLike, SparkCastOptions, StartsWith, Stddev, StringSpaceExpr,
     SubstringExpr, SumDecimal, TimestampTruncExpr, ToJson, UnboundColumn, Variance,
 };
-use datafusion_spark::function::math::expm1::SparkExpm1;
 use itertools::Itertools;
 use jni::objects::GlobalRef;
 use num::{BigInt, ToPrimitive};
@@ -154,11 +152,6 @@ impl Default for PhysicalPlanner {
 
 impl PhysicalPlanner {
     pub fn new(session_ctx: Arc<SessionContext>) -> Self {
-        // register UDFs from datafusion-spark crate
-        session_ctx.register_udf(ScalarUDF::new_from_impl(SparkExpm1::default()));
-        session_ctx.register_udf(ScalarUDF::new_from_impl(SparkBitwiseNot::default()));
-        session_ctx.register_udf(ScalarUDF::new_from_impl(SparkBitwiseCount::default()));
-        session_ctx.register_udf(ScalarUDF::new_from_impl(SparkDateTrunc::default()));
         Self {
             exec_context_id: TEST_EXEC_CONTEXT_ID,
             session_ctx,

--- a/native/spark-expr/src/lib.rs
+++ b/native/spark-expr/src/lib.rs
@@ -58,7 +58,7 @@ pub use bitwise_funcs::*;
 pub use conditional_funcs::*;
 pub use conversion_funcs::*;
 
-pub use comet_scalar_funcs::create_comet_physical_fun;
+pub use comet_scalar_funcs::{create_comet_physical_fun, register_all_comet_functions};
 pub use datetime_funcs::{
     spark_date_add, spark_date_sub, SparkDateTrunc, SparkHour, SparkMinute, SparkSecond,
     TimestampTruncExpr,


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Some registration exists in the `prepare_datafusion_session_context` and some in the `PhysicalPlanner::new`, moved to a single place - `prepare_datafusion_session_context`

## What changes are included in this PR?

1. Move `SparkExpm1` udf registration to `prepare_datafusion_session_context`
2. Move all Comet Spark UDFs like `SparkBitwiseNot`, `SparkBitwiseCount`, etc to register in `register_all_comet_functions` inside the `spark-expr` crate 

## How are these changes tested?

Existing tests
