### PR TITLE
chore: Introduce `exprHandlers` map in QueryPlanSerde

### DIFF
--- a/docs/source/user-guide/expressions.md
+++ b/docs/source/user-guide/expressions.md
@@ -127,7 +127,7 @@ The following Spark expressions are currently available. Any known compatibility
 | Log10      |                                                                     |
 | Pow        |                                                                     |
 | Round      |                                                                     |
-| Signum     | Signum does not differentiate between `0.0` and `-0.0`              |
+| Signum     |               |
 | Sin        |                                                                     |
 | Sqrt       |                                                                     |
 | Tan        |                                                                     |
@@ -186,16 +186,20 @@ The following Spark expressions are currently available. Any known compatibility
 
 ## Arrays
 
-| Expression        | Notes        |
-|-------------------|--------------|
-| ArrayAppend       | Experimental |
-| ArrayContains     | Experimental |
-| ArrayIntersect    | Experimental |
-| ArrayJoin         | Experimental |
-| ArrayRemove       |              |
-| ArraysOverlap     | Experimental |
-| ElementAt         | Arrays only  |
-| GetArrayItem      |              |
+| Expression     | Notes        |
+| -------------- | ------------ |
+| ArrayAppend    | Experimental |
+| ArrayExcept    | Experimental |
+| ArrayCompact   | Experimental |
+| ArrayContains  | Experimental |
+| ArrayInsert    | Experimental |
+| ArrayIntersect | Experimental |
+| ArrayJoin      | Experimental |
+| ArrayRemove    |              |
+| ArrayRepeat    | Experimental |
+| ArraysOverlap  | Experimental |
+| ElementAt      | Arrays only  |
+| GetArrayItem   |              |
 
 ## Structs
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We recently started to make QueryPlanSerde more maintainable by moving expression serde logic into individual classes or objects per expression using a new `CometExpressionSerde` trait. This was meant as a step towards having a registry of supported expressions to reduce some of the boilerplate code and to enable automatic generation of documentation for supported expressions.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Remove custom matching of some expressions and use a registry approach.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
