### PR TITLE
fix: Add support for StringDecode in Spark 4.0.0

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -1284,10 +1284,6 @@ object QueryPlanSerde extends Logging with CometExprShim {
             optExprWithInfo(optExpr, expr, r.child)
         }
 
-      case s: StringDecode =>
-        // Right child is the encoding expression.
-        stringDecode(expr, s.charset, s.bin, inputs, binding)
-
       case RegExpReplace(subject, pattern, replacement, startPosition) =>
         if (!RegExp.isSupportedPattern(pattern.toString) &&
           !CometConf.COMET_REGEXP_ALLOW_INCOMPATIBLE.get()) {
@@ -1672,10 +1668,10 @@ object QueryPlanSerde extends Logging with CometExprShim {
       charset: Expression,
       bin: Expression,
       inputs: Seq[Attribute],
-      binding: Boolean) = {
+      binding: Boolean): Option[Expr] = {
     charset match {
       case Literal(str, DataTypes.StringType)
-        if str.toString.toLowerCase(Locale.ROOT) == "utf-8" =>
+          if str.toString.toLowerCase(Locale.ROOT) == "utf-8" =>
         // decode(col, 'utf-8') can be treated as a cast with "try" eval mode that puts nulls
         // for invalid strings.
         // Left child is the binary expression.

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -630,7 +630,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
       }
     }
 
-    expr match {
+    versionSpecificExprToProtoInternal(expr, inputs, binding).orElse(expr match {
       case a @ Alias(_, _) =>
         val r = exprToProtoInternal(a.child, inputs, binding)
         if (r.isEmpty) {
@@ -1679,7 +1679,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
             withInfo(expr, s"${expr.prettyName} is not supported", expr.children: _*)
             None
         }
-    }
+    })
   }
 
   /**

--- a/spark/src/main/spark-3.4/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-3.4/org/apache/comet/shims/CometExprShim.scala
@@ -20,6 +20,7 @@ package org.apache.comet.shims
 
 import org.apache.comet.expressions.CometEvalMode
 import org.apache.comet.serde.ExprOuterClass.Expr
+import org.apache.comet.serde.QueryPlanSerde.stringDecode
 import org.apache.spark.sql.catalyst.expressions._
 
 /**
@@ -39,7 +40,15 @@ trait CometExprShim {
     def versionSpecificExprToProtoInternal(
         expr: Expression,
         inputs: Seq[Attribute],
-        binding: Boolean): Option[Expr] = None
+        binding: Boolean): Option[Expr] = {
+      expr match {
+        case s: StringDecode =>
+          // Right child is the encoding expression.
+          stringDecode(expr, s.charset, s.bin, inputs, binding)
+
+        case _ => None
+      }
+    }
 }
 
 object CometEvalModeUtil {

--- a/spark/src/main/spark-3.4/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-3.4/org/apache/comet/shims/CometExprShim.scala
@@ -19,6 +19,7 @@
 package org.apache.comet.shims
 
 import org.apache.comet.expressions.CometEvalMode
+import org.apache.comet.serde.ExprOuterClass.Expr
 import org.apache.spark.sql.catalyst.expressions._
 
 /**
@@ -34,6 +35,11 @@ trait CometExprShim {
 
     protected def evalMode(c: Cast): CometEvalMode.Value =
         CometEvalModeUtil.fromSparkEvalMode(c.evalMode)
+
+    def versionSpecificExprToProtoInternal(
+        expr: Expression,
+        inputs: Seq[Attribute],
+        binding: Boolean): Option[Expr] = None
 }
 
 object CometEvalModeUtil {

--- a/spark/src/main/spark-3.5/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-3.5/org/apache/comet/shims/CometExprShim.scala
@@ -20,6 +20,7 @@ package org.apache.comet.shims
 
 import org.apache.comet.expressions.CometEvalMode
 import org.apache.comet.serde.ExprOuterClass.Expr
+import org.apache.comet.serde.QueryPlanSerde.stringDecode
 import org.apache.spark.sql.catalyst.expressions._
 
 /**
@@ -39,7 +40,15 @@ trait CometExprShim {
     def versionSpecificExprToProtoInternal(
         expr: Expression,
         inputs: Seq[Attribute],
-        binding: Boolean): Option[Expr] = None
+        binding: Boolean): Option[Expr] = {
+      expr match {
+        case s: StringDecode =>
+          // Right child is the encoding expression.
+          stringDecode(expr, s.charset, s.bin, inputs, binding)
+
+        case _ => None
+      }
+    }
 }
 
 object CometEvalModeUtil {

--- a/spark/src/main/spark-3.5/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-3.5/org/apache/comet/shims/CometExprShim.scala
@@ -19,6 +19,7 @@
 package org.apache.comet.shims
 
 import org.apache.comet.expressions.CometEvalMode
+import org.apache.comet.serde.ExprOuterClass.Expr
 import org.apache.spark.sql.catalyst.expressions._
 
 /**
@@ -34,6 +35,11 @@ trait CometExprShim {
 
     protected def evalMode(c: Cast): CometEvalMode.Value =
         CometEvalModeUtil.fromSparkEvalMode(c.evalMode)
+
+    def versionSpecificExprToProtoInternal(
+        expr: Expression,
+        inputs: Seq[Attribute],
+        binding: Boolean): Option[Expr] = None
 }
 
 object CometEvalModeUtil {

--- a/spark/src/main/spark-4.0/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-4.0/org/apache/comet/shims/CometExprShim.scala
@@ -26,8 +26,6 @@ import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.internal.types.StringTypeWithCollation
 import org.apache.spark.sql.types.{BinaryType, BooleanType, StringType}
 
-import java.util.Locale
-
 /**
  * `CometExprShim` acts as a shim for for parsing expressions from different Spark versions.
  */
@@ -59,6 +57,7 @@ trait CometExprShim {
                   BooleanType) =>
           val Seq(bin, charset, _, _) = s.arguments
           stringDecode(expr, charset, bin, inputs, binding)
+
         case _ => None
       }
     }

--- a/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
@@ -271,7 +271,6 @@ class CometFuzzTestSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("decode") {
-    // https://github.com/apache/datafusion-comet/issues/1942
     val df = spark.read.parquet(filename)
     df.createOrReplaceTempView("t1")
     // We want to make sure that the schema generator wasn't modified to accidentally omit

--- a/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
@@ -38,7 +38,6 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.ParquetOutputTimestampType
 import org.apache.spark.sql.types._
 
-import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
 import org.apache.comet.testing.{DataGenOptions, ParquetGenerator}
 
 class CometFuzzTestSuite extends CometTestBase with AdaptiveSparkPlanHelper {
@@ -273,7 +272,6 @@ class CometFuzzTestSuite extends CometTestBase with AdaptiveSparkPlanHelper {
 
   test("decode") {
     // https://github.com/apache/datafusion-comet/issues/1942
-    assume(!isSpark40Plus)
     val df = spark.read.parquet(filename)
     df.createOrReplaceTempView("t1")
     // We want to make sure that the schema generator wasn't modified to accidentally omit


### PR DESCRIPTION
## Which issue does this PR close?

Closes #1942.

## Rationale for this change

## What changes are included in this PR?

## How are these changes tested?

Existing tests.