### PR TITLE
fix: Avoid spark plan execution cache preventing CometBatchRDD numPartitions change

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -274,28 +274,16 @@ abstract class CometNativeExec extends CometExec {
         sparkPlans.zipWithIndex.foreach { case (plan, idx) =>
           plan match {
             case c: CometBroadcastExchangeExec =>
-              inputs += c
-                .executeColumnarWithoutCache()
-                .asInstanceOf[CometBatchRDD]
-                .withNumPartitions(firstNonBroadcastPlanNumPartitions)
+              inputs += c.executeColumnar(firstNonBroadcastPlanNumPartitions)
             case BroadcastQueryStageExec(_, c: CometBroadcastExchangeExec, _) =>
-              inputs += c
-                .executeColumnarWithoutCache()
-                .asInstanceOf[CometBatchRDD]
-                .withNumPartitions(firstNonBroadcastPlanNumPartitions)
+              inputs += c.executeColumnar(firstNonBroadcastPlanNumPartitions)
             case ReusedExchangeExec(_, c: CometBroadcastExchangeExec) =>
-              inputs += c
-                .executeColumnarWithoutCache()
-                .asInstanceOf[CometBatchRDD]
-                .withNumPartitions(firstNonBroadcastPlanNumPartitions)
+              inputs += c.executeColumnar(firstNonBroadcastPlanNumPartitions)
             case BroadcastQueryStageExec(
                   _,
                   ReusedExchangeExec(_, c: CometBroadcastExchangeExec),
                   _) =>
-              inputs += c
-                .executeColumnarWithoutCache()
-                .asInstanceOf[CometBatchRDD]
-                .withNumPartitions(firstNonBroadcastPlanNumPartitions)
+              inputs += c.executeColumnar(firstNonBroadcastPlanNumPartitions)
             case _: CometNativeExec =>
             // no-op
             case _ if idx == firstNonBroadcastPlan.get._2 =>

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -275,17 +275,17 @@ abstract class CometNativeExec extends CometExec {
           plan match {
             case c: CometBroadcastExchangeExec =>
               inputs += c
-                .executeColumnar()
+                .executeColumnarWithoutCache()
                 .asInstanceOf[CometBatchRDD]
                 .withNumPartitions(firstNonBroadcastPlanNumPartitions)
             case BroadcastQueryStageExec(_, c: CometBroadcastExchangeExec, _) =>
               inputs += c
-                .executeColumnar()
+                .executeColumnarWithoutCache()
                 .asInstanceOf[CometBatchRDD]
                 .withNumPartitions(firstNonBroadcastPlanNumPartitions)
             case ReusedExchangeExec(_, c: CometBroadcastExchangeExec) =>
               inputs += c
-                .executeColumnar()
+                .executeColumnarWithoutCache()
                 .asInstanceOf[CometBatchRDD]
                 .withNumPartitions(firstNonBroadcastPlanNumPartitions)
             case BroadcastQueryStageExec(
@@ -293,7 +293,7 @@ abstract class CometNativeExec extends CometExec {
                   ReusedExchangeExec(_, c: CometBroadcastExchangeExec),
                   _) =>
               inputs += c
-                .executeColumnar()
+                .executeColumnarWithoutCache()
                 .asInstanceOf[CometBatchRDD]
                 .withNumPartitions(firstNonBroadcastPlanNumPartitions)
             case _: CometNativeExec =>


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2408.

## Rationale for this change

After [SPARK-48195](https://issues.apache.org/jira/browse/SPARK-48195), SparkPlan will cache the RDD, which prevents us from changing the number of partitions once CometBroadcastExchangeExec.executeColumnar() has been executed.

## What changes are included in this PR?

Add a method that always creates a new CometBatchRDD.

## How are these changes tested?

After this,  tpch q2 ran successfully on spark 4.0.1 with comet:

<img width="1920" height="431" alt="image" src="https://github.com/user-attachments/assets/c9a2d142-0c4f-469e-9dd2-eb52e42298b5" />

