### PR TITLE
feat: Add V2 scan support for `native_iceberg_compat`

### DIFF
--- a/spark/src/main/scala/org/apache/comet/parquet/CometNativeParquetPartitionReaderFactory.scala
+++ b/spark/src/main/scala/org/apache/comet/parquet/CometNativeParquetPartitionReaderFactory.scala
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.parquet
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.parquet.filter2.predicate.{FilterApi, FilterPredicate}
+import org.apache.parquet.hadoop.ParquetInputFormat
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.comet.CometMetricNode
+import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader}
+import org.apache.spark.sql.execution.datasources.PartitionedFile
+import org.apache.spark.sql.execution.datasources.parquet.ParquetOptions
+import org.apache.spark.sql.execution.datasources.v2.FilePartitionReaderFactory
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.SerializableConfiguration
+
+import org.apache.comet.CometConf
+import org.apache.comet.shims.ShimSQLConf
+
+/**
+ * A partition reader factory for V2 Parquet scans that uses NativeBatchReader (DataFusion-based
+ * Parquet reader) instead of the legacy BatchReader.
+ *
+ * This is used for native_iceberg_compat scan implementation with V2 data sources.
+ */
+case class CometNativeParquetPartitionReaderFactory(
+    @transient sqlConf: SQLConf,
+    broadcastedConf: Broadcast[SerializableConfiguration],
+    readDataSchema: StructType,
+    dataSchema: StructType,
+    partitionSchema: StructType,
+    filters: Array[Filter],
+    options: ParquetOptions,
+    metrics: Map[String, SQLMetric])
+    extends FilePartitionReaderFactory
+    with ShimSQLConf
+    with Logging {
+
+  private val isCaseSensitive = sqlConf.caseSensitiveAnalysis
+  private val useFieldId = CometParquetUtils.readFieldId(sqlConf)
+  private val ignoreMissingIds = CometParquetUtils.ignoreMissingIds(sqlConf)
+  private val pushDownDate = sqlConf.parquetFilterPushDownDate
+  private val pushDownTimestamp = sqlConf.parquetFilterPushDownTimestamp
+  private val pushDownDecimal = sqlConf.parquetFilterPushDownDecimal
+  private val pushDownStringPredicate = sqlConf.parquetFilterPushDownStringPredicate
+  private val pushDownInFilterThreshold = sqlConf.parquetFilterPushDownInFilterThreshold
+  private val datetimeRebaseModeInRead = options.datetimeRebaseModeInRead
+  private val parquetFilterPushDown = sqlConf.parquetFilterPushDown
+
+  // Comet specific configurations
+  private val batchSize = CometConf.COMET_BATCH_SIZE.get(sqlConf)
+
+  override def supportColumnarReads(partition: InputPartition): Boolean = true
+
+  override def buildReader(partitionedFile: PartitionedFile): PartitionReader[InternalRow] =
+    throw new UnsupportedOperationException(
+      "CometNativeParquetPartitionReaderFactory doesn't support row-based reads")
+
+  override def buildColumnarReader(file: PartitionedFile): PartitionReader[ColumnarBatch] = {
+    val sharedConf = broadcastedConf.value.value
+    val footer = FooterReader.readFooter(sharedConf, file)
+    val footerFileMetaData = footer.getFileMetaData
+    val datetimeRebaseSpec = CometParquetFileFormat.getDatetimeRebaseSpec(
+      file,
+      readDataSchema,
+      sharedConf,
+      footerFileMetaData,
+      datetimeRebaseModeInRead)
+
+    val parquetSchema = footerFileMetaData.getSchema
+    val parquetFilters = new ParquetFilters(
+      parquetSchema,
+      dataSchema,
+      pushDownDate,
+      pushDownTimestamp,
+      pushDownDecimal,
+      pushDownStringPredicate,
+      pushDownInFilterThreshold,
+      isCaseSensitive,
+      datetimeRebaseSpec)
+
+    // Set the predicate in the conf for row index generation
+    val pushed: Option[FilterPredicate] = if (parquetFilterPushDown) {
+      filters
+        .flatMap(parquetFilters.createFilter)
+        .reduceOption(FilterApi.and)
+    } else {
+      None
+    }
+    pushed.foreach(p => ParquetInputFormat.setFilterPredicate(sharedConf, p))
+
+    // Create native filter for DataFusion
+    val pushedNative: Option[Array[Byte]] = if (parquetFilterPushDown) {
+      parquetFilters.createNativeFilters(filters)
+    } else {
+      None
+    }
+
+    val batchReader = new NativeBatchReader(
+      sharedConf,
+      file,
+      footer,
+      pushedNative.orNull,
+      batchSize,
+      readDataSchema,
+      dataSchema,
+      isCaseSensitive,
+      useFieldId,
+      ignoreMissingIds,
+      datetimeRebaseSpec.mode == CORRECTED,
+      partitionSchema,
+      file.partitionValues,
+      metrics.asJava,
+      CometMetricNode(metrics))
+
+    try {
+      batchReader.init()
+    } catch {
+      case e: Throwable =>
+        batchReader.close()
+        throw e
+    }
+
+    CometNativePartitionReader(batchReader)
+  }
+
+  override def createReader(inputPartition: InputPartition): PartitionReader[InternalRow] =
+    throw new UnsupportedOperationException("Only 'createColumnarReader' is supported.")
+
+  /**
+   * A simple adapter on Comet's [[NativeBatchReader]].
+   */
+  private case class CometNativePartitionReader(reader: NativeBatchReader)
+      extends PartitionReader[ColumnarBatch] {
+
+    override def next(): Boolean = {
+      reader.nextBatch()
+    }
+
+    override def get(): ColumnarBatch = {
+      reader.currentBatch()
+    }
+
+    override def close(): Unit = {
+      reader.close()
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/comet/parquet/CometNativeParquetScan.scala
+++ b/spark/src/main/scala/org/apache/comet/parquet/CometNativeParquetScan.scala
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.parquet
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.comet.CometMetricNode
+import org.apache.spark.sql.connector.read.PartitionReaderFactory
+import org.apache.spark.sql.execution.datasources.parquet.ParquetOptions
+import org.apache.spark.sql.execution.datasources.v2.FileScan
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.util.SerializableConfiguration
+
+import org.apache.comet.MetricsSupport
+
+/**
+ * A V2 Parquet scan that uses NativeBatchReader (DataFusion-based Parquet reader) for the
+ * native_iceberg_compat scan implementation.
+ *
+ * This is similar to CometParquetScan but uses CometNativeParquetPartitionReaderFactory instead
+ * of CometParquetPartitionReaderFactory.
+ */
+trait CometNativeParquetScan extends FileScan with MetricsSupport {
+  def sparkSession: SparkSession
+  def hadoopConf: Configuration
+  def dataSchema: StructType
+  def readDataSchema: StructType
+  def readPartitionSchema: StructType
+  def pushedFilters: Array[Filter]
+  def options: CaseInsensitiveStringMap
+
+  override def equals(obj: Any): Boolean = obj match {
+    case other: CometNativeParquetScan =>
+      super.equals(other) && readDataSchema == other.readDataSchema &&
+      readPartitionSchema == other.readPartitionSchema &&
+      equivalentFilters(pushedFilters, other.pushedFilters)
+    case _ => false
+  }
+
+  override def hashCode(): Int = getClass.hashCode()
+
+  override def createReaderFactory(): PartitionReaderFactory = {
+    val sqlConf = sparkSession.sessionState.conf
+    CometParquetFileFormat.populateConf(sqlConf, hadoopConf)
+    val broadcastedConf =
+      sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf))
+    CometNativeParquetPartitionReaderFactory(
+      sqlConf,
+      broadcastedConf,
+      readDataSchema,
+      dataSchema,
+      readPartitionSchema,
+      pushedFilters,
+      new ParquetOptions(options.asScala.toMap, sqlConf),
+      metrics)
+  }
+}
+
+object CometNativeParquetScan {
+  def apply(session: SparkSession, scan: ParquetScan): CometNativeParquetScan = {
+    val newScan = new ParquetScan(
+      scan.sparkSession,
+      scan.hadoopConf,
+      scan.fileIndex,
+      scan.dataSchema,
+      scan.readDataSchema,
+      scan.readPartitionSchema,
+      scan.pushedFilters,
+      scan.options,
+      partitionFilters = scan.partitionFilters,
+      dataFilters = scan.dataFilters) with CometNativeParquetScan
+
+    newScan.metrics = CometMetricNode.nativeScanMetrics(session.sparkContext) ++ CometMetricNode
+      .parquetScanMetrics(session.sparkContext)
+
+    newScan
+  }
+}

--- a/spark/src/test/scala/org/apache/comet/rules/CometScanRuleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/CometScanRuleSuite.scala
@@ -143,7 +143,7 @@ class CometScanRuleSuite extends CometTestBase {
     }
   }
 
-test("V2 scan should fallback to Spark when native_datafusion is specified") {
+  test("V2 scan should fallback to Spark when native_datafusion is specified") {
     withTempPath { path =>
       createTestDataFrame.write.parquet(path.toString)
       withTempView("test_data") {

--- a/spark/src/test/scala/org/apache/comet/rules/CometScanRuleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/CometScanRuleSuite.scala
@@ -117,7 +117,10 @@ class CometScanRuleSuite extends CometTestBase {
           assert(countOperators(sparkPlan, classOf[BatchScanExec]) == 1)
 
           for (cometEnabled <- Seq(true, false)) {
-            withSQLConf(CometConf.COMET_ENABLED.key -> cometEnabled.toString) {
+            // Use SCAN_AUTO to ensure V2 scans are supported (native_datafusion falls back to Spark)
+            withSQLConf(
+              CometConf.COMET_ENABLED.key -> cometEnabled.toString,
+              CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_AUTO) {
 
               val transformedPlan = applyCometScanRule(sparkPlan)
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR adds support for `native_iceberg_compat` scan implementation with V2 data sources (BatchScanExec with ParquetScan).

## Rationale for this change

Previously, V2 Parquet scans always used the legacy `BatchReader` (the `native_comet` approach) regardless of the `COMET_NATIVE_SCAN_IMPL` setting. This was inconsistent with V1 scans which respect the scan impl configuration.

This change enables V2 scans to use the DataFusion-based `NativeBatchReader` when `native_iceberg_compat` or `auto` is specified, which is important for deprecating the legacy mutable buffer code.

## What changes are included in this PR?

### New Files
- `CometNativeParquetPartitionReaderFactory`: A V2 partition reader factory that uses `NativeBatchReader` (DataFusion-based Parquet reader)
- `CometNativeParquetScan`: A V2 scan trait that creates the new reader factory

### Behavior
- V2 scans with `auto` or `native_iceberg_compat`: Use `CometNativeParquetScan` (DataFusion-based reader)
- V2 scans with `native_comet`: Use existing `CometParquetScan` (legacy JNI-based BatchReader)
- V2 scans with `native_datafusion`: Fall back to Spark (not yet supported for V2)

## How are these changes tested?

- Updated `CometScanRuleSuite` with tests for V2 scan behavior
- Updated `ParquetReadV2Suite` to verify V2 scans work with the new implementation
- All existing tests pass