### PR TITLE
fix: [iceberg] more fixes for Iceberg integration APIs.

### DIFF
--- a/common/src/main/java/org/apache/comet/parquet/AbstractColumnReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/AbstractColumnReader.java
@@ -63,7 +63,7 @@ public abstract class AbstractColumnReader implements AutoCloseable {
   /** A pointer to the native implementation of ColumnReader. */
   protected long nativeHandle;
 
-  public AbstractColumnReader(
+  AbstractColumnReader(
       DataType type,
       Type fieldType,
       ColumnDescriptor descriptor,
@@ -76,7 +76,7 @@ public abstract class AbstractColumnReader implements AutoCloseable {
     this.useLegacyDateTimestamp = useLegacyDateTimestamp;
   }
 
-  public AbstractColumnReader(
+  AbstractColumnReader(
       DataType type,
       ColumnDescriptor descriptor,
       boolean useDecimal128,
@@ -85,7 +85,7 @@ public abstract class AbstractColumnReader implements AutoCloseable {
     TypeUtil.checkParquetType(descriptor, type);
   }
 
-  public ColumnDescriptor getDescriptor() {
+  ColumnDescriptor getDescriptor() {
     return descriptor;
   }
 

--- a/common/src/main/java/org/apache/comet/parquet/ColumnReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/ColumnReader.java
@@ -93,7 +93,7 @@ public class ColumnReader extends AbstractColumnReader {
   private ArrowArray array = null;
   private ArrowSchema schema = null;
 
-  public ColumnReader(
+  ColumnReader(
       DataType type,
       ColumnDescriptor descriptor,
       CometSchemaImporter importer,
@@ -112,7 +112,7 @@ public class ColumnReader extends AbstractColumnReader {
    *
    * @param pageReader the page reader for the new column chunk
    */
-  public void setPageReader(PageReader pageReader) throws IOException {
+  void setPageReader(PageReader pageReader) throws IOException {
     this.pageReader = pageReader;
 
     DictionaryPage dictionaryPage = pageReader.readDictionaryPage();

--- a/common/src/main/java/org/apache/comet/parquet/ConstantColumnReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/ConstantColumnReader.java
@@ -38,7 +38,7 @@ public class ConstantColumnReader extends MetadataColumnReader {
   /** The constant value in the format of Object that are used to initialize this column reader. */
   private Object value;
 
-  public ConstantColumnReader(StructField field, int batchSize, boolean useDecimal128) {
+  ConstantColumnReader(StructField field, int batchSize, boolean useDecimal128) {
     this(field.dataType(), TypeUtil.convertToParquet(field), batchSize, useDecimal128);
     this.value =
         ResolveDefaultColumns.getExistenceDefaultValues(new StructType(new StructField[] {field}))[
@@ -46,15 +46,16 @@ public class ConstantColumnReader extends MetadataColumnReader {
     init(value);
   }
 
-  public ConstantColumnReader(
+  ConstantColumnReader(
       StructField field, int batchSize, InternalRow values, int index, boolean useDecimal128) {
     this(field.dataType(), TypeUtil.convertToParquet(field), batchSize, useDecimal128);
     init(values, index);
   }
 
+  // Used by Iceberg
   public ConstantColumnReader(
-      DataType type, ColumnDescriptor descriptor, Object value, boolean useDecimal128) {
-    super(type, descriptor, useDecimal128, true);
+      DataType type, ParquetColumnSpec spec, Object value, boolean useDecimal128) {
+    super(type, spec, useDecimal128, true);
     this.value = value;
   }
 

--- a/common/src/main/java/org/apache/comet/parquet/LazyColumnReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/LazyColumnReader.java
@@ -43,7 +43,7 @@ public class LazyColumnReader extends ColumnReader {
   // The lazy vector being updated.
   private final CometLazyVector vector;
 
-  public LazyColumnReader(
+  LazyColumnReader(
       DataType sparkReadType,
       ColumnDescriptor descriptor,
       CometSchemaImporter importer,

--- a/common/src/main/java/org/apache/comet/parquet/MetadataColumnReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/MetadataColumnReader.java
@@ -42,10 +42,19 @@ public class MetadataColumnReader extends AbstractColumnReader {
 
   private boolean isConstant;
 
-  public MetadataColumnReader(
+  MetadataColumnReader(
       DataType type, ColumnDescriptor descriptor, boolean useDecimal128, boolean isConstant) {
     // TODO: should we handle legacy dates & timestamps for metadata columns?
     super(type, descriptor, useDecimal128, false);
+
+    this.isConstant = isConstant;
+  }
+
+  // Used by Iceberg
+  public MetadataColumnReader(
+      DataType type, ParquetColumnSpec spec, boolean useDecimal128, boolean isConstant) {
+    // TODO: should we handle legacy dates & timestamps for metadata columns?
+    super(type, Utils.buildColumnDescriptor(spec), useDecimal128, false);
 
     this.isConstant = isConstant;
   }

--- a/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
@@ -186,7 +186,7 @@ public class NativeBatchReader extends RecordReader<Void, ColumnarBatch> impleme
     this.taskContext = TaskContext$.MODULE$.get();
   }
 
-  public NativeBatchReader(AbstractColumnReader[] columnReaders) {
+  private NativeBatchReader(AbstractColumnReader[] columnReaders) {
     // Todo: set useDecimal128 and useLazyMaterialization
     int numColumns = columnReaders.length;
     this.columnReaders = new AbstractColumnReader[numColumns];

--- a/common/src/main/java/org/apache/comet/parquet/NativeColumnReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/NativeColumnReader.java
@@ -69,7 +69,7 @@ public class NativeColumnReader extends AbstractColumnReader {
   private long nativeBatchHandle = 0xDEADBEEFL;
   private final int columnNum;
 
-  public NativeColumnReader(
+  NativeColumnReader(
       long nativeBatchHandle,
       int columnNum,
       DataType type,

--- a/common/src/main/java/org/apache/comet/parquet/ParquetColumnSpec.java
+++ b/common/src/main/java/org/apache/comet/parquet/ParquetColumnSpec.java
@@ -21,6 +21,12 @@ package org.apache.comet.parquet;
 
 import java.util.Map;
 
+/**
+ * Parquet ColumnSpec encapsulates the information withing a Parquet ColumnDescriptor. Utility
+ * methods can convert from and to a ColumnDescriptor The only purpose of this class is to allow
+ * passing of Column descriptors between Comet and Iceberg. This is required because Iceberg shades
+ * Parquet, changing the package of Parquet classes and making then incompatible with Comet.
+ */
 public class ParquetColumnSpec {
 
   private final int fieldId;

--- a/common/src/main/java/org/apache/comet/parquet/TypeUtil.java
+++ b/common/src/main/java/org/apache/comet/parquet/TypeUtil.java
@@ -31,10 +31,12 @@ import org.apache.spark.sql.types.*;
 
 import org.apache.comet.CometConf;
 
+import static org.apache.comet.parquet.Utils.descriptorToParquetColumnSpec;
+
 public class TypeUtil {
 
   /** Converts the input Spark 'field' into a Parquet column descriptor. */
-  public static ColumnDescriptor convertToParquet(StructField field) {
+  static ColumnDescriptor convertToParquet(StructField field) {
     Type.Repetition repetition;
     int maxDefinitionLevel;
     if (field.nullable()) {
@@ -103,6 +105,10 @@ public class TypeUtil {
     }
 
     return new ColumnDescriptor(path, builder.named(field.name()), 0, maxDefinitionLevel);
+  }
+
+  public static ParquetColumnSpec convertToParquetSpec(StructField field) {
+    return descriptorToParquetColumnSpec(convertToParquet(field));
   }
 
   /**

--- a/common/src/main/java/org/apache/comet/parquet/WrappedInputFile.java
+++ b/common/src/main/java/org/apache/comet/parquet/WrappedInputFile.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.parquet;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+
+import org.apache.parquet.io.InputFile;
+import org.apache.parquet.io.SeekableInputStream;
+
+/**
+ * A Parquet {@link InputFile} implementation that's similar to {@link
+ * org.apache.parquet.hadoop.util.HadoopInputFile}, but with optimizations introduced in Hadoop 3.x,
+ * for S3 specifically.
+ */
+public class WrappedInputFile implements InputFile {
+  Object wrapped;
+
+  public WrappedInputFile(Object inputFile) {
+    this.wrapped = inputFile;
+  }
+
+  @Override
+  public long getLength() throws IOException {
+    try {
+      Method targetMethod = wrapped.getClass().getDeclaredMethod("getLength"); //
+      targetMethod.setAccessible(true);
+      return (long) targetMethod.invoke(wrapped);
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public SeekableInputStream newStream() throws IOException {
+    try {
+      Method targetMethod = wrapped.getClass().getDeclaredMethod("newStream"); //
+      targetMethod.setAccessible(true);
+      InputStream stream = (InputStream) targetMethod.invoke(wrapped);
+      return new WrappedSeekableInputStream(stream);
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return wrapped.toString();
+  }
+}

--- a/common/src/main/java/org/apache/comet/parquet/WrappedSeekableInputStream.java
+++ b/common/src/main/java/org/apache/comet/parquet/WrappedSeekableInputStream.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.parquet;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+import org.apache.parquet.io.DelegatingSeekableInputStream;
+
+/**
+ * Wraps an InputStream that possibly implements the methods of a Parquet SeekableInputStream (but
+ * is not a Parquet SeekableInputStream). Such an InputStream exists, fir instance, in Iceberg's
+ * SeekableInputStream
+ */
+public class WrappedSeekableInputStream extends DelegatingSeekableInputStream {
+
+  private final InputStream wrappedInputStream; // The InputStream we are wrapping
+
+  public WrappedSeekableInputStream(InputStream inputStream) {
+    super(inputStream);
+    this.wrappedInputStream = Objects.requireNonNull(inputStream, "InputStream cannot be null");
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    try {
+      Method targetMethod = wrappedInputStream.getClass().getDeclaredMethod("getPos"); //
+      targetMethod.setAccessible(true);
+      return (long) targetMethod.invoke(wrappedInputStream);
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public void seek(long newPos) throws IOException {
+    try {
+      Method targetMethod = wrappedInputStream.getClass().getDeclaredMethod("seek", long.class);
+      targetMethod.setAccessible(true);
+      targetMethod.invoke(wrappedInputStream, newPos);
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+}

--- a/common/src/main/java/org/apache/comet/vector/CometDelegateVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometDelegateVector.java
@@ -48,7 +48,7 @@ public class CometDelegateVector extends CometVector {
     this.delegate = delegate;
   }
 
-  public void setDelegate(CometVector delegate) {
+  protected void setDelegate(CometVector delegate) {
     this.delegate = delegate;
   }
 


### PR DESCRIPTION
## Which issue does this PR close?
When running iceberg unit and integration tests with Comet, we still encounter some issues due to Parquet shading. This PR addresses those issues.
The main changes are: For all classes in Comet that are used in Iceberg integration, make all constructors and methods package private if they have a Parquet class in the signature. Provide equivalent methods that use Parquet encapsulation classes.
Refactor the `FileReader` API to use an `InputStream` (instead of a file path) to allow implementations of Iceberg's `InputFile`. The refactoring introduces some more encapsulation classes that use reflection to call back into Iceberg (to avoid adding a circular dependency on Iceberg)
This PR may break the complementary (draft) PR in Iceberg: https://github.com/apache/iceberg/pull/13378
