### PR TITLE
fix: [iceberg] Fall back to spark for schemas with empty structs

### DIFF
--- a/spark/src/main/scala/org/apache/comet/DataTypeSupport.scala
+++ b/spark/src/main/scala/org/apache/comet/DataTypeSupport.scala
@@ -54,7 +54,7 @@ trait DataTypeSupport {
           TimestampNTZType =>
         true
       case StructType(fields) =>
-        fields.forall(f => isTypeSupported(f.dataType, f.name, fallbackReasons))
+        fields.nonEmpty && fields.forall(f => isTypeSupported(f.dataType, f.name, fallbackReasons))
       case ArrayType(elementType, _) =>
         isTypeSupported(elementType, ARRAY_ELEMENT, fallbackReasons)
       case MapType(keyType, valueType, _) =>

--- a/spark/src/main/scala/org/apache/comet/DataTypeSupport.scala
+++ b/spark/src/main/scala/org/apache/comet/DataTypeSupport.scala
@@ -54,7 +54,8 @@ trait DataTypeSupport {
           TimestampNTZType =>
         true
       case StructType(fields) =>
-        fields.nonEmpty && fields.forall(f => isTypeSupported(f.dataType, f.name, fallbackReasons))
+        fields.nonEmpty && fields.forall(f =>
+          isTypeSupported(f.dataType, f.name, fallbackReasons))
       case ArrayType(elementType, _) =>
         isTypeSupported(elementType, ARRAY_ELEMENT, fallbackReasons)
       case MapType(keyType, valueType, _) =>

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -357,6 +357,8 @@ case class CometScanTypeChecker(scanImpl: String) extends DataTypeSupport {
         false
       case _: StructType | _: ArrayType | _: MapType if scanImpl == CometConf.SCAN_NATIVE_COMET =>
         false
+      case s: StructType if s.fields.isEmpty =>
+        false
       case _ =>
         super.isTypeSupported(dt, name, fallbackReasons)
     }

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -197,8 +197,8 @@ object QueryPlanSerde extends Logging with CometExprShim {
         _: DoubleType | _: StringType | _: BinaryType | _: TimestampType | _: TimestampNTZType |
         _: DecimalType | _: DateType | _: BooleanType | _: NullType =>
       true
-    case s: StructType if allowComplex && s.fields.nonEmpty =>
-      s.fields.map(_.dataType).forall(supportedDataType(_, allowComplex))
+    case s: StructType if allowComplex =>
+      s.fields.nonEmpty && s.fields.map(_.dataType).forall(supportedDataType(_, allowComplex))
     case a: ArrayType if allowComplex =>
       supportedDataType(a.elementType, allowComplex)
     case m: MapType if allowComplex =>

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -197,7 +197,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
         _: DoubleType | _: StringType | _: BinaryType | _: TimestampType | _: TimestampNTZType |
         _: DecimalType | _: DateType | _: BooleanType | _: NullType =>
       true
-    case s: StructType if allowComplex =>
+    case s: StructType if allowComplex && s.fields.nonEmpty =>
       s.fields.map(_.dataType).forall(supportedDataType(_, allowComplex))
     case a: ArrayType if allowComplex =>
       supportedDataType(a.elementType, allowComplex)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/2086

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fall back to Spark for schemas containing empty structs (seems like an artificial edge case)

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

I tested this fix manually with Iceberg