### PR TITLE
feat: [EXPERIMENTAL] Add cost-based optimizer (CBO) for Comet vs Spark execution

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -150,6 +150,7 @@ jobs:
               org.apache.spark.CometPluginsUnifiedModeOverrideSuite
               org.apache.comet.rules.CometScanRuleSuite
               org.apache.comet.rules.CometExecRuleSuite
+              org.apache.comet.rules.CometCBOSuite
               org.apache.spark.sql.CometTPCDSQuerySuite
               org.apache.spark.sql.CometTPCDSQueryTestSuite
               org.apache.spark.sql.CometTPCHQuerySuite

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -113,6 +113,7 @@ jobs:
               org.apache.spark.CometPluginsUnifiedModeOverrideSuite
               org.apache.comet.rules.CometScanRuleSuite
               org.apache.comet.rules.CometExecRuleSuite
+              org.apache.comet.rules.CometCBOSuite
               org.apache.spark.sql.CometTPCDSQuerySuite
               org.apache.spark.sql.CometTPCDSQueryTestSuite
               org.apache.spark.sql.CometTPCHQuerySuite

--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -940,6 +940,42 @@ object CometConf extends ShimCometConf {
   def getBooleanConf(name: String, defaultValue: Boolean, conf: SQLConf): Boolean = {
     conf.getConfString(name, defaultValue.toString).toLowerCase(Locale.ROOT) == "true"
   }
+
+  // CBO expression cost configuration helpers
+
+  /** Config key prefix for CBO expression costs */
+  val COMET_CBO_EXPR_COST_PREFIX = "spark.comet.cbo.exprCost"
+
+  /**
+   * Get the config key for an expression's cost multiplier. Example:
+   * spark.comet.cbo.exprCost.AttributeReference
+   */
+  def getExprCostConfigKey(exprName: String): String = {
+    s"$COMET_CBO_EXPR_COST_PREFIX.$exprName"
+  }
+
+  /**
+   * Get the config key for an expression class's cost multiplier.
+   */
+  def getExprCostConfigKey(exprClass: Class[_]): String = {
+    getExprCostConfigKey(exprClass.getSimpleName)
+  }
+
+  /**
+   * Get the cost multiplier for an expression from config, with fallback to default. A cost
+   * multiplier < 1.0 means Comet is faster, > 1.0 means Spark is faster.
+   */
+  def getExprCost(exprName: String, defaultCost: Double, conf: SQLConf): Double = {
+    getDoubleConf(getExprCostConfigKey(exprName), defaultCost, conf)
+  }
+
+  def getDoubleConf(name: String, defaultValue: Double, conf: SQLConf): Double = {
+    try {
+      conf.getConfString(name, defaultValue.toString).toDouble
+    } catch {
+      case _: NumberFormatException => defaultValue
+    }
+  }
 }
 
 object ConfigHelpers {

--- a/spark/src/main/scala/org/apache/comet/rules/CometCostEstimator.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometCostEstimator.scala
@@ -1,0 +1,289 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.rules
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.trees.TreeNodeTag
+import org.apache.spark.sql.comet._
+import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.adaptive._
+import org.apache.spark.sql.execution.aggregate._
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
+import org.apache.spark.sql.execution.joins._
+import org.apache.spark.sql.internal.SQLConf
+
+import org.apache.comet.CometConf
+
+/**
+ * Cost analysis result containing all metrics for the CBO decision.
+ */
+case class CostAnalysis(
+    cometOperatorCount: Int,
+    sparkOperatorCount: Int,
+    transitionCount: Int,
+    estimatedRowCount: Option[Long],
+    estimatedSizeBytes: Option[Long],
+    sparkCost: Double,
+    cometCost: Double,
+    estimatedSpeedup: Double,
+    shouldUseComet: Boolean) {
+
+  def toExplainString: String = {
+    f"""CBO Analysis:
+       |  Decision: ${if (shouldUseComet) "Use Comet" else "Fall back to Spark"}
+       |  Estimated Speedup: $estimatedSpeedup%.2fx
+       |  Comet Operators: $cometOperatorCount
+       |  Spark Operators: $sparkOperatorCount
+       |  Transitions: $transitionCount
+       |  Estimated Rows: ${estimatedRowCount.map(_.toString).getOrElse("unknown")}
+       |  Spark Cost: $sparkCost%.2f
+       |  Comet Cost: $cometCost%.2f""".stripMargin
+  }
+}
+
+/**
+ * Statistics collected from plan traversal.
+ */
+case class PlanStatistics(
+    cometOps: Int = 0,
+    sparkOps: Int = 0,
+    transitions: Int = 0,
+    cometScans: Int = 0,
+    cometFilters: Int = 0,
+    cometProjects: Int = 0,
+    cometAggregates: Int = 0,
+    cometJoins: Int = 0,
+    cometSorts: Int = 0,
+    sparkScans: Int = 0,
+    sparkFilters: Int = 0,
+    sparkProjects: Int = 0,
+    sparkAggregates: Int = 0,
+    sparkJoins: Int = 0,
+    sparkSorts: Int = 0)
+
+/**
+ * Tag for attaching CBO info to plan nodes for EXPLAIN output.
+ */
+object CometCBOInfo {
+  val TAG: TreeNodeTag[CostAnalysis] = new TreeNodeTag[CostAnalysis]("CometCBOInfo")
+}
+
+/**
+ * Cost estimator for comparing Comet vs Spark execution plans.
+ *
+ * The estimator uses a heuristic-based cost model with configurable weights for different
+ * operator types and transition penalties. It estimates whether running a query with Comet will
+ * be faster than running it with Spark.
+ */
+object CometCostEstimator extends Logging {
+
+  /**
+   * Analyze a Comet plan and determine if it should be used over Spark.
+   */
+  def analyze(cometPlan: SparkPlan, conf: SQLConf): CostAnalysis = {
+    val stats = collectStats(cometPlan)
+    val rowCount = extractRowCount(cometPlan)
+    val sizeBytes = extractSizeBytes(cometPlan)
+
+    val sparkCost = calculateSparkCost(stats, rowCount, conf)
+    val cometCost = calculateCometCost(stats, rowCount, conf)
+
+    val speedup = if (cometCost > 0) sparkCost / cometCost else Double.MaxValue
+    val threshold = CometConf.COMET_CBO_SPEEDUP_THRESHOLD.get(conf)
+
+    CostAnalysis(
+      cometOperatorCount = stats.cometOps,
+      sparkOperatorCount = stats.sparkOps,
+      transitionCount = stats.transitions,
+      estimatedRowCount = rowCount,
+      estimatedSizeBytes = sizeBytes,
+      sparkCost = sparkCost,
+      cometCost = cometCost,
+      estimatedSpeedup = speedup,
+      shouldUseComet = speedup >= threshold)
+  }
+
+  private def collectStats(plan: SparkPlan): PlanStatistics = {
+    var stats = PlanStatistics()
+
+    plan.foreach {
+      // Transitions - these are expensive
+      case _: CometColumnarToRowExec | _: CometSparkToColumnarExec | _: ColumnarToRowExec |
+          _: RowToColumnarExec =>
+        stats = stats.copy(transitions = stats.transitions + 1)
+
+      // Comet scans
+      case _: CometScanExec | _: CometBatchScanExec | _: CometNativeScanExec |
+          _: CometIcebergNativeScanExec | _: CometLocalTableScanExec =>
+        stats = stats.copy(cometOps = stats.cometOps + 1, cometScans = stats.cometScans + 1)
+
+      // Comet filters
+      case _: CometFilterExec =>
+        stats = stats.copy(cometOps = stats.cometOps + 1, cometFilters = stats.cometFilters + 1)
+
+      // Comet projects
+      case _: CometProjectExec =>
+        stats = stats.copy(cometOps = stats.cometOps + 1, cometProjects = stats.cometProjects + 1)
+
+      // Comet aggregates
+      case _: CometHashAggregateExec =>
+        stats =
+          stats.copy(cometOps = stats.cometOps + 1, cometAggregates = stats.cometAggregates + 1)
+
+      // Comet joins
+      case _: CometBroadcastHashJoinExec | _: CometHashJoinExec | _: CometSortMergeJoinExec =>
+        stats = stats.copy(cometOps = stats.cometOps + 1, cometJoins = stats.cometJoins + 1)
+
+      // Comet sorts
+      case _: CometSortExec =>
+        stats = stats.copy(cometOps = stats.cometOps + 1, cometSorts = stats.cometSorts + 1)
+
+      // Other Comet operators (shuffle, window, etc.)
+      case _: CometShuffleExchangeExec | _: CometBroadcastExchangeExec | _: CometWindowExec |
+          _: CometCoalesceExec | _: CometCollectLimitExec | _: CometTakeOrderedAndProjectExec |
+          _: CometUnionExec | _: CometExpandExec | _: CometExplodeExec | _: CometLocalLimitExec |
+          _: CometGlobalLimitExec =>
+        stats = stats.copy(cometOps = stats.cometOps + 1)
+
+      // Spark scans
+      case _: FileSourceScanExec | _: BatchScanExec =>
+        stats = stats.copy(sparkOps = stats.sparkOps + 1, sparkScans = stats.sparkScans + 1)
+
+      // Spark filters
+      case _: FilterExec =>
+        stats = stats.copy(sparkOps = stats.sparkOps + 1, sparkFilters = stats.sparkFilters + 1)
+
+      // Spark projects
+      case _: ProjectExec =>
+        stats = stats.copy(sparkOps = stats.sparkOps + 1, sparkProjects = stats.sparkProjects + 1)
+
+      // Spark aggregates
+      case _: HashAggregateExec | _: ObjectHashAggregateExec =>
+        stats =
+          stats.copy(sparkOps = stats.sparkOps + 1, sparkAggregates = stats.sparkAggregates + 1)
+
+      // Spark joins
+      case _: BroadcastHashJoinExec | _: ShuffledHashJoinExec | _: SortMergeJoinExec =>
+        stats = stats.copy(sparkOps = stats.sparkOps + 1, sparkJoins = stats.sparkJoins + 1)
+
+      // Spark sorts
+      case _: SortExec =>
+        stats = stats.copy(sparkOps = stats.sparkOps + 1, sparkSorts = stats.sparkSorts + 1)
+
+      // Ignore wrapper/internal nodes
+      case _: AdaptiveSparkPlanExec | _: InputAdapter | _: QueryStageExec |
+          _: WholeStageCodegenExec | _: ReusedExchangeExec | _: AQEShuffleReadExec =>
+      // Don't count these
+
+      case _ =>
+      // Other operators not specifically categorized
+    }
+    stats
+  }
+
+  private def extractRowCount(plan: SparkPlan): Option[Long] = {
+    // Try logical plan stats first
+    plan.logicalLink.flatMap(_.stats.rowCount.map(_.toLong)).orElse {
+      // Fallback: estimate from size (assume ~100 bytes per row)
+      extractSizeBytes(plan).map(_ / 100)
+    }
+  }
+
+  private def extractSizeBytes(plan: SparkPlan): Option[Long] = {
+    plan.logicalLink.map(_.stats.sizeInBytes.toLong).orElse {
+      // Fallback: look for scan-level size info
+      plan.collectLeaves().collectFirst {
+        case scan: CometScanExec => scan.relation.sizeInBytes
+        case scan: FileSourceScanExec => scan.relation.sizeInBytes
+      }
+    }
+  }
+
+  private def calculateSparkCost(
+      stats: PlanStatistics,
+      rowCount: Option[Long],
+      conf: SQLConf): Double = {
+    val rows = rowCount.getOrElse(CometConf.COMET_CBO_DEFAULT_ROW_COUNT.get(conf)).toDouble
+
+    // Base cost for each operator type (calculate as if all operators ran in Spark)
+    val scanCost =
+      (stats.sparkScans + stats.cometScans) * CometConf.COMET_CBO_SCAN_WEIGHT.get(conf) * rows
+    val filterCost =
+      (stats.sparkFilters + stats.cometFilters) * CometConf.COMET_CBO_FILTER_WEIGHT.get(
+        conf) * rows
+    val projectCost =
+      (stats.sparkProjects + stats.cometProjects) * CometConf.COMET_CBO_PROJECT_WEIGHT
+        .get(conf) * rows
+    val aggCost =
+      (stats.sparkAggregates + stats.cometAggregates) * CometConf.COMET_CBO_AGGREGATE_WEIGHT
+        .get(conf) * rows
+    val joinCost =
+      (stats.sparkJoins + stats.cometJoins) * CometConf.COMET_CBO_JOIN_WEIGHT.get(conf) * rows
+    val sortCost = (stats.sparkSorts + stats.cometSorts) * CometConf.COMET_CBO_SORT_WEIGHT.get(
+      conf) * rows * Math.log(rows + 1)
+
+    scanCost + filterCost + projectCost + aggCost + joinCost + sortCost
+  }
+
+  private def calculateCometCost(
+      stats: PlanStatistics,
+      rowCount: Option[Long],
+      conf: SQLConf): Double = {
+    val rows = rowCount.getOrElse(CometConf.COMET_CBO_DEFAULT_ROW_COUNT.get(conf)).toDouble
+
+    // Comet operators cost less (divided by speedup factor)
+    val cometScanCost = stats.cometScans * CometConf.COMET_CBO_SCAN_WEIGHT.get(
+      conf) * rows / CometConf.COMET_CBO_SCAN_SPEEDUP.get(conf)
+    val cometFilterCost = stats.cometFilters * CometConf.COMET_CBO_FILTER_WEIGHT.get(
+      conf) * rows / CometConf.COMET_CBO_FILTER_SPEEDUP.get(conf)
+    val cometProjectCost = stats.cometProjects * CometConf.COMET_CBO_PROJECT_WEIGHT.get(
+      conf) * rows / CometConf.COMET_CBO_FILTER_SPEEDUP.get(conf)
+    val cometAggCost = stats.cometAggregates * CometConf.COMET_CBO_AGGREGATE_WEIGHT.get(
+      conf) * rows / CometConf.COMET_CBO_AGGREGATE_SPEEDUP.get(conf)
+    val cometJoinCost = stats.cometJoins * CometConf.COMET_CBO_JOIN_WEIGHT.get(
+      conf) * rows / CometConf.COMET_CBO_JOIN_SPEEDUP.get(conf)
+    val cometSortCost = stats.cometSorts * CometConf.COMET_CBO_SORT_WEIGHT.get(conf) * rows * Math
+      .log(rows + 1) / CometConf.COMET_CBO_SORT_SPEEDUP.get(conf)
+
+    val cometOpCost = cometScanCost + cometFilterCost + cometProjectCost +
+      cometAggCost + cometJoinCost + cometSortCost
+
+    // Spark operators that couldn't be converted still have full cost
+    val sparkScanCost = stats.sparkScans * CometConf.COMET_CBO_SCAN_WEIGHT.get(conf) * rows
+    val sparkFilterCost = stats.sparkFilters * CometConf.COMET_CBO_FILTER_WEIGHT.get(conf) * rows
+    val sparkProjectCost =
+      stats.sparkProjects * CometConf.COMET_CBO_PROJECT_WEIGHT.get(conf) * rows
+    val sparkAggCost =
+      stats.sparkAggregates * CometConf.COMET_CBO_AGGREGATE_WEIGHT.get(conf) * rows
+    val sparkJoinCost = stats.sparkJoins * CometConf.COMET_CBO_JOIN_WEIGHT.get(conf) * rows
+    val sparkSortCost =
+      stats.sparkSorts * CometConf.COMET_CBO_SORT_WEIGHT.get(conf) * rows * Math.log(rows + 1)
+
+    val sparkOpCost = sparkScanCost + sparkFilterCost + sparkProjectCost +
+      sparkAggCost + sparkJoinCost + sparkSortCost
+
+    // Transition penalty
+    val transitionCost = stats.transitions * CometConf.COMET_CBO_TRANSITION_COST.get(conf) * rows
+
+    cometOpCost + sparkOpCost + transitionCost
+  }
+}

--- a/spark/src/test/scala/org/apache/comet/rules/CometCBOSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/CometCBOSuite.scala
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.rules
+
+import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.comet._
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+
+import org.apache.comet.{CometConf, ExtendedExplainInfo}
+
+/**
+ * Test suite for the Comet Cost-Based Optimizer (CBO).
+ *
+ * Note: CBO only affects operator conversion (filter, project, aggregate, etc.), not scan
+ * conversion which is handled by CometScanRule.
+ */
+class CometCBOSuite extends CometTestBase with AdaptiveSparkPlanHelper {
+
+  /** Helper to check if a plan contains any Comet exec operators (excluding scans) */
+  private def containsCometExecOperators(plan: SparkPlan): Boolean = {
+    stripAQEPlan(plan).find {
+      case _: CometFilterExec | _: CometProjectExec | _: CometHashAggregateExec |
+          _: CometSortExec | _: CometBroadcastHashJoinExec | _: CometHashJoinExec |
+          _: CometSortMergeJoinExec =>
+        true
+      case _ => false
+    }.isDefined
+  }
+
+  /** Helper to check if a plan contains any Comet operators (including scans) */
+  private def containsCometPlan(plan: SparkPlan): Boolean = {
+    stripAQEPlan(plan).find(_.isInstanceOf[CometPlan]).isDefined
+  }
+
+  test("CBO prefers Comet for fully native plans") {
+    withParquetTable((0 until 1000).map(i => (i, s"val_$i")), "t") {
+      withSQLConf(
+        CometConf.COMET_CBO_ENABLED.key -> "true",
+        CometConf.COMET_CBO_SPEEDUP_THRESHOLD.key -> "1.0") {
+        val df = spark.sql("SELECT * FROM t WHERE _1 > 500")
+        val plan = df.queryExecution.executedPlan
+        assert(containsCometExecOperators(plan), "Expected Comet exec operators in the plan")
+      }
+    }
+  }
+
+  test("CBO respects speedup threshold - high threshold disables Comet exec operators") {
+    withParquetTable((0 until 100).map(i => (i, s"val_$i")), "t") {
+      // With very high threshold, CBO should fall back to Spark for exec operators
+      // Note: Scans may still be Comet since they're converted by CometScanRule
+      withSQLConf(
+        CometConf.COMET_CBO_ENABLED.key -> "true",
+        CometConf.COMET_CBO_SPEEDUP_THRESHOLD.key -> "100.0") {
+        val df = spark.sql("SELECT * FROM t WHERE _1 > 50")
+        val plan = df.queryExecution.executedPlan
+        assert(
+          !containsCometExecOperators(plan),
+          "Expected no Comet exec operators with high threshold")
+      }
+    }
+  }
+
+  test("CBO respects speedup threshold - low threshold enables Comet") {
+    withParquetTable((0 until 100).map(i => (i, s"val_$i")), "t") {
+      // With low threshold, always use Comet
+      withSQLConf(
+        CometConf.COMET_CBO_ENABLED.key -> "true",
+        CometConf.COMET_CBO_SPEEDUP_THRESHOLD.key -> "0.1") {
+        val df = spark.sql("SELECT * FROM t WHERE _1 > 50")
+        val plan = df.queryExecution.executedPlan
+        assert(
+          containsCometExecOperators(plan),
+          "Expected Comet exec operators with low threshold")
+      }
+    }
+  }
+
+  test("CBO disabled returns Comet plan unconditionally") {
+    withParquetTable((0 until 100).map(i => (i, s"val_$i")), "t") {
+      // CBO is disabled by default, so Comet operators should be used
+      withSQLConf(CometConf.COMET_CBO_ENABLED.key -> "false") {
+        val df = spark.sql("SELECT * FROM t WHERE _1 > 50")
+        val plan = df.queryExecution.executedPlan
+        // Should use Comet regardless of cost when CBO is disabled
+        assert(containsCometPlan(plan), "Expected Comet operators when CBO is disabled")
+      }
+    }
+  }
+
+  test("CBO analysis is computed when enabled") {
+    withParquetTable((0 until 100).map(i => (i, s"val_$i")), "t") {
+      withSQLConf(
+        CometConf.COMET_CBO_ENABLED.key -> "true",
+        CometConf.COMET_CBO_EXPLAIN_ENABLED.key -> "true",
+        CometConf.COMET_CBO_SPEEDUP_THRESHOLD.key -> "1.0") {
+        val df = spark.sql("SELECT * FROM t WHERE _1 > 50")
+        // Just verify the query runs successfully with CBO enabled
+        val result = df.collect()
+        assert(result.length > 0, "Query should return results")
+      }
+    }
+  }
+
+  test("results are correct regardless of CBO decision") {
+    withParquetTable((0 until 100).map(i => (i, s"val_$i")), "t") {
+      // Get expected results with Comet disabled
+      var expected: Array[org.apache.spark.sql.Row] = Array.empty
+      withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
+        expected = spark.sql("SELECT * FROM t WHERE _1 > 50").collect()
+      }
+
+      // Test with CBO enabled
+      withSQLConf(CometConf.COMET_CBO_ENABLED.key -> "true") {
+        val actual = spark.sql("SELECT * FROM t WHERE _1 > 50").collect()
+        assert(actual.toSet == expected.toSet, "Results should match regardless of CBO decision")
+      }
+    }
+  }
+
+  test("CostAnalysis correctly computes estimated speedup") {
+    // Create a simple analysis and verify computation
+    val analysis = CostAnalysis(
+      cometOperatorCount = 5,
+      sparkOperatorCount = 0,
+      transitionCount = 0,
+      estimatedRowCount = Some(1000L),
+      estimatedSizeBytes = Some(100000L),
+      sparkCost = 1000.0,
+      cometCost = 500.0,
+      estimatedSpeedup = 2.0,
+      shouldUseComet = true)
+
+    assert(analysis.estimatedSpeedup == 2.0)
+    assert(analysis.shouldUseComet)
+    assert(analysis.cometOperatorCount == 5)
+    assert(analysis.sparkOperatorCount == 0)
+  }
+
+  test("CostAnalysis toExplainString format") {
+    val analysis = CostAnalysis(
+      cometOperatorCount = 3,
+      sparkOperatorCount = 1,
+      transitionCount = 1,
+      estimatedRowCount = Some(1000L),
+      estimatedSizeBytes = Some(100000L),
+      sparkCost = 1000.0,
+      cometCost = 600.0,
+      estimatedSpeedup = 1.67,
+      shouldUseComet = true)
+
+    val explainString = analysis.toExplainString
+
+    assert(explainString.contains("CBO Analysis"))
+    assert(explainString.contains("Decision: Use Comet"))
+    assert(explainString.contains("Comet Operators: 3"))
+    assert(explainString.contains("Spark Operators: 1"))
+    assert(explainString.contains("Transitions: 1"))
+    assert(explainString.contains("Estimated Rows: 1000"))
+  }
+
+  test("CostAnalysis reflects fall back decision") {
+    val analysis = CostAnalysis(
+      cometOperatorCount = 1,
+      sparkOperatorCount = 5,
+      transitionCount = 3,
+      estimatedRowCount = Some(1000L),
+      estimatedSizeBytes = Some(100000L),
+      sparkCost = 500.0,
+      cometCost = 800.0,
+      estimatedSpeedup = 0.625,
+      shouldUseComet = false)
+
+    val explainString = analysis.toExplainString
+
+    assert(explainString.contains("Decision: Fall back to Spark"))
+    assert(!analysis.shouldUseComet)
+  }
+
+  test("CBO handles aggregation queries") {
+    withParquetTable((0 until 1000).map(i => (i % 10, s"val_$i")), "t") {
+      withSQLConf(
+        CometConf.COMET_CBO_ENABLED.key -> "true",
+        CometConf.COMET_CBO_SPEEDUP_THRESHOLD.key -> "1.0") {
+        val df = spark.sql("SELECT _1, COUNT(*) as cnt FROM t GROUP BY _1")
+        checkSparkAnswer(df)
+      }
+    }
+  }
+
+  test("CBO handles join queries") {
+    withParquetTable((0 until 100).map(i => (i, s"val_$i")), "t1") {
+      withParquetTable((0 until 100).map(i => (i, s"other_$i")), "t2") {
+        withSQLConf(
+          CometConf.COMET_CBO_ENABLED.key -> "true",
+          CometConf.COMET_CBO_SPEEDUP_THRESHOLD.key -> "1.0") {
+          val df = spark.sql("SELECT t1._1, t2._2 FROM t1 JOIN t2 ON t1._1 = t2._1")
+          checkSparkAnswer(df)
+        }
+      }
+    }
+  }
+
+  test("CBO handles sort queries") {
+    withParquetTable((0 until 100).map(i => (i, s"val_$i")), "t") {
+      withSQLConf(
+        CometConf.COMET_CBO_ENABLED.key -> "true",
+        CometConf.COMET_CBO_SPEEDUP_THRESHOLD.key -> "1.0") {
+        val df = spark.sql("SELECT * FROM t ORDER BY _1 DESC")
+        checkSparkAnswer(df)
+      }
+    }
+  }
+
+  test("PlanStatistics correctly counts operators") {
+    // Test the PlanStatistics case class
+    val stats = PlanStatistics(
+      cometOps = 5,
+      sparkOps = 2,
+      transitions = 1,
+      cometScans = 1,
+      cometFilters = 2,
+      cometProjects = 2,
+      sparkScans = 1,
+      sparkFilters = 1)
+
+    assert(stats.cometOps == 5)
+    assert(stats.sparkOps == 2)
+    assert(stats.transitions == 1)
+    assert(stats.cometScans == 1)
+    assert(stats.cometFilters == 2)
+    assert(stats.cometProjects == 2)
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces an **experimental** lightweight cost-based optimizer (CBO) that estimates whether a Comet query plan will be faster than a Spark plan, falling back to Spark when Comet execution is estimated to be slower.

> **⚠️ EXPERIMENTAL**: This feature is disabled by default and should be considered experimental. The cost model parameters are initial estimates and should be tuned with real-world benchmarks before being used in production.

## Key Features

- **Heuristic-based cost model** with configurable weights for different operator types:
  - Scan, Filter, Project, Aggregate, Join, Sort
- **Configurable speedup factors** for each Comet operator type
- **Transition penalty** for columnar↔row conversions
- **Cardinality estimation** using Spark's logical plan statistics with fallbacks
- **CBO analysis in EXPLAIN output** when enabled

## Configuration Options

| Config | Default | Description |
|--------|---------|-------------|
| `spark.comet.cbo.enabled` | `false` | Enable/disable CBO |
| `spark.comet.cbo.speedupThreshold` | `1.0` | Minimum estimated speedup required to use Comet |
| `spark.comet.cbo.explain.enabled` | `false` | Log CBO decision details |

Additional internal configs for tuning weights and speedup factors are available (see `CometConf.scala`).

## How It Works

1. After `CometExecRule` transforms operators to Comet equivalents, CBO analyzes the plan
2. Collects statistics: Comet operators, Spark operators, transitions
3. Estimates costs for both Spark-only and Comet execution
4. Calculates estimated speedup = sparkCost / cometCost
5. If speedup < threshold, falls back to original Spark plan

## Limitations

- **CBO only affects operator conversion** (filter, project, aggregate, join, sort)
- **Scan conversion is NOT affected** - handled separately by `CometScanRule`
- Cost model parameters are estimates and need tuning with benchmarks

## Example Usage

```scala
// Enable CBO with default threshold
spark.conf.set("spark.comet.cbo.enabled", "true")

// Or with custom threshold (use Comet only if 1.5x faster)
spark.conf.set("spark.comet.cbo.speedupThreshold", "1.5")

// Enable debug logging
spark.conf.set("spark.comet.cbo.explain.enabled", "true")
```

## Files Changed

- **New**: `CometCostEstimator.scala` - Core cost estimation logic
- **New**: `CometCBOSuite.scala` - Unit tests
- **Modified**: `CometConf.scala` - Configuration options
- **Modified**: `CometExecRule.scala` - CBO integration
- **Modified**: `ExtendedExplainInfo.scala` - CBO info in EXPLAIN

## Test plan

- [x] New unit tests in `CometCBOSuite` (13 tests)
- [x] Existing `CometExecRuleSuite` tests pass
- [ ] Manual testing with TPC-H/TPC-DS benchmarks (future work)
- [ ] Tune default parameters based on benchmark results (future work)

🤖 Generated with [Claude Code](https://claude.ai/code)