### PR TITLE
minor: fix kube/Dockerfile build failed

### DIFF
--- a/kube/Dockerfile
+++ b/kube/Dockerfile
@@ -25,6 +25,15 @@ RUN apt update \
     && apt install -y openjdk-11-jdk \
     && apt clean
 
+RUN apt install -y gcc-10 g++-10 cpp-10 unzip
+ENV CC="gcc-10"
+ENV CXX="g++-10"
+
+RUN PB_REL="https://github.com/protocolbuffers/protobuf/releases" \
+    && curl -LO $PB_REL/download/v30.2/protoc-30.2-linux-x86_64.zip \
+    && unzip protoc-30.2-linux-x86_64.zip -d /root/.local
+ENV PATH="$PATH:/root/.local/bin"
+
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV RUSTFLAGS="-C debuginfo=line-tables-only -C incremental=false"


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

change kube/Dockerfile to fix #1917 
- install and use GCC 10 for that [aws-lc-rs](https://github.com/aws/aws-lc-rs/blob/378163b244587013820902242de4f9ffb177ec14/aws-lc-sys/builder/cc_builder.rs#L488) would check compiler version when build, and would fail to build for GCC 9.4.0.
- install protoc

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?
`docker build -t apache/datafusion-comet -f kube/Dockerfile .` successfully.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
