### PR TITLE
fix: Prevent mixed Spark/Comet partial/final aggregates

### DIFF
--- a/spark/src/test/scala/org/apache/comet/rules/CometExecRuleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/CometExecRuleSuite.scala
@@ -240,8 +240,9 @@ class CometExecRuleSuite extends CometTestBase {
           // Verify that the partial aggregate has the expected fallback message
           val partialAggregates = findPartialAggregates(transformedPlan)
           assert(partialAggregates.nonEmpty, "Should have found at least one partial aggregate")
-          val expectedMessage = "Cannot convert final aggregate to Comet, " +
-            "so partial aggregates must also use Spark to avoid mixed execution"
+          val expectedMessage =
+            "Cannot convert final aggregate to Comet (Final aggregates disabled via test config), " +
+              "so partial aggregates must also use Spark to avoid mixed execution"
           assert(
             partialAggregates.exists(hasFallbackMessage(_, expectedMessage)),
             s"Partial aggregate should have fallback message: $expectedMessage")

--- a/spark/src/test/scala/org/apache/comet/rules/CometExecRuleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/CometExecRuleSuite.scala
@@ -384,7 +384,7 @@ class CometExecRuleSuite extends CometTestBase {
               |""".stripMargin)
 
           // Execute the plan to trigger AQE stage creation
-          val result = df.collect()
+          df.collect()
 
           // Get the executed plan which should have AQE stages
           val executedPlan = df.queryExecution.executedPlan

--- a/spark/src/test/scala/org/apache/comet/rules/CometExecRuleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/CometExecRuleSuite.scala
@@ -131,9 +131,7 @@ class CometExecRuleSuite extends CometTestBase {
     }
   }
 
-  // TODO this test exposes the bug described in
-  // https://github.com/apache/datafusion-comet/issues/1389
-  ignore("CometExecRule should not allow Comet partial and Spark final hash aggregate") {
+  test("CometExecRule should not allow Comet partial and Spark final hash aggregate") {
     withTempView("test_data") {
       createTestDataFrame.createOrReplaceTempView("test_data")
 

--- a/spark/src/test/scala/org/apache/comet/rules/CometExecRuleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/CometExecRuleSuite.scala
@@ -385,7 +385,6 @@ class CometExecRuleSuite extends CometTestBase {
 
           // Execute the plan to trigger AQE stage creation
           val result = df.collect()
-          logInfo(s"Query executed successfully, returned ${result.length} rows")
 
           // Get the executed plan which should have AQE stages
           val executedPlan = df.queryExecution.executedPlan
@@ -394,8 +393,6 @@ class CometExecRuleSuite extends CometTestBase {
           val queryStages = stripAQEPlan(executedPlan).collect { case qs: QueryStageExec => qs }
 
           assert(queryStages.nonEmpty)
-          // We have AQE stages - test the cross-stage coordination
-          logInfo(s"AQE created ${queryStages.length} stages - testing cross-stage coordination")
 
           // Verify that we have ObjectHashAggregateExec operators in the plan
           // Need to recursively search through AQE stages
@@ -460,8 +457,6 @@ class CometExecRuleSuite extends CometTestBase {
               partialAggregates.exists(hasFallbackMessage(_, expectedMessage)),
               s"Partial aggregate should have fallback message: $expectedMessage")
           }
-
-          logInfo(s"AQE cross-stage coordination test passed with ${queryStages.length} stages")
         }
       }
     } finally {

--- a/spark/src/test/scala/org/apache/comet/rules/CometExecRuleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/CometExecRuleSuite.scala
@@ -393,10 +393,9 @@ class CometExecRuleSuite extends CometTestBase {
           // Check if we have QueryStageExec nodes (indicating AQE created stages)
           val queryStages = stripAQEPlan(executedPlan).collect { case qs: QueryStageExec => qs }
 
-          assert (queryStages.nonEmpty)
+          assert(queryStages.nonEmpty)
           // We have AQE stages - test the cross-stage coordination
-          logInfo(
-            s"AQE created ${queryStages.length} stages - testing cross-stage coordination")
+          logInfo(s"AQE created ${queryStages.length} stages - testing cross-stage coordination")
 
           // Verify that we have ObjectHashAggregateExec operators in the plan
           // Need to recursively search through AQE stages

--- a/spark/src/test/scala/org/apache/comet/rules/CometExecRuleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/CometExecRuleSuite.scala
@@ -22,7 +22,7 @@ package org.apache.comet.rules
 import scala.util.Random
 
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
 import org.apache.spark.sql.catalyst.expressions.aggregate.BloomFilterAggregate


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/1389

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Prevent runtime errors. The issue is explained very well in https://github.com/apache/datafusion-comet/issues/1389.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add new `tagUnsupportedPartialAggregates` method in `CometExecRule` that will look for unsupported final aggregates and then tag the corresponding partial aggregate with a fallback reason to prevent it from being converted to Comet.

The opposite scenario (supported partial, unsupported final) is already handled in `CometHashAggregateExec`. In a future PR I will move that logic into `CometExecRule` as well.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

New unit tests in `CometExecRuleSuite`.

There are tests for partial/final pair both in the same query stage and split across query stages.