### PR TITLE
chore: Move `stringDecode()` to `CommonStringExprs` trait

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -19,8 +19,6 @@
 
 package org.apache.comet.serde
 
-import java.util.Locale
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
@@ -1485,30 +1483,6 @@ object QueryPlanSerde extends Logging with CometExprShim {
             None
         }
     })
-  }
-
-  def stringDecode(
-      expr: Expression,
-      charset: Expression,
-      bin: Expression,
-      inputs: Seq[Attribute],
-      binding: Boolean): Option[Expr] = {
-    charset match {
-      case Literal(str, DataTypes.StringType)
-          if str.toString.toLowerCase(Locale.ROOT) == "utf-8" =>
-        // decode(col, 'utf-8') can be treated as a cast with "try" eval mode that puts nulls
-        // for invalid strings.
-        // Left child is the binary expression.
-        castToProto(
-          expr,
-          None,
-          DataTypes.StringType,
-          exprToProtoInternal(bin, inputs, binding).get,
-          CometEvalMode.TRY)
-      case _ =>
-        withInfo(expr, "Comet only supports decoding with 'utf-8'.")
-        None
-    }
   }
 
   /**

--- a/spark/src/main/spark-3.4/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-3.4/org/apache/comet/shims/CometExprShim.scala
@@ -19,14 +19,14 @@
 package org.apache.comet.shims
 
 import org.apache.comet.expressions.CometEvalMode
+import org.apache.comet.serde.CommonStringExprs
 import org.apache.comet.serde.ExprOuterClass.Expr
-import org.apache.comet.serde.QueryPlanSerde.stringDecode
 import org.apache.spark.sql.catalyst.expressions._
 
 /**
  * `CometExprShim` acts as a shim for for parsing expressions from different Spark versions.
  */
-trait CometExprShim {
+trait CometExprShim extends CommonStringExprs {
     /**
      * Returns a tuple of expressions for the `unhex` function.
      */

--- a/spark/src/main/spark-3.5/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-3.5/org/apache/comet/shims/CometExprShim.scala
@@ -19,14 +19,14 @@
 package org.apache.comet.shims
 
 import org.apache.comet.expressions.CometEvalMode
+import org.apache.comet.serde.CommonStringExprs
 import org.apache.comet.serde.ExprOuterClass.Expr
-import org.apache.comet.serde.QueryPlanSerde.stringDecode
 import org.apache.spark.sql.catalyst.expressions._
 
 /**
  * `CometExprShim` acts as a shim for for parsing expressions from different Spark versions.
  */
-trait CometExprShim {
+trait CometExprShim extends CommonStringExprs {
     /**
      * Returns a tuple of expressions for the `unhex` function.
      */

--- a/spark/src/main/spark-4.0/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-4.0/org/apache/comet/shims/CometExprShim.scala
@@ -19,8 +19,8 @@
 package org.apache.comet.shims
 
 import org.apache.comet.expressions.CometEvalMode
+import org.apache.comet.serde.CommonStringExprs
 import org.apache.comet.serde.ExprOuterClass.Expr
-import org.apache.comet.serde.QueryPlanSerde.stringDecode
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.internal.types.StringTypeWithCollation
@@ -29,7 +29,7 @@ import org.apache.spark.sql.types.{BinaryType, BooleanType, StringType}
 /**
  * `CometExprShim` acts as a shim for for parsing expressions from different Spark versions.
  */
-trait CometExprShim {
+trait CometExprShim extends CommonStringExprs {
     /**
      * Returns a tuple of expressions for the `unhex` function.
      */


### PR DESCRIPTION
## Which issue does this PR close?

Follow-up to https://github.com/apache/datafusion-comet/pull/2075.

## Rationale for this change

See discussion https://github.com/apache/datafusion-comet/pull/2075#discussion_r2261157508.

## What changes are included in this PR?

Introduce `CommonStringExprs` and move `stringDecode()` to there.

## How are these changes tested?

Existing tests.
