### PR TITLE
refactor: standardize div_ceil

### DIFF
--- a/native/core/src/common/bit.rs
+++ b/native/core/src/common/bit.rs
@@ -174,12 +174,6 @@ where
     memcpy(&source.as_bytes()[..num_bytes], target)
 }
 
-/// Returns the ceil of value/divisor
-#[inline]
-pub fn ceil(value: usize, divisor: usize) -> usize {
-    value / divisor + ((value % divisor != 0) as usize)
-}
-
 /// Returns ceil(log2(x))
 #[inline]
 pub fn log2(mut x: u64) -> u32 {
@@ -354,7 +348,7 @@ impl BitWriter {
     /// Flushes the internal buffered bits and the align the buffer to the next byte.
     #[inline]
     pub fn flush(&mut self) {
-        let num_bytes = ceil(self.bit_offset, 8);
+        let num_bytes = self.bit_offset.div_ceil(8);
         debug_assert!(self.byte_offset + num_bytes <= self.max_bytes);
         memcpy_value(
             &self.buffered_values,
@@ -401,7 +395,7 @@ impl BitWriter {
 
     #[inline]
     pub fn bytes_written(&self) -> usize {
-        self.byte_offset - self.start + ceil(self.bit_offset, 8)
+        self.byte_offset - self.start + self.bit_offset.div_ceil(8)
     }
 
     #[inline]
@@ -598,7 +592,7 @@ impl BitReader {
     /// Gets the current byte offset
     #[inline]
     pub fn get_byte_offset(&self) -> usize {
-        self.byte_offset + ceil(self.bit_offset, 8)
+        self.byte_offset + self.bit_offset.div_ceil(8)
     }
 
     /// Reads a value of type `T` and of size `num_bits`.
@@ -724,7 +718,7 @@ impl BitReader {
         v >>= 8 - offset_r;
 
         // Read the rest of the bytes
-        ((offset_i + 1)..(offset_i + ceil(n + offset_r, 8))).for_each(|i| {
+        ((offset_i + 1)..(offset_i + usize::div_ceil(n + offset_r, 8))).for_each(|i| {
             dst[i] |= v as u8;
             v >>= 8;
         });
@@ -907,7 +901,7 @@ impl BitReader {
         debug_assert!(8 >= size_of::<T>());
         debug_assert!(num_bytes <= size_of::<T>());
 
-        let bytes_read = ceil(self.bit_offset, 8);
+        let bytes_read = self.bit_offset.div_ceil(8);
         if unlikely(self.byte_offset + bytes_read + num_bytes > self.total_bytes) {
             return None;
         }
@@ -1050,21 +1044,6 @@ mod tests {
     fn test_read_u32() {
         let buffer: Vec<u8> = vec![0, 1, 2, 3];
         assert_eq!(read_u32(&buffer), read_num_bytes!(u32, 4, &buffer),);
-    }
-
-    #[test]
-    fn test_ceil() {
-        assert_eq!(ceil(0, 1), 0);
-        assert_eq!(ceil(1, 1), 1);
-        assert_eq!(ceil(1, 2), 1);
-        assert_eq!(ceil(1, 8), 1);
-        assert_eq!(ceil(7, 8), 1);
-        assert_eq!(ceil(8, 8), 1);
-        assert_eq!(ceil(9, 8), 2);
-        assert_eq!(ceil(9, 9), 1);
-        assert_eq!(ceil(10000000000, 10), 1000000000);
-        assert_eq!(ceil(10, 10000000000), 1);
-        assert_eq!(ceil(10000000000, 1000000000), 10);
     }
 
     #[test]
@@ -1316,7 +1295,7 @@ mod tests {
 
     fn test_put_value_rand_numbers(total: usize, num_bits: usize) {
         assert!(num_bits < 64);
-        let num_bytes = ceil(num_bits, 8);
+        let num_bytes = num_bits.div_ceil(8);
         let mut writer = BitWriter::new(num_bytes * total);
         let values: Vec<u64> = random_numbers::<u64>(total)
             .iter()
@@ -1454,7 +1433,7 @@ mod tests {
         T: FromBytes + Default + Clone + Debug + Eq,
     {
         assert!(num_bits <= 32);
-        let num_bytes = ceil(num_bits, 8);
+        let num_bytes = num_bits.div_ceil(8);
         let mut writer = BitWriter::new(num_bytes * total);
 
         let values: Vec<u32> = random_numbers::<u32>(total)
@@ -1487,7 +1466,7 @@ mod tests {
         const SIZE: &[usize] = &[1, 31, 32, 33, 128, 129];
         for total in SIZE {
             for num_bits in 1..33 {
-                let num_bytes = ceil(num_bits, 8);
+                let num_bytes = (num_bits as usize).div_ceil(8);
                 let mut writer = BitWriter::new(num_bytes * total);
 
                 let values: Vec<u32> = random_numbers::<u32>(*total)
@@ -1533,7 +1512,7 @@ mod tests {
         assert_eq!(total % 2, 0);
 
         let aligned_value_byte_width = std::mem::size_of::<T>();
-        let value_byte_width = ceil(num_bits, 8);
+        let value_byte_width = num_bits.div_ceil(8);
         let mut writer =
             BitWriter::new((total / 2) * (aligned_value_byte_width + value_byte_width));
         let values: Vec<u32> = random_numbers::<u32>(total / 2)

--- a/native/core/src/common/bit.rs
+++ b/native/core/src/common/bit.rs
@@ -1466,7 +1466,7 @@ mod tests {
         const SIZE: &[usize] = &[1, 31, 32, 33, 128, 129];
         for total in SIZE {
             for num_bits in 1..33 {
-                let num_bytes = (num_bits as usize).div_ceil(8);
+                let num_bytes = usize::div_ceil(num_bits, 8);
                 let mut writer = BitWriter::new(num_bytes * total);
 
                 let values: Vec<u32> = random_numbers::<u32>(*total)

--- a/native/core/src/execution/util/spark_bit_array.rs
+++ b/native/core/src/execution/util/spark_bit_array.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::common::bit;
 use arrow::datatypes::ToByteSlice;
 use std::iter::zip;
 
@@ -103,7 +102,7 @@ impl SparkBitArray {
 }
 
 pub fn num_words(num_bits: i32) -> i32 {
-    bit::ceil(num_bits as usize, 64) as i32
+    usize::div_ceil(num_bits as usize, 64) as i32
 }
 
 #[cfg(test)]

--- a/native/core/src/parquet/mutable_vector.rs
+++ b/native/core/src/parquet/mutable_vector.rs
@@ -69,7 +69,7 @@ impl ParquetMutableVector {
         arrow_type: ArrowDataType,
         bit_width: usize,
     ) -> Self {
-        let validity_len = bit::ceil(capacity, 8);
+        let validity_len = capacity.div_ceil(8);
         let validity_buffer = CometBuffer::new(validity_len);
 
         let mut value_capacity = capacity;
@@ -78,7 +78,7 @@ impl ParquetMutableVector {
             value_capacity += 1;
         }
         // Make sure the capacity is positive
-        let len = bit::ceil(value_capacity * bit_width, 8);
+        let len = usize::div_ceil(value_capacity * bit_width, 8);
         let mut value_buffer = CometBuffer::new(len);
 
         let mut children = Vec::new();

--- a/native/core/src/parquet/read/levels.rs
+++ b/native/core/src/parquet/read/levels.rs
@@ -218,7 +218,7 @@ impl LevelDecoder {
                 Mode::RLE => {
                     // RLE
                     self.current_count = (indicator_value >> 1) as usize;
-                    let value_width = bit::ceil(self.bit_width as usize, 8);
+                    let value_width = (self.bit_width as usize).div_ceil(8);
                     self.current_value = bit_reader
                         .get_aligned::<i32>(value_width)
                         .expect("current value should be set");

--- a/native/core/src/parquet/read/values.rs
+++ b/native/core/src/parquet/read/values.rs
@@ -962,7 +962,7 @@ impl DictDecoder {
                 self.bit_packed_left = ((indicator_value >> 1) * 8) as usize;
             } else {
                 self.rle_left = (indicator_value >> 1) as usize;
-                let value_width = bit::ceil(self.bit_width, 8);
+                let value_width = self.bit_width.div_ceil(8);
                 self.current_value = self.bit_reader.get_aligned::<u32>(value_width).unwrap();
             }
         } else {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #1998.

## Rationale for this change

Use standard rust implementation.
Related: https://github.com/apache/datafusion-comet/pull/1954

## What changes are included in this PR?

Remove `bit::ceil` from core and use `usize::div_ceil` instead.

## How are these changes tested?

Existing tests.