### PR TITLE
experiment: disable native range partitioning by default

### DIFF
--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -329,7 +329,7 @@ object CometConf extends ShimCometConf {
     conf("spark.comet.native.shuffle.partitioning.range.enabled")
       .doc("Whether to enable range partitioning for Comet native shuffle.")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val COMET_EXEC_SHUFFLE_COMPRESSION_CODEC: ConfigEntry[String] =
     conf(s"$COMET_EXEC_CONFIG_PREFIX.shuffle.compression.codec")

--- a/spark/src/test/scala/org/apache/comet/exec/CometNativeShuffleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometNativeShuffleSuite.scala
@@ -252,38 +252,41 @@ class CometNativeShuffleSuite extends CometTestBase with AdaptiveSparkPlanHelper
   // This duplicates behavior seen in a much more complicated Spark SQL test
   // "SPARK-44647: test join key is the second cluster key"
   test("range partitioning with duplicate column references") {
-    // Test with wider schema and non-adjacent duplicate columns
-    withParquetTable(
-      (0 until 100).map(i => (i % 10, (i % 5).toByte, i % 3, i % 7, (i % 4).toShort, i.toString)),
-      "tbl") {
+    withSQLConf(CometConf.COMET_EXEC_SHUFFLE_WITH_RANGE_PARTITIONING_ENABLED.key -> "true") {
+      // Test with wider schema and non-adjacent duplicate columns
+      withParquetTable(
+        (0 until 100).map(i =>
+          (i % 10, (i % 5).toByte, i % 3, i % 7, (i % 4).toShort, i.toString)),
+        "tbl") {
 
-      val df = sql("SELECT * FROM tbl")
+        val df = sql("SELECT * FROM tbl")
 
-      // Test case 1: Adjacent duplicates (original case)
-      val rangePartitioned1 = df.repartitionByRange(3, df.col("_1"), df.col("_1"), df.col("_2"))
-      checkShuffleAnswer(rangePartitioned1, 1)
+        // Test case 1: Adjacent duplicates (original case)
+        val rangePartitioned1 = df.repartitionByRange(3, df.col("_1"), df.col("_1"), df.col("_2"))
+        checkShuffleAnswer(rangePartitioned1, 1)
 
-      // Test case 2: Non-adjacent duplicates in wider schema
-      // Duplicate _1 at positions 0 and 3, with different columns in between
-      val rangePartitioned2 =
-        df.repartitionByRange(4, df.col("_1"), df.col("_3"), df.col("_5"), df.col("_1"))
-      checkShuffleAnswer(rangePartitioned2, 1)
+        // Test case 2: Non-adjacent duplicates in wider schema
+        // Duplicate _1 at positions 0 and 3, with different columns in between
+        val rangePartitioned2 =
+          df.repartitionByRange(4, df.col("_1"), df.col("_3"), df.col("_5"), df.col("_1"))
+        checkShuffleAnswer(rangePartitioned2, 1)
 
-      // Test case 3: Multiple duplicate pairs
-      // _1 duplicated at positions 0,2 and _4 duplicated at positions 1,3
-      val rangePartitioned3 =
-        df.repartitionByRange(4, df.col("_1"), df.col("_4"), df.col("_1"), df.col("_4"))
-      checkShuffleAnswer(rangePartitioned3, 1)
+        // Test case 3: Multiple duplicate pairs
+        // _1 duplicated at positions 0,2 and _4 duplicated at positions 1,3
+        val rangePartitioned3 =
+          df.repartitionByRange(4, df.col("_1"), df.col("_4"), df.col("_1"), df.col("_4"))
+        checkShuffleAnswer(rangePartitioned3, 1)
 
-      // Test case 4: Triple duplicates with gaps
-      val rangePartitioned4 = df.repartitionByRange(
-        5,
-        df.col("_1"),
-        df.col("_2"),
-        df.col("_1"),
-        df.col("_3"),
-        df.col("_1"))
-      checkShuffleAnswer(rangePartitioned4, 1)
+        // Test case 4: Triple duplicates with gaps
+        val rangePartitioned4 = df.repartitionByRange(
+          5,
+          df.col("_1"),
+          df.col("_2"),
+          df.col("_1"),
+          df.col("_3"),
+          df.col("_1"))
+        checkShuffleAnswer(rangePartitioned4, 1)
+      }
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/apache/datafusion-comet/issues/2488

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Trying to isolate the cause of https://github.com/apache/datafusion-comet/issues/2488

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
