### PR TITLE
fix: [iceberg] Enable CometShuffleManager in Iceberg Spark tests

### DIFF
--- a/dev/diffs/iceberg/1.8.1.diff
+++ b/dev/diffs/iceberg/1.8.1.diff
@@ -195,6 +195,100 @@ index e2d2c7a..d23acef 100644
      relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
      relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
      relocate 'org.apache.hc.client5', 'org.apache.iceberg.shaded.org.apache.hc.client5'
+diff --git a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
+index 578845e..9476f19 100644
+--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
++++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/ExtensionsTestBase.java
+@@ -57,6 +57,8 @@ public abstract class ExtensionsTestBase extends CatalogTestBase {
+             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
+             .config(
+                 SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), String.valueOf(RANDOM.nextBoolean()))
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
+diff --git a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+index ade19de..2e681b0 100644
+--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
++++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+@@ -56,6 +56,8 @@ public class TestCallStatementParser {
+             .master("local[2]")
+             .config("spark.sql.extensions", IcebergSparkSessionExtensions.class.getName())
+             .config("spark.extra.prop", "value")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
+             .getOrCreate();
+     TestCallStatementParser.parser = spark.sessionState().sqlParser();
+   }
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
+index 64edb10..c3de1bf 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/DeleteOrphanFilesBenchmark.java
+@@ -179,6 +179,8 @@ public class DeleteOrphanFilesBenchmark {
+             .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", catalogWarehouse())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
+             .master("local");
+     spark = builder.getOrCreate();
+   }
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
+index a5d0456..fc90ea3 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java
+@@ -392,6 +392,8 @@ public class IcebergSortCompactionBenchmark {
+                 "spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog")
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", getCatalogWarehouse())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
+             .master("local[*]");
+     spark = builder.getOrCreate();
+     Configuration sparkHadoopConf = spark.sessionState().newHadoopConf();
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
+index c6794e4..a48af31 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVReaderBenchmark.java
+@@ -239,6 +239,8 @@ public class DVReaderBenchmark {
+             .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", newWarehouseDir())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
+             .master("local[*]")
+             .getOrCreate();
+   }
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
+index ac74fb5..cb437da 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/DVWriterBenchmark.java
+@@ -223,6 +223,8 @@ public class DVWriterBenchmark {
+             .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", newWarehouseDir())
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
+             .master("local[*]")
+             .getOrCreate();
+   }
+diff --git a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
+index 68c537e..89cf5fa 100644
+--- a/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
++++ b/spark/v3.5/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
+@@ -94,7 +94,10 @@ public abstract class IcebergSourceBenchmark {
+   }
+ 
+   protected void setupSpark(boolean enableDictionaryEncoding) {
+-    SparkSession.Builder builder = SparkSession.builder().config("spark.ui.enabled", false);
++    SparkSession.Builder builder = SparkSession.builder()
++            .config("spark.ui.enabled", false)
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager");
+     if (!enableDictionaryEncoding) {
+       builder
+           .config("parquet.dictionary.page.size", "1")
 diff --git a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
 index d6c16bb..123a300 100644
 --- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -265,6 +359,122 @@ index a361a7f..9021cd5 100644
 +    return true;
 +  }
  }
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
+index 404ba72..743a11e 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/SparkDistributedDataScanTestBase.java
+@@ -90,6 +90,8 @@ public abstract class SparkDistributedDataScanTestBase
+         .master("local[2]")
+         .config("spark.serializer", serializer)
+         .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++        .config("spark.plugins", "org.apache.spark.CometPlugin")
++        .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
+         .getOrCreate();
+   }
+ }
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
+index 659507e..ed9c4cc 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanDeletes.java
+@@ -73,6 +73,8 @@ public class TestSparkDistributedDataScanDeletes
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
+index a218f96..919eb5c 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanFilterFiles.java
+@@ -62,6 +62,8 @@ public class TestSparkDistributedDataScanFilterFiles
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
+index 2665d7b..c863caf 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestSparkDistributedDataScanReporting.java
+@@ -63,6 +63,8 @@ public class TestSparkDistributedDataScanReporting
+             .master("local[2]")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "4")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
+             .getOrCreate();
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
+index de68351..63a281b 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
+@@ -77,6 +77,8 @@ public abstract class TestBase extends SparkTestHelperBase {
+             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
+             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+index bc4e722..8650c79 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+@@ -59,7 +59,11 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    spark = SparkSession.builder().master("local[2]").getOrCreate();
++    spark = SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
+index 3a26974..ab8a08c 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/ScanTestBase.java
+@@ -54,7 +54,11 @@ public abstract class ScanTestBase extends AvroDataTest {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    ScanTestBase.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    ScanTestBase.spark = SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .getOrCreate();
+     ScanTestBase.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+index f411920..9d09edd 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+@@ -144,7 +144,11 @@ public class TestCompressionSettings extends CatalogTestBase {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestCompressionSettings.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestCompressionSettings.spark = SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .getOrCreate();
+   }
+ 
+   @BeforeEach
 diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
 index 7404b18..6ce9485 100644
 --- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
@@ -295,3 +505,263 @@ index 7404b18..6ce9485 100644
    public void testMergeSchemaIgnoreCastingDoubleToFloat() throws Exception {
      removeTables();
      sql("CREATE TABLE %s (id double, data string) USING iceberg", tableName);
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+index c4ba96e..2021ea2 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+@@ -75,7 +75,11 @@ public class TestDataSourceOptions extends TestBaseWithCatalog {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestDataSourceOptions.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestDataSourceOptions.spark = SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+index 3481735..1744488 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+@@ -110,7 +110,11 @@ public class TestFilteredScan {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestFilteredScan.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestFilteredScan.spark = SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+index 84c99a5..2d04fc4 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+@@ -93,7 +93,11 @@ public class TestForwardCompatibility {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestForwardCompatibility.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestForwardCompatibility.spark = SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+index 7eff93d..d0ab653 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+@@ -46,7 +46,11 @@ public class TestIcebergSpark {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestIcebergSpark.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestIcebergSpark.spark = SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+index 9464f68..5edccc9 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+@@ -112,7 +112,11 @@ public class TestPartitionPruning {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestPartitionPruning.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestPartitionPruning.spark = SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .getOrCreate();
+     TestPartitionPruning.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+ 
+     String optionKey = String.format("fs.%s.impl", CountOpenLocalFileSystem.scheme);
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+index 5c218f2..96f167a 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+@@ -107,7 +107,11 @@ public class TestPartitionValues {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestPartitionValues.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestPartitionValues.spark = SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+index a7334a5..c23fb08 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+@@ -87,7 +87,11 @@ public class TestSnapshotSelection {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestSnapshotSelection.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSnapshotSelection.spark = SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+index 182b1ef..79587f4 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+@@ -120,7 +120,11 @@ public class TestSparkDataFile {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestSparkDataFile.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSparkDataFile.spark = SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .getOrCreate();
+     TestSparkDataFile.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+index fb2b312..fa3d6bb 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+@@ -96,7 +96,11 @@ public class TestSparkDataWrite {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestSparkDataWrite.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSparkDataWrite.spark = SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .getOrCreate();
+   }
+ 
+   @AfterEach
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+index becf6a0..a03e9aa 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+@@ -83,7 +83,11 @@ public class TestSparkReadProjection extends TestReadProjection {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestSparkReadProjection.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestSparkReadProjection.spark = SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .getOrCreate();
+     ImmutableMap<String, String> config =
+         ImmutableMap.of(
+             "type", "hive",
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+index 4f1cef5..bcab37b 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+@@ -136,6 +136,8 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
+             .config("spark.ui.liveUpdate.period", 0)
+             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
+             .enableHiveSupport()
+             .getOrCreate();
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+index baf7fa8..c0d52bc 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+@@ -182,7 +182,9 @@ public class TestSparkReaderWithBloomFilter {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
+-            .enableHiveSupport()
++                .config("spark.plugins", "org.apache.spark.CometPlugin")
++                .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++                .enableHiveSupport()
+             .getOrCreate();
+ 
+     catalog =
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+index 17db46b..6d124b4 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+@@ -65,7 +65,9 @@ public class TestStructuredStreaming {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.sql.shuffle.partitions", 4)
+-            .getOrCreate();
++                .config("spark.plugins", "org.apache.spark.CometPlugin")
++                .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++                .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
+index 306444b..d960727 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
+@@ -75,7 +75,11 @@ public class TestTimestampWithoutZone extends TestBase {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestTimestampWithoutZone.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestTimestampWithoutZone.spark = SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .getOrCreate();
+   }
+ 
+   @AfterAll
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+index 841268a..89f30e9 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+@@ -80,7 +80,11 @@ public class TestWriteMetricsConfig {
+ 
+   @BeforeAll
+   public static void startSpark() {
+-    TestWriteMetricsConfig.spark = SparkSession.builder().master("local[2]").getOrCreate();
++    TestWriteMetricsConfig.spark = SparkSession.builder()
++            .master("local[2]")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
++            .getOrCreate();
+     TestWriteMetricsConfig.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+   }
+ 
+diff --git a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+index 6e09252..74e6c9b 100644
+--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
++++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+@@ -60,6 +60,8 @@ public class TestAggregatePushDown extends CatalogTestBase {
+         SparkSession.builder()
+             .master("local[2]")
+             .config("spark.sql.iceberg.aggregate_pushdown", "true")
++            .config("spark.plugins", "org.apache.spark.CometPlugin")
++            .config("spark.shuffle.manager", "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
+             .enableHiveSupport()
+             .getOrCreate();
+ 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #. https://github.com/apache/datafusion-comet/issues/1685

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When we enabled Iceberg Spark tests w/ Comet-enabled Spark in https://github.com/apache/datafusion-comet/pull/1715

1. We didn't enable `CometShuffleManager`, this PR fixes it.
2. We implicitly load `org.apache.comet.CometSparkSessionExtensions` b/c Iceberg depends on patched Spark. This PR configures it explicitly using `.config("spark.plugins", "org.apache.spark.CometPlugin")` so that we can depend on open-source Spark.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
