### PR TITLE
feat: add partial support for date_format expression

### DIFF
--- a/docs/source/user-guide/latest/configs.md
+++ b/docs/source/user-guide/latest/configs.md
@@ -234,6 +234,7 @@ These settings can be used to determine which parts of the plan are accelerated 
 | `spark.comet.expression.CreateArray.enabled` | Enable Comet acceleration for `CreateArray` | true |
 | `spark.comet.expression.CreateNamedStruct.enabled` | Enable Comet acceleration for `CreateNamedStruct` | true |
 | `spark.comet.expression.DateAdd.enabled` | Enable Comet acceleration for `DateAdd` | true |
+| `spark.comet.expression.DateFormatClass.enabled` | Enable Comet acceleration for `DateFormatClass` | true |
 | `spark.comet.expression.DateSub.enabled` | Enable Comet acceleration for `DateSub` | true |
 | `spark.comet.expression.DayOfMonth.enabled` | Enable Comet acceleration for `DayOfMonth` | true |
 | `spark.comet.expression.DayOfWeek.enabled` | Enable Comet acceleration for `DayOfWeek` | true |

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -185,6 +185,7 @@ object QueryPlanSerde extends Logging with CometExprShim {
 
   private val temporalExpressions: Map[Class[_ <: Expression], CometExpressionSerde[_]] = Map(
     classOf[DateAdd] -> CometDateAdd,
+    classOf[DateFormatClass] -> CometDateFormat,
     classOf[DateSub] -> CometDateSub,
     classOf[FromUnixTime] -> CometFromUnixTime,
     classOf[Hour] -> CometHour,

--- a/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
 
-import org.apache.comet.serde.{CometTruncDate, CometTruncTimestamp}
+import org.apache.comet.serde.{CometDateFormat, CometTruncDate, CometTruncTimestamp}
 import org.apache.comet.testing.{DataGenOptions, FuzzDataGenerator}
 
 class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
@@ -122,4 +122,91 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
         StructField("fmt", DataTypes.StringType, true)))
     FuzzDataGenerator.generateDataFrame(r, spark, schema, 1000, DataGenOptions())
   }
+
+  test("date_format with timestamp column") {
+    // Filter out formats with embedded quotes that need special handling
+    val supportedFormats = CometDateFormat.supportedFormats.keys.toSeq
+      .filterNot(_.contains("'"))
+
+    createTimestampTestData.createOrReplaceTempView("tbl")
+
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      for (format <- supportedFormats) {
+        checkSparkAnswerAndOperator(s"SELECT c0, date_format(c0, '$format') from tbl order by c0")
+      }
+      // Test ISO format with embedded quotes separately using double-quoted string
+      checkSparkAnswerAndOperator(
+        "SELECT c0, date_format(c0, \"yyyy-MM-dd'T'HH:mm:ss\") from tbl order by c0")
+    }
+  }
+
+  test("date_format with specific format strings") {
+    // Test specific format strings with explicit timestamp data
+    createTimestampTestData.createOrReplaceTempView("tbl")
+
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      // Date formats
+      checkSparkAnswerAndOperator("SELECT c0, date_format(c0, 'yyyy-MM-dd') from tbl order by c0")
+      checkSparkAnswerAndOperator("SELECT c0, date_format(c0, 'yyyy/MM/dd') from tbl order by c0")
+
+      // Time formats
+      checkSparkAnswerAndOperator("SELECT c0, date_format(c0, 'HH:mm:ss') from tbl order by c0")
+      checkSparkAnswerAndOperator("SELECT c0, date_format(c0, 'HH:mm') from tbl order by c0")
+
+      // Combined formats
+      checkSparkAnswerAndOperator(
+        "SELECT c0, date_format(c0, 'yyyy-MM-dd HH:mm:ss') from tbl order by c0")
+
+      // Day/month names
+      checkSparkAnswerAndOperator("SELECT c0, date_format(c0, 'EEEE') from tbl order by c0")
+      checkSparkAnswerAndOperator("SELECT c0, date_format(c0, 'MMMM') from tbl order by c0")
+
+      // 12-hour time
+      checkSparkAnswerAndOperator("SELECT c0, date_format(c0, 'hh:mm:ss a') from tbl order by c0")
+
+      // ISO format (use double single-quotes to escape the literal T)
+      checkSparkAnswerAndOperator(
+        "SELECT c0, date_format(c0, \"yyyy-MM-dd'T'HH:mm:ss\") from tbl order by c0")
+    }
+  }
+
+  test("date_format with literal timestamp") {
+    // Test specific literal timestamp formats
+    // Disable constant folding to ensure Comet actually executes the expression
+    withSQLConf(
+      SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC",
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        "org.apache.spark.sql.catalyst.optimizer.ConstantFolding") {
+      checkSparkAnswerAndOperator(
+        "SELECT date_format(TIMESTAMP '2024-03-15 14:30:45', 'yyyy-MM-dd')")
+      checkSparkAnswerAndOperator(
+        "SELECT date_format(TIMESTAMP '2024-03-15 14:30:45', 'yyyy-MM-dd HH:mm:ss')")
+      checkSparkAnswerAndOperator(
+        "SELECT date_format(TIMESTAMP '2024-03-15 14:30:45', 'HH:mm:ss')")
+      checkSparkAnswerAndOperator("SELECT date_format(TIMESTAMP '2024-03-15 14:30:45', 'EEEE')")
+      checkSparkAnswerAndOperator(
+        "SELECT date_format(TIMESTAMP '2024-03-15 14:30:45', 'hh:mm:ss a')")
+    }
+  }
+
+  test("date_format with null") {
+    withSQLConf(
+      SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC",
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        "org.apache.spark.sql.catalyst.optimizer.ConstantFolding") {
+      checkSparkAnswerAndOperator("SELECT date_format(CAST(NULL AS TIMESTAMP), 'yyyy-MM-dd')")
+    }
+  }
+
+  test("date_format unsupported format falls back to Spark") {
+    createTimestampTestData.createOrReplaceTempView("tbl")
+
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      // Unsupported format string
+      checkSparkAnswerAndFallbackReason(
+        "SELECT c0, date_format(c0, 'yyyy-MM-dd EEEE') from tbl order by c0",
+        "Format 'yyyy-MM-dd EEEE' is not supported")
+    }
+  }
+
 }

--- a/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
@@ -219,7 +219,7 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
       withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> tz) {
         // Non-UTC timezones should fall back to Spark as Incompatible
         checkSparkAnswerAndFallbackReason(
-          s"SELECT c0, date_format(c0, 'yyyy-MM-dd HH:mm:ss') from tbl order by c0",
+          "SELECT c0, date_format(c0, 'yyyy-MM-dd HH:mm:ss') from tbl order by c0",
           s"Non-UTC timezone '$tz' may produce different results")
       }
     }
@@ -236,7 +236,7 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
         "spark.comet.expr.DateFormatClass.allowIncompatible" -> "true") {
         // With allowIncompatible enabled, Comet will execute the expression
         // Results may differ from Spark but should not throw errors
-        checkSparkAnswer(s"SELECT c0, date_format(c0, 'yyyy-MM-dd') from tbl order by c0")
+        checkSparkAnswer("SELECT c0, date_format(c0, 'yyyy-MM-dd') from tbl order by c0")
       }
     }
   }


### PR DESCRIPTION
## Summary
- Adds native Comet support for Spark's `date_format` function
- Uses DataFusion's `to_char` function for the underlying implementation
- Supports a whitelist of common format strings that can be reliably mapped between Spark SimpleDateFormat patterns and strftime patterns

Supported formats include:
- Date formats: `yyyy-MM-dd`, `yyyy/MM/dd`, `yyyyMMdd`, `yyyyMM`
- Time formats: `HH:mm:ss`, `HH:mm`, `HH`, `mm`, `ss`
- DateTime formats: `yyyy-MM-dd HH:mm:ss`, `yyyy/MM/dd HH:mm:ss`
- Day/month names: `EEEE`, `EEE`, `MMMM`, `MMM`
- 12-hour time: `hh:mm:ss a`, `hh:mm a`, `h:mm a`
- ISO format: `yyyy-MM-dd'T'HH:mm:ss`
- Single components: `yyyy`, `yy`, `MM`, `dd`

Unsupported format strings will fall back to Spark execution.

### Timezone Support

Currently only UTC timezone is fully compatible. Non-UTC timezones are marked as `Incompatible` and fall back to Spark by default. Users can enable Comet execution for non-UTC timezones with `spark.comet.expr.DateFormatClass.allowIncompatible=true`, but results may differ from Spark.

See #3202 for tracking full timezone support.

## Test Plan
- Added comprehensive tests in `CometTemporalExpressionSuite`:
  - Tests all supported format strings with timestamp columns
  - Tests with literal timestamps (constant folding disabled)
  - Tests null handling
  - Tests fallback to Spark for unsupported formats
  - Tests non-UTC timezone fallback behavior
  - Tests `allowIncompatible` config for non-UTC timezones

> **Note:** This PR was generated with AI assistance.

Closes #3088