### PR TITLE
build: remove dead code for 0.8/0.9 docs that broke CI

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -25,16 +25,10 @@ mkdir temp
 cp -rf source/* temp/
 
 # Add user guide from published releases
-rm -rf comet-0.8
-rm -rf comet-0.9
 rm -rf comet-0.10
 rm -rf comet-0.11
 rm -rf comet-0.12
 python3 generate-versions.py
-
-# Remove overview pages (this used to be part of the user guide but is now a top level page)
-rm temp/user-guide/0.9/overview.md 2> /dev/null
-rm temp/user-guide/0.8/overview.md 2> /dev/null
 
 # Generate dynamic content (configs, compatibility matrices) for latest docs
 # This runs GenerateDocs against the temp copy, not source files


### PR DESCRIPTION
## Summary

- Fixes the broken docs publishing CI job
- Removes dead code in `docs/build.sh` that was trying to delete files from non-existent directories

The `docs/source/user-guide/0.8` and `0.9` directories were removed in commit 6a2209d2dbc, but `build.sh` still had `rm` commands trying to delete files from those directories. With `set -e` at the top of the script, these failing `rm` commands caused the entire docs build to exit with error code 1.

The `2> /dev/null` only suppresses stderr but doesn't prevent the non-zero exit code from terminating the script.

## Test plan

- [ ] Verify that the docs publishing CI job passes after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)