### PR TITLE
fix: CometLiteral class cast exception with arrays

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/literals.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/literals.scala
@@ -23,7 +23,7 @@ import java.lang
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Literal}
-import org.apache.spark.sql.catalyst.util.GenericArrayData
+import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteType, DateType, Decimal, DecimalType, DoubleType, FloatType, IntegerType, LongType, NullType, ShortType, StringType, TimestampNTZType, TimestampType}
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -90,9 +90,9 @@ object CometLiteral extends CometExpressionSerde[Literal] with Logging {
             com.google.protobuf.ByteString.copyFrom(value.asInstanceOf[Array[Byte]])
           exprBuilder.setBytesVal(byteStr)
 
-        case arr: ArrayType if value.isInstanceOf[GenericArrayData] =>
+        case arr: ArrayType =>
           val listLiteralBuilder: ListLiteral.Builder =
-            makeListLiteral(value.asInstanceOf[GenericArrayData].array, arr)
+            makeListLiteral(value.asInstanceOf[ArrayData].array, arr)
           exprBuilder.setListVal(listLiteralBuilder.build())
           exprBuilder.setDatatype(serializeDataType(dataType).get)
         case dt =>
@@ -198,7 +198,7 @@ object CometLiteral extends CometExpressionSerde[Literal] with Logging {
           })
       case a: ArrayType =>
         array.foreach(v => {
-          val casted = v.asInstanceOf[GenericArrayData]
+          val casted = v.asInstanceOf[ArrayData]
           listLiteralBuilder.addListValues(if (casted != null) {
             makeListLiteral(casted.array, a)
           } else ListLiteral.newBuilder())

--- a/spark/src/main/scala/org/apache/comet/serde/literals.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/literals.scala
@@ -90,7 +90,7 @@ object CometLiteral extends CometExpressionSerde[Literal] with Logging {
             com.google.protobuf.ByteString.copyFrom(value.asInstanceOf[Array[Byte]])
           exprBuilder.setBytesVal(byteStr)
 
-        case arr: ArrayType =>
+        case arr: ArrayType if value.isInstanceOf[GenericArrayData] =>
           val listLiteralBuilder: ListLiteral.Builder =
             makeListLiteral(value.asInstanceOf[GenericArrayData].array, arr)
           exprBuilder.setListVal(listLiteralBuilder.build())


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/2717

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Code assumes `GenericArrayData` but could be different impl such as `UnsafeArrayData`.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
