### PR TITLE
fix: Remove check for custom S3 endpoints

### DIFF
--- a/native/core/src/parquet/objectstore/s3.rs
+++ b/native/core/src/parquet/objectstore/s3.rs
@@ -68,12 +68,6 @@ pub fn create_store(
     }
     let path = Path::parse(path)?;
 
-    if configs.contains_key("fs.s3a.endpoint") {
-        return Err(object_store::Error::NotSupported {
-            source: "Custom S3 endpoints are not supported".into(),
-        });
-    }
-
     let mut builder = AmazonS3Builder::new()
         .with_url(url.to_string())
         .with_allow_http(true);

--- a/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
@@ -117,17 +117,6 @@ class NativeConfigSuite extends AnyFunSuite with Matchers with BeforeAndAfterEac
     assert(e.getMessage.contains(expectedError))
   }
 
-  test("validate object store config - custom s3 endpoint not supported") {
-    val hadoopConf = new Configuration()
-    hadoopConf.set("fs.s3a.endpoint", "https://acme.storage.com")
-    val e = intercept[CometNativeException] {
-      validate(hadoopConf)
-    }
-    val expectedError =
-      "Custom S3 endpoints are not supported"
-    assert(e.getMessage.contains(expectedError))
-  }
-
   test("validity cache") {
     val hadoopConf = new Configuration()
     hadoopConf.set("fs.s3a.endpoint", "https://acme.storage.com")


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This functionality was incorrect. The validation logic was not checking for a custom S3 endpoint. It was just checking whether an S3 endpoint was specified. It would cause an error even when specifying the default AWS S3 endpoint.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
