### PR TITLE
test: Trigger Spark 3.4.3 SQL tests for iceberg-compat

### DIFF
--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -84,7 +84,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         java-version: [11]
-        spark-version: [{short: '3.5', full: '3.5.6'}]
+        spark-version: [{short: '3.4', full: '3.4.3'}, {short: '3.5', full: '3.5.6'}]
         module:
           - {name: "catalyst", args1: "catalyst/test", args2: ""}
           - {name: "sql/core-1", args1: "", args2: sql/testOnly * -- -l org.apache.spark.tags.ExtendedSQLTest -l org.apache.spark.tags.SlowSQLTest}


### PR DESCRIPTION
## Which issue does this PR close?

## Rationale for this change

To trigger Spark 3.4.3 SQL tests for iceberg-compat on PRs

## What changes are included in this PR?

## How are these changes tested?

