### PR TITLE
feat: pass the ordering information to native Scan

### DIFF
--- a/native/core/src/execution/operators/scan.rs
+++ b/native/core/src/execution/operators/scan.rs
@@ -434,6 +434,19 @@ impl ScanExec {
 
         Ok(selection_indices_arrays)
     }
+
+    pub fn with_ordering(mut self, input_sorted: Vec<PhysicalSortExpr>) -> Self {
+        assert_ne!(input_sorted.len(), 0, "input_sorted cannot be empty");
+        let mut eq_properties = self.cache.eq_properties.clone();
+
+        eq_properties.add_ordering(
+            LexOrdering::new(input_sorted).expect("Must be able to create LexOrdering"),
+        );
+
+        self.cache = self.cache.with_eq_properties(eq_properties);
+
+        self
+    }
 }
 
 fn scan_schema(input_batch: &InputBatch, data_types: &[DataType]) -> SchemaRef {

--- a/native/proto/src/proto/operator.proto
+++ b/native/proto/src/proto/operator.proto
@@ -79,6 +79,8 @@ message Scan {
   string source = 2;
   // Whether native code can assume ownership of batches that it receives
   bool arrow_ffi_safe = 3;
+
+  repeated spark.spark_expression.SortOrder input_ordering = 4;
 }
 
 message NativeScan {

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometCollectLimitExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometCollectLimitExec.scala
@@ -77,7 +77,7 @@ case class CometCollectLimitExec(
         childRDD
       } else {
         val localLimitedRDD = if (limit >= 0) {
-          CometExecUtils.getNativeLimitRDD(childRDD, output, limit)
+          CometExecUtils.getNativeLimitRDD(child, childRDD, output, limit)
         } else {
           childRDD
         }
@@ -92,7 +92,7 @@ case class CometCollectLimitExec(
 
         new CometShuffledBatchRDD(dep, readMetrics)
       }
-      CometExecUtils.getNativeLimitRDD(singlePartitionRDD, output, limit, offset)
+      CometExecUtils.getNativeLimitRDD(child, singlePartitionRDD, output, limit, offset)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometTakeOrderedAndProjectExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometTakeOrderedAndProjectExec.scala
@@ -77,7 +77,7 @@ case class CometTakeOrderedAndProjectExec(
         childRDD
       } else {
         val localTopK = if (orderingSatisfies) {
-          CometExecUtils.getNativeLimitRDD(childRDD, child.output, limit)
+          CometExecUtils.getNativeLimitRDD(child, childRDD, child.output, limit)
         } else {
           val numParts = childRDD.getNumPartitions
           childRDD.mapPartitionsWithIndexInternal { case (idx, iter) =>

--- a/spark/src/test/scala/org/apache/comet/CometNativeSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometNativeSuite.scala
@@ -28,9 +28,15 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class CometNativeSuite extends CometTestBase {
   test("test handling NPE thrown by JVM") {
-    val rdd = spark.range(0, 1).rdd.map { value =>
+    val dataset = spark.range(0, 1)
+    val rdd = dataset.rdd.map { value =>
       val limitOp =
-        CometExecUtils.getLimitNativePlan(Seq(PrettyAttribute("test", LongType)), 100).get
+        CometExecUtils
+          .getLimitNativePlan(
+            dataset.queryExecution.executedPlan.children.head,
+            Seq(PrettyAttribute("test", LongType)),
+            100)
+          .get
       val cometIter = CometExec.getCometIterator(
         Seq(new Iterator[ColumnarBatch] {
           override def hasNext: Boolean = true


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Sort information can be used in specialized implementation (for example sort will not sort if the input is already sorted, hash aggregate will use GroupValues that are tracking new groups once they saw the next value)

## What changes are included in this PR?

Used the child output ordering 

## How are these changes tested?

Existing tests

-----

This can cause problems if spark says something is sorted while we don't sort it.

for example shuffle files in spark are sorted, but ours are not, so we should make sure that the sort is used correctly.
