### PR TITLE
Chore: Refactor QueryPlanSerde, move math exprs in separate file

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -23,7 +23,6 @@ import java.util.Locale
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
-import scala.math.min
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
@@ -120,7 +119,13 @@ object QueryPlanSerde extends Logging with CometExprShim {
     classOf[MapKeys] -> CometMapKeys,
     classOf[MapValues] -> CometMapValues,
     classOf[MapFromArrays] -> CometMapFromArrays,
-    classOf[GetMapValue] -> CometMapExtract)
+    classOf[GetMapValue] -> CometMapExtract,
+    classOf[Add] -> CometAdd,
+    classOf[Subtract] -> CometSubtract,
+    classOf[Multiply] -> CometMultiply,
+    classOf[Remainder] -> CometRemainder,
+    classOf[Divide] -> CometDivide,
+    classOf[IntegralDivide] -> CometIntegralDivide)
 
   def emitWarning(reason: String): Unit = {
     logWarning(s"Comet native execution is disabled due to: $reason")
@@ -629,141 +634,6 @@ object QueryPlanSerde extends Logging with CometExprShim {
 
       case c @ Cast(child, dt, timeZoneId, _) =>
         handleCast(expr, child, inputs, binding, dt, timeZoneId, evalMode(c))
-
-      case add @ Add(left, right, _) if supportedDataType(left.dataType) =>
-        createMathExpression(
-          expr,
-          left,
-          right,
-          inputs,
-          binding,
-          add.dataType,
-          add.evalMode == EvalMode.ANSI,
-          (builder, mathExpr) => builder.setAdd(mathExpr))
-
-      case add @ Add(left, _, _) if !supportedDataType(left.dataType) =>
-        withInfo(add, s"Unsupported datatype ${left.dataType}")
-        None
-
-      case sub @ Subtract(left, right, _) if supportedDataType(left.dataType) =>
-        createMathExpression(
-          expr,
-          left,
-          right,
-          inputs,
-          binding,
-          sub.dataType,
-          sub.evalMode == EvalMode.ANSI,
-          (builder, mathExpr) => builder.setSubtract(mathExpr))
-
-      case sub @ Subtract(left, _, _) if !supportedDataType(left.dataType) =>
-        withInfo(sub, s"Unsupported datatype ${left.dataType}")
-        None
-
-      case mul @ Multiply(left, right, _) if supportedDataType(left.dataType) =>
-        createMathExpression(
-          expr,
-          left,
-          right,
-          inputs,
-          binding,
-          mul.dataType,
-          mul.evalMode == EvalMode.ANSI,
-          (builder, mathExpr) => builder.setMultiply(mathExpr))
-
-      case mul @ Multiply(left, _, _) =>
-        if (!supportedDataType(left.dataType)) {
-          withInfo(mul, s"Unsupported datatype ${left.dataType}")
-        }
-        None
-
-      case div @ Divide(left, right, _) if supportedDataType(left.dataType) =>
-        // Datafusion now throws an exception for dividing by zero
-        // See https://github.com/apache/arrow-datafusion/pull/6792
-        // For now, use NullIf to swap zeros with nulls.
-        val rightExpr = nullIfWhenPrimitive(right)
-
-        createMathExpression(
-          expr,
-          left,
-          rightExpr,
-          inputs,
-          binding,
-          div.dataType,
-          div.evalMode == EvalMode.ANSI,
-          (builder, mathExpr) => builder.setDivide(mathExpr))
-
-      case div @ Divide(left, _, _) =>
-        if (!supportedDataType(left.dataType)) {
-          withInfo(div, s"Unsupported datatype ${left.dataType}")
-        }
-        None
-
-      case div @ IntegralDivide(left, right, _) if supportedDataType(left.dataType) =>
-        val rightExpr = nullIfWhenPrimitive(right)
-
-        val dataType = (left.dataType, right.dataType) match {
-          case (l: DecimalType, r: DecimalType) =>
-            // copy from IntegralDivide.resultDecimalType
-            val intDig = l.precision - l.scale + r.scale
-            DecimalType(min(if (intDig == 0) 1 else intDig, DecimalType.MAX_PRECISION), 0)
-          case _ => left.dataType
-        }
-
-        val divideExpr = createMathExpression(
-          expr,
-          left,
-          rightExpr,
-          inputs,
-          binding,
-          dataType,
-          div.evalMode == EvalMode.ANSI,
-          (builder, mathExpr) => builder.setIntegralDivide(mathExpr))
-
-        if (divideExpr.isDefined) {
-          val childExpr = if (dataType.isInstanceOf[DecimalType]) {
-            // check overflow for decimal type
-            val builder = ExprOuterClass.CheckOverflow.newBuilder()
-            builder.setChild(divideExpr.get)
-            builder.setFailOnError(div.evalMode == EvalMode.ANSI)
-            builder.setDatatype(serializeDataType(dataType).get)
-            Some(
-              ExprOuterClass.Expr
-                .newBuilder()
-                .setCheckOverflow(builder)
-                .build())
-          } else {
-            divideExpr
-          }
-
-          // cast result to long
-          castToProto(expr, None, LongType, childExpr.get, CometEvalMode.LEGACY)
-        } else {
-          None
-        }
-
-      case div @ IntegralDivide(left, _, _) =>
-        if (!supportedDataType(left.dataType)) {
-          withInfo(div, s"Unsupported datatype ${left.dataType}")
-        }
-        None
-
-      case rem @ Remainder(left, right, _) if supportedDataType(left.dataType) =>
-        createMathExpression(
-          expr,
-          left,
-          right,
-          inputs,
-          binding,
-          rem.dataType,
-          rem.evalMode == EvalMode.ANSI,
-          (builder, mathExpr) => builder.setRemainder(mathExpr))
-
-      case rem @ Remainder(left, _, _) =>
-        if (!supportedDataType(left.dataType)) {
-          withInfo(rem, s"Unsupported datatype ${left.dataType}")
-        }
-        None
 
       case EqualTo(left, right) =>
         createBinaryExpr(
@@ -1947,42 +1817,6 @@ object QueryPlanSerde extends Logging with CometExprShim {
     }
   }
 
-  private def createMathExpression(
-      expr: Expression,
-      left: Expression,
-      right: Expression,
-      inputs: Seq[Attribute],
-      binding: Boolean,
-      dataType: DataType,
-      failOnError: Boolean,
-      f: (ExprOuterClass.Expr.Builder, ExprOuterClass.MathExpr) => ExprOuterClass.Expr.Builder)
-      : Option[ExprOuterClass.Expr] = {
-    val leftExpr = exprToProtoInternal(left, inputs, binding)
-    val rightExpr = exprToProtoInternal(right, inputs, binding)
-
-    if (leftExpr.isDefined && rightExpr.isDefined) {
-      // create the generic MathExpr message
-      val builder = ExprOuterClass.MathExpr.newBuilder()
-      builder.setLeft(leftExpr.get)
-      builder.setRight(rightExpr.get)
-      builder.setFailOnError(failOnError)
-      serializeDataType(dataType).foreach { t =>
-        builder.setReturnType(t)
-      }
-      val inner = builder.build()
-      // call the user-supplied function to wrap MathExpr in a top-level Expr
-      // such as Expr.Add or Expr.Divide
-      Some(
-        f(
-          ExprOuterClass.Expr
-            .newBuilder(),
-          inner).build())
-    } else {
-      withInfo(expr, left, right)
-      None
-    }
-  }
-
   def in(
       expr: Expression,
       value: Expression,
@@ -2037,25 +1871,6 @@ object QueryPlanSerde extends Logging with CometExprShim {
     }
     Some(ExprOuterClass.Expr.newBuilder().setScalarFunc(builder).build())
   }
-
-  private def isPrimitive(expression: Expression): Boolean = expression.dataType match {
-    case _: ByteType | _: ShortType | _: IntegerType | _: LongType | _: FloatType |
-        _: DoubleType | _: TimestampType | _: DateType | _: BooleanType | _: DecimalType =>
-      true
-    case _ => false
-  }
-
-  private def nullIfWhenPrimitive(expression: Expression): Expression =
-    if (isPrimitive(expression)) {
-      val zero = Literal.default(expression.dataType)
-      expression match {
-        case _: Literal if expression != zero => expression
-        case _ =>
-          If(EqualTo(expression, zero), Literal.create(null, expression.dataType), expression)
-      }
-    } else {
-      expression
-    }
 
   private def nullIfNegative(expression: Expression): Expression = {
     val zero = Literal.default(expression.dataType)

--- a/spark/src/main/scala/org/apache/comet/serde/maths.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/maths.scala
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.serde
+
+import scala.math.min
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.types._
+
+import org.apache.comet.CometSparkSessionExtensions.withInfo
+import org.apache.comet.expressions.CometEvalMode
+import org.apache.comet.serde.QueryPlanSerde._
+
+object CometAdd extends CometExpressionSerde with MathBase {
+
+  override def convert(
+      expr: Expression,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    val add = expr.asInstanceOf[Add]
+    if (!supportedDataType(add.left.dataType)) {
+      withInfo(add, s"Unsupported datatype ${add.left.dataType}")
+      return None
+    }
+    createMathExpression(
+      expr,
+      add.left,
+      add.right,
+      inputs,
+      binding,
+      add.dataType,
+      add.evalMode == EvalMode.ANSI,
+      (builder, mathExpr) => builder.setAdd(mathExpr))
+  }
+}
+
+object CometSubtract extends CometExpressionSerde with MathBase {
+
+  override def convert(
+      expr: Expression,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    val sub = expr.asInstanceOf[Subtract]
+    if (!supportedDataType(sub.left.dataType)) {
+      withInfo(sub, s"Unsupported datatype ${sub.left.dataType}")
+      return None
+    }
+    createMathExpression(
+      expr,
+      sub.left,
+      sub.right,
+      inputs,
+      binding,
+      sub.dataType,
+      sub.evalMode == EvalMode.ANSI,
+      (builder, mathExpr) => builder.setSubtract(mathExpr))
+  }
+}
+
+object CometDivide extends CometExpressionSerde with MathBase {
+
+  override def convert(
+      expr: Expression,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    val div = expr.asInstanceOf[Divide]
+    if (!supportedDataType(div.left.dataType)) {
+      withInfo(div, s"Unsupported datatype ${div.left.dataType}")
+      return None
+    }
+    // Datafusion now throws an exception for dividing by zero
+    // See https://github.com/apache/arrow-datafusion/pull/6792
+    // For now, use NullIf to swap zeros with nulls.
+    val rightExpr = nullIfWhenPrimitive(div.right)
+
+    createMathExpression(
+      expr,
+      div.left,
+      rightExpr,
+      inputs,
+      binding,
+      div.dataType,
+      div.evalMode == EvalMode.ANSI,
+      (builder, mathExpr) => builder.setDivide(mathExpr))
+  }
+}
+
+object CometIntegralDivide extends CometExpressionSerde with MathBase {
+
+  override def convert(
+      expr: Expression,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    val div = expr.asInstanceOf[IntegralDivide]
+    if (!supportedDataType(div.left.dataType)) {
+      withInfo(div, s"Unsupported datatype ${div.left.dataType}")
+      return None
+    }
+    val rightExpr = nullIfWhenPrimitive(div.right)
+
+    val dataType = (div.left.dataType, div.right.dataType) match {
+      case (l: DecimalType, r: DecimalType) =>
+        // copy from IntegralDivide.resultDecimalType
+        val intDig = l.precision - l.scale + r.scale
+        DecimalType(min(if (intDig == 0) 1 else intDig, DecimalType.MAX_PRECISION), 0)
+      case _ => div.left.dataType
+    }
+
+    val divideExpr = createMathExpression(
+      expr,
+      div.left,
+      rightExpr,
+      inputs,
+      binding,
+      dataType,
+      div.evalMode == EvalMode.ANSI,
+      (builder, mathExpr) => builder.setIntegralDivide(mathExpr))
+
+    if (divideExpr.isDefined) {
+      val childExpr = if (dataType.isInstanceOf[DecimalType]) {
+        // check overflow for decimal type
+        val builder = ExprOuterClass.CheckOverflow.newBuilder()
+        builder.setChild(divideExpr.get)
+        builder.setFailOnError(div.evalMode == EvalMode.ANSI)
+        builder.setDatatype(serializeDataType(dataType).get)
+        Some(
+          ExprOuterClass.Expr
+            .newBuilder()
+            .setCheckOverflow(builder)
+            .build())
+      } else {
+        divideExpr
+      }
+
+      // cast result to long
+      castToProto(expr, None, LongType, childExpr.get, CometEvalMode.LEGACY)
+    } else {
+      None
+    }
+  }
+}
+
+object CometMultiply extends CometExpressionSerde with MathBase {
+
+  override def convert(
+      expr: Expression,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    val mul = expr.asInstanceOf[Multiply]
+    if (!supportedDataType(mul.left.dataType)) {
+      withInfo(mul, s"Unsupported datatype ${mul.left.dataType}")
+      return None
+    }
+    createMathExpression(
+      expr,
+      mul.left,
+      mul.right,
+      inputs,
+      binding,
+      mul.dataType,
+      mul.evalMode == EvalMode.ANSI,
+      (builder, mathExpr) => builder.setMultiply(mathExpr))
+  }
+}
+
+object CometRemainder extends CometExpressionSerde with MathBase {
+
+  override def convert(
+      expr: Expression,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    val rem = expr.asInstanceOf[Remainder]
+    if (!supportedDataType(rem.left.dataType)) {
+      withInfo(rem, s"Unsupported datatype ${rem.left.dataType}")
+      return None
+    }
+    createMathExpression(
+      expr,
+      rem.left,
+      rem.right,
+      inputs,
+      binding,
+      rem.dataType,
+      rem.evalMode == EvalMode.ANSI,
+      (builder, mathExpr) => builder.setRemainder(mathExpr))
+  }
+}
+
+sealed trait MathBase {
+
+  protected def createMathExpression(
+      expr: Expression,
+      left: Expression,
+      right: Expression,
+      inputs: Seq[Attribute],
+      binding: Boolean,
+      dataType: DataType,
+      failOnError: Boolean,
+      f: (ExprOuterClass.Expr.Builder, ExprOuterClass.MathExpr) => ExprOuterClass.Expr.Builder)
+      : Option[ExprOuterClass.Expr] = {
+    val leftExpr = exprToProtoInternal(left, inputs, binding)
+    val rightExpr = exprToProtoInternal(right, inputs, binding)
+
+    if (leftExpr.isDefined && rightExpr.isDefined) {
+      // create the generic MathExpr message
+      val builder = ExprOuterClass.MathExpr.newBuilder()
+      builder.setLeft(leftExpr.get)
+      builder.setRight(rightExpr.get)
+      builder.setFailOnError(failOnError)
+      serializeDataType(dataType).foreach { t =>
+        builder.setReturnType(t)
+      }
+      val inner = builder.build()
+      // call the user-supplied function to wrap MathExpr in a top-level Expr
+      // such as Expr.Add or Expr.Divide
+      Some(
+        f(
+          ExprOuterClass.Expr
+            .newBuilder(),
+          inner).build())
+    } else {
+      withInfo(expr, left, right)
+      None
+    }
+  }
+
+  protected def nullIfWhenPrimitive(expression: Expression): Expression =
+    if (isPrimitive(expression)) {
+      val zero = Literal.default(expression.dataType)
+      expression match {
+        case _: Literal if expression != zero => expression
+        case _ =>
+          If(EqualTo(expression, zero), Literal.create(null, expression.dataType), expression)
+      }
+    } else {
+      expression
+    }
+
+  private def isPrimitive(expression: Expression): Boolean = expression.dataType match {
+    case _: ByteType | _: ShortType | _: IntegerType | _: LongType | _: FloatType |
+        _: DoubleType | _: TimestampType | _: DateType | _: BooleanType | _: DecimalType =>
+      true
+    case _ => false
+  }
+}

--- a/spark/src/test/scala/org/apache/comet/Test.scala
+++ b/spark/src/test/scala/org/apache/comet/Test.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet
+
+import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.internal.SQLConf
+
+class Test extends CometTestBase {
+
+  test("divide by zero (ANSI disable)") {
+    // Enabling ANSI will cause native engine failure, but as we cannot catch
+    // native error now, we cannot test it here.
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "false") {
+      withParquetTable(Seq((1, 0, 1.0, 0.0, -0.0)), "tbl") {
+        checkSparkAnswerAndOperator("SELECT _1 / _2, _3 / _4, _3 / _5 FROM tbl")
+        checkSparkAnswerAndOperator("SELECT _1 % _2, _3 % _4, _3 % _5 FROM tbl")
+        checkSparkAnswerAndOperator("SELECT _1 / 0, _3 / 0.0, _3 / -0.0 FROM tbl")
+        checkSparkAnswerAndOperator("SELECT _1 % 0, _3 % 0.0, _3 % -0.0 FROM tbl")
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion-comet/issues/2019

## Rationale for this change

See https://github.com/apache/datafusion-comet/issues/2019 for rationale.

## What changes are included in this PR?

- Moved maths expressions to separate file (maths.scala)

## How are these changes tested?

There are no functional changes, so rely on existing tests.
