### PR TITLE
feat: Add option to write benchmark results to file

### DIFF
--- a/dev/benchmarks/comet-tpch.sh
+++ b/dev/benchmarks/comet-tpch.sh
@@ -50,4 +50,5 @@ $SPARK_HOME/bin/spark-submit \
     --data $TPCH_DATA \
     --queries $TPCH_QUERIES \
     --output . \
+    --write /tmp \
     --iterations 1

--- a/dev/benchmarks/tpcbench.py
+++ b/dev/benchmarks/tpcbench.py
@@ -91,7 +91,7 @@ def main(benchmark: str, data_path: str, query_path: str, iterations: int, outpu
                         df.explain()
 
                         if write_path is not None:
-                            output_path = f"{write_path}/q{query}.parquet"
+                            output_path = f"{write_path}/q{query}"
                             df.coalesce(1).write.mode("overwrite").parquet(output_path)
                             print(f"Query {query} results written to {output_path}")
                         else:

--- a/dev/benchmarks/tpcbench.py
+++ b/dev/benchmarks/tpcbench.py
@@ -91,7 +91,7 @@ def main(benchmark: str, data_path: str, query_path: str, iterations: int, outpu
                         df.explain()
 
                         if write_path is not None:
-                            output_path = f"{write_path}/{query}.parquet"
+                            output_path = f"{write_path}/q{query}.parquet"
                             df.write.parquet(output_path)
                             print(f"Query {query} results written to {output_path}")
                         else:

--- a/dev/benchmarks/tpcbench.py
+++ b/dev/benchmarks/tpcbench.py
@@ -92,7 +92,7 @@ def main(benchmark: str, data_path: str, query_path: str, iterations: int, outpu
 
                         if write_path is not None:
                             output_path = f"{write_path}/q{query}.parquet"
-                            df.write.parquet(output_path)
+                            df.coalesce(1).write.mode("overwrite").parquet(output_path)
                             print(f"Query {query} results written to {output_path}")
                         else:
                             rows = df.collect()

--- a/dev/benchmarks/tpcbench.py
+++ b/dev/benchmarks/tpcbench.py
@@ -21,7 +21,7 @@ import json
 from pyspark.sql import SparkSession
 import time
 
-def main(benchmark: str, data_path: str, query_path: str, iterations: int, output: str, name: str, query_num: int = None):
+def main(benchmark: str, data_path: str, query_path: str, iterations: int, output: str, name: str, query_num: int = None, write_path: str = None):
 
     # Initialize a SparkSession
     spark = SparkSession.builder \
@@ -89,10 +89,16 @@ def main(benchmark: str, data_path: str, query_path: str, iterations: int, outpu
                         print(f"Executing: {sql}")
                         df = spark.sql(sql)
                         df.explain()
-                        rows = df.collect()
+
+                        if write_path is not None:
+                            output_path = f"{write_path}/{query}.parquet"
+                            df.write.parquet(output_path)
+                            print(f"Query {query} results written to {output_path}")
+                        else:
+                            rows = df.collect()
+                            print(f"Query {query} returned {len(rows)} rows")
                         df.explain()
 
-                        print(f"Query {query} returned {len(rows)} rows")
 
                 end_time = time.time()
                 print(f"Query {query} took {end_time - start_time} seconds")
@@ -123,6 +129,7 @@ if __name__ == "__main__":
     parser.add_argument("--output", required=True, help="Path to write output")
     parser.add_argument("--name", required=True, help="Prefix for result file e.g. spark/comet/gluten")
     parser.add_argument("--query", required=False, type=int, help="Specific query number to run (1-based). If not specified, all queries will be run.")
+    parser.add_argument("--write", required=False, help="Path to save query results to, in Parquet format.")
     args = parser.parse_args()
 
-    main(args.benchmark, args.data, args.queries, int(args.iterations), args.output, args.name, args.query)
+    main(args.benchmark, args.data, args.queries, int(args.iterations), args.output, args.name, args.query, args.write)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

By adding the ability to write results to file, it is easier to compare output from Spark vs Comet runs to check for correctness.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add new `--write` option to `tpcbench.py`.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

I ran the benchmarks with the new `--write` parameter.

```
$ bdt view q1.parquet/
+--------------+--------------+---------------+-------------------+---------------------+-----------------------+-----------+--------------+----------+-------------+
| l_returnflag | l_linestatus | sum_qty       | sum_base_price    | sum_disc_price      | sum_charge            | avg_qty   | avg_price    | avg_disc | count_order |
+--------------+--------------+---------------+-------------------+---------------------+-----------------------+-----------+--------------+----------+-------------+
| A            | F            | 3775127758.00 | 5660776097194.45  | 5377736398183.9374  | 5592847429515.927026  | 25.499370 | 38236.116984 | 0.050002 | 148047881   |
| N            | F            | 98553062.00   | 147771098385.98   | 140384965965.0348   | 145999793032.775829   | 25.501557 | 38237.199389 | 0.049985 | 3864590     |
| N            | O            | 7528214906.00 | 11288561685812.92 | 10724143409546.1519 | 11153120405856.983757 | 25.499997 | 38237.257872 | 0.049997 | 295224143   |
| R            | F            | 3775724970.00 | 5661603032745.34  | 5378513563915.4097  | 5593662252666.916161  | 25.500066 | 38236.697258 | 0.050001 | 148067261   |
+--------------+--------------+---------------+-------------------+---------------------+-----------------------+-----------+--------------+----------+-------------+
Limiting to 10 rows. Run with --limit 0 to remove limit.
```
