### PR TITLE
mimic_spark_integral_division

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -677,7 +677,14 @@ object QueryPlanSerde extends Logging with CometExprShim {
         }
         None
 
-      case div @ IntegralDivide(left, right, _) if supportedDataType(left.dataType) =>
+      case div @ IntegralDivide(leftInt, rightInt, _) if supportedDataType(leftInt.dataType) =>
+        val left =
+          if (leftInt.dataType.isInstanceOf[DecimalType]) leftInt else Cast(leftInt, DoubleType)
+        val right =
+          if (rightInt.dataType.isInstanceOf[DecimalType]) rightInt
+          else Cast(rightInt, DoubleType)
+        withInfo(div, s"left data type ${left.dataType} casted to ${leftInt.dataType}")
+        withInfo(div, s"right data type ${right.dataType} casted to ${rightInt.dataType}")
         val rightExpr = nullIfWhenPrimitive(right)
 
         val dataType = (left.dataType, right.dataType) match {


### PR DESCRIPTION
Which issue does this PR close?
Closes https://github.com/apache/datafusion-comet/issues/1477

Rationale for this change
This change fixes an overflow eception which occurs when we divide

What changes are included in this PR?
The data types of left and right operands are casted to wider DoubleType to accommodate extreme numbers

How are these changes tested?
Unit tests in Spark repo to check an edge case (which is mentioned in the issue)

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
no