### PR TITLE
chore: fix clippy warnings for Rust 1.93

### DIFF
--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -503,12 +503,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
                 let task_ctx = exec_context.session_ctx.task_ctx();
                 // Each Comet native execution corresponds to a single Spark partition,
                 // so we should always execute partition 0.
-                let stream = exec_context
-                    .root_op
-                    .as_ref()
-                    .unwrap()
-                    .native_plan
-                    .execute(0, task_ctx)?;
+                let stream = root_op.native_plan.execute(0, task_ctx)?;
                 exec_context.stream = Some(stream);
             } else {
                 // Pull input batches
@@ -619,8 +614,7 @@ pub extern "system" fn Java_org_apache_comet_Native_releasePlan(
 
 /// Updates the metrics of the query plan.
 fn update_metrics(env: &mut JNIEnv, exec_context: &mut ExecutionContext) -> CometResult<()> {
-    if exec_context.root_op.is_some() {
-        let native_query = exec_context.root_op.as_ref().unwrap();
+    if let Some(native_query) = &exec_context.root_op {
         let metrics = exec_context.metrics.as_obj();
         update_comet_metric(env, metrics, native_query)
     } else {

--- a/native/core/src/parquet/schema_adapter.rs
+++ b/native/core/src/parquet/schema_adapter.rs
@@ -209,10 +209,9 @@ impl SchemaMapper for SchemaMapping {
                     // If this field only exists in the table, and not in the file, then we need to
                     // populate a default value for it.
                     || {
-                        if self.default_values.is_some() {
+                        if let Some(default_values) = &self.default_values {
                             // We have a map of default values, see if this field is in there.
-                            if let Some(value) =
-                                self.default_values.as_ref().unwrap().get(&field_idx)
+                            if let Some(value) = default_values.get(&field_idx)
                             // Default value exists, construct a column from it.
                             {
                                 let cv = if field.data_type() == &value.data_type() {


### PR DESCRIPTION
## Summary
- Fix clippy error where `unwrap()` would always panic by using local `root_op` variable directly
- Replace `is_some()` + `unwrap()` patterns with idiomatic `if let Some(...)` in two locations

These issues were introduced by new clippy rules in Rust 1.93.

## Test plan
- [x] `cargo clippy --all-targets` passes with Rust 1.93.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)