### PR TITLE
fix: [branch-0.9] Avoid double free in CometUnifiedShuffleMemoryAllocator

### DIFF
--- a/spark/src/main/java/org/apache/spark/shuffle/comet/CometBoundedShuffleMemoryAllocator.java
+++ b/spark/src/main/java/org/apache/spark/shuffle/comet/CometBoundedShuffleMemoryAllocator.java
@@ -146,18 +146,21 @@ public final class CometBoundedShuffleMemoryAllocator extends CometShuffleMemory
     return block;
   }
 
-  public synchronized void free(MemoryBlock block) {
-    if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER) {
+  public synchronized long free(MemoryBlock block) {
+    if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER
+        || block.pageNumber == MemoryBlock.FREED_IN_TMM_PAGE_NUMBER) {
       // Already freed block
-      return;
+      return 0;
     }
-    allocatedMemory -= block.size();
+    long blockSize = block.size();
+    allocatedMemory -= blockSize;
 
     pageTable[block.pageNumber] = null;
     allocatedPages.clear(block.pageNumber);
     block.pageNumber = MemoryBlock.FREED_IN_TMM_PAGE_NUMBER;
 
     allocator.free(block);
+    return blockSize;
   }
 
   /**

--- a/spark/src/main/java/org/apache/spark/shuffle/comet/CometShuffleMemoryAllocatorTrait.java
+++ b/spark/src/main/java/org/apache/spark/shuffle/comet/CometShuffleMemoryAllocatorTrait.java
@@ -33,7 +33,7 @@ public abstract class CometShuffleMemoryAllocatorTrait extends MemoryConsumer {
 
   public abstract MemoryBlock allocate(long required);
 
-  public abstract void free(MemoryBlock block);
+  public abstract long free(MemoryBlock block);
 
   public abstract long getOffsetInPage(long pagePlusOffsetAddress);
 

--- a/spark/src/main/java/org/apache/spark/shuffle/comet/CometUnifiedShuffleMemoryAllocator.java
+++ b/spark/src/main/java/org/apache/spark/shuffle/comet/CometUnifiedShuffleMemoryAllocator.java
@@ -57,8 +57,15 @@ public final class CometUnifiedShuffleMemoryAllocator extends CometShuffleMemory
     return this.allocatePage(required);
   }
 
-  public synchronized void free(MemoryBlock block) {
+  public synchronized long free(MemoryBlock block) {
+    if (block.pageNumber == MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER
+        || block.pageNumber == MemoryBlock.FREED_IN_TMM_PAGE_NUMBER) {
+      // Already freed block
+      return 0;
+    }
+    long blockSize = block.size();
     this.freePage(block);
+    return blockSize;
   }
 
   /**

--- a/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
+++ b/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
@@ -218,8 +218,7 @@ public abstract class SpillWriter {
   public long freeMemory() {
     long freed = 0L;
     for (MemoryBlock block : allocatedPages) {
-      freed += block.size();
-      allocator.free(block);
+      freed += allocator.free(block);
     }
     allocatedPages.clear();
     currentPage = null;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Backport fix to branch-0.9

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Backport https://github.com/apache/datafusion-comet/pull/2122

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
