### PR TITLE
chore: extract CreateArray from QueryPlanSerde

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -79,6 +79,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
     classOf[ArrayRepeat] -> CometArrayRepeat,
     classOf[ArraysOverlap] -> CometArraysOverlap,
     classOf[ArrayUnion] -> CometArrayUnion,
+    classOf[CreateArray] -> CometCreateArray,
     classOf[Ascii] -> CometAscii,
     classOf[ConcatWs] -> CometConcatWs,
     classOf[Chr] -> CometChr,
@@ -1852,16 +1853,6 @@ object QueryPlanSerde extends Logging with CometExprShim {
             .newBuilder()
             .setGetStructField(getStructFieldBuilder)
             .build()
-        }
-
-      case CreateArray(children, _) =>
-        val childExprs = children.map(exprToProtoInternal(_, inputs, binding))
-
-        if (childExprs.forall(_.isDefined)) {
-          scalarFunctionExprToProto("make_array", childExprs: _*)
-        } else {
-          withInfo(expr, "unsupported arguments for CreateArray", children: _*)
-          None
         }
 
       case GetArrayItem(child, ordinal, failOnError) =>


### PR DESCRIPTION
## Which issue does this PR close?


Closes #1990 .

## Rationale for this change

Organization.

## What changes are included in this PR?

Move the relevant match arm and implement `CometExpressionSerde` for `CometCreateArray`.

## How are these changes tested?

Existing tests verify `array`.