### PR TITLE
chore: Refactor `hex`/`unhex` SerDe to avoid code duplication

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -189,6 +189,8 @@ object QueryPlanSerde extends Logging with CometExprShim {
     classOf[Log] -> CometLog,
     classOf[Log10] -> CometLog10,
     classOf[Log2] -> CometLog2,
+    classOf[Hex] -> CometHex,
+    classOf[Unhex] -> CometUnhex,
     classOf[Pow] -> CometScalarFunction[Pow]("pow"),
     classOf[If] -> CometIf,
     classOf[CaseWhen] -> CometCaseWhen)
@@ -1014,23 +1016,6 @@ object QueryPlanSerde extends Logging with CometExprShim {
 //            withInfo(expr, child)
 //            None
 //          }
-
-      case Hex(child) =>
-        val childExpr = exprToProtoInternal(child, inputs, binding)
-        val optExpr =
-          scalarFunctionExprToProtoWithReturnType("hex", StringType, childExpr)
-
-        optExprWithInfo(optExpr, expr, child)
-
-      case e: Unhex =>
-        val unHex = unhexSerde(e)
-
-        val childExpr = exprToProtoInternal(unHex._1, inputs, binding)
-        val failOnErrorExpr = exprToProtoInternal(unHex._2, inputs, binding)
-
-        val optExpr =
-          scalarFunctionExprToProtoWithReturnType("unhex", e.dataType, childExpr, failOnErrorExpr)
-        optExprWithInfo(optExpr, expr, unHex._1)
 
       case RegExpReplace(subject, pattern, replacement, startPosition) =>
         if (!RegExp.isSupportedPattern(pattern.toString) &&

--- a/spark/src/main/scala/org/apache/comet/serde/math.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/math.scala
@@ -20,7 +20,7 @@
 package org.apache.comet.serde
 
 import org.apache.spark.sql.catalyst.expressions.{Atan2, Attribute, Ceil, Expression, Floor, Hex, If, LessThanOrEqual, Literal, Log, Log10, Log2, Unhex}
-import org.apache.spark.sql.types.{DecimalType, StringType}
+import org.apache.spark.sql.types.DecimalType
 
 import org.apache.comet.CometSparkSessionExtensions.withInfo
 import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, optExprWithInfo, scalarFunctionExprToProto, scalarFunctionExprToProtoWithReturnType}
@@ -118,7 +118,7 @@ object CometHex extends CometExpressionSerde[Hex] with MathExprBase {
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
     val childExpr = exprToProtoInternal(expr.child, inputs, binding)
-    val optExpr = scalarFunctionExprToProtoWithReturnType("hex", StringType, childExpr)
+    val optExpr = scalarFunctionExprToProtoWithReturnType("hex", expr.dataType, childExpr)
     optExprWithInfo(optExpr, expr, expr.child)
   }
 }

--- a/spark/src/main/scala/org/apache/comet/serde/math.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/math.scala
@@ -128,21 +128,12 @@ object CometUnhex extends CometExpressionSerde[Unhex] with MathExprBase {
       expr: Unhex,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val unHex = unhexSerde(expr)
-
-    val childExpr = exprToProtoInternal(unHex._1, inputs, binding)
-    val failOnErrorExpr = exprToProtoInternal(unHex._2, inputs, binding)
+    val childExpr = exprToProtoInternal(expr.child, inputs, binding)
+    val failOnErrorExpr = exprToProtoInternal(Literal(expr.failOnError), inputs, binding)
 
     val optExpr =
       scalarFunctionExprToProtoWithReturnType("unhex", expr.dataType, childExpr, failOnErrorExpr)
-    optExprWithInfo(optExpr, expr, unHex._1)
-  }
-
-  /**
-   * Returns a tuple of expressions for the `unhex` function.
-   */
-  private def unhexSerde(unhex: Unhex): (Expression, Expression) = {
-    (unhex.child, Literal(unhex.failOnError))
+    optExprWithInfo(optExpr, expr, expr.child)
   }
 }
 

--- a/spark/src/main/spark-3.4/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-3.4/org/apache/comet/shims/CometExprShim.scala
@@ -24,16 +24,9 @@ import org.apache.comet.serde.ExprOuterClass.Expr
 import org.apache.spark.sql.catalyst.expressions._
 
 /**
- * `CometExprShim` acts as a shim for for parsing expressions from different Spark versions.
+ * `CometExprShim` acts as a shim for parsing expressions from different Spark versions.
  */
 trait CometExprShim extends CommonStringExprs {
-    /**
-     * Returns a tuple of expressions for the `unhex` function.
-     */
-    protected def unhexSerde(unhex: Unhex): (Expression, Expression) = {
-        (unhex.child, Literal(unhex.failOnError))
-    }
-
     protected def evalMode(c: Cast): CometEvalMode.Value =
         CometEvalModeUtil.fromSparkEvalMode(c.evalMode)
 

--- a/spark/src/main/spark-3.5/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-3.5/org/apache/comet/shims/CometExprShim.scala
@@ -24,16 +24,9 @@ import org.apache.comet.serde.ExprOuterClass.Expr
 import org.apache.spark.sql.catalyst.expressions._
 
 /**
- * `CometExprShim` acts as a shim for for parsing expressions from different Spark versions.
+ * `CometExprShim` acts as a shim for parsing expressions from different Spark versions.
  */
 trait CometExprShim extends CommonStringExprs {
-    /**
-     * Returns a tuple of expressions for the `unhex` function.
-     */
-    protected def unhexSerde(unhex: Unhex): (Expression, Expression) = {
-        (unhex.child, Literal(unhex.failOnError))
-    }
-
     protected def evalMode(c: Cast): CometEvalMode.Value =
         CometEvalModeUtil.fromSparkEvalMode(c.evalMode)
 

--- a/spark/src/main/spark-4.0/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-4.0/org/apache/comet/shims/CometExprShim.scala
@@ -27,16 +27,9 @@ import org.apache.spark.sql.internal.types.StringTypeWithCollation
 import org.apache.spark.sql.types.{BinaryType, BooleanType, StringType}
 
 /**
- * `CometExprShim` acts as a shim for for parsing expressions from different Spark versions.
+ * `CometExprShim` acts as a shim for parsing expressions from different Spark versions.
  */
 trait CometExprShim extends CommonStringExprs {
-    /**
-     * Returns a tuple of expressions for the `unhex` function.
-     */
-    protected def unhexSerde(unhex: Unhex): (Expression, Expression) = {
-        (unhex.child, Literal(unhex.failOnError))
-    }
-
     protected def evalMode(c: Cast): CometEvalMode.Value =
         CometEvalModeUtil.fromSparkEvalMode(c.evalMode)
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/datafusion-comet/issues/2019

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
 - Reduce the complexity of `QueryPlanSerde.scala`

## What changes are included in this PR?

Make use of Comet's `hex` and `unhex` expressions.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

`CometExpressionSuite` and other unit tests passed.
