### PR TITLE
fix: Avoid double free in CometUnifiedShuffleMemoryAllocator

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -60,19 +60,3 @@ overflow-checks = false
 lto = "thin"
 codegen-units = 1
 strip = "debuginfo"
-
-# Cargo.toml
-[profile.dev]
-# Light optimization for your crate (keeps compile times reasonable)
-opt-level = 1            # 0..3; try 1 or 2 for more speed
-debug = 1                # smaller debug info; 0 = none, 2 = full
-debug-assertions = false # turn off extra checks in std & your code
-overflow-checks = false  # disable integer overflow checks
-incremental = true       # faster rebuilds (slightly slower runtime)
-codegen-units = 16       # more parallel codegen, faster builds
-lto = "off"              # keep LTO off in dev
-panic = "abort"          # faster, smaller binaries (no unwinding)
-
-# Heavier optimization for dependencies only (big win with small compile cost)
-[profile.dev.package."*"]
-opt-level = 3

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -60,3 +60,19 @@ overflow-checks = false
 lto = "thin"
 codegen-units = 1
 strip = "debuginfo"
+
+# Cargo.toml
+[profile.dev]
+# Light optimization for your crate (keeps compile times reasonable)
+opt-level = 1            # 0..3; try 1 or 2 for more speed
+debug = 1                # smaller debug info; 0 = none, 2 = full
+debug-assertions = false # turn off extra checks in std & your code
+overflow-checks = false  # disable integer overflow checks
+incremental = true       # faster rebuilds (slightly slower runtime)
+codegen-units = 16       # more parallel codegen, faster builds
+lto = "off"              # keep LTO off in dev
+panic = "abort"          # faster, smaller binaries (no unwinding)
+
+# Heavier optimization for dependencies only (big win with small compile cost)
+[profile.dev.package."*"]
+opt-level = 3

--- a/spark/src/main/java/org/apache/spark/shuffle/comet/CometBoundedShuffleMemoryAllocator.java
+++ b/spark/src/main/java/org/apache/spark/shuffle/comet/CometBoundedShuffleMemoryAllocator.java
@@ -152,14 +152,15 @@ public final class CometBoundedShuffleMemoryAllocator extends CometShuffleMemory
       // Already freed block
       return 0;
     }
-    allocatedMemory -= block.size();
+    long blockSize = block.size();
+    allocatedMemory -= blockSize;
 
     pageTable[block.pageNumber] = null;
     allocatedPages.clear(block.pageNumber);
     block.pageNumber = MemoryBlock.FREED_IN_TMM_PAGE_NUMBER;
 
     allocator.free(block);
-    return allocatedMemory;
+    return blockSize;
   }
 
   /**

--- a/spark/src/main/java/org/apache/spark/shuffle/comet/CometBoundedShuffleMemoryAllocator.java
+++ b/spark/src/main/java/org/apache/spark/shuffle/comet/CometBoundedShuffleMemoryAllocator.java
@@ -147,7 +147,8 @@ public final class CometBoundedShuffleMemoryAllocator extends CometShuffleMemory
   }
 
   public synchronized void free(MemoryBlock block) {
-    if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER) {
+    if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER ||
+      block.pageNumber == MemoryBlock.FREED_IN_TMM_PAGE_NUMBER) {
       // Already freed block
       return;
     }

--- a/spark/src/main/java/org/apache/spark/shuffle/comet/CometBoundedShuffleMemoryAllocator.java
+++ b/spark/src/main/java/org/apache/spark/shuffle/comet/CometBoundedShuffleMemoryAllocator.java
@@ -146,11 +146,11 @@ public final class CometBoundedShuffleMemoryAllocator extends CometShuffleMemory
     return block;
   }
 
-  public synchronized void free(MemoryBlock block) {
+  public synchronized long free(MemoryBlock block) {
     if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER
         || block.pageNumber == MemoryBlock.FREED_IN_TMM_PAGE_NUMBER) {
       // Already freed block
-      return;
+      return 0;
     }
     allocatedMemory -= block.size();
 
@@ -159,6 +159,7 @@ public final class CometBoundedShuffleMemoryAllocator extends CometShuffleMemory
     block.pageNumber = MemoryBlock.FREED_IN_TMM_PAGE_NUMBER;
 
     allocator.free(block);
+    return allocatedMemory;
   }
 
   /**

--- a/spark/src/main/java/org/apache/spark/shuffle/comet/CometBoundedShuffleMemoryAllocator.java
+++ b/spark/src/main/java/org/apache/spark/shuffle/comet/CometBoundedShuffleMemoryAllocator.java
@@ -147,8 +147,8 @@ public final class CometBoundedShuffleMemoryAllocator extends CometShuffleMemory
   }
 
   public synchronized void free(MemoryBlock block) {
-    if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER ||
-      block.pageNumber == MemoryBlock.FREED_IN_TMM_PAGE_NUMBER) {
+    if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER
+        || block.pageNumber == MemoryBlock.FREED_IN_TMM_PAGE_NUMBER) {
       // Already freed block
       return;
     }

--- a/spark/src/main/java/org/apache/spark/shuffle/comet/CometShuffleMemoryAllocatorTrait.java
+++ b/spark/src/main/java/org/apache/spark/shuffle/comet/CometShuffleMemoryAllocatorTrait.java
@@ -33,7 +33,7 @@ public abstract class CometShuffleMemoryAllocatorTrait extends MemoryConsumer {
 
   public abstract MemoryBlock allocate(long required);
 
-  public abstract void free(MemoryBlock block);
+  public abstract long free(MemoryBlock block);
 
   public abstract long getOffsetInPage(long pagePlusOffsetAddress);
 

--- a/spark/src/main/java/org/apache/spark/shuffle/comet/CometUnifiedShuffleMemoryAllocator.java
+++ b/spark/src/main/java/org/apache/spark/shuffle/comet/CometUnifiedShuffleMemoryAllocator.java
@@ -58,8 +58,8 @@ public final class CometUnifiedShuffleMemoryAllocator extends CometShuffleMemory
   }
 
   public synchronized void free(MemoryBlock block) {
-    if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER ||
-      block.pageNumber == MemoryBlock.FREED_IN_TMM_PAGE_NUMBER) {
+    if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER
+        || block.pageNumber == MemoryBlock.FREED_IN_TMM_PAGE_NUMBER) {
       // Already freed block
       return;
     }

--- a/spark/src/main/java/org/apache/spark/shuffle/comet/CometUnifiedShuffleMemoryAllocator.java
+++ b/spark/src/main/java/org/apache/spark/shuffle/comet/CometUnifiedShuffleMemoryAllocator.java
@@ -63,9 +63,9 @@ public final class CometUnifiedShuffleMemoryAllocator extends CometShuffleMemory
       // Already freed block
       return 0;
     }
-    long allocatedMemory = block.size();
+    long blockSize = block.size();
     this.freePage(block);
-    return allocatedMemory;
+    return blockSize;
   }
 
   /**

--- a/spark/src/main/java/org/apache/spark/shuffle/comet/CometUnifiedShuffleMemoryAllocator.java
+++ b/spark/src/main/java/org/apache/spark/shuffle/comet/CometUnifiedShuffleMemoryAllocator.java
@@ -58,7 +58,8 @@ public final class CometUnifiedShuffleMemoryAllocator extends CometShuffleMemory
   }
 
   public synchronized void free(MemoryBlock block) {
-    if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER) {
+    if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER ||
+      block.pageNumber == MemoryBlock.FREED_IN_TMM_PAGE_NUMBER) {
       // Already freed block
       return;
     }

--- a/spark/src/main/java/org/apache/spark/shuffle/comet/CometUnifiedShuffleMemoryAllocator.java
+++ b/spark/src/main/java/org/apache/spark/shuffle/comet/CometUnifiedShuffleMemoryAllocator.java
@@ -58,6 +58,10 @@ public final class CometUnifiedShuffleMemoryAllocator extends CometShuffleMemory
   }
 
   public synchronized void free(MemoryBlock block) {
+    if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER) {
+      // Already freed block
+      return;
+    }
     this.freePage(block);
   }
 

--- a/spark/src/main/java/org/apache/spark/shuffle/comet/CometUnifiedShuffleMemoryAllocator.java
+++ b/spark/src/main/java/org/apache/spark/shuffle/comet/CometUnifiedShuffleMemoryAllocator.java
@@ -57,13 +57,15 @@ public final class CometUnifiedShuffleMemoryAllocator extends CometShuffleMemory
     return this.allocatePage(required);
   }
 
-  public synchronized void free(MemoryBlock block) {
+  public synchronized long free(MemoryBlock block) {
     if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER
         || block.pageNumber == MemoryBlock.FREED_IN_TMM_PAGE_NUMBER) {
       // Already freed block
-      return;
+      return 0;
     }
+    long allocatedMemory = block.size();
     this.freePage(block);
+    return allocatedMemory;
   }
 
   /**

--- a/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
+++ b/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
@@ -220,6 +220,8 @@ public abstract class SpillWriter {
     for (MemoryBlock block : allocatedPages) {
       if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER
           || block.pageNumber == MemoryBlock.FREED_IN_TMM_PAGE_NUMBER) {
+        // Already freed block
+      } else {
         freed += block.size();
         allocator.free(block);
       }

--- a/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
+++ b/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
@@ -218,8 +218,8 @@ public abstract class SpillWriter {
   public long freeMemory() {
     long freed = 0L;
     for (MemoryBlock block : allocatedPages) {
-      if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER ||
-        block.pageNumber == MemoryBlock.FREED_IN_TMM_PAGE_NUMBER) {
+      if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER
+          || block.pageNumber == MemoryBlock.FREED_IN_TMM_PAGE_NUMBER) {
         freed += block.size();
         allocator.free(block);
       }

--- a/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
+++ b/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
@@ -218,7 +218,8 @@ public abstract class SpillWriter {
   public long freeMemory() {
     long freed = 0L;
     for (MemoryBlock block : allocatedPages) {
-      if (block.pageNumber != MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER) {
+      if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER ||
+        block.pageNumber == MemoryBlock.FREED_IN_TMM_PAGE_NUMBER) {
         freed += block.size();
         allocator.free(block);
       }

--- a/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
+++ b/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
@@ -218,13 +218,7 @@ public abstract class SpillWriter {
   public long freeMemory() {
     long freed = 0L;
     for (MemoryBlock block : allocatedPages) {
-      if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER
-          || block.pageNumber == MemoryBlock.FREED_IN_TMM_PAGE_NUMBER) {
-        // Already freed block
-      } else {
-        freed += block.size();
-        allocator.free(block);
-      }
+      freed += allocator.free(block);
     }
     allocatedPages.clear();
     currentPage = null;

--- a/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
+++ b/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
@@ -218,8 +218,10 @@ public abstract class SpillWriter {
   public long freeMemory() {
     long freed = 0L;
     for (MemoryBlock block : allocatedPages) {
-      freed += block.size();
-      allocator.free(block);
+      if (block.pageNumber != MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER) {
+        freed += block.size();
+        allocator.free(block);
+      }
     }
     allocatedPages.clear();
     currentPage = null;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/2088

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

CometUnifiedShuffleMemoryAllocator was missing checks for blocks that have already been freed. We did already have these checks in CometBoundedShuffleMemoryAllocator.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
