### PR TITLE
chore: Reduce syscalls in metrics update logic

### DIFF
--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -136,6 +136,8 @@ struct ExecutionContext {
     pub metrics_update_interval: Option<Duration>,
     // The last update time of metrics
     pub metrics_last_update_time: Instant,
+    /// Counter to avoid checking time on every poll iteration (reduces syscalls)
+    pub poll_count_since_metrics_check: u32,
     /// The time it took to create the native plan and configure the context
     pub plan_creation_time: Duration,
     /// DataFusion SessionContext
@@ -272,6 +274,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
                 metrics,
                 metrics_update_interval,
                 metrics_last_update_time: Instant::now(),
+                poll_count_since_metrics_check: 0,
                 plan_creation_time,
                 session_ctx: Arc::new(session),
                 debug_native,
@@ -509,11 +512,16 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
                 let poll_output = get_runtime().block_on(async { poll!(next_item) });
 
                 // update metrics at interval
+                // Only check time every 100 polls to reduce syscall overhead
                 if let Some(interval) = exec_context.metrics_update_interval {
-                    let now = Instant::now();
-                    if now - exec_context.metrics_last_update_time >= interval {
-                        update_metrics(&mut env, exec_context)?;
-                        exec_context.metrics_last_update_time = now;
+                    exec_context.poll_count_since_metrics_check += 1;
+                    if exec_context.poll_count_since_metrics_check >= 100 {
+                        let now = Instant::now();
+                        if now - exec_context.metrics_last_update_time >= interval {
+                            update_metrics(&mut env, exec_context)?;
+                            exec_context.metrics_last_update_time = now;
+                        }
+                        exec_context.poll_count_since_metrics_check = 0;
                     }
                 }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Reduce syscalls by 99% when checking whether it is time to update metrics (check once per 100 polls instead of on every poll).

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
