### PR TITLE
docs: fix inaccurate claim about mutable buffers in parquet scan docs

### DIFF
--- a/docs/source/contributor-guide/parquet_scans.md
+++ b/docs/source/contributor-guide/parquet_scans.md
@@ -41,8 +41,7 @@ implementation:
 - Improves performance
 
 > **Note on mutable buffers:** Both `native_comet` and `native_iceberg_compat` use reusable mutable buffers
-> when transferring data from JVM to native code via Arrow FFI. The `native_iceberg_compat` implementation uses DataFusion's native Parquet reader for data columns, bypassing Comet's mutable buffer infrastructure entirely. However, partition columns still use `ConstantColumnReader`, which relies on Comet's mutable buffers that are reused across batches. This means native operators that
-> buffer data (such as `SortExec` or `ShuffleWriterExec`) must perform deep copies to avoid data corruption.
+> when transferring data from JVM to native code via Arrow FFI. The `native_iceberg_compat` implementation uses DataFusion's native Parquet reader for data columns, bypassing Comet's mutable buffer infrastructure entirely. However, partition columns still use `ConstantColumnReader`, which relies on Comet's mutable buffers that are reused across batches. This means native operators that buffer data (such as `SortExec` or `ShuffleWriterExec`) must perform deep copies to avoid data corruption.
 > See the [FFI documentation](ffi.md) for details on the `arrow_ffi_safe` flag and ownership semantics.
 
 The `native_datafusion` and `native_iceberg_compat` scans share the following limitations:

--- a/docs/source/contributor-guide/parquet_scans.md
+++ b/docs/source/contributor-guide/parquet_scans.md
@@ -37,8 +37,14 @@ implementation:
 
 - Leverages the DataFusion community's ongoing improvements to `DataSourceExec`
 - Provides support for reading complex types (structs, arrays, and maps)
-- Removes the use of reusable mutable-buffers in Comet, which is complex to maintain
+- Delegates Parquet decoding to native Rust code rather than JVM-side decoding
 - Improves performance
+
+> **Note on mutable buffers:** Both `native_comet` and `native_iceberg_compat` use reusable mutable buffers
+> when transferring data from JVM to native code via Arrow FFI. The `native_iceberg_compat` implementation
+> still reuses `CometVector` arrays across batches in `NativeBatchReader`. This means native operators that
+> buffer data (such as `SortExec` or `ShuffleWriterExec`) must perform deep copies to avoid data corruption.
+> See the [FFI documentation](ffi.md) for details on the `arrow_ffi_safe` flag and ownership semantics.
 
 The `native_datafusion` and `native_iceberg_compat` scans share the following limitations:
 

--- a/docs/source/contributor-guide/parquet_scans.md
+++ b/docs/source/contributor-guide/parquet_scans.md
@@ -41,8 +41,7 @@ implementation:
 - Improves performance
 
 > **Note on mutable buffers:** Both `native_comet` and `native_iceberg_compat` use reusable mutable buffers
-> when transferring data from JVM to native code via Arrow FFI. The `native_iceberg_compat` implementation
-> still reuses `CometVector` arrays across batches in `NativeBatchReader`. This means native operators that
+> when transferring data from JVM to native code via Arrow FFI. The `native_iceberg_compat` implementation uses DataFusion's native Parquet reader for data columns, bypassing Comet's mutable buffer infrastructure entirely. However, partition columns still use `ConstantColumnReader`, which relies on Comet's mutable buffers that are reused across batches. This means native operators that
 > buffer data (such as `SortExec` or `ShuffleWriterExec`) must perform deep copies to avoid data corruption.
 > See the [FFI documentation](ffi.md) for details on the `arrow_ffi_safe` flag and ownership semantics.
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The documentation incorrectly claimed that `native_iceberg_compat` "removes the use of reusable mutable-buffers". I had misunderstood this, apparently.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
