### PR TITLE
minor: Improve the log message of `CometTestBase#checkCometOperators`

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -213,7 +213,7 @@ abstract class CometTestBase
           assert(
             false,
             s"Expected only Comet native operators, but found ${op.nodeName}.\n" +
-              s"plan: $plan")
+              s"plan: ${new ExtendedExplainInfo().generateVerboseExtendedInfo(plan)}")
         }
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

While working on https://github.com/apache/datafusion-comet/pull/2425, I encountered an error in `checkCometOperators`.
As a newcomer to the Comet project, I was unaware that `native_comet` does not support complex type scanning, and the current error message was unclear and difficult to understand.

This PR improves the error message by adding a fallback reason, making it friendlier to new developers.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
the log message before this PR
```
- ToPrettyString (native_comet, jvm shuffle) *** FAILED *** (2 seconds, 79 milliseconds)
  Expected only Comet native operators, but found Project.
  plan: *(1) Project [toprettystring(c16#1030, Some(America/Los_Angeles)) AS pretty_c16#1220]
  +- *(1) ColumnarToRow
     +- FileScan parquet [c16#1030] Batched: true, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex(1 paths)[file:/Users/fchen/Project/arrow-datafusion-comet/spark/target/tmp/Come..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<c16:array<boolean>> (CometTestBase.scala:215)
```

after this PR
```
- ToPrettyString (native_comet, jvm shuffle) *** FAILED *** (1 second, 788 milliseconds)
  Expected only Comet native operators, but found Project.
  plan: Project
  +- ColumnarToRow
     +-  Scan parquet  [COMET: Unsupported schema StructType(StructField(c16,ArrayType(BooleanType,true),true)) for native_comet] (CometTestBase.scala:215)
```