### PR TITLE
fix: fix memory safety issue in native c2r

### DIFF
--- a/spark/src/main/scala/org/apache/comet/NativeColumnarToRowConverter.scala
+++ b/spark/src/main/scala/org/apache/comet/NativeColumnarToRowConverter.scala
@@ -139,6 +139,6 @@ private class NativeRowIterator(info: NativeColumnarToRowInfo, unsafeRow: Unsafe
     unsafeRow.pointTo(null, rowAddress, rowSize)
     currentIdx += 1
 
-    unsafeRow
+    unsafeRow.copy()
   }
 }

--- a/spark/src/test/scala/org/apache/comet/exec/CometNativeColumnarToRowSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometNativeColumnarToRowSuite.scala
@@ -30,7 +30,6 @@ import org.scalatest.Tag
 import org.apache.spark.sql.{CometTestBase, Row}
 import org.apache.spark.sql.comet.CometNativeColumnarToRowExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 import org.apache.comet.{CometConf, NativeColumnarToRowConverter}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3308

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

`NativeRowIterator` reuses a single `UnsafeRow` object that points to native memory. The buffer is cleared on each convert() call, so any held row references become stale. Return `unsafeRow.copy()` to copy each row to Java heap memory.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
