### PR TITLE
feat: [CometFuzz] Add support for literal arguments [WIP]

### DIFF
--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Meta.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/Meta.scala
@@ -43,6 +43,7 @@ case class SparkArrayType(elementType: SparkType) extends SparkType
 case class SparkMapType(keyType: SparkType, valueType: SparkType) extends SparkType
 case class SparkStructType(fields: Seq[SparkType]) extends SparkType
 case object SparkAnyType extends SparkType
+case class SparkTypeWithValues(sparkType: SparkType, validValues: Seq[String]) extends SparkType
 
 case class FunctionSignature(inputTypes: Seq[SparkType])
 
@@ -302,7 +303,12 @@ object Meta {
       createFunctionWithInputTypes("hour", Seq(SparkDateOrTimestampType)),
       createFunctionWithInputTypes("minute", Seq(SparkDateOrTimestampType)),
       createFunctionWithInputTypes("second", Seq(SparkDateOrTimestampType)),
-      createFunctionWithInputTypes("trunc", Seq(SparkDateOrTimestampType, SparkStringType)),
+      createFunctionWithInputTypes(
+        "date_trunc",
+        Seq(SparkDateOrTimestampType, SparkTypeWithValues(SparkStringType, Seq("year", "week")))),
+      createFunctionWithInputTypes(
+        "trunc",
+        Seq(SparkDateOrTimestampType, SparkTypeWithValues(SparkStringType, Seq("year", "week")))),
       createFunctionWithInputTypes("year", Seq(SparkDateOrTimestampType)),
       createFunctionWithInputTypes("month", Seq(SparkDateOrTimestampType)),
       createFunctionWithInputTypes("day", Seq(SparkDateOrTimestampType)),

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
@@ -126,13 +126,13 @@ object QueryGen {
         case SparkIntegralType =>
           r.nextInt(10).toString
         case SparkStringType =>
-          s""""${r.nextString(4)}""""
+          formatLiteral(r.nextString(4), SparkStringType)
         case SparkTimestampType =>
           "now()"
         case SparkTypeWithValues(sparkType, values) =>
           // choose between known valid input and random input
           if (r.nextBoolean()) {
-            Utils.randomChoice(values, r)
+            formatLiteral(Utils.randomChoice(values, r), sparkType)
           } else {
             pickRandomColumnOrLiteral(r, df, sparkType)
           }
@@ -141,6 +141,13 @@ object QueryGen {
       }
     } else {
       pickRandomColumn(r, df, targetType)
+    }
+  }
+
+  private def formatLiteral(validValue: Any, sparkType: SparkType): String = {
+    sparkType match {
+      case SparkStringType => s""""$validValue""""
+      case _ => validValue.toString
     }
   }
 

--- a/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
+++ b/fuzz-testing/src/main/scala/org/apache/comet/fuzz/QueryGen.scala
@@ -121,8 +121,7 @@ object QueryGen {
       r: Random,
       df: DataFrame,
       targetType: SparkType): String = {
-    // prefer picking columns over literals
-    if (r.nextInt(10) > 7) {
+    if (r.nextBoolean) {
       targetType match {
         case SparkIntegralType =>
           r.nextInt(10).toString
@@ -130,6 +129,13 @@ object QueryGen {
           s""""${r.nextString(4)}""""
         case SparkTimestampType =>
           "now()"
+        case SparkTypeWithValues(sparkType, values) =>
+          // choose between known valid input and random input
+          if (r.nextBoolean()) {
+            Utils.randomChoice(values, r)
+          } else {
+            pickRandomColumnOrLiteral(r, df, sparkType)
+          }
         case _ =>
           pickRandomColumn(r, df, targetType)
       }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/datafusion-comet/issues/2628

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Increase test coverage by picking both columns and literals for arguments to scalar functions.

```sql
SELECT "뇾涓鼁覔", c26, instr("뇾涓鼁覔", c26) AS x FROM test1 ORDER BY "뇾涓鼁覔", c26;
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
