### PR TITLE
fix: Make Sha2 fallback message more user-friendly

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/hash.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/hash.scala
@@ -75,7 +75,7 @@ object CometSha2 extends CometExpressionSerde[Sha2] {
     // It's possible for spark to dynamically compute the number of bits from input
     // expression, however DataFusion does not support that yet.
     if (!expr.right.foldable) {
-      withInfo(expr, "For Sha2, non-foldable right argument is not supported")
+      withInfo(expr, "For Sha2, non literal numBits is not supported")
       return None
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2193 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

With a recent change, the Sha2 fallback message is now not very user-friendly. This PR brings back the older message.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
A simple fallback message change.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
N/A
