### PR TITLE
fix: [iceberg] additional parquet independent api for iceberg integration

### DIFF
--- a/common/src/main/java/org/apache/comet/parquet/RowGroupReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/RowGroupReader.java
@@ -30,7 +30,7 @@ import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.internal.filter2.columnindex.RowRanges;
 
 public class RowGroupReader implements PageReadStore {
-  private final Map<ColumnDescriptor, PageReader> readers = new HashMap<>();
+  private final Map<String, PageReader> readers = new HashMap<>();
   private final long rowCount;
   private final RowRanges rowRanges;
   private final long rowIndexOffset;
@@ -54,7 +54,11 @@ public class RowGroupReader implements PageReadStore {
 
   @Override
   public PageReader getPageReader(ColumnDescriptor path) {
-    final PageReader pageReader = readers.get(path);
+    return getPageReader(path.getPath());
+  }
+
+  public PageReader getPageReader(String[] path) {
+    final PageReader pageReader = readers.get(String.join(".", path));
     if (pageReader == null) {
       throw new IllegalArgumentException(
           path + " is not found: " + readers.keySet() + " " + rowCount);
@@ -73,7 +77,7 @@ public class RowGroupReader implements PageReadStore {
   }
 
   void addColumn(ColumnDescriptor path, ColumnPageReader reader) {
-    if (readers.put(path, reader) != null) {
+    if (readers.put(String.join(".", path.getPath()), reader) != null) {
       throw new IllegalStateException(path + " was already added");
     }
   }


### PR DESCRIPTION
…

## Which issue does this PR close?

Part of https://github.com/apache/datafusion-comet/issues/2079

## Rationale for this change

Needed for iceberg integration. Without this API the current PRs to fix shading issues in Iceberg-Comet still hit a method not found error.

## What changes are included in this PR?

Adds a new API to Comet's RowGroupReader that does not use ColumnDescriptor (which is a Parquet class)

## How are these changes tested?

With a local build of Comet, and corresponding changes in Iceberg. After this all tests pass.
