### PR TITLE
feat: Improve some confusing fallback reasons

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -396,6 +396,13 @@ object CometSparkSessionExtensions extends Logging {
     withInfos(node, Set.empty, exprs: _*)
   }
 
+  /**
+   * Checks whether a TreeNode has any explain information attached
+   */
+  def hasExplainInfo(node: TreeNode[_]): Boolean = {
+    node.getTagValue(CometExplainInfo.EXTENSION_INFO).exists(_.nonEmpty)
+  }
+
   // Helper to reduce boilerplate
   def createMessage(condition: Boolean, message: => String): Option[String] = {
     if (condition) {

--- a/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
@@ -540,8 +540,13 @@ case class CometExecRule(session: SparkSession) extends Rule[SparkPlan] {
             // these cases specially here so we do not add a misleading 'info' message
             op
           case _ =>
-            // An operator that is not supported by Comet
-            withInfo(op, s"${op.nodeName} is not supported")
+            if (!hasExplainInfo(op)) {
+              // An operator that is not supported by Comet
+              withInfo(op, s"${op.nodeName} is not supported")
+            } else {
+              // Already has fallback reason, do not override it
+              op
+            }
         }
     }
   }

--- a/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
@@ -741,7 +741,7 @@ case class CometExecRule(session: SparkSession) extends Rule[SparkPlan] {
         s"Comet shuffle is not enabled: ${COMET_EXEC_SHUFFLE_ENABLED.key} is not enabled")
       false
     } else if (!isCometShuffleManagerEnabled(op.conf)) {
-      withInfo(op, s"spark.shuffle.manager is not set to ${CometShuffleManager.getClass.getName}")
+      withInfo(op, s"spark.shuffle.manager is not set to ${classOf[CometShuffleManager].getName}")
       false
     } else {
       true


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2300.

## Rationale for this change

> Comet cannot accelerate ProjectExec because: Comet is not enabled

We do not need to add fallback info for spark plan node when Comet is not enabled

> Comet cannot accelerate ProjectExec because: Comet Scan is not enabled

`Comet Scan is not enabled` fallback reason should be placed in the scan node

> Comet cannot accelerate CometProjectExec because: Metadata column is not supported

ditto

> Comet cannot accelerate ShuffleExchangeExec because: spark.shuffle.manager is not set to org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager$

CometShuffleManager class name should be `org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager`

## What changes are included in this PR?

Improve some confusing fallback reasons

## How are these changes tested?

disable comet shuffle manager conf in `CometTestBase` and run the following test case:

```
  test("test fallback reasons") {
    withSQLConf(CometConf.COMET_LOG_FALLBACK_REASONS.key -> "true") {
      withTable("t1") {
        sql("create table t1 using parquet as select id as c1, id + 1 as c2 from range(10)")

        // Comet cannot accelerate ProjectExec because: Comet is not enabled
        withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
          sql("select c1 + c2 from t1").collect()
        }
        // Comet cannot accelerate ProjectExec because: Comet Scan is not enabled
        withSQLConf(CometConf.COMET_NATIVE_SCAN_ENABLED.key -> "false") {
          sql("select c1 + c2 from t1").collect()
        }
        // Comet cannot accelerate CometProjectExec because: Metadata column is not supported
        sql("select _metadata from t1").collect()
        // Comet cannot accelerate ShuffleExchangeExec because: spark.shuffle.manager is not set to org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager$
        sql("select /*+ repartition */ * from t1").collect()
      }
    }
  }
```

before this:

```
Comet cannot accelerate ProjectExec because: Comet is not enabled

Comet cannot accelerate ProjectExec because: Comet Scan is not enabled
Comet cannot accelerate FileSourceScanExec because: Scan parquet spark_catalog.default.t1 is not supported

Comet cannot accelerate ProjectExec because: Metadata column is not supported
Comet cannot accelerate FileSourceScanExec because: Scan parquet spark_catalog.default.t1 is not supported

Comet cannot accelerate ShuffleExchangeExec because: spark.shuffle.manager is not set to org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager$
```

after this:

```

Comet cannot accelerate FileSourceScanExec because: Comet Scan is not enabled

Comet cannot accelerate FileSourceScanExec because: Metadata column is not supported

CometSparkSessionExtensions: Comet cannot accelerate ShuffleExchangeExec because: spark.shuffle.manager is not set to org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager
```
