### PR TITLE
perf: New Configuration from shared conf to avoid high costs

### DIFF
--- a/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
@@ -433,7 +433,7 @@ public class NativeBatchReader extends RecordReader<Void, ColumnarBatch> impleme
   private ParquetColumn getParquetColumn(MessageType schema, StructType sparkSchema) {
     // We use a different config from the config that is passed in.
     // This follows the setting  used in Spark's SpecificParquetRecordReaderBase
-    Configuration config = new Configuration();
+    Configuration config = new Configuration(conf);
     config.setBoolean(SQLConf.PARQUET_BINARY_AS_STRING().key(), false);
     config.setBoolean(SQLConf.PARQUET_INT96_AS_TIMESTAMP().key(), false);
     config.setBoolean(SQLConf.CASE_SENSITIVE().key(), false);


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2401.

## Rationale for this change

High cost of creating Configuration in NativeBatchReader 

## What changes are included in this PR?

New Configuration from shared conf to avoid the high cost of loading from resource files

## How are these changes tested?
Before this:
<img width="1813" height="476" alt="image" src="https://github.com/user-attachments/assets/a0d41aed-fa3b-47c6-8f1f-3f38d44ad887" />

After this:

<img width="1845" height="476" alt="image" src="https://github.com/user-attachments/assets/14be3f41-f74c-437c-b47c-01362c651c3c" />

