### PR TITLE
Chore: Fix Scala code warnings - common module

### DIFF
--- a/common/src/main/scala/org/apache/spark/sql/comet/util/Utils.scala
+++ b/common/src/main/scala/org/apache/spark/sql/comet/util/Utils.scala
@@ -223,9 +223,9 @@ object Utils extends CometTypeShim {
       writer.close()
 
       if (out.size() > 0) {
-        (batch.numRows(), cbbos.toChunkedByteBuffer)
+        (batch.numRows().toLong, cbbos.toChunkedByteBuffer)
       } else {
-        (batch.numRows(), new ChunkedByteBuffer(Array.empty[ByteBuffer]))
+        (batch.numRows().toLong, new ChunkedByteBuffer(Array.empty[ByteBuffer]))
       }
     }
   }

--- a/common/src/main/spark-3.x/org/apache/comet/shims/CometTypeShim.scala
+++ b/common/src/main/spark-3.x/org/apache/comet/shims/CometTypeShim.scala
@@ -20,6 +20,9 @@ package org.apache.comet.shims
 
 import org.apache.spark.sql.types.DataType
 
+import scala.annotation.nowarn
+
 trait CometTypeShim {
+    @nowarn // Spark 4 feature; stubbed to false in Spark 3.x for compatibility.
     def isStringCollationType(dt: DataType): Boolean = false
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Partially closes #.https://github.com/apache/datafusion-comet/issues/2255

## Rationale for this change

* To perform code clean / refactor on the codebase, in order to comply with the new maven profile https://github.com/apache/datafusion-comet/issues/2255, one module at a time.

## What changes are included in this PR?

* Add explicit cast (int -> long) to avoid the warning
* Add a suppress warning on shim and put up a comment to justify it. 

## How are these changes tested?
* `mvn test -pl :comet-common-spark3.5_2.12 -Pstrict-warnings` to make sure the common module is now comply with the `strict-warnings` profile setting
* CI is green


