### PR TITLE
fix: use `spark.comet.batchSize` instead of `conf.arrowMaxRecordsPerBatch` for data that is coming from Java

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometSparkToColumnarExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometSparkToColumnarExec.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-import org.apache.comet.DataTypeSupport
+import org.apache.comet.{CometConf, DataTypeSupport}
 
 case class CometSparkToColumnarExec(child: SparkPlan)
     extends RowToColumnarTransition
@@ -94,7 +94,7 @@ case class CometSparkToColumnarExec(child: SparkPlan)
     val numInputRows = longMetric("numInputRows")
     val numOutputBatches = longMetric("numOutputBatches")
     val conversionTime = longMetric("conversionTime")
-    val maxRecordsPerBatch = conf.arrowMaxRecordsPerBatch
+    val maxRecordsPerBatch = CometConf.COMET_BATCH_SIZE.get(conf)
     val timeZoneId = conf.sessionLocalTimeZone
     val schema = child.schema
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

It seems like a mistake that we are passing to native different batch sizes than configured, no?

## What changes are included in this PR?

just

## How are these changes tested?

manually by adding prints in Scan to make sure that it now return the correct batch size, and existing tests for correctness 