### PR TITLE
perf: Optimize `SumDecimalGroupsAccumulator::update_single`

### DIFF
--- a/native/spark-expr/src/agg_funcs/sum_decimal.rs
+++ b/native/spark-expr/src/agg_funcs/sum_decimal.rs
@@ -287,24 +287,16 @@ impl SumDecimalGroupsAccumulator {
         !self.is_empty.get_bit(index) && !self.is_not_null.get_bit(index)
     }
 
+    #[inline]
     fn update_single(&mut self, group_index: usize, value: i128) {
-        if unlikely(self.is_overflow(group_index)) {
-            // This means there's a overflow in decimal, so we will just skip the rest
-            // of the computation
-            return;
-        }
-
         self.is_empty.set_bit(group_index, false);
         let (new_sum, is_overflow) = self.sum[group_index].overflowing_add(value);
+        self.sum[group_index] = new_sum;
 
-        if is_overflow || !is_valid_decimal_precision(new_sum, self.precision) {
+        if unlikely(is_overflow || !is_valid_decimal_precision(new_sum, self.precision)) {
             // Overflow: set buffer accumulator to null
             self.is_not_null.set_bit(group_index, false);
-            return;
         }
-
-        self.sum[group_index] = new_sum;
-        self.is_not_null.set_bit(group_index, true)
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Parts of #951 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Same tricks like #1893 

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1. Avoid check `is_overflow`
2. update sum before overflow check
3. hint inline
4. hint overflow unlikely

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
5. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests in
org.apache.comet.exec.CometAggregateSuite