### PR TITLE
fix: Remove unreachable code in `CometScanRule`

### DIFF
--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -307,10 +307,7 @@ case class CometScanRule(session: SparkSession) extends Rule[SparkPlan] with Com
           // maps containing complex types are not supported
           isComplexType(m.keyType) || isComplexType(m.valueType) ||
           hasUnsupportedType(m.keyType) || hasUnsupportedType(m.valueType)
-        case dt => isStringCollationType(dt)
-        case _: StringType =>
-          // we only support `case object StringType` and not other instances of `class StringType`
-          dataType != StringType
+        case dt if isStringCollationType(dt) => true
         case _ => false
       }
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Fix this compiler warning (introduced in https://github.com/apache/datafusion-comet/pull/1975):

```
CometScanRule.scala:327: unreachable code due to variable pattern 'dt' on line 310
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
