### PR TITLE
feat: Add `COMET_TEST_SHOW_ANSWERS`

### DIFF
--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -709,6 +709,13 @@ object CometConf extends ShimCometConf {
     .booleanConf
     .createWithDefault(sys.env.getOrElse("ENABLE_COMET_STRICT_TESTING", "false").toBoolean)
 
+  val COMET_TEST_SHOW_ANSWERS: ConfigEntry[Boolean] = conf(s"$COMET_PREFIX.testing.showAnswers")
+    .category(CATEGORY_TESTING)
+    .doc("When enabled, print query plan and subset of results from calls to testing methods " +
+      "starting with `checkSparkAnswer`.")
+    .booleanConf
+    .createWithDefault(sys.env.getOrElse("COMET_TESTING_SHOW_ANSWERS", "false").toBoolean)
+
   /** Create a config to enable a specific operator */
   private def createExecEnabledConfig(
       exec: String,

--- a/docs/source/user-guide/latest/configs.md
+++ b/docs/source/user-guide/latest/configs.md
@@ -130,6 +130,7 @@ These settings can be used to determine which parts of the plan are accelerated 
 | `spark.comet.exec.onHeap.enabled` | Whether to allow Comet to run in on-heap mode. Required for running Spark SQL tests. | false |
 | `spark.comet.exec.onHeap.memoryPool` | The type of memory pool to be used for Comet native execution when running Spark in on-heap mode. Available pool types are `greedy`, `fair_spill`, `greedy_task_shared`, `fair_spill_task_shared`, `greedy_global`, `fair_spill_global`, and `unbounded`. | greedy_task_shared |
 | `spark.comet.memoryOverhead` | The amount of additional memory to be allocated per executor process for Comet, in MiB, when running Spark in on-heap mode. | 1024 MiB |
+| `spark.comet.testing.showAnswers` | When enabled, print query plan and subset of results from calls to testing methods starting with `checkSparkAnswer`. | false |
 | `spark.comet.testing.strict` | Experimental option to enable strict testing, which will fail tests that could be more comprehensive, such as checking for a specific fallback reason | false |
 <!--END:CONFIG_TABLE-->
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

When writing tests using `checkSparkAnswerAndOperator`, the testing API doesn't provide a convenient way to check that the query is actually producing the ~correct~ expected results, or any results at all. I have filed https://github.com/apache/datafusion-comet/issues/2692 to track this and come up with a good solution, but for now, just being able to see the results when writing the test helps ensure that tests are working as expected.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

New config, that can be set with an env var, to show Spark and Comet plans and results in tests.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Manually. Example output:

```
Spark Plan: AdaptiveSparkPlan isFinalPlan=true
+- == Final Plan ==
   *(2) Project [c0#2, trunc(c0, year)#6]
   +- *(2) Sort [c0#2 ASC NULLS FIRST, c1#3 ASC NULLS FIRST], true, 0
      +- AQEShuffleRead coalesced
         +- ShuffleQueryStage 0
            +- Exchange rangepartitioning(c0#2 ASC NULLS FIRST, c1#3 ASC NULLS FIRST, 10), ENSURE_REQUIREMENTS, [plan_id=28]
               +- *(1) Project [c0#2, trunc(c0#2, year) AS trunc(c0, year)#6, c1#3]
                  +- *(1) Scan ExistingRDD[c0#2,c1#3]
+- == Initial Plan ==
   Project [c0#2, trunc(c0, year)#6]
   +- Sort [c0#2 ASC NULLS FIRST, c1#3 ASC NULLS FIRST], true, 0
      +- Exchange rangepartitioning(c0#2 ASC NULLS FIRST, c1#3 ASC NULLS FIRST, 10), ENSURE_REQUIREMENTS, [plan_id=19]
         +- Project [c0#2, trunc(c0#2, year) AS trunc(c0, year)#6, c1#3]
            +- Scan ExistingRDD[c0#2,c1#3]

Spark Answers:
+----------+---------------+
|c0        |trunc(c0, year)|
+----------+---------------+
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-04|3332-01-01     |
|3332-12-04|3332-01-01     |
|3332-12-04|3332-01-01     |
+----------+---------------+
only showing top 20 rows

Comet Plan: AdaptiveSparkPlan isFinalPlan=false
+- CometProject [c0#2, trunc(c0, year)#23], [c0#2, trunc(c0, year)#23]
   +- CometSort [c0#2, trunc(c0, year)#23, c1#3], [c0#2 ASC NULLS FIRST, c1#3 ASC NULLS FIRST]
      +- CometExchange rangepartitioning(c0#2 ASC NULLS FIRST, c1#3 ASC NULLS FIRST, 10), ENSURE_REQUIREMENTS, CometNativeShuffle, [plan_id=99]
         +- CometProject [c0#2, trunc(c0, year)#23, c1#3], [c0#2, trunc(c0#2, year) AS trunc(c0, year)#23, c1#3]
            +- CometSparkRowToColumnar
               +- Scan ExistingRDD[c0#2,c1#3]

Comet Answers:
+----------+---------------+
|c0        |trunc(c0, year)|
+----------+---------------+
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-03|3332-01-01     |
|3332-12-04|3332-01-01     |
|3332-12-04|3332-01-01     |
|3332-12-04|3332-01-01     |
+----------+---------------+
only showing top 20 rows
```
