### PR TITLE
fix: Fix logic error in `CometExecRule` for disabling CometHashAggregate when Comet shuffle is disabled

### DIFF
--- a/docs/source/user-guide/latest/compatibility.md
+++ b/docs/source/user-guide/latest/compatibility.md
@@ -70,7 +70,7 @@ this can be overridden by setting `spark.comet.regexp.allowIncompatible=true`.
 
 ## Window Functions
 
-Comet's support for window functions is incomplete and known to be incorrect. It is disabled by default and 
+Comet's support for window functions is incomplete and known to be incorrect. It is disabled by default and
 should not be used in production. The feature will be enabled in a future release. Tracking issue: [#2721](https://github.com/apache/datafusion-comet/issues/2721).
 
 ## Cast

--- a/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
@@ -236,8 +236,8 @@ case class CometExecRule(session: SparkSession) extends Rule[SparkPlan] {
       // to CometHashAggregate. Otherwise, we probably get partial Comet aggregation
       // and final Spark aggregation.
       case op: BaseAggregateExec
-          if op.isInstanceOf[HashAggregateExec] ||
-            op.isInstanceOf[ObjectHashAggregateExec] &&
+          if (op.isInstanceOf[HashAggregateExec] ||
+            op.isInstanceOf[ObjectHashAggregateExec]) &&
             isCometShuffleEnabled(conf) =>
         val modes = op.aggregateExpressions.map(_.mode).distinct
         // In distinct aggregates there can be a combination of modes

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -1017,8 +1017,7 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
 
   test("Decimal Avg with DF") {
     Seq(true, false).foreach { dictionaryEnabled =>
-      withSQLConf(
-        CometConf.COMET_EXPR_ALLOW_INCOMPATIBLE.key -> "true") {
+      withSQLConf(CometConf.COMET_EXPR_ALLOW_INCOMPATIBLE.key -> "true") {
         withTempDir { dir =>
           val path = new Path(dir.toURI.toString, "test")
           makeParquetFile(path, 1000, 20, dictionaryEnabled)
@@ -1030,8 +1029,9 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
               expectedNumOfCometAggregates)
 
             checkSparkAnswerWithTolerance("SELECT _g3, AVG(_8) FROM tbl GROUP BY _g3")
-            assert(getNumCometHashAggregate(
-              sql("SELECT _g3, AVG(_8) FROM tbl GROUP BY _g3")) == expectedNumOfCometAggregates)
+            assert(
+              getNumCometHashAggregate(
+                sql("SELECT _g3, AVG(_8) FROM tbl GROUP BY _g3")) == expectedNumOfCometAggregates)
 
             checkSparkAnswerAndNumOfAggregates(
               "SELECT _g4, AVG(_9) FROM tbl GROUP BY _g4",
@@ -1042,8 +1042,9 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
               expectedNumOfCometAggregates)
 
             checkSparkAnswerWithTolerance("SELECT AVG(_8) FROM tbl")
-            assert(getNumCometHashAggregate(
-              sql("SELECT AVG(_8) FROM tbl")) == expectedNumOfCometAggregates)
+            assert(
+              getNumCometHashAggregate(
+                sql("SELECT AVG(_8) FROM tbl")) == expectedNumOfCometAggregates)
 
             checkSparkAnswerAndNumOfAggregates(
               "SELECT AVG(_9) FROM tbl",


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Helps with https://github.com/apache/datafusion-comet/issues/1389, but we still need to fix the real issue.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Fix logic error

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
