### PR TITLE
fix: Fall back to `native_comet` when object store not supported by `native_iceberg_compat`

### DIFF
--- a/common/src/main/java/org/apache/comet/parquet/Native.java
+++ b/common/src/main/java/org/apache/comet/parquet/Native.java
@@ -247,7 +247,7 @@ public final class Native extends NativeBase {
    * @param filePath
    * @return true if the object store is supported
    */
-  public static native boolean isValidObjectStore(
+  public static native void validateObjectStoreConfig(
       String filePath, Map<String, String> objectStoreOptions);
 
   /**

--- a/common/src/main/java/org/apache/comet/parquet/Native.java
+++ b/common/src/main/java/org/apache/comet/parquet/Native.java
@@ -242,8 +242,8 @@ public final class Native extends NativeBase {
   //      Add batch size, datetimeRebaseModeSpec, metrics(how?)...
 
   /**
-   * Verify that object store options are valid. An exception
-   * will be thrown if the provided options are not valid.
+   * Verify that object store options are valid. An exception will be thrown if the provided options
+   * are not valid.
    */
   public static native void validateObjectStoreConfig(
       String filePath, Map<String, String> objectStoreOptions);

--- a/common/src/main/java/org/apache/comet/parquet/Native.java
+++ b/common/src/main/java/org/apache/comet/parquet/Native.java
@@ -243,9 +243,6 @@ public final class Native extends NativeBase {
 
   /**
    * Verify that object store options are valid.
-   *
-   * @param filePath
-   * @return true if the object store is supported
    */
   public static native void validateObjectStoreConfig(
       String filePath, Map<String, String> objectStoreOptions);

--- a/common/src/main/java/org/apache/comet/parquet/Native.java
+++ b/common/src/main/java/org/apache/comet/parquet/Native.java
@@ -242,6 +242,15 @@ public final class Native extends NativeBase {
   //      Add batch size, datetimeRebaseModeSpec, metrics(how?)...
 
   /**
+   * Verify that object store options are valid.
+   *
+   * @param filePath
+   * @return true if the object store is supported
+   */
+  public static native boolean isValidObjectStore(
+      String filePath, Map<String, String> objectStoreOptions);
+
+  /**
    * Initialize a record batch reader for a PartitionedFile
    *
    * @param filePath

--- a/common/src/main/java/org/apache/comet/parquet/Native.java
+++ b/common/src/main/java/org/apache/comet/parquet/Native.java
@@ -242,7 +242,8 @@ public final class Native extends NativeBase {
   //      Add batch size, datetimeRebaseModeSpec, metrics(how?)...
 
   /**
-   * Verify that object store options are valid.
+   * Verify that object store options are valid. An exception
+   * will be thrown if the provided options are not valid.
    */
   public static native void validateObjectStoreConfig(
       String filePath, Map<String, String> objectStoreOptions);

--- a/docs/source/user-guide/compatibility.md
+++ b/docs/source/user-guide/compatibility.md
@@ -73,6 +73,11 @@ The `native_datafusion` scan has some additional limitations:
 [#1545]: https://github.com/apache/datafusion-comet/issues/1545
 [#1758]: https://github.com/apache/datafusion-comet/issues/1758
 
+### S3 Support with `native_iceberg_compat`
+
+- When using the default AWS S3 endpoint (no custom endpoint configured), a valid region is required. Comet 
+  will attempt to resolve the region if it is not provided.
+
 ## ANSI Mode
 
 Comet will fall back to Spark for the following expressions when ANSI mode is enabled, unless

--- a/native/core/src/parquet/mod.rs
+++ b/native/core/src/parquet/mod.rs
@@ -677,9 +677,9 @@ pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_validateObjec
 ) {
     try_unwrap_or_throw(&e, |mut env| unsafe {
         let session_config = SessionConfig::new();
-        let planer =
+        let planner =
             PhysicalPlanner::new(Arc::new(SessionContext::new_with_config(session_config)), 0);
-        let session_ctx = planer.session_ctx();
+        let session_ctx = planner.session_ctx();
         let path: String = env
             .get_string(&JString::from_raw(file_path))
             .unwrap()
@@ -715,9 +715,9 @@ pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_initRecordBat
 ) -> jlong {
     try_unwrap_or_throw(&e, |mut env| unsafe {
         let session_config = SessionConfig::new().with_batch_size(batch_size as usize);
-        let planer =
+        let planner =
             PhysicalPlanner::new(Arc::new(SessionContext::new_with_config(session_config)), 0);
-        let session_ctx = planer.session_ctx();
+        let session_ctx = planner.session_ctx();
 
         let path: String = env
             .get_string(&JString::from_raw(file_path))
@@ -745,7 +745,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_initRecordBat
             let filter_buffer = env.convert_byte_array(&filter_array)?;
             let filter_expr = serde::deserialize_expr(filter_buffer.as_slice())?;
             Some(vec![
-                planer.create_expr(&filter_expr, Arc::clone(&data_schema))?
+                planner.create_expr(&filter_expr, Arc::clone(&data_schema))?
             ])
         } else {
             None

--- a/native/core/src/parquet/mod.rs
+++ b/native/core/src/parquet/mod.rs
@@ -674,7 +674,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_isValidObject
     _jclass: JClass,
     file_path: jstring,
     object_store_options: jobject,
-) -> jboolean {
+) {
     try_unwrap_or_throw(&e, |mut env| unsafe {
         let session_config = SessionConfig::new();
         let planer =
@@ -691,7 +691,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_isValidObject
             path.clone(),
             &object_store_config,
         )?;
-        Ok(1)
+        Ok(())
     })
 }
 

--- a/native/core/src/parquet/mod.rs
+++ b/native/core/src/parquet/mod.rs
@@ -669,7 +669,7 @@ pub fn get_object_store_options(
 /// # Safety
 /// This function is inherently unsafe since it deals with raw pointers passed from JNI.
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_isValidObjectStore(
+pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_validateObjectStoreConfig(
     e: JNIEnv,
     _jclass: JClass,
     file_path: jstring,

--- a/native/core/src/parquet/mod.rs
+++ b/native/core/src/parquet/mod.rs
@@ -669,6 +669,35 @@ pub fn get_object_store_options(
 /// # Safety
 /// This function is inherently unsafe since it deals with raw pointers passed from JNI.
 #[no_mangle]
+pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_isValidObjectStore(
+    e: JNIEnv,
+    _jclass: JClass,
+    file_path: jstring,
+    object_store_options: jobject,
+) -> jboolean {
+    try_unwrap_or_throw(&e, |mut env| unsafe {
+        let session_config = SessionConfig::new();
+        let planer =
+            PhysicalPlanner::new(Arc::new(SessionContext::new_with_config(session_config)), 0);
+        let session_ctx = planer.session_ctx();
+        let path: String = env
+            .get_string(&JString::from_raw(file_path))
+            .unwrap()
+            .into();
+        let object_store_config =
+            get_object_store_options(&mut env, JObject::from_raw(object_store_options))?;
+        let (_, _) = prepare_object_store_with_configs(
+            session_ctx.runtime_env(),
+            path.clone(),
+            &object_store_config,
+        )?;
+        Ok(1)
+    })
+}
+
+/// # Safety
+/// This function is inherently unsafe since it deals with raw pointers passed from JNI.
+#[no_mangle]
 pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_initRecordBatchReader(
     e: JNIEnv,
     _jclass: JClass,

--- a/native/core/src/parquet/objectstore/s3.rs
+++ b/native/core/src/parquet/objectstore/s3.rs
@@ -68,6 +68,12 @@ pub fn create_store(
     }
     let path = Path::parse(path)?;
 
+    if configs.contains_key("fs.s3a.endpoint") {
+        return Err(object_store::Error::NotSupported {
+            source: "Custom S3 endpoints are not supported".into(),
+        });
+    }
+
     let mut builder = AmazonS3Builder::new()
         .with_url(url.to_string())
         .with_allow_http(true);

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -308,7 +308,7 @@ case class CometScanRule(session: SparkSession) extends Rule[SparkPlan] with Com
           Native.validateObjectStoreConfig(filePath, objectStoreOptions)
         } catch {
           case e: Exception =>
-            fallbackReasons += s"Object store config not supported by " +
+            fallbackReasons += "Object store config not supported by " +
               s"$SCAN_NATIVE_ICEBERG_COMPAT: ${e.getMessage}"
         }
       }

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -427,11 +427,12 @@ object CometScanRule extends Logging {
       configValidityMap.clear()
     }
 
-    val maybeMaybeString: Option[Option[String]] = configValidityMap.get(cacheKey)
-    maybeMaybeString match {
-      case Some(reason) =>
-        fallbackReasons += reason.get
-        throw new CometNativeException(reason.get)
+    configValidityMap.get(cacheKey) match {
+      case Some(Some(reason)) =>
+        fallbackReasons += reason
+        throw new CometNativeException(reason)
+      case Some(None) =>
+      // previously validated
       case _ =>
         try {
           val objectStoreOptions = JavaConverters.mapAsJavaMap(objectStoreConfigMap)

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -304,8 +304,11 @@ case class CometScanRule(session: SparkSession) extends Rule[SparkPlan] with Com
       JavaConverters.mapAsJavaMap(
         NativeConfig.extractObjectStoreOptions(session.sparkContext.hadoopConfiguration, URI.create(filePath)));
 
-    if (!Native.isValidObjectStore(filePath, objectStoreOptions)) {
-      fallbackReasons += s"Object store config not supported by $SCAN_NATIVE_ICEBERG_COMPAT"
+    try {
+      Native.validateObjectStoreConfig(filePath, objectStoreOptions)
+    } catch {
+      case e: Exception =>
+        fallbackReasons += s"Object store config not supported by $SCAN_NATIVE_ICEBERG_COMPAT: ${e.getMessage}"
     }
 
     val typeChecker = CometScanTypeChecker(SCAN_NATIVE_ICEBERG_COMPAT)

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -295,15 +295,13 @@ case class CometScanRule(session: SparkSession) extends Rule[SparkPlan] with Com
     if (scanExec.relation.inputFiles
         .forall(path => path.startsWith("file://") || path.startsWith("s3a://"))) {
 
-      val filePath = scanExec.relation.inputFiles.head
-      if (filePath.startsWith("s3a://")) {
-
+      val filePath = scanExec.relation.inputFiles.headOption
+      if (filePath.exists(_.startsWith("s3a://"))) {
         val objectStoreOptions =
           JavaConverters.mapAsJavaMap(
             NativeConfig.extractObjectStoreOptions(
               session.sparkContext.hadoopConfiguration,
-              URI.create(filePath)))
-
+              URI.create(filePath.get)))
         try {
           Native.validateObjectStoreConfig(filePath, objectStoreOptions)
         } catch {

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -24,7 +24,6 @@ import java.net.URI
 import scala.collection.JavaConverters
 import scala.collection.mutable.ListBuffer
 
-import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, GenericInternalRow, PlanExpression}
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -302,13 +301,16 @@ case class CometScanRule(session: SparkSession) extends Rule[SparkPlan] with Com
 
     val objectStoreOptions =
       JavaConverters.mapAsJavaMap(
-        NativeConfig.extractObjectStoreOptions(session.sparkContext.hadoopConfiguration, URI.create(filePath)));
+        NativeConfig.extractObjectStoreOptions(
+          session.sparkContext.hadoopConfiguration,
+          URI.create(filePath)))
 
     try {
       Native.validateObjectStoreConfig(filePath, objectStoreOptions)
     } catch {
       case e: Exception =>
-        fallbackReasons += s"Object store config not supported by $SCAN_NATIVE_ICEBERG_COMPAT: ${e.getMessage}"
+        fallbackReasons += s"Object store config not supported by " +
+          s"$SCAN_NATIVE_ICEBERG_COMPAT: ${e.getMessage}"
     }
 
     val typeChecker = CometScanTypeChecker(SCAN_NATIVE_ICEBERG_COMPAT)

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -300,11 +300,9 @@ case class CometScanRule(session: SparkSession) extends Rule[SparkPlan] with Com
 
     val filePath = scanExec.relation.inputFiles.head
 
-    // TODO how to get Hadoop config from driver?
-    val conf = new Configuration()
     val objectStoreOptions =
       JavaConverters.mapAsJavaMap(
-        NativeConfig.extractObjectStoreOptions(conf, URI.create(filePath)));
+        NativeConfig.extractObjectStoreOptions(session.sparkContext.hadoopConfiguration, URI.create(filePath)));
 
     if (!Native.isValidObjectStore(filePath, objectStoreOptions)) {
       fallbackReasons += s"Object store config not supported by $SCAN_NATIVE_ICEBERG_COMPAT"

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -303,7 +303,7 @@ case class CometScanRule(session: SparkSession) extends Rule[SparkPlan] with Com
               session.sparkContext.hadoopConfiguration,
               URI.create(filePath.get)))
         try {
-          Native.validateObjectStoreConfig(filePath, objectStoreOptions)
+          Native.validateObjectStoreConfig(filePath.get, objectStoreOptions)
         } catch {
           case e: Exception =>
             fallbackReasons += "Object store config not supported by " +

--- a/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
@@ -78,13 +78,17 @@ class NativeConfigSuite extends AnyFunSuite with Matchers {
 
   test("validate object store config - no provider") {
     val config: Map[String, String] = Map.empty
-    Native.validateObjectStoreConfig("s3a://path/to/file.parquet", JavaConverters.mapAsJavaMap(config))
+    Native.validateObjectStoreConfig(
+      "s3a://path/to/file.parquet",
+      JavaConverters.mapAsJavaMap(config))
   }
 
   test("validate object store config - invalid provider") {
     val config = Map("fs.s3a.aws.credentials.provider" -> "invalid")
     val e = intercept[CometNativeException] {
-      Native.validateObjectStoreConfig("s3a://path/to/file.parquet", JavaConverters.mapAsJavaMap(config))
+      Native.validateObjectStoreConfig(
+        "s3a://path/to/file.parquet",
+        JavaConverters.mapAsJavaMap(config))
     }
     assert(e.getMessage != null && e.getMessage.contains("Unsupported credential provider"))
   }

--- a/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
@@ -76,11 +76,16 @@ class NativeConfigSuite extends AnyFunSuite with Matchers {
     assert(unsupportedOptions.isEmpty, "Unsupported scheme should return empty options")
   }
 
+  test("validate object store config - no provider") {
+    val config: Map[String, String] = Map.empty
+    Native.validateObjectStoreConfig("s3a://path/to/file.parquet", JavaConverters.mapAsJavaMap(config))
+  }
+
   test("validate object store config - invalid provider") {
-    val config = Map("aws.credentials.provider" -> "invalid")
+    val config = Map("fs.s3a.aws.credentials.provider" -> "invalid")
     val e = intercept[CometNativeException] {
-      Native.validateObjectStoreConfig("path_tbd", JavaConverters.mapAsJavaMap(config))
+      Native.validateObjectStoreConfig("s3a://path/to/file.parquet", JavaConverters.mapAsJavaMap(config))
     }
-    assert(e.getMessage != null && e.getMessage.contains("tbd"))
+    assert(e.getMessage != null && e.getMessage.contains("Unsupported credential provider"))
   }
 }

--- a/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
@@ -103,6 +103,17 @@ class NativeConfigSuite extends AnyFunSuite with Matchers {
     assert(e.getMessage.contains(expectedError))
   }
 
+  test("validate object store config - custom s3 endpoint not supported") {
+    val hadoopConf = new Configuration()
+    hadoopConf.set("fs.s3a.endpoint", "https://acme.storage.com")
+    val e = intercept[CometNativeException] {
+      validate(hadoopConf)
+    }
+    val expectedError =
+      "Custom S3 endpoints are not supported"
+    assert(e.getMessage.contains(expectedError))
+  }
+
   private def validate(hadoopConf: Configuration): Unit = {
     val path = "s3a://path/to/file.parquet"
     val configMap = NativeConfig.extractObjectStoreOptions(hadoopConf, URI.create(path))

--- a/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
@@ -81,6 +81,14 @@ class NativeConfigSuite extends AnyFunSuite with Matchers {
     validate(hadoopConf)
   }
 
+  test("validate object store config - valid providers") {
+    val hadoopConf = new Configuration()
+    val provider1 = "com.amazonaws.auth.EnvironmentVariableCredentialsProvider"
+    val provider2 = "com.amazonaws.auth.WebIdentityTokenCredentialsProvider"
+    hadoopConf.set("fs.s3a.aws.credentials.provider", Seq(provider1, provider2).mkString(","))
+    validate(hadoopConf)
+  }
+
   test("validate object store config - invalid provider") {
     val hadoopConf = new Configuration()
     hadoopConf.set("fs.s3a.aws.credentials.provider", "invalid")

--- a/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
@@ -21,10 +21,15 @@ package org.apache.comet.objectstore
 
 import java.net.URI
 
+import scala.collection.JavaConverters
+
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 import org.apache.hadoop.conf.Configuration
+
+import org.apache.comet.CometNativeException
+import org.apache.comet.parquet.Native
 
 class NativeConfigSuite extends AnyFunSuite with Matchers {
 
@@ -69,5 +74,13 @@ class NativeConfigSuite extends AnyFunSuite with Matchers {
       hadoopConf,
       new URI("unsupported://test-bucket/test-object"))
     assert(unsupportedOptions.isEmpty, "Unsupported scheme should return empty options")
+  }
+
+  test("validate object store config - invalid provider") {
+    val config = Map("aws.credentials.provider" -> "invalid")
+    val e = intercept[CometNativeException] {
+      Native.validateObjectStoreConfig("path_tbd", JavaConverters.mapAsJavaMap(config))
+    }
+    assert(e.getMessage != null && e.getMessage.contains("tbd"))
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/2248

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Check that S3 object store configs are valid at planning time rather than at execution time. Fall back to `native_comet` if object store configs are not valid for `native_iceberg_compat`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
