### PR TITLE
chore: Add microbenchmark for casting string to temporal types

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometCastStringToTemporalBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometCastStringToTemporalBenchmark.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.benchmark
+
+import org.apache.spark.sql.internal.SQLConf
+
+case class CastStringToTemporalConfig(
+    name: String,
+    query: String,
+    extraCometConfigs: Map[String, String] = Map.empty)
+
+/**
+ * Benchmark to measure performance of Comet cast from String to temporal types. To run this
+ * benchmark: `SPARK_GENERATE_BENCHMARK_FILES=1 make
+ * benchmark-org.apache.spark.sql.benchmark.CometCastStringToTemporalBenchmark` Results will be
+ * written to "spark/benchmarks/CometCastStringToTemporalBenchmark-**results.txt".
+ */
+object CometCastStringToTemporalBenchmark extends CometBenchmarkBase {
+
+  /**
+   * Generic method to run a cast benchmark with the given configuration.
+   */
+  def runCastBenchmark(config: CastStringToTemporalConfig, values: Int): Unit = {
+    withTempPath { dir =>
+      withTempTable("parquetV1Table") {
+        // Generate date strings like "2020-01-01", "2020-01-02", etc.
+        // This covers the full range for date parsing
+        prepareTable(
+          dir,
+          spark.sql(
+            s"SELECT CAST(DATE_ADD('2020-01-01', CAST(value % 3650 AS INT)) AS STRING) AS c1 FROM $tbl"))
+
+        runExpressionBenchmark(config.name, values, config.query, config.extraCometConfigs)
+      }
+    }
+  }
+
+  /**
+   * Benchmark for String to Timestamp with timestamp-formatted strings.
+   */
+  def runTimestampCastBenchmark(config: CastStringToTemporalConfig, values: Int): Unit = {
+    withTempPath { dir =>
+      withTempTable("parquetV1Table") {
+        // Generate timestamp strings like "2020-01-01 12:34:56", etc.
+        prepareTable(
+          dir,
+          spark.sql(
+            s"SELECT CAST(TIMESTAMP_MICROS(value % 9999999999) AS STRING) AS c1 FROM $tbl"))
+
+        runExpressionBenchmark(config.name, values, config.query, config.extraCometConfigs)
+      }
+    }
+  }
+
+  // Configuration for String to temporal cast benchmarks
+  private val castConfigs = List(
+    // Date
+    CastStringToTemporalConfig(
+      "Cast String to Date (LEGACY)",
+      "SELECT CAST(c1 AS DATE) FROM parquetV1Table",
+      Map(SQLConf.ANSI_ENABLED.key -> "false")),
+    CastStringToTemporalConfig(
+      "Cast String to Date (ANSI)",
+      "SELECT CAST(c1 AS DATE) FROM parquetV1Table",
+      Map(SQLConf.ANSI_ENABLED.key -> "true")))
+
+  private val timestampCastConfigs = List(
+    // Timestamp (only UTC timezone is compatible)
+    CastStringToTemporalConfig(
+      "Cast String to Timestamp (LEGACY, UTC)",
+      "SELECT CAST(c1 AS TIMESTAMP) FROM parquetV1Table",
+      Map(SQLConf.ANSI_ENABLED.key -> "false")),
+    CastStringToTemporalConfig(
+      "Cast String to Timestamp (ANSI, UTC)",
+      "SELECT CAST(c1 AS TIMESTAMP) FROM parquetV1Table",
+      Map(SQLConf.ANSI_ENABLED.key -> "true")))
+
+  override def runCometBenchmark(mainArgs: Array[String]): Unit = {
+    val values = 1024 * 1024 * 10 // 10M rows
+
+    // Run date casts
+    castConfigs.foreach { config =>
+      runBenchmarkWithTable(config.name, values) { v =>
+        runCastBenchmark(config, v)
+      }
+    }
+
+    // Run timestamp casts
+    timestampCastConfigs.foreach { config =>
+      runBenchmarkWithTable(config.name, values) { v =>
+        runTimestampCastBenchmark(config, v)
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometCastStringToTemporalBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometCastStringToTemporalBenchmark.scala
@@ -19,8 +19,6 @@
 
 package org.apache.spark.sql.benchmark
 
-import org.apache.spark.sql.internal.SQLConf
-
 case class CastStringToTemporalConfig(
     name: String,
     query: String,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

```
OpenJDK 64-Bit Server VM 11.0.22+7-LTS on Mac OS X 14.6.1
Apple M3 Max
Cast String to Date:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Spark                                               923            943          22         11.4          88.0       1.0X
Comet (Scan)                                       1064           1072          12          9.9         101.5       0.9X
Comet (Scan + Exec)                                 429            442          15         24.5          40.9       2.2X

OpenJDK 64-Bit Server VM 11.0.22+7-LTS on Mac OS X 14.6.1
Apple M3 Max
Try_Cast String to Date:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Spark                                               921            941          33         11.4          87.9       1.0X
Comet (Scan)                                       1120           1125           6          9.4         106.8       0.8X
Comet (Scan + Exec)                                 428            451          18         24.5          40.8       2.2X

OpenJDK 64-Bit Server VM 11.0.22+7-LTS on Mac OS X 14.6.1
Apple M3 Max
Cast String to Timestamp:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Spark                                              1290           1296          10          8.1         123.0       1.0X
Comet (Scan)                                       1341           1377          51          7.8         127.9       1.0X
Comet (Scan + Exec)                                1348           1352           6          7.8         128.6       1.0X

OpenJDK 64-Bit Server VM 11.0.22+7-LTS on Mac OS X 14.6.1
Apple M3 Max
Try_Cast String to Timestamp:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Spark                                              1309           1327          25          8.0         124.8       1.0X
Comet (Scan)                                       1314           1316           3          8.0         125.3       1.0X
Comet (Scan + Exec)                                1372           1390          25          7.6         130.8       1.0X
```