### PR TITLE
chore: Improve test assertions in plan stability suite

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/comet/CometPlanStabilitySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/CometPlanStabilitySuite.scala
@@ -95,7 +95,7 @@ trait CometPlanStabilitySuite extends DisableAdaptiveExecutionSuite with TPCDSBa
    *
    * @param dir
    *   the directory to write to
-   * @param name
+   * @param simplified
    *   the simplified plan
    * @param explain
    *   the full explain output; this is saved to help debug later as the simplified plan is not

--- a/spark/src/test/scala/org/apache/spark/sql/comet/CometPlanStabilitySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/CometPlanStabilitySuite.scala
@@ -24,8 +24,6 @@ import java.nio.charset.StandardCharsets
 
 import scala.collection.mutable
 
-import org.junit.ComparisonFailure
-
 import org.apache.commons.io.FileUtils
 import org.apache.spark.SparkContext
 import org.apache.spark.internal.config.{MEMORY_OFFHEAP_ENABLED, MEMORY_OFFHEAP_SIZE}
@@ -91,96 +89,65 @@ trait CometPlanStabilitySuite extends DisableAdaptiveExecutionSuite with TPCDSBa
     new File(goldenFilePath, goldenFileName)
   }
 
-  private def isApproved(
-      dir: File,
-      actualSimplifiedPlan: String,
-      actualExplain: String): Boolean = {
-    val simplifiedFile = new File(dir, "simplified.txt")
-    val expectedSimplified = FileUtils.readFileToString(simplifiedFile, StandardCharsets.UTF_8)
-    val explainFile = new File(dir, "explain.txt")
-    val expectedExplain = FileUtils.readFileToString(explainFile, StandardCharsets.UTF_8)
-    expectedSimplified == actualSimplifiedPlan && expectedExplain == actualExplain
-  }
-
   /**
    * Serialize and save this SparkPlan. The resulting file is used by [[checkWithApproved]] to
    * check stability.
    *
-   * @param plan
-   *   the SparkPlan
+   * @param dir
+   *   the directory to write to
    * @param name
-   *   the name of the query
+   *   the simplified plan
    * @param explain
    *   the full explain output; this is saved to help debug later as the simplified plan is not
    *   too useful for debugging
    */
-  private def generateGoldenFile(plan: SparkPlan, name: String, explain: String): Unit = {
-    val dir = getDirForTest(name)
-    val simplified = getSimplifiedPlan(plan)
-    val foundMatch = dir.exists() && isApproved(dir, simplified, explain)
-
-    if (!foundMatch) {
-      FileUtils.deleteDirectory(dir)
-      if (!dir.mkdirs()) {
-        fail(s"Could not create dir: $dir")
-      }
-
-      val file = new File(dir, "simplified.txt")
-      FileUtils.writeStringToFile(file, simplified, StandardCharsets.UTF_8)
-      val fileOriginalPlan = new File(dir, "explain.txt")
-      FileUtils.writeStringToFile(fileOriginalPlan, explain, StandardCharsets.UTF_8)
-      logDebug(s"APPROVED: $file $fileOriginalPlan")
+  private def generateGoldenFile(dir: File, simplified: String, explain: String): Unit = {
+    FileUtils.deleteDirectory(dir)
+    if (!dir.mkdirs()) {
+      fail(s"Could not create dir: $dir")
     }
+
+    val file = new File(dir, "simplified.txt")
+    FileUtils.writeStringToFile(file, simplified, StandardCharsets.UTF_8)
+    val fileOriginalPlan = new File(dir, "explain.txt")
+    FileUtils.writeStringToFile(fileOriginalPlan, explain, StandardCharsets.UTF_8)
+    logDebug(s"APPROVED: $file $fileOriginalPlan")
   }
 
-  private def checkWithApproved(plan: SparkPlan, name: String, actualExplain: String): Unit = {
-    val dir = getDirForTest(name)
+  private def checkWithApproved(
+      dir: File,
+      name: String,
+      simplified: String,
+      explain: String): Unit = {
+
+    val approvedSimplifiedFile = new File(dir, "simplified.txt")
+    val approvedExplainFile = new File(dir, "explain.txt")
+
+    // write actual files out for debugging
     val tempDir = FileUtils.getTempDirectory
-    val actualSimplified = getSimplifiedPlan(plan)
-    val foundMatch = isApproved(dir, actualSimplified, actualExplain)
+    val actualSimplifiedFile = new File(tempDir, s"$name.actual.simplified.txt")
+    val actualExplainFile = new File(tempDir, s"$name.actual.explain.txt")
+    FileUtils.writeStringToFile(actualSimplifiedFile, simplified, StandardCharsets.UTF_8)
+    FileUtils.writeStringToFile(actualExplainFile, explain, StandardCharsets.UTF_8)
 
-    if (!foundMatch) {
-      // read approved files
-      val approvedSimplifiedFile = new File(dir, "simplified.txt")
-      val approvedExplainFile = new File(dir, "explain.txt")
-      val approvedSimplified =
-        FileUtils.readFileToString(approvedSimplifiedFile, StandardCharsets.UTF_8)
-      val approvedExplain =
-        FileUtils.readFileToString(approvedExplainFile, StandardCharsets.UTF_8)
-
-      // write actual files out for debugging
-      val actualSimplifiedFile = new File(tempDir, s"$name.actual.simplified.txt")
-      val actualExplainFile = new File(tempDir, s"$name.actual.explain.txt")
-      FileUtils.writeStringToFile(actualSimplifiedFile, actualSimplified, StandardCharsets.UTF_8)
-      FileUtils.writeStringToFile(actualExplainFile, actualExplain, StandardCharsets.UTF_8)
-
-      comparePlans(
-        "simplified",
-        approvedSimplified,
-        actualSimplified,
-        approvedSimplifiedFile,
-        actualSimplifiedFile)
-
-      comparePlans(
-        "explain",
-        approvedExplain,
-        actualExplain,
-        approvedExplainFile,
-        actualExplainFile)
-    }
+    comparePlans("simplified", approvedSimplifiedFile, actualSimplifiedFile)
+    comparePlans("explain", approvedExplainFile, actualExplainFile)
   }
 
-  private def comparePlans(
-      planType: String,
-      expected: String,
-      actual: String,
-      expectedFile: File,
-      actualFile: File): Unit = {
+  private def comparePlans(planType: String, expectedFile: File, actualFile: File): Unit = {
+    val expected = FileUtils.readFileToString(expectedFile, StandardCharsets.UTF_8)
+    val actual = FileUtils.readFileToString(actualFile, StandardCharsets.UTF_8)
     if (expected != actual) {
-      val message =
-        s"Expected $planType plan in ${expectedFile.getAbsolutePath} did not match " +
-          s"actual $planType plan in ${actualFile.getAbsolutePath}"
-      throw new ComparisonFailure(message, expected, actual)
+      fail(s"""
+              |Plans did not match:
+              |last approved $planType plan: ${expectedFile.getAbsolutePath}
+              |
+              |$expected
+              |
+              |actual $planType plan: ${actualFile.getAbsolutePath}
+              |
+              |$actual
+        """.stripMargin)
     }
   }
 
@@ -292,13 +259,16 @@ trait CometPlanStabilitySuite extends DisableAdaptiveExecutionSuite with TPCDSBa
       val qe = sql(queryString).queryExecution
       val plan = qe.executedPlan
       val explain = normalizeLocation(normalizeIds(qe.explainString(FormattedMode)))
-
+      val simplified = getSimplifiedPlan(plan)
       assert(ValidateRequirements.validate(plan))
 
+      val name = query + suffix
+      val dir = getDirForTest(name)
+
       if (regenerateGoldenFiles) {
-        generateGoldenFile(plan, query + suffix, explain)
+        generateGoldenFile(dir, simplified, explain)
       } else {
-        checkWithApproved(plan, query + suffix, explain)
+        checkWithApproved(dir, name, simplified, explain)
       }
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

In the plan stability suite, there is a check that the expected and actual simplified and explain plans match, but only the simplified plan gets logged. This means that when the actual vs expected explain plan is different, no information is logged to show the difference. I discovered this while working on https://github.com/apache/datafusion-comet/pull/2492

I split these changes out into a separate PR from https://github.com/apache/datafusion-comet/pull/2492 to make reviews easier.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
