### PR TITLE
fix: use -status:failure for pending PR filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ under the License.
 [license-url]: https://github.com/apache/datafusion-comet/blob/main/LICENSE.txt
 [discord-badge]: https://img.shields.io/discord/885562378132000778.svg?logo=discord&style=flat-square
 [discord-url]: https://discord.gg/3EAr4ZX6JK
-[pending-pr-badge]: https://img.shields.io/github/issues-search/apache/datafusion-comet?query=is%3Apr+is%3Aopen+draft%3Afalse+review%3Arequired+status%3Asuccess&label=Pending%20PRs&logo=github
-[pending-pr-url]: https://github.com/apache/datafusion-comet/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+review%3Arequired+status%3Asuccess+sort%3Aupdated-desc
+[pending-pr-badge]: https://img.shields.io/github/issues-search/apache/datafusion-comet?query=is%3Apr+is%3Aopen+draft%3Afalse+review%3Arequired+-status%3Afailure&label=Pending%20PRs&logo=github
+[pending-pr-url]: https://github.com/apache/datafusion-comet/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+review%3Arequired+-status%3Afailure+sort%3Aupdated-desc
 [maven-badge]: https://img.shields.io/maven-central/v/org.apache.datafusion/comet-spark-spark4.0_2.13
 [maven-url]: https://search.maven.org/search?q=g:org.apache.datafusion%20AND%20comet-spark
 


### PR DESCRIPTION
## Summary
- The pending PR badge and link in README use `status:success` which excludes PRs where skipped checks (e.g. iceberg matrix jobs with unexpanded variables) prevent GitHub from reporting overall status as "success"
- Changed to `-status:failure` so PRs are included unless they have actually failing checks

## Test plan
- Verify the [pending PR link](https://github.com/apache/datafusion-comet/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+review%3Arequired+-status%3Afailure+sort%3Aupdated-desc) now includes PRs like #3358 that were previously excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)