### PR TITLE
chore: Introduce `strict-warning` profile for Scala

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -718,6 +718,30 @@ under the License.
         </pluginManagement>
       </build>
     </profile>
+    <profile>
+          <id>strict-warnings</id>
+          <build>
+              <plugins>
+                  <plugin>
+                      <groupId>net.alchim31.maven</groupId>
+                      <artifactId>scala-maven-plugin</artifactId>
+                      <configuration>
+                          <args>
+                              <arg>-deprecation</arg>
+                              <arg>-unchecked</arg>
+                              <arg>-feature</arg>
+                              <arg>-Xlint:_</arg>
+                              <arg>-Ywarn-dead-code</arg>
+                              <arg>-Ywarn-numeric-widen</arg>
+                              <arg>-Ywarn-value-discard</arg>
+                              <arg>-Ywarn-unused:imports,patvars,privates,locals,params,-implicits</arg>
+                              <arg>-Xfatal-warnings</arg>
+                          </args>
+                      </configuration>
+                  </plugin>
+              </plugins>
+          </build>
+    </profile>
   </profiles>
 
   <build>


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Follow up on https://github.com/apache/datafusion-comet/pull/2252#pullrequestreview-3162500690.

## Rationale for this change

Create a profile `strict-warning` which will fail on Scala code warns, keeping the code hygiene

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
