### PR TITLE
minor: Add RDDScan to default value of sparkToColumnar.supportedOperatorList

### DIFF
--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -599,7 +599,7 @@ object CometConf extends ShimCometConf {
           "format when 'spark.comet.sparkToColumnar.enabled' is true")
       .stringConf
       .toSequence
-      .createWithDefault(Seq("Range,InMemoryTableScan"))
+      .createWithDefault(Seq("Range,InMemoryTableScan,RDDScan"))
 
   val COMET_CASE_CONVERSION_ENABLED: ConfigEntry[Boolean] =
     conf("spark.comet.caseConversion.enabled")


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

To make it easier for us to write test cases for comet expressions like #2410.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

This test case ran successfully:

```
  test("test array literal") {
    withSQLConf(
      CometConf.COMET_SPARK_TO_ARROW_ENABLED.key -> "true",
      SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> "org.apache.spark.sql.catalyst.optimizer.ConstantFolding") {
      checkSparkAnswerAndOperator("select array('1', '2', '3')")
    }
  }
```
