### PR TITLE
docs: document datetime rebasing and V2 API limitations for DataFusion-based scans

### DIFF
--- a/docs/source/contributor-guide/parquet_scans.md
+++ b/docs/source/contributor-guide/parquet_scans.md
@@ -49,6 +49,15 @@ The `native_datafusion` and `native_iceberg_compat` scans share the following li
   types (regardless of the logical type). This behavior can be disabled by setting
   `spark.comet.scan.allowIncompatible=true`.
 - No support for default values that are nested types (e.g., maps, arrays, structs). Literal default values are supported.
+- No support for datetime rebasing detection or the `spark.comet.exceptionOnDatetimeRebase` configuration. When reading
+  Parquet files containing dates or timestamps written before Spark 3.0 (which used a hybrid Julian/Gregorian calendar),
+  the `native_comet` implementation can detect these legacy values and either throw an exception or read them without
+  rebasing. The DataFusion-based implementations do not have this detection capability and will read all dates/timestamps
+  as if they were written using the Proleptic Gregorian calendar. This may produce incorrect results for dates before
+  October 15, 1582.
+- No support for Spark's Datasource V2 API. When `spark.sql.sources.useV1SourceList` does not include `parquet`,
+  Spark uses the V2 API for Parquet scans. The DataFusion-based implementations only support the V1 API, so Comet
+  will fall back to `native_comet` when V2 is enabled.
 
 The `native_datafusion` scan has some additional limitations:
 


### PR DESCRIPTION
## Summary

- Document that `native_datafusion` and `native_iceberg_compat` do not support datetime rebasing detection
- Document that these implementations do not support Spark's Datasource V2 API

## Background

While investigating `ParquetDatetimeRebaseSuite` tests that explicitly set `native_comet`, we discovered these are intentional limitations of the DataFusion-based scan implementations, not test issues.

### Datetime Rebasing

Parquet files written before Spark 3.0 may contain dates/timestamps using the hybrid Julian/Gregorian calendar. The `native_comet` implementation:
- Detects legacy datetime metadata in Parquet files
- Can throw `SparkException` when `spark.comet.exceptionOnDatetimeRebase=true`
- Or reads values without rebasing (CORRECTED mode)

The DataFusion-based implementations (`native_datafusion`, `native_iceberg_compat`) do not have this detection capability and read all dates/timestamps as Proleptic Gregorian, which may produce incorrect results for dates before October 15, 1582.

### Datasource V2 API

The DataFusion-based implementations only support Spark's V1 datasource API. When `spark.sql.sources.useV1SourceList` does not include `parquet`, Comet falls back to `native_comet`.

## Test plan

- [x] Documentation only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)