### PR TITLE
chore: Add type parameter to `CometExpressionSerde`

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -1480,7 +1480,8 @@ object QueryPlanSerde extends Logging with CometExprShim {
         convert(ae, CometArrayExcept)
       case expr =>
         QueryPlanSerde.exprSerdeMap.get(expr.getClass) match {
-          case Some(handler) => convert(expr, handler.asInstanceOf[CometExpressionSerde[Expression]])
+          case Some(handler) =>
+            convert(expr, handler.asInstanceOf[CometExpressionSerde[Expression]])
           case _ =>
             withInfo(expr, s"${expr.prettyName} is not supported", expr.children: _*)
             None
@@ -2416,8 +2417,6 @@ trait CometExpressionSerde[T <: Expression] {
    * Convert a Spark expression into a protocol buffer representation that can be passed into
    * native code.
    *
-   * @tparam T
-   *   The type of the Spark expression
    * @param expr
    *   The Spark expression.
    * @param inputs
@@ -2429,10 +2428,7 @@ trait CometExpressionSerde[T <: Expression] {
    *   case it is expected that the input expression will have been tagged with reasons why it
    *   could not be converted.
    */
-  def convert(
-      expr: T,
-      inputs: Seq[Attribute],
-      binding: Boolean): Option[ExprOuterClass.Expr]
+  def convert(expr: T, inputs: Seq[Attribute], binding: Boolean): Option[ExprOuterClass.Expr]
 }
 
 /**
@@ -2472,10 +2468,7 @@ trait IncompatExpr {}
 
 /** Serde for scalar function. */
 case class CometScalarFunction[T <: Expression](name: String) extends CometExpressionSerde[T] {
-  override def convert(
-      expr: T,
-      inputs: Seq[Attribute],
-      binding: Boolean): Option[Expr] = {
+  override def convert(expr: T, inputs: Seq[Attribute], binding: Boolean): Option[Expr] = {
     val childExpr = expr.children.map(exprToProtoInternal(_, inputs, binding))
     val optExpr = scalarFunctionExprToProto(name, childExpr: _*)
     optExprWithInfo(optExpr, expr, expr.children: _*)

--- a/spark/src/main/scala/org/apache/comet/serde/arithmetic.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arithmetic.scala
@@ -85,140 +85,133 @@ trait MathBase {
 
 }
 
-object CometAdd extends CometExpressionSerde with MathBase {
+object CometAdd extends CometExpressionSerde[Add] with MathBase {
   override def convert(
-      expr: Expression,
+      expr: Add,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val add = expr.asInstanceOf[Add]
-    if (!supportedDataType(add.left.dataType)) {
-      withInfo(add, s"Unsupported datatype ${add.left.dataType}")
+    if (!supportedDataType(expr.left.dataType)) {
+      withInfo(expr, s"Unsupported datatype ${expr.left.dataType}")
       return None
     }
-    if (add.evalMode == EvalMode.TRY) {
-      withInfo(add, s"Eval mode ${add.evalMode} is not supported")
+    if (expr.evalMode == EvalMode.TRY) {
+      withInfo(expr, s"Eval mode ${expr.evalMode} is not supported")
       return None
     }
     createMathExpression(
       expr,
-      add.left,
-      add.right,
+      expr.left,
+      expr.right,
       inputs,
       binding,
-      add.dataType,
-      add.evalMode,
+      expr.dataType,
+      expr.evalMode,
       (builder, mathExpr) => builder.setAdd(mathExpr))
   }
 }
 
-object CometSubtract extends CometExpressionSerde with MathBase {
+object CometSubtract extends CometExpressionSerde[Subtract] with MathBase {
   override def convert(
-      expr: Expression,
+      expr: Subtract,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val sub = expr.asInstanceOf[Subtract]
-    if (!supportedDataType(sub.left.dataType)) {
-      withInfo(sub, s"Unsupported datatype ${sub.left.dataType}")
+    if (!supportedDataType(expr.left.dataType)) {
+      withInfo(expr, s"Unsupported datatype ${expr.left.dataType}")
       return None
     }
-    if (sub.evalMode == EvalMode.TRY) {
-      withInfo(sub, s"Eval mode ${sub.evalMode} is not supported")
+    if (expr.evalMode == EvalMode.TRY) {
+      withInfo(expr, s"Eval mode ${expr.evalMode} is not supported")
       return None
     }
     createMathExpression(
       expr,
-      sub.left,
-      sub.right,
+      expr.left,
+      expr.right,
       inputs,
       binding,
-      sub.dataType,
-      sub.evalMode,
+      expr.dataType,
+      expr.evalMode,
       (builder, mathExpr) => builder.setSubtract(mathExpr))
   }
 }
 
-object CometMultiply extends CometExpressionSerde with MathBase {
+object CometMultiply extends CometExpressionSerde[Multiply] with MathBase {
   override def convert(
-      expr: Expression,
+      expr: Multiply,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val mul = expr.asInstanceOf[Multiply]
-    if (!supportedDataType(mul.left.dataType)) {
-      withInfo(mul, s"Unsupported datatype ${mul.left.dataType}")
+    if (!supportedDataType(expr.left.dataType)) {
+      withInfo(expr, s"Unsupported datatype ${expr.left.dataType}")
       return None
     }
-    if (mul.evalMode == EvalMode.TRY) {
-      withInfo(mul, s"Eval mode ${mul.evalMode} is not supported")
+    if (expr.evalMode == EvalMode.TRY) {
+      withInfo(expr, s"Eval mode ${expr.evalMode} is not supported")
       return None
     }
     createMathExpression(
       expr,
-      mul.left,
-      mul.right,
+      expr.left,
+      expr.right,
       inputs,
       binding,
-      mul.dataType,
-      mul.evalMode,
+      expr.dataType,
+      expr.evalMode,
       (builder, mathExpr) => builder.setMultiply(mathExpr))
   }
 }
 
-object CometDivide extends CometExpressionSerde with MathBase {
+object CometDivide extends CometExpressionSerde[Divide] with MathBase {
   override def convert(
-      expr: Expression,
+      expr: Divide,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val div = expr.asInstanceOf[Divide]
-
     // Datafusion now throws an exception for dividing by zero
     // See https://github.com/apache/arrow-datafusion/pull/6792
     // For now, use NullIf to swap zeros with nulls.
-    val rightExpr = nullIfWhenPrimitive(div.right)
+    val rightExpr = nullIfWhenPrimitive(expr.right)
 
-    if (!supportedDataType(div.left.dataType)) {
-      withInfo(div, s"Unsupported datatype ${div.left.dataType}")
+    if (!supportedDataType(expr.left.dataType)) {
+      withInfo(expr, s"Unsupported datatype ${expr.left.dataType}")
       return None
     }
-    if (div.evalMode == EvalMode.TRY) {
-      withInfo(div, s"Eval mode ${div.evalMode} is not supported")
+    if (expr.evalMode == EvalMode.TRY) {
+      withInfo(expr, s"Eval mode ${expr.evalMode} is not supported")
       return None
     }
     createMathExpression(
       expr,
-      div.left,
+      expr.left,
       rightExpr,
       inputs,
       binding,
-      div.dataType,
-      div.evalMode,
+      expr.dataType,
+      expr.evalMode,
       (builder, mathExpr) => builder.setDivide(mathExpr))
   }
 }
 
-object CometIntegralDivide extends CometExpressionSerde with MathBase {
+object CometIntegralDivide extends CometExpressionSerde[IntegralDivide] with MathBase {
   override def convert(
-      expr: Expression,
+      expr: IntegralDivide,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val div = expr.asInstanceOf[IntegralDivide]
-
-    if (!supportedDataType(div.left.dataType)) {
-      withInfo(div, s"Unsupported datatype ${div.left.dataType}")
+    if (!supportedDataType(expr.left.dataType)) {
+      withInfo(expr, s"Unsupported datatype ${expr.left.dataType}")
       return None
     }
-    if (div.evalMode == EvalMode.TRY) {
-      withInfo(div, s"Eval mode ${div.evalMode} is not supported")
+    if (expr.evalMode == EvalMode.TRY) {
+      withInfo(expr, s"Eval mode ${expr.evalMode} is not supported")
       return None
     }
 
 //    Precision is set to 19 (max precision for a numerical data type except DecimalType)
 
     val left =
-      if (div.left.dataType.isInstanceOf[DecimalType]) div.left
-      else Cast(div.left, DecimalType(19, 0))
+      if (expr.left.dataType.isInstanceOf[DecimalType]) expr.left
+      else Cast(expr.left, DecimalType(19, 0))
     val right =
-      if (div.right.dataType.isInstanceOf[DecimalType]) div.right
-      else Cast(div.right, DecimalType(19, 0))
+      if (expr.right.dataType.isInstanceOf[DecimalType]) expr.right
+      else Cast(expr.right, DecimalType(19, 0))
 
     val rightExpr = nullIfWhenPrimitive(right)
 
@@ -237,7 +230,7 @@ object CometIntegralDivide extends CometExpressionSerde with MathBase {
       inputs,
       binding,
       dataType,
-      div.evalMode,
+      expr.evalMode,
       (builder, mathExpr) => builder.setIntegralDivide(mathExpr))
 
     if (divideExpr.isDefined) {
@@ -245,7 +238,7 @@ object CometIntegralDivide extends CometExpressionSerde with MathBase {
         // check overflow for decimal type
         val builder = ExprOuterClass.CheckOverflow.newBuilder()
         builder.setChild(divideExpr.get)
-        builder.setFailOnError(div.evalMode == EvalMode.ANSI)
+        builder.setFailOnError(expr.evalMode == EvalMode.ANSI)
         builder.setDatatype(serializeDataType(dataType).get)
         Some(
           ExprOuterClass.Expr
@@ -264,29 +257,28 @@ object CometIntegralDivide extends CometExpressionSerde with MathBase {
   }
 }
 
-object CometRemainder extends CometExpressionSerde with MathBase {
+object CometRemainder extends CometExpressionSerde[Remainder] with MathBase {
   override def convert(
-      expr: Expression,
+      expr: Remainder,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val remainder = expr.asInstanceOf[Remainder]
-    if (!supportedDataType(remainder.left.dataType)) {
-      withInfo(remainder, s"Unsupported datatype ${remainder.left.dataType}")
+    if (!supportedDataType(expr.left.dataType)) {
+      withInfo(expr, s"Unsupported datatype ${expr.left.dataType}")
       return None
     }
-    if (remainder.evalMode == EvalMode.TRY) {
-      withInfo(remainder, s"Eval mode ${remainder.evalMode} is not supported")
+    if (expr.evalMode == EvalMode.TRY) {
+      withInfo(expr, s"Eval mode ${expr.evalMode} is not supported")
       return None
     }
 
     createMathExpression(
       expr,
-      remainder.left,
-      remainder.right,
+      expr.left,
+      expr.right,
       inputs,
       binding,
-      remainder.dataType,
-      remainder.evalMode,
+      expr.dataType,
+      expr.evalMode,
       (builder, mathExpr) => builder.setRemainder(mathExpr))
   }
 }

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -21,7 +21,7 @@ package org.apache.comet.serde
 
 import scala.annotation.tailrec
 
-import org.apache.spark.sql.catalyst.expressions.{ArrayAppend, ArrayContains, ArrayDistinct, ArrayExcept, ArrayInsert, ArrayIntersect, ArrayJoin, ArrayMax, ArrayRemove, ArrayRepeat, ArrayUnion, ArraysOverlap, Attribute, CreateArray, Expression, Literal}
+import org.apache.spark.sql.catalyst.expressions.{ArrayAppend, ArrayContains, ArrayDistinct, ArrayExcept, ArrayInsert, ArrayIntersect, ArrayJoin, ArrayMax, ArrayRemove, ArrayRepeat, ArraysOverlap, ArrayUnion, Attribute, CreateArray, Expression, Literal}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
@@ -240,7 +240,10 @@ object CometArrayCompact extends CometExpressionSerde[Expression] with IncompatE
   }
 }
 
-object CometArrayExcept extends CometExpressionSerde[ArrayExcept] with CometExprShim with IncompatExpr {
+object CometArrayExcept
+    extends CometExpressionSerde[ArrayExcept]
+    with CometExprShim
+    with IncompatExpr {
 
   @tailrec
   def isTypeSupported(dt: DataType): Boolean = {

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -21,7 +21,7 @@ package org.apache.comet.serde
 
 import scala.annotation.tailrec
 
-import org.apache.spark.sql.catalyst.expressions.{ArrayExcept, ArrayJoin, ArrayRemove, Attribute, Expression, Literal}
+import org.apache.spark.sql.catalyst.expressions.{ArrayAppend, ArrayContains, ArrayDistinct, ArrayExcept, ArrayInsert, ArrayIntersect, ArrayJoin, ArrayMax, ArrayRemove, ArrayRepeat, ArrayUnion, ArraysOverlap, Attribute, CreateArray, Expression, Literal}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
@@ -29,7 +29,7 @@ import org.apache.comet.CometSparkSessionExtensions.withInfo
 import org.apache.comet.serde.QueryPlanSerde._
 import org.apache.comet.shims.CometExprShim
 
-object CometArrayRemove extends CometExpressionSerde with CometExprShim {
+object CometArrayRemove extends CometExpressionSerde[ArrayRemove] with CometExprShim {
 
   /** Exposed for unit testing */
   @tailrec
@@ -49,31 +49,30 @@ object CometArrayRemove extends CometExpressionSerde with CometExprShim {
   }
 
   override def convert(
-      expr: Expression,
+      expr: ArrayRemove,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val ar = expr.asInstanceOf[ArrayRemove]
-    val inputTypes: Set[DataType] = ar.children.map(_.dataType).toSet
+    val inputTypes: Set[DataType] = expr.children.map(_.dataType).toSet
     for (dt <- inputTypes) {
       if (!isTypeSupported(dt)) {
         withInfo(expr, s"data type not supported: $dt")
         return None
       }
     }
-    val arrayExprProto = exprToProto(ar.left, inputs, binding)
-    val keyExprProto = exprToProto(ar.right, inputs, binding)
+    val arrayExprProto = exprToProto(expr.left, inputs, binding)
+    val keyExprProto = exprToProto(expr.right, inputs, binding)
 
     val arrayRemoveScalarExpr =
       scalarFunctionExprToProto("array_remove_all", arrayExprProto, keyExprProto)
 
     val isNotNullExpr = createUnaryExpr(
       expr,
-      ar.right,
+      expr.right,
       inputs,
       binding,
       (builder, unaryExpr) => builder.setIsNotNull(unaryExpr))
 
-    val nullLiteralProto = exprToProto(Literal(null, ar.right.dataType), Seq.empty)
+    val nullLiteralProto = exprToProto(Literal(null, expr.right.dataType), Seq.empty)
 
     if (arrayRemoveScalarExpr.isDefined && isNotNullExpr.isDefined && nullLiteralProto.isDefined) {
       val caseWhenExpr = ExprOuterClass.CaseWhen
@@ -94,9 +93,9 @@ object CometArrayRemove extends CometExpressionSerde with CometExprShim {
   }
 }
 
-object CometArrayAppend extends CometExpressionSerde with IncompatExpr {
+object CometArrayAppend extends CometExpressionSerde[ArrayAppend] with IncompatExpr {
   override def convert(
-      expr: Expression,
+      expr: ArrayAppend,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
     val child = expr.children.head
@@ -136,9 +135,9 @@ object CometArrayAppend extends CometExpressionSerde with IncompatExpr {
   }
 }
 
-object CometArrayContains extends CometExpressionSerde {
+object CometArrayContains extends CometExpressionSerde[ArrayContains] {
   override def convert(
-      expr: Expression,
+      expr: ArrayContains,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
     val arrayExprProto = exprToProto(expr.children.head, inputs, binding)
@@ -150,9 +149,9 @@ object CometArrayContains extends CometExpressionSerde {
   }
 }
 
-object CometArrayDistinct extends CometExpressionSerde with IncompatExpr {
+object CometArrayDistinct extends CometExpressionSerde[ArrayDistinct] with IncompatExpr {
   override def convert(
-      expr: Expression,
+      expr: ArrayDistinct,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
     val arrayExprProto = exprToProto(expr.children.head, inputs, binding)
@@ -163,9 +162,9 @@ object CometArrayDistinct extends CometExpressionSerde with IncompatExpr {
   }
 }
 
-object CometArrayIntersect extends CometExpressionSerde with IncompatExpr {
+object CometArrayIntersect extends CometExpressionSerde[ArrayIntersect] with IncompatExpr {
   override def convert(
-      expr: Expression,
+      expr: ArrayIntersect,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
     val leftArrayExprProto = exprToProto(expr.children.head, inputs, binding)
@@ -177,9 +176,9 @@ object CometArrayIntersect extends CometExpressionSerde with IncompatExpr {
   }
 }
 
-object CometArrayMax extends CometExpressionSerde {
+object CometArrayMax extends CometExpressionSerde[ArrayMax] {
   override def convert(
-      expr: Expression,
+      expr: ArrayMax,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
     val arrayExprProto = exprToProto(expr.children.head, inputs, binding)
@@ -190,9 +189,9 @@ object CometArrayMax extends CometExpressionSerde {
   }
 }
 
-object CometArraysOverlap extends CometExpressionSerde with IncompatExpr {
+object CometArraysOverlap extends CometExpressionSerde[ArraysOverlap] with IncompatExpr {
   override def convert(
-      expr: Expression,
+      expr: ArraysOverlap,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
     val leftArrayExprProto = exprToProto(expr.children.head, inputs, binding)
@@ -207,9 +206,9 @@ object CometArraysOverlap extends CometExpressionSerde with IncompatExpr {
   }
 }
 
-object CometArrayRepeat extends CometExpressionSerde with IncompatExpr {
+object CometArrayRepeat extends CometExpressionSerde[ArrayRepeat] with IncompatExpr {
   override def convert(
-      expr: Expression,
+      expr: ArrayRepeat,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
     val leftArrayExprProto = exprToProto(expr.children.head, inputs, binding)
@@ -221,7 +220,7 @@ object CometArrayRepeat extends CometExpressionSerde with IncompatExpr {
   }
 }
 
-object CometArrayCompact extends CometExpressionSerde with IncompatExpr {
+object CometArrayCompact extends CometExpressionSerde[Expression] with IncompatExpr {
   override def convert(
       expr: Expression,
       inputs: Seq[Attribute],
@@ -241,7 +240,7 @@ object CometArrayCompact extends CometExpressionSerde with IncompatExpr {
   }
 }
 
-object CometArrayExcept extends CometExpressionSerde with CometExprShim with IncompatExpr {
+object CometArrayExcept extends CometExpressionSerde[ArrayExcept] with CometExprShim with IncompatExpr {
 
   @tailrec
   def isTypeSupported(dt: DataType): Boolean = {
@@ -259,19 +258,18 @@ object CometArrayExcept extends CometExpressionSerde with CometExprShim with Inc
   }
 
   override def convert(
-      expr: Expression,
+      expr: ArrayExcept,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val arrayExceptExpr = expr.asInstanceOf[ArrayExcept]
-    val inputTypes = arrayExceptExpr.children.map(_.dataType).toSet
+    val inputTypes = expr.children.map(_.dataType).toSet
     for (dt <- inputTypes) {
       if (!isTypeSupported(dt)) {
         withInfo(expr, s"data type not supported: $dt")
         return None
       }
     }
-    val leftArrayExprProto = exprToProto(arrayExceptExpr.left, inputs, binding)
-    val rightArrayExprProto = exprToProto(arrayExceptExpr.right, inputs, binding)
+    val leftArrayExprProto = exprToProto(expr.left, inputs, binding)
+    val rightArrayExprProto = exprToProto(expr.right, inputs, binding)
 
     val arrayExceptScalarExpr =
       scalarFunctionExprToProto("array_except", leftArrayExprProto, rightArrayExprProto)
@@ -279,9 +277,9 @@ object CometArrayExcept extends CometExpressionSerde with CometExprShim with Inc
   }
 }
 
-object CometArrayJoin extends CometExpressionSerde with IncompatExpr {
+object CometArrayJoin extends CometExpressionSerde[ArrayJoin] with IncompatExpr {
   override def convert(
-      expr: Expression,
+      expr: ArrayJoin,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
     val arrayExpr = expr.asInstanceOf[ArrayJoin]
@@ -313,9 +311,9 @@ object CometArrayJoin extends CometExpressionSerde with IncompatExpr {
   }
 }
 
-object CometArrayInsert extends CometExpressionSerde with IncompatExpr {
+object CometArrayInsert extends CometExpressionSerde[ArrayInsert] with IncompatExpr {
   override def convert(
-      expr: Expression,
+      expr: ArrayInsert,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
     val srcExprProto = exprToProtoInternal(expr.children.head, inputs, binding)
@@ -348,9 +346,9 @@ object CometArrayInsert extends CometExpressionSerde with IncompatExpr {
   }
 }
 
-object CometArrayUnion extends CometExpressionSerde with IncompatExpr {
+object CometArrayUnion extends CometExpressionSerde[ArrayUnion] with IncompatExpr {
   override def convert(
-      expr: Expression,
+      expr: ArrayUnion,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
     val leftArrayExprProto = exprToProto(expr.children.head, inputs, binding)
@@ -362,9 +360,9 @@ object CometArrayUnion extends CometExpressionSerde with IncompatExpr {
   }
 }
 
-object CometCreateArray extends CometExpressionSerde {
+object CometCreateArray extends CometExpressionSerde[CreateArray] {
   override def convert(
-      expr: Expression,
+      expr: CreateArray,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
     val children = expr.children

--- a/spark/src/main/scala/org/apache/comet/serde/bitwise.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/bitwise.scala
@@ -24,84 +24,79 @@ import org.apache.spark.sql.types.{ByteType, IntegerType, LongType}
 
 import org.apache.comet.serde.QueryPlanSerde._
 
-object CometBitwiseAdd extends CometExpressionSerde {
+object CometBitwiseAnd extends CometExpressionSerde[BitwiseAnd] {
   override def convert(
-      expr: Expression,
+      expr: BitwiseAnd,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val bitwiseAndExpr = expr.asInstanceOf[BitwiseAnd]
     createBinaryExpr(
       expr,
-      bitwiseAndExpr.left,
-      bitwiseAndExpr.right,
+      expr.left,
+      expr.right,
       inputs,
       binding,
       (builder, binaryExpr) => builder.setBitwiseAnd(binaryExpr))
   }
 }
 
-object CometBitwiseNot extends CometExpressionSerde {
+object CometBitwiseNot extends CometExpressionSerde[BitwiseNot] {
   override def convert(
-      expr: Expression,
+      expr: BitwiseNot,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val bitwiseNotExpr = expr.asInstanceOf[BitwiseNot]
-    val childProto = exprToProto(bitwiseNotExpr.child, inputs, binding)
+    val childProto = exprToProto(expr.child, inputs, binding)
     val bitNotScalarExpr =
       scalarFunctionExprToProto("bit_not", childProto)
     optExprWithInfo(bitNotScalarExpr, expr, expr.children: _*)
   }
 }
 
-object CometBitwiseOr extends CometExpressionSerde {
+object CometBitwiseOr extends CometExpressionSerde[BitwiseOr] {
   override def convert(
-      expr: Expression,
+      expr: BitwiseOr,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val bitwiseOrExpr = expr.asInstanceOf[BitwiseOr]
     createBinaryExpr(
       expr,
-      bitwiseOrExpr.left,
-      bitwiseOrExpr.right,
+      expr.left,
+      expr.right,
       inputs,
       binding,
       (builder, binaryExpr) => builder.setBitwiseOr(binaryExpr))
   }
 }
 
-object CometBitwiseXor extends CometExpressionSerde {
+object CometBitwiseXor extends CometExpressionSerde[BitwiseXor] {
   override def convert(
-      expr: Expression,
+      expr: BitwiseXor,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val bitwiseXorExpr = expr.asInstanceOf[BitwiseXor]
     createBinaryExpr(
       expr,
-      bitwiseXorExpr.left,
-      bitwiseXorExpr.right,
+      expr.left,
+      expr.right,
       inputs,
       binding,
       (builder, binaryExpr) => builder.setBitwiseXor(binaryExpr))
   }
 }
 
-object CometShiftRight extends CometExpressionSerde {
+object CometShiftRight extends CometExpressionSerde[ShiftRight] {
   override def convert(
-      expr: Expression,
+      expr: ShiftRight,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val shiftRightExpr = expr.asInstanceOf[ShiftRight]
     // DataFusion bitwise shift right expression requires
     // same data type between left and right side
-    val rightExpression = if (shiftRightExpr.left.dataType == LongType) {
-      Cast(shiftRightExpr.right, LongType)
+    val rightExpression = if (expr.left.dataType == LongType) {
+      Cast(expr.right, LongType)
     } else {
-      shiftRightExpr.right
+      expr.right
     }
 
     createBinaryExpr(
       expr,
-      shiftRightExpr.left,
+      expr.left,
       rightExpression,
       inputs,
       binding,
@@ -109,23 +104,22 @@ object CometShiftRight extends CometExpressionSerde {
   }
 }
 
-object CometShiftLeft extends CometExpressionSerde {
+object CometShiftLeft extends CometExpressionSerde[ShiftLeft] {
   override def convert(
-      expr: Expression,
+      expr: ShiftLeft,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val shiftLeftLeft = expr.asInstanceOf[ShiftLeft]
     // DataFusion bitwise shift right expression requires
     // same data type between left and right side
-    val rightExpression = if (shiftLeftLeft.left.dataType == LongType) {
-      Cast(shiftLeftLeft.right, LongType)
+    val rightExpression = if (expr.left.dataType == LongType) {
+      Cast(expr.right, LongType)
     } else {
-      shiftLeftLeft.right
+      expr.right
     }
 
     createBinaryExpr(
       expr,
-      shiftLeftLeft.left,
+      expr.left,
       rightExpression,
       inputs,
       binding,
@@ -133,27 +127,25 @@ object CometShiftLeft extends CometExpressionSerde {
   }
 }
 
-object CometBitwiseGet extends CometExpressionSerde {
+object CometBitwiseGet extends CometExpressionSerde[BitwiseGet] {
   override def convert(
-      expr: Expression,
+      expr: BitwiseGet,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val bitwiseGetExpr = expr.asInstanceOf[BitwiseGet]
-    val argProto = exprToProto(bitwiseGetExpr.left, inputs, binding)
-    val posProto = exprToProto(bitwiseGetExpr.right, inputs, binding)
+    val argProto = exprToProto(expr.left, inputs, binding)
+    val posProto = exprToProto(expr.right, inputs, binding)
     val bitGetScalarExpr =
       scalarFunctionExprToProtoWithReturnType("bit_get", ByteType, argProto, posProto)
     optExprWithInfo(bitGetScalarExpr, expr, expr.children: _*)
   }
 }
 
-object CometBitwiseCount extends CometExpressionSerde {
+object CometBitwiseCount extends CometExpressionSerde[BitwiseCount] {
   override def convert(
-      expr: Expression,
+      expr: BitwiseCount,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val bitwiseCountExpr = expr.asInstanceOf[BitwiseCount]
-    val childProto = exprToProto(bitwiseCountExpr.child, inputs, binding)
+    val childProto = exprToProto(expr.child, inputs, binding)
     val bitCountScalarExpr =
       scalarFunctionExprToProtoWithReturnType("bit_count", IntegerType, childProto)
     optExprWithInfo(bitCountScalarExpr, expr, expr.children: _*)

--- a/spark/src/main/scala/org/apache/comet/serde/comparisons.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/comparisons.scala
@@ -28,153 +28,137 @@ import org.apache.comet.CometSparkSessionExtensions.withInfo
 import org.apache.comet.serde.ExprOuterClass.Expr
 import org.apache.comet.serde.QueryPlanSerde._
 
-object CometGreaterThan extends CometExpressionSerde {
+object CometGreaterThan extends CometExpressionSerde[GreaterThan] {
   override def convert(
-      expr: Expression,
+      expr: GreaterThan,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val greaterThan = expr.asInstanceOf[GreaterThan]
-
     createBinaryExpr(
       expr,
-      greaterThan.left,
-      greaterThan.right,
+      expr.left,
+      expr.right,
       inputs,
       binding,
       (builder, binaryExpr) => builder.setGt(binaryExpr))
   }
 }
 
-object CometGreaterThanOrEqual extends CometExpressionSerde {
+object CometGreaterThanOrEqual extends CometExpressionSerde[GreaterThanOrEqual] {
   override def convert(
-      expr: Expression,
+      expr: GreaterThanOrEqual,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val greaterThanOrEqual = expr.asInstanceOf[GreaterThanOrEqual]
-
     createBinaryExpr(
       expr,
-      greaterThanOrEqual.left,
-      greaterThanOrEqual.right,
+      expr.left,
+      expr.right,
       inputs,
       binding,
       (builder, binaryExpr) => builder.setGtEq(binaryExpr))
   }
 }
 
-object CometLessThan extends CometExpressionSerde {
+object CometLessThan extends CometExpressionSerde[LessThan] {
   override def convert(
-      expr: Expression,
+      expr: LessThan,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val lessThan = expr.asInstanceOf[LessThan]
-
     createBinaryExpr(
       expr,
-      lessThan.left,
-      lessThan.right,
+      expr.left,
+      expr.right,
       inputs,
       binding,
       (builder, binaryExpr) => builder.setLt(binaryExpr))
   }
 }
 
-object CometLessThanOrEqual extends CometExpressionSerde {
+object CometLessThanOrEqual extends CometExpressionSerde[LessThanOrEqual] {
   override def convert(
-      expr: Expression,
+      expr: LessThanOrEqual,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val lessThanOrEqual = expr.asInstanceOf[LessThanOrEqual]
-
     createBinaryExpr(
       expr,
-      lessThanOrEqual.left,
-      lessThanOrEqual.right,
+      expr.left,
+      expr.right,
       inputs,
       binding,
       (builder, binaryExpr) => builder.setLtEq(binaryExpr))
   }
 }
 
-object CometIsNull extends CometExpressionSerde {
+object CometIsNull extends CometExpressionSerde[IsNull] {
   override def convert(
-      expr: Expression,
+      expr: IsNull,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val isNull = expr.asInstanceOf[IsNull]
-
     createUnaryExpr(
       expr,
-      isNull.child,
+      expr.child,
       inputs,
       binding,
       (builder, unaryExpr) => builder.setIsNull(unaryExpr))
   }
 }
 
-object CometIsNotNull extends CometExpressionSerde {
+object CometIsNotNull extends CometExpressionSerde[IsNotNull] {
   override def convert(
-      expr: Expression,
+      expr: IsNotNull,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val isNotNull = expr.asInstanceOf[IsNotNull]
-
     createUnaryExpr(
       expr,
-      isNotNull.child,
+      expr.child,
       inputs,
       binding,
       (builder, unaryExpr) => builder.setIsNotNull(unaryExpr))
   }
 }
 
-object CometIsNaN extends CometExpressionSerde {
+object CometIsNaN extends CometExpressionSerde[IsNaN] {
   override def convert(
-      expr: Expression,
+      expr: IsNaN,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val isNaN = expr.asInstanceOf[IsNaN]
-    val childExpr = exprToProtoInternal(isNaN.child, inputs, binding)
+    val childExpr = exprToProtoInternal(expr.child, inputs, binding)
     val optExpr = scalarFunctionExprToProtoWithReturnType("isnan", BooleanType, childExpr)
 
-    optExprWithInfo(optExpr, expr, isNaN.child)
+    optExprWithInfo(optExpr, expr, expr.child)
   }
 }
 
-object CometIn extends CometExpressionSerde {
+object CometIn extends CometExpressionSerde[In] {
   override def convert(
-      expr: Expression,
+      expr: In,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val inExpr = expr.asInstanceOf[In]
-    ComparisonUtils.in(expr, inExpr.value, inExpr.list, inputs, binding, negate = false)
+    ComparisonUtils.in(expr, expr.value, expr.list, inputs, binding, negate = false)
   }
 }
 
-object CometNotIn extends CometExpressionSerde {
+object CometNotIn extends CometExpressionSerde[Not] {
   override def convert(
-      expr: Expression,
+      expr: Not,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val notExpr = expr.asInstanceOf[Not]
-    val inExpr = notExpr.child.asInstanceOf[In]
+    val inExpr = expr.child.asInstanceOf[In]
     ComparisonUtils.in(expr, inExpr.value, inExpr.list, inputs, binding, negate = true)
   }
 }
 
-object CometInSet extends CometExpressionSerde {
+object CometInSet extends CometExpressionSerde[InSet] {
   override def convert(
-      expr: Expression,
+      expr: InSet,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val inSetExpr = expr.asInstanceOf[InSet]
-    val valueDataType = inSetExpr.child.dataType
-    val list = inSetExpr.hset.map { setVal =>
+    val valueDataType = expr.child.dataType
+    val list = expr.hset.map { setVal =>
       Literal(setVal, valueDataType)
     }.toSeq
     // Change `InSet` to `In` expression
     // We do Spark `InSet` optimization in native (DataFusion) side.
-    ComparisonUtils.in(expr, inSetExpr.child, list, inputs, binding, negate = false)
+    ComparisonUtils.in(expr, expr.child, list, inputs, binding, negate = false)
   }
 }
 

--- a/spark/src/main/scala/org/apache/comet/serde/datetime.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/datetime.scala
@@ -19,21 +19,20 @@
 
 package org.apache.comet.serde
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, DateAdd, DateSub, Expression, Hour, Literal, Minute, Second, TruncDate, TruncTimestamp, Year}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, DateAdd, DateSub, Hour, Literal, Minute, Second, TruncDate, TruncTimestamp, Year}
 import org.apache.spark.sql.types.{DateType, IntegerType}
 
 import org.apache.comet.CometSparkSessionExtensions.withInfo
 import org.apache.comet.serde.ExprOuterClass.Expr
 import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, optExprWithInfo, scalarFunctionExprToProto, scalarFunctionExprToProtoWithReturnType, serializeDataType}
 
-object CometYear extends CometExpressionSerde {
+object CometYear extends CometExpressionSerde[Year] {
   override def convert(
-      expr: Expression,
+      expr: Year,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val year = expr.asInstanceOf[Year]
     val periodType = exprToProtoInternal(Literal("year"), inputs, binding)
-    val childExpr = exprToProtoInternal(year.child, inputs, binding)
+    val childExpr = exprToProtoInternal(expr.child, inputs, binding)
     val optExpr = scalarFunctionExprToProto("datepart", Seq(periodType, childExpr): _*)
       .map(e => {
         Expr
@@ -48,23 +47,22 @@ object CometYear extends CometExpressionSerde {
               .build())
           .build()
       })
-    optExprWithInfo(optExpr, expr, year.child)
+    optExprWithInfo(optExpr, expr, expr.child)
   }
 }
 
-object CometHour extends CometExpressionSerde {
+object CometHour extends CometExpressionSerde[Hour] {
   override def convert(
-      expr: Expression,
+      expr: Hour,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val hour = expr.asInstanceOf[Hour]
-    val childExpr = exprToProtoInternal(hour.child, inputs, binding)
+    val childExpr = exprToProtoInternal(expr.child, inputs, binding)
 
     if (childExpr.isDefined) {
       val builder = ExprOuterClass.Hour.newBuilder()
       builder.setChild(childExpr.get)
 
-      val timeZone = hour.timeZoneId.getOrElse("UTC")
+      val timeZone = expr.timeZoneId.getOrElse("UTC")
       builder.setTimezone(timeZone)
 
       Some(
@@ -73,25 +71,24 @@ object CometHour extends CometExpressionSerde {
           .setHour(builder)
           .build())
     } else {
-      withInfo(expr, hour.child)
+      withInfo(expr, expr.child)
       None
     }
   }
 }
 
-object CometMinute extends CometExpressionSerde {
+object CometMinute extends CometExpressionSerde[Minute] {
   override def convert(
-      expr: Expression,
+      expr: Minute,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val minute = expr.asInstanceOf[Minute]
-    val childExpr = exprToProtoInternal(minute.child, inputs, binding)
+    val childExpr = exprToProtoInternal(expr.child, inputs, binding)
 
     if (childExpr.isDefined) {
       val builder = ExprOuterClass.Minute.newBuilder()
       builder.setChild(childExpr.get)
 
-      val timeZone = minute.timeZoneId.getOrElse("UTC")
+      val timeZone = expr.timeZoneId.getOrElse("UTC")
       builder.setTimezone(timeZone)
 
       Some(
@@ -100,25 +97,24 @@ object CometMinute extends CometExpressionSerde {
           .setMinute(builder)
           .build())
     } else {
-      withInfo(expr, minute.child)
+      withInfo(expr, expr.child)
       None
     }
   }
 }
 
-object CometSecond extends CometExpressionSerde {
+object CometSecond extends CometExpressionSerde[Second] {
   override def convert(
-      expr: Expression,
+      expr: Second,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val second = expr.asInstanceOf[Second]
-    val childExpr = exprToProtoInternal(second.child, inputs, binding)
+    val childExpr = exprToProtoInternal(expr.child, inputs, binding)
 
     if (childExpr.isDefined) {
       val builder = ExprOuterClass.Second.newBuilder()
       builder.setChild(childExpr.get)
 
-      val timeZone = second.timeZoneId.getOrElse("UTC")
+      val timeZone = expr.timeZoneId.getOrElse("UTC")
       builder.setTimezone(timeZone)
 
       Some(
@@ -127,69 +123,65 @@ object CometSecond extends CometExpressionSerde {
           .setSecond(builder)
           .build())
     } else {
-      withInfo(expr, second.child)
+      withInfo(expr, expr.child)
       None
     }
   }
 }
 
-object CometDateAdd extends CometExpressionSerde {
+object CometDateAdd extends CometExpressionSerde[DateAdd] {
   override def convert(
-      expr: Expression,
+      expr: DateAdd,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val dateAdd = expr.asInstanceOf[DateAdd]
-    val leftExpr = exprToProtoInternal(dateAdd.left, inputs, binding)
-    val rightExpr = exprToProtoInternal(dateAdd.right, inputs, binding)
+    val leftExpr = exprToProtoInternal(expr.left, inputs, binding)
+    val rightExpr = exprToProtoInternal(expr.right, inputs, binding)
     val optExpr =
       scalarFunctionExprToProtoWithReturnType("date_add", DateType, leftExpr, rightExpr)
-    optExprWithInfo(optExpr, expr, dateAdd.left, dateAdd.right)
+    optExprWithInfo(optExpr, expr, expr.left, expr.right)
   }
 }
 
-object CometDateSub extends CometExpressionSerde {
+object CometDateSub extends CometExpressionSerde[DateSub] {
   override def convert(
-      expr: Expression,
+      expr: DateSub,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val dateSub = expr.asInstanceOf[DateSub]
-    val leftExpr = exprToProtoInternal(dateSub.left, inputs, binding)
-    val rightExpr = exprToProtoInternal(dateSub.right, inputs, binding)
+    val leftExpr = exprToProtoInternal(expr.left, inputs, binding)
+    val rightExpr = exprToProtoInternal(expr.right, inputs, binding)
     val optExpr =
       scalarFunctionExprToProtoWithReturnType("date_sub", DateType, leftExpr, rightExpr)
-    optExprWithInfo(optExpr, expr, dateSub.left, dateSub.right)
+    optExprWithInfo(optExpr, expr, expr.left, expr.right)
   }
 }
 
-object CometTruncDate extends CometExpressionSerde {
+object CometTruncDate extends CometExpressionSerde[TruncDate] {
   override def convert(
-      expr: Expression,
+      expr: TruncDate,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val truncDate = expr.asInstanceOf[TruncDate]
-    val childExpr = exprToProtoInternal(truncDate.date, inputs, binding)
-    val formatExpr = exprToProtoInternal(truncDate.format, inputs, binding)
+    val childExpr = exprToProtoInternal(expr.date, inputs, binding)
+    val formatExpr = exprToProtoInternal(expr.format, inputs, binding)
     val optExpr =
       scalarFunctionExprToProtoWithReturnType("date_trunc", DateType, childExpr, formatExpr)
-    optExprWithInfo(optExpr, expr, truncDate.date, truncDate.format)
+    optExprWithInfo(optExpr, expr, expr.date, expr.format)
   }
 }
 
-object CometTruncTimestamp extends CometExpressionSerde {
+object CometTruncTimestamp extends CometExpressionSerde[TruncTimestamp] {
   override def convert(
-      expr: Expression,
+      expr: TruncTimestamp,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val truncTimestamp = expr.asInstanceOf[TruncTimestamp]
-    val childExpr = exprToProtoInternal(truncTimestamp.timestamp, inputs, binding)
-    val formatExpr = exprToProtoInternal(truncTimestamp.format, inputs, binding)
+    val childExpr = exprToProtoInternal(expr.timestamp, inputs, binding)
+    val formatExpr = exprToProtoInternal(expr.format, inputs, binding)
 
     if (childExpr.isDefined && formatExpr.isDefined) {
       val builder = ExprOuterClass.TruncTimestamp.newBuilder()
       builder.setChild(childExpr.get)
       builder.setFormat(formatExpr.get)
 
-      val timeZone = truncTimestamp.timeZoneId.getOrElse("UTC")
+      val timeZone = expr.timeZoneId.getOrElse("UTC")
       builder.setTimezone(timeZone)
 
       Some(
@@ -198,7 +190,7 @@ object CometTruncTimestamp extends CometExpressionSerde {
           .setTruncTimestamp(builder)
           .build())
     } else {
-      withInfo(expr, truncTimestamp.timestamp, truncTimestamp.format)
+      withInfo(expr, expr.timestamp, expr.format)
       None
     }
   }

--- a/spark/src/main/scala/org/apache/comet/serde/maps.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/maps.scala
@@ -24,70 +24,65 @@ import org.apache.spark.sql.types.{ArrayType, MapType}
 
 import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, optExprWithInfo, scalarFunctionExprToProto, scalarFunctionExprToProtoWithReturnType}
 
-object CometMapKeys extends CometExpressionSerde {
+object CometMapKeys extends CometExpressionSerde[MapKeys] {
 
   override def convert(
-      expr: Expression,
+      expr: MapKeys,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val mk = expr.asInstanceOf[MapKeys]
-    val childExpr = exprToProtoInternal(mk.child, inputs, binding)
+    val childExpr = exprToProtoInternal(expr.child, inputs, binding)
     val mapKeysScalarExpr = scalarFunctionExprToProto("map_keys", childExpr)
     optExprWithInfo(mapKeysScalarExpr, expr, expr.children: _*)
   }
 }
 
-object CometMapEntries extends CometExpressionSerde {
+object CometMapEntries extends CometExpressionSerde[MapEntries] {
 
   override def convert(
-      expr: Expression,
+      expr: MapEntries,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val mk = expr.asInstanceOf[MapEntries]
-    val childExpr = exprToProtoInternal(mk.child, inputs, binding)
+    val childExpr = exprToProtoInternal(expr.child, inputs, binding)
     val mapEntriesScalarExpr = scalarFunctionExprToProto("map_entries", childExpr)
     optExprWithInfo(mapEntriesScalarExpr, expr, expr.children: _*)
   }
 }
 
-object CometMapValues extends CometExpressionSerde {
+object CometMapValues extends CometExpressionSerde[MapValues] {
 
   override def convert(
-      expr: Expression,
+      expr: MapValues,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val mv = expr.asInstanceOf[MapValues]
-    val childExpr = exprToProtoInternal(mv.child, inputs, binding)
+    val childExpr = exprToProtoInternal(expr.child, inputs, binding)
     val mapValuesScalarExpr = scalarFunctionExprToProto("map_values", childExpr)
     optExprWithInfo(mapValuesScalarExpr, expr, expr.children: _*)
   }
 }
 
-object CometMapExtract extends CometExpressionSerde {
+object CometMapExtract extends CometExpressionSerde[GetMapValue] {
 
   override def convert(
-      expr: Expression,
+      expr: GetMapValue,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val gmv = expr.asInstanceOf[GetMapValue]
-    val mapExpr = exprToProtoInternal(gmv.child, inputs, binding)
-    val keyExpr = exprToProtoInternal(gmv.key, inputs, binding)
+    val mapExpr = exprToProtoInternal(expr.child, inputs, binding)
+    val keyExpr = exprToProtoInternal(expr.key, inputs, binding)
     val mapExtractExpr = scalarFunctionExprToProto("map_extract", mapExpr, keyExpr)
     optExprWithInfo(mapExtractExpr, expr, expr.children: _*)
   }
 }
 
-object CometMapFromArrays extends CometExpressionSerde {
+object CometMapFromArrays extends CometExpressionSerde[MapFromArrays] {
 
   override def convert(
-      expr: Expression,
+      expr: MapFromArrays,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val mfa = expr.asInstanceOf[MapFromArrays]
-    val keysExpr = exprToProtoInternal(mfa.left, inputs, binding)
-    val valuesExpr = exprToProtoInternal(mfa.right, inputs, binding)
-    val keyType = mfa.left.dataType.asInstanceOf[ArrayType].elementType
-    val valueType = mfa.right.dataType.asInstanceOf[ArrayType].elementType
+    val keysExpr = exprToProtoInternal(expr.left, inputs, binding)
+    val valuesExpr = exprToProtoInternal(expr.right, inputs, binding)
+    val keyType = expr.left.dataType.asInstanceOf[ArrayType].elementType
+    val valueType = expr.right.dataType.asInstanceOf[ArrayType].elementType
     val returnType = MapType(keyType = keyType, valueType = valueType)
     val mapFromArraysExpr =
       scalarFunctionExprToProtoWithReturnType("map", returnType, keysExpr, valuesExpr)

--- a/spark/src/main/scala/org/apache/comet/serde/strings.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/strings.scala
@@ -19,7 +19,7 @@
 
 package org.apache.comet.serde
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Expression, Like, Literal, RLike, StringRPad, Substring}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Expression, InitCap, Like, Literal, Lower, RLike, StringRPad, StringRepeat, Substring, Upper}
 import org.apache.spark.sql.types.{DataTypes, LongType, StringType}
 
 import org.apache.comet.CometConf
@@ -27,10 +27,10 @@ import org.apache.comet.CometSparkSessionExtensions.withInfo
 import org.apache.comet.serde.ExprOuterClass.Expr
 import org.apache.comet.serde.QueryPlanSerde.{createBinaryExpr, exprToProtoInternal, optExprWithInfo, scalarFunctionExprToProto}
 
-object CometStringRepeat extends CometExpressionSerde {
+object CometStringRepeat extends CometExpressionSerde[StringRepeat] {
 
   override def convert(
-      expr: Expression,
+      expr: StringRepeat,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
     val children = expr.children
@@ -43,10 +43,10 @@ object CometStringRepeat extends CometExpressionSerde {
   }
 }
 
-class CometCaseConversionBase(function: String) extends CometScalarFunction(function) {
+class CometCaseConversionBase[T <: Expression](function: String) extends CometScalarFunction[T](function) {
 
   override def convert(
-      expr: Expression,
+      expr: T,
       inputs: Seq[Attribute],
       binding: Boolean): Option[Expr] = {
     if (!CometConf.COMET_CASE_CONVERSION_ENABLED.get()) {
@@ -61,14 +61,14 @@ class CometCaseConversionBase(function: String) extends CometScalarFunction(func
   }
 }
 
-object CometUpper extends CometCaseConversionBase("upper")
+object CometUpper extends CometCaseConversionBase[Upper]("upper")
 
-object CometLower extends CometCaseConversionBase("lower")
+object CometLower extends CometCaseConversionBase[Lower]("lower")
 
-object CometInitCap extends CometScalarFunction("initcap") {
+object CometInitCap extends CometScalarFunction[InitCap]("initcap") {
 
   override def convert(
-      expr: Expression,
+      expr: InitCap,
       inputs: Seq[Attribute],
       binding: Boolean): Option[Expr] = {
     if (!CometConf.COMET_EXEC_INITCAP_ENABLED.get()) {
@@ -83,16 +83,15 @@ object CometInitCap extends CometScalarFunction("initcap") {
   }
 }
 
-object CometSubstring extends CometExpressionSerde {
+object CometSubstring extends CometExpressionSerde[Substring] {
 
   override def convert(
-      expr: Expression,
+      expr: Substring,
       inputs: Seq[Attribute],
       binding: Boolean): Option[Expr] = {
-    val substring = expr.asInstanceOf[Substring]
-    (substring.pos, substring.len) match {
+    (expr.pos, expr.len) match {
       case (Literal(pos, _), Literal(len, _)) =>
-        exprToProtoInternal(substring.str, inputs, binding) match {
+        exprToProtoInternal(expr.str, inputs, binding) match {
           case Some(strExpr) =>
             val builder = ExprOuterClass.Substring.newBuilder()
             builder.setChild(strExpr)
@@ -100,7 +99,7 @@ object CometSubstring extends CometExpressionSerde {
             builder.setLen(len.asInstanceOf[Int])
             Some(ExprOuterClass.Expr.newBuilder().setSubstring(builder).build())
           case None =>
-            withInfo(expr, substring.str)
+            withInfo(expr, expr.str)
             None
         }
       case _ =>
@@ -110,36 +109,34 @@ object CometSubstring extends CometExpressionSerde {
   }
 }
 
-object CometLike extends CometExpressionSerde {
+object CometLike extends CometExpressionSerde[Like] {
 
   override def convert(
-      expr: Expression,
+      expr: Like,
       inputs: Seq[Attribute],
       binding: Boolean): Option[Expr] = {
-    val like = expr.asInstanceOf[Like]
-    if (like.escapeChar == '\\') {
+    if (expr.escapeChar == '\\') {
       createBinaryExpr(
         expr,
-        like.left,
-        like.right,
+        expr.left,
+        expr.right,
         inputs,
         binding,
         (builder, binaryExpr) => builder.setLike(binaryExpr))
     } else {
-      withInfo(expr, s"custom escape character ${like.escapeChar} not supported in LIKE")
+      withInfo(expr, s"custom escape character ${expr.escapeChar} not supported in LIKE")
       None
     }
   }
 }
 
-object CometRLike extends CometExpressionSerde {
+object CometRLike extends CometExpressionSerde[RLike] {
 
   override def convert(
-      expr: Expression,
+      expr: RLike,
       inputs: Seq[Attribute],
       binding: Boolean): Option[Expr] = {
-    val rlike = expr.asInstanceOf[RLike]
-    rlike.right match {
+    expr.right match {
       case Literal(pattern, DataTypes.StringType) =>
         val regex = pattern.toString
         if (regex.contains("(?i)") || regex.contains("(?-i)")) {
@@ -148,8 +145,8 @@ object CometRLike extends CometExpressionSerde {
         } else {
           createBinaryExpr(
             expr,
-            rlike.left,
-            rlike.right,
+            expr.left,
+            expr.right,
             inputs,
             binding,
             (builder, binaryExpr) => builder.setRlike(binaryExpr))
@@ -161,19 +158,18 @@ object CometRLike extends CometExpressionSerde {
   }
 }
 
-object CometStringRPad extends CometExpressionSerde {
+object CometStringRPad extends CometExpressionSerde[StringRPad] {
 
   override def convert(
-      expr: Expression,
+      expr: StringRPad,
       inputs: Seq[Attribute],
       binding: Boolean): Option[Expr] = {
-    val stringRPad = expr.asInstanceOf[StringRPad]
-    stringRPad.pad match {
+    expr.pad match {
       case Literal(str, DataTypes.StringType) if str.toString == " " =>
         scalarFunctionExprToProto(
           "rpad",
-          exprToProtoInternal(stringRPad.str, inputs, binding),
-          exprToProtoInternal(stringRPad.len, inputs, binding))
+          exprToProtoInternal(expr.str, inputs, binding),
+          exprToProtoInternal(expr.len, inputs, binding))
       case _ =>
         withInfo(expr, "StringRPad with non-space characters is not supported")
         None

--- a/spark/src/main/scala/org/apache/comet/serde/strings.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/strings.scala
@@ -19,7 +19,7 @@
 
 package org.apache.comet.serde
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Expression, InitCap, Like, Literal, Lower, RLike, StringRPad, StringRepeat, Substring, Upper}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Expression, InitCap, Like, Literal, Lower, RLike, StringRepeat, StringRPad, Substring, Upper}
 import org.apache.spark.sql.types.{DataTypes, LongType, StringType}
 
 import org.apache.comet.CometConf
@@ -43,12 +43,10 @@ object CometStringRepeat extends CometExpressionSerde[StringRepeat] {
   }
 }
 
-class CometCaseConversionBase[T <: Expression](function: String) extends CometScalarFunction[T](function) {
+class CometCaseConversionBase[T <: Expression](function: String)
+    extends CometScalarFunction[T](function) {
 
-  override def convert(
-      expr: T,
-      inputs: Seq[Attribute],
-      binding: Boolean): Option[Expr] = {
+  override def convert(expr: T, inputs: Seq[Attribute], binding: Boolean): Option[Expr] = {
     if (!CometConf.COMET_CASE_CONVERSION_ENABLED.get()) {
       withInfo(
         expr,
@@ -67,10 +65,7 @@ object CometLower extends CometCaseConversionBase[Lower]("lower")
 
 object CometInitCap extends CometScalarFunction[InitCap]("initcap") {
 
-  override def convert(
-      expr: InitCap,
-      inputs: Seq[Attribute],
-      binding: Boolean): Option[Expr] = {
+  override def convert(expr: InitCap, inputs: Seq[Attribute], binding: Boolean): Option[Expr] = {
     if (!CometConf.COMET_EXEC_INITCAP_ENABLED.get()) {
       withInfo(
         expr,
@@ -111,10 +106,7 @@ object CometSubstring extends CometExpressionSerde[Substring] {
 
 object CometLike extends CometExpressionSerde[Like] {
 
-  override def convert(
-      expr: Like,
-      inputs: Seq[Attribute],
-      binding: Boolean): Option[Expr] = {
+  override def convert(expr: Like, inputs: Seq[Attribute], binding: Boolean): Option[Expr] = {
     if (expr.escapeChar == '\\') {
       createBinaryExpr(
         expr,
@@ -132,10 +124,7 @@ object CometLike extends CometExpressionSerde[Like] {
 
 object CometRLike extends CometExpressionSerde[RLike] {
 
-  override def convert(
-      expr: RLike,
-      inputs: Seq[Attribute],
-      binding: Boolean): Option[Expr] = {
+  override def convert(expr: RLike, inputs: Seq[Attribute], binding: Boolean): Option[Expr] = {
     expr.right match {
       case Literal(pattern, DataTypes.StringType) =>
         val regex = pattern.toString


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

This PR adds a `T` type parameter to `CometExpressionSerde` so as to simplify its `convert()` implementations and to open up the way for further ones.

## What changes are included in this PR?

See above.

## How are these changes tested?

Existing UTs.
