### PR TITLE
fix: Validating object store configs should not throw exception

### DIFF
--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -434,7 +434,6 @@ object CometScanRule extends Logging {
     configValidityMap.get(cacheKey) match {
       case Some(Some(reason)) =>
         fallbackReasons += reason
-        throw new CometNativeException(reason)
       case Some(None) =>
       // previously validated
       case _ =>
@@ -442,12 +441,11 @@ object CometScanRule extends Logging {
           val objectStoreOptions = JavaConverters.mapAsJavaMap(objectStoreConfigMap)
           Native.validateObjectStoreConfig(filePath, objectStoreOptions)
         } catch {
-          case e: Exception =>
+          case e: CometNativeException =>
             val reason = "Object store config not supported by " +
               s"$SCAN_NATIVE_ICEBERG_COMPAT: ${e.getMessage}"
             fallbackReasons += reason
             configValidityMap.put(cacheKey, Some(reason))
-            throw e
         }
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/2305

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
