### PR TITLE
feat: monotonically_increasing_id and spark_partition_id implementation

### DIFF
--- a/dev/diffs/4.0.0.diff
+++ b/dev/diffs/4.0.0.diff
@@ -1,5 +1,5 @@
 diff --git a/pom.xml b/pom.xml
-index 443d46a4302..3b8483173f1 100644
+index a4b1b2c3c9f..63ec4784625 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -148,6 +148,8 @@
@@ -698,55 +698,6 @@ index 9c529d14221..069b7c5adeb 100644
            }.flatten
            assert(filters.contains(GreaterThan(scan.logicalPlan.output.head, Literal(5L))))
          }
-diff --git a/sql/core/src/test/scala/org/apache/spark/sql/IgnoreComet.scala b/sql/core/src/test/scala/org/apache/spark/sql/IgnoreComet.scala
-new file mode 100644
-index 00000000000..5eb3fa17ca8
---- /dev/null
-+++ b/sql/core/src/test/scala/org/apache/spark/sql/IgnoreComet.scala
-@@ -0,0 +1,43 @@
-+/*
-+ * Licensed to the Apache Software Foundation (ASF) under one or more
-+ * contributor license agreements.  See the NOTICE file distributed with
-+ * this work for additional information regarding copyright ownership.
-+ * The ASF licenses this file to You under the Apache License, Version 2.0
-+ * (the "License"); you may not use this file except in compliance with
-+ * the License.  You may obtain a copy of the License at
-+ *
-+ *    http://www.apache.org/licenses/LICENSE-2.0
-+ *
-+ * Unless required by applicable law or agreed to in writing, software
-+ * distributed under the License is distributed on an "AS IS" BASIS,
-+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-+ * See the License for the specific language governing permissions and
-+ * limitations under the License.
-+ */
-+
-+package org.apache.spark.sql
-+
-+import org.scalactic.source.Position
-+import org.scalatest.Tag
-+
-+import org.apache.spark.sql.test.SQLTestUtils
-+
-+/**
-+ * Tests with this tag will be ignored when Comet is enabled (e.g., via `ENABLE_COMET`).
-+ */
-+case class IgnoreComet(reason: String) extends Tag("DisableComet")
-+case class IgnoreCometNativeScan(reason: String) extends Tag("DisableComet")
-+
-+/**
-+ * Helper trait that disables Comet for all tests regardless of default config values.
-+ */
-+trait IgnoreCometSuite extends SQLTestUtils {
-+  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)
-+    (implicit pos: Position): Unit = {
-+    if (isCometEnabled) {
-+      ignore(testName + " (disabled when Comet is on)", testTags: _*)(testFun)
-+    } else {
-+      super.test(testName, testTags: _*)(testFun)
-+    }
-+  }
-+}
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
 index 7d7185ae6c1..442a5bddeb8 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
@@ -1732,14 +1683,14 @@ index aed11badb71..ab7e9456e26 100644
            spark.range(1).foreach { _ =>
              columnarToRowExec.canonicalized
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
-index a3cfdc5a240..f4afc393ba0 100644
+index a3cfdc5a240..1b08a1f42ee 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
 @@ -22,6 +22,7 @@ import org.apache.spark.rdd.MapPartitionsWithEvaluatorRDD
  import org.apache.spark.sql.{Dataset, QueryTest, Row, SaveMode}
  import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
  import org.apache.spark.sql.catalyst.expressions.codegen.{ByteCodeStats, CodeAndComment, CodeGenerator}
-+import org.apache.spark.sql.comet.{CometHashJoinExec, CometSortExec, CometSortMergeJoinExec}
++import org.apache.spark.sql.comet.{CometColumnarToRowExec, CometHashJoinExec, CometSortExec, CometSortMergeJoinExec}
  import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecutionSuite
  import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, SortAggregateExec}
  import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
@@ -1952,6 +1903,16 @@ index a3cfdc5a240..f4afc393ba0 100644
            val projection = Seq.tabulate(columnNum)(i => s"c$i + c$i as newC$i")
            val df = spark.read.parquet(path).selectExpr(projection: _*)
  
+@@ -815,6 +852,9 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
+       assert(distinctWithId.queryExecution.executedPlan.exists {
+         case WholeStageCodegenExec(
+           ProjectExec(_, BroadcastHashJoinExec(_, _, _, _, _, _: HashAggregateExec, _, _))) => true
++        case WholeStageCodegenExec(
++          ProjectExec(_, BroadcastHashJoinExec(_, _, _, _, _, _: CometColumnarToRowExec, _, _))) =>
++            true
+         case _ => false
+       })
+       checkAnswer(distinctWithId, Seq(Row(1, 0), Row(1, 0)))
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
 index 272be70f9fe..06957694002 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala

--- a/dev/diffs/4.0.0.diff
+++ b/dev/diffs/4.0.0.diff
@@ -698,6 +698,55 @@ index 9c529d14221..069b7c5adeb 100644
            }.flatten
            assert(filters.contains(GreaterThan(scan.logicalPlan.output.head, Literal(5L))))
          }
+diff --git a/sql/core/src/test/scala/org/apache/spark/sql/IgnoreComet.scala b/sql/core/src/test/scala/org/apache/spark/sql/IgnoreComet.scala
+new file mode 100644
+index 00000000000..5eb3fa17ca8
+--- /dev/null
++++ b/sql/core/src/test/scala/org/apache/spark/sql/IgnoreComet.scala
+@@ -0,0 +1,43 @@
++/*
++ * Licensed to the Apache Software Foundation (ASF) under one or more
++ * contributor license agreements.  See the NOTICE file distributed with
++ * this work for additional information regarding copyright ownership.
++ * The ASF licenses this file to You under the Apache License, Version 2.0
++ * (the "License"); you may not use this file except in compliance with
++ * the License.  You may obtain a copy of the License at
++ *
++ *    http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++package org.apache.spark.sql
++
++import org.scalactic.source.Position
++import org.scalatest.Tag
++
++import org.apache.spark.sql.test.SQLTestUtils
++
++/**
++ * Tests with this tag will be ignored when Comet is enabled (e.g., via `ENABLE_COMET`).
++ */
++case class IgnoreComet(reason: String) extends Tag("DisableComet")
++case class IgnoreCometNativeScan(reason: String) extends Tag("DisableComet")
++
++/**
++ * Helper trait that disables Comet for all tests regardless of default config values.
++ */
++trait IgnoreCometSuite extends SQLTestUtils {
++  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)
++    (implicit pos: Position): Unit = {
++    if (isCometEnabled) {
++      ignore(testName + " (disabled when Comet is on)", testTags: _*)(testFun)
++    } else {
++      super.test(testName, testTags: _*)(testFun)
++    }
++  }
++}
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
 index 7d7185ae6c1..442a5bddeb8 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala

--- a/docs/spark_expressions_support.md
+++ b/docs/spark_expressions_support.md
@@ -349,11 +349,11 @@
  - [ ] input_file_block_length
  - [ ] input_file_block_start
  - [ ] input_file_name
- - [ ] monotonically_increasing_id
+ - [x] monotonically_increasing_id
  - [ ] raise_error
  - [x] rand
  - [x] randn
- - [ ] spark_partition_id
+ - [x] spark_partition_id
  - [ ] typeof
  - [x] user
  - [ ] uuid

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -802,9 +802,9 @@ impl PhysicalPlanner {
             ExprStruct::SparkPartitionId(_) => Ok(Arc::new(DataFusionLiteral::new(
                 ScalarValue::Int32(Some(self.partition)),
             ))),
-            ExprStruct::MonotonicallyIncreasingId(_) => {
-                Ok(Arc::new(MonotonicallyIncreasingId::new(self.partition)))
-            }
+            ExprStruct::MonotonicallyIncreasingId(_) => Ok(Arc::new(
+                MonotonicallyIncreasingId::from_partition_id(self.partition),
+            )),
             expr => Err(GeneralError(format!("Not implemented: {expr:?}"))),
         }
     }

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -803,8 +803,7 @@ impl PhysicalPlanner {
                 ScalarValue::Int32(Some(self.partition)),
             ))),
             ExprStruct::MonotonicallyIncreasingId(_) => {
-                let offset = (self.partition as i64) << 33;
-                Ok(Arc::new(MonotonicallyIncreasingId::new(offset)))
+                Ok(Arc::new(MonotonicallyIncreasingId::new(self.partition)))
             }
             expr => Err(GeneralError(format!("Not implemented: {expr:?}"))),
         }

--- a/native/proto/src/proto/expr.proto
+++ b/native/proto/src/proto/expr.proto
@@ -82,6 +82,8 @@ message Expr {
     ToPrettyString to_pretty_string = 60;
     Rand rand = 61;
     Rand randn = 62;
+    EmptyExpr spark_partition_id = 63;
+    EmptyExpr monotonically_increasing_id = 64;
   }
 }
 
@@ -248,6 +250,9 @@ message BinaryExpr {
 
 message UnaryExpr {
   Expr child = 1;
+}
+
+message EmptyExpr {
 }
 
 // Bound to a particular vector array in input batch.

--- a/native/spark-expr/src/nondetermenistic_funcs/mod.rs
+++ b/native/spark-expr/src/nondetermenistic_funcs/mod.rs
@@ -20,6 +20,5 @@ pub mod monotonically_increasing_id;
 pub mod rand;
 pub mod randn;
 
-pub use monotonically_increasing_id::monotonically_increasing_id;
 pub use rand::RandExpr;
 pub use randn::RandnExpr;

--- a/native/spark-expr/src/nondetermenistic_funcs/mod.rs
+++ b/native/spark-expr/src/nondetermenistic_funcs/mod.rs
@@ -16,8 +16,10 @@
 // under the License.
 
 pub mod internal;
+pub mod monotonically_increasing_id;
 pub mod rand;
 pub mod randn;
 
+pub use monotonically_increasing_id::monotonically_increasing_id;
 pub use rand::RandExpr;
 pub use randn::RandnExpr;

--- a/native/spark-expr/src/nondetermenistic_funcs/monotonically_increasing_id.rs
+++ b/native/spark-expr/src/nondetermenistic_funcs/monotonically_increasing_id.rs
@@ -1,0 +1,163 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::{Int64Array, RecordBatch};
+use arrow::datatypes::{DataType, Schema};
+use datafusion::common::Result;
+use datafusion::logical_expr::ColumnarValue;
+use datafusion::physical_expr::PhysicalExpr;
+use std::any::Any;
+use std::fmt::{Debug, Display, Formatter};
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug)]
+pub struct MonotonicallyIncreasingId {
+    initial_offset: i64,
+    current_offset: Arc<Mutex<i64>>,
+}
+
+impl MonotonicallyIncreasingId {
+    pub fn new(offset: i64) -> Self {
+        Self {
+            initial_offset: offset,
+            current_offset: Arc::new(Mutex::new(offset)),
+        }
+    }
+}
+
+pub fn monotonically_increasing_id(offset: i64) -> Arc<dyn PhysicalExpr> {
+    Arc::new(MonotonicallyIncreasingId::new(offset))
+}
+
+impl Display for MonotonicallyIncreasingId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "monotonically_increasing_id()")
+    }
+}
+
+impl PartialEq for MonotonicallyIncreasingId {
+    fn eq(&self, other: &Self) -> bool {
+        self.initial_offset == other.initial_offset
+    }
+}
+
+impl Eq for MonotonicallyIncreasingId {}
+
+impl Hash for MonotonicallyIncreasingId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.children().hash(state);
+    }
+}
+
+impl PhysicalExpr for MonotonicallyIncreasingId {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn evaluate(&self, batch: &RecordBatch) -> Result<ColumnarValue> {
+        let mut current_offset = self.current_offset.lock().unwrap();
+        let start = *current_offset;
+        let end = *current_offset + batch.num_rows() as i64;
+        let array_ref = Arc::new(Int64Array::from_iter_values(start..end));
+        *current_offset = start + batch.num_rows() as i64;
+        Ok(ColumnarValue::Array(array_ref))
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn PhysicalExpr>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        Ok(Arc::new(MonotonicallyIncreasingId::new(
+            self.initial_offset,
+        )))
+    }
+
+    fn fmt_sql(&self, _: &mut Formatter<'_>) -> std::fmt::Result {
+        unimplemented!()
+    }
+
+    fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
+        Ok(DataType::Int64)
+    }
+
+    fn nullable(&self, _input_schema: &Schema) -> Result<bool> {
+        Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, Int64Array};
+    use arrow::compute::concat;
+    use arrow::{array::StringArray, datatypes::*};
+    use datafusion::common::cast::as_int64_array;
+
+    #[test]
+    fn test_monotonically_increasing_id_single_batch() -> Result<()> {
+        let schema = Schema::new(vec![Field::new("a", DataType::Utf8, true)]);
+        let data = StringArray::from(vec![Some("foo"), None, None, Some("bar"), None]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(data)])?;
+        let mid_expr = monotonically_increasing_id(0);
+        let result = mid_expr.evaluate(&batch)?.into_array(batch.num_rows())?;
+        let result = as_int64_array(&result)?;
+        let expected = &Int64Array::from_iter_values(0..batch.num_rows() as i64);
+        assert_eq!(result, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_monotonically_increasing_id_multi_batch() -> Result<()> {
+        let first_batch_schema = Schema::new(vec![Field::new("a", DataType::Int64, true)]);
+        let first_batch_data = Int64Array::from(vec![Some(42), None]);
+        let second_batch_schema = first_batch_schema.clone();
+        let second_batch_data = Int64Array::from(vec![None, Some(-42), None]);
+        let starting_offset: i64 = 100;
+        let mid_expr = monotonically_increasing_id(starting_offset);
+        let first_batch = RecordBatch::try_new(
+            Arc::new(first_batch_schema),
+            vec![Arc::new(first_batch_data)],
+        )?;
+        let first_batch_result = mid_expr
+            .evaluate(&first_batch)?
+            .into_array(first_batch.num_rows())?;
+        let second_batch = RecordBatch::try_new(
+            Arc::new(second_batch_schema),
+            vec![Arc::new(second_batch_data)],
+        )?;
+        let second_batch_result = mid_expr
+            .evaluate(&second_batch)?
+            .into_array(second_batch.num_rows())?;
+        let result_arrays: Vec<&dyn Array> = vec![
+            as_int64_array(&first_batch_result)?,
+            as_int64_array(&second_batch_result)?,
+        ];
+        let result_arrays = &concat(&result_arrays)?;
+        let final_result = as_int64_array(result_arrays)?;
+        let range_start = starting_offset;
+        let range_end =
+            starting_offset + first_batch.num_rows() as i64 + second_batch.num_rows() as i64;
+        let expected = &Int64Array::from_iter_values(range_start..range_end);
+        assert_eq!(final_result, expected);
+        Ok(())
+    }
+}

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -120,7 +120,11 @@ object QueryPlanSerde extends Logging with CometExprShim {
     classOf[MapKeys] -> CometMapKeys,
     classOf[MapValues] -> CometMapValues,
     classOf[MapFromArrays] -> CometMapFromArrays,
-    classOf[GetMapValue] -> CometMapExtract)
+    classOf[GetMapValue] -> CometMapExtract,
+    classOf[Rand] -> CometRand,
+    classOf[Randn] -> CometRandn,
+    classOf[SparkPartitionID] -> CometSparkPartitionId,
+    classOf[MonotonicallyIncreasingID] -> CometMonotonicallyIncreasingId)
 
   def emitWarning(reason: String): Unit = {
     logWarning(s"Comet native execution is disabled due to: $reason")
@@ -1859,28 +1863,6 @@ object QueryPlanSerde extends Logging with CometExprShim {
         convert(CometArrayCompact)
       case _: ArrayExcept =>
         convert(CometArrayExcept)
-      case Rand(child, _) =>
-        val seed = child match {
-          case Literal(seed: Long, _) => Some(seed)
-          case Literal(null, _) => Some(0L)
-          case _ => None
-        }
-        seed.map(seed =>
-          ExprOuterClass.Expr
-            .newBuilder()
-            .setRand(ExprOuterClass.Rand.newBuilder().setSeed(seed))
-            .build())
-      case Randn(child, _) =>
-        val seed = child match {
-          case Literal(seed: Long, _) => Some(seed)
-          case Literal(null, _) => Some(0L)
-          case _ => None
-        }
-        seed.map(seed =>
-          ExprOuterClass.Expr
-            .newBuilder()
-            .setRandn(ExprOuterClass.Rand.newBuilder().setSeed(seed))
-            .build())
       case expr =>
         QueryPlanSerde.exprSerdeMap.get(expr.getClass) match {
           case Some(handler) => convert(handler)

--- a/spark/src/main/scala/org/apache/comet/serde/nondetermenistic.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/nondetermenistic.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.serde
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, Literal, MonotonicallyIncreasingID, Rand, Randn, SparkPartitionID}
+
+object CometSparkPartitionId extends CometExpressionSerde {
+  override def convert(
+      expr: Expression,
+      _inputs: Seq[Attribute],
+      _binding: Boolean): Option[ExprOuterClass.Expr] = {
+    assert(expr.isInstanceOf[SparkPartitionID])
+    Some(
+      ExprOuterClass.Expr
+        .newBuilder()
+        .setSparkPartitionId(ExprOuterClass.EmptyExpr.newBuilder())
+        .build())
+  }
+}
+
+object CometMonotonicallyIncreasingId extends CometExpressionSerde {
+  override def convert(
+      expr: Expression,
+      _inputs: Seq[Attribute],
+      _binding: Boolean): Option[ExprOuterClass.Expr] = {
+    assert(expr.isInstanceOf[MonotonicallyIncreasingID])
+    Some(
+      ExprOuterClass.Expr
+        .newBuilder()
+        .setMonotonicallyIncreasingId(ExprOuterClass.EmptyExpr.newBuilder())
+        .build())
+  }
+}
+
+sealed abstract class CometRandCommonSerde extends CometExpressionSerde {
+  protected def extractSeedFromExpr(expr: Expression): Option[Long] = {
+    expr match {
+      case Literal(seed: Long, _) => Some(seed)
+      case Literal(null, _) => Some(0L)
+      case _ => None
+    }
+  }
+}
+
+object CometRand extends CometRandCommonSerde {
+  override def convert(
+      expr: Expression,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    val Rand(child, _) = expr
+    extractSeedFromExpr(child).map { seed =>
+      ExprOuterClass.Expr
+        .newBuilder()
+        .setRand(ExprOuterClass.Rand.newBuilder().setSeed(seed))
+        .build()
+    }
+  }
+}
+
+object CometRandn extends CometRandCommonSerde {
+  override def convert(
+      expr: Expression,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    val Randn(child, _) = expr
+    extractSeedFromExpr(child).map { seed =>
+      ExprOuterClass.Expr
+        .newBuilder()
+        .setRandn(ExprOuterClass.Rand.newBuilder().setSeed(seed))
+        .build()
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -2781,6 +2781,26 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("spark_partition_id expression on random dataset") {
+    testOnShuffledRangeWithRandomParameters { df =>
+      val dfWithRandParameters =
+        df.withColumn("pid1", spark_partition_id())
+          .repartition(3)
+          .withColumn("pid2", spark_partition_id())
+      checkSparkAnswerAndOperator(dfWithRandParameters)
+    }
+  }
+
+  test("monotonically_increasing_id expression on random dataset") {
+    testOnShuffledRangeWithRandomParameters { df =>
+      val dfWithRandParameters =
+        df.withColumn("mid1", monotonically_increasing_id())
+          .repartition(3)
+          .withColumn("mid2", monotonically_increasing_id())
+      checkSparkAnswerAndOperator(dfWithRandParameters)
+    }
+  }
+
   test("multiple nondetermenistic expressions with shuffle") {
     testOnShuffledRangeWithRandomParameters { df =>
       val seed1 = Random.nextLong()


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change
Added support for spark_partition_id and monotonically_increasing_id expressions

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Spark-compatible spark_partition_id and monotonically_increasing_id expressions implementation and small refactoring of the scala serde-code related to non-deterministic functions.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?
Unit tests in scala and rust. 
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
