### PR TITLE
chore: Remove `row_step` from `process_sorted_row_partition`

### DIFF
--- a/native/core/src/execution/shuffle/row.rs
+++ b/native/core/src/execution/shuffle/row.rs
@@ -765,7 +765,6 @@ pub fn process_sorted_row_partition(
     initial_checksum: Option<u32>,
     codec: &CompressionCodec,
 ) -> Result<(i64, Option<u32>), CometError> {
-
     // The current row number we are reading
     let mut current_row = 0;
     // Total number of bytes written

--- a/native/core/src/execution/shuffle/row.rs
+++ b/native/core/src/execution/shuffle/row.rs
@@ -765,8 +765,6 @@ pub fn process_sorted_row_partition(
     initial_checksum: Option<u32>,
     codec: &CompressionCodec,
 ) -> Result<(i64, Option<u32>), CometError> {
-    // TODO: We can tune this parameter automatically based on row size and cache size.
-    let row_step = 10;
 
     // The current row number we are reading
     let mut current_row = 0;
@@ -790,26 +788,19 @@ pub fn process_sorted_row_partition(
         })?;
 
         // Appends rows to the array builders.
-        let mut row_start: usize = current_row;
-        while row_start < current_row + n {
-            let row_end = std::cmp::min(row_start + row_step, current_row + n);
-
-            // For each column, iterating over rows and appending values to corresponding array
-            // builder.
-            for (idx, builder) in data_builders.iter_mut().enumerate() {
-                append_columns(
-                    row_addresses_ptr,
-                    row_sizes_ptr,
-                    row_start,
-                    row_end,
-                    schema,
-                    idx,
-                    builder,
-                    prefer_dictionary_ratio,
-                )?;
-            }
-
-            row_start = row_end;
+        // For each column, iterating over rows and appending values to corresponding array
+        // builder.
+        for (idx, builder) in data_builders.iter_mut().enumerate() {
+            append_columns(
+                row_addresses_ptr,
+                row_sizes_ptr,
+                current_row,
+                current_row + n,
+                schema,
+                idx,
+                builder,
+                prefer_dictionary_ratio,
+            )?;
         }
 
         // Writes a record batch generated from the array builders to the output file.


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The `row_step` optimization uses an inner loop processing 10 rows at a time and downcast the builders every 10 rows. It does not seem to do anything to actually improve performance, so I removed it. The code is simpler to understand now and should be faster.


Before:

```
row_array_conversion/row_to_array
                        time:   [3.9986 ms 4.0807 ms 4.1705 ms]
Found 22 outliers among 100 measurements (22.00%)
  10 (10.00%) high mild
  12 (12.00%) high severe
```

After:

```
row_array_conversion/row_to_array
                        time:   [3.6814 ms 3.8756 ms 4.0666 ms]
                        change: [−9.9184% −5.0275% +0.4773%] (p = 0.06 > 0.05)
                        No change in performance detected.
```

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
