### PR TITLE
fix: CometBroadcastExchangeExec should respect AQE shuffle partition coalescing

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometBroadcastExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometBroadcastExchangeExec.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.comet.util.Utils
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.{ColumnarToRowExec, ShufflePartitionSpec, SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.adaptive.{AQEShuffleReadExec, ShuffleQueryStageExec}
-import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, BroadcastExchangeLike, ReusedExchangeExec, ShuffleExchangeLike}
+import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, BroadcastExchangeLike, ReusedExchangeExec}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.vectorized.ColumnarBatch


### PR DESCRIPTION
## Summary

- Fix `CometBroadcastExchangeExec` to properly use AQE's coalesced shuffle partition specs
- When `AQEShuffleReadExec` wraps a `CometShuffleExchangeExec`, use `getShuffleRDD(partitionSpecs)` to get the coalesced RDD instead of bypassing AQE

## Problem

When AQE (Adaptive Query Execution) coalesces shuffle partitions based on runtime statistics, `CometBroadcastExchangeExec` was bypassing this optimization by reading directly from the inner shuffle plan. This caused broadcast exchanges to spawn many tasks (e.g., 200) even when AQE determined that only 1 task was needed due to small data volume after filtering.

For example, in TPC-H Q18, after the filter `sum(l_quantity) > 313`, there are only ~900 rows to broadcast. AQE correctly identifies this and coalesces 200 shuffle partitions into 1. However, Comet's broadcast exchange was ignoring this and still reading from all 200 original partitions.

## Solution

Added proper handling for `AQEShuffleReadExec` wrapping `CometShuffleExchangeExec`:

1. Extract partition specs from `AQEShuffleReadExec`
2. Use `CometShuffleExchangeExec.getShuffleRDD(partitionSpecs)` to get the coalesced RDD
3. Serialize batches from the coalesced RDD for broadcasting

## Test plan

- [x] Existing unit tests pass (`CometExecSuite`, `CometShuffleSuite`)
- [x] Verified with TPC-H Q18: broadcast stages now use 1 task instead of 200 when AQE coalesces partitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)