### PR TITLE
build: fix build of 'hdfs-opendal' feature for MacOS

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1535,6 +1535,7 @@ dependencies = [
  "datafusion-spark",
  "futures",
  "hdfs-sys",
+ "hdrs",
  "hex",
  "itertools 0.14.0",
  "jni",

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -81,6 +81,9 @@ opendal = { version ="0.54.0", optional = true, features = ["services-hdfs"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.18.0"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+hdrs = { version = "0.3.2", features = ["vendored"] }
+
 [dev-dependencies]
 pprof = { version = "0.15", features = ["flamegraph"] }
 criterion = { version = "0.7", features = ["async", "async_tokio", "async_std"] }


### PR DESCRIPTION
## Rationale for this change

Building with the `hdfs-opendal` feature enabled fails on MacOS. 

## What changes are included in this PR?

Add a `hdrs` dependency to allow the correct shared library to be found. See: https://opendal.apache.org/docs/rust/opendal/services/struct.Hdfs.html#macos-specific-note

