### PR TITLE
chore: Refactor serde for named expressions `alias` and `attributeReference`

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/namedExpressions.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/namedExpressions.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.serde
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, BindReferences, BoundReference}
+
+import org.apache.comet.CometSparkSessionExtensions.withInfo
+import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, serializeDataType}
+
+object CometAlias extends CometExpressionSerde[Alias] {
+  override def convert(
+      a: Alias,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    val r = exprToProtoInternal(a.child, inputs, binding)
+    if (r.isEmpty) {
+      withInfo(a, a.child)
+    }
+    r
+  }
+}
+
+object CometAttributeReference extends CometExpressionSerde[AttributeReference] {
+  override def convert(
+      attr: AttributeReference,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    val dataType = serializeDataType(attr.dataType)
+
+    if (dataType.isDefined) {
+      if (binding) {
+        // Spark may produce unresolvable attributes in some cases,
+        // for example https://github.com/apache/datafusion-comet/issues/925.
+        // So, we allow the binding to fail.
+        val boundRef: Any = BindReferences
+          .bindReference(attr, inputs, allowFailures = true)
+
+        if (boundRef.isInstanceOf[AttributeReference]) {
+          withInfo(attr, s"cannot resolve $attr among ${inputs.mkString(", ")}")
+          return None
+        }
+
+        val boundExpr = ExprOuterClass.BoundReference
+          .newBuilder()
+          .setIndex(boundRef.asInstanceOf[BoundReference].ordinal)
+          .setDatatype(dataType.get)
+          .build()
+
+        Some(
+          ExprOuterClass.Expr
+            .newBuilder()
+            .setBound(boundExpr)
+            .build())
+      } else {
+        val unboundRef = ExprOuterClass.UnboundReference
+          .newBuilder()
+          .setName(attr.name)
+          .setDatatype(dataType.get)
+          .build()
+
+        Some(
+          ExprOuterClass.Expr
+            .newBuilder()
+            .setUnbound(unboundRef)
+            .build())
+      }
+    } else {
+      withInfo(attr, s"unsupported datatype: ${attr.dataType}")
+      None
+    }
+
+  }
+}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/datafusion-comet/issues/2019

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

See https://github.com/apache/datafusion-comet/issues/2019 for motivation

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Refactors `alias` and `attributeReference`.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
