### PR TITLE
chore: Remove obsolete supportedSortType function after Arrow updates

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometTakeOrderedAndProjectExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometTakeOrderedAndProjectExec.scala
@@ -30,7 +30,6 @@ import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics, SQLShuffleR
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import org.apache.comet.serde.QueryPlanSerde.exprToProto
-import org.apache.comet.serde.QueryPlanSerde.supportedSortType
 
 /**
  * Comet physical plan node for Spark `TakeOrderedAndProjectExec`.
@@ -134,7 +133,6 @@ object CometTakeOrderedAndProjectExec {
   def isSupported(plan: TakeOrderedAndProjectExec): Boolean = {
     val exprs = plan.projectList.map(exprToProto(_, plan.child.output))
     val sortOrders = plan.sortOrder.map(exprToProto(_, plan.child.output))
-    exprs.forall(_.isDefined) && sortOrders.forall(_.isDefined) && plan.offset == 0 &&
-    supportedSortType(plan, plan.sortOrder)
+    exprs.forall(_.isDefined) && sortOrders.forall(_.isDefined) && plan.offset == 0
   }
 }

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -167,7 +167,7 @@ class CometExecSuite extends CometTestBase {
     }
   }
 
-  test("Sort on single struct should fallback to Spark") {
+  test("Sort on single struct should work in Comet") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false",
@@ -180,7 +180,7 @@ class CometExecSuite extends CometTestBase {
       withParquetFile(data1) { file =>
         readParquetFile(file) { df =>
           val sort = df.sort("_1")
-          checkSparkAnswer(sort)
+          checkSparkAnswerAndOperator(sort)
         }
       }
 
@@ -195,7 +195,7 @@ class CometExecSuite extends CometTestBase {
       withParquetFile(data2) { file =>
         readParquetFile(file) { df =>
           val sort = df.sort("_1")
-          checkSparkAnswer(sort)
+          checkSparkAnswerAndOperator(sort)
         }
       }
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1854

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The supportedSortType function was a fallback mechanism added to avoid Comet errors on complex single column case, as DataFusion SortExec calls arrow's lexsort_to_indices and the function fallbacks to sort_to_indices for single column case. However, sort_to_indices doesn't support all data types, e.g., struct which led to errors , as reported in this [issue](https://github.com/apache/datafusion-comet/issues/807) 
   
However, with recent Arrow updates, these limitations have been resolved by this [PR](https://github.com/apache/arrow-rs/pull/6225/)

As a result, the supportedSortType fallback is no longer needed and, in fact, prevents us from taking advantage of the improved native performance. This PR removes the function and its usages, allowing Comet to handle these sorting operations directly.
## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Removed the supportedSortType function and it's usages 
- Updated the tests accordingly to confirm operations are handled by comet instead of falling back to spark 

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
The existing test case been updated. By changing the test assertion from checkSparkAnswer to checkSparkAnswerAndOperator, we now verify that the operation is correctly executed by the Comet native operator, confirming the fallback to Spark is no longer triggered.