### PR TITLE
minor: Skip calculating per-task memory limit when in off-heap mode

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -93,6 +93,14 @@ class CometExecIterator(
     }
     val protobufSparkConfigs = builder.build().toByteArray
 
+    val memoryLimitPerTask = if (offHeapMode) {
+      // this per-task limit is not used in native code when using unified memory
+      // so we can skip calculating it and avoid logging irrelevant information
+      0
+    } else {
+      getMemoryLimitPerTask(conf)
+    }
+
     nativeLib.createPlan(
       id,
       cometBatchIterators,
@@ -107,7 +115,7 @@ class CometExecIterator(
       offHeapMode,
       memoryPoolType = COMET_EXEC_MEMORY_POOL_TYPE.get(),
       memoryLimit,
-      memoryLimitPerTask = getMemoryLimitPerTask(conf),
+      memoryLimitPerTask,
       taskAttemptId = TaskContext.get().taskAttemptId,
       debug = COMET_DEBUG_ENABLED.get(),
       explain = COMET_EXPLAIN_NATIVE_ENABLED.get(),


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When running benchmarks, I see this verbose logging in the executors:

```
25/09/26 14:43:41 INFO CometExecIterator: Calculated per-task memory limit of 0 (0 * 1.0 / 4.0)
25/09/26 14:43:41 INFO CometExecIterator: Calculated per-task memory limit of 0 (0 * 1.0 / 4.0)
...
```

This limit is only applicable when using one of the on-heap memory pools and I am running in off-heap mode, so I don't want to see this logging.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
