### PR TITLE
Tests use default scan

### DIFF
--- a/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
@@ -374,7 +374,10 @@ class CometFuzzTestSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit
       pos: Position): Unit = {
     Seq("native", "jvm").foreach { shuffleMode =>
-      Seq("native_comet", "native_datafusion", "native_iceberg_compat").foreach { scanImpl =>
+      Seq(
+        CometConf.SCAN_NATIVE_COMET,
+        CometConf.SCAN_NATIVE_DATAFUSION,
+        CometConf.SCAN_NATIVE_ICEBERG_COMPAT).foreach { scanImpl =>
         super.test(testName + s" ($scanImpl, $shuffleMode shuffle)", testTags: _*) {
           withSQLConf(
             CometConf.COMET_NATIVE_SCAN_IMPL.key -> scanImpl,

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -86,67 +86,74 @@ abstract class ParquetReadSuite extends CometTestBase {
   }
 
   test("unsupported Spark types") {
-    // for native iceberg compat, CometScanExec supports some types that native_comet does not.
-    // note that native_datafusion does not use CometScanExec so we need not include that in
-    // the check
-    val isDataFusionScan = usingDataSourceExec(conf)
-    Seq(
-      NullType -> false,
-      BooleanType -> true,
-      ByteType -> true,
-      ShortType -> true,
-      IntegerType -> true,
-      LongType -> true,
-      FloatType -> true,
-      DoubleType -> true,
-      BinaryType -> true,
-      StringType -> true,
-      // Timestamp here arbitrary for picking a concrete data type to from ArrayType
-      // Any other type works
-      ArrayType(TimestampType) -> isDataFusionScan,
-      StructType(
-        Seq(
-          StructField("f1", DecimalType.SYSTEM_DEFAULT),
-          StructField("f2", StringType))) -> isDataFusionScan,
-      MapType(keyType = LongType, valueType = DateType) -> isDataFusionScan,
-      StructType(
-        Seq(StructField("f1", ByteType), StructField("f2", StringType))) -> isDataFusionScan,
-      MapType(keyType = IntegerType, valueType = BinaryType) -> isDataFusionScan)
-      .foreach { case (dt, expected) =>
-        val fallbackReasons = new ListBuffer[String]()
-        assert(
-          CometScanTypeChecker(CometConf.COMET_NATIVE_SCAN_IMPL.get())
-            .isTypeSupported(dt, "", fallbackReasons) == expected)
-        // usingDataFusionParquetExec does not support CometBatchScanExec yet
-        if (!isDataFusionScan) {
-          assert(CometBatchScanExec.isTypeSupported(dt, "", fallbackReasons) == expected)
+    withSQLConf(CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_COMET) {
+      // for native iceberg compat, CometScanExec supports some types that native_comet does not.
+      // note that native_datafusion does not use CometScanExec so we need not include that in
+      // the check
+      val isDataFusionScan = usingDataSourceExec(conf)
+      Seq(
+        NullType -> false,
+        BooleanType -> true,
+        ByteType -> true,
+        ShortType -> true,
+        IntegerType -> true,
+        LongType -> true,
+        FloatType -> true,
+        DoubleType -> true,
+        BinaryType -> true,
+        StringType -> true,
+        // Timestamp here arbitrary for picking a concrete data type to from ArrayType
+        // Any other type works
+        ArrayType(TimestampType) -> isDataFusionScan,
+        StructType(
+          Seq(
+            StructField("f1", DecimalType.SYSTEM_DEFAULT),
+            StructField("f2", StringType))) -> isDataFusionScan,
+        MapType(keyType = LongType, valueType = DateType) -> isDataFusionScan,
+        StructType(
+          Seq(StructField("f1", ByteType), StructField("f2", StringType))) -> isDataFusionScan,
+        MapType(keyType = IntegerType, valueType = BinaryType) -> isDataFusionScan)
+        .foreach { case (dt, expected) =>
+          val fallbackReasons = new ListBuffer[String]()
+          assert(
+            CometScanTypeChecker(CometConf.COMET_NATIVE_SCAN_IMPL.get())
+              .isTypeSupported(dt, "", fallbackReasons) == expected)
+          // usingDataFusionParquetExec does not support CometBatchScanExec yet
+          if (!isDataFusionScan) {
+            assert(CometBatchScanExec.isTypeSupported(dt, "", fallbackReasons) == expected)
+          }
         }
-      }
+    }
   }
 
   test("unsupported Spark schema") {
-    val schemaDDLs =
-      Seq("f1 int, f2 boolean", "f1 int, f2 array<int>", "f1 map<long, string>, f2 array<double>")
-        .map(s => StructType.fromDDL(s))
+    withSQLConf(CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_COMET) {
+      val schemaDDLs =
+        Seq(
+          "f1 int, f2 boolean",
+          "f1 int, f2 array<int>",
+          "f1 map<long, string>, f2 array<double>")
+          .map(s => StructType.fromDDL(s))
 
-    // Arrays support for iceberg compat native and for Parquet V1
-    val cometScanExecSupported =
-      if (usingDataSourceExec(conf) && this.isInstanceOf[ParquetReadV1Suite])
-        Seq(true, true, true)
-      else Seq(true, false, false)
+      // Arrays support for iceberg compat native and for Parquet V1
+      val cometScanExecSupported =
+        if (usingDataSourceExec(conf) && this.isInstanceOf[ParquetReadV1Suite])
+          Seq(true, true, true)
+        else Seq(true, false, false)
 
-    val cometBatchScanExecSupported = Seq(true, false, false)
-    val fallbackReasons = new ListBuffer[String]()
+      val cometBatchScanExecSupported = Seq(true, false, false)
+      val fallbackReasons = new ListBuffer[String]()
 
-    schemaDDLs.zip(cometScanExecSupported).foreach { case (schema, expected) =>
-      assert(
-        CometScanTypeChecker(CometConf.COMET_NATIVE_SCAN_IMPL.get())
-          .isSchemaSupported(StructType(schema), fallbackReasons) == expected)
-    }
+      schemaDDLs.zip(cometScanExecSupported).foreach { case (schema, expected) =>
+        assert(
+          CometScanTypeChecker(CometConf.COMET_NATIVE_SCAN_IMPL.get())
+            .isSchemaSupported(StructType(schema), fallbackReasons) == expected)
+      }
 
-    schemaDDLs.zip(cometBatchScanExecSupported).foreach { case (schema, expected) =>
-      assert(
-        CometBatchScanExec.isSchemaSupported(StructType(schema), fallbackReasons) == expected)
+      schemaDDLs.zip(cometBatchScanExecSupported).foreach { case (schema, expected) =>
+        assert(
+          CometBatchScanExec.isSchemaSupported(StructType(schema), fallbackReasons) == expected)
+      }
     }
   }
 
@@ -354,8 +361,6 @@ abstract class ParquetReadSuite extends CometTestBase {
   }
 
   test("test multiple pages with different sizes and nulls") {
-    // https://github.com/apache/datafusion-comet/issues/1441
-    assume(!usingDataSourceExec)
     def makeRawParquetFile(
         path: Path,
         dictionaryEnabled: Boolean,
@@ -425,40 +430,42 @@ abstract class ParquetReadSuite extends CometTestBase {
       expected
     }
 
-    Seq(64, 128, 256, 512, 1024, 4096, 5000).foreach { pageSize =>
-      withTempDir { dir =>
-        val path = new Path(dir.toURI.toString, "part-r-0.parquet")
-        val expected = makeRawParquetFile(path, dictionaryEnabled = false, 10000, pageSize)
-        readParquetFile(path.toString) { df =>
-          checkAnswer(
-            df,
-            expected.map {
-              case None =>
-                Row(null, null, null, null, null, null, null, null, null, null, null, null, null,
-                  null)
-              case Some(i) =>
-                val flba_field = Array.fill(3)(i % 10 + 48) // char '0' is 48 in ascii
-                Row(
-                  i % 2 == 0,
-                  i.toByte,
-                  i.toShort,
-                  i,
-                  i.toLong,
-                  i.toFloat,
-                  i.toDouble,
-                  i.toString * 48,
-                  (-i).toByte,
-                  (-i).toShort,
-                  java.lang.Integer.toUnsignedLong(-i),
-                  new BigDecimal(UnsignedLong.fromLongBits((-i).toLong).bigIntegerValue()),
-                  i.toString,
-                  flba_field)
-            })
-        }
-        readParquetFile(path.toString) { df =>
-          assert(
-            df.filter("_8 IS NOT NULL AND _4 % 256 == 255").count() ==
-              expected.flatten.count(_ % 256 == 255))
+    withSQLConf(CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_COMET) {
+      Seq(64, 128, 256, 512, 1024, 4096, 5000).foreach { pageSize =>
+        withTempDir { dir =>
+          val path = new Path(dir.toURI.toString, "part-r-0.parquet")
+          val expected = makeRawParquetFile(path, dictionaryEnabled = false, 10000, pageSize)
+          readParquetFile(path.toString) { df =>
+            checkAnswer(
+              df,
+              expected.map {
+                case None =>
+                  Row(null, null, null, null, null, null, null, null, null, null, null, null,
+                    null, null)
+                case Some(i) =>
+                  val flba_field = Array.fill(3)(i % 10 + 48) // char '0' is 48 in ascii
+                  Row(
+                    i % 2 == 0,
+                    i.toByte,
+                    i.toShort,
+                    i,
+                    i.toLong,
+                    i.toFloat,
+                    i.toDouble,
+                    i.toString * 48,
+                    (-i).toByte,
+                    (-i).toShort,
+                    java.lang.Integer.toUnsignedLong(-i),
+                    new BigDecimal(UnsignedLong.fromLongBits((-i).toLong).bigIntegerValue()),
+                    i.toString,
+                    flba_field)
+              })
+          }
+          readParquetFile(path.toString) { df =>
+            assert(
+              df.filter("_8 IS NOT NULL AND _4 % 256 == 255").count() ==
+                expected.flatten.count(_ % 256 == 255))
+          }
         }
       }
     }
@@ -1330,51 +1337,51 @@ abstract class ParquetReadSuite extends CometTestBase {
   }
 
   test("scan metrics") {
-    // https://github.com/apache/datafusion-comet/issues/1441
-    assume(CometConf.COMET_NATIVE_SCAN_IMPL.get() != CometConf.SCAN_NATIVE_ICEBERG_COMPAT)
+    withSQLConf(CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_COMET) {
 
-    val cometScanMetricNames = Seq(
-      "ParquetRowGroups",
-      "ParquetNativeDecodeTime",
-      "ParquetNativeLoadTime",
-      "ParquetLoadRowGroupTime",
-      "ParquetInputFileReadTime",
-      "ParquetInputFileReadSize",
-      "ParquetInputFileReadThroughput")
+      val cometScanMetricNames = Seq(
+        "ParquetRowGroups",
+        "ParquetNativeDecodeTime",
+        "ParquetNativeLoadTime",
+        "ParquetLoadRowGroupTime",
+        "ParquetInputFileReadTime",
+        "ParquetInputFileReadSize",
+        "ParquetInputFileReadThroughput")
 
-    val cometNativeScanMetricNames = Seq(
-      "time_elapsed_scanning_total",
-      "bytes_scanned",
-      "output_rows",
-      "time_elapsed_opening",
-      "time_elapsed_processing",
-      "time_elapsed_scanning_until_data")
+      val cometNativeScanMetricNames = Seq(
+        "time_elapsed_scanning_total",
+        "bytes_scanned",
+        "output_rows",
+        "time_elapsed_opening",
+        "time_elapsed_processing",
+        "time_elapsed_scanning_until_data")
 
-    withParquetTable((0 until 10000).map(i => (i, i.toDouble)), "tbl") {
-      val df = sql("SELECT * FROM tbl WHERE _1 > 0")
-      val scans = df.queryExecution.executedPlan collect {
-        case s: CometScanExec => s
-        case s: CometBatchScanExec => s
-        case s: CometNativeScanExec => s
-      }
-      assert(scans.size == 1, s"Expect one scan node but found ${scans.size}")
-      val metrics = scans.head.metrics
+      withParquetTable((0 until 10000).map(i => (i, i.toDouble)), "tbl") {
+        val df = sql("SELECT * FROM tbl WHERE _1 > 0")
+        val scans = df.queryExecution.executedPlan collect {
+          case s: CometScanExec => s
+          case s: CometBatchScanExec => s
+          case s: CometNativeScanExec => s
+        }
+        assert(scans.size == 1, s"Expect one scan node but found ${scans.size}")
+        val metrics = scans.head.metrics
 
-      val metricNames = scans.head match {
-        case _: CometNativeScanExec => cometNativeScanMetricNames
-        case _ => cometScanMetricNames
-      }
+        val metricNames = scans.head match {
+          case _: CometNativeScanExec => cometNativeScanMetricNames
+          case _ => cometScanMetricNames
+        }
 
-      metricNames.foreach { metricName =>
-        assert(metrics.contains(metricName), s"metric $metricName was not found")
-      }
+        metricNames.foreach { metricName =>
+          assert(metrics.contains(metricName), s"metric $metricName was not found")
+        }
 
-      df.collect()
+        df.collect()
 
-      metricNames.foreach { metricName =>
-        assert(
-          metrics(metricName).value > 0,
-          s"Expect metric value for $metricName to be positive")
+        metricNames.foreach { metricName =>
+          assert(
+            metrics(metricName).value > 0,
+            s"Expect metric value for $metricName to be positive")
+        }
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -82,10 +82,6 @@ abstract class CometTestBase
     conf.set(CometConf.COMET_RESPECT_PARQUET_FILTER_PUSHDOWN.key, "true")
     conf.set(CometConf.COMET_SPARK_TO_ARROW_ENABLED.key, "true")
     conf.set(CometConf.COMET_NATIVE_SCAN_ENABLED.key, "true")
-    // set the scan impl to SCAN_NATIVE_COMET because many tests are implemented
-    // with the assumption that this is the default and would need updating if we
-    // change the default
-    conf.set(CometConf.COMET_NATIVE_SCAN_IMPL.key, CometConf.SCAN_NATIVE_COMET)
     conf.set(CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.key, "true")
     conf.set(CometConf.COMET_MEMORY_OVERHEAD.key, "2g")
     conf.set(CometConf.COMET_EXEC_SORT_MERGE_JOIN_WITH_JOIN_FILTER_ENABLED.key, "true")

--- a/spark/src/test/scala/org/apache/spark/sql/comet/CometPlanStabilitySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/CometPlanStabilitySuite.scala
@@ -300,6 +300,7 @@ trait CometPlanStabilitySuite extends DisableAdaptiveExecutionSuite with TPCDSBa
     conf.set(CometConf.COMET_ENABLED.key, "true")
     conf.set(CometConf.COMET_EXEC_ENABLED.key, "true")
     conf.set(CometConf.COMET_NATIVE_SCAN_ENABLED.key, "true")
+    conf.set(CometConf.COMET_NATIVE_SCAN_IMPL.key, CometConf.SCAN_NATIVE_COMET)
     conf.set(CometConf.COMET_MEMORY_OVERHEAD.key, "1g")
     conf.set(CometConf.COMET_EXEC_SHUFFLE_ENABLED.key, "true")
 

--- a/spark/src/test/scala/org/apache/spark/sql/comet/ParquetDatetimeRebaseSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/ParquetDatetimeRebaseSuite.scala
@@ -40,6 +40,7 @@ abstract class ParquetDatetimeRebaseSuite extends CometTestBase {
   test("reading ancient dates before 1582") {
     Seq(true, false).foreach { exceptionOnRebase =>
       withSQLConf(
+        CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_COMET,
         CometConf.COMET_EXCEPTION_ON_LEGACY_DATE_TIMESTAMP.key ->
           exceptionOnRebase.toString) {
         Seq("2_4_5", "2_4_6", "3_2_0").foreach { sparkVersion =>
@@ -65,6 +66,7 @@ abstract class ParquetDatetimeRebaseSuite extends CometTestBase {
     assume(!usingDataSourceExec(conf))
     Seq(true, false).foreach { exceptionOnRebase =>
       withSQLConf(
+        CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_COMET,
         CometConf.COMET_EXCEPTION_ON_LEGACY_DATE_TIMESTAMP.key ->
           exceptionOnRebase.toString) {
         Seq("2_4_5", "2_4_6", "3_2_0").foreach { sparkVersion =>
@@ -91,6 +93,7 @@ abstract class ParquetDatetimeRebaseSuite extends CometTestBase {
     assume(!usingDataSourceExec(conf))
     Seq(true, false).foreach { exceptionOnRebase =>
       withSQLConf(
+        CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_COMET,
         CometConf.COMET_EXCEPTION_ON_LEGACY_DATE_TIMESTAMP.key ->
           exceptionOnRebase.toString) {
         Seq("2_4_5", "2_4_6", "3_2_0").foreach { sparkVersion =>


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/2172

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Comet's default scan implementation is `auto`, so we should use that same default in the test suite.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
