### PR TITLE
feat: Add JNI-based Hadoop FileSystem support for S3 and other Hadoop-compatible stores

### DIFF
--- a/common/src/main/java/org/apache/comet/parquet/Native.java
+++ b/common/src/main/java/org/apache/comet/parquet/Native.java
@@ -19,8 +19,15 @@
 
 package org.apache.comet.parquet;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 
 import org.apache.comet.NativeBase;
 
@@ -292,4 +299,105 @@ public final class Native extends NativeBase {
    * @param handle
    */
   public static native void closeRecordBatchReader(long handle);
+
+  /**
+   * Reads a byte range from a file using Hadoop FileSystem API.
+   *
+   * @param path The file path to read from
+   * @param configs Configuration properties for the filesystem
+   * @param offset Starting byte position (0-based)
+   * @param len Number of bytes to read
+   * @return Byte array containing the read data, or null if error occurs
+   * @throws IllegalArgumentException If parameters are invalid
+   */
+  public static byte[] read(String path, Map<String, String> configs, long offset, int len) {
+    if (path == null || path.isEmpty()) {
+      throw new IllegalArgumentException("Path cannot be null or empty");
+    }
+    if (offset < 0) {
+      throw new IllegalArgumentException("Offset cannot be negative");
+    }
+    if (len < 0) {
+      throw new IllegalArgumentException("Length cannot be negative");
+    }
+
+    try {
+      Path p = new Path(path);
+      Configuration conf = new Configuration();
+
+      // Set configurations if provided
+      if (configs != null) {
+        for (Map.Entry<String, String> entry : configs.entrySet()) {
+          conf.set(entry.getKey(), entry.getValue());
+        }
+      }
+      org.apache.hadoop.fs.FileSystem fs = p.getFileSystem(conf);
+
+      long fileLen = fs.getFileStatus(p).getLen();
+
+      if (offset > fileLen) {
+        throw new IOException(
+            "Offset beyond file length: offset=" + offset + ", fileLen=" + fileLen);
+      }
+
+      if (len == 0) {
+        return new byte[0];
+      }
+
+      // Adjust length if it exceeds remaining bytes
+      if (offset + len > fileLen) {
+        len = (int) (fileLen - offset);
+        if (len <= 0) {
+          return new byte[0];
+        }
+      }
+
+      FSDataInputStream inputStream = fs.open(p);
+      inputStream.seek(offset);
+      byte[] buffer = new byte[len];
+      int totalBytesRead = 0;
+      while (totalBytesRead < len) {
+        int read = inputStream.read(buffer, totalBytesRead, len - totalBytesRead);
+        if (read == -1) break;
+        totalBytesRead += read;
+      }
+      inputStream.close();
+
+      return totalBytesRead < len ? Arrays.copyOf(buffer, totalBytesRead) : buffer;
+
+    } catch (Exception e) {
+      System.err.println("Native.read failed: " + e);
+      return null;
+    }
+  }
+
+  /**
+   * Gets the length of a file using Hadoop FileSystem API.
+   *
+   * @param path The file path to check
+   * @param configs Configuration properties for the filesystem
+   * @return File length in bytes, or -1 if the file doesn't exist
+   * @throws IllegalArgumentException If path is invalid or configs contain invalid values
+   */
+  public static long getLength(String path, Map<String, String> configs) {
+    if (path == null || path.isEmpty()) {
+      throw new IllegalArgumentException("Path cannot be null or empty");
+    }
+
+    try {
+      Path p = new Path(path);
+      Configuration conf = new Configuration();
+      if (configs != null) {
+        for (Map.Entry<String, String> entry : configs.entrySet()) {
+          conf.set(entry.getKey(), entry.getValue());
+        }
+      }
+
+      FileSystem fs = p.getFileSystem(conf);
+      return fs.getFileStatus(p).getLen();
+    } catch (Exception e) {
+      System.err.println("Native.getLength failed: " + e);
+      return -1;
+    }
+  }
 }

--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -65,6 +65,15 @@ object CometConf extends ShimCometConf {
 
   val COMET_EXEC_CONFIG_PREFIX = "spark.comet.exec";
 
+  val COMET_USE_JNI_OBJECT_STORE: ConfigEntry[Boolean] =
+    conf("spark.comet.use_jni_object_store")
+      .doc(
+        "If enabled, Comet will access Hadoop-compatible file systems using the Hadoop FileSystem" +
+          " API via JNI, bypassing the native Rust object store implementations.")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
   val COMET_ENABLED: ConfigEntry[Boolean] = conf("spark.comet.enabled")
     .doc(
       "Whether to enable Comet extension for Spark. When this is turned on, Spark will use " +

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1370,6 +1370,7 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "bytes",
+ "chrono",
  "crc32fast",
  "criterion",
  "datafusion",

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -50,6 +50,7 @@ lazy_static = "1.4.0"
 prost = "0.13.5"
 jni = "0.21"
 snap = "1.1"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 # we disable default features in lz4_flex to force the use of the faster unsafe encoding and decoding implementation
 lz4_flex = { version = "0.11.3", default-features = false }
 zstd = "0.13.3"

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -77,6 +77,9 @@ use log::info;
 use once_cell::sync::Lazy;
 #[cfg(feature = "jemalloc")]
 use tikv_jemalloc_ctl::{epoch, stats};
+use crate::parquet::objectstore::jni::init_jvm;
+
+
 
 static TOKIO_RUNTIME: Lazy<Runtime> = Lazy::new(|| {
     let mut builder = tokio::runtime::Builder::new_multi_thread();
@@ -166,6 +169,8 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
 ) -> jlong {
     try_unwrap_or_throw(&e, |mut env| {
         with_trace("createPlan", tracing_enabled != JNI_FALSE, || {
+            init_jvm(&env);
+
             // Init JVM classes
             JVMClasses::init(&mut env);
 

--- a/native/core/src/parquet/mod.rs
+++ b/native/core/src/parquet/mod.rs
@@ -26,7 +26,7 @@ pub mod parquet_support;
 pub mod read;
 pub mod schema_adapter;
 
-mod objectstore;
+pub mod objectstore;
 
 use std::collections::HashMap;
 use std::task::Poll;

--- a/native/core/src/parquet/objectstore/jni.rs
+++ b/native/core/src/parquet/objectstore/jni.rs
@@ -1,0 +1,353 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use chrono::Utc;
+use futures::{stream, stream::BoxStream, StreamExt};
+use jni::{
+    objects::{JClass, JObject, JValue},
+    JNIEnv, JavaVM
+};
+use once_cell::sync::OnceCell;
+use object_store::{
+    path::Path,
+    Attributes, Error as ObjectStoreError, GetOptions, GetRange, GetResult, GetResultPayload,
+    ListResult, MultipartUpload, ObjectMeta, ObjectStore, PutMultipartOpts, PutOptions, PutPayload,
+    PutResult,
+};
+
+static JVM: OnceCell<JavaVM> = OnceCell::new();
+
+pub fn init_jvm(env: &JNIEnv) {
+    let _ = JVM.set(env.get_java_vm().expect("Failed to get JavaVM"));
+}
+
+fn get_jni_env<'a>() -> jni::AttachGuard<'a> {
+    JVM.get()
+        .expect("JVM not initialized")
+        .attach_current_thread()
+        .expect("Failed to attach thread")
+}
+
+mod jni_helpers {
+    use super::*;
+
+    pub fn create_jni_hashmap<'local>(
+        env: &mut JNIEnv<'local>,
+        configs: &HashMap<String, String>,
+    ) -> Result<JObject<'local>, ObjectStoreError> {
+        let map_class = env.find_class("java/util/HashMap").map_err(jni_error)?;
+        let jmap = env.new_object(map_class, "()V", &[]).map_err(jni_error)?;
+
+        for (k, v) in configs {
+            let jkey = env.new_string(k).map_err(jni_error)?;
+            let jval = env.new_string(v).map_err(jni_error)?;
+
+            env.call_method(
+                &jmap,
+                "put",
+                "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+                &[JValue::Object(&jkey), JValue::Object(&jval)],
+            )
+            .map_err(jni_error)?;
+        }
+
+        Ok(jmap)
+    }
+
+    pub fn jni_error(e: jni::errors::Error) -> ObjectStoreError {
+        ObjectStoreError::Generic {
+            store: "jni",
+            source: Box::new(e),
+        }
+    }
+
+    pub fn get_native_class<'local>(
+        env: &mut JNIEnv<'local>,
+    ) -> Result<JClass<'local>, ObjectStoreError> {
+        env.find_class("org/apache/comet/parquet/Native")
+            .map_err(jni_error)
+    }
+}
+
+/// Retrieves the length (in bytes) of a file through JNI interface.
+///
+/// This method makes a JNI call to Java to get the size of the file at the specified path,
+/// using the provided configuration parameters for the storage backend.
+///
+/// # Arguments
+/// * `path` - The filesystem path or URI of the target file
+/// * `configs` - Configuration parameters for the storage backend as key-value pairs.
+///               Common configurations include authentication credentials, region settings,
+///               and timeout values.
+///
+/// # Returns
+/// Returns `Ok(usize)` with the file size in bytes on success, or an `ObjectStoreError`
+/// if the operation fails.
+pub fn call_get_length(
+    path: &str,
+    configs: &HashMap<String, String>,
+) -> Result<usize, ObjectStoreError> {
+    let mut env = get_jni_env();
+    let jmap = jni_helpers::create_jni_hashmap(&mut env, configs)?;
+    let class = jni_helpers::get_native_class(&mut env)?;
+    let jpath = env.new_string(path).map_err(jni_helpers::jni_error)?;
+
+    let result = env
+        .call_static_method(
+            class,
+            "getLength",
+            "(Ljava/lang/String;Ljava/util/Map;)J",
+            &[JValue::Object(&jpath), JValue::Object(&jmap)],
+        )
+        .map_err(jni_helpers::jni_error)?
+        .j()
+        .unwrap_or(-1);
+
+    if result < 0 {
+        Err(ObjectStoreError::NotFound {
+            path: path.to_string(),
+            source: Box::new(Arc::new(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("File not found or error reading: {}", path),
+            ))),
+        })
+    } else {
+        Ok(result as usize)
+    }
+}
+
+/// Reads a range of bytes from a file through JNI interface.
+///
+/// # Arguments
+/// * `raw_path` - The filesystem path or URI of the file to read
+/// * `configs` - Configuration parameters for the read operation as key-value pairs
+/// * `offset` - The starting byte position to read from (0-based)
+/// * `len` - The number of bytes to read
+///
+/// # Returns
+/// Returns `Ok(Vec<u8>)` containing the requested bytes on success, or an
+/// `ObjectStoreError` if the operation fails.
+pub fn call_read(
+    path: &str,
+    configs: &HashMap<String, String>,
+    offset: usize,
+    len: usize,
+) -> Result<Vec<u8>, ObjectStoreError> {
+    let mut env = get_jni_env();
+    let jmap = jni_helpers::create_jni_hashmap(&mut env, configs)?;
+    let class = jni_helpers::get_native_class(&mut env)?;
+
+    let jpath = env.new_string(path).map_err(jni_helpers::jni_error)?;
+
+    let result = env
+        .call_static_method(
+            class,
+            "read",
+            "(Ljava/lang/String;Ljava/util/Map;JI)[B",
+            &[
+                JValue::Object(&jpath),
+                JValue::Object(&jmap),
+                JValue::Long(offset as i64),
+                JValue::Int(len as i32),
+            ],
+        )
+        .map_err(jni_helpers::jni_error)?;
+
+    let byte_array = jni::objects::JByteArray::from(
+        result
+            .l()
+            .map_err(jni_helpers::jni_error)?,
+    );
+
+    if byte_array.is_null() {
+        return Err(ObjectStoreError::Generic {
+            store: "jni",
+            source: "Received null byte array from Java".into(),
+        });
+    }
+
+    let output = env
+        .convert_byte_array(byte_array)
+        .map_err(jni_helpers::jni_error)?;
+    Ok(output)
+}
+
+/// A JNI-backed implementation of [`ObjectStore`] for interacting with storage systems
+/// through Java Native Interface.
+#[derive(Debug, Clone)]
+pub struct JniObjectStore {
+    base_uri: String,
+    configs: HashMap<String, String>,
+}
+
+// Mark as thread-safe
+unsafe impl Send for JniObjectStore {}
+unsafe impl Sync for JniObjectStore {}
+
+impl JniObjectStore {
+    /// Creates a new JniObjectStore with the given base URI and configurations.
+    pub fn new(base_uri: String, configs: HashMap<String, String>) -> Self {
+        Self {
+            base_uri: base_uri.trim_end_matches('/').to_string(),
+            configs,
+        }
+    }
+
+    /// Converts a relative path to an absolute URI using the store's base URI.
+    fn to_absolute_uri(&self, location: &Path) -> String {
+        let path_str = location.to_string();
+
+        // If already absolute-looking (s3a://, hdfs://, etc.), return as is
+        if path_str.contains("://") {
+            return path_str;
+        }
+
+        // Handle absolute-looking paths (start with /)
+        let clean_path = path_str.trim_start_matches('/');
+        format!("{}/{}", self.base_uri, clean_path)
+    }
+}
+
+impl std::fmt::Display for JniObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "JniObjectStore")
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for JniObjectStore {
+    async fn get_opts(
+        &self,
+        location: &Path,
+        options: GetOptions,
+    ) -> Result<GetResult, ObjectStoreError> {
+        let path_str = self.to_absolute_uri(location);
+        let total_len = call_get_length(&path_str, &self.configs)? as u64;
+
+        let range = match options.range {
+            Some(GetRange::Bounded(range)) => range,
+            Some(GetRange::Offset(offset)) => offset..total_len,
+            Some(GetRange::Suffix(length)) => {
+                let start = total_len.saturating_sub(length);
+                start..total_len
+            }
+            None => 0..total_len,
+        };
+
+        if range.end > total_len {
+            return Err(ObjectStoreError::NotFound {
+                path: path_str.clone(),
+                source: format!(
+                    "Invalid range {}-{} for file of length {}",
+                    range.start,
+                    range.end,
+                    total_len
+                ).into(),
+            });
+        }
+
+        let range_len = (range.end - range.start) as usize;
+        let bytes = call_read(&path_str, &self.configs, range.start as usize, range_len)?;
+
+        Ok(GetResult {
+            payload: GetResultPayload::Stream(Box::pin(stream::once(async move {
+                Ok(Bytes::from(bytes))
+            }))),
+            meta: ObjectMeta {
+                location: location.clone(),
+                last_modified: Utc::now(),
+                size: total_len,
+                version: None,
+                e_tag: None,
+            },
+            range,
+            attributes: Attributes::default(),
+        })
+    }
+
+    async fn put_opts(
+        &self,
+        _location: &Path,
+        _bytes: PutPayload,
+        _opts: PutOptions,
+    ) -> Result<PutResult, ObjectStoreError> {
+        todo!()
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        _location: &Path,
+        _opts: PutMultipartOpts,
+    ) -> Result<Box<dyn MultipartUpload + 'static>, ObjectStoreError> {
+        todo!()
+    }
+
+    async fn delete(
+        &self,
+        _location: &Path,
+    ) -> Result<(), ObjectStoreError> {
+        todo!()
+    }
+
+    fn list(
+        &self,
+        _prefix: Option<&Path>,
+    ) -> BoxStream<'static, Result<ObjectMeta, ObjectStoreError>> {
+        futures::stream::empty().boxed()
+    }
+
+    async fn list_with_delimiter(
+        &self,
+        _prefix: Option<&Path>,
+    ) -> Result<ListResult, ObjectStoreError> {
+        todo!()
+    }
+
+    async fn copy(
+        &self,
+        _from: &Path,
+        _to: &Path,
+    ) -> Result<(), ObjectStoreError> {
+        todo!()
+    }
+
+    async fn copy_if_not_exists(
+        &self,
+        _from: &Path,
+        _to: &Path,
+    ) -> Result<(), ObjectStoreError> {
+        todo!()
+    }
+    async fn head(
+        &self,
+        location: &Path,
+    ) -> Result<ObjectMeta, ObjectStoreError> {
+        let path = location.to_string();
+        let len = call_get_length(&path, &self.configs)? as usize;
+        Ok(ObjectMeta {
+            location: location.clone(),
+            last_modified: Utc::now(),
+            size: len as u64,
+            version: None,
+            e_tag: None,
+        })
+    }
+}

--- a/native/core/src/parquet/objectstore/mod.rs
+++ b/native/core/src/parquet/objectstore/mod.rs
@@ -16,3 +16,4 @@
 // under the License.
 
 pub mod s3;
+pub mod jni;


### PR DESCRIPTION


## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

This PR adds support for Approach 2 (JNI-based Hadoop FileSystem access) to enable S3 reads via the native DataFusion Parquet scanner. The original discussion of both approaches can be found in [issue #1766](https://github.com/apache/datafusion-comet/issues/1766).

## What changes are included in this PR?

Added JNI-based integration for accessing Hadoop FileSystem in Comet

Introduced a new config flag: `spark.comet.use_jni_object_store` to toggle this feature

## How are these changes tested?

new test
