### PR TITLE
fix: Use Spark session timezone in native execution when creating Arrow schema [WIP]

### DIFF
--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -646,13 +646,17 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_writeSortedFileNative
     compression_codec: JString,
     compression_level: jint,
     tracing_enabled: jboolean,
+    session_timezone: JString,
 ) -> jlongArray {
     try_unwrap_or_throw(&e, |mut env| unsafe {
         with_trace(
             "writeSortedFileNative",
             tracing_enabled != JNI_FALSE,
             || {
-                let data_types = convert_datatype_arrays(&mut env, serialized_datatypes, "UTC")?;
+                let session_time_zone_id: String =
+                    env.get_string(&session_timezone).unwrap().into();
+                let data_types =
+                    convert_datatype_arrays(&mut env, serialized_datatypes, &session_time_zone_id)?;
 
                 let row_num = env.get_array_length(&row_addresses)? as usize;
                 let row_addresses =

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -3297,7 +3297,7 @@ mod tests {
             datafusion_functions_nested::make_array::MakeArray::new(),
         ));
         let task_ctx = session_ctx.task_ctx();
-        let planner = PhysicalPlanner::new(Arc::from(session_ctx), 0);
+        let planner = PhysicalPlanner::new(Arc::from(session_ctx), "UTC", 0);
 
         // Create a plan for
         // ProjectionExec: expr=[make_array(col_0@0) as col_0]
@@ -3415,7 +3415,7 @@ mod tests {
     fn test_array_repeat() {
         let session_ctx = SessionContext::new();
         let task_ctx = session_ctx.task_ctx();
-        let planner = PhysicalPlanner::new(Arc::from(session_ctx), 0);
+        let planner = PhysicalPlanner::new(Arc::from(session_ctx), "UTC", 0);
 
         // Mock scan operator with 3 INT32 columns
         let op_scan = Operator {

--- a/native/core/src/parquet/mod.rs
+++ b/native/core/src/parquet/mod.rs
@@ -669,8 +669,11 @@ pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_validateObjec
 ) {
     try_unwrap_or_throw(&e, |mut env| {
         let session_config = SessionConfig::new();
-        let planner =
-            PhysicalPlanner::new(Arc::new(SessionContext::new_with_config(session_config)), 0);
+        let planner = PhysicalPlanner::new(
+            Arc::new(SessionContext::new_with_config(session_config)),
+            "UTC",
+            0,
+        );
         let session_ctx = planner.session_ctx();
         let path: String = env.get_string(&file_path).unwrap().into();
         let object_store_config = get_object_store_options(&mut env, object_store_options)?;
@@ -706,8 +709,11 @@ pub unsafe extern "system" fn Java_org_apache_comet_parquet_Native_initRecordBat
     try_unwrap_or_throw(&e, |mut env| unsafe {
         JVMClasses::init(&mut env);
         let session_config = SessionConfig::new().with_batch_size(batch_size as usize);
-        let planner =
-            PhysicalPlanner::new(Arc::new(SessionContext::new_with_config(session_config)), 0);
+        let planner = PhysicalPlanner::new(
+            Arc::new(SessionContext::new_with_config(session_config)),
+            "UTC",
+            0,
+        );
         let session_ctx = planner.session_ctx();
 
         let path: String = env.get_string(&file_path).unwrap().into();

--- a/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
+++ b/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
@@ -33,6 +33,7 @@ import org.apache.spark.memory.SparkOutOfMemoryError;
 import org.apache.spark.shuffle.ShuffleWriteMetricsReporter;
 import org.apache.spark.shuffle.comet.CometShuffleMemoryAllocatorTrait;
 import org.apache.spark.shuffle.sort.RowPartition;
+import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.memory.MemoryBlock;
 
@@ -196,7 +197,8 @@ public abstract class SpillWriter {
             currentChecksum,
             compressionCodec,
             compressionLevel,
-            tracingEnabled);
+            tracingEnabled,
+            SQLConf.get().sessionLocalTimeZone());
 
     long written = results[0];
     checksum = results[1];

--- a/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
+++ b/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
@@ -33,7 +33,6 @@ import org.apache.spark.memory.SparkOutOfMemoryError;
 import org.apache.spark.shuffle.ShuffleWriteMetricsReporter;
 import org.apache.spark.shuffle.comet.CometShuffleMemoryAllocatorTrait;
 import org.apache.spark.shuffle.sort.RowPartition;
-import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.memory.MemoryBlock;
 
@@ -199,7 +198,7 @@ public abstract class SpillWriter {
             compressionLevel,
             tracingEnabled,
             // TODO using session time zone causes regressions in Parquet scan
-            //SQLConf.get().sessionLocalTimeZone()
+            // SQLConf.get().sessionLocalTimeZone()
             "UTC");
 
     long written = results[0];

--- a/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
+++ b/spark/src/main/java/org/apache/spark/sql/comet/execution/shuffle/SpillWriter.java
@@ -198,7 +198,9 @@ public abstract class SpillWriter {
             compressionCodec,
             compressionLevel,
             tracingEnabled,
-            SQLConf.get().sessionLocalTimeZone());
+            // TODO using session time zone causes regressions in Parquet scan
+            //SQLConf.get().sessionLocalTimeZone()
+            "UTC");
 
     long written = results[0];
     checksum = results[1];

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -21,9 +21,7 @@ package org.apache.comet
 
 import java.io.FileNotFoundException
 import java.lang.management.ManagementFactory
-
 import scala.util.matching.Regex
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
@@ -32,12 +30,12 @@ import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.comet.CometMetricNode
 import org.apache.spark.sql.vectorized._
 import org.apache.spark.util.SerializableConfiguration
-
 import org.apache.comet.CometConf._
 import org.apache.comet.Tracing.withTrace
 import org.apache.comet.parquet.CometFileKeyUnwrapper
 import org.apache.comet.serde.Config.ConfigMap
 import org.apache.comet.vector.NativeUtil
+import org.apache.spark.sql.internal.SQLConf
 
 /**
  * An iterator class used to execute Comet native query. It takes an input iterator which comes
@@ -124,7 +122,8 @@ class CometExecIterator(
       memoryConfig.memoryLimit,
       memoryConfig.memoryLimitPerTask,
       taskAttemptId,
-      keyUnwrapper)
+      keyUnwrapper,
+      SQLConf.get.sessionLocalTimeZone)
   }
 
   private var nextBatch: Option[ColumnarBatch] = None

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -21,21 +21,24 @@ package org.apache.comet
 
 import java.io.FileNotFoundException
 import java.lang.management.ManagementFactory
+
 import scala.util.matching.Regex
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.comet.CometMetricNode
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.vectorized._
 import org.apache.spark.util.SerializableConfiguration
+
 import org.apache.comet.CometConf._
 import org.apache.comet.Tracing.withTrace
 import org.apache.comet.parquet.CometFileKeyUnwrapper
 import org.apache.comet.serde.Config.ConfigMap
 import org.apache.comet.vector.NativeUtil
-import org.apache.spark.sql.internal.SQLConf
 
 /**
  * An iterator class used to execute Comet native query. It takes an input iterator which comes

--- a/spark/src/main/scala/org/apache/comet/Native.scala
+++ b/spark/src/main/scala/org/apache/comet/Native.scala
@@ -68,7 +68,8 @@ class Native extends NativeBase {
       memoryLimit: Long,
       memoryLimitPerTask: Long,
       taskAttemptId: Long,
-      keyUnwrapper: CometFileKeyUnwrapper): Long
+      keyUnwrapper: CometFileKeyUnwrapper,
+      timeZoneId: String): Long
   // scalastyle:on
 
   /**

--- a/spark/src/main/scala/org/apache/comet/Native.scala
+++ b/spark/src/main/scala/org/apache/comet/Native.scala
@@ -148,7 +148,8 @@ class Native extends NativeBase {
       currentChecksum: Long,
       compressionCodec: String,
       compressionLevel: Int,
-      tracingEnabled: Boolean): Array[Long]
+      tracingEnabled: Boolean,
+      timeZoneId: String): Array[Long]
   // scalastyle:on
 
   /**

--- a/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
@@ -68,7 +68,7 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
 
     // TODO test fails with non-UTC timezone
     // https://github.com/apache/datafusion-comet/issues/2649
-    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "America/Denver") {
       for (format <- supportedFormats) {
         checkSparkAnswerAndOperator(s"SELECT c0, date_trunc('$format', c0) from tbl order by c0")
       }

--- a/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
@@ -68,7 +68,7 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
 
     // TODO test fails with non-UTC timezone
     // https://github.com/apache/datafusion-comet/issues/2649
-    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "America/Denver") {
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
       for (format <- supportedFormats) {
         checkSparkAnswerAndOperator(s"SELECT c0, date_trunc('$format', c0) from tbl order by c0")
       }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Partial fix for #2649

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

In native code, we had a hard-coded `UTC` when converting Spark schema to Arrow schema. 

In `to_arrow_datatype`:

```rust
DataTypeId::Timestamp => {
          ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".to_string().into()))
      }
```

This would lead to a runtime error when running a query against a **DataFrame** (not a Parquet file) that is not in `UTC`:

```
RowConverter column schema mismatch, expected Timestamp(Microsecond, Some("America/Denver")) got Timestamp(Microsecond, Some("UTC")).
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Pass Spark timeZoneId into native code and use that instead of hard-coded `UTC`.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

WIP