### PR TITLE
minor: Remove some hard-coded UTC timezones

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/datetime.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/datetime.scala
@@ -177,6 +177,13 @@ object CometQuarter extends CometExpressionSerde[Quarter] with CometExprGetDateF
 }
 
 object CometHour extends CometExpressionSerde[Hour] {
+  override def getSupportLevel(expr: Hour): SupportLevel = {
+    if (expr.timeZoneId.isEmpty) {
+      return Unsupported(Some("Missing timeZoneId"))
+    }
+    Compatible()
+  }
+
   override def convert(
       expr: Hour,
       inputs: Seq[Attribute],
@@ -186,9 +193,7 @@ object CometHour extends CometExpressionSerde[Hour] {
     if (childExpr.isDefined) {
       val builder = ExprOuterClass.Hour.newBuilder()
       builder.setChild(childExpr.get)
-
-      val timeZone = expr.timeZoneId.getOrElse("UTC")
-      builder.setTimezone(timeZone)
+      builder.setTimezone(expr.timeZoneId.get)
 
       Some(
         ExprOuterClass.Expr
@@ -203,6 +208,13 @@ object CometHour extends CometExpressionSerde[Hour] {
 }
 
 object CometMinute extends CometExpressionSerde[Minute] {
+  override def getSupportLevel(expr: Minute): SupportLevel = {
+    if (expr.timeZoneId.isEmpty) {
+      return Unsupported(Some("Missing timeZoneId"))
+    }
+    Compatible()
+  }
+
   override def convert(
       expr: Minute,
       inputs: Seq[Attribute],
@@ -212,9 +224,7 @@ object CometMinute extends CometExpressionSerde[Minute] {
     if (childExpr.isDefined) {
       val builder = ExprOuterClass.Minute.newBuilder()
       builder.setChild(childExpr.get)
-
-      val timeZone = expr.timeZoneId.getOrElse("UTC")
-      builder.setTimezone(timeZone)
+      builder.setTimezone(expr.timeZoneId.get)
 
       Some(
         ExprOuterClass.Expr
@@ -229,6 +239,13 @@ object CometMinute extends CometExpressionSerde[Minute] {
 }
 
 object CometSecond extends CometExpressionSerde[Second] {
+  override def getSupportLevel(expr: Second): SupportLevel = {
+    if (expr.timeZoneId.isEmpty) {
+      return Unsupported(Some("Missing timeZoneId"))
+    }
+    Compatible()
+  }
+
   override def convert(
       expr: Second,
       inputs: Seq[Attribute],
@@ -238,9 +255,7 @@ object CometSecond extends CometExpressionSerde[Second] {
     if (childExpr.isDefined) {
       val builder = ExprOuterClass.Second.newBuilder()
       builder.setChild(childExpr.get)
-
-      val timeZone = expr.timeZoneId.getOrElse("UTC")
-      builder.setTimezone(timeZone)
+      builder.setTimezone(expr.timeZoneId.get)
 
       Some(
         ExprOuterClass.Expr
@@ -315,6 +330,9 @@ object CometTruncTimestamp extends CometExpressionSerde[TruncTimestamp] {
       "microsecond")
 
   override def getSupportLevel(expr: TruncTimestamp): SupportLevel = {
+    if (expr.timeZoneId.isEmpty) {
+      return Unsupported(Some("Missing timeZoneId"))
+    }
     expr.format match {
       case Literal(fmt: UTF8String, _) =>
         if (supportedFormats.contains(fmt.toString.toLowerCase(Locale.ROOT))) {
@@ -339,9 +357,7 @@ object CometTruncTimestamp extends CometExpressionSerde[TruncTimestamp] {
       val builder = ExprOuterClass.TruncTimestamp.newBuilder()
       builder.setChild(childExpr.get)
       builder.setFormat(formatExpr.get)
-
-      val timeZone = expr.timeZoneId.getOrElse("UTC")
-      builder.setTimezone(timeZone)
+      builder.setTimezone(expr.timeZoneId.get)
 
       Some(
         ExprOuterClass.Expr

--- a/spark/src/main/scala/org/apache/comet/serde/structs.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/structs.scala
@@ -103,6 +103,12 @@ object CometGetArrayStructFields extends CometExpressionSerde[GetArrayStructFiel
 
 object CometStructsToJson extends CometExpressionSerde[StructsToJson] {
 
+  override def getSupportLevel(expr: StructsToJson): SupportLevel = {
+    if (expr.timeZoneId.isEmpty) {
+      return Unsupported(Some("Missing timeZoneId"))
+    }
+    Compatible()
+  }
   override def convert(
       expr: StructsToJson,
       inputs: Seq[Attribute],
@@ -148,7 +154,7 @@ object CometStructsToJson extends CometExpressionSerde[StructsToJson] {
             val toJson = ExprOuterClass.ToJson
               .newBuilder()
               .setChild(p)
-              .setTimezone(expr.timeZoneId.getOrElse("UTC"))
+              .setTimezone(expr.timeZoneId.get)
               .setIgnoreNullFields(true)
               .build()
             Some(

--- a/spark/src/main/spark-4.0/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-4.0/org/apache/comet/shims/CometExprShim.scala
@@ -69,6 +69,11 @@ trait CometExprShim extends CommonStringExprs {
         stringDecode(expr, charset, bin, inputs, binding)
 
       case expr @ ToPrettyString(child, timeZoneId) =>
+        if (timeZoneId.isEmpty) {
+          withInfo(expr, "Missing timeZoneId")
+          return None
+        }
+
         val castSupported = CometCast.isSupported(
           child.dataType,
           DataTypes.StringType,
@@ -87,7 +92,7 @@ trait CometExprShim extends CommonStringExprs {
               val toPrettyString = ExprOuterClass.ToPrettyString
                 .newBuilder()
                 .setChild(p)
-                .setTimezone(timeZoneId.getOrElse("UTC"))
+                .setTimezone(timeZoneId.get)
                 .setBinaryOutputStyle(binaryOutputStyle)
                 .build()
               Some(


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Partial fix for https://github.com/apache/datafusion-comet/issues/2730

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Hard-coded time zones make me nervous.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Remove some hard-coded timezones. I don't think they were ever actually used because Spark has a `ResolveTimeZone` rule that populates `timeZoneId` in all instances of `TimeZoneAwareExpression`.

```scala
object ResolveTimeZone extends Rule[LogicalPlan] {
  private val transformTimeZoneExprs: PartialFunction[Expression, Expression] = {
    case e: TimeZoneAwareExpression if e.timeZoneId.isEmpty =>
      e.withTimeZone(conf.sessionLocalTimeZone)
```

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
