### PR TITLE
minor: Improve exception message for unimplemented CometVector methods

### DIFF
--- a/common/src/main/java/org/apache/comet/vector/CometVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometVector.java
@@ -22,8 +22,6 @@ package org.apache.comet.vector;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
-import org.jetbrains.annotations.NotNull;
-
 import org.apache.arrow.vector.FixedWidthVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.ListVector;
@@ -264,7 +262,7 @@ public abstract class CometVector extends ColumnVector {
     return getVector(vector, useDecimal128, null);
   }
 
-  private @NotNull UnsupportedOperationException notImplementedException() {
+  private UnsupportedOperationException notImplementedException() {
     return new UnsupportedOperationException(
         "CometVector subclass " + this.getClass().getName() + " does not implement this method");
   }

--- a/common/src/main/java/org/apache/comet/vector/CometVector.java
+++ b/common/src/main/java/org/apache/comet/vector/CometVector.java
@@ -22,6 +22,8 @@ package org.apache.comet.vector;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
+import org.jetbrains.annotations.NotNull;
+
 import org.apache.arrow.vector.FixedWidthVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.ListVector;
@@ -143,66 +145,66 @@ public abstract class CometVector extends ColumnVector {
 
   @Override
   public boolean getBoolean(int rowId) {
-    throw new UnsupportedOperationException("Not yet supported");
+    throw notImplementedException();
   }
 
   @Override
   public byte getByte(int rowId) {
-    throw new UnsupportedOperationException("Not yet supported");
+    throw notImplementedException();
   }
 
   @Override
   public short getShort(int rowId) {
-    throw new UnsupportedOperationException("Not yet supported");
+    throw notImplementedException();
   }
 
   @Override
   public int getInt(int rowId) {
-    throw new UnsupportedOperationException("Not yet supported");
+    throw notImplementedException();
   }
 
   @Override
   public long getLong(int rowId) {
-    throw new UnsupportedOperationException("Not yet supported");
+    throw notImplementedException();
   }
 
   public long getLongDecimal(int rowId) {
-    throw new UnsupportedOperationException("Not yet supported");
+    throw notImplementedException();
   }
 
   @Override
   public float getFloat(int rowId) {
-    throw new UnsupportedOperationException("Not yet supported");
+    throw notImplementedException();
   }
 
   @Override
   public double getDouble(int rowId) {
-    throw new UnsupportedOperationException("Not yet supported");
+    throw notImplementedException();
   }
 
   @Override
   public UTF8String getUTF8String(int rowId) {
-    throw new UnsupportedOperationException("Not yet supported");
+    throw notImplementedException();
   }
 
   @Override
   public byte[] getBinary(int rowId) {
-    throw new UnsupportedOperationException("Not yet supported");
+    throw notImplementedException();
   }
 
   @Override
   public ColumnarArray getArray(int i) {
-    throw new UnsupportedOperationException("Not yet supported");
+    throw notImplementedException();
   }
 
   @Override
   public ColumnarMap getMap(int i) {
-    throw new UnsupportedOperationException("Not yet supported");
+    throw notImplementedException();
   }
 
   @Override
   public ColumnVector getChild(int i) {
-    throw new UnsupportedOperationException("Not yet supported");
+    throw notImplementedException();
   }
 
   @Override
@@ -260,5 +262,10 @@ public abstract class CometVector extends ColumnVector {
 
   protected static CometVector getVector(ValueVector vector, boolean useDecimal128) {
     return getVector(vector, useDecimal128, null);
+  }
+
+  private @NotNull UnsupportedOperationException notImplementedException() {
+    return new UnsupportedOperationException(
+        "CometVector subclass " + this.getClass().getName() + " does not implement this method");
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I am running into the following error:

```
java.lang.UnsupportedOperationException: Not yet supported
	at org.apache.comet.vector.CometVector.getLong(CometVector.java:166)
```

This error is not very helpful because it does not tell me which subclass of `CometVector` is being invoked. I would like the error to be more helpful.

With the changes in this PR:

```
java.lang.UnsupportedOperationException: CometVector subclass org.apache.comet.vector.CometListVector does not implement this method
	at org.apache.comet.vector.CometVector.notImplementedException(CometVector.java:267)
	at org.apache.comet.vector.CometVector.getLong(CometVector.java:166)
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
