### PR TITLE
feat: Support more data part expressions

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -170,7 +170,16 @@ object QueryPlanSerde extends Logging with CometExprShim {
     classOf[OctetLength] -> CometScalarFunction("octet_length"),
     classOf[Reverse] -> CometScalarFunction("reverse"),
     classOf[StringRPad] -> CometStringRPad,
+
+    // GetDateField functions
     classOf[Year] -> CometYear,
+    classOf[Month] -> CometMonth,
+    classOf[DayOfMonth] -> CometDayOfMonth,
+    classOf[DayOfWeek] -> CometDayOfWeek,
+    classOf[DayOfYear] -> CometDayOfYear,
+    classOf[WeekOfYear] -> CometWeekOfYear,
+    classOf[Quarter] -> CometQuarter,
+
     classOf[Hour] -> CometHour,
     classOf[Minute] -> CometMinute,
     classOf[Second] -> CometSecond,

--- a/spark/src/main/scala/org/apache/comet/serde/datetime.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/datetime.scala
@@ -19,19 +19,40 @@
 
 package org.apache.comet.serde
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, DateAdd, DateSub, Hour, Literal, Minute, Second, TruncDate, TruncTimestamp, Year}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, DateAdd, DateSub, DayOfMonth, DayOfWeek, DayOfYear, GetDateField, Hour, Literal, Minute, Month, Quarter, Second, TruncDate, TruncTimestamp, WeekOfYear, Year}
 import org.apache.spark.sql.types.{DateType, IntegerType}
 
 import org.apache.comet.CometSparkSessionExtensions.withInfo
+import org.apache.comet.serde.CometGetDateField.CometGetDateField
 import org.apache.comet.serde.ExprOuterClass.Expr
 import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, optExprWithInfo, scalarFunctionExprToProto, scalarFunctionExprToProtoWithReturnType, serializeDataType}
 
-object CometYear extends CometExpressionSerde[Year] {
-  override def convert(
-      expr: Year,
+private object CometGetDateField extends Enumeration {
+  type CometGetDateField = Value
+
+  // See: https://datafusion.apache.org/user-guide/sql/scalar_functions.html#date-part
+  val Year: Value = Value("year")
+  val Month: Value = Value("month")
+  val DayOfMonth: Value = Value("day")
+  val DayOfWeek: Value = Value("dow")
+  val DayOfYear: Value = Value("doy")
+  val WeekOfYear: Value = Value("week")
+  val Quarter: Value = Value("quarter")
+}
+
+/**
+ * Convert spark [[org.apache.spark.sql.catalyst.expressions.GetDateField]] expressions to
+ * Datafusion
+ * [[https://datafusion.apache.org/user-guide/sql/scalar_functions.html#date-part datepart]]
+ * function.
+ */
+trait CometExprGetDateField[T <: GetDateField] {
+  def getDateField(
+      expr: T,
+      field: CometGetDateField,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val periodType = exprToProtoInternal(Literal("year"), inputs, binding)
+    val periodType = exprToProtoInternal(Literal(field.toString), inputs, binding)
     val childExpr = exprToProtoInternal(expr.child, inputs, binding)
     val optExpr = scalarFunctionExprToProto("datepart", Seq(periodType, childExpr): _*)
       .map(e => {
@@ -48,6 +69,77 @@ object CometYear extends CometExpressionSerde[Year] {
           .build()
       })
     optExprWithInfo(optExpr, expr, expr.child)
+  }
+}
+
+object CometYear extends CometExpressionSerde[Year] with CometExprGetDateField[Year] {
+  override def convert(
+      expr: Year,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    getDateField(expr, CometGetDateField.Year, inputs, binding)
+  }
+}
+
+object CometMonth extends CometExpressionSerde[Month] with CometExprGetDateField[Month] {
+  override def convert(
+      expr: Month,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    getDateField(expr, CometGetDateField.Month, inputs, binding)
+  }
+}
+
+object CometDayOfMonth
+    extends CometExpressionSerde[DayOfMonth]
+    with CometExprGetDateField[DayOfMonth] {
+  override def convert(
+      expr: DayOfMonth,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    getDateField(expr, CometGetDateField.DayOfMonth, inputs, binding)
+  }
+}
+
+object CometDayOfWeek
+    extends CometExpressionSerde[DayOfWeek]
+    with CometExprGetDateField[DayOfWeek] {
+  override def convert(
+      expr: DayOfWeek,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    getDateField(expr, CometGetDateField.DayOfWeek, inputs, binding)
+  }
+}
+
+object CometDayOfYear
+    extends CometExpressionSerde[DayOfYear]
+    with CometExprGetDateField[DayOfYear] {
+  override def convert(
+      expr: DayOfYear,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    getDateField(expr, CometGetDateField.DayOfYear, inputs, binding)
+  }
+}
+
+object CometWeekOfYear
+    extends CometExpressionSerde[WeekOfYear]
+    with CometExprGetDateField[WeekOfYear] {
+  override def convert(
+      expr: WeekOfYear,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    getDateField(expr, CometGetDateField.WeekOfYear, inputs, binding)
+  }
+}
+
+object CometQuarter extends CometExpressionSerde[Quarter] with CometExprGetDateField[Quarter] {
+  override def convert(
+      expr: Quarter,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    getDateField(expr, CometGetDateField.Quarter, inputs, binding)
   }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2315.

## Rationale for this change

Support more data part expressions

## What changes are included in this PR?

Convert more spark GetDateField expressions to Datafusion [data_part](https://datafusion.apache.org/user-guide/sql/scalar_functions.html#date-part) function.

## How are these changes tested?

TODO
