### PR TITLE
cast_operands_to_double_type_to_fix_arithmetic_overflow

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -677,7 +677,13 @@ object QueryPlanSerde extends Logging with CometExprShim {
         }
         None
 
-      case div @ IntegralDivide(left, right, _) if supportedDataType(left.dataType) =>
+      case div @ IntegralDivide(leftPrimitive, rightPrimitive, _)
+          if supportedDataType(leftPrimitive.dataType) =>
+        withInfo(
+          div,
+          "Casting to DoubleType to match default Spark behavior and avoid integer overflow ")
+        val left = Cast(leftPrimitive, DoubleType)
+        val right = Cast(rightPrimitive, DoubleType)
         val rightExpr = nullIfWhenPrimitive(right)
 
         val dataType = (left.dataType, right.dataType) match {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #1477 

## Rationale for this change

This change fixes an overflow eception which occurs when we divide 

## What changes are included in this PR?

The data types of left and right operands are casted to wider DoubleType to accommodate extreme numbers

## How are these changes tested?
Unit tests in Spark repo to check an edge case (which is mentioned in the issue)

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
no