### PR TITLE
feat: Reset data buf of NativeBatchDecoderIterator on close

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/NativeBatchDecoderIterator.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/NativeBatchDecoderIterator.scala
@@ -182,6 +182,7 @@ case class NativeBatchDecoderIterator(
           currentBatch = null
         }
         in.close()
+        NativeBatchDecoderIterator.resetDataBuf()
         isClosed = true
       }
     }
@@ -192,4 +193,8 @@ object NativeBatchDecoderIterator {
   private val threadLocalDataBuf: ThreadLocal[ByteBuffer] = ThreadLocal.withInitial(() => {
     ByteBuffer.allocateDirect(128 * 1024)
   })
+
+  private def resetDataBuf(): Unit = {
+    threadLocalDataBuf.set(ByteBuffer.allocateDirect(128 * 1024))
+  }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2234.

## Rationale for this change

`NativeBatchDecoderIterator.threadLocalDataBuf` may be grown at runtime, so we should reset it on close to avoid reserving too much memory.

https://github.com/apache/datafusion-comet/blob/1b344def1be595f8de5d86994dddb029ef68f20a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/NativeBatchDecoderIterator.scala#L145-L152

## What changes are included in this PR?

Reset data buf of NativeBatchDecoderIterator on close

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
