### PR TITLE
fix: Quick fix for memory corruption in SortExec queries

### DIFF
--- a/native/core/src/execution/operators/scan.rs
+++ b/native/core/src/execution/operators/scan.rs
@@ -63,6 +63,8 @@ pub struct ScanExec {
     pub input_source: Option<Arc<GlobalRef>>,
     /// A description of the input source for informational purposes
     pub input_source_description: String,
+    /// Whether this is a native_comet scan that reuses buffers
+    pub has_buffer_reuse: bool,
     /// The data types of columns of the input batch. Converted from Spark schema.
     pub data_types: Vec<DataType>,
     /// Schema of first batch
@@ -88,6 +90,7 @@ impl ScanExec {
         input_source: Option<Arc<GlobalRef>>,
         input_source_description: &str,
         data_types: Vec<DataType>,
+        has_buffer_reuse: bool,
     ) -> Result<Self, CometError> {
         let metrics_set = ExecutionPlanMetricsSet::default();
         let baseline_metrics = BaselineMetrics::new(&metrics_set, 0);
@@ -130,6 +133,7 @@ impl ScanExec {
             exec_context_id,
             input_source,
             input_source_description: input_source_description.to_string(),
+            has_buffer_reuse,
             data_types,
             batch: Arc::new(Mutex::new(Some(first_batch))),
             cache,

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -1430,8 +1430,13 @@ impl PhysicalPlanner {
                     };
 
                 // The `ScanExec` operator will take actual arrays from Spark during execution
-                let scan =
-                    ScanExec::new(self.exec_context_id, input_source, &scan.source, data_types)?;
+                let scan = ScanExec::new(
+                    self.exec_context_id,
+                    input_source,
+                    &scan.source,
+                    data_types,
+                    scan.has_buffer_reuse,
+                )?;
 
                 Ok((
                     vec![scan.clone()],
@@ -2798,6 +2803,7 @@ mod tests {
     use crate::execution::{operators::InputBatch, planner::PhysicalPlanner};
 
     use crate::execution::operators::ExecutionError;
+    use crate::execution::spark_plan::SparkPlan;
     use crate::parquet::parquet_support::SparkParquetOptions;
     use crate::parquet::schema_adapter::SparkSchemaAdapterFactory;
     use datafusion_comet_proto::spark_expression::expr::ExprStruct;
@@ -2809,7 +2815,6 @@ mod tests {
         spark_operator::{operator::OpStruct, Operator},
     };
     use datafusion_comet_spark_expr::EvalMode;
-    use crate::execution::spark_plan::SparkPlan;
 
     #[test]
     fn test_unpack_dictionary_primitive() {
@@ -2822,6 +2827,7 @@ mod tests {
                     type_info: None,
                 }],
                 source: "".to_string(),
+                has_buffer_reuse: true,
             })),
         };
 
@@ -2895,6 +2901,7 @@ mod tests {
                     type_info: None,
                 }],
                 source: "".to_string(),
+                has_buffer_reuse: true,
             })),
         };
 
@@ -3175,6 +3182,7 @@ mod tests {
             op_struct: Some(OpStruct::Scan(spark_operator::Scan {
                 fields: vec![create_proto_datatype()],
                 source: "".to_string(),
+                has_buffer_reuse: true,
             })),
         }
     }
@@ -3217,6 +3225,7 @@ mod tests {
                     },
                 ],
                 source: "".to_string(),
+                has_buffer_reuse: true,
             })),
         };
 
@@ -3331,6 +3340,7 @@ mod tests {
                     },
                 ],
                 source: "".to_string(),
+                has_buffer_reuse: true,
             })),
         };
 

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -2785,6 +2785,7 @@ mod tests {
     use datafusion::logical_expr::ScalarUDF;
     use datafusion::physical_plan::ExecutionPlan;
     use datafusion::{assert_batches_eq, physical_plan::common::collect, prelude::SessionContext};
+    use datafusion::physical_plan::display::DisplayableExecutionPlan;
     use tempfile::TempDir;
     use tokio::sync::mpsc;
 
@@ -2802,6 +2803,42 @@ mod tests {
         spark_operator::{operator::OpStruct, Operator},
     };
     use datafusion_comet_spark_expr::EvalMode;
+
+    #[test]
+    fn copy_exec() {
+        let scan_exec = create_scan();
+        
+        // Create a SortOrder expression that sorts by the first column (index 0)
+        // in ascending order with nulls first
+        let sort_order_expr = spark_expression::Expr {
+            expr_struct: Some(ExprStruct::SortOrder(Box::new(spark_expression::SortOrder {
+                child: Some(Box::new(spark_expression::Expr {
+                    expr_struct: Some(ExprStruct::Bound(spark_expression::BoundReference {
+                        index: 0,
+                        datatype: Some(spark_expression::DataType {
+                            type_id: 3, // Int32
+                            type_info: None,
+                        }),
+                    })),
+                })),
+                direction: spark_expression::SortDirection::Ascending as i32,
+                null_ordering: spark_expression::NullOrdering::NullsFirst as i32,
+            }))),
+        };
+        
+        let sort_exec = Operator {
+            plan_id: 0,
+            children: vec![scan_exec],
+            op_struct: Some(OpStruct::Sort(spark_operator::Sort {
+                sort_orders: vec![sort_order_expr],
+                fetch: None,
+            }))
+        };
+        let planner = PhysicalPlanner::default();
+        let (_scans, datafusion_plan) = planner.create_plan(&sort_exec, &mut vec![], 1).unwrap();
+        let plan_str = format!("{}", DisplayableExecutionPlan::new(datafusion_plan.native_plan.as_ref()).indent(true));
+        println!("{plan_str}");
+    }
 
     #[test]
     fn test_unpack_dictionary_primitive() {

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -3002,7 +3002,7 @@ mod tests {
     }
 
     #[test]
-    fn add_copy_to_scan() {
+    fn add_copy_to_sort_on_scan() {
         let scan_exec = create_scan();
         let sort_exec = create_sort_exec(scan_exec);
         let planner = PhysicalPlanner::default();
@@ -3010,12 +3010,13 @@ mod tests {
         let plan_str = explain_plan(datafusion_plan);
         let expected_str = r"SortExec: expr=[col_0@0 ASC], preserve_partitioning=[false]
   CopyExec [UnpackOrDeepCopy]
-    ScanExec: source=[], schema=[col_0: Int32]";
+    ScanExec: source=[], schema=[col_0: Int32]
+";
         assert_eq!(plan_str, expected_str);
     }
 
     #[test]
-    fn add_copy_to_filter_scan() {
+    fn add_copy_to_sort_on_filtered_scan() {
         let scan_exec = create_scan();
         let filter_exec = create_filter(scan_exec, 1);
         let sort_exec = create_sort_exec(filter_exec);
@@ -3025,7 +3026,8 @@ mod tests {
         let expected_str = r"SortExec: expr=[col_0@0 ASC], preserve_partitioning=[false]
   CopyExec [UnpackOrDeepCopy]
     CometFilterExec: col_0@0 = 1
-      ScanExec: source=[], schema=[col_0: Int32]";
+      ScanExec: source=[], schema=[col_0: Int32]
+";
         assert_eq!(plan_str, expected_str);
     }
 

--- a/native/proto/src/proto/operator.proto
+++ b/native/proto/src/proto/operator.proto
@@ -76,6 +76,10 @@ message Scan {
   // is purely for informational purposes when viewing native query plans in
   // debug mode.
   string source = 2;
+  // we need to specialize if the source is native_comet scan (either directly,
+  // or via Iceberg) because the native code needs to insert CopyExec nodes to
+  // avoid memory corruption issues due to the reuse of mutable buffers
+  bool has_buffer_reuse = 3;
 }
 
 message NativeScan {

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -1796,6 +1796,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
           // TODO this could be optimized more to stop walking the tree on hitting
           //  certain operators such as join or aggregate which will copy batches
           def containsNativeCometScan(plan: SparkPlan): Boolean = {
+            // TODO this needs updating to support Iceberg invoking native_comet scan
             plan match {
               case w: CometScanWrapper => containsNativeCometScan(w.originalPlan)
               case scan: CometScanExec => scan.scanImpl == CometConf.SCAN_NATIVE_COMET


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/datafusion-comet/issues/2131

Closes https://github.com/apache/datafusion-comet/issues/2121

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Quick fix to unblock Iceberg integration work. I am working on a real fix to close https://github.com/apache/datafusion-comet/issues/2131 and should have a PR up later this week.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
