### PR TITLE
chore: create copy of fs-hdfs

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -11,3 +11,6 @@ Specifically:
 
 This product includes software developed at
 DataFusion HDFS ObjectStore Contrib Package(https://github.com/datafusion-contrib/datafusion-objectstore-hdfs)
+
+This product includes software developed at
+DataFusion fs-hdfs3 Contrib Package(https://github.com/datafusion-contrib/fs-hdfs)

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tracing",
- "uuid",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -1430,7 +1430,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "url",
- "uuid",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -1539,7 +1539,7 @@ dependencies = [
  "bytes",
  "chrono",
  "fs-hdfs",
- "fs-hdfs3",
+ "fs-hdfs3 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "object_store",
  "tokio",
@@ -1803,7 +1803,7 @@ dependencies = [
  "regex",
  "sha2",
  "unicode-segmentation",
- "uuid",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -2101,7 +2101,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
- "uuid",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -2305,6 +2305,21 @@ dependencies = [
  "libc",
  "log",
  "url",
+]
+
+[[package]]
+name = "fs-hdfs3"
+version = "0.1.12"
+dependencies = [
+ "bindgen 0.64.0",
+ "cc",
+ "java-locator",
+ "lazy_static",
+ "libc",
+ "log",
+ "tempfile",
+ "url",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -4483,7 +4498,7 @@ dependencies = [
  "debugid",
  "memmap2",
  "stable_deref_trait",
- "uuid",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -4939,6 +4954,15 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.16",
+]
 
 [[package]]
 name = "uuid"

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1532,6 +1532,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-comet-fs-hdfs3"
+version = "0.1.12"
+dependencies = [
+ "bindgen 0.64.0",
+ "cc",
+ "java-locator",
+ "lazy_static",
+ "libc",
+ "log",
+ "tempfile",
+ "url",
+ "uuid 0.8.2",
+]
+
+[[package]]
 name = "datafusion-comet-objectstore-hdfs"
 version = "0.10.0"
 dependencies = [
@@ -1539,7 +1554,7 @@ dependencies = [
  "bytes",
  "chrono",
  "fs-hdfs",
- "fs-hdfs3 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs-hdfs3",
  "futures",
  "object_store",
  "tokio",
@@ -2305,21 +2320,6 @@ dependencies = [
  "libc",
  "log",
  "url",
-]
-
-[[package]]
-name = "fs-hdfs3"
-version = "0.1.12"
-dependencies = [
- "bindgen 0.64.0",
- "cc",
- "java-locator",
- "lazy_static",
- "libc",
- "log",
- "tempfile",
- "url",
- "uuid 0.8.2",
 ]
 
 [[package]]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -17,7 +17,7 @@
 
 [workspace]
 default-members = ["core", "spark-expr", "proto"]
-members = ["core", "spark-expr", "proto", "hdfs"]
+members = ["core", "spark-expr", "proto", "hdfs", "fs-hdfs"]
 resolver = "2"
 
 [workspace.package]

--- a/native/fs-hdfs/Cargo.toml
+++ b/native/fs-hdfs/Cargo.toml
@@ -16,7 +16,7 @@
 # under the License.
 
 [package]
-name = "fs-hdfs3"
+name = "datafusion-comet-fs-hdfs3"
 version = "0.1.12"
 edition = "2021"
 

--- a/native/fs-hdfs/Cargo.toml
+++ b/native/fs-hdfs/Cargo.toml
@@ -21,13 +21,14 @@ version = "0.1.12"
 edition = "2021"
 
 description = "libhdfs binding library and safe Rust APIs"
-authors = ["Yanghong Zhong <nju_yaho@apache.org>"]
+authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
 license = "Apache-2.0"
 
 keywords = ["hdfs", "hadoop"]
 documentation = "https://docs.rs/crate/fs-hdfs3"
 homepage = "https://github.com/datafusion-contrib/fs-hdfs"
 repository = "https://github.com/datafusion-contrib/fs-hdfs"
+publish = false
 readme = "README.md"
 
 [lib]

--- a/native/fs-hdfs/Cargo.toml
+++ b/native/fs-hdfs/Cargo.toml
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+name = "fs-hdfs3"
+version = "0.1.12"
+edition = "2021"
+
+description = "libhdfs binding library and safe Rust APIs"
+authors = ["Yanghong Zhong <nju_yaho@apache.org>"]
+license = "Apache-2.0"
+
+keywords = ["hdfs", "hadoop"]
+documentation = "https://docs.rs/crate/fs-hdfs3"
+homepage = "https://github.com/datafusion-contrib/fs-hdfs"
+repository = "https://github.com/datafusion-contrib/fs-hdfs"
+readme = "README.md"
+
+[lib]
+name = "hdfs"
+path = "src/lib.rs"
+
+[features]
+default = ["test_util"]
+test_util = []
+use_existing_hdfs = []
+
+[build-dependencies]
+cc = "1"
+bindgen = "0.64.0"
+java-locator = { version = "0.1.9", features = ["locate-jdk-only"] }
+
+[dependencies]
+lazy_static = "^1.4"
+libc = "^0.2"
+url = "^2.2"
+log = "^0.4"
+
+[dev-dependencies]
+uuid = {version = "^0.8", features = ["v4"]}
+tempfile = "^3.2"

--- a/native/fs-hdfs/LICENSE.txt
+++ b/native/fs-hdfs/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/native/fs-hdfs/README.md
+++ b/native/fs-hdfs/README.md
@@ -1,3 +1,22 @@
+ <!--
+Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
 # fs-hdfs3
 
 It's based on the version ``0.0.4`` of http://hyunsik.github.io/hdfs-rs to provide libhdfs binding library and rust APIs which safely wraps libhdfs binding APIs.

--- a/native/fs-hdfs/README.md
+++ b/native/fs-hdfs/README.md
@@ -1,0 +1,87 @@
+# fs-hdfs3
+
+It's based on the version ``0.0.4`` of http://hyunsik.github.io/hdfs-rs to provide libhdfs binding library and rust APIs which safely wraps libhdfs binding APIs.
+
+# Current Status
+* All libhdfs FFI APIs are ported.
+* Safe Rust wrapping APIs to cover most of the libhdfs APIs except those related to zero-copy read.
+* Compared to hdfs-rs, it removes the lifetime in HdfsFs, which will be more friendly for others to depend on.
+
+## Documentation
+* [API documentation] (https://docs.rs/crate/fs-hdfs3)
+
+## Requirements
+* The C related files are from the branch ``3.1.4`` of hadoop repository. For rust usage, a few changes are also applied.
+* No need to compile the Hadoop native library by yourself. However, the Hadoop jar dependencies are still required.
+
+## Usage
+Add this to your Cargo.toml:
+
+```toml
+[dependencies]
+fs-hdfs3 = "0.1.12"
+```
+
+### Build
+
+We need to specify ```$JAVA_HOME``` to make Java shared library available for building.
+
+### Run
+Since our compiled libhdfs is JNI-based implementation, 
+it requires Hadoop-related classes available through ``CLASSPATH``. An example,
+
+```sh
+export CLASSPATH=$CLASSPATH:`hadoop classpath --glob`
+```
+
+Also, we need to specify the JVM dynamic library path for the application to load the JVM shared library at runtime.
+
+For jdk8 and macOS, it's
+
+```sh
+export DYLD_LIBRARY_PATH=$JAVA_HOME/jre/lib/server
+```
+
+For jdk11 (or later jdks) and macOS, it's
+
+```sh
+export DYLD_LIBRARY_PATH=$JAVA_HOME/lib/server
+```
+
+For jdk8 and Centos
+```sh
+export LD_LIBRARY_PATH=$JAVA_HOME/jre/lib/amd64/server
+```
+
+For jdk11 (or later jdks) and Centos
+```sh
+export LD_LIBRARY_PATH=$JAVA_HOME/lib/server
+```
+
+### Testing
+The test also requires the ``CLASSPATH`` and `DYLD_LIBRARY_PATH` (or `LD_LIBRARY_PATH`). In case that the java class of ``org.junit.Assert`` can't be found. Refine the ``$CLASSPATH`` as follows:
+
+```sh
+export CLASSPATH=$CLASSPATH:`hadoop classpath --glob`:$HADOOP_HOME/share/hadoop/tools/lib/*
+```
+
+Here, ``$HADOOP_HOME`` need to be specified and exported.
+
+Then you can run
+
+```bash
+cargo test
+```
+
+## Example
+
+```rust
+use std::sync::Arc;
+use hdfs::hdfs::{get_hdfs_by_full_path, HdfsFs};
+
+let fs: Arc<HdfsFs> = get_hdfs_by_full_path("hdfs://localhost:8020/").ok().unwrap();
+match fs.mkdir("/data") {
+    Ok(_) => { println!("/data has been created") },
+    Err(_)  => { panic!("/data creation has failed") }
+};
+```

--- a/native/fs-hdfs/build.rs
+++ b/native/fs-hdfs/build.rs
@@ -1,0 +1,158 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let vec_flags = &get_build_flags();
+
+    build_hdfs_lib(vec_flags);
+
+    build_minidfs_lib(vec_flags);
+
+    build_ffi(vec_flags);
+}
+
+fn build_ffi(flags: &[String]) {
+    let (header, output) = ("c_src/wrapper.h", "hdfs-native.rs");
+    // Tell cargo to invalidate the built crate whenever the wrapper changes
+    println!("cargo:rerun-if-changed={}", header);
+    println!("cargo:rerun-if-changed={}", get_hdfs_file_path("hdfs.h"));
+    println!(
+        "cargo:rerun-if-changed={}",
+        get_minidfs_file_path("native_mini_dfs.h")
+    );
+
+    // To avoid the order issue of dependent dynamic libraries
+    println!("cargo:rustc-link-lib=jvm");
+
+    let bindings = bindgen::Builder::default()
+        .header(header)
+        .allowlist_function("nmd.*")
+        .allowlist_function("hdfs.*")
+        .allowlist_function("hadoop.*")
+        .clang_args(flags)
+        .rustified_enum("tObjectKind")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join(output))
+        .expect("Couldn't write bindings!");
+}
+
+fn build_hdfs_lib(flags: &[String]) {
+    println!("cargo:rerun-if-changed={}", get_hdfs_file_path("hdfs.c"));
+
+    let mut builder = cc::Build::new();
+
+    // includes
+    builder
+        .include(get_hdfs_source_dir())
+        .include(format!("{}/os/posix", get_hdfs_source_dir()));
+
+    // files
+    builder
+        .file(get_hdfs_file_path("exception.c"))
+        .file(get_hdfs_file_path("htable.c"))
+        .file(get_hdfs_file_path("jni_helper.c"))
+        .file(get_hdfs_file_os_path("mutexes.c"))
+        .file(get_hdfs_file_os_path("thread_local_storage.c"))
+        .file(get_hdfs_file_path("hdfs.c"));
+
+    for flag in flags {
+        builder.flag(flag);
+    }
+
+    // disable the warning message
+    builder.warnings(false);
+
+    builder.compile("hdfs");
+}
+
+fn build_minidfs_lib(flags: &[String]) {
+    println!(
+        "cargo:rerun-if-changed={}",
+        get_minidfs_file_path("native_mini_dfs.c")
+    );
+
+    let mut builder = cc::Build::new();
+
+    // includes
+    builder
+        .include(get_hdfs_source_dir())
+        .include(format!("{}/os/posix", get_hdfs_source_dir()));
+
+    // files
+    builder.file(get_minidfs_file_path("native_mini_dfs.c"));
+
+    for flag in flags {
+        builder.flag(flag.as_str());
+    }
+    builder.compile("minidfs");
+}
+
+fn get_build_flags() -> Vec<String> {
+    let mut result = vec![];
+
+    result.extend(get_java_dependency());
+    result.push(String::from("-Wno-incompatible-pointer-types"));
+
+    result
+}
+
+fn get_java_dependency() -> Vec<String> {
+    let mut result = vec![];
+
+    // Include directories
+    let java_home = java_locator::locate_java_home()
+        .expect("JAVA_HOME could not be found, trying setting the variable manually");
+    result.push(format!("-I{java_home}/include"));
+    #[cfg(target_os = "linux")]
+    result.push(format!("-I{java_home}/include/linux"));
+    #[cfg(target_os = "macos")]
+    result.push(format!("-I{java_home}/include/darwin"));
+
+    // libjvm link
+    let jvm_lib_location = java_locator::locate_jvm_dyn_library().unwrap();
+    println!("cargo:rustc-link-search=native={}", jvm_lib_location);
+    println!("cargo:rustc-link-lib=jvm");
+
+    // For tests, add libjvm path to rpath, this does not propagate upwards,
+    // unless building an .so, as per Cargo specs, so is only used when testing
+    println!("cargo:rustc-link-arg=-Wl,-rpath,{jvm_lib_location}");
+
+    result
+}
+
+fn get_hdfs_file_path(filename: &'static str) -> String {
+    format!("{}/{}", get_hdfs_source_dir(), filename)
+}
+
+fn get_hdfs_file_os_path(filename: &'static str) -> String {
+    format!("{}/os/posix/{}", get_hdfs_source_dir(), filename)
+}
+
+fn get_hdfs_source_dir() -> &'static str {
+    "c_src/libhdfs"
+}
+
+fn get_minidfs_file_path(filename: &'static str) -> String {
+    format!("{}/{}", "c_src/libminidfs", filename)
+}

--- a/native/fs-hdfs/build.rs
+++ b/native/fs-hdfs/build.rs
@@ -31,7 +31,7 @@ fn main() {
 fn build_ffi(flags: &[String]) {
     let (header, output) = ("c_src/wrapper.h", "hdfs-native.rs");
     // Tell cargo to invalidate the built crate whenever the wrapper changes
-    println!("cargo:rerun-if-changed={}", header);
+    println!("cargo:rerun-if-changed={header}");
     println!("cargo:rerun-if-changed={}", get_hdfs_file_path("hdfs.h"));
     println!(
         "cargo:rerun-if-changed={}",
@@ -131,7 +131,7 @@ fn get_java_dependency() -> Vec<String> {
 
     // libjvm link
     let jvm_lib_location = java_locator::locate_jvm_dyn_library().unwrap();
-    println!("cargo:rustc-link-search=native={}", jvm_lib_location);
+    println!("cargo:rustc-link-search=native={jvm_lib_location}");
     println!("cargo:rustc-link-lib=jvm");
 
     // For tests, add libjvm path to rpath, this does not propagate upwards,

--- a/native/fs-hdfs/c_src/libhdfs/config.h
+++ b/native/fs-hdfs/c_src/libhdfs/config.h
@@ -1,0 +1,27 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#define _FUSE_DFS_VERSION "0.1.0"
+
+#define HAVE_BETTER_TLS
+
+#define HAVE_INTEL_SSE_INTRINSICS
+
+#endif

--- a/native/fs-hdfs/c_src/libhdfs/exception.c
+++ b/native/fs-hdfs/c_src/libhdfs/exception.c
@@ -1,0 +1,272 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exception.h"
+#include "hdfs.h"
+#include "jni_helper.h"
+#include "platform.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define EXCEPTION_INFO_LEN (sizeof(gExceptionInfo)/sizeof(gExceptionInfo[0]))
+
+struct ExceptionInfo {
+    const char * const name;
+    int noPrintFlag;
+    int excErrno;
+};
+
+static const struct ExceptionInfo gExceptionInfo[] = {
+    {
+        "java.io.FileNotFoundException",
+        NOPRINT_EXC_FILE_NOT_FOUND,
+        ENOENT,
+    },
+    {
+        "org.apache.hadoop.security.AccessControlException",
+        NOPRINT_EXC_ACCESS_CONTROL,
+        EACCES,
+    },
+    {
+        "org.apache.hadoop.fs.UnresolvedLinkException",
+        NOPRINT_EXC_UNRESOLVED_LINK,
+        ENOLINK,
+    },
+    {
+        "org.apache.hadoop.fs.ParentNotDirectoryException",
+        NOPRINT_EXC_PARENT_NOT_DIRECTORY,
+        ENOTDIR,
+    },
+    {
+        "java.lang.IllegalArgumentException",
+        NOPRINT_EXC_ILLEGAL_ARGUMENT,
+        EINVAL,
+    },
+    {
+        "java.lang.OutOfMemoryError",
+        0,
+        ENOMEM,
+    },
+    {
+        "org.apache.hadoop.hdfs.server.namenode.SafeModeException",
+        0,
+        EROFS,
+    },
+    {
+        "org.apache.hadoop.fs.FileAlreadyExistsException",
+        0,
+        EEXIST,
+    },
+    {
+        "org.apache.hadoop.hdfs.protocol.QuotaExceededException",
+        0,
+        EDQUOT,
+    },
+    {
+        "java.lang.UnsupportedOperationException",
+        0,
+        ENOTSUP,
+    },
+    {
+        "org.apache.hadoop.hdfs.server.namenode.LeaseExpiredException",
+        0,
+        ESTALE,
+    },
+};
+
+void getExceptionInfo(const char *excName, int noPrintFlags,
+                      int *excErrno, int *shouldPrint)
+{
+    int i;
+
+    for (i = 0; i < EXCEPTION_INFO_LEN; i++) {
+        if (strstr(gExceptionInfo[i].name, excName)) {
+            break;
+        }
+    }
+    if (i < EXCEPTION_INFO_LEN) {
+        *shouldPrint = !(gExceptionInfo[i].noPrintFlag & noPrintFlags);
+        *excErrno = gExceptionInfo[i].excErrno;
+    } else {
+        *shouldPrint = 1;
+        *excErrno = EINTERNAL;
+    }
+}
+
+/**
+ * getExceptionUtilString: A helper function that calls 'methodName' in
+ * ExceptionUtils. The function 'methodName' should have a return type of a
+ * java String.
+ *
+ * @param env        The JNI environment.
+ * @param exc        The exception to get information for.
+ * @param methodName The method of ExceptionUtils to call that has a String
+ *                    return type.
+ *
+ * @return           A C-type string containing the string returned by
+ *                   ExceptionUtils.'methodName', or NULL on failure.
+ */
+static char* getExceptionUtilString(JNIEnv *env, jthrowable exc, char *methodName)
+{
+    jthrowable jthr;
+    jvalue jVal;
+    jstring jStr = NULL;
+    char *excString = NULL;
+    jthr = invokeMethod(env, &jVal, STATIC, NULL,
+        "org/apache/commons/lang/exception/ExceptionUtils",
+        methodName, "(Ljava/lang/Throwable;)Ljava/lang/String;", exc);
+    if (jthr) {
+        destroyLocalReference(env, jthr);
+        return NULL;
+    }
+    jStr = jVal.l;
+    jthr = newCStr(env, jStr, &excString);
+    if (jthr) {
+        destroyLocalReference(env, jthr);
+        return NULL;
+    }
+    destroyLocalReference(env, jStr);
+    return excString;
+}
+
+int printExceptionAndFreeV(JNIEnv *env, jthrowable exc, int noPrintFlags,
+        const char *fmt, va_list ap)
+{
+    int i, noPrint, excErrno;
+    char *className = NULL;
+    jthrowable jthr;
+    const char *stackTrace;
+    const char *rootCause;
+
+    jthr = classNameOfObject(exc, env, &className);
+    if (jthr) {
+        fprintf(stderr, "PrintExceptionAndFree: error determining class name "
+            "of exception.\n");
+        className = strdup("(unknown)");
+        destroyLocalReference(env, jthr);
+    }
+    for (i = 0; i < EXCEPTION_INFO_LEN; i++) {
+        if (!strcmp(gExceptionInfo[i].name, className)) {
+            break;
+        }
+    }
+    if (i < EXCEPTION_INFO_LEN) {
+        noPrint = (gExceptionInfo[i].noPrintFlag & noPrintFlags);
+        excErrno = gExceptionInfo[i].excErrno;
+    } else {
+        noPrint = 0;
+        excErrno = EINTERNAL;
+    }
+
+    // We don't want to use ExceptionDescribe here, because that requires a
+    // pending exception. Instead, use ExceptionUtils.
+    rootCause = getExceptionUtilString(env, exc, "getRootCauseMessage");
+    stackTrace = getExceptionUtilString(env, exc, "getStackTrace");
+    // Save the exception details in the thread-local state.
+    setTLSExceptionStrings(rootCause, stackTrace);
+
+    if (!noPrint) {
+        vfprintf(stderr, fmt, ap);
+        fprintf(stderr, " error:\n");
+
+        if (!rootCause) {
+            fprintf(stderr, "(unable to get root cause for %s)\n", className);
+        } else {
+            fprintf(stderr, "%s", rootCause);
+        }
+        if (!stackTrace) {
+            fprintf(stderr, "(unable to get stack trace for %s)\n", className);
+        } else {
+            fprintf(stderr, "%s", stackTrace);
+        }
+    }
+
+    destroyLocalReference(env, exc);
+    free(className);
+    return excErrno;
+}
+
+int printExceptionAndFree(JNIEnv *env, jthrowable exc, int noPrintFlags,
+        const char *fmt, ...)
+{
+    va_list ap;
+    int ret;
+
+    va_start(ap, fmt);
+    ret = printExceptionAndFreeV(env, exc, noPrintFlags, fmt, ap);
+    va_end(ap);
+    return ret;
+}
+
+int printPendingExceptionAndFree(JNIEnv *env, int noPrintFlags,
+        const char *fmt, ...)
+{
+    va_list ap;
+    int ret;
+    jthrowable exc;
+
+    exc = (*env)->ExceptionOccurred(env);
+    if (!exc) {
+        va_start(ap, fmt);
+        vfprintf(stderr, fmt, ap);
+        va_end(ap);
+        fprintf(stderr, " error: (no exception)");
+        ret = 0;
+    } else {
+        (*env)->ExceptionClear(env);
+        va_start(ap, fmt);
+        ret = printExceptionAndFreeV(env, exc, noPrintFlags, fmt, ap);
+        va_end(ap);
+    }
+    return ret;
+}
+
+jthrowable getPendingExceptionAndClear(JNIEnv *env)
+{
+    jthrowable jthr = (*env)->ExceptionOccurred(env);
+    if (!jthr)
+        return NULL;
+    (*env)->ExceptionClear(env);
+    return jthr;
+}
+
+jthrowable newRuntimeError(JNIEnv *env, const char *fmt, ...)
+{
+    char buf[512];
+    jobject out, exc;
+    jstring jstr;
+    va_list ap;
+
+    va_start(ap, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    jstr = (*env)->NewStringUTF(env, buf);
+    if (!jstr) {
+        // We got an out of memory exception rather than a RuntimeException.
+        // Too bad...
+        return getPendingExceptionAndClear(env);
+    }
+    exc = constructNewObjectOfClass(env, &out, "RuntimeException",
+        "(java/lang/String;)V", jstr);
+    (*env)->DeleteLocalRef(env, jstr);
+    // Again, we'll either get an out of memory exception or the
+    // RuntimeException we wanted.
+    return (exc) ? exc : out;
+}

--- a/native/fs-hdfs/c_src/libhdfs/exception.h
+++ b/native/fs-hdfs/c_src/libhdfs/exception.h
@@ -1,0 +1,190 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LIBHDFS_EXCEPTION_H
+#define LIBHDFS_EXCEPTION_H
+
+/**
+ * Exception handling routines for libhdfs.
+ *
+ * The convention we follow here is to clear pending exceptions as soon as they
+ * are raised.  Never assume that the caller of your function will clean up
+ * after you-- do it yourself.  Unhandled exceptions can lead to memory leaks
+ * and other undefined behavior.
+ *
+ * If you encounter an exception, return a local reference to it.  The caller is
+ * responsible for freeing the local reference, by calling a function like
+ * printExceptionAndFree. (You can also free exceptions directly by calling
+ * DeleteLocalRef.  However, that would not produce an error message, so it's
+ * usually not what you want.)
+ *
+ * The root cause and stack trace exception strings retrieved from the last
+ * exception that happened on a thread are stored in the corresponding
+ * thread local state and are accessed by hdfsGetLastExceptionRootCause and
+ * hdfsGetLastExceptionStackTrace respectively.
+ */
+
+#include "platform.h"
+
+#include <jni.h>
+#include <stdio.h>
+
+#include <stdlib.h>
+#include <stdarg.h>
+#include <search.h>
+#include <errno.h>
+
+/**
+ * Exception noprint flags
+ *
+ * Theses flags determine which exceptions should NOT be printed to stderr by
+ * the exception printing routines.  For example, if you expect to see
+ * FileNotFound, you might use NOPRINT_EXC_FILE_NOT_FOUND, to avoid filling the
+ * logs with messages about routine events.
+ *
+ * On the other hand, if you don't expect any failures, you might pass
+ * PRINT_EXC_ALL.
+ *
+ * You can OR these flags together to avoid printing multiple classes of
+ * exceptions.
+ */
+#define PRINT_EXC_ALL                           0x00
+#define NOPRINT_EXC_FILE_NOT_FOUND              0x01
+#define NOPRINT_EXC_ACCESS_CONTROL              0x02
+#define NOPRINT_EXC_UNRESOLVED_LINK             0x04
+#define NOPRINT_EXC_PARENT_NOT_DIRECTORY        0x08
+#define NOPRINT_EXC_ILLEGAL_ARGUMENT            0x10
+
+#ifdef WIN32
+#ifdef LIBHDFS_DLL_EXPORT
+        #define LIBHDFS_EXTERNAL __declspec(dllexport)
+    #elif LIBHDFS_DLL_IMPORT
+        #define LIBHDFS_EXTERNAL __declspec(dllimport)
+    #else
+        #define LIBHDFS_EXTERNAL
+    #endif
+#else
+#ifdef LIBHDFS_DLL_EXPORT
+#define LIBHDFS_EXTERNAL __attribute__((visibility("default")))
+#elif LIBHDFS_DLL_IMPORT
+#define LIBHDFS_EXTERNAL __attribute__((visibility("default")))
+#else
+#define LIBHDFS_EXTERNAL
+#endif
+#endif
+
+/**
+ * Get information about an exception.
+ *
+ * @param excName         The Exception name.
+ *                        This is a Java class name in JNI format.
+ * @param noPrintFlags    Flags which determine which exceptions we should NOT
+ *                        print.
+ * @param excErrno        (out param) The POSIX error number associated with the
+ *                        exception.
+ * @param shouldPrint     (out param) Nonzero if we should print this exception,
+ *                        based on the noPrintFlags and its name. 
+ */
+LIBHDFS_EXTERNAL
+void getExceptionInfo(const char *excName, int noPrintFlags,
+                      int *excErrno, int *shouldPrint);
+
+/**
+ * Store the information about an exception in the thread-local state and print
+ * it and free the jthrowable object.
+ *
+ * @param env             The JNI environment
+ * @param exc             The exception to print and free
+ * @param noPrintFlags    Flags which determine which exceptions we should NOT
+ *                        print.
+ * @param fmt             Printf-style format list
+ * @param ap              Printf-style varargs
+ *
+ * @return                The POSIX error number associated with the exception
+ *                        object.
+ */
+LIBHDFS_EXTERNAL
+int printExceptionAndFreeV(JNIEnv *env, jthrowable exc, int noPrintFlags,
+        const char *fmt, va_list ap);
+
+/**
+ * Store the information about an exception in the thread-local state and print
+ * it and free the jthrowable object.
+ *
+ * @param env             The JNI environment
+ * @param exc             The exception to print and free
+ * @param noPrintFlags    Flags which determine which exceptions we should NOT
+ *                        print.
+ * @param fmt             Printf-style format list
+ * @param ...             Printf-style varargs
+ *
+ * @return                The POSIX error number associated with the exception
+ *                        object.
+ */
+LIBHDFS_EXTERNAL
+int printExceptionAndFree(JNIEnv *env, jthrowable exc, int noPrintFlags,
+        const char *fmt, ...) TYPE_CHECKED_PRINTF_FORMAT(4, 5);
+
+/**
+ * Store the information about the pending exception in the thread-local state
+ * and print it and free the jthrowable object.
+ *
+ * @param env             The JNI environment
+ * @param noPrintFlags    Flags which determine which exceptions we should NOT
+ *                        print.
+ * @param fmt             Printf-style format list
+ * @param ...             Printf-style varargs
+ *
+ * @return                The POSIX error number associated with the exception
+ *                        object.
+ */
+LIBHDFS_EXTERNAL
+int printPendingExceptionAndFree(JNIEnv *env, int noPrintFlags,
+        const char *fmt, ...) TYPE_CHECKED_PRINTF_FORMAT(3, 4);
+
+/**
+ * Get a local reference to the pending exception and clear it.
+ *
+ * Once it is cleared, the exception will no longer be pending.  The caller will
+ * have to decide what to do with the exception object.
+ *
+ * @param env             The JNI environment
+ *
+ * @return                The exception, or NULL if there was no exception
+ */
+LIBHDFS_EXTERNAL
+jthrowable getPendingExceptionAndClear(JNIEnv *env);
+
+/**
+ * Create a new runtime error.
+ *
+ * This creates (but does not throw) a new RuntimeError.
+ *
+ * @param env             The JNI environment
+ * @param fmt             Printf-style format list
+ * @param ...             Printf-style varargs
+ *
+ * @return                A local reference to a RuntimeError
+ */
+LIBHDFS_EXTERNAL
+jthrowable newRuntimeError(JNIEnv *env, const char *fmt, ...)
+        TYPE_CHECKED_PRINTF_FORMAT(2, 3);
+
+#undef TYPE_CHECKED_PRINTF_FORMAT
+#undef LIBHDFS_EXTERNAL
+#endif

--- a/native/fs-hdfs/c_src/libhdfs/hdfs.c
+++ b/native/fs-hdfs/c_src/libhdfs/hdfs.c
@@ -1,0 +1,3605 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exception.h"
+#include "hdfs.h"
+#include "jni_helper.h"
+#include "platform.h"
+
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Some frequently used Java paths */
+#define HADOOP_CONF     "org/apache/hadoop/conf/Configuration"
+#define HADOOP_PATH     "org/apache/hadoop/fs/Path"
+#define HADOOP_LOCALFS  "org/apache/hadoop/fs/LocalFileSystem"
+#define HADOOP_FS       "org/apache/hadoop/fs/FileSystem"
+#define HADOOP_FSSTATUS "org/apache/hadoop/fs/FsStatus"
+#define HADOOP_BLK_LOC  "org/apache/hadoop/fs/BlockLocation"
+#define HADOOP_DFS      "org/apache/hadoop/hdfs/DistributedFileSystem"
+#define HADOOP_ISTRM    "org/apache/hadoop/fs/FSDataInputStream"
+#define HADOOP_OSTRM    "org/apache/hadoop/fs/FSDataOutputStream"
+#define HADOOP_STAT     "org/apache/hadoop/fs/FileStatus"
+#define HADOOP_FSPERM   "org/apache/hadoop/fs/permission/FsPermission"
+#define JAVA_NET_ISA    "java/net/InetSocketAddress"
+#define JAVA_NET_URI    "java/net/URI"
+#define JAVA_STRING     "java/lang/String"
+#define READ_OPTION     "org/apache/hadoop/fs/ReadOption"
+#define RENAME_OPTION   "org/apache/hadoop/fs/Options$Rename"
+
+#define JAVA_VOID       "V"
+
+/* Macros for constructing method signatures */
+#define JPARAM(X)           "L" X ";"
+#define JARRPARAM(X)        "[L" X ";"
+#define JMETHOD1(X, R)      "(" X ")" R
+#define JMETHOD2(X, Y, R)   "(" X Y ")" R
+#define JMETHOD3(X, Y, Z, R)   "(" X Y Z")" R
+
+#define KERBEROS_TICKET_CACHE_PATH "hadoop.security.kerberos.ticket.cache.path"
+
+// Bit fields for hdfsFile_internal flags
+#define HDFS_FILE_SUPPORTS_DIRECT_READ (1<<0)
+
+tSize readDirect(hdfsFS fs, hdfsFile f, void* buffer, tSize length);
+static void hdfsFreeFileInfoEntry(hdfsFileInfo *hdfsFileInfo);
+
+/**
+ * The C equivalent of org.apache.org.hadoop.FSData(Input|Output)Stream .
+ */
+enum hdfsStreamType
+{
+    HDFS_STREAM_UNINITIALIZED = 0,
+    HDFS_STREAM_INPUT = 1,
+    HDFS_STREAM_OUTPUT = 2,
+};
+
+/**
+ * The 'file-handle' to a file in hdfs.
+ */
+struct hdfsFile_internal {
+    void* file;
+    enum hdfsStreamType type;
+    int flags;
+};
+
+#define HDFS_EXTENDED_FILE_INFO_ENCRYPTED 0x1
+
+/**
+ * Extended file information.
+ */
+struct hdfsExtendedFileInfo {
+    int flags;
+};
+
+int hdfsFileIsOpenForRead(hdfsFile file)
+{
+    return (file->type == HDFS_STREAM_INPUT);
+}
+
+int hdfsGetHedgedReadMetrics(hdfsFS fs, struct hdfsHedgedReadMetrics **metrics)
+{
+    jthrowable jthr;
+    jobject hedgedReadMetrics = NULL;
+    jvalue jVal;
+    struct hdfsHedgedReadMetrics *m = NULL;
+    int ret;
+    jobject jFS = (jobject)fs;
+    JNIEnv* env = getJNIEnv();
+
+    if (env == NULL) {
+        errno = EINTERNAL;
+        return -1;
+    }
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, jFS,
+                  HADOOP_DFS,
+                  "getHedgedReadMetrics",
+                  "()Lorg/apache/hadoop/hdfs/DFSHedgedReadMetrics;");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsGetHedgedReadMetrics: getHedgedReadMetrics failed");
+        goto done;
+    }
+    hedgedReadMetrics = jVal.l;
+
+    m = malloc(sizeof(struct hdfsHedgedReadMetrics));
+    if (!m) {
+      ret = ENOMEM;
+      goto done;
+    }
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, hedgedReadMetrics,
+                  "org/apache/hadoop/hdfs/DFSHedgedReadMetrics",
+                  "getHedgedReadOps", "()J");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsGetHedgedReadStatistics: getHedgedReadOps failed");
+        goto done;
+    }
+    m->hedgedReadOps = jVal.j;
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, hedgedReadMetrics,
+                  "org/apache/hadoop/hdfs/DFSHedgedReadMetrics",
+                  "getHedgedReadWins", "()J");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsGetHedgedReadStatistics: getHedgedReadWins failed");
+        goto done;
+    }
+    m->hedgedReadOpsWin = jVal.j;
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, hedgedReadMetrics,
+                  "org/apache/hadoop/hdfs/DFSHedgedReadMetrics",
+                  "getHedgedReadOpsInCurThread", "()J");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsGetHedgedReadStatistics: getHedgedReadOpsInCurThread failed");
+        goto done;
+    }
+    m->hedgedReadOpsInCurThread = jVal.j;
+
+    *metrics = m;
+    m = NULL;
+    ret = 0;
+
+done:
+    destroyLocalReference(env, hedgedReadMetrics);
+    free(m);
+    if (ret) {
+      errno = ret;
+      return -1;
+    }
+    return 0;
+}
+
+void hdfsFreeHedgedReadMetrics(struct hdfsHedgedReadMetrics *metrics)
+{
+  free(metrics);
+}
+
+int hdfsFileGetReadStatistics(hdfsFile file,
+                              struct hdfsReadStatistics **stats)
+{
+    jthrowable jthr;
+    jobject readStats = NULL;
+    jvalue jVal;
+    struct hdfsReadStatistics *s = NULL;
+    int ret;
+    JNIEnv* env = getJNIEnv();
+
+    if (env == NULL) {
+        errno = EINTERNAL;
+        return -1;
+    }
+    if (file->type != HDFS_STREAM_INPUT) {
+        ret = EINVAL;
+        goto done;
+    }
+    jthr = invokeMethod(env, &jVal, INSTANCE, file->file, 
+                  "org/apache/hadoop/hdfs/client/HdfsDataInputStream",
+                  "getReadStatistics",
+                  "()Lorg/apache/hadoop/hdfs/ReadStatistics;");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsFileGetReadStatistics: getReadStatistics failed");
+        goto done;
+    }
+    readStats = jVal.l;
+    s = malloc(sizeof(struct hdfsReadStatistics));
+    if (!s) {
+        ret = ENOMEM;
+        goto done;
+    }
+    jthr = invokeMethod(env, &jVal, INSTANCE, readStats,
+                  "org/apache/hadoop/hdfs/ReadStatistics",
+                  "getTotalBytesRead", "()J");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsFileGetReadStatistics: getTotalBytesRead failed");
+        goto done;
+    }
+    s->totalBytesRead = jVal.j;
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, readStats,
+                  "org/apache/hadoop/hdfs/ReadStatistics",
+                  "getTotalLocalBytesRead", "()J");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsFileGetReadStatistics: getTotalLocalBytesRead failed");
+        goto done;
+    }
+    s->totalLocalBytesRead = jVal.j;
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, readStats,
+                  "org/apache/hadoop/hdfs/ReadStatistics",
+                  "getTotalShortCircuitBytesRead", "()J");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsFileGetReadStatistics: getTotalShortCircuitBytesRead failed");
+        goto done;
+    }
+    s->totalShortCircuitBytesRead = jVal.j;
+    jthr = invokeMethod(env, &jVal, INSTANCE, readStats,
+                  "org/apache/hadoop/hdfs/ReadStatistics",
+                  "getTotalZeroCopyBytesRead", "()J");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsFileGetReadStatistics: getTotalZeroCopyBytesRead failed");
+        goto done;
+    }
+    s->totalZeroCopyBytesRead = jVal.j;
+    *stats = s;
+    s = NULL;
+    ret = 0;
+
+done:
+    destroyLocalReference(env, readStats);
+    free(s);
+    if (ret) {
+      errno = ret;
+      return -1;
+    }
+    return 0;
+}
+
+int64_t hdfsReadStatisticsGetRemoteBytesRead(
+                            const struct hdfsReadStatistics *stats)
+{
+    return stats->totalBytesRead - stats->totalLocalBytesRead;
+}
+
+int hdfsFileClearReadStatistics(hdfsFile file)
+{
+    jthrowable jthr;
+    int ret;
+    JNIEnv* env = getJNIEnv();
+
+    if (env == NULL) {
+        errno = EINTERNAL;
+        return EINTERNAL;
+    }
+    if (file->type != HDFS_STREAM_INPUT) {
+        ret = EINVAL;
+        goto done;
+    }
+    jthr = invokeMethod(env, NULL, INSTANCE, file->file,
+                  "org/apache/hadoop/hdfs/client/HdfsDataInputStream",
+                  "clearReadStatistics", "()V");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsFileClearReadStatistics: clearReadStatistics failed");
+        goto done;
+    }
+    ret = 0;
+done:
+    if (ret) {
+        errno = ret;
+        return ret;
+    }
+    return 0;
+}
+
+void hdfsFileFreeReadStatistics(struct hdfsReadStatistics *stats)
+{
+    free(stats);
+}
+
+int hdfsFileIsOpenForWrite(hdfsFile file)
+{
+    return (file->type == HDFS_STREAM_OUTPUT);
+}
+
+int hdfsFileUsesDirectRead(hdfsFile file)
+{
+    return !!(file->flags & HDFS_FILE_SUPPORTS_DIRECT_READ);
+}
+
+void hdfsFileDisableDirectRead(hdfsFile file)
+{
+    file->flags &= ~HDFS_FILE_SUPPORTS_DIRECT_READ;
+}
+
+int hdfsDisableDomainSocketSecurity(void)
+{
+    jthrowable jthr;
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+    jthr = invokeMethod(env, NULL, STATIC, NULL,
+            "org/apache/hadoop/net/unix/DomainSocket",
+            "disableBindPathValidation", "()V");
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "DomainSocket#disableBindPathValidation");
+        return -1;
+    }
+    return 0;
+}
+
+/**
+ * hdfsJniEnv: A wrapper struct to be used as 'value'
+ * while saving thread -> JNIEnv* mappings
+ */
+typedef struct
+{
+    JNIEnv* env;
+} hdfsJniEnv;
+
+/**
+ * Helper function to create a org.apache.hadoop.fs.Path object.
+ * @param env: The JNIEnv pointer. 
+ * @param path: The file-path for which to construct org.apache.hadoop.fs.Path
+ * object.
+ * @return Returns a jobject on success and NULL on error.
+ */
+static jthrowable constructNewObjectOfPath(JNIEnv *env, const char *path,
+                                           jobject *out)
+{
+    jthrowable jthr;
+    jstring jPathString;
+    jobject jPath;
+
+    //Construct a java.lang.String object
+    jthr = newJavaStr(env, path, &jPathString);
+    if (jthr)
+        return jthr;
+    //Construct the org.apache.hadoop.fs.Path object
+    jthr = constructNewObjectOfClass(env, &jPath, "org/apache/hadoop/fs/Path",
+                                     "(Ljava/lang/String;)V", jPathString);
+    destroyLocalReference(env, jPathString);
+    if (jthr)
+        return jthr;
+    *out = jPath;
+    return NULL;
+}
+
+static jthrowable hadoopConfGetStr(JNIEnv *env, jobject jConfiguration,
+        const char *key, char **val)
+{
+    jthrowable jthr;
+    jvalue jVal;
+    jstring jkey = NULL, jRet = NULL;
+
+    jthr = newJavaStr(env, key, &jkey);
+    if (jthr)
+        goto done;
+    jthr = invokeMethod(env, &jVal, INSTANCE, jConfiguration,
+            HADOOP_CONF, "get", JMETHOD1(JPARAM(JAVA_STRING),
+                                         JPARAM(JAVA_STRING)), jkey);
+    if (jthr)
+        goto done;
+    jRet = jVal.l;
+    jthr = newCStr(env, jRet, val);
+done:
+    destroyLocalReference(env, jkey);
+    destroyLocalReference(env, jRet);
+    return jthr;
+}
+
+int hdfsConfGetStr(const char *key, char **val)
+{
+    JNIEnv *env;
+    int ret;
+    jthrowable jthr;
+    jobject jConfiguration = NULL;
+
+    env = getJNIEnv();
+    if (env == NULL) {
+        ret = EINTERNAL;
+        goto done;
+    }
+    jthr = constructNewObjectOfClass(env, &jConfiguration, HADOOP_CONF, "()V");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsConfGetStr(%s): new Configuration", key);
+        goto done;
+    }
+    jthr = hadoopConfGetStr(env, jConfiguration, key, val);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsConfGetStr(%s): hadoopConfGetStr", key);
+        goto done;
+    }
+    ret = 0;
+done:
+    destroyLocalReference(env, jConfiguration);
+    if (ret)
+        errno = ret;
+    return ret;
+}
+
+void hdfsConfStrFree(char *val)
+{
+    free(val);
+}
+
+static jthrowable hadoopConfGetInt(JNIEnv *env, jobject jConfiguration,
+        const char *key, int32_t *val)
+{
+    jthrowable jthr = NULL;
+    jvalue jVal;
+    jstring jkey = NULL;
+
+    jthr = newJavaStr(env, key, &jkey);
+    if (jthr)
+        return jthr;
+    jthr = invokeMethod(env, &jVal, INSTANCE, jConfiguration,
+            HADOOP_CONF, "getInt", JMETHOD2(JPARAM(JAVA_STRING), "I", "I"),
+            jkey, (jint)(*val));
+    destroyLocalReference(env, jkey);
+    if (jthr)
+        return jthr;
+    *val = jVal.i;
+    return NULL;
+}
+
+int hdfsConfGetInt(const char *key, int32_t *val)
+{
+    JNIEnv *env;
+    int ret;
+    jobject jConfiguration = NULL;
+    jthrowable jthr;
+
+    env = getJNIEnv();
+    if (env == NULL) {
+      ret = EINTERNAL;
+      goto done;
+    }
+    jthr = constructNewObjectOfClass(env, &jConfiguration, HADOOP_CONF, "()V");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsConfGetInt(%s): new Configuration", key);
+        goto done;
+    }
+    jthr = hadoopConfGetInt(env, jConfiguration, key, val);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsConfGetInt(%s): hadoopConfGetInt", key);
+        goto done;
+    }
+    ret = 0;
+done:
+    destroyLocalReference(env, jConfiguration);
+    if (ret)
+        errno = ret;
+    return ret;
+}
+
+struct hdfsBuilderConfOpt {
+    struct hdfsBuilderConfOpt *next;
+    const char *key;
+    const char *val;
+};
+
+struct hdfsBuilder {
+    int forceNewInstance;
+    const char *nn;
+    tPort port;
+    const char *kerbTicketCachePath;
+    const char *userName;
+    struct hdfsBuilderConfOpt *opts;
+};
+
+struct hdfsBuilder *hdfsNewBuilder(void)
+{
+    struct hdfsBuilder *bld = calloc(1, sizeof(struct hdfsBuilder));
+    if (!bld) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return bld;
+}
+
+int hdfsBuilderConfSetStr(struct hdfsBuilder *bld, const char *key,
+                          const char *val)
+{
+    struct hdfsBuilderConfOpt *opt, *next;
+    
+    opt = calloc(1, sizeof(struct hdfsBuilderConfOpt));
+    if (!opt)
+        return -ENOMEM;
+    next = bld->opts;
+    bld->opts = opt;
+    opt->next = next;
+    opt->key = key;
+    opt->val = val;
+    return 0;
+}
+
+void hdfsFreeBuilder(struct hdfsBuilder *bld)
+{
+    struct hdfsBuilderConfOpt *cur, *next;
+
+    cur = bld->opts;
+    for (cur = bld->opts; cur; ) {
+        next = cur->next;
+        free(cur);
+        cur = next;
+    }
+    free(bld);
+}
+
+void hdfsBuilderSetForceNewInstance(struct hdfsBuilder *bld)
+{
+    bld->forceNewInstance = 1;
+}
+
+void hdfsBuilderSetNameNode(struct hdfsBuilder *bld, const char *nn)
+{
+    bld->nn = nn;
+}
+
+void hdfsBuilderSetNameNodePort(struct hdfsBuilder *bld, tPort port)
+{
+    bld->port = port;
+}
+
+void hdfsBuilderSetUserName(struct hdfsBuilder *bld, const char *userName)
+{
+    bld->userName = userName;
+}
+
+void hdfsBuilderSetKerbTicketCachePath(struct hdfsBuilder *bld,
+                                       const char *kerbTicketCachePath)
+{
+    bld->kerbTicketCachePath = kerbTicketCachePath;
+}
+
+hdfsFS hdfsConnect(const char *host, tPort port)
+{
+    struct hdfsBuilder *bld = hdfsNewBuilder();
+    if (!bld)
+        return NULL;
+    hdfsBuilderSetNameNode(bld, host);
+    hdfsBuilderSetNameNodePort(bld, port);
+    return hdfsBuilderConnect(bld);
+}
+
+/** Always return a new FileSystem handle */
+hdfsFS hdfsConnectNewInstance(const char *host, tPort port)
+{
+    struct hdfsBuilder *bld = hdfsNewBuilder();
+    if (!bld)
+        return NULL;
+    hdfsBuilderSetNameNode(bld, host);
+    hdfsBuilderSetNameNodePort(bld, port);
+    hdfsBuilderSetForceNewInstance(bld);
+    return hdfsBuilderConnect(bld);
+}
+
+hdfsFS hdfsConnectAsUser(const char *host, tPort port, const char *user)
+{
+    struct hdfsBuilder *bld = hdfsNewBuilder();
+    if (!bld)
+        return NULL;
+    hdfsBuilderSetNameNode(bld, host);
+    hdfsBuilderSetNameNodePort(bld, port);
+    hdfsBuilderSetUserName(bld, user);
+    return hdfsBuilderConnect(bld);
+}
+
+/** Always return a new FileSystem handle */
+hdfsFS hdfsConnectAsUserNewInstance(const char *host, tPort port,
+        const char *user)
+{
+    struct hdfsBuilder *bld = hdfsNewBuilder();
+    if (!bld)
+        return NULL;
+    hdfsBuilderSetNameNode(bld, host);
+    hdfsBuilderSetNameNodePort(bld, port);
+    hdfsBuilderSetForceNewInstance(bld);
+    hdfsBuilderSetUserName(bld, user);
+    return hdfsBuilderConnect(bld);
+}
+
+
+/**
+ * Calculate the effective URI to use, given a builder configuration.
+ *
+ * If there is not already a URI scheme, we prepend 'hdfs://'.
+ *
+ * If there is not already a port specified, and a port was given to the
+ * builder, we suffix that port.  If there is a port specified but also one in
+ * the URI, that is an error.
+ *
+ * @param bld       The hdfs builder object
+ * @param uri       (out param) dynamically allocated string representing the
+ *                  effective URI
+ *
+ * @return          0 on success; error code otherwise
+ */
+static int calcEffectiveURI(struct hdfsBuilder *bld, char ** uri)
+{
+    const char *scheme;
+    char suffix[64];
+    const char *lastColon;
+    char *u;
+    size_t uriLen;
+
+    if (!bld->nn)
+        return EINVAL;
+    scheme = (strstr(bld->nn, "://")) ? "" : "hdfs://";
+    if (bld->port == 0) {
+        suffix[0] = '\0';
+    } else {
+        lastColon = strrchr(bld->nn, ':');
+        if (lastColon && (strspn(lastColon + 1, "0123456789") ==
+                          strlen(lastColon + 1))) {
+            fprintf(stderr, "port %d was given, but URI '%s' already "
+                "contains a port!\n", bld->port, bld->nn);
+            return EINVAL;
+        }
+        snprintf(suffix, sizeof(suffix), ":%d", bld->port);
+    }
+
+    uriLen = strlen(scheme) + strlen(bld->nn) + strlen(suffix);
+    u = malloc((uriLen + 1) * (sizeof(char)));
+    if (!u) {
+        fprintf(stderr, "calcEffectiveURI: out of memory");
+        return ENOMEM;
+    }
+    snprintf(u, uriLen + 1, "%s%s%s", scheme, bld->nn, suffix);
+    *uri = u;
+    return 0;
+}
+
+static const char *maybeNull(const char *str)
+{
+    return str ? str : "(NULL)";
+}
+
+static const char *hdfsBuilderToStr(const struct hdfsBuilder *bld,
+                                    char *buf, size_t bufLen)
+{
+    snprintf(buf, bufLen, "forceNewInstance=%d, nn=%s, port=%d, "
+             "kerbTicketCachePath=%s, userName=%s",
+             bld->forceNewInstance, maybeNull(bld->nn), bld->port,
+             maybeNull(bld->kerbTicketCachePath), maybeNull(bld->userName));
+    return buf;
+}
+
+hdfsFS hdfsBuilderConnect(struct hdfsBuilder *bld)
+{
+    JNIEnv *env = 0;
+    jobject jConfiguration = NULL, jFS = NULL, jURI = NULL, jCachePath = NULL;
+    jstring jURIString = NULL, jUserString = NULL;
+    jvalue  jVal;
+    jthrowable jthr = NULL;
+    char *cURI = 0, buf[512];
+    int ret;
+    jobject jRet = NULL;
+    struct hdfsBuilderConfOpt *opt;
+
+    //Get the JNIEnv* corresponding to current thread
+    env = getJNIEnv();
+    if (env == NULL) {
+        ret = EINTERNAL;
+        goto done;
+    }
+
+    //  jConfiguration = new Configuration();
+    jthr = constructNewObjectOfClass(env, &jConfiguration, HADOOP_CONF, "()V");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsBuilderConnect(%s)", hdfsBuilderToStr(bld, buf, sizeof(buf)));
+        goto done;
+    }
+    // set configuration values
+    for (opt = bld->opts; opt; opt = opt->next) {
+        jthr = hadoopConfSetStr(env, jConfiguration, opt->key, opt->val);
+        if (jthr) {
+            ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                "hdfsBuilderConnect(%s): error setting conf '%s' to '%s'",
+                hdfsBuilderToStr(bld, buf, sizeof(buf)), opt->key, opt->val);
+            goto done;
+        }
+    }
+ 
+    //Check what type of FileSystem the caller wants...
+    if (bld->nn == NULL) {
+        // Get a local filesystem.
+        if (bld->forceNewInstance) {
+            // fs = FileSytem#newInstanceLocal(conf);
+            jthr = invokeMethod(env, &jVal, STATIC, NULL, HADOOP_FS,
+                    "newInstanceLocal", JMETHOD1(JPARAM(HADOOP_CONF),
+                    JPARAM(HADOOP_LOCALFS)), jConfiguration);
+            if (jthr) {
+                ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                    "hdfsBuilderConnect(%s)",
+                    hdfsBuilderToStr(bld, buf, sizeof(buf)));
+                goto done;
+            }
+            jFS = jVal.l;
+        } else {
+            // fs = FileSytem#getLocal(conf);
+            jthr = invokeMethod(env, &jVal, STATIC, NULL, HADOOP_FS, "getLocal",
+                             JMETHOD1(JPARAM(HADOOP_CONF),
+                                      JPARAM(HADOOP_LOCALFS)),
+                             jConfiguration);
+            if (jthr) {
+                ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                    "hdfsBuilderConnect(%s)",
+                    hdfsBuilderToStr(bld, buf, sizeof(buf)));
+                goto done;
+            }
+            jFS = jVal.l;
+        }
+    } else {
+        if (!strcmp(bld->nn, "default")) {
+            // jURI = FileSystem.getDefaultUri(conf)
+            jthr = invokeMethod(env, &jVal, STATIC, NULL, HADOOP_FS,
+                          "getDefaultUri",
+                          "(Lorg/apache/hadoop/conf/Configuration;)Ljava/net/URI;",
+                          jConfiguration);
+            if (jthr) {
+                ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                    "hdfsBuilderConnect(%s)",
+                    hdfsBuilderToStr(bld, buf, sizeof(buf)));
+                goto done;
+            }
+            jURI = jVal.l;
+        } else {
+            // fs = FileSystem#get(URI, conf, ugi);
+            ret = calcEffectiveURI(bld, &cURI);
+            if (ret)
+                goto done;
+            jthr = newJavaStr(env, cURI, &jURIString);
+            if (jthr) {
+                ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                    "hdfsBuilderConnect(%s)",
+                    hdfsBuilderToStr(bld, buf, sizeof(buf)));
+                goto done;
+            }
+            jthr = invokeMethod(env, &jVal, STATIC, NULL, JAVA_NET_URI,
+                             "create", "(Ljava/lang/String;)Ljava/net/URI;",
+                             jURIString);
+            if (jthr) {
+                ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                    "hdfsBuilderConnect(%s)",
+                    hdfsBuilderToStr(bld, buf, sizeof(buf)));
+                goto done;
+            }
+            jURI = jVal.l;
+        }
+
+        if (bld->kerbTicketCachePath) {
+            jthr = hadoopConfSetStr(env, jConfiguration,
+                KERBEROS_TICKET_CACHE_PATH, bld->kerbTicketCachePath);
+            if (jthr) {
+                ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                    "hdfsBuilderConnect(%s)",
+                    hdfsBuilderToStr(bld, buf, sizeof(buf)));
+                goto done;
+            }
+        }
+        jthr = newJavaStr(env, bld->userName, &jUserString);
+        if (jthr) {
+            ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                "hdfsBuilderConnect(%s)",
+                hdfsBuilderToStr(bld, buf, sizeof(buf)));
+            goto done;
+        }
+        if (bld->forceNewInstance) {
+            jthr = invokeMethod(env, &jVal, STATIC, NULL, HADOOP_FS,
+                    "newInstance", JMETHOD3(JPARAM(JAVA_NET_URI), 
+                        JPARAM(HADOOP_CONF), JPARAM(JAVA_STRING),
+                        JPARAM(HADOOP_FS)),
+                    jURI, jConfiguration, jUserString);
+            if (jthr) {
+                ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                    "hdfsBuilderConnect(%s)",
+                    hdfsBuilderToStr(bld, buf, sizeof(buf)));
+                goto done;
+            }
+            jFS = jVal.l;
+        } else {
+            jthr = invokeMethod(env, &jVal, STATIC, NULL, HADOOP_FS, "get",
+                    JMETHOD3(JPARAM(JAVA_NET_URI), JPARAM(HADOOP_CONF),
+                        JPARAM(JAVA_STRING), JPARAM(HADOOP_FS)),
+                        jURI, jConfiguration, jUserString);
+            if (jthr) {
+                ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                    "hdfsBuilderConnect(%s)",
+                    hdfsBuilderToStr(bld, buf, sizeof(buf)));
+                goto done;
+            }
+            jFS = jVal.l;
+        }
+    }
+    jRet = (*env)->NewGlobalRef(env, jFS);
+    if (!jRet) {
+        ret = printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+                    "hdfsBuilderConnect(%s)",
+                    hdfsBuilderToStr(bld, buf, sizeof(buf)));
+        goto done;
+    }
+    ret = 0;
+
+done:
+    // Release unnecessary local references
+    destroyLocalReference(env, jConfiguration);
+    destroyLocalReference(env, jFS);
+    destroyLocalReference(env, jURI);
+    destroyLocalReference(env, jCachePath);
+    destroyLocalReference(env, jURIString);
+    destroyLocalReference(env, jUserString);
+    free(cURI);
+    hdfsFreeBuilder(bld);
+
+    if (ret) {
+        errno = ret;
+        return NULL;
+    }
+    return (hdfsFS)jRet;
+}
+
+int hdfsDisconnect(hdfsFS fs)
+{
+    // JAVA EQUIVALENT:
+    //  fs.close()
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    int ret;
+    jobject jFS;
+    jthrowable jthr;
+
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    //Parameters
+    jFS = (jobject)fs;
+
+    //Sanity check
+    if (fs == NULL) {
+        errno = EBADF;
+        return -1;
+    }
+
+    jthr = invokeMethod(env, NULL, INSTANCE, jFS, HADOOP_FS,
+                     "close", "()V");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsDisconnect: FileSystem#close");
+    } else {
+        ret = 0;
+    }
+    (*env)->DeleteGlobalRef(env, jFS);
+    if (ret) {
+        errno = ret;
+        return -1;
+    }
+    return 0;
+}
+
+/**
+ * Get the default block size of a FileSystem object.
+ *
+ * @param env       The Java env
+ * @param jFS       The FileSystem object
+ * @param jPath     The path to find the default blocksize at
+ * @param out       (out param) the default block size
+ *
+ * @return          NULL on success; or the exception
+ */
+static jthrowable getDefaultBlockSize(JNIEnv *env, jobject jFS,
+                                      jobject jPath, jlong *out)
+{
+    jthrowable jthr;
+    jvalue jVal;
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, jFS, HADOOP_FS,
+                 "getDefaultBlockSize", JMETHOD1(JPARAM(HADOOP_PATH), "J"), jPath);
+    if (jthr)
+        return jthr;
+    *out = jVal.j;
+    return NULL;
+}
+
+hdfsFile hdfsOpenFile(hdfsFS fs, const char *path, int flags,
+                      int bufferSize, short replication, tSize blockSize)
+{
+    struct hdfsStreamBuilder *bld = hdfsStreamBuilderAlloc(fs, path, flags);
+    if (bufferSize != 0) {
+      hdfsStreamBuilderSetBufferSize(bld, bufferSize);
+    }
+    if (replication != 0) {
+      hdfsStreamBuilderSetReplication(bld, replication);
+    }
+    if (blockSize != 0) {
+      hdfsStreamBuilderSetDefaultBlockSize(bld, blockSize);
+    }
+    return hdfsStreamBuilderBuild(bld);
+}
+
+struct hdfsStreamBuilder {
+    hdfsFS fs;
+    int flags;
+    int32_t bufferSize;
+    int16_t replication;
+    int64_t defaultBlockSize;
+    char path[1];
+};
+
+struct hdfsStreamBuilder *hdfsStreamBuilderAlloc(hdfsFS fs,
+                                            const char *path, int flags)
+{
+    int path_len = strlen(path);
+    struct hdfsStreamBuilder *bld;
+
+    // sizeof(hdfsStreamBuilder->path) includes one byte for the string
+    // terminator
+    bld = malloc(sizeof(struct hdfsStreamBuilder) + path_len);
+    if (!bld) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    bld->fs = fs;
+    bld->flags = flags;
+    bld->bufferSize = 0;
+    bld->replication = 0;
+    bld->defaultBlockSize = 0;
+    memcpy(bld->path, path, path_len);
+    bld->path[path_len] = '\0';
+    return bld;
+}
+
+void hdfsStreamBuilderFree(struct hdfsStreamBuilder *bld)
+{
+    free(bld);
+}
+
+int hdfsStreamBuilderSetBufferSize(struct hdfsStreamBuilder *bld,
+                                   int32_t bufferSize)
+{
+    if ((bld->flags & O_ACCMODE) != O_WRONLY) {
+        errno = EINVAL;
+        return -1;
+    }
+    bld->bufferSize = bufferSize;
+    return 0;
+}
+
+int hdfsStreamBuilderSetReplication(struct hdfsStreamBuilder *bld,
+                                    int16_t replication)
+{
+    if ((bld->flags & O_ACCMODE) != O_WRONLY) {
+        errno = EINVAL;
+        return -1;
+    }
+    bld->replication = replication;
+    return 0;
+}
+
+int hdfsStreamBuilderSetDefaultBlockSize(struct hdfsStreamBuilder *bld,
+                                         int64_t defaultBlockSize)
+{
+    if ((bld->flags & O_ACCMODE) != O_WRONLY) {
+        errno = EINVAL;
+        return -1;
+    }
+    bld->defaultBlockSize = defaultBlockSize;
+    return 0;
+}
+
+static hdfsFile hdfsOpenFileImpl(hdfsFS fs, const char *path, int flags,
+                  int32_t bufferSize, int16_t replication, int64_t blockSize)
+{
+    /*
+      JAVA EQUIVALENT:
+       File f = new File(path);
+       FSData{Input|Output}Stream f{is|os} = fs.create(f);
+       return f{is|os};
+    */
+    int accmode = flags & O_ACCMODE;
+    jstring jStrBufferSize = NULL, jStrReplication = NULL;
+    jobject jConfiguration = NULL, jPath = NULL, jFile = NULL;
+    jobject jFS = (jobject)fs;
+    jthrowable jthr;
+    jvalue jVal;
+    hdfsFile file = NULL;
+    int ret;
+    jint jBufferSize = bufferSize;
+    jshort jReplication = replication;
+
+    /* The hadoop java api/signature */
+    const char *method = NULL;
+    const char *signature = NULL;
+
+    /* Get the JNIEnv* corresponding to current thread */
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return NULL;
+    }
+
+
+    if (accmode == O_RDONLY || accmode == O_WRONLY) {
+	/* yay */
+    } else if (accmode == O_RDWR) {
+      fprintf(stderr, "ERROR: cannot open an hdfs file in O_RDWR mode\n");
+      errno = ENOTSUP;
+      return NULL;
+    } else {
+      fprintf(stderr, "ERROR: cannot open an hdfs file in mode 0x%x\n", accmode);
+      errno = EINVAL;
+      return NULL;
+    }
+
+    if ((flags & O_CREAT) && (flags & O_EXCL)) {
+      fprintf(stderr, "WARN: hdfs does not truly support O_CREATE && O_EXCL\n");
+    }
+
+    if (accmode == O_RDONLY) {
+	method = "open";
+        signature = JMETHOD2(JPARAM(HADOOP_PATH), "I", JPARAM(HADOOP_ISTRM));
+    } else if (flags & O_APPEND) {
+	method = "append";
+	signature = JMETHOD1(JPARAM(HADOOP_PATH), JPARAM(HADOOP_OSTRM));
+    } else {
+	method = "create";
+	signature = JMETHOD2(JPARAM(HADOOP_PATH), "ZISJ", JPARAM(HADOOP_OSTRM));
+    }
+
+    /* Create an object of org.apache.hadoop.fs.Path */
+    jthr = constructNewObjectOfPath(env, path, &jPath);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsOpenFile(%s): constructNewObjectOfPath", path);
+        goto done;
+    }
+
+    /* Get the Configuration object from the FileSystem object */
+    jthr = invokeMethod(env, &jVal, INSTANCE, jFS, HADOOP_FS,
+                     "getConf", JMETHOD1("", JPARAM(HADOOP_CONF)));
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsOpenFile(%s): FileSystem#getConf", path);
+        goto done;
+    }
+    jConfiguration = jVal.l;
+
+    jStrBufferSize = (*env)->NewStringUTF(env, "io.file.buffer.size"); 
+    if (!jStrBufferSize) {
+        ret = printPendingExceptionAndFree(env, PRINT_EXC_ALL, "OOM");
+        goto done;
+    }
+    jStrReplication = (*env)->NewStringUTF(env, "dfs.replication");
+    if (!jStrReplication) {
+        ret = printPendingExceptionAndFree(env, PRINT_EXC_ALL, "OOM");
+        goto done;
+    }
+
+    if (!bufferSize) {
+        jthr = invokeMethod(env, &jVal, INSTANCE, jConfiguration, 
+                         HADOOP_CONF, "getInt", "(Ljava/lang/String;I)I",
+                         jStrBufferSize, 4096);
+        if (jthr) {
+            ret = printExceptionAndFree(env, jthr, NOPRINT_EXC_FILE_NOT_FOUND |
+                NOPRINT_EXC_ACCESS_CONTROL | NOPRINT_EXC_UNRESOLVED_LINK,
+                "hdfsOpenFile(%s): Configuration#getInt(io.file.buffer.size)",
+                path);
+            goto done;
+        }
+        jBufferSize = jVal.i;
+    }
+
+    if ((accmode == O_WRONLY) && (flags & O_APPEND) == 0) {
+        if (!replication) {
+            jthr = invokeMethod(env, &jVal, INSTANCE, jConfiguration, 
+                             HADOOP_CONF, "getInt", "(Ljava/lang/String;I)I",
+                             jStrReplication, 1);
+            if (jthr) {
+                ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                    "hdfsOpenFile(%s): Configuration#getInt(dfs.replication)",
+                    path);
+                goto done;
+            }
+            jReplication = (jshort)jVal.i;
+        }
+    }
+ 
+    /* Create and return either the FSDataInputStream or
+       FSDataOutputStream references jobject jStream */
+
+    // READ?
+    if (accmode == O_RDONLY) {
+        jthr = invokeMethod(env, &jVal, INSTANCE, jFS, HADOOP_FS,
+                       method, signature, jPath, jBufferSize);
+    }  else if ((accmode == O_WRONLY) && (flags & O_APPEND)) {
+        // WRITE/APPEND?
+       jthr = invokeMethod(env, &jVal, INSTANCE, jFS, HADOOP_FS,
+                       method, signature, jPath);
+    } else {
+        // WRITE/CREATE
+        jboolean jOverWrite = 1;
+        jlong jBlockSize = blockSize;
+
+        if (jBlockSize == 0) {
+            jthr = getDefaultBlockSize(env, jFS, jPath, &jBlockSize);
+            if (jthr) {
+                ret = EIO;
+                goto done;
+            }
+        }
+        jthr = invokeMethod(env, &jVal, INSTANCE, jFS, HADOOP_FS,
+                         method, signature, jPath, jOverWrite,
+                         jBufferSize, jReplication, jBlockSize);
+    }
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsOpenFile(%s): FileSystem#%s(%s)", path, method, signature);
+        goto done;
+    }
+    jFile = jVal.l;
+
+    file = calloc(1, sizeof(struct hdfsFile_internal));
+    if (!file) {
+        fprintf(stderr, "hdfsOpenFile(%s): OOM create hdfsFile\n", path);
+        ret = ENOMEM;
+        goto done;
+    }
+    file->file = (*env)->NewGlobalRef(env, jFile);
+    if (!file->file) {
+        ret = printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+            "hdfsOpenFile(%s): NewGlobalRef", path); 
+        goto done;
+    }
+    file->type = (((flags & O_WRONLY) == 0) ? HDFS_STREAM_INPUT :
+        HDFS_STREAM_OUTPUT);
+    file->flags = 0;
+
+    if ((flags & O_WRONLY) == 0) {
+        // Try a test read to see if we can do direct reads
+        char buf;
+        if (readDirect(fs, file, &buf, 0) == 0) {
+            // Success - 0-byte read should return 0
+            file->flags |= HDFS_FILE_SUPPORTS_DIRECT_READ;
+        } else if (errno != ENOTSUP) {
+            // Unexpected error. Clear it, don't set the direct flag.
+            fprintf(stderr,
+                  "hdfsOpenFile(%s): WARN: Unexpected error %d when testing "
+                  "for direct read compatibility\n", path, errno);
+        }
+    }
+    ret = 0;
+
+done:
+    destroyLocalReference(env, jStrBufferSize);
+    destroyLocalReference(env, jStrReplication);
+    destroyLocalReference(env, jConfiguration); 
+    destroyLocalReference(env, jPath); 
+    destroyLocalReference(env, jFile); 
+    if (ret) {
+        if (file) {
+            if (file->file) {
+                (*env)->DeleteGlobalRef(env, file->file);
+            }
+            free(file);
+        }
+        errno = ret;
+        return NULL;
+    }
+    return file;
+}
+
+hdfsFile hdfsStreamBuilderBuild(struct hdfsStreamBuilder *bld)
+{
+    hdfsFile file = hdfsOpenFileImpl(bld->fs, bld->path, bld->flags,
+                  bld->bufferSize, bld->replication, bld->defaultBlockSize);
+    int prevErrno = errno;
+    hdfsStreamBuilderFree(bld);
+    errno = prevErrno;
+    return file;
+}
+
+int hdfsTruncateFile(hdfsFS fs, const char* path, tOffset newlength)
+{
+    jobject jFS = (jobject)fs;
+    jthrowable jthr;
+    jvalue jVal;
+    jobject jPath = NULL;
+
+    JNIEnv *env = getJNIEnv();
+
+    if (!env) {
+        errno = EINTERNAL;
+        return -1;
+    }
+
+    /* Create an object of org.apache.hadoop.fs.Path */
+    jthr = constructNewObjectOfPath(env, path, &jPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsTruncateFile(%s): constructNewObjectOfPath", path);
+        return -1;
+    }
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, jFS, HADOOP_FS,
+                        "truncate", JMETHOD2(JPARAM(HADOOP_PATH), "J", "Z"),
+                        jPath, newlength);
+    destroyLocalReference(env, jPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsTruncateFile(%s): FileSystem#truncate", path);
+        return -1;
+    }
+    if (jVal.z == JNI_TRUE) {
+        return 1;
+    }
+    return 0;
+}
+
+int hdfsUnbufferFile(hdfsFile file)
+{
+    int ret;
+    jthrowable jthr;
+    JNIEnv *env = getJNIEnv();
+
+    if (!env) {
+        ret = EINTERNAL;
+        goto done;
+    }
+    if (file->type != HDFS_STREAM_INPUT) {
+        ret = ENOTSUP;
+        goto done;
+    }
+    jthr = invokeMethod(env, NULL, INSTANCE, file->file, HADOOP_ISTRM,
+                     "unbuffer", "()V");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                HADOOP_ISTRM "#unbuffer failed:");
+        goto done;
+    }
+    ret = 0;
+
+done:
+    errno = ret;
+    return ret;
+}
+
+int hdfsCloseFile(hdfsFS fs, hdfsFile file)
+{
+    int ret;
+    // JAVA EQUIVALENT:
+    //  file.close 
+
+    //The interface whose 'close' method to be called
+    const char *interface;
+    const char *interfaceShortName;
+
+    //Caught exception
+    jthrowable jthr;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+        errno = EINTERNAL;
+        return -1;
+    }
+
+    //Sanity check
+    if (!file || file->type == HDFS_STREAM_UNINITIALIZED) {
+        errno = EBADF;
+        return -1;
+    }
+
+    interface = (file->type == HDFS_STREAM_INPUT) ?
+        HADOOP_ISTRM : HADOOP_OSTRM;
+  
+    jthr = invokeMethod(env, NULL, INSTANCE, file->file, interface,
+                     "close", "()V");
+    if (jthr) {
+        interfaceShortName = (file->type == HDFS_STREAM_INPUT) ? 
+            "FSDataInputStream" : "FSDataOutputStream";
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                "%s#close", interfaceShortName);
+    } else {
+        ret = 0;
+    }
+
+    //De-allocate memory
+    (*env)->DeleteGlobalRef(env, file->file);
+    free(file);
+
+    if (ret) {
+        errno = ret;
+        return -1;
+    }
+    return 0;
+}
+
+int hdfsExists(hdfsFS fs, const char *path)
+{
+    JNIEnv *env = getJNIEnv();
+    jobject jPath;
+    jvalue  jVal;
+    jobject jFS = (jobject)fs;
+    jthrowable jthr;
+
+    if (env == NULL) {
+        errno = EINTERNAL;
+        return -1;
+    }
+    
+    if (path == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    jthr = constructNewObjectOfPath(env, path, &jPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsExists: constructNewObjectOfPath");
+        return -1;
+    }
+    jthr = invokeMethod(env, &jVal, INSTANCE, jFS, HADOOP_FS,
+            "exists", JMETHOD1(JPARAM(HADOOP_PATH), "Z"), jPath);
+    destroyLocalReference(env, jPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsExists: invokeMethod(%s)",
+            JMETHOD1(JPARAM(HADOOP_PATH), "Z"));
+        return -1;
+    }
+    if (jVal.z) {
+        return 0;
+    } else {
+        errno = ENOENT;
+        return -1;
+    }
+}
+
+// Checks input file for readiness for reading.
+static int readPrepare(JNIEnv* env, hdfsFS fs, hdfsFile f,
+                       jobject* jInputStream)
+{
+    *jInputStream = (jobject)(f ? f->file : NULL);
+
+    //Sanity check
+    if (!f || f->type == HDFS_STREAM_UNINITIALIZED) {
+      errno = EBADF;
+      return -1;
+    }
+
+    //Error checking... make sure that this file is 'readable'
+    if (f->type != HDFS_STREAM_INPUT) {
+      fprintf(stderr, "Cannot read from a non-InputStream object!\n");
+      errno = EINVAL;
+      return -1;
+    }
+
+    return 0;
+}
+
+tSize hdfsRead(hdfsFS fs, hdfsFile f, void* buffer, tSize length)
+{
+    jobject jInputStream;
+    jbyteArray jbRarray;
+    jint noReadBytes = length;
+    jvalue jVal;
+    jthrowable jthr;
+    JNIEnv* env;
+
+    if (length == 0) {
+        return 0;
+    } else if (length < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (f->flags & HDFS_FILE_SUPPORTS_DIRECT_READ) {
+      return readDirect(fs, f, buffer, length);
+    }
+
+    // JAVA EQUIVALENT:
+    //  byte [] bR = new byte[length];
+    //  fis.read(bR);
+
+    //Get the JNIEnv* corresponding to current thread
+    env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    //Parameters
+    if (readPrepare(env, fs, f, &jInputStream) == -1) {
+      return -1;
+    }
+
+    //Read the requisite bytes
+    jbRarray = (*env)->NewByteArray(env, length);
+    if (!jbRarray) {
+        errno = printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+            "hdfsRead: NewByteArray");
+        return -1;
+    }
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, jInputStream, HADOOP_ISTRM,
+                               "read", "([B)I", jbRarray);
+    if (jthr) {
+        destroyLocalReference(env, jbRarray);
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsRead: FSDataInputStream#read");
+        return -1;
+    }
+    if (jVal.i < 0) {
+        // EOF
+        destroyLocalReference(env, jbRarray);
+        return 0;
+    } else if (jVal.i == 0) {
+        destroyLocalReference(env, jbRarray);
+        errno = EINTR;
+        return -1;
+    }
+    (*env)->GetByteArrayRegion(env, jbRarray, 0, noReadBytes, buffer);
+    destroyLocalReference(env, jbRarray);
+    if ((*env)->ExceptionCheck(env)) {
+        errno = printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+            "hdfsRead: GetByteArrayRegion");
+        return -1;
+    }
+    return jVal.i;
+}
+
+// Reads using the read(ByteBuffer) API, which does fewer copies
+tSize readDirect(hdfsFS fs, hdfsFile f, void* buffer, tSize length)
+{
+    // JAVA EQUIVALENT:
+    //  ByteBuffer bbuffer = ByteBuffer.allocateDirect(length) // wraps C buffer
+    //  fis.read(bbuffer);
+
+    jobject jInputStream;
+    jvalue jVal;
+    jthrowable jthr;
+    jobject bb;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    if (readPrepare(env, fs, f, &jInputStream) == -1) {
+      return -1;
+    }
+
+    //Read the requisite bytes
+    bb = (*env)->NewDirectByteBuffer(env, buffer, length);
+    if (bb == NULL) {
+        errno = printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+            "readDirect: NewDirectByteBuffer");
+        return -1;
+    }
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, jInputStream,
+        HADOOP_ISTRM, "read", "(Ljava/nio/ByteBuffer;)I", bb);
+    destroyLocalReference(env, bb);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "readDirect: FSDataInputStream#read");
+        return -1;
+    }
+    return (jVal.i < 0) ? 0 : jVal.i;
+}
+
+tSize hdfsPread(hdfsFS fs, hdfsFile f, tOffset position,
+                void* buffer, tSize length)
+{
+    JNIEnv* env;
+    jbyteArray jbRarray;
+    jvalue jVal;
+    jthrowable jthr;
+
+    if (length == 0) {
+        return 0;
+    } else if (length < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!f || f->type == HDFS_STREAM_UNINITIALIZED) {
+        errno = EBADF;
+        return -1;
+    }
+
+    env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    //Error checking... make sure that this file is 'readable'
+    if (f->type != HDFS_STREAM_INPUT) {
+        fprintf(stderr, "Cannot read from a non-InputStream object!\n");
+        errno = EINVAL;
+        return -1;
+    }
+
+    // JAVA EQUIVALENT:
+    //  byte [] bR = new byte[length];
+    //  fis.read(pos, bR, 0, length);
+    jbRarray = (*env)->NewByteArray(env, length);
+    if (!jbRarray) {
+        errno = printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+            "hdfsPread: NewByteArray");
+        return -1;
+    }
+    jthr = invokeMethod(env, &jVal, INSTANCE, f->file, HADOOP_ISTRM,
+                     "read", "(J[BII)I", position, jbRarray, 0, length);
+    if (jthr) {
+        destroyLocalReference(env, jbRarray);
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsPread: FSDataInputStream#read");
+        return -1;
+    }
+    if (jVal.i < 0) {
+        // EOF
+        destroyLocalReference(env, jbRarray);
+        return 0;
+    } else if (jVal.i == 0) {
+        destroyLocalReference(env, jbRarray);
+        errno = EINTR;
+        return -1;
+    }
+    (*env)->GetByteArrayRegion(env, jbRarray, 0, jVal.i, buffer);
+    destroyLocalReference(env, jbRarray);
+    if ((*env)->ExceptionCheck(env)) {
+        errno = printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+            "hdfsPread: GetByteArrayRegion");
+        return -1;
+    }
+    return jVal.i;
+}
+
+tSize hdfsWrite(hdfsFS fs, hdfsFile f, const void* buffer, tSize length)
+{
+    // JAVA EQUIVALENT
+    // byte b[] = str.getBytes();
+    // fso.write(b);
+
+    jobject jOutputStream;
+    jbyteArray jbWarray;
+    jthrowable jthr;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    //Sanity check
+    if (!f || f->type == HDFS_STREAM_UNINITIALIZED) {
+        errno = EBADF;
+        return -1;
+    }
+
+    jOutputStream = f->file;
+    
+    if (length < 0) {
+    	errno = EINVAL;
+    	return -1;
+    }
+
+    //Error checking... make sure that this file is 'writable'
+    if (f->type != HDFS_STREAM_OUTPUT) {
+        fprintf(stderr, "Cannot write into a non-OutputStream object!\n");
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (length < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (length == 0) {
+        return 0;
+    }
+    //Write the requisite bytes into the file
+    jbWarray = (*env)->NewByteArray(env, length);
+    if (!jbWarray) {
+        errno = printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+            "hdfsWrite: NewByteArray");
+        return -1;
+    }
+    (*env)->SetByteArrayRegion(env, jbWarray, 0, length, buffer);
+    if ((*env)->ExceptionCheck(env)) {
+        destroyLocalReference(env, jbWarray);
+        errno = printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+            "hdfsWrite(length = %d): SetByteArrayRegion", length);
+        return -1;
+    }
+    jthr = invokeMethod(env, NULL, INSTANCE, jOutputStream,
+            HADOOP_OSTRM, "write", "([B)V", jbWarray);
+    destroyLocalReference(env, jbWarray);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsWrite: FSDataOutputStream#write");
+        return -1;
+    }
+    // Unlike most Java streams, FSDataOutputStream never does partial writes.
+    // If we succeeded, all the data was written.
+    return length;
+}
+
+int hdfsSeek(hdfsFS fs, hdfsFile f, tOffset desiredPos) 
+{
+    // JAVA EQUIVALENT
+    //  fis.seek(pos);
+
+    jobject jInputStream;
+    jthrowable jthr;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    //Sanity check
+    if (!f || f->type != HDFS_STREAM_INPUT) {
+        errno = EBADF;
+        return -1;
+    }
+
+    jInputStream = f->file;
+    jthr = invokeMethod(env, NULL, INSTANCE, jInputStream,
+            HADOOP_ISTRM, "seek", "(J)V", desiredPos);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsSeek(desiredPos=%" PRId64 ")"
+            ": FSDataInputStream#seek", desiredPos);
+        return -1;
+    }
+    return 0;
+}
+
+
+
+tOffset hdfsTell(hdfsFS fs, hdfsFile f)
+{
+    // JAVA EQUIVALENT
+    //  pos = f.getPos();
+
+    jobject jStream;
+    const char *interface;
+    jvalue jVal;
+    jthrowable jthr;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    //Sanity check
+    if (!f || f->type == HDFS_STREAM_UNINITIALIZED) {
+        errno = EBADF;
+        return -1;
+    }
+
+    //Parameters
+    jStream = f->file;
+    interface = (f->type == HDFS_STREAM_INPUT) ?
+        HADOOP_ISTRM : HADOOP_OSTRM;
+    jthr = invokeMethod(env, &jVal, INSTANCE, jStream,
+                     interface, "getPos", "()J");
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsTell: %s#getPos",
+            ((f->type == HDFS_STREAM_INPUT) ? "FSDataInputStream" :
+                                 "FSDataOutputStream"));
+        return -1;
+    }
+    return jVal.j;
+}
+
+int hdfsFlush(hdfsFS fs, hdfsFile f) 
+{
+    // JAVA EQUIVALENT
+    //  fos.flush();
+
+    jthrowable jthr;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    //Sanity check
+    if (!f || f->type != HDFS_STREAM_OUTPUT) {
+        errno = EBADF;
+        return -1;
+    }
+    jthr = invokeMethod(env, NULL, INSTANCE, f->file,
+                     HADOOP_OSTRM, "flush", "()V");
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsFlush: FSDataInputStream#flush");
+        return -1;
+    }
+    return 0;
+}
+
+int hdfsHFlush(hdfsFS fs, hdfsFile f)
+{
+    jobject jOutputStream;
+    jthrowable jthr;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    //Sanity check
+    if (!f || f->type != HDFS_STREAM_OUTPUT) {
+        errno = EBADF;
+        return -1;
+    }
+
+    jOutputStream = f->file;
+    jthr = invokeMethod(env, NULL, INSTANCE, jOutputStream,
+                     HADOOP_OSTRM, "hflush", "()V");
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsHFlush: FSDataOutputStream#hflush");
+        return -1;
+    }
+    return 0;
+}
+
+int hdfsHSync(hdfsFS fs, hdfsFile f)
+{
+    jobject jOutputStream;
+    jthrowable jthr;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    //Sanity check
+    if (!f || f->type != HDFS_STREAM_OUTPUT) {
+        errno = EBADF;
+        return -1;
+    }
+
+    jOutputStream = f->file;
+    jthr = invokeMethod(env, NULL, INSTANCE, jOutputStream,
+                     HADOOP_OSTRM, "hsync", "()V");
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsHSync: FSDataOutputStream#hsync");
+        return -1;
+    }
+    return 0;
+}
+
+int hdfsAvailable(hdfsFS fs, hdfsFile f)
+{
+    // JAVA EQUIVALENT
+    //  fis.available();
+
+    jobject jInputStream;
+    jvalue jVal;
+    jthrowable jthr;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    //Sanity check
+    if (!f || f->type != HDFS_STREAM_INPUT) {
+        errno = EBADF;
+        return -1;
+    }
+
+    //Parameters
+    jInputStream = f->file;
+    jthr = invokeMethod(env, &jVal, INSTANCE, jInputStream,
+                     HADOOP_ISTRM, "available", "()I");
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsAvailable: FSDataInputStream#available");
+        return -1;
+    }
+    return jVal.i;
+}
+
+static int hdfsCopyImpl(hdfsFS srcFS, const char *src, hdfsFS dstFS,
+        const char *dst, jboolean deleteSource)
+{
+    //JAVA EQUIVALENT
+    //  FileUtil#copy(srcFS, srcPath, dstFS, dstPath,
+    //                 deleteSource = false, conf)
+
+    //Parameters
+    jobject jSrcFS = (jobject)srcFS;
+    jobject jDstFS = (jobject)dstFS;
+    jobject jConfiguration = NULL, jSrcPath = NULL, jDstPath = NULL;
+    jthrowable jthr;
+    jvalue jVal;
+    int ret;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    jthr = constructNewObjectOfPath(env, src, &jSrcPath);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsCopyImpl(src=%s): constructNewObjectOfPath", src);
+        goto done;
+    }
+    jthr = constructNewObjectOfPath(env, dst, &jDstPath);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsCopyImpl(dst=%s): constructNewObjectOfPath", dst);
+        goto done;
+    }
+
+    //Create the org.apache.hadoop.conf.Configuration object
+    jthr = constructNewObjectOfClass(env, &jConfiguration,
+                                     HADOOP_CONF, "()V");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsCopyImpl: Configuration constructor");
+        goto done;
+    }
+
+    //FileUtil#copy
+    jthr = invokeMethod(env, &jVal, STATIC,
+            NULL, "org/apache/hadoop/fs/FileUtil", "copy",
+            "(Lorg/apache/hadoop/fs/FileSystem;Lorg/apache/hadoop/fs/Path;"
+            "Lorg/apache/hadoop/fs/FileSystem;Lorg/apache/hadoop/fs/Path;"
+            "ZLorg/apache/hadoop/conf/Configuration;)Z",
+            jSrcFS, jSrcPath, jDstFS, jDstPath, deleteSource, 
+            jConfiguration);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsCopyImpl(src=%s, dst=%s, deleteSource=%d): "
+            "FileUtil#copy", src, dst, deleteSource);
+        goto done;
+    }
+    if (!jVal.z) {
+        ret = EIO;
+        goto done;
+    }
+    ret = 0;
+
+done:
+    destroyLocalReference(env, jConfiguration);
+    destroyLocalReference(env, jSrcPath);
+    destroyLocalReference(env, jDstPath);
+  
+    if (ret) {
+        errno = ret;
+        return -1;
+    }
+    return 0;
+}
+
+int hdfsCopy(hdfsFS srcFS, const char *src, hdfsFS dstFS, const char *dst)
+{
+    return hdfsCopyImpl(srcFS, src, dstFS, dst, 0);
+}
+
+int hdfsMove(hdfsFS srcFS, const char *src, hdfsFS dstFS, const char *dst)
+{
+    return hdfsCopyImpl(srcFS, src, dstFS, dst, 1);
+}
+
+int hdfsDelete(hdfsFS fs, const char *path, int recursive)
+{
+    // JAVA EQUIVALENT:
+    //  Path p = new Path(path);
+    //  bool retval = fs.delete(p, recursive);
+
+    jobject jFS = (jobject)fs;
+    jthrowable jthr;
+    jobject jPath;
+    jvalue jVal;
+    jboolean jRecursive;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    jthr = constructNewObjectOfPath(env, path, &jPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsDelete(path=%s): constructNewObjectOfPath", path);
+        return -1;
+    }
+    jRecursive = recursive ? JNI_TRUE : JNI_FALSE;
+    jthr = invokeMethod(env, &jVal, INSTANCE, jFS, HADOOP_FS,
+                     "delete", "(Lorg/apache/hadoop/fs/Path;Z)Z",
+                     jPath, jRecursive);
+    destroyLocalReference(env, jPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsDelete(path=%s, recursive=%d): "
+            "FileSystem#delete", path, recursive);
+        return -1;
+    }
+    if (!jVal.z) {
+        errno = EIO;
+        return -1;
+    }
+    return 0;
+}
+
+
+
+int hdfsRename(hdfsFS fs, const char *oldPath, const char *newPath)
+{
+    // JAVA EQUIVALENT:
+    //  Path old = new Path(oldPath);
+    //  Path new = new Path(newPath);
+    //  fs.rename(old, new);
+
+    jobject jFS = (jobject)fs;
+    jthrowable jthr;
+    jobject jOldPath = NULL, jNewPath = NULL;
+    int ret = -1;
+    jvalue jVal;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    jthr = constructNewObjectOfPath(env, oldPath, &jOldPath );
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsRename: constructNewObjectOfPath(%s)", oldPath);
+        goto done;
+    }
+    jthr = constructNewObjectOfPath(env, newPath, &jNewPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsRename: constructNewObjectOfPath(%s)", newPath);
+        goto done;
+    }
+
+    // Rename the file
+    // TODO: use rename2 here?  (See HDFS-3592)
+    jthr = invokeMethod(env, &jVal, INSTANCE, jFS, HADOOP_FS, "rename",
+                     JMETHOD2(JPARAM(HADOOP_PATH), JPARAM(HADOOP_PATH), "Z"),
+                     jOldPath, jNewPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsRename(oldPath=%s, newPath=%s): FileSystem#rename",
+            oldPath, newPath);
+        goto done;
+    }
+    if (!jVal.z) {
+        errno = EIO;
+        goto done;
+    }
+    ret = 0;
+
+done:
+    destroyLocalReference(env, jOldPath);
+    destroyLocalReference(env, jNewPath);
+    return ret;
+}
+
+int hdfsRenameOverwrite(hdfsFS fs, const char *oldPath, const char *newPath)
+{
+    // JAVA EQUIVALENT:
+    //  Path old = new Path(oldPath);
+    //  Path new = new Path(newPath);
+    //  fs.rename(old, new, overwrite = true);
+
+    jobject jFS = (jobject)fs;
+    jthrowable jthr;
+    jobject jOldPath = NULL, jNewPath = NULL;
+    int ret = -1;
+    jvalue jVal;
+    jobject enumInst = NULL, enumSetObj = NULL;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    jthr = fetchEnumInstance(env, RENAME_OPTION,
+              "OVERWRITE", &enumInst);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsRename: fetchEnumInstance(" RENAME_OPTION ", OVERWRITE)");
+        goto done;
+    }
+    jthr = invokeMethod(env, &jVal, STATIC, NULL,
+            "java/util/EnumSet", "of",
+            "(Ljava/lang/Enum;)Ljava/util/EnumSet;", enumInst);
+    if (jthr) {
+        goto done;
+    }
+    enumSetObj = jVal.l;
+
+    jclass enumSetClass = (*env)->FindClass(env, "java/util/EnumSet");
+    jmethodID toArrayTypedMethodID = (*env)->GetMethodID(env, enumSetClass, "toArray", "([Ljava/lang/Object;)[Ljava/lang/Object;");
+    jclass renameOptionClass = (*env)->FindClass(env, "org/apache/hadoop/fs/Options$Rename");
+    jobjectArray typedArray = (*env)->NewObjectArray(env, 1, renameOptionClass, NULL);
+    jobjectArray enumArray = (jobjectArray)(*env)->CallObjectMethod(env, enumSetObj, toArrayTypedMethodID, typedArray);
+
+    jthr = constructNewObjectOfPath(env, oldPath, &jOldPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsRename: constructNewObjectOfPath(%s)", oldPath);
+        goto done;
+    }
+    jthr = constructNewObjectOfPath(env, newPath, &jNewPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsRename: constructNewObjectOfPath(%s)", newPath);
+        goto done;
+    }
+
+    // Rename the file
+    // TODO: use rename2 here?  (See HDFS-3592)
+    jthr = invokeMethod(env, &jVal, INSTANCE, jFS, HADOOP_FS, "rename",
+                     "(Lorg/apache/hadoop/fs/Path;Lorg/apache/hadoop/fs/Path;[Lorg/apache/hadoop/fs/Options$Rename;)V",
+                     jOldPath, jNewPath, enumArray);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsRename(oldPath=%s, newPath=%s): FileSystem#rename",
+            oldPath, newPath);
+        goto done;
+    }
+    ret = 0;
+
+done:
+    destroyLocalReference(env, jOldPath);
+    destroyLocalReference(env, jNewPath);
+    destroyLocalReference(env, enumInst);
+    destroyLocalReference(env, enumSetObj);
+    return ret;
+}
+
+
+
+char* hdfsGetWorkingDirectory(hdfsFS fs, char* buffer, size_t bufferSize)
+{
+    // JAVA EQUIVALENT:
+    //  Path p = fs.getWorkingDirectory(); 
+    //  return p.toString()
+
+    jobject jPath = NULL;
+    jstring jPathString = NULL;
+    jobject jFS = (jobject)fs;
+    jvalue jVal;
+    jthrowable jthr;
+    int ret;
+    const char *jPathChars = NULL;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return NULL;
+    }
+
+    //FileSystem#getWorkingDirectory()
+    jthr = invokeMethod(env, &jVal, INSTANCE, jFS,
+                     HADOOP_FS, "getWorkingDirectory",
+                     "()Lorg/apache/hadoop/fs/Path;");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsGetWorkingDirectory: FileSystem#getWorkingDirectory");
+        goto done;
+    }
+    jPath = jVal.l;
+    if (!jPath) {
+        fprintf(stderr, "hdfsGetWorkingDirectory: "
+            "FileSystem#getWorkingDirectory returned NULL");
+        ret = -EIO;
+        goto done;
+    }
+
+    //Path#toString()
+    jthr = invokeMethod(env, &jVal, INSTANCE, jPath, 
+                     "org/apache/hadoop/fs/Path", "toString",
+                     "()Ljava/lang/String;");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsGetWorkingDirectory: Path#toString");
+        goto done;
+    }
+    jPathString = jVal.l;
+    jPathChars = (*env)->GetStringUTFChars(env, jPathString, NULL);
+    if (!jPathChars) {
+        ret = printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+            "hdfsGetWorkingDirectory: GetStringUTFChars");
+        goto done;
+    }
+
+    //Copy to user-provided buffer
+    ret = snprintf(buffer, bufferSize, "%s", jPathChars);
+    if (ret >= bufferSize) {
+        ret = ENAMETOOLONG;
+        goto done;
+    }
+    ret = 0;
+
+done:
+    if (jPathChars) {
+        (*env)->ReleaseStringUTFChars(env, jPathString, jPathChars);
+    }
+    destroyLocalReference(env, jPath);
+    destroyLocalReference(env, jPathString);
+
+    if (ret) {
+        errno = ret;
+        return NULL;
+    }
+    return buffer;
+}
+
+
+
+int hdfsSetWorkingDirectory(hdfsFS fs, const char *path)
+{
+    // JAVA EQUIVALENT:
+    //  fs.setWorkingDirectory(Path(path)); 
+
+    jobject jFS = (jobject)fs;
+    jthrowable jthr;
+    jobject jPath;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    //Create an object of org.apache.hadoop.fs.Path
+    jthr = constructNewObjectOfPath(env, path, &jPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsSetWorkingDirectory(%s): constructNewObjectOfPath",
+            path);
+        return -1;
+    }
+
+    //FileSystem#setWorkingDirectory()
+    jthr = invokeMethod(env, NULL, INSTANCE, jFS, HADOOP_FS,
+                     "setWorkingDirectory", 
+                     "(Lorg/apache/hadoop/fs/Path;)V", jPath);
+    destroyLocalReference(env, jPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, NOPRINT_EXC_ILLEGAL_ARGUMENT,
+            "hdfsSetWorkingDirectory(%s): FileSystem#setWorkingDirectory",
+            path);
+        return -1;
+    }
+    return 0;
+}
+
+
+
+int hdfsCreateDirectory(hdfsFS fs, const char *path)
+{
+    // JAVA EQUIVALENT:
+    //  fs.mkdirs(new Path(path));
+
+    jobject jFS = (jobject)fs;
+    jobject jPath;
+    jthrowable jthr;
+    jvalue jVal;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    //Create an object of org.apache.hadoop.fs.Path
+    jthr = constructNewObjectOfPath(env, path, &jPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsCreateDirectory(%s): constructNewObjectOfPath", path);
+        return -1;
+    }
+
+    //Create the directory
+    jVal.z = 0;
+    jthr = invokeMethod(env, &jVal, INSTANCE, jFS, HADOOP_FS,
+                     "mkdirs", "(Lorg/apache/hadoop/fs/Path;)Z",
+                     jPath);
+    destroyLocalReference(env, jPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr,
+            NOPRINT_EXC_ACCESS_CONTROL | NOPRINT_EXC_FILE_NOT_FOUND |
+            NOPRINT_EXC_UNRESOLVED_LINK | NOPRINT_EXC_PARENT_NOT_DIRECTORY,
+            "hdfsCreateDirectory(%s): FileSystem#mkdirs", path);
+        return -1;
+    }
+    if (!jVal.z) {
+        // It's unclear under exactly which conditions FileSystem#mkdirs
+        // is supposed to return false (as opposed to throwing an exception.)
+        // It seems like the current code never actually returns false.
+        // So we're going to translate this to EIO, since there seems to be
+        // nothing more specific we can do with it.
+        errno = EIO;
+        return -1;
+    }
+    return 0;
+}
+
+
+int hdfsSetReplication(hdfsFS fs, const char *path, int16_t replication)
+{
+    // JAVA EQUIVALENT:
+    //  fs.setReplication(new Path(path), replication);
+
+    jobject jFS = (jobject)fs;
+    jthrowable jthr;
+    jobject jPath;
+    jvalue jVal;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    //Create an object of org.apache.hadoop.fs.Path
+    jthr = constructNewObjectOfPath(env, path, &jPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsSetReplication(path=%s): constructNewObjectOfPath", path);
+        return -1;
+    }
+
+    //Create the directory
+    jthr = invokeMethod(env, &jVal, INSTANCE, jFS, HADOOP_FS,
+                     "setReplication", "(Lorg/apache/hadoop/fs/Path;S)Z",
+                     jPath, replication);
+    destroyLocalReference(env, jPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsSetReplication(path=%s, replication=%d): "
+            "FileSystem#setReplication", path, replication);
+        return -1;
+    }
+    if (!jVal.z) {
+        // setReplication returns false "if file does not exist or is a
+        // directory."  So the nearest translation to that is ENOENT.
+        errno = ENOENT;
+        return -1;
+    }
+
+    return 0;
+}
+
+int hdfsChown(hdfsFS fs, const char *path, const char *owner, const char *group)
+{
+    // JAVA EQUIVALENT:
+    //  fs.setOwner(path, owner, group)
+
+    jobject jFS = (jobject)fs;
+    jobject jPath = NULL;
+    jstring jOwner = NULL, jGroup = NULL;
+    jthrowable jthr;
+    int ret;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    if (owner == NULL && group == NULL) {
+      return 0;
+    }
+
+    jthr = constructNewObjectOfPath(env, path, &jPath);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsChown(path=%s): constructNewObjectOfPath", path);
+        goto done;
+    }
+
+    jthr = newJavaStr(env, owner, &jOwner); 
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsChown(path=%s): newJavaStr(%s)", path, owner);
+        goto done;
+    }
+    jthr = newJavaStr(env, group, &jGroup);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsChown(path=%s): newJavaStr(%s)", path, group);
+        goto done;
+    }
+
+    //Create the directory
+    jthr = invokeMethod(env, NULL, INSTANCE, jFS, HADOOP_FS,
+            "setOwner", JMETHOD3(JPARAM(HADOOP_PATH), 
+                    JPARAM(JAVA_STRING), JPARAM(JAVA_STRING), JAVA_VOID),
+            jPath, jOwner, jGroup);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr,
+            NOPRINT_EXC_ACCESS_CONTROL | NOPRINT_EXC_FILE_NOT_FOUND |
+            NOPRINT_EXC_UNRESOLVED_LINK,
+            "hdfsChown(path=%s, owner=%s, group=%s): "
+            "FileSystem#setOwner", path, owner, group);
+        goto done;
+    }
+    ret = 0;
+
+done:
+    destroyLocalReference(env, jPath);
+    destroyLocalReference(env, jOwner);
+    destroyLocalReference(env, jGroup);
+
+    if (ret) {
+        errno = ret;
+        return -1;
+    }
+    return 0;
+}
+
+int hdfsChmod(hdfsFS fs, const char *path, short mode)
+{
+    int ret;
+    // JAVA EQUIVALENT:
+    //  fs.setPermission(path, FsPermission)
+
+    jthrowable jthr;
+    jobject jPath = NULL, jPermObj = NULL;
+    jobject jFS = (jobject)fs;
+    jshort jmode = mode;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    // construct jPerm = FsPermission.createImmutable(short mode);
+    jthr = constructNewObjectOfClass(env, &jPermObj,
+                HADOOP_FSPERM,"(S)V",jmode);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "constructNewObjectOfClass(%s)", HADOOP_FSPERM);
+        return -1;
+    }
+
+    //Create an object of org.apache.hadoop.fs.Path
+    jthr = constructNewObjectOfPath(env, path, &jPath);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsChmod(%s): constructNewObjectOfPath", path);
+        goto done;
+    }
+
+    //Create the directory
+    jthr = invokeMethod(env, NULL, INSTANCE, jFS, HADOOP_FS,
+            "setPermission",
+            JMETHOD2(JPARAM(HADOOP_PATH), JPARAM(HADOOP_FSPERM), JAVA_VOID),
+            jPath, jPermObj);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr,
+            NOPRINT_EXC_ACCESS_CONTROL | NOPRINT_EXC_FILE_NOT_FOUND |
+            NOPRINT_EXC_UNRESOLVED_LINK,
+            "hdfsChmod(%s): FileSystem#setPermission", path);
+        goto done;
+    }
+    ret = 0;
+
+done:
+    destroyLocalReference(env, jPath);
+    destroyLocalReference(env, jPermObj);
+
+    if (ret) {
+        errno = ret;
+        return -1;
+    }
+    return 0;
+}
+
+int hdfsUtime(hdfsFS fs, const char *path, tTime mtime, tTime atime)
+{
+    // JAVA EQUIVALENT:
+    //  fs.setTimes(src, mtime, atime)
+
+    jthrowable jthr;
+    jobject jFS = (jobject)fs;
+    jobject jPath;
+    static const tTime NO_CHANGE = -1;
+    jlong jmtime, jatime;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    //Create an object of org.apache.hadoop.fs.Path
+    jthr = constructNewObjectOfPath(env, path, &jPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsUtime(path=%s): constructNewObjectOfPath", path);
+        return -1;
+    }
+
+    jmtime = (mtime == NO_CHANGE) ? -1 : (mtime * (jlong)1000);
+    jatime = (atime == NO_CHANGE) ? -1 : (atime * (jlong)1000);
+
+    jthr = invokeMethod(env, NULL, INSTANCE, jFS, HADOOP_FS,
+            "setTimes", JMETHOD3(JPARAM(HADOOP_PATH), "J", "J", JAVA_VOID),
+            jPath, jmtime, jatime);
+    destroyLocalReference(env, jPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr,
+            NOPRINT_EXC_ACCESS_CONTROL | NOPRINT_EXC_FILE_NOT_FOUND |
+            NOPRINT_EXC_UNRESOLVED_LINK,
+            "hdfsUtime(path=%s): FileSystem#setTimes", path);
+        return -1;
+    }
+    return 0;
+}
+
+/**
+ * Zero-copy options.
+ *
+ * We cache the EnumSet of ReadOptions which has to be passed into every
+ * readZero call, to avoid reconstructing it each time.  This cache is cleared
+ * whenever an element changes.
+ */
+struct hadoopRzOptions
+{
+    JNIEnv *env;
+    int skipChecksums;
+    jobject byteBufferPool;
+    jobject cachedEnumSet;
+};
+
+struct hadoopRzOptions *hadoopRzOptionsAlloc(void)
+{
+    struct hadoopRzOptions *opts;
+    JNIEnv *env;
+
+    env = getJNIEnv();
+    if (!env) {
+        // Check to make sure the JNI environment is set up properly.
+        errno = EINTERNAL;
+        return NULL;
+    }
+    opts = calloc(1, sizeof(struct hadoopRzOptions));
+    if (!opts) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return opts;
+}
+
+static void hadoopRzOptionsClearCached(JNIEnv *env,
+        struct hadoopRzOptions *opts)
+{
+    if (!opts->cachedEnumSet) {
+        return;
+    }
+    (*env)->DeleteGlobalRef(env, opts->cachedEnumSet);
+    opts->cachedEnumSet = NULL;
+}
+
+int hadoopRzOptionsSetSkipChecksum(
+        struct hadoopRzOptions *opts, int skip)
+{
+    JNIEnv *env;
+    env = getJNIEnv();
+    if (!env) {
+        errno = EINTERNAL;
+        return -1;
+    }
+    hadoopRzOptionsClearCached(env, opts);
+    opts->skipChecksums = !!skip;
+    return 0;
+}
+
+int hadoopRzOptionsSetByteBufferPool(
+        struct hadoopRzOptions *opts, const char *className)
+{
+    JNIEnv *env;
+    jthrowable jthr;
+    jobject byteBufferPool = NULL;
+
+    env = getJNIEnv();
+    if (!env) {
+        errno = EINTERNAL;
+        return -1;
+    }
+
+    if (className) {
+      // Note: we don't have to call hadoopRzOptionsClearCached in this
+      // function, since the ByteBufferPool is passed separately from the
+      // EnumSet of ReadOptions.
+
+      jthr = constructNewObjectOfClass(env, &byteBufferPool, className, "()V");
+      if (jthr) {
+          printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+              "hadoopRzOptionsSetByteBufferPool(className=%s): ", className);
+          errno = EINVAL;
+          return -1;
+      }
+    }
+    if (opts->byteBufferPool) {
+        // Delete any previous ByteBufferPool we had.
+        (*env)->DeleteGlobalRef(env, opts->byteBufferPool);
+    }
+    opts->byteBufferPool = byteBufferPool;
+    return 0;
+}
+
+void hadoopRzOptionsFree(struct hadoopRzOptions *opts)
+{
+    JNIEnv *env;
+    env = getJNIEnv();
+    if (!env) {
+        return;
+    }
+    hadoopRzOptionsClearCached(env, opts);
+    if (opts->byteBufferPool) {
+        (*env)->DeleteGlobalRef(env, opts->byteBufferPool);
+        opts->byteBufferPool = NULL;
+    }
+    free(opts);
+}
+
+struct hadoopRzBuffer
+{
+    jobject byteBuffer;
+    uint8_t *ptr;
+    int32_t length;
+    int direct;
+};
+
+static jthrowable hadoopRzOptionsGetEnumSet(JNIEnv *env,
+        struct hadoopRzOptions *opts, jobject *enumSet)
+{
+    jthrowable jthr = NULL;
+    jobject enumInst = NULL, enumSetObj = NULL;
+    jvalue jVal;
+
+    if (opts->cachedEnumSet) {
+        // If we cached the value, return it now.
+        *enumSet = opts->cachedEnumSet;
+        goto done;
+    }
+    if (opts->skipChecksums) {
+        jthr = fetchEnumInstance(env, READ_OPTION,
+                  "SKIP_CHECKSUMS", &enumInst);
+        if (jthr) {
+            goto done;
+        }
+        jthr = invokeMethod(env, &jVal, STATIC, NULL,
+                "java/util/EnumSet", "of",
+                "(Ljava/lang/Enum;)Ljava/util/EnumSet;", enumInst);
+        if (jthr) {
+            goto done;
+        }
+        enumSetObj = jVal.l;
+    } else {
+        jclass clazz = (*env)->FindClass(env, READ_OPTION);
+        if (!clazz) {
+            jthr = newRuntimeError(env, "failed "
+                    "to find class for %s", READ_OPTION);
+            goto done;
+        }
+        jthr = invokeMethod(env, &jVal, STATIC, NULL,
+                "java/util/EnumSet", "noneOf",
+                "(Ljava/lang/Class;)Ljava/util/EnumSet;", clazz);
+        enumSetObj = jVal.l;
+    }
+    // create global ref
+    opts->cachedEnumSet = (*env)->NewGlobalRef(env, enumSetObj);
+    if (!opts->cachedEnumSet) {
+        jthr = getPendingExceptionAndClear(env);
+        goto done;
+    }
+    *enumSet = opts->cachedEnumSet;
+    jthr = NULL;
+done:
+    (*env)->DeleteLocalRef(env, enumInst);
+    (*env)->DeleteLocalRef(env, enumSetObj);
+    return jthr;
+}
+
+static int hadoopReadZeroExtractBuffer(JNIEnv *env,
+        const struct hadoopRzOptions *opts, struct hadoopRzBuffer *buffer)
+{
+    int ret;
+    jthrowable jthr;
+    jvalue jVal;
+    uint8_t *directStart;
+    void *mallocBuf = NULL;
+    jint position;
+    jarray array = NULL;
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, buffer->byteBuffer,
+                     "java/nio/ByteBuffer", "remaining", "()I");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                "hadoopReadZeroExtractBuffer: ByteBuffer#remaining failed: ");
+        goto done;
+    }
+    buffer->length = jVal.i;
+    jthr = invokeMethod(env, &jVal, INSTANCE, buffer->byteBuffer,
+                     "java/nio/ByteBuffer", "position", "()I");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                "hadoopReadZeroExtractBuffer: ByteBuffer#position failed: ");
+        goto done;
+    }
+    position = jVal.i;
+    directStart = (*env)->GetDirectBufferAddress(env, buffer->byteBuffer);
+    if (directStart) {
+        // Handle direct buffers.
+        buffer->ptr = directStart + position;
+        buffer->direct = 1;
+        ret = 0;
+        goto done;
+    }
+    // Handle indirect buffers.
+    // The JNI docs don't say that GetDirectBufferAddress throws any exceptions
+    // when it fails.  However, they also don't clearly say that it doesn't.  It
+    // seems safest to clear any pending exceptions here, to prevent problems on
+    // various JVMs.
+    (*env)->ExceptionClear(env);
+    if (!opts->byteBufferPool) {
+        fputs("hadoopReadZeroExtractBuffer: we read through the "
+                "zero-copy path, but failed to get the address of the buffer via "
+                "GetDirectBufferAddress.  Please make sure your JVM supports "
+                "GetDirectBufferAddress.\n", stderr);
+        ret = ENOTSUP;
+        goto done;
+    }
+    // Get the backing array object of this buffer.
+    jthr = invokeMethod(env, &jVal, INSTANCE, buffer->byteBuffer,
+                     "java/nio/ByteBuffer", "array", "()[B");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                "hadoopReadZeroExtractBuffer: ByteBuffer#array failed: ");
+        goto done;
+    }
+    array = jVal.l;
+    if (!array) {
+        fputs("hadoopReadZeroExtractBuffer: ByteBuffer#array returned NULL.",
+              stderr);
+        ret = EIO;
+        goto done;
+    }
+    mallocBuf = malloc(buffer->length);
+    if (!mallocBuf) {
+        fprintf(stderr, "hadoopReadZeroExtractBuffer: failed to allocate %d bytes of memory\n",
+                buffer->length);
+        ret = ENOMEM;
+        goto done;
+    }
+    (*env)->GetByteArrayRegion(env, array, position, buffer->length, mallocBuf);
+    jthr = (*env)->ExceptionOccurred(env);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                "hadoopReadZeroExtractBuffer: GetByteArrayRegion failed: ");
+        goto done;
+    }
+    buffer->ptr = mallocBuf;
+    buffer->direct = 0;
+    ret = 0;
+
+done:
+    free(mallocBuf);
+    (*env)->DeleteLocalRef(env, array);
+    return ret;
+}
+
+static int translateZCRException(JNIEnv *env, jthrowable exc)
+{
+    int ret;
+    char *className = NULL;
+    jthrowable jthr = classNameOfObject(exc, env, &className);
+
+    if (jthr) {
+        fputs("hadoopReadZero: failed to get class name of "
+                "exception from read().\n", stderr);
+        destroyLocalReference(env, exc);
+        destroyLocalReference(env, jthr);
+        ret = EIO;
+        goto done;
+    }
+    if (!strcmp(className, "java.lang.UnsupportedOperationException")) {
+        ret = EPROTONOSUPPORT;
+        goto done;
+    }
+    ret = printExceptionAndFree(env, exc, PRINT_EXC_ALL,
+            "hadoopZeroCopyRead: ZeroCopyCursor#read failed");
+done:
+    free(className);
+    return ret;
+}
+
+struct hadoopRzBuffer* hadoopReadZero(hdfsFile file,
+            struct hadoopRzOptions *opts, int32_t maxLength)
+{
+    JNIEnv *env;
+    jthrowable jthr = NULL;
+    jvalue jVal;
+    jobject enumSet = NULL, byteBuffer = NULL;
+    struct hadoopRzBuffer* buffer = NULL;
+    int ret;
+
+    env = getJNIEnv();
+    if (!env) {
+        errno = EINTERNAL;
+        return NULL;
+    }
+    if (file->type != HDFS_STREAM_INPUT) {
+        fputs("Cannot read from a non-InputStream object!\n", stderr);
+        ret = EINVAL;
+        goto done;
+    }
+    buffer = calloc(1, sizeof(struct hadoopRzBuffer));
+    if (!buffer) {
+        ret = ENOMEM;
+        goto done;
+    }
+    jthr = hadoopRzOptionsGetEnumSet(env, opts, &enumSet);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                "hadoopReadZero: hadoopRzOptionsGetEnumSet failed: ");
+        goto done;
+    }
+    jthr = invokeMethod(env, &jVal, INSTANCE, file->file, HADOOP_ISTRM, "read",
+        "(Lorg/apache/hadoop/io/ByteBufferPool;ILjava/util/EnumSet;)"
+        "Ljava/nio/ByteBuffer;", opts->byteBufferPool, maxLength, enumSet);
+    if (jthr) {
+        ret = translateZCRException(env, jthr);
+        goto done;
+    }
+    byteBuffer = jVal.l;
+    if (!byteBuffer) {
+        buffer->byteBuffer = NULL;
+        buffer->length = 0;
+        buffer->ptr = NULL;
+    } else {
+        buffer->byteBuffer = (*env)->NewGlobalRef(env, byteBuffer);
+        if (!buffer->byteBuffer) {
+            ret = printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+                "hadoopReadZero: failed to create global ref to ByteBuffer");
+            goto done;
+        }
+        ret = hadoopReadZeroExtractBuffer(env, opts, buffer);
+        if (ret) {
+            goto done;
+        }
+    }
+    ret = 0;
+done:
+    (*env)->DeleteLocalRef(env, byteBuffer);
+    if (ret) {
+        if (buffer) {
+            if (buffer->byteBuffer) {
+                (*env)->DeleteGlobalRef(env, buffer->byteBuffer);
+            }
+            free(buffer);
+        }
+        errno = ret;
+        return NULL;
+    } else {
+        errno = 0;
+    }
+    return buffer;
+}
+
+int32_t hadoopRzBufferLength(const struct hadoopRzBuffer *buffer)
+{
+    return buffer->length;
+}
+
+const void *hadoopRzBufferGet(const struct hadoopRzBuffer *buffer)
+{
+    return buffer->ptr;
+}
+
+void hadoopRzBufferFree(hdfsFile file, struct hadoopRzBuffer *buffer)
+{
+    jvalue jVal;
+    jthrowable jthr;
+    JNIEnv* env;
+    
+    env = getJNIEnv();
+    if (env == NULL) {
+        errno = EINTERNAL;
+        return;
+    }
+    if (buffer->byteBuffer) {
+        jthr = invokeMethod(env, &jVal, INSTANCE, file->file,
+                    HADOOP_ISTRM, "releaseBuffer",
+                    "(Ljava/nio/ByteBuffer;)V", buffer->byteBuffer);
+        if (jthr) {
+            printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                    "hadoopRzBufferFree: releaseBuffer failed: ");
+            // even on error, we have to delete the reference.
+        }
+        (*env)->DeleteGlobalRef(env, buffer->byteBuffer);
+    }
+    if (!buffer->direct) {
+        free(buffer->ptr);
+    }
+    memset(buffer, 0, sizeof(*buffer));
+    free(buffer);
+}
+
+char***
+hdfsGetHosts(hdfsFS fs, const char *path, tOffset start, tOffset length)
+{
+    // JAVA EQUIVALENT:
+    //  fs.getFileBlockLoctions(new Path(path), start, length);
+
+    jobject jFS = (jobject)fs;
+    jthrowable jthr;
+    jobject jPath = NULL;
+    jobject jFileStatus = NULL;
+    jvalue jFSVal, jVal;
+    jobjectArray jBlockLocations = NULL, jFileBlockHosts = NULL;
+    jstring jHost = NULL;
+    char*** blockHosts = NULL;
+    int i, j, ret;
+    jsize jNumFileBlocks = 0;
+    jobject jFileBlock;
+    jsize jNumBlockHosts;
+    const char *hostName;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return NULL;
+    }
+
+    //Create an object of org.apache.hadoop.fs.Path
+    jthr = constructNewObjectOfPath(env, path, &jPath);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsGetHosts(path=%s): constructNewObjectOfPath", path);
+        goto done;
+    }
+    jthr = invokeMethod(env, &jFSVal, INSTANCE, jFS,
+            HADOOP_FS, "getFileStatus", "(Lorg/apache/hadoop/fs/Path;)"
+            "Lorg/apache/hadoop/fs/FileStatus;", jPath);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, NOPRINT_EXC_FILE_NOT_FOUND,
+                "hdfsGetHosts(path=%s, start=%"PRId64", length=%"PRId64"):"
+                "FileSystem#getFileStatus", path, start, length);
+        destroyLocalReference(env, jPath);
+        goto done;
+    }
+    jFileStatus = jFSVal.l;
+
+    //org.apache.hadoop.fs.FileSystem#getFileBlockLocations
+    jthr = invokeMethod(env, &jVal, INSTANCE, jFS,
+                     HADOOP_FS, "getFileBlockLocations", 
+                     "(Lorg/apache/hadoop/fs/FileStatus;JJ)"
+                     "[Lorg/apache/hadoop/fs/BlockLocation;",
+                     jFileStatus, start, length);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                "hdfsGetHosts(path=%s, start=%"PRId64", length=%"PRId64"):"
+                "FileSystem#getFileBlockLocations", path, start, length);
+        goto done;
+    }
+    jBlockLocations = jVal.l;
+
+    //Figure out no of entries in jBlockLocations
+    //Allocate memory and add NULL at the end
+    jNumFileBlocks = (*env)->GetArrayLength(env, jBlockLocations);
+
+    blockHosts = calloc(jNumFileBlocks + 1, sizeof(char**));
+    if (blockHosts == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+    if (jNumFileBlocks == 0) {
+        ret = 0;
+        goto done;
+    }
+
+    //Now parse each block to get hostnames
+    for (i = 0; i < jNumFileBlocks; ++i) {
+        jFileBlock =
+            (*env)->GetObjectArrayElement(env, jBlockLocations, i);
+        if (!jFileBlock) {
+            ret = printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+                "hdfsGetHosts(path=%s, start=%"PRId64", length=%"PRId64"):"
+                "GetObjectArrayElement(%d)", path, start, length, i);
+            goto done;
+        }
+        
+        jthr = invokeMethod(env, &jVal, INSTANCE, jFileBlock, HADOOP_BLK_LOC,
+                         "getHosts", "()[Ljava/lang/String;");
+        if (jthr) {
+            ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                "hdfsGetHosts(path=%s, start=%"PRId64", length=%"PRId64"):"
+                "BlockLocation#getHosts", path, start, length);
+            goto done;
+        }
+        jFileBlockHosts = jVal.l;
+        if (!jFileBlockHosts) {
+            fprintf(stderr,
+                "hdfsGetHosts(path=%s, start=%"PRId64", length=%"PRId64"):"
+                "BlockLocation#getHosts returned NULL", path, start, length);
+            ret = EINTERNAL;
+            goto done;
+        }
+        //Figure out no of hosts in jFileBlockHosts, and allocate the memory
+        jNumBlockHosts = (*env)->GetArrayLength(env, jFileBlockHosts);
+        blockHosts[i] = calloc(jNumBlockHosts + 1, sizeof(char*));
+        if (!blockHosts[i]) {
+            ret = ENOMEM;
+            goto done;
+        }
+
+        //Now parse each hostname
+        for (j = 0; j < jNumBlockHosts; ++j) {
+            jHost = (*env)->GetObjectArrayElement(env, jFileBlockHosts, j);
+            if (!jHost) {
+                ret = printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+                    "hdfsGetHosts(path=%s, start=%"PRId64", length=%"PRId64"): "
+                    "NewByteArray", path, start, length);
+                goto done;
+            }
+            hostName =
+                (const char*)((*env)->GetStringUTFChars(env, jHost, NULL));
+            if (!hostName) {
+                ret = printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+                    "hdfsGetHosts(path=%s, start=%"PRId64", length=%"PRId64", "
+                    "j=%d out of %d): GetStringUTFChars",
+                    path, start, length, j, jNumBlockHosts);
+                goto done;
+            }
+            blockHosts[i][j] = strdup(hostName);
+            (*env)->ReleaseStringUTFChars(env, jHost, hostName);
+            if (!blockHosts[i][j]) {
+                ret = ENOMEM;
+                goto done;
+            }
+            destroyLocalReference(env, jHost);
+            jHost = NULL;
+        }
+
+        destroyLocalReference(env, jFileBlockHosts);
+        jFileBlockHosts = NULL;
+    }
+    ret = 0;
+
+done:
+    destroyLocalReference(env, jPath);
+    destroyLocalReference(env, jFileStatus);
+    destroyLocalReference(env, jBlockLocations);
+    destroyLocalReference(env, jFileBlockHosts);
+    destroyLocalReference(env, jHost);
+    if (ret) {
+        errno = ret;
+        if (blockHosts) {
+            hdfsFreeHosts(blockHosts);
+        }
+        return NULL;
+    }
+
+    return blockHosts;
+}
+
+
+void hdfsFreeHosts(char ***blockHosts)
+{
+    int i, j;
+    for (i=0; blockHosts[i]; i++) {
+        for (j=0; blockHosts[i][j]; j++) {
+            free(blockHosts[i][j]);
+        }
+        free(blockHosts[i]);
+    }
+    free(blockHosts);
+}
+
+
+tOffset hdfsGetDefaultBlockSize(hdfsFS fs)
+{
+    // JAVA EQUIVALENT:
+    //  fs.getDefaultBlockSize();
+
+    jobject jFS = (jobject)fs;
+    jvalue jVal;
+    jthrowable jthr;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    //FileSystem#getDefaultBlockSize()
+    jthr = invokeMethod(env, &jVal, INSTANCE, jFS, HADOOP_FS,
+                     "getDefaultBlockSize", "()J");
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsGetDefaultBlockSize: FileSystem#getDefaultBlockSize");
+        return -1;
+    }
+    return jVal.j;
+}
+
+
+tOffset hdfsGetDefaultBlockSizeAtPath(hdfsFS fs, const char *path)
+{
+    // JAVA EQUIVALENT:
+    //  fs.getDefaultBlockSize(path);
+
+    jthrowable jthr;
+    jobject jFS = (jobject)fs;
+    jobject jPath;
+    tOffset blockSize;
+    JNIEnv* env = getJNIEnv();
+
+    if (env == NULL) {
+        errno = EINTERNAL;
+        return -1;
+    }
+    jthr = constructNewObjectOfPath(env, path, &jPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsGetDefaultBlockSize(path=%s): constructNewObjectOfPath",
+            path);
+        return -1;
+    }
+    jthr = getDefaultBlockSize(env, jFS, jPath, &blockSize);
+    (*env)->DeleteLocalRef(env, jPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsGetDefaultBlockSize(path=%s): "
+            "FileSystem#getDefaultBlockSize", path);
+        return -1;
+    }
+    return blockSize;
+}
+
+
+tOffset hdfsGetCapacity(hdfsFS fs)
+{
+    // JAVA EQUIVALENT:
+    //  FsStatus fss = fs.getStatus();
+    //  return Fss.getCapacity();
+
+    jobject jFS = (jobject)fs;
+    jvalue  jVal;
+    jthrowable jthr;
+    jobject fss;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    //FileSystem#getStatus
+    jthr = invokeMethod(env, &jVal, INSTANCE, jFS, HADOOP_FS,
+                     "getStatus", "()Lorg/apache/hadoop/fs/FsStatus;");
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsGetCapacity: FileSystem#getStatus");
+        return -1;
+    }
+    fss = (jobject)jVal.l;
+    jthr = invokeMethod(env, &jVal, INSTANCE, fss, HADOOP_FSSTATUS,
+                     "getCapacity", "()J");
+    destroyLocalReference(env, fss);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsGetCapacity: FsStatus#getCapacity");
+        return -1;
+    }
+    return jVal.j;
+}
+
+
+  
+tOffset hdfsGetUsed(hdfsFS fs)
+{
+    // JAVA EQUIVALENT:
+    //  FsStatus fss = fs.getStatus();
+    //  return Fss.getUsed();
+
+    jobject jFS = (jobject)fs;
+    jvalue  jVal;
+    jthrowable jthr;
+    jobject fss;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+
+    //FileSystem#getStatus
+    jthr = invokeMethod(env, &jVal, INSTANCE, jFS, HADOOP_FS,
+                     "getStatus", "()Lorg/apache/hadoop/fs/FsStatus;");
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsGetUsed: FileSystem#getStatus");
+        return -1;
+    }
+    fss = (jobject)jVal.l;
+    jthr = invokeMethod(env, &jVal, INSTANCE, fss, HADOOP_FSSTATUS,
+                     "getUsed", "()J");
+    destroyLocalReference(env, fss);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsGetUsed: FsStatus#getUsed");
+        return -1;
+    }
+    return jVal.j;
+}
+ 
+/**
+ * We cannot add new fields to the hdfsFileInfo structure because it would break
+ * binary compatibility.  The reason is because we return an array
+ * of hdfsFileInfo structures from hdfsListDirectory.  So changing the size of
+ * those structures would break all programs that relied on finding the second
+ * element in the array at <base_offset> + sizeof(struct hdfsFileInfo).
+ *
+ * So instead, we add the new fields to the hdfsExtendedFileInfo structure.
+ * This structure is contained in the mOwner string found inside the
+ * hdfsFileInfo.  Specifically, the format of mOwner is:
+ *
+ * [owner-string] [null byte] [padding] [hdfsExtendedFileInfo structure]
+ *
+ * The padding is added so that the hdfsExtendedFileInfo structure starts on an
+ * 8-byte boundary.
+ *
+ * @param str           The string to locate the extended info in.
+ * @return              The offset of the hdfsExtendedFileInfo structure.
+ */
+static size_t getExtendedFileInfoOffset(const char *str)
+{
+    int num_64_bit_words = ((strlen(str) + 1) + 7) / 8;
+    return num_64_bit_words * 8;
+}
+
+static struct hdfsExtendedFileInfo *getExtendedFileInfo(hdfsFileInfo *fileInfo)
+{
+    char *owner = fileInfo->mOwner;
+    return (struct hdfsExtendedFileInfo *)(owner +
+                getExtendedFileInfoOffset(owner));
+}
+
+static jthrowable
+getFileInfoFromStat(JNIEnv *env, jobject jStat, hdfsFileInfo *fileInfo)
+{
+    jvalue jVal;
+    jthrowable jthr;
+    jobject jPath = NULL;
+    jstring jPathName = NULL;
+    jstring jUserName = NULL;
+    jstring jGroupName = NULL;
+    jobject jPermission = NULL;
+    const char *cPathName;
+    const char *cUserName;
+    const char *cGroupName;
+    struct hdfsExtendedFileInfo *extInfo;
+    size_t extOffset;
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, jStat,
+                     HADOOP_STAT, "isDir", "()Z");
+    if (jthr)
+        goto done;
+    fileInfo->mKind = jVal.z ? kObjectKindDirectory : kObjectKindFile;
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, jStat,
+                     HADOOP_STAT, "getReplication", "()S");
+    if (jthr)
+        goto done;
+    fileInfo->mReplication = jVal.s;
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, jStat,
+                     HADOOP_STAT, "getBlockSize", "()J");
+    if (jthr)
+        goto done;
+    fileInfo->mBlockSize = jVal.j;
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, jStat,
+                     HADOOP_STAT, "getModificationTime", "()J");
+    if (jthr)
+        goto done;
+    fileInfo->mLastMod = jVal.j / 1000;
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, jStat,
+                     HADOOP_STAT, "getAccessTime", "()J");
+    if (jthr)
+        goto done;
+    fileInfo->mLastAccess = (tTime) (jVal.j / 1000);
+
+    if (fileInfo->mKind == kObjectKindFile) {
+        jthr = invokeMethod(env, &jVal, INSTANCE, jStat,
+                         HADOOP_STAT, "getLen", "()J");
+        if (jthr)
+            goto done;
+        fileInfo->mSize = jVal.j;
+    }
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, jStat, HADOOP_STAT,
+                     "getPath", "()Lorg/apache/hadoop/fs/Path;");
+    if (jthr)
+        goto done;
+    jPath = jVal.l;
+    if (jPath == NULL) {
+        jthr = newRuntimeError(env, "org.apache.hadoop.fs.FileStatus#"
+            "getPath returned NULL!");
+        goto done;
+    }
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, jPath, HADOOP_PATH,
+                     "toString", "()Ljava/lang/String;");
+    if (jthr)
+        goto done;
+    jPathName = jVal.l;
+    cPathName =
+        (const char*) ((*env)->GetStringUTFChars(env, jPathName, NULL));
+    if (!cPathName) {
+        jthr = getPendingExceptionAndClear(env);
+        goto done;
+    }
+    fileInfo->mName = strdup(cPathName);
+    (*env)->ReleaseStringUTFChars(env, jPathName, cPathName);
+    jthr = invokeMethod(env, &jVal, INSTANCE, jStat, HADOOP_STAT,
+                    "getOwner", "()Ljava/lang/String;");
+    if (jthr)
+        goto done;
+    jUserName = jVal.l;
+    cUserName =
+        (const char*) ((*env)->GetStringUTFChars(env, jUserName, NULL));
+    if (!cUserName) {
+        jthr = getPendingExceptionAndClear(env);
+        goto done;
+    }
+    extOffset = getExtendedFileInfoOffset(cUserName);
+    fileInfo->mOwner = malloc(extOffset + sizeof(struct hdfsExtendedFileInfo));
+    if (!fileInfo->mOwner) {
+        jthr = newRuntimeError(env, "getFileInfo: OOM allocating mOwner");
+        goto done;
+    }
+    strcpy(fileInfo->mOwner, cUserName);
+    (*env)->ReleaseStringUTFChars(env, jUserName, cUserName);
+    extInfo = getExtendedFileInfo(fileInfo);
+    memset(extInfo, 0, sizeof(*extInfo));
+    jthr = invokeMethod(env, &jVal, INSTANCE, jStat,
+                    HADOOP_STAT, "isEncrypted", "()Z");
+    if (jthr) {
+        goto done;
+    }
+    if (jVal.z == JNI_TRUE) {
+        extInfo->flags |= HDFS_EXTENDED_FILE_INFO_ENCRYPTED;
+    }
+    jthr = invokeMethod(env, &jVal, INSTANCE, jStat, HADOOP_STAT,
+                    "getGroup", "()Ljava/lang/String;");
+    if (jthr)
+        goto done;
+    jGroupName = jVal.l;
+    cGroupName = (const char*) ((*env)->GetStringUTFChars(env, jGroupName, NULL));
+    if (!cGroupName) {
+        jthr = getPendingExceptionAndClear(env);
+        goto done;
+    }
+    fileInfo->mGroup = strdup(cGroupName);
+    (*env)->ReleaseStringUTFChars(env, jGroupName, cGroupName);
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, jStat, HADOOP_STAT,
+            "getPermission",
+            "()Lorg/apache/hadoop/fs/permission/FsPermission;");
+    if (jthr)
+        goto done;
+    if (jVal.l == NULL) {
+        jthr = newRuntimeError(env, "%s#getPermission returned NULL!",
+            HADOOP_STAT);
+        goto done;
+    }
+    jPermission = jVal.l;
+    jthr = invokeMethod(env, &jVal, INSTANCE, jPermission, HADOOP_FSPERM,
+                         "toShort", "()S");
+    if (jthr)
+        goto done;
+    fileInfo->mPermissions = jVal.s;
+    jthr = NULL;
+
+done:
+    if (jthr)
+        hdfsFreeFileInfoEntry(fileInfo);
+    destroyLocalReference(env, jPath);
+    destroyLocalReference(env, jPathName);
+    destroyLocalReference(env, jUserName);
+    destroyLocalReference(env, jGroupName);
+    destroyLocalReference(env, jPermission);
+    destroyLocalReference(env, jPath);
+    return jthr;
+}
+
+static jthrowable
+getFileInfo(JNIEnv *env, jobject jFS, jobject jPath, hdfsFileInfo **fileInfo)
+{
+    // JAVA EQUIVALENT:
+    //  fs.isDirectory(f)
+    //  fs.getModificationTime()
+    //  fs.getAccessTime()
+    //  fs.getLength(f)
+    //  f.getPath()
+    //  f.getOwner()
+    //  f.getGroup()
+    //  f.getPermission().toShort()
+    jobject jStat;
+    jvalue  jVal;
+    jthrowable jthr;
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, jFS, HADOOP_FS,
+                     "exists", JMETHOD1(JPARAM(HADOOP_PATH), "Z"),
+                     jPath);
+    if (jthr)
+        return jthr;
+    if (jVal.z == 0) {
+        *fileInfo = NULL;
+        return NULL;
+    }
+    jthr = invokeMethod(env, &jVal, INSTANCE, jFS,
+            HADOOP_FS, "getFileStatus",
+            JMETHOD1(JPARAM(HADOOP_PATH), JPARAM(HADOOP_STAT)), jPath);
+    if (jthr)
+        return jthr;
+    jStat = jVal.l;
+    *fileInfo = calloc(1, sizeof(hdfsFileInfo));
+    if (!*fileInfo) {
+        destroyLocalReference(env, jStat);
+        return newRuntimeError(env, "getFileInfo: OOM allocating hdfsFileInfo");
+    }
+    jthr = getFileInfoFromStat(env, jStat, *fileInfo); 
+    destroyLocalReference(env, jStat);
+    return jthr;
+}
+
+
+
+hdfsFileInfo* hdfsListDirectory(hdfsFS fs, const char *path, int *numEntries)
+{
+    // JAVA EQUIVALENT:
+    //  Path p(path);
+    //  Path []pathList = fs.listPaths(p)
+    //  foreach path in pathList 
+    //    getFileInfo(path)
+
+    jobject jFS = (jobject)fs;
+    jthrowable jthr;
+    jobject jPath = NULL;
+    hdfsFileInfo *pathList = NULL; 
+    jobjectArray jPathList = NULL;
+    jvalue jVal;
+    jsize jPathListSize = 0;
+    int ret;
+    jsize i;
+    jobject tmpStat;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return NULL;
+    }
+
+    //Create an object of org.apache.hadoop.fs.Path
+    jthr = constructNewObjectOfPath(env, path, &jPath);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsListDirectory(%s): constructNewObjectOfPath", path);
+        goto done;
+    }
+
+    jthr = invokeMethod(env, &jVal, INSTANCE, jFS, HADOOP_DFS, "listStatus",
+                     JMETHOD1(JPARAM(HADOOP_PATH), JARRPARAM(HADOOP_STAT)),
+                     jPath);
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr,
+            NOPRINT_EXC_ACCESS_CONTROL | NOPRINT_EXC_FILE_NOT_FOUND |
+            NOPRINT_EXC_UNRESOLVED_LINK,
+            "hdfsListDirectory(%s): FileSystem#listStatus", path);
+        goto done;
+    }
+    jPathList = jVal.l;
+
+    //Figure out the number of entries in that directory
+    jPathListSize = (*env)->GetArrayLength(env, jPathList);
+    if (jPathListSize == 0) {
+        ret = 0;
+        goto done;
+    }
+
+    //Allocate memory
+    pathList = calloc(jPathListSize, sizeof(hdfsFileInfo));
+    if (pathList == NULL) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    //Save path information in pathList
+    for (i=0; i < jPathListSize; ++i) {
+        tmpStat = (*env)->GetObjectArrayElement(env, jPathList, i);
+        if (!tmpStat) {
+            ret = printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+                "hdfsListDirectory(%s): GetObjectArrayElement(%d out of %d)",
+                path, i, jPathListSize);
+            goto done;
+        }
+        jthr = getFileInfoFromStat(env, tmpStat, &pathList[i]);
+        destroyLocalReference(env, tmpStat);
+        if (jthr) {
+            ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                "hdfsListDirectory(%s): getFileInfoFromStat(%d out of %d)",
+                path, i, jPathListSize);
+            goto done;
+        }
+    }
+    ret = 0;
+
+done:
+    destroyLocalReference(env, jPath);
+    destroyLocalReference(env, jPathList);
+
+    if (ret) {
+        hdfsFreeFileInfo(pathList, jPathListSize);
+        errno = ret;
+        return NULL;
+    }
+    *numEntries = jPathListSize;
+    errno = 0;
+    return pathList;
+}
+
+
+
+hdfsFileInfo *hdfsGetPathInfo(hdfsFS fs, const char *path)
+{
+    // JAVA EQUIVALENT:
+    //  File f(path);
+    //  fs.isDirectory(f)
+    //  fs.lastModified() ??
+    //  fs.getLength(f)
+    //  f.getPath()
+
+    jobject jFS = (jobject)fs;
+    jobject jPath;
+    jthrowable jthr;
+    hdfsFileInfo *fileInfo;
+
+    //Get the JNIEnv* corresponding to current thread
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return NULL;
+    }
+
+    //Create an object of org.apache.hadoop.fs.Path
+    jthr = constructNewObjectOfPath(env, path, &jPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "hdfsGetPathInfo(%s): constructNewObjectOfPath", path);
+        return NULL;
+    }
+    jthr = getFileInfo(env, jFS, jPath, &fileInfo);
+    destroyLocalReference(env, jPath);
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr,
+            NOPRINT_EXC_ACCESS_CONTROL | NOPRINT_EXC_FILE_NOT_FOUND |
+            NOPRINT_EXC_UNRESOLVED_LINK,
+            "hdfsGetPathInfo(%s): getFileInfo", path);
+        return NULL;
+    }
+    if (!fileInfo) {
+        errno = ENOENT;
+        return NULL;
+    }
+    return fileInfo;
+}
+
+static void hdfsFreeFileInfoEntry(hdfsFileInfo *hdfsFileInfo)
+{
+    free(hdfsFileInfo->mName);
+    free(hdfsFileInfo->mOwner);
+    free(hdfsFileInfo->mGroup);
+    memset(hdfsFileInfo, 0, sizeof(*hdfsFileInfo));
+}
+
+void hdfsFreeFileInfo(hdfsFileInfo *hdfsFileInfo, int numEntries)
+{
+    //Free the mName, mOwner, and mGroup
+    int i;
+    for (i=0; i < numEntries; ++i) {
+        hdfsFreeFileInfoEntry(hdfsFileInfo + i);
+    }
+
+    //Free entire block
+    free(hdfsFileInfo);
+}
+
+int hdfsFileIsEncrypted(hdfsFileInfo *fileInfo)
+{
+    struct hdfsExtendedFileInfo *extInfo;
+
+    extInfo = getExtendedFileInfo(fileInfo);
+    return !!(extInfo->flags & HDFS_EXTENDED_FILE_INFO_ENCRYPTED);
+}
+
+char* hdfsGetLastExceptionRootCause()
+{
+  return getLastTLSExceptionRootCause();
+}
+
+char* hdfsGetLastExceptionStackTrace()
+{
+  return getLastTLSExceptionStackTrace();
+}
+
+/**
+ * vim: ts=4: sw=4: et:
+ */

--- a/native/fs-hdfs/c_src/libhdfs/hdfs.h
+++ b/native/fs-hdfs/c_src/libhdfs/hdfs.h
@@ -1,0 +1,1091 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LIBHDFS_HDFS_H
+#define LIBHDFS_HDFS_H
+
+#include <errno.h> /* for EINTERNAL, etc. */
+#include <fcntl.h> /* for O_RDONLY, O_WRONLY */
+#include <stdint.h> /* for uint64_t, etc. */
+#include <time.h> /* for time_t */
+
+/*
+ * Support export of DLL symbols during libhdfs build, and import of DLL symbols
+ * during client application build.  A client application may optionally define
+ * symbol LIBHDFS_DLL_IMPORT in its build.  This is not strictly required, but
+ * the compiler can produce more efficient code with it.
+ */
+#ifdef WIN32
+    #ifdef LIBHDFS_DLL_EXPORT
+        #define LIBHDFS_EXTERNAL __declspec(dllexport)
+    #elif LIBHDFS_DLL_IMPORT
+        #define LIBHDFS_EXTERNAL __declspec(dllimport)
+    #else
+        #define LIBHDFS_EXTERNAL
+    #endif
+#else
+    #ifdef LIBHDFS_DLL_EXPORT
+        #define LIBHDFS_EXTERNAL __attribute__((visibility("default")))
+    #elif LIBHDFS_DLL_IMPORT
+        #define LIBHDFS_EXTERNAL __attribute__((visibility("default")))
+    #else
+        #define LIBHDFS_EXTERNAL
+    #endif
+#endif
+
+#ifndef O_RDONLY
+#define O_RDONLY 1
+#endif
+
+#ifndef O_WRONLY 
+#define O_WRONLY 2
+#endif
+
+#ifndef EINTERNAL
+#define EINTERNAL 255 
+#endif
+
+#define ELASTIC_BYTE_BUFFER_POOL_CLASS \
+  "org/apache/hadoop/io/ElasticByteBufferPool"
+
+/** All APIs set errno to meaningful values */
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+    /**
+     * Some utility decls used in libhdfs.
+     */
+    struct hdfsBuilder;
+    typedef int32_t   tSize; /// size of data for read/write io ops 
+    typedef time_t    tTime; /// time type in seconds
+    typedef int64_t   tOffset;/// offset within the file
+    typedef uint16_t  tPort; /// port
+    typedef enum tObjectKind {
+        kObjectKindFile = 'F',
+        kObjectKindDirectory = 'D',
+    } tObjectKind;
+    struct hdfsStreamBuilder;
+
+
+    /**
+     * The C reflection of org.apache.org.hadoop.FileSystem .
+     */
+    struct hdfs_internal;
+    typedef struct hdfs_internal* hdfsFS;
+    
+    struct hdfsFile_internal;
+    typedef struct hdfsFile_internal* hdfsFile;
+
+    struct hadoopRzOptions;
+
+    struct hadoopRzBuffer;
+
+    /**
+     * Determine if a file is open for read.
+     *
+     * @param file     The HDFS file
+     * @return         1 if the file is open for read; 0 otherwise
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsFileIsOpenForRead(hdfsFile file);
+
+    /**
+     * Determine if a file is open for write.
+     *
+     * @param file     The HDFS file
+     * @return         1 if the file is open for write; 0 otherwise
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsFileIsOpenForWrite(hdfsFile file);
+
+    struct hdfsReadStatistics {
+      uint64_t totalBytesRead;
+      uint64_t totalLocalBytesRead;
+      uint64_t totalShortCircuitBytesRead;
+      uint64_t totalZeroCopyBytesRead;
+    };
+
+    /**
+     * Get read statistics about a file.  This is only applicable to files
+     * opened for reading.
+     *
+     * @param file     The HDFS file
+     * @param stats    (out parameter) on a successful return, the read
+     *                 statistics.  Unchanged otherwise.  You must free the
+     *                 returned statistics with hdfsFileFreeReadStatistics.
+     * @return         0 if the statistics were successfully returned,
+     *                 -1 otherwise.  On a failure, please check errno against
+     *                 ENOTSUP.  webhdfs, LocalFilesystem, and so forth may
+     *                 not support read statistics.
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsFileGetReadStatistics(hdfsFile file,
+                                  struct hdfsReadStatistics **stats);
+
+    /**
+     * @param stats    HDFS read statistics for a file.
+     *
+     * @return the number of remote bytes read.
+     */
+    LIBHDFS_EXTERNAL
+    int64_t hdfsReadStatisticsGetRemoteBytesRead(
+                            const struct hdfsReadStatistics *stats);
+
+    /**
+     * Clear the read statistics for a file.
+     *
+     * @param file      The file to clear the read statistics of.
+     *
+     * @return          0 on success; the error code otherwise.
+     *                  EINVAL: the file is not open for reading.
+     *                  ENOTSUP: the file does not support clearing the read
+     *                  statistics.
+     *                  Errno will also be set to this code on failure.
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsFileClearReadStatistics(hdfsFile file);
+
+    /**
+     * Free some HDFS read statistics.
+     *
+     * @param stats    The HDFS read statistics to free.
+     */
+    LIBHDFS_EXTERNAL
+    void hdfsFileFreeReadStatistics(struct hdfsReadStatistics *stats);
+
+    struct hdfsHedgedReadMetrics {
+      uint64_t hedgedReadOps;
+      uint64_t hedgedReadOpsWin;
+      uint64_t hedgedReadOpsInCurThread;
+    };
+
+    /**
+     * Get cluster wide hedged read metrics.
+     *
+     * @param fs       The configured filesystem handle
+     * @param metrics  (out parameter) on a successful return, the hedged read
+     *                 metrics. Unchanged otherwise. You must free the returned
+     *                 statistics with hdfsFreeHedgedReadMetrics.
+     * @return         0 if the metrics were successfully returned, -1 otherwise.
+     *                 On a failure, please check errno against
+     *                 ENOTSUP. webhdfs, LocalFilesystem, and so forth may
+     *                 not support hedged read metrics.
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsGetHedgedReadMetrics(hdfsFS fs, struct hdfsHedgedReadMetrics **metrics);
+
+    /**
+     * Free HDFS Hedged read metrics.
+     *
+     * @param metrics  The HDFS Hedged read metrics to free
+     */
+    LIBHDFS_EXTERNAL
+    void hdfsFreeHedgedReadMetrics(struct hdfsHedgedReadMetrics *metrics);
+
+    /** 
+     * hdfsConnectAsUser - Connect to a hdfs file system as a specific user
+     * Connect to the hdfs.
+     * @param nn   The NameNode.  See hdfsBuilderSetNameNode for details.
+     * @param port The port on which the server is listening.
+     * @param user the user name (this is hadoop domain user). Or NULL is equivelant to hhdfsConnect(host, port)
+     * @return Returns a handle to the filesystem or NULL on error.
+     * @deprecated Use hdfsBuilderConnect instead. 
+     */
+     LIBHDFS_EXTERNAL
+     hdfsFS hdfsConnectAsUser(const char* nn, tPort port, const char *user);
+
+    /** 
+     * hdfsConnect - Connect to a hdfs file system.
+     * Connect to the hdfs.
+     * @param nn   The NameNode.  See hdfsBuilderSetNameNode for details.
+     * @param port The port on which the server is listening.
+     * @return Returns a handle to the filesystem or NULL on error.
+     * @deprecated Use hdfsBuilderConnect instead. 
+     */
+     LIBHDFS_EXTERNAL
+     hdfsFS hdfsConnect(const char* nn, tPort port);
+
+    /** 
+     * hdfsConnect - Connect to an hdfs file system.
+     *
+     * Forces a new instance to be created
+     *
+     * @param nn     The NameNode.  See hdfsBuilderSetNameNode for details.
+     * @param port   The port on which the server is listening.
+     * @param user   The user name to use when connecting
+     * @return       Returns a handle to the filesystem or NULL on error.
+     * @deprecated   Use hdfsBuilderConnect instead. 
+     */
+     LIBHDFS_EXTERNAL
+     hdfsFS hdfsConnectAsUserNewInstance(const char* nn, tPort port, const char *user );
+
+    /** 
+     * hdfsConnect - Connect to an hdfs file system.
+     *
+     * Forces a new instance to be created
+     *
+     * @param nn     The NameNode.  See hdfsBuilderSetNameNode for details.
+     * @param port   The port on which the server is listening.
+     * @return       Returns a handle to the filesystem or NULL on error.
+     * @deprecated   Use hdfsBuilderConnect instead. 
+     */
+     LIBHDFS_EXTERNAL
+     hdfsFS hdfsConnectNewInstance(const char* nn, tPort port);
+
+    /** 
+     * Connect to HDFS using the parameters defined by the builder.
+     *
+     * The HDFS builder will be freed, whether or not the connection was
+     * successful.
+     *
+     * Every successful call to hdfsBuilderConnect should be matched with a call
+     * to hdfsDisconnect, when the hdfsFS is no longer needed.
+     *
+     * @param bld    The HDFS builder
+     * @return       Returns a handle to the filesystem, or NULL on error.
+     */
+     LIBHDFS_EXTERNAL
+     hdfsFS hdfsBuilderConnect(struct hdfsBuilder *bld);
+
+    /**
+     * Create an HDFS builder.
+     *
+     * @return The HDFS builder, or NULL on error.
+     */
+    LIBHDFS_EXTERNAL
+    struct hdfsBuilder *hdfsNewBuilder(void);
+
+    /**
+     * Force the builder to always create a new instance of the FileSystem,
+     * rather than possibly finding one in the cache.
+     *
+     * @param bld The HDFS builder
+     */
+    LIBHDFS_EXTERNAL
+    void hdfsBuilderSetForceNewInstance(struct hdfsBuilder *bld);
+
+    /**
+     * Set the HDFS NameNode to connect to.
+     *
+     * @param bld  The HDFS builder
+     * @param nn   The NameNode to use.
+     *             If the string given is 'default', the default NameNode
+     *             configuration will be used (from the XML configuration files)
+     *             If NULL is given, a LocalFileSystem will be created.
+     *             If the string starts with a protocol type such as file:// or
+     *             hdfs://, this protocol type will be used.  If not, the
+     *             hdfs:// protocol type will be used.
+     *             You may specify a NameNode port in the usual way by
+     *             passing a string of the format hdfs://<hostname>:<port>.
+     *             Alternately, you may set the port with
+     *             hdfsBuilderSetNameNodePort.  However, you must not pass the
+     *             port in two different ways.
+     */
+    LIBHDFS_EXTERNAL
+    void hdfsBuilderSetNameNode(struct hdfsBuilder *bld, const char *nn);
+
+    /**
+     * Set the port of the HDFS NameNode to connect to.
+     *
+     * @param bld The HDFS builder
+     * @param port The port.
+     */
+    LIBHDFS_EXTERNAL
+    void hdfsBuilderSetNameNodePort(struct hdfsBuilder *bld, tPort port);
+
+    /**
+     * Set the username to use when connecting to the HDFS cluster.
+     *
+     * @param bld The HDFS builder
+     * @param userName The user name.  The string will be shallow-copied.
+     */
+    LIBHDFS_EXTERNAL
+    void hdfsBuilderSetUserName(struct hdfsBuilder *bld, const char *userName);
+
+    /**
+     * Set the path to the Kerberos ticket cache to use when connecting to
+     * the HDFS cluster.
+     *
+     * @param bld The HDFS builder
+     * @param kerbTicketCachePath The Kerberos ticket cache path.  The string
+     *                            will be shallow-copied.
+     */
+    LIBHDFS_EXTERNAL
+    void hdfsBuilderSetKerbTicketCachePath(struct hdfsBuilder *bld,
+                                   const char *kerbTicketCachePath);
+
+    /**
+     * Free an HDFS builder.
+     *
+     * It is normally not necessary to call this function since
+     * hdfsBuilderConnect frees the builder.
+     *
+     * @param bld The HDFS builder
+     */
+    LIBHDFS_EXTERNAL
+    void hdfsFreeBuilder(struct hdfsBuilder *bld);
+
+    /**
+     * Set a configuration string for an HdfsBuilder.
+     *
+     * @param key      The key to set.
+     * @param val      The value, or NULL to set no value.
+     *                 This will be shallow-copied.  You are responsible for
+     *                 ensuring that it remains valid until the builder is
+     *                 freed.
+     *
+     * @return         0 on success; nonzero error code otherwise.
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsBuilderConfSetStr(struct hdfsBuilder *bld, const char *key,
+                              const char *val);
+
+    /**
+     * Get a configuration string.
+     *
+     * @param key      The key to find
+     * @param val      (out param) The value.  This will be set to NULL if the
+     *                 key isn't found.  You must free this string with
+     *                 hdfsConfStrFree.
+     *
+     * @return         0 on success; nonzero error code otherwise.
+     *                 Failure to find the key is not an error.
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsConfGetStr(const char *key, char **val);
+
+    /**
+     * Get a configuration integer.
+     *
+     * @param key      The key to find
+     * @param val      (out param) The value.  This will NOT be changed if the
+     *                 key isn't found.
+     *
+     * @return         0 on success; nonzero error code otherwise.
+     *                 Failure to find the key is not an error.
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsConfGetInt(const char *key, int32_t *val);
+
+    /**
+     * Free a configuration string found with hdfsConfGetStr. 
+     *
+     * @param val      A configuration string obtained from hdfsConfGetStr
+     */
+    LIBHDFS_EXTERNAL
+    void hdfsConfStrFree(char *val);
+
+    /** 
+     * hdfsDisconnect - Disconnect from the hdfs file system.
+     * Disconnect from hdfs.
+     * @param fs The configured filesystem handle.
+     * @return Returns 0 on success, -1 on error.
+     *         Even if there is an error, the resources associated with the
+     *         hdfsFS will be freed.
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsDisconnect(hdfsFS fs);
+        
+    /** 
+     * hdfsOpenFile - Open a hdfs file in given mode.
+     * @deprecated    Use the hdfsStreamBuilder functions instead.
+     * This function does not support setting block sizes bigger than 2 GB.
+     *
+     * @param fs The configured filesystem handle.
+     * @param path The full path to the file.
+     * @param flags - an | of bits/fcntl.h file flags - supported flags are O_RDONLY, O_WRONLY (meaning create or overwrite i.e., implies O_TRUNCAT), 
+     * O_WRONLY|O_APPEND. Other flags are generally ignored other than (O_RDWR || (O_EXCL & O_CREAT)) which return NULL and set errno equal ENOTSUP.
+     * @param bufferSize Size of buffer for read/write - pass 0 if you want
+     * to use the default configured values.
+     * @param replication Block replication - pass 0 if you want to use
+     * the default configured values.
+     * @param blocksize Size of block - pass 0 if you want to use the
+     * default configured values.  Note that if you want a block size bigger
+     * than 2 GB, you must use the hdfsStreamBuilder API rather than this
+     * deprecated function.
+     * @return Returns the handle to the open file or NULL on error.
+     */
+    LIBHDFS_EXTERNAL
+    hdfsFile hdfsOpenFile(hdfsFS fs, const char* path, int flags,
+                          int bufferSize, short replication, tSize blocksize);
+
+    /**
+     * hdfsStreamBuilderAlloc - Allocate an HDFS stream builder.
+     *
+     * @param fs The configured filesystem handle.
+     * @param path The full path to the file.  Will be deep-copied.
+     * @param flags The open flags, as in hdfsOpenFile.
+     * @return Returns the hdfsStreamBuilder, or NULL on error.
+     */
+    LIBHDFS_EXTERNAL
+    struct hdfsStreamBuilder *hdfsStreamBuilderAlloc(hdfsFS fs,
+                                      const char *path, int flags);
+
+    /**
+     * hdfsStreamBuilderFree - Free an HDFS file builder.
+     *
+     * It is normally not necessary to call this function since
+     * hdfsStreamBuilderBuild frees the builder.
+     *
+     * @param bld The hdfsStreamBuilder to free.
+     */
+    LIBHDFS_EXTERNAL
+    void hdfsStreamBuilderFree(struct hdfsStreamBuilder *bld);
+
+    /**
+     * hdfsStreamBuilderSetBufferSize - Set the stream buffer size.
+     *
+     * @param bld The hdfs stream builder.
+     * @param bufferSize The buffer size to set.
+     *
+     * @return 0 on success, or -1 on error.  Errno will be set on error.
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsStreamBuilderSetBufferSize(struct hdfsStreamBuilder *bld,
+                                       int32_t bufferSize);
+
+    /**
+     * hdfsStreamBuilderSetReplication - Set the replication for the stream.
+     * This is only relevant for output streams, which will create new blocks.
+     *
+     * @param bld The hdfs stream builder.
+     * @param replication The replication to set.
+     *
+     * @return 0 on success, or -1 on error.  Errno will be set on error.
+     *              If you call this on an input stream builder, you will get
+     *              EINVAL, because this configuration is not relevant to input
+     *              streams.
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsStreamBuilderSetReplication(struct hdfsStreamBuilder *bld,
+                                        int16_t replication);
+
+    /**
+     * hdfsStreamBuilderSetDefaultBlockSize - Set the default block size for
+     * the stream.  This is only relevant for output streams, which will create
+     * new blocks.
+     *
+     * @param bld The hdfs stream builder.
+     * @param defaultBlockSize The default block size to set.
+     *
+     * @return 0 on success, or -1 on error.  Errno will be set on error.
+     *              If you call this on an input stream builder, you will get
+     *              EINVAL, because this configuration is not relevant to input
+     *              streams.
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsStreamBuilderSetDefaultBlockSize(struct hdfsStreamBuilder *bld,
+                                       int64_t defaultBlockSize);
+
+    /**
+     * hdfsStreamBuilderBuild - Build the stream by calling open or create.
+     *
+     * @param bld The hdfs stream builder.  This pointer will be freed, whether
+     *            or not the open succeeds.
+     *
+     * @return the stream pointer on success, or NULL on error.  Errno will be
+     * set on error.
+     */
+    LIBHDFS_EXTERNAL
+    hdfsFile hdfsStreamBuilderBuild(struct hdfsStreamBuilder *bld);
+
+    /**
+     * hdfsTruncateFile - Truncate a hdfs file to given lenght.
+     * @param fs The configured filesystem handle.
+     * @param path The full path to the file.
+     * @param newlength The size the file is to be truncated to
+     * @return 1 if the file has been truncated to the desired newlength 
+     *         and is immediately available to be reused for write operations 
+     *         such as append.
+     *         0 if a background process of adjusting the length of the last 
+     *         block has been started, and clients should wait for it to
+     *         complete before proceeding with further file updates.
+     *         -1 on error.
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsTruncateFile(hdfsFS fs, const char* path, tOffset newlength);
+
+    /**
+     * hdfsUnbufferFile - Reduce the buffering done on a file.
+     *
+     * @param file  The file to unbuffer.
+     * @return      0 on success
+     *              ENOTSUP if the file does not support unbuffering
+     *              Errno will also be set to this value.
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsUnbufferFile(hdfsFile file);
+
+    /** 
+     * hdfsCloseFile - Close an open file. 
+     * @param fs The configured filesystem handle.
+     * @param file The file handle.
+     * @return Returns 0 on success, -1 on error.  
+     *         On error, errno will be set appropriately.
+     *         If the hdfs file was valid, the memory associated with it will
+     *         be freed at the end of this call, even if there was an I/O
+     *         error.
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsCloseFile(hdfsFS fs, hdfsFile file);
+
+
+    /** 
+     * hdfsExists - Checks if a given path exsits on the filesystem 
+     * @param fs The configured filesystem handle.
+     * @param path The path to look for
+     * @return Returns 0 on success, -1 on error.  
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsExists(hdfsFS fs, const char *path);
+
+
+    /** 
+     * hdfsSeek - Seek to given offset in file. 
+     * This works only for files opened in read-only mode. 
+     * @param fs The configured filesystem handle.
+     * @param file The file handle.
+     * @param desiredPos Offset into the file to seek into.
+     * @return Returns 0 on success, -1 on error.  
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsSeek(hdfsFS fs, hdfsFile file, tOffset desiredPos); 
+
+
+    /** 
+     * hdfsTell - Get the current offset in the file, in bytes.
+     * @param fs The configured filesystem handle.
+     * @param file The file handle.
+     * @return Current offset, -1 on error.
+     */
+    LIBHDFS_EXTERNAL
+    tOffset hdfsTell(hdfsFS fs, hdfsFile file);
+
+
+    /** 
+     * hdfsRead - Read data from an open file.
+     * @param fs The configured filesystem handle.
+     * @param file The file handle.
+     * @param buffer The buffer to copy read bytes into.
+     * @param length The length of the buffer.
+     * @return      On success, a positive number indicating how many bytes
+     *              were read.
+     *              On end-of-file, 0.
+     *              On error, -1.  Errno will be set to the error code.
+     *              Just like the POSIX read function, hdfsRead will return -1
+     *              and set errno to EINTR if data is temporarily unavailable,
+     *              but we are not yet at the end of the file.
+     */
+    LIBHDFS_EXTERNAL
+    tSize hdfsRead(hdfsFS fs, hdfsFile file, void* buffer, tSize length);
+
+    /** 
+     * hdfsPread - Positional read of data from an open file.
+     * @param fs The configured filesystem handle.
+     * @param file The file handle.
+     * @param position Position from which to read
+     * @param buffer The buffer to copy read bytes into.
+     * @param length The length of the buffer.
+     * @return      See hdfsRead
+     */
+    LIBHDFS_EXTERNAL
+    tSize hdfsPread(hdfsFS fs, hdfsFile file, tOffset position,
+                    void* buffer, tSize length);
+
+
+    /** 
+     * hdfsWrite - Write data into an open file.
+     * @param fs The configured filesystem handle.
+     * @param file The file handle.
+     * @param buffer The data.
+     * @param length The no. of bytes to write. 
+     * @return Returns the number of bytes written, -1 on error.
+     */
+    LIBHDFS_EXTERNAL
+    tSize hdfsWrite(hdfsFS fs, hdfsFile file, const void* buffer,
+                    tSize length);
+
+
+    /** 
+     * hdfsWrite - Flush the data. 
+     * @param fs The configured filesystem handle.
+     * @param file The file handle.
+     * @return Returns 0 on success, -1 on error. 
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsFlush(hdfsFS fs, hdfsFile file);
+
+
+    /**
+     * hdfsHFlush - Flush out the data in client's user buffer. After the
+     * return of this call, new readers will see the data.
+     * @param fs configured filesystem handle
+     * @param file file handle
+     * @return 0 on success, -1 on error and sets errno
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsHFlush(hdfsFS fs, hdfsFile file);
+
+
+    /**
+     * hdfsHSync - Similar to posix fsync, Flush out the data in client's 
+     * user buffer. all the way to the disk device (but the disk may have 
+     * it in its cache).
+     * @param fs configured filesystem handle
+     * @param file file handle
+     * @return 0 on success, -1 on error and sets errno
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsHSync(hdfsFS fs, hdfsFile file);
+
+
+    /**
+     * hdfsAvailable - Number of bytes that can be read from this
+     * input stream without blocking.
+     * @param fs The configured filesystem handle.
+     * @param file The file handle.
+     * @return Returns available bytes; -1 on error. 
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsAvailable(hdfsFS fs, hdfsFile file);
+
+
+    /**
+     * hdfsCopy - Copy file from one filesystem to another.
+     * @param srcFS The handle to source filesystem.
+     * @param src The path of source file. 
+     * @param dstFS The handle to destination filesystem.
+     * @param dst The path of destination file. 
+     * @return Returns 0 on success, -1 on error. 
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsCopy(hdfsFS srcFS, const char* src, hdfsFS dstFS, const char* dst);
+
+
+    /**
+     * hdfsMove - Move file from one filesystem to another.
+     * @param srcFS The handle to source filesystem.
+     * @param src The path of source file. 
+     * @param dstFS The handle to destination filesystem.
+     * @param dst The path of destination file. 
+     * @return Returns 0 on success, -1 on error. 
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsMove(hdfsFS srcFS, const char* src, hdfsFS dstFS, const char* dst);
+
+
+    /**
+     * hdfsDelete - Delete file. 
+     * @param fs The configured filesystem handle.
+     * @param path The path of the file. 
+     * @param recursive if path is a directory and set to 
+     * non-zero, the directory is deleted else throws an exception. In
+     * case of a file the recursive argument is irrelevant.
+     * @return Returns 0 on success, -1 on error. 
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsDelete(hdfsFS fs, const char* path, int recursive);
+
+    /**
+     * hdfsRename - Rename file. 
+     * @param fs The configured filesystem handle.
+     * @param oldPath The path of the source file. 
+     * @param newPath The path of the destination file. 
+     * @return Returns 0 on success, -1 on error. 
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsRename(hdfsFS fs, const char* oldPath, const char* newPath);
+
+    /**
+     * hdfsRename - Rename file and overwrite if exists.
+     * @param fs The configured filesystem handle.
+     * @param oldPath The path of the source file.
+     * @param newPath The path of the destination file.
+     * @return Returns 0 on success, -1 on error.
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsRenameOverwrite(hdfsFS fs, const char* oldPath, const char* newPath);
+
+
+    /** 
+     * hdfsGetWorkingDirectory - Get the current working directory for
+     * the given filesystem.
+     * @param fs The configured filesystem handle.
+     * @param buffer The user-buffer to copy path of cwd into. 
+     * @param bufferSize The length of user-buffer.
+     * @return Returns buffer, NULL on error.
+     */
+    LIBHDFS_EXTERNAL
+    char* hdfsGetWorkingDirectory(hdfsFS fs, char *buffer, size_t bufferSize);
+
+
+    /** 
+     * hdfsSetWorkingDirectory - Set the working directory. All relative
+     * paths will be resolved relative to it.
+     * @param fs The configured filesystem handle.
+     * @param path The path of the new 'cwd'. 
+     * @return Returns 0 on success, -1 on error. 
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsSetWorkingDirectory(hdfsFS fs, const char* path);
+
+
+    /** 
+     * hdfsCreateDirectory - Make the given file and all non-existent
+     * parents into directories.
+     * @param fs The configured filesystem handle.
+     * @param path The path of the directory. 
+     * @return Returns 0 on success, -1 on error. 
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsCreateDirectory(hdfsFS fs, const char* path);
+
+
+    /** 
+     * hdfsSetReplication - Set the replication of the specified
+     * file to the supplied value
+     * @param fs The configured filesystem handle.
+     * @param path The path of the file. 
+     * @return Returns 0 on success, -1 on error. 
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsSetReplication(hdfsFS fs, const char* path, int16_t replication);
+
+
+    /** 
+     * hdfsFileInfo - Information about a file/directory.
+     */
+    typedef struct  {
+        tObjectKind mKind;   /* file or directory */
+        char *mName;         /* the name of the file */
+        tTime mLastMod;      /* the last modification time for the file in seconds */
+        tOffset mSize;       /* the size of the file in bytes */
+        short mReplication;    /* the count of replicas */
+        tOffset mBlockSize;  /* the block size for the file */
+        char *mOwner;        /* the owner of the file */
+        char *mGroup;        /* the group associated with the file */
+        short mPermissions;  /* the permissions associated with the file */
+        tTime mLastAccess;    /* the last access time for the file in seconds */
+    } hdfsFileInfo;
+
+
+    /** 
+     * hdfsListDirectory - Get list of files/directories for a given
+     * directory-path. hdfsFreeFileInfo should be called to deallocate memory. 
+     * @param fs The configured filesystem handle.
+     * @param path The path of the directory. 
+     * @param numEntries Set to the number of files/directories in path.
+     * @return Returns a dynamically-allocated array of hdfsFileInfo
+     * objects; NULL on error or empty directory.
+     * errno is set to non-zero on error or zero on success.
+     */
+    LIBHDFS_EXTERNAL
+    hdfsFileInfo *hdfsListDirectory(hdfsFS fs, const char* path,
+                                    int *numEntries);
+
+
+    /** 
+     * hdfsGetPathInfo - Get information about a path as a (dynamically
+     * allocated) single hdfsFileInfo struct. hdfsFreeFileInfo should be
+     * called when the pointer is no longer needed.
+     * @param fs The configured filesystem handle.
+     * @param path The path of the file. 
+     * @return Returns a dynamically-allocated hdfsFileInfo object;
+     * NULL on error.
+     */
+    LIBHDFS_EXTERNAL
+    hdfsFileInfo *hdfsGetPathInfo(hdfsFS fs, const char* path);
+
+
+    /** 
+     * hdfsFreeFileInfo - Free up the hdfsFileInfo array (including fields) 
+     * @param hdfsFileInfo The array of dynamically-allocated hdfsFileInfo
+     * objects.
+     * @param numEntries The size of the array.
+     */
+    LIBHDFS_EXTERNAL
+    void hdfsFreeFileInfo(hdfsFileInfo *hdfsFileInfo, int numEntries);
+
+    /**
+     * hdfsFileIsEncrypted: determine if a file is encrypted based on its
+     * hdfsFileInfo.
+     * @return -1 if there was an error (errno will be set), 0 if the file is
+     *         not encrypted, 1 if the file is encrypted.
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsFileIsEncrypted(hdfsFileInfo *hdfsFileInfo);
+
+
+    /** 
+     * hdfsGetHosts - Get hostnames where a particular block (determined by
+     * pos & blocksize) of a file is stored. The last element in the array
+     * is NULL. Due to replication, a single block could be present on
+     * multiple hosts.
+     * @param fs The configured filesystem handle.
+     * @param path The path of the file. 
+     * @param start The start of the block.
+     * @param length The length of the block.
+     * @return Returns a dynamically-allocated 2-d array of blocks-hosts;
+     * NULL on error.
+     */
+    LIBHDFS_EXTERNAL
+    char*** hdfsGetHosts(hdfsFS fs, const char* path, 
+            tOffset start, tOffset length);
+
+
+    /** 
+     * hdfsFreeHosts - Free up the structure returned by hdfsGetHosts
+     * @param hdfsFileInfo The array of dynamically-allocated hdfsFileInfo
+     * objects.
+     * @param numEntries The size of the array.
+     */
+    LIBHDFS_EXTERNAL
+    void hdfsFreeHosts(char ***blockHosts);
+
+
+    /** 
+     * hdfsGetDefaultBlockSize - Get the default blocksize.
+     *
+     * @param fs            The configured filesystem handle.
+     * @deprecated          Use hdfsGetDefaultBlockSizeAtPath instead.
+     *
+     * @return              Returns the default blocksize, or -1 on error.
+     */
+    LIBHDFS_EXTERNAL
+    tOffset hdfsGetDefaultBlockSize(hdfsFS fs);
+
+
+    /** 
+     * hdfsGetDefaultBlockSizeAtPath - Get the default blocksize at the
+     * filesystem indicated by a given path.
+     *
+     * @param fs            The configured filesystem handle.
+     * @param path          The given path will be used to locate the actual
+     *                      filesystem.  The full path does not have to exist.
+     *
+     * @return              Returns the default blocksize, or -1 on error.
+     */
+    LIBHDFS_EXTERNAL
+    tOffset hdfsGetDefaultBlockSizeAtPath(hdfsFS fs, const char *path);
+
+
+    /** 
+     * hdfsGetCapacity - Return the raw capacity of the filesystem.  
+     * @param fs The configured filesystem handle.
+     * @return Returns the raw-capacity; -1 on error. 
+     */
+    LIBHDFS_EXTERNAL
+    tOffset hdfsGetCapacity(hdfsFS fs);
+
+
+    /** 
+     * hdfsGetUsed - Return the total raw size of all files in the filesystem.
+     * @param fs The configured filesystem handle.
+     * @return Returns the total-size; -1 on error. 
+     */
+    LIBHDFS_EXTERNAL
+    tOffset hdfsGetUsed(hdfsFS fs);
+
+    /** 
+     * Change the user and/or group of a file or directory.
+     *
+     * @param fs            The configured filesystem handle.
+     * @param path          the path to the file or directory
+     * @param owner         User string.  Set to NULL for 'no change'
+     * @param group         Group string.  Set to NULL for 'no change'
+     * @return              0 on success else -1
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsChown(hdfsFS fs, const char* path, const char *owner,
+                  const char *group);
+
+    /** 
+     * hdfsChmod
+     * @param fs The configured filesystem handle.
+     * @param path the path to the file or directory
+     * @param mode the bitmask to set it to
+     * @return 0 on success else -1
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsChmod(hdfsFS fs, const char* path, short mode);
+
+    /** 
+     * hdfsUtime
+     * @param fs The configured filesystem handle.
+     * @param path the path to the file or directory
+     * @param mtime new modification time or -1 for no change
+     * @param atime new access time or -1 for no change
+     * @return 0 on success else -1
+     */
+    LIBHDFS_EXTERNAL
+    int hdfsUtime(hdfsFS fs, const char* path, tTime mtime, tTime atime);
+
+    /**
+     * Allocate a zero-copy options structure.
+     *
+     * You must free all options structures allocated with this function using
+     * hadoopRzOptionsFree.
+     *
+     * @return            A zero-copy options structure, or NULL if one could
+     *                    not be allocated.  If NULL is returned, errno will
+     *                    contain the error number.
+     */
+    LIBHDFS_EXTERNAL
+    struct hadoopRzOptions *hadoopRzOptionsAlloc(void);
+
+    /**
+     * Determine whether we should skip checksums in read0.
+     *
+     * @param opts        The options structure.
+     * @param skip        Nonzero to skip checksums sometimes; zero to always
+     *                    check them.
+     *
+     * @return            0 on success; -1 plus errno on failure.
+     */
+    LIBHDFS_EXTERNAL
+    int hadoopRzOptionsSetSkipChecksum(
+            struct hadoopRzOptions *opts, int skip);
+
+    /**
+     * Set the ByteBufferPool to use with read0.
+     *
+     * @param opts        The options structure.
+     * @param className   If this is NULL, we will not use any
+     *                    ByteBufferPool.  If this is non-NULL, it will be
+     *                    treated as the name of the pool class to use.
+     *                    For example, you can use
+     *                    ELASTIC_BYTE_BUFFER_POOL_CLASS.
+     *
+     * @return            0 if the ByteBufferPool class was found and
+     *                    instantiated;
+     *                    -1 plus errno otherwise.
+     */
+    LIBHDFS_EXTERNAL
+    int hadoopRzOptionsSetByteBufferPool(
+            struct hadoopRzOptions *opts, const char *className);
+
+    /**
+     * Free a hadoopRzOptionsFree structure.
+     *
+     * @param opts        The options structure to free.
+     *                    Any associated ByteBufferPool will also be freed.
+     */
+    LIBHDFS_EXTERNAL
+    void hadoopRzOptionsFree(struct hadoopRzOptions *opts);
+
+    /**
+     * Perform a byte buffer read.
+     * If possible, this will be a zero-copy (mmap) read.
+     *
+     * @param file       The file to read from.
+     * @param opts       An options structure created by hadoopRzOptionsAlloc.
+     * @param maxLength  The maximum length to read.  We may read fewer bytes
+     *                   than this length.
+     *
+     * @return           On success, we will return a new hadoopRzBuffer.
+     *                   This buffer will continue to be valid and readable
+     *                   until it is released by readZeroBufferFree.  Failure to
+     *                   release a buffer will lead to a memory leak.
+     *                   You can access the data within the hadoopRzBuffer with
+     *                   hadoopRzBufferGet.  If you have reached EOF, the data
+     *                   within the hadoopRzBuffer will be NULL.  You must still
+     *                   free hadoopRzBuffer instances containing NULL.
+     *                   On failure, we will return NULL plus an errno code.
+     *                   errno = EOPNOTSUPP indicates that we could not do a
+     *                   zero-copy read, and there was no ByteBufferPool
+     *                   supplied.
+     */
+    LIBHDFS_EXTERNAL
+    struct hadoopRzBuffer* hadoopReadZero(hdfsFile file,
+            struct hadoopRzOptions *opts, int32_t maxLength);
+
+    /**
+     * Determine the length of the buffer returned from readZero.
+     *
+     * @param buffer     a buffer returned from readZero.
+     * @return           the length of the buffer.
+     */
+    LIBHDFS_EXTERNAL
+    int32_t hadoopRzBufferLength(const struct hadoopRzBuffer *buffer);
+
+    /**
+     * Get a pointer to the raw buffer returned from readZero.
+     *
+     * To find out how many bytes this buffer contains, call
+     * hadoopRzBufferLength.
+     *
+     * @param buffer     a buffer returned from readZero.
+     * @return           a pointer to the start of the buffer.  This will be
+     *                   NULL when end-of-file has been reached.
+     */
+    LIBHDFS_EXTERNAL
+    const void *hadoopRzBufferGet(const struct hadoopRzBuffer *buffer);
+
+    /**
+     * Release a buffer obtained through readZero.
+     *
+     * @param file       The hdfs stream that created this buffer.  This must be
+     *                   the same stream you called hadoopReadZero on.
+     * @param buffer     The buffer to release.
+     */
+    LIBHDFS_EXTERNAL
+    void hadoopRzBufferFree(hdfsFile file, struct hadoopRzBuffer *buffer);
+
+    /**
+     * Get the last exception root cause that happened in the context of the
+     * current thread, i.e. the thread that called into libHDFS.
+     *
+     * The pointer returned by this function is guaranteed to be valid until
+     * the next call into libHDFS by the current thread.
+     * Users of this function should not free the pointer.
+     *
+     * A NULL will be returned if no exception information could be retrieved
+     * for the previous call.
+     *
+     * @return           The root cause as a C-string.
+     */
+    LIBHDFS_EXTERNAL
+    char* hdfsGetLastExceptionRootCause();
+
+    /**
+     * Get the last exception stack trace that happened in the context of the
+     * current thread, i.e. the thread that called into libHDFS.
+     *
+     * The pointer returned by this function is guaranteed to be valid until
+     * the next call into libHDFS by the current thread.
+     * Users of this function should not free the pointer.
+     *
+     * A NULL will be returned if no exception information could be retrieved
+     * for the previous call.
+     *
+     * @return           The stack trace as a C-string.
+     */
+    LIBHDFS_EXTERNAL
+    char* hdfsGetLastExceptionStackTrace();
+
+#ifdef __cplusplus
+}
+#endif
+
+#undef LIBHDFS_EXTERNAL
+#endif /*LIBHDFS_HDFS_H*/
+
+/**
+ * vim: ts=4: sw=4: et
+ */

--- a/native/fs-hdfs/c_src/libhdfs/htable.c
+++ b/native/fs-hdfs/c_src/libhdfs/htable.c
@@ -1,0 +1,287 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "htable.h"
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+struct htable_pair {
+    void *key;
+    void *val;
+};
+
+/**
+ * A hash table which uses linear probing.
+ */
+struct htable {
+    uint32_t capacity;
+    uint32_t used;
+    htable_hash_fn_t hash_fun;
+    htable_eq_fn_t eq_fun;
+    struct htable_pair *elem;
+};
+
+/**
+ * An internal function for inserting a value into the hash table.
+ *
+ * Note: this function assumes that you have made enough space in the table.
+ *
+ * @param nelem         The new element to insert.
+ * @param capacity      The capacity of the hash table.
+ * @param hash_fun      The hash function to use.
+ * @param key           The key to insert.
+ * @param val           The value to insert.
+ */
+static void htable_insert_internal(struct htable_pair *nelem, 
+        uint32_t capacity, htable_hash_fn_t hash_fun, void *key,
+        void *val)
+{
+    uint32_t i;
+
+    i = hash_fun(key, capacity);
+    while (1) {
+        if (!nelem[i].key) {
+            nelem[i].key = key;
+            nelem[i].val = val;
+            return;
+        }
+        i++;
+        if (i == capacity) {
+            i = 0;
+        }
+    }
+}
+
+static int htable_realloc(struct htable *htable, uint32_t new_capacity)
+{
+    struct htable_pair *nelem;
+    uint32_t i, old_capacity = htable->capacity;
+    htable_hash_fn_t hash_fun = htable->hash_fun;
+
+    nelem = calloc(new_capacity, sizeof(struct htable_pair));
+    if (!nelem) {
+        return ENOMEM;
+    }
+    for (i = 0; i < old_capacity; i++) {
+        struct htable_pair *pair = htable->elem + i;
+        if (pair->key) {
+            htable_insert_internal(nelem, new_capacity, hash_fun,
+                                   pair->key, pair->val);
+        }
+    }
+    free(htable->elem);
+    htable->elem = nelem;
+    htable->capacity = new_capacity;
+    return 0;
+}
+
+static uint32_t round_up_to_power_of_2(uint32_t i)
+{
+    if (i == 0) {
+        return 1;
+    }
+    i--;
+    i |= i >> 1;
+    i |= i >> 2;
+    i |= i >> 4;
+    i |= i >> 8;
+    i |= i >> 16;
+    i++;
+    return i;
+}
+
+struct htable *htable_alloc(uint32_t size,
+                htable_hash_fn_t hash_fun, htable_eq_fn_t eq_fun)
+{
+    struct htable *htable;
+
+    htable = calloc(1, sizeof(*htable));
+    if (!htable) {
+        return NULL;
+    }
+    size = round_up_to_power_of_2(size);
+    if (size < HTABLE_MIN_SIZE) {
+        size = HTABLE_MIN_SIZE;
+    }
+    htable->hash_fun = hash_fun;
+    htable->eq_fun = eq_fun;
+    htable->used = 0;
+    if (htable_realloc(htable, size)) {
+        free(htable);
+        return NULL;
+    }
+    return htable;
+}
+
+void htable_visit(struct htable *htable, visitor_fn_t fun, void *ctx)
+{
+    uint32_t i;
+
+    for (i = 0; i != htable->capacity; ++i) {
+        struct htable_pair *elem = htable->elem + i;
+        if (elem->key) {
+            fun(ctx, elem->key, elem->val);
+        }
+    }
+}
+
+void htable_free(struct htable *htable)
+{
+    if (htable) {
+        free(htable->elem);
+        free(htable);
+    }
+}
+
+int htable_put(struct htable *htable, void *key, void *val)
+{
+    int ret;
+    uint32_t nused;
+
+    // NULL is not a valid key value.
+    // This helps us implement htable_get_internal efficiently, since we know
+    // that we can stop when we encounter the first NULL key.
+    if (!key) {
+        return EINVAL;
+    }
+    // NULL is not a valid value.  Otherwise the results of htable_get would
+    // be confusing (does a NULL return mean entry not found, or that the
+    // entry was found and was NULL?) 
+    if (!val) {
+        return EINVAL;
+    }
+    // Re-hash if we have used more than half of the hash table
+    nused = htable->used + 1;
+    if (nused >= (htable->capacity / 2)) {
+        ret = htable_realloc(htable, htable->capacity * 2);
+        if (ret)
+            return ret;
+    }
+    htable_insert_internal(htable->elem, htable->capacity,
+                                htable->hash_fun, key, val);
+    htable->used++;
+    return 0;
+}
+
+static int htable_get_internal(const struct htable *htable,
+                               const void *key, uint32_t *out)
+{
+    uint32_t start_idx, idx;
+
+    start_idx = htable->hash_fun(key, htable->capacity);
+    idx = start_idx;
+    while (1) {
+        struct htable_pair *pair = htable->elem + idx;
+        if (!pair->key) {
+            // We always maintain the invariant that the entries corresponding
+            // to a given key are stored in a contiguous block, not separated
+            // by any NULLs.  So if we encounter a NULL, our search is over.
+            return ENOENT;
+        } else if (htable->eq_fun(pair->key, key)) {
+            *out = idx;
+            return 0;
+        }
+        idx++;
+        if (idx == htable->capacity) {
+            idx = 0;
+        }
+        if (idx == start_idx) {
+            return ENOENT;
+        }
+    }
+}
+
+void *htable_get(const struct htable *htable, const void *key)
+{
+    uint32_t idx;
+
+    if (htable_get_internal(htable, key, &idx)) {
+        return NULL;
+    }
+    return htable->elem[idx].val;
+}
+
+void htable_pop(struct htable *htable, const void *key,
+                void **found_key, void **found_val)
+{
+    uint32_t hole, i;
+    const void *nkey;
+
+    if (htable_get_internal(htable, key, &hole)) {
+        *found_key = NULL;
+        *found_val = NULL;
+        return;
+    }
+    i = hole;
+    htable->used--;
+    // We need to maintain the compactness invariant used in
+    // htable_get_internal.  This invariant specifies that the entries for any
+    // given key are never separated by NULLs (although they may be separated
+    // by entries for other keys.)
+    while (1) {
+        i++;
+        if (i == htable->capacity) {
+            i = 0;
+        }
+        nkey = htable->elem[i].key;
+        if (!nkey) {
+            *found_key = htable->elem[hole].key;
+            *found_val = htable->elem[hole].val;
+            htable->elem[hole].key = NULL;
+            htable->elem[hole].val = NULL;
+            return;
+        } else if (htable->eq_fun(key, nkey)) {
+            htable->elem[hole].key = htable->elem[i].key;
+            htable->elem[hole].val = htable->elem[i].val;
+            hole = i;
+        }
+    }
+}
+
+uint32_t htable_used(const struct htable *htable)
+{
+    return htable->used;
+}
+
+uint32_t htable_capacity(const struct htable *htable)
+{
+    return htable->capacity;
+}
+
+uint32_t ht_hash_string(const void *str, uint32_t max)
+{
+    const char *s = str;
+    uint32_t hash = 0;
+
+    while (*s) {
+        hash = (hash * 31) + *s;
+        s++;
+    }
+    return hash % max;
+}
+
+int ht_compare_string(const void *a, const void *b)
+{
+    return strcmp(a, b) == 0;
+}
+
+// vim: ts=4:sw=4:tw=79:et

--- a/native/fs-hdfs/c_src/libhdfs/htable.h
+++ b/native/fs-hdfs/c_src/libhdfs/htable.h
@@ -1,0 +1,161 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HADOOP_CORE_COMMON_HASH_TABLE
+#define HADOOP_CORE_COMMON_HASH_TABLE
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdint.h>
+
+#define HTABLE_MIN_SIZE 4
+
+struct htable;
+
+/**
+ * An HTable hash function.
+ *
+ * @param key       The key.
+ * @param capacity  The total capacity.
+ *
+ * @return          The hash slot.  Must be less than the capacity.
+ */
+typedef uint32_t (*htable_hash_fn_t)(const void *key, uint32_t capacity);
+
+/**
+ * An HTable equality function.  Compares two keys.
+ *
+ * @param a         First key.
+ * @param b         Second key.
+ *
+ * @return          nonzero if the keys are equal.
+ */
+typedef int (*htable_eq_fn_t)(const void *a, const void *b);
+
+/**
+ * Allocate a new hash table.
+ *
+ * @param capacity  The minimum suggested starting capacity.
+ * @param hash_fun  The hash function to use in this hash table.
+ * @param eq_fun    The equals function to use in this hash table.
+ *
+ * @return          The new hash table on success; NULL on OOM.
+ */
+struct htable *htable_alloc(uint32_t capacity, htable_hash_fn_t hash_fun,
+                            htable_eq_fn_t eq_fun);
+
+typedef void (*visitor_fn_t)(void *ctx, void *key, void *val);
+
+/**
+ * Visit all of the entries in the hash table.
+ *
+ * @param htable    The hash table.
+ * @param fun       The callback function to invoke on each key and value.
+ * @param ctx       Context pointer to pass to the callback.
+ */
+void htable_visit(struct htable *htable, visitor_fn_t fun, void *ctx);
+
+/**
+ * Free the hash table.
+ *
+ * It is up the calling code to ensure that the keys and values inside the
+ * table are de-allocated, if that is necessary.
+ *
+ * @param htable    The hash table.
+ */
+void htable_free(struct htable *htable);
+
+/**
+ * Add an entry to the hash table.
+ *
+ * @param htable    The hash table.
+ * @param key       The key to add.  This cannot be NULL.
+ * @param fun       The value to add.  This cannot be NULL.
+ *
+ * @return          0 on success;
+ *                  EEXIST if the value already exists in the table;
+ *                  ENOMEM if there is not enough memory to add the element.
+ *                  EFBIG if the hash table has too many entries to fit in 32
+ *                      bits.
+ */
+int htable_put(struct htable *htable, void *key, void *val);
+
+/**
+ * Get an entry from the hash table.
+ *
+ * @param htable    The hash table.
+ * @param key       The key to find.
+ *
+ * @return          NULL if there is no such entry; the entry otherwise.
+ */
+void *htable_get(const struct htable *htable, const void *key);
+
+/**
+ * Get an entry from the hash table and remove it.
+ *
+ * @param htable    The hash table.
+ * @param key       The key for the entry find and remove.
+ * @param found_key (out param) NULL if the entry was not found; the found key
+ *                      otherwise.
+ * @param found_val (out param) NULL if the entry was not found; the found
+ *                      value otherwise.
+ */
+void htable_pop(struct htable *htable, const void *key,
+                void **found_key, void **found_val);
+
+/**
+ * Get the number of entries used in the hash table.
+ *
+ * @param htable    The hash table.
+ *
+ * @return          The number of entries used in the hash table.
+ */
+uint32_t htable_used(const struct htable *htable);
+
+/**
+ * Get the capacity of the hash table.
+ *
+ * @param htable    The hash table.
+ *
+ * @return          The capacity of the hash table.
+ */
+uint32_t htable_capacity(const struct htable *htable);
+
+/**
+ * Hash a string.
+ *
+ * @param str       The string.
+ * @param max       Maximum hash value
+ *
+ * @return          A number less than max.
+ */
+uint32_t ht_hash_string(const void *str, uint32_t max);
+
+/**
+ * Compare two strings.
+ *
+ * @param a         The first string.
+ * @param b         The second string.
+ *
+ * @return          1 if the strings are identical; 0 otherwise.
+ */
+int ht_compare_string(const void *a, const void *b);
+
+#endif
+
+// vim: ts=4:sw=4:tw=79:et

--- a/native/fs-hdfs/c_src/libhdfs/jni_helper.c
+++ b/native/fs-hdfs/c_src/libhdfs/jni_helper.c
@@ -1,0 +1,941 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "config.h"
+#include "exception.h"
+#include "jni_helper.h"
+#include "platform.h"
+#include "htable.h"
+#include "os/mutexes.h"
+#include "os/thread_local_storage.h"
+
+#include <errno.h>
+#include <dirent.h>
+#include <stdio.h> 
+#include <string.h> 
+
+static struct htable *gClassRefHTable = NULL;
+
+/** The Native return types that methods could return */
+#define JVOID         'V'
+#define JOBJECT       'L'
+#define JARRAYOBJECT  '['
+#define JBOOLEAN      'Z'
+#define JBYTE         'B'
+#define JCHAR         'C'
+#define JSHORT        'S'
+#define JINT          'I'
+#define JLONG         'J'
+#define JFLOAT        'F'
+#define JDOUBLE       'D'
+
+
+/**
+ * MAX_HASH_TABLE_ELEM: The maximum no. of entries in the hashtable.
+ * It's set to 4096 to account for (classNames + No. of threads)
+ */
+#define MAX_HASH_TABLE_ELEM 4096
+
+/**
+ * Length of buffer for retrieving created JVMs.  (We only ever create one.)
+ */
+#define VM_BUF_LENGTH 1
+
+void destroyLocalReference(JNIEnv *env, jobject jObject)
+{
+  if (jObject)
+    (*env)->DeleteLocalRef(env, jObject);
+}
+
+static jthrowable validateMethodType(JNIEnv *env, MethType methType)
+{
+    if (methType != STATIC && methType != INSTANCE) {
+        return newRuntimeError(env, "validateMethodType(methType=%d): "
+            "illegal method type.\n", methType);
+    }
+    return NULL;
+}
+
+jthrowable newJavaStr(JNIEnv *env, const char *str, jstring *out)
+{
+    jstring jstr;
+
+    if (!str) {
+        /* Can't pass NULL to NewStringUTF: the result would be
+         * implementation-defined. */
+        *out = NULL;
+        return NULL;
+    }
+    jstr = (*env)->NewStringUTF(env, str);
+    if (!jstr) {
+        /* If NewStringUTF returns NULL, an exception has been thrown,
+         * which we need to handle.  Probaly an OOM. */
+        return getPendingExceptionAndClear(env);
+    }
+    *out = jstr;
+    return NULL;
+}
+
+jthrowable newCStr(JNIEnv *env, jstring jstr, char **out)
+{
+    const char *tmp;
+
+    if (!jstr) {
+        *out = NULL;
+        return NULL;
+    }
+    tmp = (*env)->GetStringUTFChars(env, jstr, NULL);
+    if (!tmp) {
+        return getPendingExceptionAndClear(env);
+    }
+    *out = strdup(tmp);
+    (*env)->ReleaseStringUTFChars(env, jstr, tmp);
+    return NULL;
+}
+
+jthrowable invokeMethod(JNIEnv *env, jvalue *retval, MethType methType,
+                 jobject instObj, const char *className,
+                 const char *methName, const char *methSignature, ...)
+{
+    va_list args;
+    jclass cls;
+    jmethodID mid;
+    jthrowable jthr;
+    const char *str; 
+    char returnType;
+    
+    jthr = validateMethodType(env, methType);
+    if (jthr)
+        return jthr;
+    jthr = globalClassReference(className, env, &cls);
+    if (jthr)
+        return jthr;
+    jthr = methodIdFromClass(className, methName, methSignature, 
+                            methType, env, &mid);
+    if (jthr)
+        return jthr;
+    str = methSignature;
+    while (*str != ')') str++;
+    str++;
+    returnType = *str;
+    va_start(args, methSignature);
+    if (returnType == JOBJECT || returnType == JARRAYOBJECT) {
+        jobject jobj = NULL;
+        if (methType == STATIC) {
+            jobj = (*env)->CallStaticObjectMethodV(env, cls, mid, args);
+        }
+        else if (methType == INSTANCE) {
+            jobj = (*env)->CallObjectMethodV(env, instObj, mid, args);
+        }
+        retval->l = jobj;
+    }
+    else if (returnType == JVOID) {
+        if (methType == STATIC) {
+            (*env)->CallStaticVoidMethodV(env, cls, mid, args);
+        }
+        else if (methType == INSTANCE) {
+            (*env)->CallVoidMethodV(env, instObj, mid, args);
+        }
+    }
+    else if (returnType == JBOOLEAN) {
+        jboolean jbool = 0;
+        if (methType == STATIC) {
+            jbool = (*env)->CallStaticBooleanMethodV(env, cls, mid, args);
+        }
+        else if (methType == INSTANCE) {
+            jbool = (*env)->CallBooleanMethodV(env, instObj, mid, args);
+        }
+        retval->z = jbool;
+    }
+    else if (returnType == JSHORT) {
+        jshort js = 0;
+        if (methType == STATIC) {
+            js = (*env)->CallStaticShortMethodV(env, cls, mid, args);
+        }
+        else if (methType == INSTANCE) {
+            js = (*env)->CallShortMethodV(env, instObj, mid, args);
+        }
+        retval->s = js;
+    }
+    else if (returnType == JLONG) {
+        jlong jl = -1;
+        if (methType == STATIC) {
+            jl = (*env)->CallStaticLongMethodV(env, cls, mid, args);
+        }
+        else if (methType == INSTANCE) {
+            jl = (*env)->CallLongMethodV(env, instObj, mid, args);
+        }
+        retval->j = jl;
+    }
+    else if (returnType == JINT) {
+        jint ji = -1;
+        if (methType == STATIC) {
+            ji = (*env)->CallStaticIntMethodV(env, cls, mid, args);
+        }
+        else if (methType == INSTANCE) {
+            ji = (*env)->CallIntMethodV(env, instObj, mid, args);
+        }
+        retval->i = ji;
+    }
+    va_end(args);
+
+    jthr = (*env)->ExceptionOccurred(env);
+    if (jthr) {
+        (*env)->ExceptionClear(env);
+        return jthr;
+    }
+    return NULL;
+}
+
+jthrowable constructNewObjectOfClass(JNIEnv *env, jobject *out, const char *className, 
+                                  const char *ctorSignature, ...)
+{
+    va_list args;
+    jclass cls;
+    jmethodID mid; 
+    jobject jobj;
+    jthrowable jthr;
+
+    jthr = globalClassReference(className, env, &cls);
+    if (jthr)
+        return jthr;
+    jthr = methodIdFromClass(className, "<init>", ctorSignature, 
+                            INSTANCE, env, &mid);
+    if (jthr)
+        return jthr;
+    va_start(args, ctorSignature);
+    jobj = (*env)->NewObjectV(env, cls, mid, args);
+    va_end(args);
+    if (!jobj)
+        return getPendingExceptionAndClear(env);
+    *out = jobj;
+    return NULL;
+}
+
+
+jthrowable methodIdFromClass(const char *className, const char *methName, 
+                            const char *methSignature, MethType methType, 
+                            JNIEnv *env, jmethodID *out)
+{
+    jclass cls;
+    jthrowable jthr;
+    jmethodID mid = 0;
+
+    jthr = globalClassReference(className, env, &cls);
+    if (jthr)
+        return jthr;
+    jthr = validateMethodType(env, methType);
+    if (jthr)
+        return jthr;
+    if (methType == STATIC) {
+        mid = (*env)->GetStaticMethodID(env, cls, methName, methSignature);
+    }
+    else if (methType == INSTANCE) {
+        mid = (*env)->GetMethodID(env, cls, methName, methSignature);
+    }
+    if (mid == NULL) {
+        fprintf(stderr, "could not find method %s from class %s with "
+            "signature %s\n", methName, className, methSignature);
+        return getPendingExceptionAndClear(env);
+    }
+    *out = mid;
+    return NULL;
+}
+
+jthrowable globalClassReference(const char *className, JNIEnv *env, jclass *out)
+{
+    jthrowable jthr = NULL;
+    jclass local_clazz = NULL;
+    jclass clazz = NULL;
+    int ret;
+
+    mutexLock(&hdfsHashMutex);
+    if (!gClassRefHTable) {
+        gClassRefHTable = htable_alloc(MAX_HASH_TABLE_ELEM, ht_hash_string,
+            ht_compare_string);
+        if (!gClassRefHTable) {
+            jthr = newRuntimeError(env, "htable_alloc failed\n");
+            goto done;
+        }
+    }
+    clazz = htable_get(gClassRefHTable, className);
+    if (clazz) {
+        *out = clazz;
+        goto done;
+    }
+    local_clazz = (*env)->FindClass(env,className);
+    if (!local_clazz) {
+        jthr = getPendingExceptionAndClear(env);
+        goto done;
+    }
+    clazz = (*env)->NewGlobalRef(env, local_clazz);
+    if (!clazz) {
+        jthr = getPendingExceptionAndClear(env);
+        goto done;
+    }
+    ret = htable_put(gClassRefHTable, (void*)className, clazz);
+    if (ret) {
+        jthr = newRuntimeError(env, "htable_put failed with error "
+                               "code %d\n", ret);
+        goto done;
+    }
+    *out = clazz;
+    jthr = NULL;
+done:
+    mutexUnlock(&hdfsHashMutex);
+    (*env)->DeleteLocalRef(env, local_clazz);
+    if (jthr && clazz) {
+        (*env)->DeleteGlobalRef(env, clazz);
+    }
+    return jthr;
+}
+
+jthrowable classNameOfObject(jobject jobj, JNIEnv *env, char **name)
+{
+    jthrowable jthr;
+    jclass cls, clsClass = NULL;
+    jmethodID mid;
+    jstring str = NULL;
+    const char *cstr = NULL;
+    char *newstr;
+
+    cls = (*env)->GetObjectClass(env, jobj);
+    if (cls == NULL) {
+        jthr = getPendingExceptionAndClear(env);
+        goto done;
+    }
+    clsClass = (*env)->FindClass(env, "java/lang/Class");
+    if (clsClass == NULL) {
+        jthr = getPendingExceptionAndClear(env);
+        goto done;
+    }
+    mid = (*env)->GetMethodID(env, clsClass, "getName", "()Ljava/lang/String;");
+    if (mid == NULL) {
+        jthr = getPendingExceptionAndClear(env);
+        goto done;
+    }
+    str = (*env)->CallObjectMethod(env, cls, mid);
+    if (str == NULL) {
+        jthr = getPendingExceptionAndClear(env);
+        goto done;
+    }
+    cstr = (*env)->GetStringUTFChars(env, str, NULL);
+    if (!cstr) {
+        jthr = getPendingExceptionAndClear(env);
+        goto done;
+    }
+    newstr = strdup(cstr);
+    if (newstr == NULL) {
+        jthr = newRuntimeError(env, "classNameOfObject: out of memory");
+        goto done;
+    }
+    *name = newstr;
+    jthr = NULL;
+
+done:
+    destroyLocalReference(env, cls);
+    destroyLocalReference(env, clsClass);
+    if (str) {
+        if (cstr)
+            (*env)->ReleaseStringUTFChars(env, str, cstr);
+        (*env)->DeleteLocalRef(env, str);
+    }
+    return jthr;
+}
+
+
+/**
+ * For the given path, expand it by filling in with all *.jar or *.JAR files,
+ * separated by PATH_SEPARATOR. Assumes that expanded is big enough to hold the
+ * string, eg allocated after using this function with expanded=NULL to get the
+ * right size. Also assumes that the path ends with a "/.". The length of the
+ * expanded path is returned, which includes space at the end for either a
+ * PATH_SEPARATOR or null terminator.
+ */
+static ssize_t wildcard_expandPath(const char* path, char* expanded)
+{
+    struct dirent* file;
+    char* dest = expanded;
+    ssize_t length = 0;
+    size_t pathLength = strlen(path);
+    DIR* dir;
+
+    dir = opendir(path);
+    if (dir != NULL) {
+        // can open dir so try to match with all *.jar and *.JAR entries
+
+#ifdef _LIBHDFS_JNI_HELPER_DEBUGGING_ON_
+        printf("wildcard_expandPath: %s\n", path);
+#endif
+
+        errno = 0;
+        while ((file = readdir(dir)) != NULL) {
+            const char* filename = file->d_name;
+            const size_t filenameLength = strlen(filename);
+            const char* jarExtension;
+
+            // If filename is smaller than 4 characters then it can not possibly
+            // have extension ".jar" or ".JAR"
+            if (filenameLength < 4) {
+                continue;
+            }
+
+            jarExtension = &filename[filenameLength-4];
+            if ((strcmp(jarExtension, ".jar") == 0) ||
+                (strcmp(jarExtension, ".JAR") == 0)) {
+
+                // pathLength includes an extra '.' which we'll use for either
+                // separator or null termination
+                length += pathLength + filenameLength;
+
+#ifdef _LIBHDFS_JNI_HELPER_DEBUGGING_ON_
+                printf("wildcard_scanPath:\t%s\t:\t%zd\n", filename, length);
+#endif
+
+                if (expanded != NULL) {
+                    // pathLength includes an extra '.'
+                    strncpy(dest, path, pathLength-1);
+                    dest += pathLength - 1;
+                    strncpy(dest, filename, filenameLength);
+                    dest += filenameLength;
+                    *dest = PATH_SEPARATOR;
+                    dest++;
+
+#ifdef _LIBHDFS_JNI_HELPER_DEBUGGING_ON_
+                    printf("wildcard_expandPath:\t%s\t:\t%s\n",
+                      filename, expanded);
+#endif
+                }
+            }
+        }
+
+        if (errno != 0) {
+            fprintf(stderr, "wildcard_expandPath: on readdir %s: %s\n",
+              path, strerror(errno));
+            length = -1;
+        }
+
+        if (closedir(dir) != 0) {
+            fprintf(stderr, "wildcard_expandPath: on closedir %s: %s\n",
+                    path, strerror(errno));
+        }
+    } else if ((errno != EACCES) && (errno != ENOENT) && (errno != ENOTDIR)) {
+        // can not opendir due to an error we can not handle
+        fprintf(stderr, "wildcard_expandPath: on opendir %s: %s\n", path,
+                strerror(errno));
+        length = -1;
+    }
+
+    if (length == 0) {
+        // either we failed to open dir due to EACCESS, ENOENT, or ENOTDIR, or
+        // we did not find any file that matches *.jar or *.JAR
+
+#ifdef _LIBHDFS_JNI_HELPER_DEBUGGING_ON_
+        fprintf(stderr, "wildcard_expandPath: can not expand %.*s*: %s\n",
+                (int)(pathLength-1), path, strerror(errno));
+#endif
+
+        // in this case, the wildcard expansion is the same as the original
+        // +1 for PATH_SEPARTOR or null termination
+        length = pathLength + 1;
+        if (expanded != NULL) {
+            // pathLength includes an extra '.'
+            strncpy(dest, path, pathLength-1);
+            dest += pathLength-1;
+            *dest = '*'; // restore wildcard
+            dest++;
+            *dest = PATH_SEPARATOR;
+            dest++;
+        }
+    }
+
+    return length;
+}
+
+/**
+ * Helper to expand classpaths. Returns the total length of the expanded
+ * classpath. If expandedClasspath is not NULL, then fills that with the
+ * expanded classpath. It assumes that expandedClasspath is of correct size, eg
+ * allocated after using this function with expandedClasspath=NULL to get the
+ * right size.
+ */
+static ssize_t getClassPath_helper(const char *classpath, char* expandedClasspath)
+{
+    ssize_t length;
+    ssize_t retval;
+    char* expandedCP_curr;
+    char* cp_token;
+    char* classpath_dup;
+
+    classpath_dup = strdup(classpath);
+    if (classpath_dup == NULL) {
+        fprintf(stderr, "getClassPath_helper: failed strdup: %s\n",
+          strerror(errno));
+        return -1;
+    }
+
+    length = 0;
+
+    // expandedCP_curr is the current pointer
+    expandedCP_curr = expandedClasspath;
+
+    cp_token = strtok(classpath_dup, PATH_SEPARATOR_STR);
+    while (cp_token != NULL) {
+        size_t tokenlen;
+
+#ifdef _LIBHDFS_JNI_HELPER_DEBUGGING_ON_
+        printf("%s\n", cp_token);
+#endif
+
+        tokenlen = strlen(cp_token);
+        // We only expand if token ends with "/*"
+        if ((tokenlen > 1) &&
+          (cp_token[tokenlen-1] == '*') && (cp_token[tokenlen-2] == '/')) {
+            // replace the '*' with '.' so that we don't have to allocate another
+            // string for passing to opendir() in wildcard_expandPath()
+            cp_token[tokenlen-1] = '.';
+            retval = wildcard_expandPath(cp_token, expandedCP_curr);
+            if (retval < 0) {
+                free(classpath_dup);
+                return -1;
+            }
+
+            length += retval;
+            if (expandedCP_curr != NULL) {
+                expandedCP_curr += retval;
+            }
+        } else {
+            // +1 for path separator or null terminator
+            length += tokenlen + 1;
+            if (expandedCP_curr != NULL) {
+                strncpy(expandedCP_curr, cp_token, tokenlen);
+                expandedCP_curr += tokenlen;
+                *expandedCP_curr = PATH_SEPARATOR;
+                expandedCP_curr++;
+            }
+        }
+
+        cp_token = strtok(NULL, PATH_SEPARATOR_STR);
+    }
+
+    // Fix the last ':' and use it to null terminate
+    if (expandedCP_curr != NULL) {
+        expandedCP_curr--;
+        *expandedCP_curr = '\0';
+    }
+
+    free(classpath_dup);
+    return length;
+}
+
+/**
+ * Gets the classpath. Wild card entries are resolved only if the entry ends
+ * with "/\*" (backslash to escape commenting) to match against .jar and .JAR.
+ * All other wild card entries (eg /path/to/dir/\*foo*) are not resolved,
+ * following JAVA default behavior, see:
+ * https://docs.oracle.com/javase/8/docs/technotes/tools/unix/classpath.html
+ */
+static char* getClassPath()
+{
+    char* classpath;
+    char* expandedClasspath;
+    ssize_t length;
+    ssize_t retval;
+
+    classpath = getenv("CLASSPATH");
+    if (classpath == NULL) {
+      return NULL;
+    }
+
+    // First, get the total size of the string we will need for the expanded
+    // classpath
+    length = getClassPath_helper(classpath, NULL);
+    if (length < 0) {
+      return NULL;
+    }
+
+#ifdef _LIBHDFS_JNI_HELPER_DEBUGGING_ON_
+    printf("+++++++++++++++++\n");
+#endif
+
+    // we don't have to do anything if classpath has no valid wildcards
+    // we get length = 0 when CLASSPATH is set but empty
+    // if CLASSPATH is not empty, then length includes null terminator
+    // if length of expansion is same as original, then return a duplicate of
+    // original since expansion can only be longer
+    if ((length == 0) || ((length - 1) == strlen(classpath))) {
+
+#ifdef _LIBHDFS_JNI_HELPER_DEBUGGING_ON_
+        if ((length == 0) && (strlen(classpath) != 0)) {
+            fprintf(stderr, "Something went wrong with getting the wildcard \
+              expansion length\n" );
+        }
+#endif
+
+        expandedClasspath = strdup(classpath);
+
+#ifdef _LIBHDFS_JNI_HELPER_DEBUGGING_ON_
+        printf("Expanded classpath=%s\n", expandedClasspath);
+#endif
+
+        return expandedClasspath;
+    }
+
+    // Allocte memory for expanded classpath string
+    expandedClasspath = calloc(length, sizeof(char));
+    if (expandedClasspath == NULL) {
+        fprintf(stderr, "getClassPath: failed calloc: %s\n", strerror(errno));
+        return NULL;
+    }
+
+    // Actual expansion
+    retval = getClassPath_helper(classpath, expandedClasspath);
+    if (retval < 0) {
+        free(expandedClasspath);
+        return NULL;
+    }
+
+    // This should not happen, but dotting i's and crossing t's
+    if (retval != length) {
+        fprintf(stderr,
+          "Expected classpath expansion length to be %zu but instead got %zu\n",
+          length, retval);
+        free(expandedClasspath);
+        return NULL;
+    }
+
+#ifdef _LIBHDFS_JNI_HELPER_DEBUGGING_ON_
+    printf("===============\n");
+    printf("Allocated %zd for expanding classpath\n", length);
+    printf("Used %zu for expanding classpath\n", strlen(expandedClasspath) + 1);
+    printf("Expanded classpath=%s\n", expandedClasspath);
+#endif
+
+    return expandedClasspath;
+}
+
+
+/**
+ * Get the global JNI environemnt.
+ *
+ * We only have to create the JVM once.  After that, we can use it in
+ * every thread.  You must be holding the jvmMutex when you call this
+ * function.
+ *
+ * @return          The JNIEnv on success; error code otherwise
+ */
+static JNIEnv* getGlobalJNIEnv(void)
+{
+    JavaVM* vmBuf[VM_BUF_LENGTH]; 
+    JNIEnv *env;
+    jint rv = 0; 
+    jint noVMs = 0;
+    jthrowable jthr;
+    char *hadoopClassPath;
+    const char *hadoopClassPathVMArg = "-Djava.class.path=";
+    size_t optHadoopClassPathLen;
+    char *optHadoopClassPath;
+    int noArgs = 1;
+    char *hadoopJvmArgs;
+    char jvmArgDelims[] = " ";
+    char *str, *token, *savePtr;
+    JavaVMInitArgs vm_args;
+    JavaVM *vm;
+    JavaVMOption *options;
+
+    rv = JNI_GetCreatedJavaVMs(&(vmBuf[0]), VM_BUF_LENGTH, &noVMs);
+    if (rv != 0) {
+        fprintf(stderr, "JNI_GetCreatedJavaVMs failed with error: %d\n", rv);
+        return NULL;
+    }
+
+    if (noVMs == 0) {
+        //Get the environment variables for initializing the JVM
+        hadoopClassPath = getClassPath();
+        if (hadoopClassPath == NULL) {
+            fprintf(stderr, "Environment variable CLASSPATH not set!\n");
+            return NULL;
+        } 
+        optHadoopClassPathLen = strlen(hadoopClassPath) + 
+          strlen(hadoopClassPathVMArg) + 1;
+        optHadoopClassPath = malloc(sizeof(char)*optHadoopClassPathLen);
+        snprintf(optHadoopClassPath, optHadoopClassPathLen,
+                "%s%s", hadoopClassPathVMArg, hadoopClassPath);
+
+        free(hadoopClassPath);
+
+        // Determine the # of LIBHDFS_OPTS args
+        hadoopJvmArgs = getenv("LIBHDFS_OPTS");
+        if (hadoopJvmArgs != NULL)  {
+          hadoopJvmArgs = strdup(hadoopJvmArgs);
+          for (noArgs = 1, str = hadoopJvmArgs; ; noArgs++, str = NULL) {
+            token = strtok_r(str, jvmArgDelims, &savePtr);
+            if (NULL == token) {
+              break;
+            }
+          }
+          free(hadoopJvmArgs);
+        }
+
+        // Now that we know the # args, populate the options array
+        options = calloc(noArgs, sizeof(JavaVMOption));
+        if (!options) {
+          fputs("Call to calloc failed\n", stderr);
+          free(optHadoopClassPath);
+          return NULL;
+        }
+        options[0].optionString = optHadoopClassPath;
+        hadoopJvmArgs = getenv("LIBHDFS_OPTS");
+	if (hadoopJvmArgs != NULL)  {
+          hadoopJvmArgs = strdup(hadoopJvmArgs);
+          for (noArgs = 1, str = hadoopJvmArgs; ; noArgs++, str = NULL) {
+            token = strtok_r(str, jvmArgDelims, &savePtr);
+            if (NULL == token) {
+              break;
+            }
+            options[noArgs].optionString = token;
+          }
+        }
+
+        //Create the VM
+        vm_args.version = JNI_VERSION_1_2;
+        vm_args.options = options;
+        vm_args.nOptions = noArgs; 
+        vm_args.ignoreUnrecognized = 1;
+
+        rv = JNI_CreateJavaVM(&vm, (void*)&env, &vm_args);
+
+        if (hadoopJvmArgs != NULL)  {
+          free(hadoopJvmArgs);
+        }
+        free(optHadoopClassPath);
+        free(options);
+
+        if (rv != 0) {
+            fprintf(stderr, "Call to JNI_CreateJavaVM failed "
+                    "with error: %d\n", rv);
+            return NULL;
+        }
+        jthr = invokeMethod(env, NULL, STATIC, NULL,
+                         "org/apache/hadoop/fs/FileSystem",
+                         "loadFileSystems", "()V");
+        if (jthr) {
+            printExceptionAndFree(env, jthr, PRINT_EXC_ALL, "loadFileSystems");
+        }
+    }
+    else {
+        //Attach this thread to the VM
+        vm = vmBuf[0];
+        rv = (*vm)->AttachCurrentThread(vm, (void*)&env, 0);
+        if (rv != 0) {
+            fprintf(stderr, "Call to AttachCurrentThread "
+                    "failed with error: %d\n", rv);
+            return NULL;
+        }
+    }
+
+    return env;
+}
+
+/**
+ * getJNIEnv: A helper function to get the JNIEnv* for the given thread.
+ * If no JVM exists, then one will be created. JVM command line arguments
+ * are obtained from the LIBHDFS_OPTS environment variable.
+ *
+ * Implementation note: we rely on POSIX thread-local storage (tls).
+ * This allows us to associate a destructor function with each thread, that
+ * will detach the thread from the Java VM when the thread terminates.  If we
+ * failt to do this, it will cause a memory leak.
+ *
+ * However, POSIX TLS is not the most efficient way to do things.  It requires a
+ * key to be initialized before it can be used.  Since we don't know if this key
+ * is initialized at the start of this function, we have to lock a mutex first
+ * and check.  Luckily, most operating systems support the more efficient
+ * __thread construct, which is initialized by the linker.
+ *
+ * @param: None.
+ * @return The JNIEnv* corresponding to the thread.
+ */
+JNIEnv* getJNIEnv(void)
+{
+    struct ThreadLocalState *state = NULL;
+    THREAD_LOCAL_STORAGE_GET_QUICK(&state);
+    if (state) return state->env;
+
+    mutexLock(&jvmMutex);
+    if (threadLocalStorageGet(&state)) {
+      mutexUnlock(&jvmMutex);
+      return NULL;
+    }
+    if (state) {
+      mutexUnlock(&jvmMutex);
+
+      // Free any stale exception strings.
+      free(state->lastExceptionRootCause);
+      free(state->lastExceptionStackTrace);
+      state->lastExceptionRootCause = NULL;
+      state->lastExceptionStackTrace = NULL;
+
+      return state->env;
+    }
+
+    /* Create a ThreadLocalState for this thread */
+    state = threadLocalStorageCreate();
+    if (!state) {
+      mutexUnlock(&jvmMutex);
+      fprintf(stderr, "getJNIEnv: Unable to create ThreadLocalState\n");
+      return NULL;
+    }
+    if (threadLocalStorageSet(state)) {
+      mutexUnlock(&jvmMutex);
+      goto fail;
+    }
+    THREAD_LOCAL_STORAGE_SET_QUICK(state);
+
+    state->env = getGlobalJNIEnv();
+    mutexUnlock(&jvmMutex);
+    if (!state->env) {
+      goto fail;
+    }
+    return state->env;
+
+fail:
+    fprintf(stderr, "getJNIEnv: getGlobalJNIEnv failed\n");
+    hdfsThreadDestructor(state);
+    return NULL;
+}
+
+char* getLastTLSExceptionRootCause()
+{
+    struct ThreadLocalState *state = NULL;
+    THREAD_LOCAL_STORAGE_GET_QUICK(&state);
+    if (!state) {
+        mutexLock(&jvmMutex);
+        if (threadLocalStorageGet(&state)) {
+            mutexUnlock(&jvmMutex);
+            return NULL;
+        }
+        mutexUnlock(&jvmMutex);
+    }
+    return state->lastExceptionRootCause;
+}
+
+char* getLastTLSExceptionStackTrace()
+{
+    struct ThreadLocalState *state = NULL;
+    THREAD_LOCAL_STORAGE_GET_QUICK(&state);
+    if (!state) {
+        mutexLock(&jvmMutex);
+        if (threadLocalStorageGet(&state)) {
+            mutexUnlock(&jvmMutex);
+            return NULL;
+        }
+        mutexUnlock(&jvmMutex);
+    }
+    return state->lastExceptionStackTrace;
+}
+
+void setTLSExceptionStrings(const char *rootCause, const char *stackTrace)
+{
+    struct ThreadLocalState *state = NULL;
+    THREAD_LOCAL_STORAGE_GET_QUICK(&state);
+    if (!state) {
+        mutexLock(&jvmMutex);
+        if (threadLocalStorageGet(&state)) {
+            mutexUnlock(&jvmMutex);
+            return;
+        }
+        mutexUnlock(&jvmMutex);
+    }
+
+    free(state->lastExceptionRootCause);
+    free(state->lastExceptionStackTrace);
+    state->lastExceptionRootCause = (char*)rootCause;
+    state->lastExceptionStackTrace = (char*)stackTrace;
+}
+
+int javaObjectIsOfClass(JNIEnv *env, jobject obj, const char *name)
+{
+    jclass clazz;
+    int ret;
+
+    clazz = (*env)->FindClass(env, name);
+    if (!clazz) {
+        printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+            "javaObjectIsOfClass(%s)", name);
+        return -1;
+    }
+    ret = (*env)->IsInstanceOf(env, obj, clazz);
+    (*env)->DeleteLocalRef(env, clazz);
+    return ret == JNI_TRUE ? 1 : 0;
+}
+
+jthrowable hadoopConfSetStr(JNIEnv *env, jobject jConfiguration,
+        const char *key, const char *value)
+{
+    jthrowable jthr;
+    jstring jkey = NULL, jvalue = NULL;
+
+    jthr = newJavaStr(env, key, &jkey);
+    if (jthr)
+        goto done;
+    jthr = newJavaStr(env, value, &jvalue);
+    if (jthr)
+        goto done;
+    jthr = invokeMethod(env, NULL, INSTANCE, jConfiguration,
+            "org/apache/hadoop/conf/Configuration", "set", 
+            "(Ljava/lang/String;Ljava/lang/String;)V",
+            jkey, jvalue);
+    if (jthr)
+        goto done;
+done:
+    (*env)->DeleteLocalRef(env, jkey);
+    (*env)->DeleteLocalRef(env, jvalue);
+    return jthr;
+}
+
+jthrowable fetchEnumInstance(JNIEnv *env, const char *className,
+                         const char *valueName, jobject *out)
+{
+    jclass clazz;
+    jfieldID fieldId;
+    jobject jEnum;
+    char prettyClass[256];
+
+    clazz = (*env)->FindClass(env, className);
+    if (!clazz) {
+        return newRuntimeError(env, "fetchEnum(%s, %s): failed to find class.",
+                className, valueName);
+    }
+    if (snprintf(prettyClass, sizeof(prettyClass), "L%s;", className)
+          >= sizeof(prettyClass)) {
+        return newRuntimeError(env, "fetchEnum(%s, %s): class name too long.",
+                className, valueName);
+    }
+    fieldId = (*env)->GetStaticFieldID(env, clazz, valueName, prettyClass);
+    if (!fieldId) {
+        return getPendingExceptionAndClear(env);
+    }
+    jEnum = (*env)->GetStaticObjectField(env, clazz, fieldId);
+    if (!jEnum) {
+        return getPendingExceptionAndClear(env);
+    }
+    *out = jEnum;
+    return NULL;
+}
+

--- a/native/fs-hdfs/c_src/libhdfs/jni_helper.h
+++ b/native/fs-hdfs/c_src/libhdfs/jni_helper.h
@@ -1,0 +1,237 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LIBHDFS_JNI_HELPER_H
+#define LIBHDFS_JNI_HELPER_H
+
+#include <jni.h>
+#include <stdio.h>
+
+#include <stdlib.h>
+#include <stdarg.h>
+#include <errno.h>
+
+#ifdef WIN32
+    #define PATH_SEPARATOR ';'
+    #define PATH_SEPARATOR_STR ";"
+#else
+    #define PATH_SEPARATOR ':'
+    #define PATH_SEPARATOR_STR ":"
+#endif
+
+// #define _LIBHDFS_JNI_HELPER_DEBUGGING_ON_
+
+#ifdef WIN32
+#ifdef LIBHDFS_DLL_EXPORT
+        #define LIBHDFS_EXTERNAL __declspec(dllexport)
+    #elif LIBHDFS_DLL_IMPORT
+        #define LIBHDFS_EXTERNAL __declspec(dllimport)
+    #else
+        #define LIBHDFS_EXTERNAL
+    #endif
+#else
+#ifdef LIBHDFS_DLL_EXPORT
+#define LIBHDFS_EXTERNAL __attribute__((visibility("default")))
+#elif LIBHDFS_DLL_IMPORT
+#define LIBHDFS_EXTERNAL __attribute__((visibility("default")))
+#else
+#define LIBHDFS_EXTERNAL
+#endif
+#endif
+
+/** Denote the method we want to invoke as STATIC or INSTANCE */
+typedef enum {
+    STATIC,
+    INSTANCE
+} MethType;
+
+/**
+ * Create a new malloc'ed C string from a Java string.
+ *
+ * @param env       The JNI environment
+ * @param jstr      The Java string
+ * @param out       (out param) the malloc'ed C string
+ *
+ * @return          NULL on success; the exception otherwise
+ */
+LIBHDFS_EXTERNAL
+jthrowable newCStr(JNIEnv *env, jstring jstr, char **out);
+
+/**
+ * Create a new Java string from a C string.
+ *
+ * @param env       The JNI environment
+ * @param str       The C string
+ * @param out       (out param) the java string
+ *
+ * @return          NULL on success; the exception otherwise
+ */
+LIBHDFS_EXTERNAL
+jthrowable newJavaStr(JNIEnv *env, const char *str, jstring *out);
+
+/**
+ * Helper function to destroy a local reference of java.lang.Object
+ * @param env: The JNIEnv pointer. 
+ * @param jFile: The local reference of java.lang.Object object
+ * @return None.
+ */
+LIBHDFS_EXTERNAL
+void destroyLocalReference(JNIEnv *env, jobject jObject);
+
+/** invokeMethod: Invoke a Static or Instance method.
+ * className: Name of the class where the method can be found
+ * methName: Name of the method
+ * methSignature: the signature of the method "(arg-types)ret-type"
+ * methType: The type of the method (STATIC or INSTANCE)
+ * instObj: Required if the methType is INSTANCE. The object to invoke
+   the method on.
+ * env: The JNIEnv pointer
+ * retval: The pointer to a union type which will contain the result of the
+   method invocation, e.g. if the method returns an Object, retval will be
+   set to that, if the method returns boolean, retval will be set to the
+   value (JNI_TRUE or JNI_FALSE), etc.
+ * exc: If the methods throws any exception, this will contain the reference
+ * Arguments (the method arguments) must be passed after methSignature
+ * RETURNS: -1 on error and 0 on success. If -1 is returned, exc will have 
+   a valid exception reference, and the result stored at retval is undefined.
+ */
+LIBHDFS_EXTERNAL
+jthrowable invokeMethod(JNIEnv *env, jvalue *retval, MethType methType,
+                 jobject instObj, const char *className, const char *methName, 
+                 const char *methSignature, ...);
+
+LIBHDFS_EXTERNAL
+jthrowable constructNewObjectOfClass(JNIEnv *env, jobject *out, const char *className,
+                                  const char *ctorSignature, ...);
+
+LIBHDFS_EXTERNAL
+jthrowable methodIdFromClass(const char *className, const char *methName,
+                            const char *methSignature, MethType methType, 
+                            JNIEnv *env, jmethodID *out);
+
+LIBHDFS_EXTERNAL
+jthrowable globalClassReference(const char *className, JNIEnv *env, jclass *out);
+
+/** classNameOfObject: Get an object's class name.
+ * @param jobj: The object.
+ * @param env: The JNIEnv pointer.
+ * @param name: (out param) On success, will contain a string containing the
+ * class name. This string must be freed by the caller.
+ * @return NULL on success, or the exception
+ */
+LIBHDFS_EXTERNAL
+jthrowable classNameOfObject(jobject jobj, JNIEnv *env, char **name);
+
+/** getJNIEnv: A helper function to get the JNIEnv* for the given thread.
+ * It gets this from the ThreadLocalState if it exists. If a ThreadLocalState
+ * does not exist, one will be created.
+ * If no JVM exists, then one will be created. JVM command line arguments
+ * are obtained from the LIBHDFS_OPTS environment variable.
+ * @param: None.
+ * @return The JNIEnv* corresponding to the thread.
+ * */
+LIBHDFS_EXTERNAL
+JNIEnv* getJNIEnv(void);
+
+/**
+ * Get the last exception root cause that happened in the context of the
+ * current thread.
+ *
+ * The pointer returned by this function is guaranteed to be valid until
+ * the next call to invokeMethod() by the current thread.
+ * Users of this function should not free the pointer.
+ *
+ * @return The root cause as a C-string.
+ */
+LIBHDFS_EXTERNAL
+char* getLastTLSExceptionRootCause();
+
+/**
+ * Get the last exception stack trace that happened in the context of the
+ * current thread.
+ *
+ * The pointer returned by this function is guaranteed to be valid until
+ * the next call to invokeMethod() by the current thread.
+ * Users of this function should not free the pointer.
+ *
+ * @return The stack trace as a C-string.
+ */
+LIBHDFS_EXTERNAL
+char* getLastTLSExceptionStackTrace();
+
+/** setTLSExceptionStrings: Sets the 'rootCause' and 'stackTrace' in the
+ * ThreadLocalState if one exists for the current thread.
+ *
+ * @param rootCause A string containing the root cause of an exception.
+ * @param stackTrace A string containing the stack trace of an exception.
+ * @return None.
+ */
+LIBHDFS_EXTERNAL
+void setTLSExceptionStrings(const char *rootCause, const char *stackTrace);
+
+/**
+ * Figure out if a Java object is an instance of a particular class.
+ *
+ * @param env  The Java environment.
+ * @param obj  The object to check.
+ * @param name The class name to check.
+ *
+ * @return     -1 if we failed to find the referenced class name.
+ *             0 if the object is not of the given class.
+ *             1 if the object is of the given class.
+ */
+LIBHDFS_EXTERNAL
+int javaObjectIsOfClass(JNIEnv *env, jobject obj, const char *name);
+
+/**
+ * Set a value in a configuration object.
+ *
+ * @param env               The JNI environment
+ * @param jConfiguration    The configuration object to modify
+ * @param key               The key to modify
+ * @param value             The value to set the key to
+ *
+ * @return                  NULL on success; exception otherwise
+ */
+LIBHDFS_EXTERNAL
+jthrowable hadoopConfSetStr(JNIEnv *env, jobject jConfiguration,
+        const char *key, const char *value);
+
+/**
+ * Fetch an instance of an Enum.
+ *
+ * @param env               The JNI environment.
+ * @param className         The enum class name.
+ * @param valueName         The name of the enum value
+ * @param out               (out param) on success, a local reference to an
+ *                          instance of the enum object.  (Since Java enums are
+ *                          singletones, this is also the only instance.)
+ *
+ * @return                  NULL on success; exception otherwise
+ */
+LIBHDFS_EXTERNAL
+jthrowable fetchEnumInstance(JNIEnv *env, const char *className,
+                             const char *valueName, jobject *out);
+
+#undef LIBHDFS_EXTERNAL
+#endif /*LIBHDFS_JNI_HELPER_H*/
+
+/**
+ * vim: ts=4: sw=4: et:
+ */
+

--- a/native/fs-hdfs/c_src/libhdfs/os/mutexes.h
+++ b/native/fs-hdfs/c_src/libhdfs/os/mutexes.h
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LIBHDFS_MUTEXES_H
+#define LIBHDFS_MUTEXES_H
+
+/*
+ * Defines abstraction over platform-specific mutexes.  libhdfs has no formal
+ * initialization function that users would call from a single-threaded context
+ * to initialize the library.  This creates a challenge for bootstrapping the
+ * mutexes.  To address this, all required mutexes are pre-defined here with
+ * external storage.  Platform-specific implementations must guarantee that the
+ * mutexes are initialized via static initialization.
+ */
+
+#include "platform.h"
+
+/** Mutex protecting the class reference hash table. */
+extern mutex hdfsHashMutex;
+
+/** Mutex protecting singleton JVM instance. */
+extern mutex jvmMutex;
+
+/**
+ * Locks a mutex.
+ *
+ * @param m mutex
+ * @return 0 if successful, non-zero otherwise
+ */
+int mutexLock(mutex *m);
+
+/**
+ * Unlocks a mutex.
+ *
+ * @param m mutex
+ * @return 0 if successful, non-zero otherwise
+ */
+int mutexUnlock(mutex *m);
+
+#endif

--- a/native/fs-hdfs/c_src/libhdfs/os/posix/mutexes.c
+++ b/native/fs-hdfs/c_src/libhdfs/os/posix/mutexes.c
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "os/mutexes.h"
+
+#include <pthread.h>
+#include <stdio.h>
+
+mutex hdfsHashMutex = PTHREAD_MUTEX_INITIALIZER;
+mutex jvmMutex;
+pthread_mutexattr_t jvmMutexAttr;
+
+__attribute__((constructor)) static void init() {
+  pthread_mutexattr_init(&jvmMutexAttr);
+  pthread_mutexattr_settype(&jvmMutexAttr, PTHREAD_MUTEX_RECURSIVE);
+  pthread_mutex_init(&jvmMutex, &jvmMutexAttr);
+}
+
+int mutexLock(mutex *m) {
+  int ret = pthread_mutex_lock(m);
+  if (ret) {
+    fprintf(stderr, "mutexLock: pthread_mutex_lock failed with error %d\n",
+      ret);
+  }
+  return ret;
+}
+
+int mutexUnlock(mutex *m) {
+  int ret = pthread_mutex_unlock(m);
+  if (ret) {
+    fprintf(stderr, "mutexUnlock: pthread_mutex_unlock failed with error %d\n",
+      ret);
+  }
+  return ret;
+}

--- a/native/fs-hdfs/c_src/libhdfs/os/posix/platform.h
+++ b/native/fs-hdfs/c_src/libhdfs/os/posix/platform.h
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LIBHDFS_PLATFORM_H
+#define LIBHDFS_PLATFORM_H
+
+#include <pthread.h>
+
+/* Use gcc type-checked format arguments. */
+#define TYPE_CHECKED_PRINTF_FORMAT(formatArg, varArgs) \
+  __attribute__((format(printf, formatArg, varArgs)))
+
+/*
+ * Mutex and thread data types defined by pthreads.
+ */
+typedef pthread_mutex_t mutex;
+typedef pthread_t threadId;
+
+#endif

--- a/native/fs-hdfs/c_src/libhdfs/os/posix/thread.c
+++ b/native/fs-hdfs/c_src/libhdfs/os/posix/thread.c
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "os/thread.h"
+
+#include <pthread.h>
+#include <stdio.h>
+
+/**
+ * Defines a helper function that adapts function pointer provided by caller to
+ * the type required by pthread_create.
+ *
+ * @param toRun thread to run
+ * @return void* result of running thread (always NULL)
+ */
+static void* runThread(void *toRun) {
+  const thread *t = toRun;
+  t->start(t->arg);
+  return NULL;
+}
+
+int threadCreate(thread *t) {
+  int ret;
+  ret = pthread_create(&t->id, NULL, runThread, t);
+  if (ret) {
+    fprintf(stderr, "threadCreate: pthread_create failed with error %d\n", ret);
+  }
+  return ret;
+}
+
+int threadJoin(const thread *t) {
+  int ret = pthread_join(t->id, NULL);
+  if (ret) {
+    fprintf(stderr, "threadJoin: pthread_join failed with error %d\n", ret);
+  }
+  return ret;
+}

--- a/native/fs-hdfs/c_src/libhdfs/os/posix/thread_local_storage.c
+++ b/native/fs-hdfs/c_src/libhdfs/os/posix/thread_local_storage.c
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "os/thread_local_storage.h"
+
+#include <jni.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <stdio.h>
+
+/** Key that allows us to retrieve thread-local storage */
+static pthread_key_t gTlsKey;
+
+/** nonzero if we succeeded in initializing gTlsKey. Protected by the jvmMutex */
+static int gTlsKeyInitialized = 0;
+
+/**
+ * The function that is called whenever a thread with libhdfs thread local data
+ * is destroyed.
+ *
+ * @param v         The thread-local data
+ */
+void hdfsThreadDestructor(void *v)
+{
+  JavaVM *vm;
+  struct ThreadLocalState *state = (struct ThreadLocalState*)v;
+  JNIEnv *env = state->env;;
+  jint ret;
+
+  /* Detach the current thread from the JVM */
+  if (env) {
+    ret = (*env)->GetJavaVM(env, &vm);
+    if (ret) {
+      fprintf(stderr, "hdfsThreadDestructor: GetJavaVM failed with error %d\n",
+        ret);
+      (*env)->ExceptionDescribe(env);
+    } else {
+      (*vm)->DetachCurrentThread(vm);
+    }
+  }
+
+  /* Free exception strings */
+  if (state->lastExceptionStackTrace) free(state->lastExceptionStackTrace);
+  if (state->lastExceptionRootCause) free(state->lastExceptionRootCause);
+
+  /* Free the state itself */
+  free(state);
+}
+
+struct ThreadLocalState* threadLocalStorageCreate()
+{
+  struct ThreadLocalState *state;
+  state = (struct ThreadLocalState*)malloc(sizeof(struct ThreadLocalState));
+  if (state == NULL) {
+    fprintf(stderr,
+      "threadLocalStorageSet: OOM - Unable to allocate thread local state\n");
+    return NULL;
+  }
+  state->lastExceptionStackTrace = NULL;
+  state->lastExceptionRootCause = NULL;
+  return state;
+}
+
+int threadLocalStorageGet(struct ThreadLocalState **state)
+{
+  int ret = 0;
+  if (!gTlsKeyInitialized) {
+    ret = pthread_key_create(&gTlsKey, hdfsThreadDestructor);
+    if (ret) {
+      fprintf(stderr,
+        "threadLocalStorageGet: pthread_key_create failed with error %d\n",
+        ret);
+      return ret;
+    }
+    gTlsKeyInitialized = 1;
+  }
+  *state = pthread_getspecific(gTlsKey);
+  return ret;
+}
+
+int threadLocalStorageSet(struct ThreadLocalState *state)
+{
+  int ret = pthread_setspecific(gTlsKey, state);
+  if (ret) {
+    fprintf(stderr,
+      "threadLocalStorageSet: pthread_setspecific failed with error %d\n",
+      ret);
+    hdfsThreadDestructor(state);
+  }
+  return ret;
+}

--- a/native/fs-hdfs/c_src/libhdfs/os/thread.h
+++ b/native/fs-hdfs/c_src/libhdfs/os/thread.h
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LIBHDFS_THREAD_H
+#define LIBHDFS_THREAD_H
+
+/*
+ * Defines abstraction over platform-specific threads.
+ */
+
+#include "platform.h"
+
+/** Pointer to function to run in thread. */
+typedef void (*threadProcedure)(void *);
+
+/** Structure containing a thread's ID, starting address and argument. */
+typedef struct {
+  threadId id;
+  threadProcedure start;
+  void *arg;
+} thread;
+
+/**
+ * Creates and immediately starts a new thread.
+ *
+ * @param t thread to create
+ * @return 0 if successful, non-zero otherwise
+ */
+int threadCreate(thread *t);
+
+/**
+ * Joins to the given thread, blocking if necessary.
+ *
+ * @param t thread to join
+ * @return 0 if successful, non-zero otherwise
+ */
+int threadJoin(const thread *t);
+
+#endif

--- a/native/fs-hdfs/c_src/libhdfs/os/thread_local_storage.h
+++ b/native/fs-hdfs/c_src/libhdfs/os/thread_local_storage.h
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LIBHDFS_THREAD_LOCAL_STORAGE_H
+#define LIBHDFS_THREAD_LOCAL_STORAGE_H
+
+/*
+ * Defines abstraction over platform-specific thread-local storage.  libhdfs
+ * currently only needs thread-local storage for a single piece of data: the
+ * thread's JNIEnv.  For simplicity, this interface is defined in terms of
+ * JNIEnv, not general-purpose thread-local storage of any arbitrary data.
+ */
+
+#include <jni.h>
+
+/*
+ * Most operating systems support the more efficient __thread construct, which
+ * is initialized by the linker.  The following macros use this technique on the
+ * operating systems that support it.
+ */
+#ifdef HAVE_BETTER_TLS
+  #define THREAD_LOCAL_STORAGE_GET_QUICK(state) \
+    static __thread struct ThreadLocalState *quickTlsEnv = NULL; \
+    { \
+      if (quickTlsEnv) { \
+        *state = quickTlsEnv; \
+      } \
+    }
+
+  #define THREAD_LOCAL_STORAGE_SET_QUICK(state) \
+    { \
+      quickTlsEnv = (state); \
+    }
+#else
+  #define THREAD_LOCAL_STORAGE_GET_QUICK(state)
+  #define THREAD_LOCAL_STORAGE_SET_QUICK(state)
+#endif
+
+struct ThreadLocalState {
+  /* The JNIEnv associated with the current thread */
+  JNIEnv *env;
+  /* The last exception stack trace that occured on this thread */
+  char *lastExceptionStackTrace;
+  /* The last exception root cause that occured on this thread */
+  char *lastExceptionRootCause;
+};
+
+/**
+ * The function that is called whenever a thread with libhdfs thread local data
+ * is destroyed.
+ *
+ * @param v         The thread-local data
+ */
+void hdfsThreadDestructor(void *v);
+
+/**
+ * Creates an object of ThreadLocalState.
+ *
+ * @return The newly created object if successful, NULL otherwise.
+ */
+struct ThreadLocalState* threadLocalStorageCreate();
+
+/**
+ * Gets the ThreadLocalState in thread-local storage for the current thread.
+ * If the call succeeds, and there is a ThreadLocalState associated with this
+ * thread, then returns 0 and populates 'state'.  If the call succeeds, but
+ * there is no ThreadLocalState associated with this thread, then returns 0
+ * and sets ThreadLocalState to NULL. If the call fails, then returns non-zero.
+ * Only one thread at a time may execute this function. The caller is
+ * responsible for enforcing mutual exclusion.
+ *
+ * @param env ThreadLocalState out parameter
+ * @return 0 if successful, non-zero otherwise
+ */
+int threadLocalStorageGet(struct ThreadLocalState **state);
+
+/**
+ * Sets the ThreadLocalState in thread-local storage for the current thread.
+ *
+ * @param env ThreadLocalState to set
+ * @return 0 if successful, non-zero otherwise
+ */
+int threadLocalStorageSet(struct ThreadLocalState *state);
+
+#endif

--- a/native/fs-hdfs/c_src/libminidfs/native_mini_dfs.c
+++ b/native/fs-hdfs/c_src/libminidfs/native_mini_dfs.c
@@ -1,0 +1,396 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../libhdfs/hdfs.h"
+#include "exception.h"
+#include "jni_helper.h"
+#include "native_mini_dfs.h"
+#include "platform.h"
+
+#include <errno.h>
+#include <jni.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifndef EINTERNAL
+#define EINTERNAL 255
+#endif
+
+#define MINIDFS_CLUSTER_BUILDER "org/apache/hadoop/hdfs/MiniDFSCluster$Builder"
+#define MINIDFS_CLUSTER "org/apache/hadoop/hdfs/MiniDFSCluster"
+#define HADOOP_CONF     "org/apache/hadoop/conf/Configuration"
+#define HADOOP_NAMENODE "org/apache/hadoop/hdfs/server/namenode/NameNode"
+#define JAVA_INETSOCKETADDRESS "java/net/InetSocketAddress"
+
+struct NativeMiniDfsCluster {
+    /**
+     * The NativeMiniDfsCluster object
+     */
+    jobject obj;
+
+    /**
+     * Path to the domain socket, or the empty string if there is none.
+     */
+    char domainSocketPath[PATH_MAX];
+};
+
+static int hdfsDisableDomainSocketSecurity(void)
+{
+    jthrowable jthr;
+    JNIEnv* env = getJNIEnv();
+    if (env == NULL) {
+      errno = EINTERNAL;
+      return -1;
+    }
+    jthr = invokeMethod(env, NULL, STATIC, NULL,
+            "org/apache/hadoop/net/unix/DomainSocket",
+            "disableBindPathValidation", "()V");
+    if (jthr) {
+        errno = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "DomainSocket#disableBindPathValidation");
+        return -1;
+    }
+    return 0;
+}
+
+static jthrowable nmdConfigureShortCircuit(JNIEnv *env,
+              struct NativeMiniDfsCluster *cl, jobject cobj)
+{
+    jthrowable jthr;
+    char *tmpDir;
+
+    int ret = hdfsDisableDomainSocketSecurity();
+    if (ret) {
+        return newRuntimeError(env, "failed to disable hdfs domain "
+                               "socket security: error %d", ret);
+    }
+    jthr = hadoopConfSetStr(env, cobj, "dfs.client.read.shortcircuit", "true");
+    if (jthr) {
+        return jthr;
+    }
+    tmpDir = getenv("TMPDIR");
+    if (!tmpDir) {
+        tmpDir = "/tmp";
+    }
+    snprintf(cl->domainSocketPath, PATH_MAX, "%s/native_mini_dfs.sock.%d.%d",
+             tmpDir, getpid(), rand());
+    snprintf(cl->domainSocketPath, PATH_MAX, "%s/native_mini_dfs.sock.%d.%d",
+             tmpDir, getpid(), rand());
+    jthr = hadoopConfSetStr(env, cobj, "dfs.domain.socket.path",
+                            cl->domainSocketPath);
+    if (jthr) {
+        return jthr;
+    }
+    return NULL;
+}
+
+struct NativeMiniDfsCluster* nmdCreate(const struct NativeMiniDfsConf *conf)
+{
+    struct NativeMiniDfsCluster* cl = NULL;
+    jobject bld = NULL, cobj = NULL, cluster = NULL;
+    jvalue  val;
+    JNIEnv *env = getJNIEnv();
+    jthrowable jthr;
+    jstring jconfStr = NULL;
+
+    if (!env) {
+        fprintf(stderr, "nmdCreate: unable to construct JNIEnv.\n");
+        return NULL;
+    }
+    cl = calloc(1, sizeof(struct NativeMiniDfsCluster));
+    if (!cl) {
+        fprintf(stderr, "nmdCreate: OOM");
+        goto error;
+    }
+    jthr = constructNewObjectOfClass(env, &cobj, HADOOP_CONF, "()V");
+    if (jthr) {
+        printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "nmdCreate: new Configuration");
+        goto error;
+    }
+    if (jthr) {
+        printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                              "nmdCreate: Configuration::setBoolean");
+        goto error;
+    }
+    // Disable 'minimum block size' -- it's annoying in tests.
+    (*env)->DeleteLocalRef(env, jconfStr);
+    jconfStr = NULL;
+    jthr = newJavaStr(env, "dfs.namenode.fs-limits.min-block-size", &jconfStr);
+    if (jthr) {
+        printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                              "nmdCreate: new String");
+        goto error;
+    }
+    jthr = invokeMethod(env, NULL, INSTANCE, cobj, HADOOP_CONF,
+                        "setLong", "(Ljava/lang/String;J)V", jconfStr, 0LL);
+    if (jthr) {
+        printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                              "nmdCreate: Configuration::setLong");
+        goto error;
+    }
+    // Creae MiniDFSCluster object
+    jthr = constructNewObjectOfClass(env, &bld, MINIDFS_CLUSTER_BUILDER,
+                    "(L"HADOOP_CONF";)V", cobj);
+    if (jthr) {
+        printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "nmdCreate: NativeMiniDfsCluster#Builder#Builder");
+        goto error;
+    }
+    if (conf->configureShortCircuit) {
+        jthr = nmdConfigureShortCircuit(env, cl, cobj);
+        if (jthr) {
+            printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                "nmdCreate: nmdConfigureShortCircuit error");
+            goto error;
+        }
+    }
+    jthr = invokeMethod(env, &val, INSTANCE, bld, MINIDFS_CLUSTER_BUILDER,
+            "format", "(Z)L" MINIDFS_CLUSTER_BUILDER ";", conf->doFormat);
+    if (jthr) {
+        printExceptionAndFree(env, jthr, PRINT_EXC_ALL, "nmdCreate: "
+                              "Builder::format");
+        goto error;
+    }
+    (*env)->DeleteLocalRef(env, val.l);
+    if (conf->webhdfsEnabled) {
+        jthr = invokeMethod(env, &val, INSTANCE, bld, MINIDFS_CLUSTER_BUILDER,
+                        "nameNodeHttpPort", "(I)L" MINIDFS_CLUSTER_BUILDER ";",
+                        conf->namenodeHttpPort);
+        if (jthr) {
+            printExceptionAndFree(env, jthr, PRINT_EXC_ALL, "nmdCreate: "
+                                  "Builder::nameNodeHttpPort");
+            goto error;
+        }
+        (*env)->DeleteLocalRef(env, val.l);
+    }
+    jthr = invokeMethod(env, &val, INSTANCE, bld, MINIDFS_CLUSTER_BUILDER,
+            "build", "()L" MINIDFS_CLUSTER ";");
+    if (jthr) {
+        printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                              "nmdCreate: Builder#build");
+        goto error;
+    }
+    cluster = val.l;
+	  cl->obj = (*env)->NewGlobalRef(env, val.l);
+    if (!cl->obj) {
+        printPendingExceptionAndFree(env, PRINT_EXC_ALL,
+            "nmdCreate: NewGlobalRef");
+        goto error;
+    }
+    (*env)->DeleteLocalRef(env, cluster);
+    (*env)->DeleteLocalRef(env, bld);
+    (*env)->DeleteLocalRef(env, cobj);
+    (*env)->DeleteLocalRef(env, jconfStr);
+    return cl;
+
+error:
+    (*env)->DeleteLocalRef(env, cluster);
+    (*env)->DeleteLocalRef(env, bld);
+    (*env)->DeleteLocalRef(env, cobj);
+    (*env)->DeleteLocalRef(env, jconfStr);
+    free(cl);
+    return NULL;
+}
+
+void nmdFree(struct NativeMiniDfsCluster* cl)
+{
+    JNIEnv *env = getJNIEnv();
+    if (!env) {
+        fprintf(stderr, "nmdFree: getJNIEnv failed\n");
+        free(cl);
+        return;
+    }
+    (*env)->DeleteGlobalRef(env, cl->obj);
+    free(cl);
+}
+
+int nmdShutdownInner(struct NativeMiniDfsCluster* cl, jboolean deleteDfsDir)
+{
+    JNIEnv *env = getJNIEnv();
+    jthrowable jthr;
+
+    if (!env) {
+        fprintf(stderr, "nmdShutdown: getJNIEnv failed\n");
+        return -EIO;
+    }
+    jthr = invokeMethod(env, NULL, INSTANCE, cl->obj,
+                        MINIDFS_CLUSTER, "shutdown", "(Z)V", deleteDfsDir);
+    if (jthr) {
+        printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                              "nmdShutdown: MiniDFSCluster#shutdown");
+        return -EIO;
+    }
+    return 0;
+}
+
+int nmdShutdown(struct NativeMiniDfsCluster *cl) {
+    return nmdShutdownInner(cl, 0);
+}
+
+int nmdShutdownClean(struct NativeMiniDfsCluster *cl) {
+    return nmdShutdownInner(cl, 1);
+}
+
+int nmdWaitClusterUp(struct NativeMiniDfsCluster *cl)
+{
+    jthrowable jthr;
+    JNIEnv *env = getJNIEnv();
+    if (!env) {
+        fprintf(stderr, "nmdWaitClusterUp: getJNIEnv failed\n");
+        return -EIO;
+    }
+    jthr = invokeMethod(env, NULL, INSTANCE, cl->obj,
+            MINIDFS_CLUSTER, "waitClusterUp", "()V");
+    if (jthr) {
+        printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "nmdWaitClusterUp: MiniDFSCluster#waitClusterUp ");
+        return -EIO;
+    }
+    return 0;
+}
+
+int nmdGetNameNodePort(const struct NativeMiniDfsCluster *cl)
+{
+    JNIEnv *env = getJNIEnv();
+    jvalue jVal;
+    jthrowable jthr;
+
+    if (!env) {
+        fprintf(stderr, "nmdHdfsConnect: getJNIEnv failed\n");
+        return -EIO;
+    }
+    // Note: this will have to be updated when HA nativeMiniDfs clusters are
+    // supported
+    jthr = invokeMethod(env, &jVal, INSTANCE, cl->obj,
+            MINIDFS_CLUSTER, "getNameNodePort", "()I");
+    if (jthr) {
+        printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+            "nmdHdfsConnect: MiniDFSCluster#getNameNodePort");
+        return -EIO;
+    }
+    return jVal.i;
+}
+
+int nmdGetNameNodeHttpAddress(const struct NativeMiniDfsCluster *cl,
+                               int *port, const char **hostName)
+{
+    JNIEnv *env = getJNIEnv();
+    jvalue jVal;
+    jobject jNameNode, jAddress;
+    jthrowable jthr;
+    int ret = 0;
+    const char *host;
+    
+    if (!env) {
+        fprintf(stderr, "nmdHdfsConnect: getJNIEnv failed\n");
+        return -EIO;
+    }
+    // First get the (first) NameNode of the cluster
+    jthr = invokeMethod(env, &jVal, INSTANCE, cl->obj, MINIDFS_CLUSTER,
+                        "getNameNode", "()L" HADOOP_NAMENODE ";");
+    if (jthr) {
+        printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                              "nmdGetNameNodeHttpAddress: "
+                              "MiniDFSCluster#getNameNode");
+        return -EIO;
+    }
+    jNameNode = jVal.l;
+    
+    // Then get the http address (InetSocketAddress) of the NameNode
+    jthr = invokeMethod(env, &jVal, INSTANCE, jNameNode, HADOOP_NAMENODE,
+                        "getHttpAddress", "()L" JAVA_INETSOCKETADDRESS ";");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                                    "nmdGetNameNodeHttpAddress: "
+                                    "NameNode#getHttpAddress");
+        goto error_dlr_nn;
+    }
+    jAddress = jVal.l;
+    
+    jthr = invokeMethod(env, &jVal, INSTANCE, jAddress,
+                        JAVA_INETSOCKETADDRESS, "getPort", "()I");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                                    "nmdGetNameNodeHttpAddress: "
+                                    "InetSocketAddress#getPort");
+        goto error_dlr_addr;
+    }
+    *port = jVal.i;
+    
+    jthr = invokeMethod(env, &jVal, INSTANCE, jAddress, JAVA_INETSOCKETADDRESS,
+                        "getHostName", "()Ljava/lang/String;");
+    if (jthr) {
+        ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                                    "nmdGetNameNodeHttpAddress: "
+                                    "InetSocketAddress#getHostName");
+        goto error_dlr_addr;
+    }
+    host = (*env)->GetStringUTFChars(env, jVal.l, NULL);
+    *hostName = strdup(host);
+    (*env)->ReleaseStringUTFChars(env, jVal.l, host);
+    
+error_dlr_addr:
+    (*env)->DeleteLocalRef(env, jAddress);
+error_dlr_nn:
+    (*env)->DeleteLocalRef(env, jNameNode);
+    
+    return ret;
+}
+
+const char *hdfsGetDomainSocketPath(const struct NativeMiniDfsCluster *cl) {
+    if (cl->domainSocketPath[0]) {
+        return cl->domainSocketPath;
+    }
+
+    return NULL;
+}
+
+int nmdConfigureHdfsBuilder(struct NativeMiniDfsCluster *cl,
+                            struct hdfsBuilder *bld) {
+    int ret;
+    tPort port;
+    const char *domainSocket;
+
+    hdfsBuilderSetNameNode(bld, "localhost");
+    port = (tPort) nmdGetNameNodePort(cl);
+    if (port < 0) {
+        fprintf(stderr, "nmdGetNameNodePort failed with error %d\n", -port);
+        return EIO;
+    }
+    hdfsBuilderSetNameNodePort(bld, port);
+
+    domainSocket = hdfsGetDomainSocketPath(cl);
+
+    if (domainSocket) {
+        ret = hdfsBuilderConfSetStr(bld, "dfs.client.read.shortcircuit", "true");
+        if (ret) {
+            return ret;
+        }
+        ret = hdfsBuilderConfSetStr(bld, "dfs.domain.socket.path",
+                                    domainSocket);
+        if (ret) {
+            return ret;
+        }
+    }
+    return 0;
+}

--- a/native/fs-hdfs/c_src/libminidfs/native_mini_dfs.h
+++ b/native/fs-hdfs/c_src/libminidfs/native_mini_dfs.h
@@ -1,0 +1,154 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LIBHDFS_NATIVE_MINI_DFS_H
+#define LIBHDFS_NATIVE_MINI_DFS_H
+
+#include <jni.h> /* for jboolean */
+
+#ifdef __cplusplus
+extern  "C" {
+#endif
+
+struct hdfsBuilder;
+/**
+* <div rustbindgen replaces="MiniDfsCluster"></div>
+*/
+struct NativeMiniDfsCluster; 
+
+/**
+ * <div rustbindgen replaces="MiniDfsConf"></div>
+ *
+ * Represents a configuration to use for creating a Native MiniDFSCluster
+ */
+struct NativeMiniDfsConf {
+    /**
+     * Nonzero if the cluster should be formatted prior to startup.
+     */
+    jboolean doFormat;
+
+    /**
+     * Whether or not to enable webhdfs in MiniDfsCluster
+     */
+    jboolean webhdfsEnabled;
+
+    /**
+     * The http port of the namenode in MiniDfsCluster
+     */
+    jint namenodeHttpPort;
+
+    /**
+     * Nonzero if we should configure short circuit.
+     */
+    jboolean configureShortCircuit;
+};
+
+/**
+ * Create a NativeMiniDfsBuilder
+ *
+ * @param conf      (inout) The cluster configuration
+ *
+ * @return      a NativeMiniDfsBuilder, or a NULL pointer on error.
+ */
+struct NativeMiniDfsCluster* nmdCreate(const struct NativeMiniDfsConf *conf);
+
+/**
+ * Wait until a MiniDFSCluster comes out of safe mode.
+ *
+ * @param cl        The cluster
+ *
+ * @return          0 on success; a non-zero error code if the cluster fails to
+ *                  come out of safe mode.
+ */
+int nmdWaitClusterUp(struct NativeMiniDfsCluster *cl);
+
+/**
+ * Shut down a NativeMiniDFS cluster
+ *
+ * @param cl        The cluster
+ *
+ * @return          0 on success; a non-zero error code if an exception is
+ *                  thrown.
+ */
+int nmdShutdown(struct NativeMiniDfsCluster *cl);
+
+/**
+ * Shut down a NativeMiniDFS cluster with deleting hdfs directory
+ *
+ * @param cl        The cluster
+ *
+ * @return          0 on success; a non-zero error code if an exception is
+ *                  thrown.
+ */
+int nmdShutdownClean(struct NativeMiniDfsCluster *cl);
+
+/**
+ * Destroy a Native MiniDFSCluster
+ *
+ * @param cl        The cluster to destroy
+ */
+void nmdFree(struct NativeMiniDfsCluster* cl);
+
+/**
+ * Get the port that's in use by the given (non-HA) nativeMiniDfs
+ *
+ * @param cl        The initialized NativeMiniDfsCluster
+ *
+ * @return          the port, or a negative error code
+ */
+int nmdGetNameNodePort(const struct NativeMiniDfsCluster *cl); 
+
+/**
+ * Get the http address that's in use by the given (non-HA) nativeMiniDfs
+ *
+ * @param cl        The initialized NativeMiniDfsCluster
+ * @param port      Used to capture the http port of the NameNode 
+ *                  of the NativeMiniDfsCluster
+ * @param hostName  Used to capture the http hostname of the NameNode
+ *                  of the NativeMiniDfsCluster
+ *
+ * @return          0 on success; a non-zero error code if failing to
+ *                  get the information.
+ */
+int nmdGetNameNodeHttpAddress(const struct NativeMiniDfsCluster *cl,
+                               int *port, const char **hostName);
+
+/**
+ * Get domain socket path set for this cluster.
+ *
+ * @param cl        The cluster
+ *
+ * @return          A const string of domain socket path, or NULL if not set.
+ */
+const char *hdfsGetDomainSocketPath(const struct NativeMiniDfsCluster *cl);
+
+/**
+ * Configure the HDFS builder appropriately to connect to this cluster.
+ *
+ * @param bld       The hdfs builder
+ *
+ * @return          the port, or a negative error code
+ */
+int nmdConfigureHdfsBuilder(struct NativeMiniDfsCluster *cl,
+                            struct hdfsBuilder *bld);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/native/fs-hdfs/c_src/wrapper.h
+++ b/native/fs-hdfs/c_src/wrapper.h
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WRAPPER_HDFS_H
+#define WRAPPER_HDFS_H
+
+#include "libhdfs/hdfs.h"
+#include "libminidfs/native_mini_dfs.h"
+
+#endif //WRAPPER_HDFS_H

--- a/native/fs-hdfs/rustfmt.toml
+++ b/native/fs-hdfs/rustfmt.toml
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+edition = "2018"
+max_width = 90

--- a/native/fs-hdfs/src/err.rs
+++ b/native/fs-hdfs/src/err.rs
@@ -35,15 +35,15 @@ pub enum HdfsErr {
 impl Display for HdfsErr {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            HdfsErr::FileNotFound(path) => write!(f, "Hdfs file {} not found", path),
+            HdfsErr::FileNotFound(path) => write!(f, "Hdfs file {path} not found"),
             HdfsErr::FileAlreadyExists(path) => {
-                write!(f, "Hdfs file {} already exists", path)
+                write!(f, "Hdfs file {path} already exists")
             }
-            HdfsErr::InvalidUrl(path) => write!(f, "Hdfs url {} is not valid", path),
+            HdfsErr::InvalidUrl(path) => write!(f, "Hdfs url {path} is not valid"),
             HdfsErr::CannotConnectToNameNode(namenode_uri) => {
-                write!(f, "Cannot connect to name node {}", namenode_uri)
+                write!(f, "Cannot connect to name node {namenode_uri}")
             }
-            HdfsErr::Generic(err_str) => write!(f, "Generic error with msg: {}", err_str),
+            HdfsErr::Generic(err_str) => write!(f, "Generic error with msg: {err_str}"),
         }
     }
 }

--- a/native/fs-hdfs/src/err.rs
+++ b/native/fs-hdfs/src/err.rs
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+/// Errors which can occur during accessing Hdfs cluster
+#[derive(Debug)]
+pub enum HdfsErr {
+    Generic(String),
+    /// file path
+    FileNotFound(String),
+    /// file path           
+    FileAlreadyExists(String),
+    /// name node address
+    CannotConnectToNameNode(String),
+    /// URL
+    InvalidUrl(String),
+}
+
+impl Display for HdfsErr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HdfsErr::FileNotFound(path) => write!(f, "Hdfs file {} not found", path),
+            HdfsErr::FileAlreadyExists(path) => {
+                write!(f, "Hdfs file {} already exists", path)
+            }
+            HdfsErr::InvalidUrl(path) => write!(f, "Hdfs url {} is not valid", path),
+            HdfsErr::CannotConnectToNameNode(namenode_uri) => {
+                write!(f, "Cannot connect to name node {}", namenode_uri)
+            }
+            HdfsErr::Generic(err_str) => write!(f, "Generic error with msg: {}", err_str),
+        }
+    }
+}
+
+impl Error for HdfsErr {}

--- a/native/fs-hdfs/src/hdfs.rs
+++ b/native/fs-hdfs/src/hdfs.rs
@@ -175,8 +175,7 @@ impl HdfsFs {
     fn new_hdfs_file(&self, path: &str, file: hdfsFile) -> Result<HdfsFile, HdfsErr> {
         if file.is_null() {
             Err(HdfsErr::FileNotFound(format!(
-                "Fail to create/open file {}",
-                path
+                "Fail to create/open file {path}"
             )))
         } else {
             Ok(HdfsFile {
@@ -224,8 +223,7 @@ impl HdfsFs {
 
         if ptr.is_null() {
             Err(HdfsErr::FileNotFound(format!(
-                "Fail to get file status for {}",
-                path
+                "Fail to get file status for {path}"
             )))
         } else {
             Ok(FileStatus::new(ptr))
@@ -280,8 +278,7 @@ impl HdfsFs {
             Ok(block_sz as usize)
         } else {
             Err(HdfsErr::Generic(format!(
-                "Fail to get block size for file {}",
-                path
+                "Fail to get block size for file {path}"
             )))
         }
     }
@@ -340,8 +337,7 @@ impl HdfsFs {
             Ok(BlockHosts { ptr })
         } else {
             Err(HdfsErr::Generic(format!(
-                "Fail to get block hosts for file {} from {} with length {}",
-                path, start, length
+                "Fail to get block hosts for file {path} from {start} with length {length}"
             )))
         }
     }
@@ -433,8 +429,7 @@ impl HdfsFs {
             Ok(true)
         } else {
             Err(HdfsErr::Generic(format!(
-                "Fail to create directory for {}",
-                path
+                "Fail to create directory for {path}"
             )))
         }
     }
@@ -463,8 +458,7 @@ impl HdfsFs {
             Ok(true)
         } else {
             Err(HdfsErr::Generic(format!(
-                "Fail to rename {} to {}",
-                old_path, new_path
+                "Fail to rename {old_path} to {new_path}"
             )))
         }
     }
@@ -479,8 +473,7 @@ impl HdfsFs {
             Ok(true)
         } else {
             Err(HdfsErr::Generic(format!(
-                "Fail to set replication {} for {}",
-                num, path
+                "Fail to set replication {num} for {path}"
             )))
         }
     }
@@ -495,8 +488,7 @@ impl HdfsFs {
             Ok(true)
         } else {
             Err(HdfsErr::Generic(format!(
-                "Fail to delete {} with recursive mode {}",
-                path, recursive
+                "Fail to delete {path} with recursive mode {recursive}"
             )))
         }
     }
@@ -626,9 +618,8 @@ impl HdfsFile {
             Ok(read_len)
         } else {
             Err(HdfsErr::Generic(format!(
-                "Fail to read contents from {} with return code {}",
-                self.path(),
-                read_len
+                "Fail to read contents from {} with return code {read_len}",
+                self.path()
             )))
         }
     }
@@ -652,10 +643,8 @@ impl HdfsFile {
             Ok(read_len)
         } else {
             Err(HdfsErr::Generic(format!(
-                "Fail to read contents from {} with offset {} and return code {}",
-                self.path(),
-                pos,
-                read_len
+                "Fail to read contents from {} with offset {pos} and return code {read_len}",
+                self.path()
             )))
         }
     }
@@ -862,7 +851,7 @@ fn get_namenode_uri(path: &str) -> Result<String, HdfsErr> {
                     write!(&mut uri_builder, "{}://{}", url.scheme(), host).unwrap();
 
                     if let Some(port) = url.port() {
-                        write!(&mut uri_builder, ":{}", port).unwrap();
+                        write!(&mut uri_builder, ":{port}").unwrap();
                     }
                     Ok(uri_builder)
                 } else {
@@ -878,7 +867,7 @@ fn get_namenode_uri(path: &str) -> Result<String, HdfsErr> {
 #[inline]
 pub fn get_uri(path: &str) -> Result<String, HdfsErr> {
     let path = if path.starts_with('/') {
-        format!("{}://{}", LOCAL_FS_SCHEME, path)
+        format!("{LOCAL_FS_SCHEME}://{path}")
     } else {
         path.to_string()
     };
@@ -945,16 +934,16 @@ mod test {
             // Test directory
             {
                 let uuid = Uuid::new_v4().to_string();
-                let test_dir = format!("/{}", uuid);
+                let test_dir = format!("/{uuid}");
 
                 match fs.mkdir(&test_dir) {
-                    Ok(_) => println!("{} created", test_dir),
-                    Err(_) => panic!("Couldn't create {} directory", test_dir),
+                    Ok(_) => println!("{test_dir} created"),
+                    Err(_) => panic!("Couldn't create {test_dir} directory"),
                 };
 
                 let file_info = fs.get_file_status(&test_dir).ok().unwrap();
 
-                let expected_path = format!("{}{}", minidfs_addr, test_dir);
+                let expected_path = format!("{minidfs_addr}{test_dir}");
                 assert_eq!(&expected_path, file_info.name());
                 assert!(!file_info.is_file());
                 assert!(file_info.is_directory());
@@ -962,12 +951,12 @@ mod test {
                 let sub_dir_num = 3;
                 let mut expected_list = Vec::new();
                 for x in 0..sub_dir_num {
-                    let filename = format!("{}/{}", test_dir, x);
-                    expected_list.push(format!("{}{}/{}", minidfs_addr, test_dir, x));
+                    let filename = format!("{test_dir}/{x}");
+                    expected_list.push(format!("{minidfs_addr}{test_dir}/{x}"));
 
                     match fs.mkdir(&filename) {
-                        Ok(_) => println!("{} created", filename),
-                        Err(_) => panic!("Couldn't create {} directory", filename),
+                        Ok(_) => println!("{filename} created"),
+                        Err(_) => panic!("Couldn't create {filename} directory"),
                     };
                 }
 
@@ -997,23 +986,23 @@ mod test {
             // Test list status with empty directory
             {
                 let uuid = Uuid::new_v4().to_string();
-                let test_dir = format!("/{}", uuid);
-                let empty_dir = format!("/{}", "_empty");
+                let test_dir = format!("/{uuid}",);
+                let empty_dir = "/_empty".to_string();
 
                 match fs.mkdir(&test_dir) {
-                    Ok(_) => println!("{} created", test_dir),
-                    Err(_) => panic!("Couldn't create {} directory", test_dir),
+                    Ok(_) => println!("{test_dir} created"),
+                    Err(_) => panic!("Couldn't create {test_dir} directory"),
                 };
 
                 match fs.mkdir(&empty_dir) {
-                    Ok(_) => println!("{} created", test_dir),
-                    Err(_) => panic!("Couldn't create {} directory", test_dir),
+                    Ok(_) => println!("{test_dir} created"),
+                    Err(_) => panic!("Couldn't create {test_dir} directory"),
                 };
 
-                let test_file = format!("{}/{}", &test_dir, "test.txt");
+                let test_file = format!("{test_dir}/test.txt");
                 match fs.create(&test_file) {
-                    Ok(_) => println!("{} created", test_file),
-                    Err(_) => panic!("Couldn't create {} ", test_file),
+                    Ok(_) => println!("{test_file} created"),
+                    Err(_) => panic!("Couldn't create {test_file}"),
                 }
 
                 let file_info = fs.list_status(&test_dir).ok().unwrap();

--- a/native/fs-hdfs/src/hdfs.rs
+++ b/native/fs-hdfs/src/hdfs.rs
@@ -1,0 +1,1086 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! it's a modified version of hdfs-rs
+use std::collections::HashMap;
+use std::ffi::{CStr, CString};
+use std::fmt::Write;
+use std::fmt::{Debug, Formatter};
+use std::marker::PhantomData;
+use std::string::String;
+use std::sync::{Arc, RwLock};
+
+use lazy_static::lazy_static;
+use libc::{c_char, c_int, c_short, c_void, time_t};
+use log::info;
+use url::Url;
+
+pub use crate::err::HdfsErr;
+use crate::native::*;
+
+/// These flags should be consistent with the ones in fcntl.h
+const O_RDONLY: c_int = 0;
+const O_WRONLY: c_int = 1;
+const O_APPEND: c_int = 8;
+
+lazy_static! {
+    static ref HDFS_MANAGER: HdfsManager = HdfsManager::new();
+}
+
+/// Create instance of HdfsFs with a global cache.
+/// For each namenode uri, only one instance will be created
+pub fn get_hdfs_by_full_path(path: &str) -> Result<Arc<HdfsFs>, HdfsErr> {
+    HDFS_MANAGER.get_hdfs_by_full_path(path)
+}
+
+/// The default NameNode configuration will be used (from the XML configuration files)
+pub fn get_hdfs() -> Result<Arc<HdfsFs>, HdfsErr> {
+    HDFS_MANAGER.get_hdfs_by_full_path("default")
+}
+
+/// Remove an instance of HdfsFs from the cache by a specified path with uri
+pub fn unload_hdfs_cache_by_full_path(
+    path: &str,
+) -> Result<Option<Arc<HdfsFs>>, HdfsErr> {
+    HDFS_MANAGER.remove_hdfs_by_full_path(path)
+}
+
+/// Remove an instance of HdfsFs from the cache
+pub fn unload_hdfs_cache(hdfs: Arc<HdfsFs>) -> Result<Option<Arc<HdfsFs>>, HdfsErr> {
+    HDFS_MANAGER.remove_hdfs(hdfs)
+}
+
+/// Hdfs manager
+/// All of the HdfsFs instances will be managed in a singleton HdfsManager
+struct HdfsManager {
+    hdfs_cache: Arc<RwLock<HashMap<String, Arc<HdfsFs>>>>,
+}
+
+impl HdfsManager {
+    fn new() -> Self {
+        Self {
+            hdfs_cache: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    fn get_hdfs_by_full_path(&self, path: &str) -> Result<Arc<HdfsFs>, HdfsErr> {
+        let namenode_uri = match path {
+            "default" => "default".to_owned(),
+            _ => get_namenode_uri(path)?,
+        };
+
+        // Get if already exists
+        if let Some(hdfs_fs) = {
+            let cache = self.hdfs_cache.read().unwrap();
+            cache.get(&namenode_uri).cloned()
+        } {
+            return Ok(hdfs_fs);
+        }
+
+        let mut cache = self.hdfs_cache.write().unwrap();
+        // Check again if exists
+        let ret = if let Some(hdfs_fs) = cache.get(&namenode_uri) {
+            hdfs_fs.clone()
+        } else {
+            let hdfs_fs = unsafe {
+                let hdfs_builder = hdfsNewBuilder();
+                let cstr_uri = CString::new(namenode_uri.as_bytes()).unwrap();
+                hdfsBuilderSetNameNode(hdfs_builder, cstr_uri.as_ptr());
+                info!("Connecting to Namenode ({})", &namenode_uri);
+                hdfsBuilderConnect(hdfs_builder)
+            };
+
+            if hdfs_fs.is_null() {
+                return Err(HdfsErr::CannotConnectToNameNode(namenode_uri.clone()));
+            }
+
+            let hdfs_fs = Arc::new(HdfsFs {
+                url: namenode_uri.clone(),
+                raw: hdfs_fs,
+                _marker: PhantomData,
+            });
+            cache.insert(namenode_uri.clone(), hdfs_fs.clone());
+            hdfs_fs
+        };
+
+        Ok(ret)
+    }
+
+    fn remove_hdfs_by_full_path(
+        &self,
+        path: &str,
+    ) -> Result<Option<Arc<HdfsFs>>, HdfsErr> {
+        let namenode_uri = match path {
+            "default" => String::from("default"),
+            _ => get_namenode_uri(path)?,
+        };
+
+        self.remove_hdfs_inner(&namenode_uri)
+    }
+
+    fn remove_hdfs(&self, hdfs: Arc<HdfsFs>) -> Result<Option<Arc<HdfsFs>>, HdfsErr> {
+        self.remove_hdfs_inner(hdfs.url())
+    }
+
+    fn remove_hdfs_inner(&self, hdfs_key: &str) -> Result<Option<Arc<HdfsFs>>, HdfsErr> {
+        let mut cache = self.hdfs_cache.write().unwrap();
+        Ok(cache.remove(hdfs_key))
+    }
+}
+
+/// Hdfs Filesystem
+///
+/// It is basically thread safe because the native API for hdfsFs is thread-safe.
+#[derive(Clone)]
+pub struct HdfsFs {
+    url: String,
+    raw: hdfsFS,
+    _marker: PhantomData<()>,
+}
+
+impl Debug for HdfsFs {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HdfsFs").field("url", &self.url).finish()
+    }
+}
+
+impl HdfsFs {
+    /// Get HDFS namenode url
+    #[inline]
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Get a raw pointer of JNI API's HdfsFs
+    #[inline]
+    pub fn raw(&self) -> hdfsFS {
+        self.raw
+    }
+
+    /// Create HdfsFile from hdfsFile
+    fn new_hdfs_file(&self, path: &str, file: hdfsFile) -> Result<HdfsFile, HdfsErr> {
+        if file.is_null() {
+            Err(HdfsErr::FileNotFound(format!(
+                "Fail to create/open file {}",
+                path
+            )))
+        } else {
+            Ok(HdfsFile {
+                fs: self.clone(),
+                path: path.to_owned(),
+                file,
+                _marker: PhantomData,
+            })
+        }
+    }
+
+    /// open a file to read
+    #[inline]
+    pub fn open(&self, path: &str) -> Result<HdfsFile, HdfsErr> {
+        self.open_with_buf_size(path, 0)
+    }
+
+    /// open a file to read with a buffer size
+    pub fn open_with_buf_size(
+        &self,
+        path: &str,
+        buf_size: i32,
+    ) -> Result<HdfsFile, HdfsErr> {
+        let file = unsafe {
+            let cstr_path = CString::new(path).unwrap();
+            hdfsOpenFile(
+                self.raw,
+                cstr_path.as_ptr(),
+                O_RDONLY,
+                buf_size as c_int,
+                0,
+                0,
+            )
+        };
+
+        self.new_hdfs_file(path, file)
+    }
+
+    /// Get the file status, including file size, last modified time, etc
+    pub fn get_file_status(&self, path: &str) -> Result<FileStatus, HdfsErr> {
+        let ptr = unsafe {
+            let cstr_path = CString::new(path).unwrap();
+            hdfsGetPathInfo(self.raw, cstr_path.as_ptr())
+        };
+
+        if ptr.is_null() {
+            Err(HdfsErr::FileNotFound(format!(
+                "Fail to get file status for {}",
+                path
+            )))
+        } else {
+            Ok(FileStatus::new(ptr))
+        }
+    }
+
+    /// Get the file status for each entry under the specified directory
+    pub fn list_status(&self, path: &str) -> Result<Vec<FileStatus>, HdfsErr> {
+        let mut entry_num: c_int = 0;
+
+        let ptr = unsafe {
+            let cstr_path = CString::new(path).unwrap();
+            hdfsListDirectory(self.raw, cstr_path.as_ptr(), &mut entry_num)
+        };
+
+        let mut list = Vec::new();
+
+        if ptr.is_null() {
+            return Ok(list);
+        }
+
+        let shared_ptr = Arc::new(HdfsFileInfoPtr::new_array(ptr, entry_num));
+
+        for idx in 0..entry_num {
+            list.push(FileStatus::from_array(shared_ptr.clone(), idx as u32));
+        }
+
+        Ok(list)
+    }
+
+    /// Get the default blocksize.
+    pub fn default_blocksize(&self) -> Result<usize, HdfsErr> {
+        let block_sz = unsafe { hdfsGetDefaultBlockSize(self.raw) };
+
+        if block_sz >= 0 {
+            Ok(block_sz as usize)
+        } else {
+            Err(HdfsErr::Generic(
+                "Fail to get default block size".to_owned(),
+            ))
+        }
+    }
+
+    /// Get the default blocksize at the filesystem indicated by a given path.
+    pub fn block_size(&self, path: &str) -> Result<usize, HdfsErr> {
+        let block_sz = unsafe {
+            let cstr_path = CString::new(path).unwrap();
+            hdfsGetDefaultBlockSizeAtPath(self.raw, cstr_path.as_ptr())
+        };
+
+        if block_sz >= 0 {
+            Ok(block_sz as usize)
+        } else {
+            Err(HdfsErr::Generic(format!(
+                "Fail to get block size for file {}",
+                path
+            )))
+        }
+    }
+
+    /// Return the raw capacity of the filesystem.
+    pub fn capacity(&self) -> Result<usize, HdfsErr> {
+        let capacity = unsafe { hdfsGetCapacity(self.raw) };
+
+        if capacity >= 0 {
+            Ok(capacity as usize)
+        } else {
+            Err(HdfsErr::Generic("Fail to get capacity".to_owned()))
+        }
+    }
+
+    /// Return the total raw size of all files in the filesystem.
+    pub fn used(&self) -> Result<usize, HdfsErr> {
+        let used = unsafe { hdfsGetUsed(self.raw) };
+
+        if used >= 0 {
+            Ok(used as usize)
+        } else {
+            Err(HdfsErr::Generic("Fail to get used size".to_owned()))
+        }
+    }
+
+    /// Checks if a given path exsits on the filesystem
+    pub fn exist(&self, path: &str) -> bool {
+        (unsafe {
+            let cstr_path = CString::new(path).unwrap();
+            hdfsExists(self.raw, cstr_path.as_ptr())
+        } == 0)
+    }
+
+    /// Get hostnames where a particular block (determined by
+    /// pos & blocksize) of a file is stored. The last element in the array
+    /// is NULL. Due to replication, a single block could be present on
+    /// multiple hosts.
+    pub fn get_hosts(
+        &self,
+        path: &str,
+        start: usize,
+        length: usize,
+    ) -> Result<BlockHosts, HdfsErr> {
+        let ptr = unsafe {
+            let cstr_path = CString::new(path).unwrap();
+            hdfsGetHosts(
+                self.raw,
+                cstr_path.as_ptr(),
+                start as tOffset,
+                length as tOffset,
+            )
+        };
+
+        if !ptr.is_null() {
+            Ok(BlockHosts { ptr })
+        } else {
+            Err(HdfsErr::Generic(format!(
+                "Fail to get block hosts for file {} from {} with length {}",
+                path, start, length
+            )))
+        }
+    }
+
+    #[inline]
+    pub fn create(&self, path: &str) -> Result<HdfsFile, HdfsErr> {
+        self.create_with_params(path, false, 0, 0, 0)
+    }
+
+    #[inline]
+    pub fn create_with_overwrite(
+        &self,
+        path: &str,
+        overwrite: bool,
+    ) -> Result<HdfsFile, HdfsErr> {
+        self.create_with_params(path, overwrite, 0, 0, 0)
+    }
+
+    pub fn create_with_params(
+        &self,
+        path: &str,
+        overwrite: bool,
+        buf_size: i32,
+        replica_num: i16,
+        block_size: i32,
+    ) -> Result<HdfsFile, HdfsErr> {
+        if !overwrite && self.exist(path) {
+            return Err(HdfsErr::FileAlreadyExists(path.to_owned()));
+        }
+
+        let file = unsafe {
+            let cstr_path = CString::new(path).unwrap();
+            hdfsOpenFile(
+                self.raw,
+                cstr_path.as_ptr(),
+                O_WRONLY,
+                buf_size as c_int,
+                replica_num as c_short,
+                block_size as tSize,
+            )
+        };
+
+        self.new_hdfs_file(path, file)
+    }
+
+    /// set permission
+    pub fn chmod(&self, path: &str, mode: i16) -> bool {
+        (unsafe {
+            let cstr_path = CString::new(path).unwrap();
+            hdfsChmod(self.raw, cstr_path.as_ptr(), mode as c_short)
+        }) == 0
+    }
+
+    pub fn chown(&self, path: &str, owner: &str, group: &str) -> bool {
+        (unsafe {
+            let cstr_path = CString::new(path).unwrap();
+            let cstr_owner = CString::new(owner).unwrap();
+            let cstr_group = CString::new(group).unwrap();
+            hdfsChown(
+                self.raw,
+                cstr_path.as_ptr(),
+                cstr_owner.as_ptr(),
+                cstr_group.as_ptr(),
+            )
+        }) == 0
+    }
+
+    /// Open a file for append
+    pub fn append(&self, path: &str) -> Result<HdfsFile, HdfsErr> {
+        if !self.exist(path) {
+            return Err(HdfsErr::FileNotFound(path.to_owned()));
+        }
+
+        let file = unsafe {
+            let cstr_path = CString::new(path).unwrap();
+            hdfsOpenFile(self.raw, cstr_path.as_ptr(), O_APPEND | O_WRONLY, 0, 0, 0)
+        };
+
+        self.new_hdfs_file(path, file)
+    }
+
+    /// create a directory
+    pub fn mkdir(&self, path: &str) -> Result<bool, HdfsErr> {
+        if unsafe {
+            let cstr_path = CString::new(path).unwrap();
+            hdfsCreateDirectory(self.raw, cstr_path.as_ptr())
+        } == 0
+        {
+            Ok(true)
+        } else {
+            Err(HdfsErr::Generic(format!(
+                "Fail to create directory for {}",
+                path
+            )))
+        }
+    }
+
+    /// Rename file.
+    pub fn rename(&self, old_path: &str, new_path: &str, overwrite: bool) -> Result<bool, HdfsErr> {
+        if unsafe {
+            let cstr_old_path = CString::new(old_path).unwrap();
+            let cstr_new_path = CString::new(new_path).unwrap();
+            if overwrite {
+                hdfsRenameOverwrite(self.raw, cstr_old_path.as_ptr(), cstr_new_path.as_ptr())
+            } else {
+                hdfsRename(self.raw, cstr_old_path.as_ptr(), cstr_new_path.as_ptr())
+            }
+        } == 0
+        {
+            Ok(true)
+        } else {
+            Err(HdfsErr::Generic(format!(
+                "Fail to rename {} to {}",
+                old_path, new_path
+            )))
+        }
+    }
+
+    /// Set the replication of the specified file to the supplied value
+    pub fn set_replication(&self, path: &str, num: i16) -> Result<bool, HdfsErr> {
+        if unsafe {
+            let cstr_path = CString::new(path).unwrap();
+            hdfsSetReplication(self.raw, cstr_path.as_ptr(), num)
+        } == 0
+        {
+            Ok(true)
+        } else {
+            Err(HdfsErr::Generic(format!(
+                "Fail to set replication {} for {}",
+                num, path
+            )))
+        }
+    }
+
+    /// Delete file.
+    pub fn delete(&self, path: &str, recursive: bool) -> Result<bool, HdfsErr> {
+        if unsafe {
+            let cstr_path = CString::new(path).unwrap();
+            hdfsDelete(self.raw, cstr_path.as_ptr(), recursive as c_int)
+        } == 0
+        {
+            Ok(true)
+        } else {
+            Err(HdfsErr::Generic(format!(
+                "Fail to delete {} with recursive mode {}",
+                path, recursive
+            )))
+        }
+    }
+}
+
+/// since HDFS client handles are completely thread safe, here we implement Send+Sync trait for HdfsFs
+unsafe impl Send for HdfsFs {}
+
+unsafe impl Sync for HdfsFs {}
+
+/// open hdfs file
+#[derive(Clone)]
+pub struct HdfsFile {
+    fs: HdfsFs,
+    path: String,
+    file: hdfsFile,
+    _marker: PhantomData<()>,
+}
+
+impl Debug for HdfsFile {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HdfsFile")
+            .field("url", &self.fs.url)
+            .field("path", &self.path)
+            .finish()
+    }
+}
+
+impl HdfsFile {
+    /// Get HdfsFs
+    #[inline]
+    pub fn fs(&self) -> &HdfsFs {
+        &self.fs
+    }
+
+    /// Return a file path
+    #[inline]
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    pub fn available(&self) -> Result<bool, HdfsErr> {
+        if unsafe { hdfsAvailable(self.fs.raw, self.file) } == 0 {
+            Ok(true)
+        } else {
+            Err(HdfsErr::Generic(format!(
+                "File {} is not available",
+                self.path()
+            )))
+        }
+    }
+
+    /// Close the opened file
+    pub fn close(&self) -> Result<bool, HdfsErr> {
+        if unsafe { hdfsCloseFile(self.fs.raw, self.file) } == 0 {
+            Ok(true)
+        } else {
+            Err(HdfsErr::Generic(format!(
+                "Fail to close file {}",
+                self.path()
+            )))
+        }
+    }
+
+    /// Flush the data.
+    pub fn flush(&self) -> bool {
+        (unsafe { hdfsFlush(self.fs.raw, self.file) }) == 0
+    }
+
+    /// Flush out the data in client's user buffer. After the return of this
+    /// call, new readers will see the data.
+    pub fn hflush(&self) -> bool {
+        (unsafe { hdfsHFlush(self.fs.raw, self.file) }) == 0
+    }
+
+    /// Similar to posix fsync, Flush out the data in client's
+    /// user buffer. all the way to the disk device (but the disk may have
+    /// it in its cache).
+    pub fn hsync(&self) -> bool {
+        (unsafe { hdfsHSync(self.fs.raw, self.file) }) == 0
+    }
+
+    /// Determine if a file is open for read.
+    pub fn is_readable(&self) -> bool {
+        (unsafe { hdfsFileIsOpenForRead(self.file) }) == 1
+    }
+
+    /// Determine if a file is open for write.
+    pub fn is_writable(&self) -> bool {
+        (unsafe { hdfsFileIsOpenForWrite(self.file) }) == 1
+    }
+
+    /// Get the file status, including file size, last modified time, etc
+    pub fn get_file_status(&self) -> Result<FileStatus, HdfsErr> {
+        self.fs.get_file_status(self.path())
+    }
+
+    /// Get the current offset in the file, in bytes.
+    pub fn pos(&self) -> Result<u64, HdfsErr> {
+        let pos = unsafe { hdfsTell(self.fs.raw, self.file) };
+
+        if pos >= 0 {
+            Ok(pos as u64)
+        } else {
+            Err(HdfsErr::Generic(format!(
+                "Fail to get current offset of file {}",
+                self.path()
+            )))
+        }
+    }
+
+    /// Read data from an open file.
+    pub fn read(&self, buf: &mut [u8]) -> Result<i32, HdfsErr> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        let read_len = unsafe {
+            hdfsRead(
+                self.fs.raw,
+                self.file,
+                buf.as_ptr() as *mut c_void,
+                buf.len() as tSize,
+            )
+        };
+
+        if read_len >= 0 {
+            Ok(read_len)
+        } else {
+            Err(HdfsErr::Generic(format!(
+                "Fail to read contents from {} with return code {}",
+                self.path(),
+                read_len
+            )))
+        }
+    }
+
+    /// Positional read of data from an open file.
+    pub fn read_with_pos(&self, pos: i64, buf: &mut [u8]) -> Result<i32, HdfsErr> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        let read_len = unsafe {
+            hdfsPread(
+                self.fs.raw,
+                self.file,
+                pos as tOffset,
+                buf.as_ptr() as *mut c_void,
+                buf.len() as tSize,
+            )
+        };
+
+        if read_len >= 0 {
+            Ok(read_len)
+        } else {
+            Err(HdfsErr::Generic(format!(
+                "Fail to read contents from {} with offset {} and return code {}",
+                self.path(),
+                pos,
+                read_len
+            )))
+        }
+    }
+
+    /// Seek to given offset in file.
+    pub fn seek(&self, offset: u64) -> bool {
+        (unsafe { hdfsSeek(self.fs.raw, self.file, offset as tOffset) }) == 0
+    }
+
+    /// Write data into an open file.
+    pub fn write(&self, buf: &[u8]) -> Result<i32, HdfsErr> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        let written_len = unsafe {
+            hdfsWrite(
+                self.fs.raw,
+                self.file,
+                buf.as_ptr() as *mut c_void,
+                buf.len() as tSize,
+            )
+        };
+
+        if written_len >= 0 {
+            Ok(written_len)
+        } else {
+            Err(HdfsErr::Generic(format!(
+                "Fail to write contents to file {}",
+                self.path()
+            )))
+        }
+    }
+}
+
+/// since HdfsFile is only the pointer to the file on Hdfs, here we implement Send+Sync trait
+unsafe impl Send for HdfsFile {}
+
+unsafe impl Sync for HdfsFile {}
+
+/// Interface that represents the client side information for a file or directory.
+#[derive(Clone)]
+pub struct FileStatus {
+    raw: Arc<HdfsFileInfoPtr>,
+    idx: u32,
+    _marker: PhantomData<()>,
+}
+
+impl FileStatus {
+    /// create FileStatus from *const hdfsFileInfo
+    #[inline]
+    fn new(ptr: *const hdfsFileInfo) -> FileStatus {
+        FileStatus {
+            raw: Arc::new(HdfsFileInfoPtr::new(ptr)),
+            idx: 0,
+            _marker: PhantomData,
+        }
+    }
+
+    /// create FileStatus from *const hdfsFileInfo which points
+    /// to dynamically allocated array.
+    #[inline]
+    fn from_array(raw: Arc<HdfsFileInfoPtr>, idx: u32) -> FileStatus {
+        FileStatus {
+            raw,
+            idx,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Get the pointer to hdfsFileInfo
+    #[inline]
+    fn ptr(&self) -> *const hdfsFileInfo {
+        unsafe { self.raw.ptr.offset(self.idx as isize) }
+    }
+
+    /// Get the name of the file
+    #[inline]
+    pub fn name(&self) -> &str {
+        let slice = unsafe { CStr::from_ptr((*self.ptr()).mName) }.to_bytes();
+        std::str::from_utf8(slice).unwrap()
+    }
+
+    /// Is this a file?
+    #[inline]
+    pub fn is_file(&self) -> bool {
+        match unsafe { &*self.ptr() }.mKind {
+            tObjectKind::kObjectKindFile => true,
+            tObjectKind::kObjectKindDirectory => false,
+        }
+    }
+
+    /// Is this a directory?
+    #[inline]
+    pub fn is_directory(&self) -> bool {
+        match unsafe { &*self.ptr() }.mKind {
+            tObjectKind::kObjectKindFile => false,
+            tObjectKind::kObjectKindDirectory => true,
+        }
+    }
+
+    /// Get the owner of the file
+    #[inline]
+    pub fn owner(&self) -> &str {
+        let slice = unsafe { CStr::from_ptr((*self.ptr()).mOwner) }.to_bytes();
+        std::str::from_utf8(slice).unwrap()
+    }
+
+    /// Get the group associated with the file
+    #[inline]
+    pub fn group(&self) -> &str {
+        let slice = unsafe { CStr::from_ptr((*self.ptr()).mGroup) }.to_bytes();
+        std::str::from_utf8(slice).unwrap()
+    }
+
+    /// Get the permissions associated with the file
+    #[inline]
+    pub fn permission(&self) -> i16 {
+        unsafe { &*self.ptr() }.mPermissions
+    }
+
+    /// Get the length of this file, in bytes.
+    #[allow(clippy::len_without_is_empty)]
+    #[inline]
+    pub fn len(&self) -> usize {
+        unsafe { &*self.ptr() }.mSize as usize
+    }
+
+    /// Get the block size of the file.
+    #[inline]
+    pub fn block_size(&self) -> usize {
+        unsafe { &*self.ptr() }.mBlockSize as usize
+    }
+
+    /// Get the replication factor of a file.
+    #[inline]
+    pub fn replica_count(&self) -> i16 {
+        unsafe { &*self.ptr() }.mReplication
+    }
+
+    /// Get the last modification time for the file in seconds
+    #[inline]
+    pub fn last_modified(&self) -> time_t {
+        unsafe { &*self.ptr() }.mLastMod
+    }
+
+    /// Get the last access time for the file in seconds
+    #[inline]
+    pub fn last_access(&self) -> time_t {
+        unsafe { &*self.ptr() }.mLastAccess
+    }
+}
+
+/// Safely deallocable hdfsFileInfo pointer
+struct HdfsFileInfoPtr {
+    pub ptr: *const hdfsFileInfo,
+    pub len: i32,
+}
+
+/// for safe deallocation
+impl Drop for HdfsFileInfoPtr {
+    fn drop(&mut self) {
+        unsafe { hdfsFreeFileInfo(self.ptr as *mut hdfsFileInfo, self.len) };
+    }
+}
+
+impl HdfsFileInfoPtr {
+    fn new(ptr: *const hdfsFileInfo) -> HdfsFileInfoPtr {
+        HdfsFileInfoPtr { ptr, len: 1 }
+    }
+
+    pub fn new_array(ptr: *const hdfsFileInfo, len: i32) -> HdfsFileInfoPtr {
+        HdfsFileInfoPtr { ptr, len }
+    }
+}
+
+/// since HdfsFileInfoPtr is only the pointer to the Hdfs file info, here we implement Send+Sync trait
+unsafe impl Send for HdfsFileInfoPtr {}
+
+unsafe impl Sync for HdfsFileInfoPtr {}
+
+/// Includes hostnames where a particular block of a file is stored.
+pub struct BlockHosts {
+    ptr: *mut *mut *mut c_char,
+}
+
+impl Drop for BlockHosts {
+    fn drop(&mut self) {
+        unsafe { hdfsFreeHosts(self.ptr) };
+    }
+}
+
+pub const LOCAL_FS_SCHEME: &str = "file";
+pub const HDFS_FS_SCHEME: &str = "hdfs";
+pub const VIEW_FS_SCHEME: &str = "viewfs";
+
+#[inline]
+fn get_namenode_uri(path: &str) -> Result<String, HdfsErr> {
+    match Url::parse(path) {
+        Ok(url) => match url.scheme() {
+            LOCAL_FS_SCHEME => Ok("file:///".to_string()),
+            HDFS_FS_SCHEME | VIEW_FS_SCHEME => {
+                if let Some(host) = url.host() {
+                    let mut uri_builder = String::new();
+                    write!(&mut uri_builder, "{}://{}", url.scheme(), host).unwrap();
+
+                    if let Some(port) = url.port() {
+                        write!(&mut uri_builder, ":{}", port).unwrap();
+                    }
+                    Ok(uri_builder)
+                } else {
+                    Err(HdfsErr::InvalidUrl(path.to_string()))
+                }
+            }
+            _ => Err(HdfsErr::InvalidUrl(path.to_string())),
+        },
+        Err(_) => Err(HdfsErr::InvalidUrl(path.to_string())),
+    }
+}
+
+#[inline]
+pub fn get_uri(path: &str) -> Result<String, HdfsErr> {
+    let path = if path.starts_with('/') {
+        format!("{}://{}", LOCAL_FS_SCHEME, path)
+    } else {
+        path.to_string()
+    };
+    match Url::parse(&path) {
+        Ok(url) => match url.scheme() {
+            LOCAL_FS_SCHEME | HDFS_FS_SCHEME | VIEW_FS_SCHEME => Ok(url.to_string()),
+            _ => Err(HdfsErr::InvalidUrl(path.to_string())),
+        },
+        Err(_) => Err(HdfsErr::InvalidUrl(path.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use uuid::Uuid;
+
+    use crate::minidfs::get_dfs;
+
+    #[cfg(feature = "use_existing_hdfs")]
+    #[test]
+    fn test_hdfs_default() {
+        let fs = super::get_hdfs().ok().unwrap();
+
+        let uuid = Uuid::new_v4().to_string();
+        let test_file = uuid.as_str();
+        let created_file = match fs.create(test_file) {
+            Ok(f) => f,
+            Err(_) => panic!("Couldn't create a file"),
+        };
+        assert!(created_file.close().is_ok());
+        assert!(fs.exist(test_file));
+
+        assert!(fs.delete(test_file, false).is_ok());
+        assert!(!fs.exist(test_file));
+    }
+
+    #[test]
+    fn test_hdfs() {
+        let dfs = get_dfs();
+        {
+            let minidfs_addr = dfs.namenode_addr();
+            let fs = dfs.get_hdfs().ok().unwrap();
+
+            // Test hadoop file
+            {
+                // create a file, check existence, and close
+                let uuid = Uuid::new_v4().to_string();
+                let test_file = uuid.as_str();
+                let created_file = match fs.create(test_file) {
+                    Ok(f) => f,
+                    Err(_) => panic!("Couldn't create a file"),
+                };
+                assert!(created_file.close().is_ok());
+                assert!(fs.exist(test_file));
+
+                // open a file and close
+                let opened_file = fs.open(test_file).ok().unwrap();
+                assert!(opened_file.close().is_ok());
+
+                // Clean up
+                assert!(fs.delete(test_file, false).is_ok());
+            }
+
+            // Test directory
+            {
+                let uuid = Uuid::new_v4().to_string();
+                let test_dir = format!("/{}", uuid);
+
+                match fs.mkdir(&test_dir) {
+                    Ok(_) => println!("{} created", test_dir),
+                    Err(_) => panic!("Couldn't create {} directory", test_dir),
+                };
+
+                let file_info = fs.get_file_status(&test_dir).ok().unwrap();
+
+                let expected_path = format!("{}{}", minidfs_addr, test_dir);
+                assert_eq!(&expected_path, file_info.name());
+                assert!(!file_info.is_file());
+                assert!(file_info.is_directory());
+
+                let sub_dir_num = 3;
+                let mut expected_list = Vec::new();
+                for x in 0..sub_dir_num {
+                    let filename = format!("{}/{}", test_dir, x);
+                    expected_list.push(format!("{}{}/{}", minidfs_addr, test_dir, x));
+
+                    match fs.mkdir(&filename) {
+                        Ok(_) => println!("{} created", filename),
+                        Err(_) => panic!("Couldn't create {} directory", filename),
+                    };
+                }
+
+                let mut list = fs.list_status(&test_dir).ok().unwrap();
+                assert_eq!(sub_dir_num, list.len());
+
+                list.sort_by(|a, b| Ord::cmp(a.name(), b.name()));
+                for (expected, name) in expected_list
+                    .iter()
+                    .zip(list.iter().map(|status| status.name()))
+                {
+                    assert_eq!(expected, name);
+                }
+
+                // Clean up
+                assert!(fs.delete(&test_dir, true).is_ok());
+            }
+        }
+    }
+
+    #[test]
+    fn test_list_status_with_empty_dir() {
+        let dfs = get_dfs();
+        {
+            let fs = dfs.get_hdfs().ok().unwrap();
+
+            // Test list status with empty directory
+            {
+                let uuid = Uuid::new_v4().to_string();
+                let test_dir = format!("/{}", uuid);
+                let empty_dir = format!("/{}", "_empty");
+
+                match fs.mkdir(&test_dir) {
+                    Ok(_) => println!("{} created", test_dir),
+                    Err(_) => panic!("Couldn't create {} directory", test_dir),
+                };
+
+                match fs.mkdir(&empty_dir) {
+                    Ok(_) => println!("{} created", test_dir),
+                    Err(_) => panic!("Couldn't create {} directory", test_dir),
+                };
+
+                let test_file = format!("{}/{}", &test_dir, "test.txt");
+                match fs.create(&test_file) {
+                    Ok(_) => println!("{} created", test_file),
+                    Err(_) => panic!("Couldn't create {} ", test_file),
+                }
+
+                let file_info = fs.list_status(&test_dir).ok().unwrap();
+                assert_eq!(file_info.len(), 1);
+
+                let file_info = fs.list_status(&empty_dir).ok().unwrap();
+                assert_eq!(file_info.len(), 0);
+
+                // Clean up
+                assert!(fs.delete(&test_dir, true).is_ok());
+            }
+        }
+    }
+
+    #[test]
+    fn test_write_read() {
+        let dfs = get_dfs();
+        let fs = dfs.get_hdfs().ok().unwrap();
+
+        let data = "Hello World!!!".as_bytes();
+
+        let uuid = Uuid::new_v4().to_string();
+        let test_file = uuid.as_str();
+
+        // Test write to hadoop file
+        {
+            // create a file, check existence, and close
+            let created_file = match fs.create_with_params(test_file, false, 0, 1, 0) {
+                Ok(f) => f,
+                Err(_) => panic!("Couldn't create a hdfs file"),
+            };
+            match created_file.write(data) {
+                Ok(len) => assert_eq!(len as usize, data.len()),
+                Err(_) => panic!("Couldn't write contents to a hdfs file"),
+            }
+            assert!(created_file.close().is_ok());
+        };
+
+        // Test append to hadoop file
+        {
+            // create a file, check existence, and close
+            let appended_file = match fs.append(test_file) {
+                Ok(f) => f,
+                Err(_) => panic!("Couldn't create a hdfs file"),
+            };
+            match appended_file.write(data) {
+                Ok(len) => assert_eq!(len as usize, data.len()),
+                Err(_) => panic!("Couldn't write contents to a hdfs file"),
+            }
+            assert!(appended_file.close().is_ok());
+        };
+
+        // Test read
+        {
+            assert!(fs.exist(test_file));
+
+            let mut data2 = vec![];
+            data2.append(&mut data.to_vec());
+            data2.append(&mut data.to_vec());
+
+            // open a file, read, check the contents and close
+            let opened_file = fs.open(test_file).ok().unwrap();
+            let mut buf = vec![0u8; data2.len()];
+            assert!(opened_file.read(&mut buf).is_ok());
+            assert_eq!(data2, buf);
+            assert!(opened_file.close().is_ok());
+
+            // open a file, read_with_pos, check the contents and close
+            let opened_file = fs.open(test_file).ok().unwrap();
+            let mut buf = vec![0u8; data2.len()];
+            assert!(opened_file.read_with_pos(0, &mut buf).is_ok());
+            assert_eq!(data2, buf);
+            assert!(opened_file.close().is_ok());
+        }
+
+        // Clean up
+        assert!(fs.delete(test_file, false).is_ok());
+    }
+}

--- a/native/fs-hdfs/src/hdfs.rs
+++ b/native/fs-hdfs/src/hdfs.rs
@@ -440,12 +440,21 @@ impl HdfsFs {
     }
 
     /// Rename file.
-    pub fn rename(&self, old_path: &str, new_path: &str, overwrite: bool) -> Result<bool, HdfsErr> {
+    pub fn rename(
+        &self,
+        old_path: &str,
+        new_path: &str,
+        overwrite: bool,
+    ) -> Result<bool, HdfsErr> {
         if unsafe {
             let cstr_old_path = CString::new(old_path).unwrap();
             let cstr_new_path = CString::new(new_path).unwrap();
             if overwrite {
-                hdfsRenameOverwrite(self.raw, cstr_old_path.as_ptr(), cstr_new_path.as_ptr())
+                hdfsRenameOverwrite(
+                    self.raw,
+                    cstr_old_path.as_ptr(),
+                    cstr_new_path.as_ptr(),
+                )
             } else {
                 hdfsRename(self.raw, cstr_old_path.as_ptr(), cstr_new_path.as_ptr())
             }

--- a/native/fs-hdfs/src/lib.rs
+++ b/native/fs-hdfs/src/lib.rs
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! fs-hdfs3 is a library for accessing to HDFS cluster.
+//! Basically, it provides libhdfs FFI APIs.
+//! It also provides more idiomatic and abstract Rust APIs,
+//! hiding manual memory management and some thread-safety problem of libhdfs.
+//! Rust APIs are highly recommended for most users.
+//!
+//! ## Important Note
+//! The original ``libhdfs`` implementation allows only one ``HdfsFs`` instance for the
+//! same namenode because ``libhdfs`` only keeps a single ``hdfsFs`` entry for each namenode.
+//! As a result, a global singleton ``HdfsManager`` is introduced to control only one single ``hdfsFs`` entry created for each namenode.
+//! Contrast, ``HdfsFs`` instance itself is thread-safe.
+//!
+//! This library mainly provides two public methods to load and unload ``HdfsFs``
+//! - pub fn get_hdfs_by_full_path(path: &str) -> Result<Arc<HdfsFs>, HdfsErr>
+//! - pub fn unload_hdfs_cache_by_full_path(path: &str) -> Result<Option<Arc<HdfsFs>>, HdfsErr>
+//!
+//! ## Usage
+//! in Cargo.toml:
+//!
+//! ```ignore
+//! [dependencies]
+//! fs-hdfs3 = "0.1.12"
+//! ```
+//! or
+//!
+//! ```ignore
+//! [dependencies.fs-hdfs3]
+//! git = "https://github.com/datafusion-contrib/fs-hdfs"
+//! ```
+//!
+//! Firstly, we need to add library path for the jvm related dependencies.
+//! An example for MacOS,
+//!
+//! ```bash ignore
+//! export DYLD_LIBRARY_PATH=$JAVA_HOME/jre/lib/server
+//! ```
+//!
+//! Here, ``$JAVA_HOME`` need to be specified and exported.
+//!
+//! Since our compiled libhdfs is JNI native implementation, it requires the proper ``CLASSPATH``.
+//! An example,
+//!
+//! ```bash ignore
+//! export CLASSPATH=$CLASSPATH:`hadoop classpath --glob`
+//! ```
+//!
+//! ## Testing
+//! The test also requires the ``CLASSPATH``. In case that the java class of ``org.junit.Assert``
+//! can't be found. Refine the ``$CLASSPATH`` as follows:
+//!
+//! ```bash ignore
+//! export CLASSPATH=$CLASSPATH:`hadoop classpath --glob`:$HADOOP_HOME/share/hadoop/tools/lib/*
+//! ```
+//!
+//! Here, ``$HADOOP_HOME`` need to be specified and exported.
+//!
+//! Then you can run
+//!
+//! ```ignore
+//! cargo test
+//! ```
+//!
+//! ## Example
+//!
+//! ```ignore
+//! use std::sync::Arc;
+//! use hdfs::hdfs::{get_hdfs_by_full_path, unload_hdfs_cache, HdfsFs};
+//!
+//! let fs: Arc<HdfsFs> = get_hdfs_by_full_path("hdfs://localhost:8020/").ok().unwrap();
+//! match fs.mkdir("/data") {
+//!   Ok(_) => { println!("/data has been created") },
+//!   Err(_)  => { panic!("/data creation has failed") }
+//! };
+//!
+//! match unload_hdfs_cache(fs) {
+//!   Ok(Some(_)) => { println!("Unloading hdfs cache succeeded") },
+//!   _  => { panic!("Unloading hdfs cache failed") }
+//! }
+//! ```
+
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+#[allow(deref_nullptr)]
+mod native;
+
+pub mod err;
+/// Rust APIs wrapping libhdfs API, providing better semantic and abstraction
+pub mod hdfs;
+#[cfg(feature = "test_util")]
+/// Mainly for unit test
+pub mod minidfs;
+#[cfg(feature = "test_util")]
+pub mod util;
+/// For list files in a directory recursively
+pub mod walkdir;

--- a/native/fs-hdfs/src/minidfs.rs
+++ b/native/fs-hdfs/src/minidfs.rs
@@ -91,7 +91,7 @@ impl MiniDFS {
 
     pub fn namenode_addr(&self) -> String {
         if let Some(port) = self.namenode_port() {
-            format!("hdfs://localhost:{}", port)
+            format!("hdfs://localhost:{port}")
         } else {
             "hdfs://localhost".to_string()
         }

--- a/native/fs-hdfs/src/minidfs.rs
+++ b/native/fs-hdfs/src/minidfs.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 //! MiniDfs Cluster
 //!
 //! MiniDFS provides a embedded HDFS cluster. It is only for testing.

--- a/native/fs-hdfs/src/minidfs.rs
+++ b/native/fs-hdfs/src/minidfs.rs
@@ -1,0 +1,128 @@
+//! MiniDfs Cluster
+//!
+//! MiniDFS provides a embedded HDFS cluster. It is only for testing.
+//!
+//! Since it's not supported to create multiple MiniDFS instances for parallel testing,
+//! we only use a global one which can be get by ``get_dfs()``.
+//! And when it is finally destroyed, it's ``drop()`` method will be invoked so that users don't need to care about the resource releasing.
+//!
+//! ## Example
+//!
+//! ```ignore
+//! use hdfs::minidfs;
+//!
+//! let dfs = minidfs::get_dfs();
+//! let port = dfs.namenode_port();
+//! ...
+//! ```
+
+use lazy_static::lazy_static;
+use libc::{c_char, c_int};
+use std::ffi;
+use std::mem;
+use std::str;
+use std::sync::Arc;
+
+use crate::err::HdfsErr;
+use crate::hdfs;
+use crate::hdfs::HdfsFs;
+use crate::native::*;
+
+lazy_static! {
+    static ref MINI_DFS: Arc<MiniDFS> = Arc::new(MiniDFS::new());
+}
+
+pub fn get_dfs() -> Arc<MiniDFS> {
+    MINI_DFS.clone()
+}
+
+pub struct MiniDFS {
+    cluster: *mut MiniDfsCluster,
+}
+
+unsafe impl Send for MiniDFS {}
+
+unsafe impl Sync for MiniDFS {}
+
+impl Drop for MiniDFS {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+impl MiniDFS {
+    fn new() -> MiniDFS {
+        let conf = new_mini_dfs_conf();
+        MiniDFS::start(&conf).unwrap()
+    }
+
+    fn start(conf: &MiniDfsConf) -> Option<MiniDFS> {
+        match unsafe { nmdCreate(conf) } {
+            val if !val.is_null() => Some(MiniDFS { cluster: val }),
+            _ => None,
+        }
+    }
+
+    fn stop(&self) {
+        // remove hdfs from global cache
+        hdfs::unload_hdfs_cache_by_full_path(self.namenode_addr().as_str()).ok();
+        unsafe {
+            nmdShutdownClean(self.cluster);
+            nmdFree(self.cluster);
+        }
+    }
+
+    #[allow(dead_code)]
+    fn wait_for_clusterup(&self) -> bool {
+        unsafe { nmdWaitClusterUp(self.cluster) == 0 }
+    }
+
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    pub fn set_hdfs_builder(&self, builder: *mut hdfsBuilder) -> bool {
+        unsafe { nmdConfigureHdfsBuilder(self.cluster, builder) == 0 }
+    }
+
+    pub fn namenode_port(&self) -> Option<i32> {
+        match unsafe { nmdGetNameNodePort(self.cluster) } {
+            val if val > 0 => Some(val),
+            _ => None,
+        }
+    }
+
+    pub fn namenode_addr(&self) -> String {
+        if let Some(port) = self.namenode_port() {
+            format!("hdfs://localhost:{}", port)
+        } else {
+            "hdfs://localhost".to_string()
+        }
+    }
+
+    pub fn namenode_http_addr(&self) -> Option<(&str, i32)> {
+        let mut hostname: *const c_char = unsafe { mem::zeroed() };
+        let mut port: c_int = 0;
+
+        match unsafe { nmdGetNameNodeHttpAddress(self.cluster, &mut port, &mut hostname) }
+        {
+            0 => {
+                let slice = unsafe { ffi::CStr::from_ptr(hostname) }.to_bytes();
+                let str = str::from_utf8(slice).unwrap();
+
+                Some((str, port))
+            }
+            _ => None,
+        }
+    }
+
+    pub fn get_hdfs(&self) -> Result<Arc<HdfsFs>, HdfsErr> {
+        hdfs::get_hdfs_by_full_path(self.namenode_addr().as_str())
+    }
+}
+
+fn new_mini_dfs_conf() -> MiniDfsConf {
+    MiniDfsConf {
+        doFormat: 1,
+        webhdfsEnabled: 0,
+        namenodeHttpPort: 0,
+        configureShortCircuit: 0,
+    }
+}

--- a/native/fs-hdfs/src/native.rs
+++ b/native/fs-hdfs/src/native.rs
@@ -1,0 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#![allow(unused_imports)]
+#![allow(dead_code)]
+include!(concat!(env!("OUT_DIR"), "/hdfs-native.rs"));

--- a/native/fs-hdfs/src/util.rs
+++ b/native/fs-hdfs/src/util.rs
@@ -1,3 +1,7 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/native/fs-hdfs/src/util.rs
+++ b/native/fs-hdfs/src/util.rs
@@ -1,0 +1,247 @@
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Hdfs Utility
+
+use crate::err::HdfsErr;
+use crate::hdfs;
+use crate::hdfs::{get_uri, HdfsFs};
+use crate::minidfs::MiniDFS;
+use crate::native::{hdfsCopy, hdfsMove};
+use std::ffi::CString;
+use std::sync::Arc;
+
+/// Hdfs Utility
+pub struct HdfsUtil;
+
+impl HdfsUtil {
+    /// Copy file to hdfs
+    pub fn copy_file_to_hdfs(
+        dfs: Arc<MiniDFS>,
+        src_path: &str,
+        dst_path: &str,
+    ) -> Result<bool, HdfsErr> {
+        let src_uri = get_uri(src_path)?;
+        let src_fs = hdfs::get_hdfs_by_full_path(&src_uri)?;
+
+        let dst_fs = dfs.get_hdfs()?;
+
+        HdfsUtil::copy(&src_fs, src_path, &dst_fs, dst_path)
+    }
+
+    /// Copy file from hdfs
+    pub fn copy_file_from_hdfs(
+        dfs: Arc<MiniDFS>,
+        src_path: &str,
+        dst_path: &str,
+    ) -> Result<bool, HdfsErr> {
+        let src_fs = dfs.get_hdfs()?;
+
+        let dst_uri = get_uri(dst_path)?;
+        let dst_fs = hdfs::get_hdfs_by_full_path(&dst_uri)?;
+
+        HdfsUtil::copy(&src_fs, src_path, &dst_fs, dst_path)
+    }
+
+    /// Move file to hdfs
+    pub fn mv_file_to_hdfs(
+        dfs: Arc<MiniDFS>,
+        src_path: &str,
+        dst_path: &str,
+    ) -> Result<bool, HdfsErr> {
+        let src_uri = get_uri(src_path)?;
+        let src_fs = hdfs::get_hdfs_by_full_path(&src_uri)?;
+
+        let dst_fs = dfs.get_hdfs()?;
+
+        HdfsUtil::mv(&src_fs, src_path, &dst_fs, dst_path)
+    }
+
+    /// Move file from hdfs
+    pub fn mv_file_from_hdfs(
+        dfs: Arc<MiniDFS>,
+        src_path: &str,
+        dst_path: &str,
+    ) -> Result<bool, HdfsErr> {
+        let src_fs = dfs.get_hdfs()?;
+
+        let dst_uri = get_uri(dst_path)?;
+        let dst_fs = hdfs::get_hdfs_by_full_path(&dst_uri)?;
+
+        HdfsUtil::mv(&src_fs, src_path, &dst_fs, dst_path)
+    }
+
+    /// Copy file from one filesystem to another.
+    ///
+    /// #### Params
+    /// * ```srcFS``` - The handle to source filesystem.
+    /// * ```src``` - The path of source file.
+    /// * ```dstFS``` - The handle to destination filesystem.
+    /// * ```dst``` - The path of destination file.
+    pub fn copy(
+        src_fs: &HdfsFs,
+        src: &str,
+        dst_fs: &HdfsFs,
+        dst: &str,
+    ) -> Result<bool, HdfsErr> {
+        let res = unsafe {
+            let cstr_src = CString::new(src).unwrap();
+            let cstr_dst = CString::new(dst).unwrap();
+            hdfsCopy(
+                src_fs.raw(),
+                cstr_src.as_ptr(),
+                dst_fs.raw(),
+                cstr_dst.as_ptr(),
+            )
+        };
+
+        if res == 0 {
+            Ok(true)
+        } else {
+            Err(HdfsErr::Generic(format!(
+                "Fail to copy file from {} to {}",
+                src, dst
+            )))
+        }
+    }
+
+    /// Move file from one filesystem to another.
+    ///
+    /// #### Params
+    /// * ```srcFS``` - The handle to source filesystem.
+    /// * ```src``` - The path of source file.
+    /// * ```dstFS``` - The handle to destination filesystem.
+    /// * ```dst``` - The path of destination file.
+    pub fn mv(
+        src_fs: &HdfsFs,
+        src: &str,
+        dst_fs: &HdfsFs,
+        dst: &str,
+    ) -> Result<bool, HdfsErr> {
+        let res = unsafe {
+            let cstr_src = CString::new(src).unwrap();
+            let cstr_dst = CString::new(dst).unwrap();
+            hdfsMove(
+                src_fs.raw(),
+                cstr_src.as_ptr(),
+                dst_fs.raw(),
+                cstr_dst.as_ptr(),
+            )
+        };
+
+        if res == 0 {
+            Ok(true)
+        } else {
+            Err(HdfsErr::Generic(format!(
+                "Fail to move file from {} to {}",
+                src, dst
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::minidfs::get_dfs;
+    use std::path::Path;
+    use tempfile::tempdir;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_from_local() {
+        // Prepare file source from local file system
+        let temp_file = tempfile::Builder::new().tempfile().unwrap();
+        let src_path = temp_file.path();
+        let src_file_name = src_path.file_name().unwrap().to_str().unwrap();
+        let src_file = src_path.to_str().unwrap();
+
+        let dfs = get_dfs();
+        {
+            // Source
+            let src_file_uri = format!("file://{}", src_path.to_str().unwrap());
+            let src_fs = hdfs::get_hdfs_by_full_path(&src_file_uri).ok().unwrap();
+
+            // Destination
+            let dst_file = format!("/{}", src_file_name);
+            let dst_fs = dfs.get_hdfs().ok().unwrap();
+
+            // Test copy
+            {
+                assert!(
+                    HdfsUtil::copy_file_to_hdfs(dfs.clone(), src_file, &dst_file).is_ok()
+                );
+                assert!(dst_fs.exist(&dst_file));
+                assert!(src_fs.exist(src_file));
+                assert!(Path::new(src_file).exists());
+            }
+
+            // Clean up
+            assert!(dst_fs.delete(&dst_file, false).is_ok());
+
+            // Test move
+            {
+                assert!(HdfsUtil::mv_file_to_hdfs(dfs, src_file, &dst_file).is_ok());
+                assert!(dst_fs.exist(&dst_file));
+                assert!(!src_fs.exist(src_file));
+                assert!(!Path::new(src_file).exists());
+            }
+
+            // Clean up
+            assert!(dst_fs.delete(&dst_file, false).is_ok());
+        }
+    }
+
+    #[test]
+    fn test_to_local() {
+        let uuid = Uuid::new_v4().to_string();
+        let file_name = uuid.as_str();
+
+        let temp_dir = tempdir().unwrap();
+        let dst_path = temp_dir.path().join(file_name);
+        let dst_file = dst_path.to_str().unwrap();
+
+        let dfs = get_dfs();
+        {
+            // Source
+            let src_file = format!("/{}", file_name);
+            let src_fs = dfs.get_hdfs().ok().unwrap();
+            src_fs.create(&src_file).ok().unwrap();
+
+            // Destination
+            let dst_file_uri = format!("file://{}", dst_file);
+            let dst_fs = hdfs::get_hdfs_by_full_path(&dst_file_uri).ok().unwrap();
+
+            // Test copy
+            {
+                assert!(
+                    HdfsUtil::copy_file_from_hdfs(dfs.clone(), &src_file, dst_file)
+                        .is_ok()
+                );
+                assert!(src_fs.exist(&src_file));
+                assert!(dst_fs.exist(dst_file));
+                assert!(Path::new(dst_file).exists());
+            }
+
+            // Clean up
+            assert!(dst_fs.delete(dst_file, false).is_ok());
+
+            {
+                assert!(HdfsUtil::mv_file_from_hdfs(dfs, &src_file, dst_file).is_ok());
+                assert!(!src_fs.exist(&src_file));
+                assert!(dst_fs.exist(dst_file));
+                assert!(Path::new(dst_file).exists());
+            }
+        }
+    }
+}

--- a/native/fs-hdfs/src/util.rs
+++ b/native/fs-hdfs/src/util.rs
@@ -109,8 +109,7 @@ impl HdfsUtil {
             Ok(true)
         } else {
             Err(HdfsErr::Generic(format!(
-                "Fail to copy file from {} to {}",
-                src, dst
+                "Fail to copy file from {src} to {dst}"
             )))
         }
     }
@@ -143,8 +142,7 @@ impl HdfsUtil {
             Ok(true)
         } else {
             Err(HdfsErr::Generic(format!(
-                "Fail to move file from {} to {}",
-                src, dst
+                "Fail to move file from {src} to {dst}"
             )))
         }
     }
@@ -173,7 +171,7 @@ mod test {
             let src_fs = hdfs::get_hdfs_by_full_path(&src_file_uri).ok().unwrap();
 
             // Destination
-            let dst_file = format!("/{}", src_file_name);
+            let dst_file = format!("/{src_file_name}");
             let dst_fs = dfs.get_hdfs().ok().unwrap();
 
             // Test copy
@@ -214,12 +212,12 @@ mod test {
         let dfs = get_dfs();
         {
             // Source
-            let src_file = format!("/{}", file_name);
+            let src_file = format!("/{file_name}");
             let src_fs = dfs.get_hdfs().ok().unwrap();
             src_fs.create(&src_file).ok().unwrap();
 
             // Destination
-            let dst_file_uri = format!("file://{}", dst_file);
+            let dst_file_uri = format!("file://{dst_file}");
             let dst_fs = hdfs::get_hdfs_by_full_path(&dst_file_uri).ok().unwrap();
 
             // Test copy

--- a/native/fs-hdfs/src/walkdir/mod.rs
+++ b/native/fs-hdfs/src/walkdir/mod.rs
@@ -1,0 +1,201 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use crate::err::HdfsErr;
+use crate::hdfs;
+use crate::hdfs::{FileStatus, HdfsFs};
+use crate::walkdir::tree_iter::{IterOptions, TreeIter, TreeManager};
+
+pub mod tree_iter;
+
+#[derive(Debug)]
+pub struct HdfsWalkDir {
+    hdfs: Arc<HdfsFs>,
+    root: String,
+    opts: IterOptions,
+}
+
+impl HdfsWalkDir {
+    pub fn new(root: String) -> Result<Self, HdfsErr> {
+        let hdfs = hdfs::get_hdfs_by_full_path(&root)?;
+        Ok(Self::new_with_hdfs(root, hdfs))
+    }
+
+    pub fn new_with_hdfs(root: String, hdfs: Arc<HdfsFs>) -> Self {
+        Self {
+            hdfs,
+            root,
+            opts: IterOptions {
+                min_depth: 0,
+                max_depth: ::std::usize::MAX,
+            },
+        }
+    }
+
+    /// Set the minimum depth of entries yielded by the iterator.
+    ///
+    /// The smallest depth is `0` and always corresponds to the path given
+    /// to the `new` function on this type. Its direct descendents have depth
+    /// `1`, and their descendents have depth `2`, and so on.
+    pub fn min_depth(mut self, depth: usize) -> Self {
+        self.opts.min_depth = depth;
+        if self.opts.min_depth > self.opts.max_depth {
+            self.opts.min_depth = self.opts.max_depth;
+        }
+        self
+    }
+
+    /// Set the maximum depth of entries yield by the iterator.
+    ///
+    /// The smallest depth is `0` and always corresponds to the path given
+    /// to the `new` function on this type. Its direct descendents have depth
+    /// `1`, and their descendents have depth `2`, and so on.
+    ///
+    /// Note that this will not simply filter the entries of the iterator, but
+    /// it will actually avoid descending into directories when the depth is
+    /// exceeded.
+    pub fn max_depth(mut self, depth: usize) -> Self {
+        self.opts.max_depth = depth;
+        if self.opts.max_depth < self.opts.min_depth {
+            self.opts.max_depth = self.opts.min_depth;
+        }
+        self
+    }
+}
+
+impl IntoIterator for HdfsWalkDir {
+    type Item = Result<FileStatus, HdfsErr>;
+    type IntoIter = TreeIter<String, FileStatus, HdfsErr>;
+
+    fn into_iter(self) -> TreeIter<String, FileStatus, HdfsErr> {
+        TreeIter::new(
+            Box::new(HdfsTreeManager {
+                hdfs: self.hdfs.clone(),
+            }),
+            self.opts,
+            self.root,
+        )
+    }
+}
+
+struct HdfsTreeManager {
+    hdfs: Arc<HdfsFs>,
+}
+
+impl TreeManager<String, FileStatus, HdfsErr> for HdfsTreeManager {
+    fn to_value(&self, v: String) -> Result<FileStatus, HdfsErr> {
+        self.hdfs.get_file_status(&v)
+    }
+
+    fn get_children(&self, n: &FileStatus) -> Result<Vec<FileStatus>, HdfsErr> {
+        self.hdfs.list_status(n.name())
+    }
+
+    fn is_leaf(&self, n: &FileStatus) -> bool {
+        n.is_file()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use crate::hdfs::{HdfsErr, HdfsFs};
+    use crate::minidfs::get_dfs;
+    use crate::walkdir::HdfsWalkDir;
+
+    #[test]
+    fn test_hdfs_file_list() -> Result<(), HdfsErr> {
+        let hdfs = set_up_hdfs_env()?;
+
+        let hdfs_walk_dir =
+            HdfsWalkDir::new_with_hdfs("/testing".to_owned(), hdfs.clone())
+                .min_depth(0)
+                .max_depth(2);
+        let mut iter = hdfs_walk_dir.into_iter();
+
+        let ret_vec = [
+            "/testing",
+            "/testing/c",
+            "/testing/b",
+            "/testing/b/3",
+            "/testing/b/2",
+            "/testing/b/1",
+            "/testing/a",
+            "/testing/a/3",
+            "/testing/a/2",
+            "/testing/a/1",
+        ];
+        for entry in ret_vec.into_iter() {
+            assert_eq!(
+                format!("{}{}", hdfs.url(), entry),
+                iter.next().unwrap()?.name()
+            );
+        }
+        assert!(iter.next().is_none());
+
+        let hdfs_walk_dir =
+            HdfsWalkDir::new_with_hdfs("/testing".to_owned(), hdfs.clone())
+                .min_depth(2)
+                .max_depth(3);
+        let mut iter = hdfs_walk_dir.into_iter();
+
+        let ret_vec = [
+            "/testing/b/3",
+            "/testing/b/2",
+            "/testing/b/1",
+            "/testing/a/3",
+            "/testing/a/2",
+            "/testing/a/2/11",
+            "/testing/a/1",
+            "/testing/a/1/12",
+            "/testing/a/1/11",
+        ];
+        for entry in ret_vec.into_iter() {
+            assert_eq!(
+                format!("{}{}", hdfs.url(), entry),
+                iter.next().unwrap()?.name()
+            );
+        }
+        assert!(iter.next().is_none());
+
+        Ok(())
+    }
+
+    fn set_up_hdfs_env() -> Result<Arc<HdfsFs>, HdfsErr> {
+        let dfs = get_dfs();
+        let hdfs = dfs.get_hdfs()?;
+
+        hdfs.mkdir("/testing")?;
+        hdfs.mkdir("/testing/a")?;
+        hdfs.mkdir("/testing/b")?;
+        hdfs.create("/testing/c")?;
+        hdfs.mkdir("/testing/a/1")?;
+        hdfs.mkdir("/testing/a/2")?;
+        hdfs.create("/testing/a/3")?;
+        hdfs.create("/testing/b/1")?;
+        hdfs.create("/testing/b/2")?;
+        hdfs.create("/testing/b/3")?;
+        hdfs.create("/testing/a/1/11")?;
+        hdfs.create("/testing/a/1/12")?;
+        hdfs.create("/testing/a/2/11")?;
+
+        Ok(hdfs)
+    }
+}

--- a/native/fs-hdfs/src/walkdir/mod.rs
+++ b/native/fs-hdfs/src/walkdir/mod.rs
@@ -43,7 +43,7 @@ impl HdfsWalkDir {
             root,
             opts: IterOptions {
                 min_depth: 0,
-                max_depth: ::std::usize::MAX,
+                max_depth: usize::MAX,
             },
         }
     }

--- a/native/fs-hdfs/src/walkdir/tree_iter.rs
+++ b/native/fs-hdfs/src/walkdir/tree_iter.rs
@@ -1,0 +1,259 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt;
+
+/// A utility struct for iterator tree nodes
+pub struct TreeIter<V, N, E> {
+    /// For checking node properties, like leaf node or not, finding children, etc.
+    manager: Box<dyn TreeManager<V, N, E>>,
+    /// Options specified in the builder. Depths, etc.
+    opts: IterOptions,
+    /// The start path.
+    /// This is only `Some(...)` at the beginning. After the first iteration,
+    /// this is always `None`.
+    start: Option<V>,
+    /// A stack of unvisited qualified entries
+    stack_nodes: Vec<TreeNode<N>>,
+    /// A stack of unqualified parent entries
+    deferred_nodes: Vec<TreeNode<N>>,
+}
+
+impl<V, N, E> TreeIter<V, N, E> {
+    pub fn new(
+        manager: Box<dyn TreeManager<V, N, E>>,
+        opts: IterOptions,
+        start: V,
+    ) -> TreeIter<V, N, E> {
+        TreeIter {
+            manager,
+            opts,
+            start: Some(start),
+            stack_nodes: vec![],
+            deferred_nodes: vec![],
+        }
+    }
+
+    fn next_item(&mut self) -> Result<Option<N>, E> {
+        // Initialize if possible
+        if let Some(start) = self.start.take() {
+            let root = self.manager.to_value(start)?;
+            match (0 == self.opts.min_depth, self.manager.is_leaf(&root)) {
+                (true, true) => return Ok(Some(root)),
+                (true, false) => self.stack_nodes.push(TreeNode {
+                    node: root,
+                    layer: 0,
+                }),
+                (false, true) => return Ok(None),
+                (false, false) => self.deferred_nodes.push(TreeNode {
+                    node: root,
+                    layer: 0,
+                }),
+            }
+        }
+
+        // Check whether there are items in the qualified layer
+        if let Some(next_node) = self.stack_nodes.pop() {
+            if next_node.layer < self.opts.max_depth
+                && !self.manager.is_leaf(&next_node.node)
+            {
+                self.stack_nodes.extend(
+                    self.manager
+                        .get_children(&next_node.node)?
+                        .into_iter()
+                        .map(|node| TreeNode {
+                            node,
+                            layer: next_node.layer + 1,
+                        }),
+                );
+            }
+            return Ok(Some(next_node.node));
+        }
+
+        // Check deferred nodes whose children is not empty
+        if let Some(prev_node) = self.deferred_nodes.pop() {
+            assert!(!self.manager.is_leaf(&prev_node.node));
+            let children = self.manager.get_children(&prev_node.node)?;
+            if prev_node.layer + 1 == self.opts.min_depth {
+                self.stack_nodes
+                    .extend(children.into_iter().map(|node| TreeNode {
+                        node,
+                        layer: prev_node.layer + 1,
+                    }));
+            } else {
+                self.deferred_nodes.extend(
+                    children
+                        .into_iter()
+                        .filter(|node| !self.manager.is_leaf(node))
+                        .map(|node| TreeNode {
+                            node,
+                            layer: prev_node.layer + 1,
+                        }),
+                );
+            }
+            return self.next_item();
+        }
+
+        Ok(None)
+    }
+}
+
+impl<V, N, E> Iterator for TreeIter<V, N, E> {
+    type Item = Result<N, E>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_item().transpose()
+    }
+}
+
+pub struct TreeNode<N> {
+    node: N,
+    layer: usize,
+}
+
+pub struct IterOptions {
+    pub min_depth: usize,
+    pub max_depth: usize,
+}
+
+impl fmt::Debug for IterOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IterOptions")
+            .field("min_depth", &self.min_depth)
+            .field("max_depth", &self.max_depth)
+            .finish()
+    }
+}
+
+pub trait TreeManager<V, N, E>: Send + Sync {
+    fn to_value(&self, v: V) -> Result<N, E>;
+
+    fn get_children(&self, n: &N) -> Result<Vec<N>, E>;
+
+    fn is_leaf(&self, n: &N) -> bool;
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeMap;
+    use std::io::Error;
+
+    use crate::walkdir::tree_iter::{IterOptions, TreeIter, TreeManager};
+
+    #[test]
+    fn test_tree_iter() -> Result<(), Error> {
+        let mut iter = TreeIter::new(
+            Box::new(create_test_tree_manager()),
+            IterOptions {
+                min_depth: 0,
+                max_depth: 2,
+            },
+            "/testing".to_owned(),
+        );
+
+        let ret_vec = [
+            "/testing",
+            "/testing/c",
+            "/testing/b",
+            "/testing/b/3",
+            "/testing/b/2",
+            "/testing/b/1",
+            "/testing/a",
+            "/testing/a/3",
+            "/testing/a/2",
+            "/testing/a/1",
+        ];
+        for entry in ret_vec.into_iter() {
+            assert_eq!(entry.to_owned(), iter.next().unwrap()?);
+        }
+        assert!(iter.next().is_none());
+
+        let mut iter = TreeIter::new(
+            Box::new(create_test_tree_manager()),
+            IterOptions {
+                min_depth: 2,
+                max_depth: 3,
+            },
+            "/testing".to_owned(),
+        );
+
+        let ret_vec = [
+            "/testing/b/3",
+            "/testing/b/2",
+            "/testing/b/1",
+            "/testing/a/3",
+            "/testing/a/2",
+            "/testing/a/2/11",
+            "/testing/a/1",
+            "/testing/a/1/12",
+            "/testing/a/1/11",
+        ];
+        for entry in ret_vec.into_iter() {
+            assert_eq!(entry.to_owned(), iter.next().unwrap()?);
+        }
+        assert!(iter.next().is_none());
+        Ok(())
+    }
+
+    // Testing data with pairs. The first one indicating the node value. The second one indicating whether it's a leaf node or not.
+    fn create_test_tree_manager() -> TestTreeManager {
+        TestTreeManager {
+            data: BTreeMap::from([
+                ("/testing".to_owned(), false),
+                ("/testing/a".to_owned(), false),
+                ("/testing/b".to_owned(), false),
+                ("/testing/c".to_owned(), true),
+                ("/testing/a/1".to_owned(), false),
+                ("/testing/a/2".to_owned(), false),
+                ("/testing/a/3".to_owned(), true),
+                ("/testing/b/1".to_owned(), true),
+                ("/testing/b/2".to_owned(), true),
+                ("/testing/b/3".to_owned(), true),
+                ("/testing/a/1/11".to_owned(), true),
+                ("/testing/a/1/12".to_owned(), true),
+                ("/testing/a/2/11".to_owned(), true),
+            ]),
+        }
+    }
+
+    struct TestTreeManager {
+        data: BTreeMap<String, bool>,
+    }
+
+    impl TreeManager<String, String, Error> for TestTreeManager {
+        fn to_value(&self, v: String) -> Result<String, Error> {
+            Ok(v)
+        }
+
+        fn get_children(&self, n: &String) -> Result<Vec<String>, Error> {
+            Ok(self
+                .data
+                .keys()
+                .filter(|entry| {
+                    entry.len() > n.len()
+                        && entry.starts_with(n)
+                        && !entry[n.len() + 1..].contains('/')
+                })
+                .map(|entry| entry.to_owned())
+                .collect())
+        }
+
+        fn is_leaf(&self, n: &String) -> bool {
+            *self.data.get(n).unwrap()
+        }
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion-comet/issues/2034

## Rationale for this change

We are using `fs-hdfs` but the project is not responsive and PRs are not getting merged.

## What changes are included in this PR?
This simply adds a copy of the code of `fs-hdfs3` in the Comet code base. The hdfs module code still refers to the published crate(s) of the fs-hdfs project.

## How are these changes tested?

No test yet.