### PR TITLE
feat: Add new trait for operator serde

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/CometProjectExec.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/CometProjectExec.scala
@@ -32,7 +32,7 @@ object CometProjectExec extends CometOperatorSerde[ProjectExec] {
 
   override def convert(
       op: ProjectExec,
-      result: Operator.Builder,
+      builder: Operator.Builder,
       childOp: Operator*): Option[OperatorOuterClass.Operator] = {
     if (!CometConf.COMET_EXEC_PROJECT_ENABLED.get(op.conf)) {
       withInfo(
@@ -46,7 +46,7 @@ object CometProjectExec extends CometOperatorSerde[ProjectExec] {
       val projectBuilder = OperatorOuterClass.Projection
         .newBuilder()
         .addAllProjectList(exprs.map(_.get).asJava)
-      Some(result.setProjection(projectBuilder).build())
+      Some(builder.setProjection(projectBuilder).build())
     } else {
       withInfo(op, op.projectList: _*)
       None

--- a/spark/src/main/scala/org/apache/comet/serde/CometProjectExec.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/CometProjectExec.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.serde
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.execution.ProjectExec
+
+import org.apache.comet.CometConf
+import org.apache.comet.CometSparkSessionExtensions.withInfo
+import org.apache.comet.serde.OperatorOuterClass.Operator
+import org.apache.comet.serde.QueryPlanSerde.exprToProto
+
+object CometProjectExec extends CometOperatorSerde[ProjectExec] {
+
+  override def convert(
+      op: ProjectExec,
+      result: Operator.Builder,
+      childOp: Operator*): Option[OperatorOuterClass.Operator] = {
+    if (!CometConf.COMET_EXEC_PROJECT_ENABLED.get(op.conf)) {
+      withInfo(
+        op,
+        s"CometProjectExec is disabled. Set ${CometConf.COMET_EXEC_PROJECT_ENABLED.key}=true to enable it.")
+      return None
+    }
+    val exprs = op.projectList.map(exprToProto(_, op.child.output))
+
+    if (exprs.forall(_.isDefined) && childOp.nonEmpty) {
+      val projectBuilder = OperatorOuterClass.Projection
+        .newBuilder()
+        .addAllProjectList(exprs.map(_.get).asJava)
+      Some(result.setProjection(projectBuilder).build())
+    } else {
+      withInfo(op, op.projectList: _*)
+      None
+    }
+  }
+}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

For consistency with the expression serde, I would like to introduce a trait for operator serde.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Add `opSerdeMap`
- Add `CometOperatorSerde` trait
- Add `CometProjectExec` implementation
- Update `operator2Proto` to lookup serde handlers from the map
- Improve fallback reporting in the case where `COMET_EXEC_PROJECT_ENABLED` is `false`

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
