### PR TITLE
fix: Ignore a test case fails on Miri

### DIFF
--- a/native/spark-expr/src/conversion_funcs/cast.rs
+++ b/native/spark-expr/src/conversion_funcs/cast.rs
@@ -2661,6 +2661,13 @@ mod tests {
     }
 
     #[test]
+    // Currently the cast function depending on `f64::powi`, which has unspecified precision according to the doc
+    // https://doc.rust-lang.org/std/primitive.f64.html#unspecified-precision.
+    // Miri deliberately apply random floating-point errors to these operations to expose bugs
+    // https://github.com/rust-lang/miri/issues/4395.
+    // The random errors may interfere with test cases at rounding edge, so we ignore it on miri for now.
+    // Once https://github.com/apache/datafusion-comet/issues/1371 is fixed, this should no longer be an issue.
+    #[cfg_attr(miri, ignore)]
     fn test_cast_float_to_decimal() {
         let a: ArrayRef = Arc::new(Float64Array::from(vec![
             Some(42.),
@@ -2681,7 +2688,7 @@ mod tests {
         assert_eq!(casted.value(0), 42000000);
         // https://github.com/apache/datafusion-comet/issues/1371
         // assert_eq!(casted.value(1), 515313);
-        // assert_eq!(casted.value(2), -42424242);
+        assert_eq!(casted.value(2), -42424242);
         assert_eq!(casted.value(3), 0);
         assert_eq!(casted.value(4), 0);
         assert!(casted.is_null(5));

--- a/native/spark-expr/src/conversion_funcs/cast.rs
+++ b/native/spark-expr/src/conversion_funcs/cast.rs
@@ -2681,7 +2681,7 @@ mod tests {
         assert_eq!(casted.value(0), 42000000);
         // https://github.com/apache/datafusion-comet/issues/1371
         // assert_eq!(casted.value(1), 515313);
-        assert_eq!(casted.value(2), -42424242);
+        // assert_eq!(casted.value(2), -42424242);
         assert_eq!(casted.value(3), 0);
         assert_eq!(casted.value(4), 0);
         assert!(casted.is_null(5));


### PR DESCRIPTION
I am really sorry for causing CI fail.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When scale = 6
```rust
    let mul = 10_f64.powi(scale as i32);
```
mul = 1000000.000000000000000000000000000000000000000000 on rustc.
mul = 999999.999999999883584678173065185546875000000000  on miri nightly-2025-06-28, which causes the test to fail.

But why previous miri's CI success?
mul = 1000000.000000000465661287307739257812500000000000 on miri nightly-2025-06-24, which will pass the test.

The doc for f64::powi also says that [the precision of this function is non-deterministic](https://doc.rust-lang.org/std/primitive.f64.html#unspecified-precision).
It seems that it is a feature of miri that it applies random errors to imprecise operations.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Ignore the test case.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
