### PR TITLE
fix: [iceberg] Add LogicalTypeAnnotation in ParquetColumnSpec

### DIFF
--- a/common/src/main/java/org/apache/comet/parquet/ParquetColumnSpec.java
+++ b/common/src/main/java/org/apache/comet/parquet/ParquetColumnSpec.java
@@ -19,6 +19,8 @@
 
 package org.apache.comet.parquet;
 
+import java.util.Map;
+
 public class ParquetColumnSpec {
 
   private final String[] path;
@@ -27,6 +29,8 @@ public class ParquetColumnSpec {
   private final boolean isRepeated;
   private final int maxDefinitionLevel;
   private final int maxRepetitionLevel;
+  private String logicalTypeName;
+  private Map<String, String> logicalTypeParams;
 
   public ParquetColumnSpec(
       String[] path,
@@ -34,13 +38,17 @@ public class ParquetColumnSpec {
       int typeLength,
       boolean isRepeated,
       int maxDefinitionLevel,
-      int maxRepetitionLevel) {
+      int maxRepetitionLevel,
+      String logicalTypeName,
+      Map<String, String> logicalTypeParams) {
     this.path = path;
     this.physicalType = physicalType;
     this.typeLength = typeLength;
     this.isRepeated = isRepeated;
     this.maxDefinitionLevel = maxDefinitionLevel;
     this.maxRepetitionLevel = maxRepetitionLevel;
+    this.logicalTypeName = logicalTypeName;
+    this.logicalTypeParams = logicalTypeParams;
   }
 
   public String[] getPath() {
@@ -65,5 +73,13 @@ public class ParquetColumnSpec {
 
   public int getMaxDefinitionLevel() {
     return maxDefinitionLevel;
+  }
+
+  public String getLogicalTypeName() {
+    return logicalTypeName;
+  }
+
+  public Map<String, String> getLogicalTypeParams() {
+    return logicalTypeParams;
   }
 }

--- a/common/src/main/java/org/apache/comet/parquet/ParquetColumnSpec.java
+++ b/common/src/main/java/org/apache/comet/parquet/ParquetColumnSpec.java
@@ -23,16 +23,20 @@ import java.util.Map;
 
 public class ParquetColumnSpec {
 
+  private final int fieldId;
   private final String[] path;
   private final String physicalType;
   private final int typeLength;
   private final boolean isRepeated;
   private final int maxDefinitionLevel;
   private final int maxRepetitionLevel;
+
+  // Logical type info
   private String logicalTypeName;
   private Map<String, String> logicalTypeParams;
 
   public ParquetColumnSpec(
+      int fieldId,
       String[] path,
       String physicalType,
       int typeLength,
@@ -41,6 +45,7 @@ public class ParquetColumnSpec {
       int maxRepetitionLevel,
       String logicalTypeName,
       Map<String, String> logicalTypeParams) {
+    this.fieldId = fieldId;
     this.path = path;
     this.physicalType = physicalType;
     this.typeLength = typeLength;
@@ -49,6 +54,10 @@ public class ParquetColumnSpec {
     this.maxRepetitionLevel = maxRepetitionLevel;
     this.logicalTypeName = logicalTypeName;
     this.logicalTypeParams = logicalTypeParams;
+  }
+
+  public int getFieldId() {
+    return fieldId;
   }
 
   public String[] getPath() {

--- a/common/src/main/java/org/apache/comet/parquet/Utils.java
+++ b/common/src/main/java/org/apache/comet/parquet/Utils.java
@@ -24,6 +24,7 @@ import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Types;
 import org.apache.spark.sql.types.*;
 
 import org.apache.comet.CometSchemaImporter;
@@ -290,15 +291,129 @@ public class Utils {
     }
 
     String name = columnSpec.getPath()[columnSpec.getPath().length - 1];
+    // Reconstruct the logical type from parameters
+    LogicalTypeAnnotation logicalType = null;
+    if (columnSpec.getLogicalTypeName() != null) {
+      logicalType =
+          reconstructLogicalType(
+              columnSpec.getLogicalTypeName(), columnSpec.getLogicalTypeParams());
+    }
 
     PrimitiveType primitiveType;
     if (primType == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY) {
-      primitiveType = new PrimitiveType(repetition, primType, columnSpec.getTypeLength(), name);
+      primitiveType =
+          Types.primitive(primType, repetition)
+              .length(columnSpec.getTypeLength())
+              .as(logicalType)
+              .named(name);
     } else {
-      primitiveType = new PrimitiveType(repetition, primType, name);
+      primitiveType = Types.primitive(primType, repetition).as(logicalType).named(name);
     }
 
     MessageType schema = new MessageType("root", primitiveType);
     return schema.getColumnDescription(columnSpec.getPath());
+  }
+
+  private static LogicalTypeAnnotation reconstructLogicalType(
+      String logicalTypeName, java.util.Map<String, String> params) {
+
+    switch (logicalTypeName) {
+        // MAP
+      case "MapLogicalTypeAnnotation":
+        return LogicalTypeAnnotation.mapType();
+
+        // LIST
+      case "ListLogicalTypeAnnotation":
+        return LogicalTypeAnnotation.listType();
+
+        // STRING
+      case "StringLogicalTypeAnnotation":
+        return LogicalTypeAnnotation.stringType();
+
+        // MAP_KEY_VALUE
+      case "MapKeyValueLogicalTypeAnnotation":
+        return LogicalTypeAnnotation.MapKeyValueTypeAnnotation.getInstance();
+
+        // ENUM
+      case "EnumLogicalTypeAnnotation":
+        return LogicalTypeAnnotation.enumType();
+
+        // DECIMAL
+      case "DecimalLogicalTypeAnnotation":
+        int scale = Integer.parseInt(params.get("scale"));
+        int precision = Integer.parseInt(params.get("precision"));
+        return LogicalTypeAnnotation.decimalType(scale, precision);
+
+        // DATE
+      case "DateLogicalTypeAnnotation":
+        return LogicalTypeAnnotation.dateType();
+
+        // TIME
+      case "TimeLogicalTypeAnnotation":
+        boolean isUTC = Boolean.parseBoolean(params.getOrDefault("isAdjustedToUTC", "true"));
+        String timeUnitStr = params.getOrDefault("unit", "MICROS");
+
+        LogicalTypeAnnotation.TimeUnit timeUnit;
+        switch (timeUnitStr) {
+          case "MILLIS":
+            timeUnit = LogicalTypeAnnotation.TimeUnit.MILLIS;
+            break;
+          case "MICROS":
+            timeUnit = LogicalTypeAnnotation.TimeUnit.MICROS;
+            break;
+          case "NANOS":
+            timeUnit = LogicalTypeAnnotation.TimeUnit.NANOS;
+            break;
+          default:
+            timeUnit = LogicalTypeAnnotation.TimeUnit.MICROS;
+        }
+        return LogicalTypeAnnotation.timeType(isUTC, timeUnit);
+
+        // TIMESTAMP
+      case "TimestampLogicalTypeAnnotation":
+        boolean isAdjustedToUTC = Boolean.parseBoolean(params.get("isAdjustedToUTC"));
+        String unitStr = params.getOrDefault("unit", "MICROS");
+
+        LogicalTypeAnnotation.TimeUnit unit;
+        switch (unitStr) {
+          case "MILLIS":
+            unit = LogicalTypeAnnotation.TimeUnit.MILLIS;
+            break;
+          case "MICROS":
+            unit = LogicalTypeAnnotation.TimeUnit.MICROS;
+            break;
+          case "NANOS":
+            unit = LogicalTypeAnnotation.TimeUnit.NANOS;
+            break;
+          default:
+            unit = LogicalTypeAnnotation.TimeUnit.MICROS;
+        }
+        return LogicalTypeAnnotation.timestampType(isAdjustedToUTC, unit);
+
+        // INTEGER
+      case "IntLogicalTypeAnnotation":
+        boolean isSigned = Boolean.parseBoolean(params.get("isSigned"));
+        int bitWidth = Integer.parseInt(params.get("bitWidth"));
+        return LogicalTypeAnnotation.intType(bitWidth, isSigned);
+
+        // JSON
+      case "JsonLogicalTypeAnnotation":
+        return LogicalTypeAnnotation.jsonType();
+
+        // BSON
+      case "BsonLogicalTypeAnnotation":
+        return LogicalTypeAnnotation.bsonType();
+
+        // UUID
+      case "UUIDLogicalTypeAnnotation":
+        return LogicalTypeAnnotation.uuidType();
+
+        // INTERVAL
+      case "IntervalLogicalTypeAnnotation":
+        return LogicalTypeAnnotation.IntervalLogicalTypeAnnotation.getInstance();
+
+      default:
+        throw new IllegalArgumentException("Unknown logical type: " + logicalTypeName);
+    }
   }
 }

--- a/common/src/main/java/org/apache/comet/parquet/Utils.java
+++ b/common/src/main/java/org/apache/comet/parquet/Utils.java
@@ -21,7 +21,6 @@ package org.apache.comet.parquet;
 
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
-import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
@@ -305,13 +304,21 @@ public class Utils {
           Types.primitive(primType, repetition)
               .length(columnSpec.getTypeLength())
               .as(logicalType)
+              .id(columnSpec.getFieldId())
               .named(name);
     } else {
-      primitiveType = Types.primitive(primType, repetition).as(logicalType).named(name);
+      primitiveType =
+          Types.primitive(primType, repetition)
+              .as(logicalType)
+              .id(columnSpec.getFieldId())
+              .named(name);
     }
 
-    MessageType schema = new MessageType("root", primitiveType);
-    return schema.getColumnDescription(columnSpec.getPath());
+    return new ColumnDescriptor(
+        columnSpec.getPath(),
+        primitiveType,
+        columnSpec.getMaxRepetitionLevel(),
+        columnSpec.getMaxDefinitionLevel());
   }
 
   private static LogicalTypeAnnotation reconstructLogicalType(


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

In order to pass and reassemble the `ColumnDescriptor` from Iceberg to Comet, we need to include `LogicalTypeAnnotation` too.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
