### PR TITLE
fix: correct `missingInput` for `CometHashAggregateExec`

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -692,6 +692,8 @@ case class CometHashAggregateExec(
     override val serializedPlanOpt: SerializedPlan)
     extends CometUnaryExec
     with PartitioningPreservingUnaryExecNode {
+  override def producedAttributes: AttributeSet = outputSet ++ AttributeSet(resultExpressions)
+
   override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
     this.copy(child = newChild)
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2214 .

I'm not sure if unit test is needed but here is a proof


```
== Parsed Logical Plan ==
'Aggregate ['id], [unresolvedalias('count('id), None)]
+- 'UnresolvedRelation [t2], [], false

== Analyzed Logical Plan ==
count(id): bigint
Aggregate [id#43], [count(id#43) AS count(id)#48L]
+- SubqueryAlias t2
   +- View (`t2`, [id#43,value#44])
      +- Relation [id#43,value#44] parquet

== Optimized Logical Plan ==
Aggregate [id#43], [count(id#43) AS count(id)#48L]
+- Project [id#43]
   +- Relation [id#43,value#44] parquet

== Physical Plan ==
*(1) CometColumnarToRow
+- CometHashAggregate [id#43, count#51L], Final, [id#43], [count(id#43)]
   +- CometExchange hashpartitioning(id#43, 10), ENSURE_REQUIREMENTS, CometNativeShuffle, [plan_id=140]
      +- CometHashAggregate [id#43], Partial, [id#43], [partial_count(id#43)]
         +- CometScan [native_iceberg_compat] parquet [id#43] Batched: true, DataFilters: [], Format: CometParquet, Location: InMemoryFileIndex(1 paths)[file:/tmp/test_11], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<id:int>
```

Before the fix it was 

```
== Physical Plan ==
*(1) CometColumnarToRow
+- !CometHashAggregate [id#43, count#51L], Final, [id#43], [count(id#43)]
   +- CometExchange hashpartitioning(id#43, 10), ENSURE_REQUIREMENTS, CometNativeShuffle, [plan_id=140]
      +- !CometHashAggregate [id#43], Partial, [id#43], [partial_count(id#43)]
         +- CometScan [native_iceberg_compat] parquet [id#43] Batched: true, DataFilters: [], Format: CometParquet, Location: InMemoryFileIndex(1 paths)[file:/tmp/test_11], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<id:int>
```

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
