### PR TITLE
fix: Mark SortOrder with floating-point as incompatible

### DIFF
--- a/docs/source/user-guide/latest/compatibility.md
+++ b/docs/source/user-guide/latest/compatibility.md
@@ -97,6 +97,9 @@ because they are handled well in Spark (e.g., `SQLOrderingUtil.compareFloats`). 
 functions of arrow-rs used by DataFusion do not normalize NaN and zero (e.g., [arrow::compute::kernels::cmp::eq](https://docs.rs/arrow/latest/arrow/compute/kernels/cmp/fn.eq.html#)).
 So Comet will add additional normalization expression of NaN and zero for comparison.
 
+Sorting on floating-point data types (or complex types containing floating-point values) is not compatible with 
+Spark if the data contains both zero and negative zero. 
+
 There is a known bug with using count(distinct) within aggregate queries, where each NaN value will be counted
 separately [#1824](https://github.com/apache/datafusion-comet/issues/1824).
 

--- a/docs/source/user-guide/latest/compatibility.md
+++ b/docs/source/user-guide/latest/compatibility.md
@@ -98,7 +98,8 @@ functions of arrow-rs used by DataFusion do not normalize NaN and zero (e.g., [a
 So Comet will add additional normalization expression of NaN and zero for comparison.
 
 Sorting on floating-point data types (or complex types containing floating-point values) is not compatible with 
-Spark if the data contains both zero and negative zero. 
+Spark if the data contains both zero and negative zero. This is likely an edge case that is not of concern for many users
+and sorting on floating-point data can be enabled by setting `spark.comet.expression.SortOrder.allowIncompatible=true`.
 
 There is a known bug with using count(distinct) within aggregate queries, where each NaN value will be counted
 separately [#1824](https://github.com/apache/datafusion-comet/issues/1824).

--- a/docs/source/user-guide/latest/tuning.md
+++ b/docs/source/user-guide/latest/tuning.md
@@ -100,6 +100,12 @@ Comet Performance
 
 It may be possible to reduce Comet's memory overhead by reducing batch sizes or increasing number of partitions.
 
+## Optimizing Sorting on Floating-Point
+
+Sorting on floating point values is disabled by default, because of known differences when the data 
+contains both positive and negative zero. This is likely an edge case that is not of concern for many users
+and sorting on floating-point data can be enabled by setting `spark.comet.expression.SortOrder.allowIncompatible=true`.
+
 ## Optimizing Joins
 
 Spark often chooses `SortMergeJoin` over `ShuffledHashJoin` for stability reasons. If the build-side of a

--- a/docs/source/user-guide/latest/tuning.md
+++ b/docs/source/user-guide/latest/tuning.md
@@ -100,7 +100,7 @@ Comet Performance
 
 It may be possible to reduce Comet's memory overhead by reducing batch sizes or increasing number of partitions.
 
-## Optimizing Sorting on Floating-Point
+## Optimizing Sorting on Floating-Point Values
 
 Sorting on floating point values is disabled by default, because of known differences when the data 
 contains both positive and negative zero. This is likely an edge case that is not of concern for many users

--- a/docs/source/user-guide/latest/tuning.md
+++ b/docs/source/user-guide/latest/tuning.md
@@ -102,8 +102,8 @@ It may be possible to reduce Comet's memory overhead by reducing batch sizes or 
 
 ## Optimizing Sorting on Floating-Point Values
 
-Sorting on floating point values is disabled by default, because of known differences when the data 
-contains both positive and negative zero. This is likely an edge case that is not of concern for many users
+Sorting on floating-point data types (or complex types containing floating-point values) is not compatible with
+Spark if the data contains both zero and negative zero. This is likely an edge case that is not of concern for many users
 and sorting on floating-point data can be enabled by setting `spark.comet.expression.SortOrder.allowIncompatible=true`.
 
 ## Optimizing Joins

--- a/spark/src/main/scala/org/apache/comet/serde/CometSort.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/CometSort.scala
@@ -32,8 +32,6 @@ import org.apache.comet.serde.QueryPlanSerde.{exprToProto, exprToProtoInternal, 
 
 object CometSortOrder extends CometExpressionSerde[SortOrder] {
 
-  val floatFallbackMessage = "Complex types containing floating-point not supported"
-
   override def getSupportLevel(expr: SortOrder): SupportLevel = {
 
     def containsFloatingPoint(dt: DataType): Boolean = {
@@ -48,7 +46,7 @@ object CometSortOrder extends CometExpressionSerde[SortOrder] {
     }
 
     if (containsFloatingPoint(expr.child.dataType)) {
-      Incompatible(Some(floatFallbackMessage))
+      Incompatible(Some(s"Sorting on floating-point is not 100% compatible with Spark. ${CometConf.COMPAT_GUIDE}"))
     } else {
       Compatible()
     }

--- a/spark/src/main/scala/org/apache/comet/serde/CometSort.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/CometSort.scala
@@ -46,7 +46,8 @@ object CometSortOrder extends CometExpressionSerde[SortOrder] {
     }
 
     if (containsFloatingPoint(expr.child.dataType)) {
-      Incompatible(Some(s"Sorting on floating-point is not 100% compatible with Spark. ${CometConf.COMPAT_GUIDE}"))
+      Incompatible(Some(
+        s"Sorting on floating-point is not 100% compatible with Spark. ${CometConf.COMPAT_GUIDE}"))
     } else {
       Compatible()
     }

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -20,11 +20,14 @@
 package org.apache.comet
 
 import java.time.{Duration, Period}
+
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.Random
+
 import org.scalactic.source.Position
 import org.scalatest.Tag
+
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{CometTestBase, DataFrame, Row}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Literal}
@@ -37,6 +40,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.SESSION_LOCAL_TIMEZONE
 import org.apache.spark.sql.types._
+
 import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
 import org.apache.comet.testing.{DataGenOptions, FuzzDataGenerator}
 
@@ -58,11 +62,16 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     """Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead"""
 
   test("sort floating point with negative zero") {
-    val schema = StructType(Seq(
-      StructField("c0", DataTypes.FloatType, true),
-      StructField("c0", DataTypes.DoubleType, true)
-    ))
-    val df = FuzzDataGenerator.generateDataFrame(new Random(42), spark, schema, 1000, DataGenOptions(generateNegativeZero = true))
+    val schema = StructType(
+      Seq(
+        StructField("c0", DataTypes.FloatType, true),
+        StructField("c0", DataTypes.DoubleType, true)))
+    val df = FuzzDataGenerator.generateDataFrame(
+      new Random(42),
+      spark,
+      schema,
+      1000,
+      DataGenOptions(generateNegativeZero = true))
     df.createOrReplaceTempView("tbl")
     checkSparkAnswerAndOperator("select * from tbl order by 1, 2")
   }

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -65,7 +65,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     val schema = StructType(
       Seq(
         StructField("c0", DataTypes.FloatType, true),
-        StructField("c0", DataTypes.DoubleType, true)))
+        StructField("c1", DataTypes.DoubleType, true)))
     val df = FuzzDataGenerator.generateDataFrame(
       new Random(42),
       spark,
@@ -73,7 +73,47 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       1000,
       DataGenOptions(generateNegativeZero = true))
     df.createOrReplaceTempView("tbl")
-    checkSparkAnswerAndOperator("select * from tbl order by 1, 2")
+
+    // TODO check fallback reason
+    checkSparkAnswer("select * from tbl order by 1, 2")
+  }
+
+  test("sort array of floating point with negative zero") {
+    val schema = StructType(
+      Seq(
+        StructField("c0", DataTypes.createArrayType(DataTypes.FloatType), true),
+        StructField("c1", DataTypes.createArrayType(DataTypes.DoubleType), true)))
+    val df = FuzzDataGenerator.generateDataFrame(
+      new Random(42),
+      spark,
+      schema,
+      1000,
+      DataGenOptions(generateNegativeZero = true))
+    df.createOrReplaceTempView("tbl")
+
+    // TODO check fallback reason
+    checkSparkAnswer("select * from tbl order by 1, 2")
+  }
+
+  test("sort struct containing floating point with negative zero") {
+    val schema = StructType(
+      Seq(
+        StructField(
+          "float_struct",
+          StructType(Seq(StructField("c0", DataTypes.FloatType, true)))),
+        StructField(
+          "float_double",
+          StructType(Seq(StructField("c0", DataTypes.DoubleType, true))))))
+    val df = FuzzDataGenerator.generateDataFrame(
+      new Random(42),
+      spark,
+      schema,
+      1000,
+      DataGenOptions(generateNegativeZero = true))
+    df.createOrReplaceTempView("tbl")
+
+    // TODO check fallback reason
+    checkSparkAnswer("select * from tbl order by 1, 2")
   }
 
   test("compare true/false to negative zero") {

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -74,8 +74,11 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       DataGenOptions(generateNegativeZero = true))
     df.createOrReplaceTempView("tbl")
 
-    // TODO check fallback reason
-    checkSparkAnswer("select * from tbl order by 1, 2")
+    withSQLConf(CometConf.getExprAllowIncompatConfigKey("SortOrder") -> "false") {
+      checkSparkAnswerAndFallbackReason(
+        "select * from tbl order by 1, 2",
+        "unsupported range partitioning sort order")
+    }
   }
 
   test("sort array of floating point with negative zero") {
@@ -91,8 +94,11 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       DataGenOptions(generateNegativeZero = true))
     df.createOrReplaceTempView("tbl")
 
-    // TODO check fallback reason
-    checkSparkAnswer("select * from tbl order by 1, 2")
+    withSQLConf(CometConf.getExprAllowIncompatConfigKey("SortOrder") -> "false") {
+      checkSparkAnswerAndFallbackReason(
+        "select * from tbl order by 1, 2",
+        "unsupported range partitioning sort order")
+    }
   }
 
   test("sort struct containing floating point with negative zero") {
@@ -112,8 +118,11 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       DataGenOptions(generateNegativeZero = true))
     df.createOrReplaceTempView("tbl")
 
-    // TODO check fallback reason
-    checkSparkAnswer("select * from tbl order by 1, 2")
+    withSQLConf(CometConf.getExprAllowIncompatConfigKey("SortOrder") -> "false") {
+      checkSparkAnswerAndFallbackReason(
+        "select * from tbl order by 1, 2",
+        "unsupported range partitioning sort order")
+    }
   }
 
   test("compare true/false to negative zero") {

--- a/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
@@ -144,7 +144,9 @@ class CometFuzzTestSuite extends CometFuzzTestBase {
       val randomSize = Random.nextInt(shuffledPrimitiveCols.length) + 1
       val randomColsSubset = shuffledPrimitiveCols.take(randomSize).toArray.mkString(",")
       val sql = s"SELECT $randomColsSubset FROM t1 ORDER BY $randomColsSubset"
-      checkSparkAnswerAndOperator(sql)
+
+      // TODO
+      checkSparkAnswer/*AndOperator*/(sql)
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
@@ -146,7 +146,7 @@ class CometFuzzTestSuite extends CometFuzzTestBase {
       val sql = s"SELECT $randomColsSubset FROM t1 ORDER BY $randomColsSubset"
 
       // TODO
-      checkSparkAnswer/*AndOperator*/(sql)
+      checkSparkAnswer /*AndOperator*/ (sql)
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
@@ -144,9 +144,7 @@ class CometFuzzTestSuite extends CometFuzzTestBase {
       val randomSize = Random.nextInt(shuffledPrimitiveCols.length) + 1
       val randomColsSubset = shuffledPrimitiveCols.take(randomSize).toArray.mkString(",")
       val sql = s"SELECT $randomColsSubset FROM t1 ORDER BY $randomColsSubset"
-
-      // TODO
-      checkSparkAnswer /*AndOperator*/ (sql)
+      checkSparkAnswerAndOperator(sql)
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -86,6 +86,9 @@ abstract class CometTestBase
     conf.set(CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.key, "true")
     conf.set(CometConf.COMET_ONHEAP_MEMORY_OVERHEAD.key, "2g")
     conf.set(CometConf.COMET_EXEC_SORT_MERGE_JOIN_WITH_JOIN_FILTER_ENABLED.key, "true")
+    // SortOrder is incompatible for mixed zero and negative zero floating point values, but
+    // this is an edge case, and we expect most users to allow sorts on floating point, so we
+    // enable this for the tests
     conf.set(CometConf.getExprAllowIncompatConfigKey("SortOrder"), "true")
     conf
   }

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -86,6 +86,7 @@ abstract class CometTestBase
     conf.set(CometConf.COMET_SCAN_ALLOW_INCOMPATIBLE.key, "true")
     conf.set(CometConf.COMET_ONHEAP_MEMORY_OVERHEAD.key, "2g")
     conf.set(CometConf.COMET_EXEC_SORT_MERGE_JOIN_WITH_JOIN_FILTER_ENABLED.key, "true")
+    conf.set(CometConf.getExprAllowIncompatConfigKey("SortOrder"), "true")
     conf
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/2626

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Fall back to Spark by default when sorting on floating-point values. Users can opt in if they don't care about the different handling of +0.0 vs -0.0.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- [x] Refactor serde for `SortOrder`
- [x] Add specific tests
- [x] Write documentation (compatibility and tuning guide)

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
