### PR TITLE
fix: preserve partitioning in CometNativeScanExec for bucketed scans

### DIFF
--- a/dev/diffs/3.4.3.diff
+++ b/dev/diffs/3.4.3.diff
@@ -1157,7 +1157,7 @@ index cfc8b2cc845..c6fcfd7bd08 100644
  import org.apache.spark.SparkConf
  import org.apache.spark.sql.{AnalysisException, QueryTest}
  import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-+import org.apache.spark.sql.comet.CometScanExec
++import org.apache.spark.sql.comet.{CometNativeScanExec, CometScanExec}
  import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability}
  import org.apache.spark.sql.connector.read.ScanBuilder
  import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
@@ -1167,7 +1167,7 @@ index cfc8b2cc845..c6fcfd7bd08 100644
              assert(
 -              df.queryExecution.executedPlan.exists(_.isInstanceOf[FileSourceScanExec]))
 +              df.queryExecution.executedPlan.exists {
-+                case _: FileSourceScanExec | _: CometScanExec => true
++                case _: FileSourceScanExec | _: CometScanExec | _: CometNativeScanExec => true
 +                case _ => false
 +              }
 +            )

--- a/dev/diffs/3.5.8.diff
+++ b/dev/diffs/3.5.8.diff
@@ -1111,7 +1111,7 @@ index cfc8b2cc845..c6fcfd7bd08 100644
  import org.apache.spark.SparkConf
  import org.apache.spark.sql.{AnalysisException, QueryTest}
  import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-+import org.apache.spark.sql.comet.CometScanExec
++import org.apache.spark.sql.comet.{CometNativeScanExec, CometScanExec}
  import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability}
  import org.apache.spark.sql.connector.read.ScanBuilder
  import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
@@ -1121,7 +1121,7 @@ index cfc8b2cc845..c6fcfd7bd08 100644
              assert(
 -              df.queryExecution.executedPlan.exists(_.isInstanceOf[FileSourceScanExec]))
 +              df.queryExecution.executedPlan.exists {
-+                case _: FileSourceScanExec | _: CometScanExec => true
++                case _: FileSourceScanExec | _: CometScanExec | _: CometNativeScanExec => true
 +                case _ => false
 +              }
 +            )

--- a/dev/diffs/4.0.1.diff
+++ b/dev/diffs/4.0.1.diff
@@ -1443,7 +1443,7 @@ index 2a0ab21ddb0..e8a5a891105 100644
  import org.apache.spark.{SparkConf, SparkException}
  import org.apache.spark.sql.QueryTest
  import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-+import org.apache.spark.sql.comet.CometScanExec
++import org.apache.spark.sql.comet.{CometNativeScanExec, CometScanExec}
  import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability}
  import org.apache.spark.sql.connector.read.ScanBuilder
  import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
@@ -1453,7 +1453,7 @@ index 2a0ab21ddb0..e8a5a891105 100644
              assert(
 -              df.queryExecution.executedPlan.exists(_.isInstanceOf[FileSourceScanExec]))
 +              df.queryExecution.executedPlan.exists {
-+                case _: FileSourceScanExec | _: CometScanExec => true
++                case _: FileSourceScanExec | _: CometScanExec | _: CometNativeScanExec => true
 +                case _ => false
 +              }
 +            )

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
@@ -65,8 +65,16 @@ case class CometNativeScanExec(
   override val nodeName: String =
     s"CometNativeScan $relation ${tableIdentifier.map(_.unquotedString).getOrElse("")}"
 
-  override lazy val outputPartitioning: Partitioning =
-    UnknownPartitioning(originalPlan.inputRDD.getNumPartitions)
+  // exposed for testing
+  lazy val bucketedScan: Boolean = originalPlan.bucketedScan && !disableBucketedScan
+
+  override lazy val outputPartitioning: Partitioning = {
+    if (bucketedScan) {
+      originalPlan.outputPartitioning
+    } else {
+      UnknownPartitioning(originalPlan.inputRDD.getNumPartitions)
+    }
+  }
 
   override lazy val outputOrdering: Seq[SortOrder] = originalPlan.outputOrdering
 


### PR DESCRIPTION
## Which issue does this PR close?

Partially addresses #3315 (fixes 3 of the 4 failing test categories)

## Rationale for this change

When `native_datafusion` is enabled, several Spark SQL tests fail because `CometNativeScanExec`:
1. Always returns `UnknownPartitioning` instead of preserving the original partitioning for bucketed scans
2. Is not recognized in plan structure checks that look for `FileSourceScanExec` or `CometScanExec`

## What changes are included in this PR?

1. **Fixed `CometNativeScanExec.scala`**: Updated `outputPartitioning` to preserve the original partitioning for bucketed scans, matching the pattern used by `CometScanExec`. This fixes the **BroadcastJoinSuite** tests that expected `PartitioningCollection` but got `UnknownPartitioning`.

2. **Updated diff files**: Added `CometNativeScanExec` to the pattern match in `FileDataSourceV2FallBackSuite` for the "Fallback Parquet V2 to V1" test across all three diff files (3.4.3, 3.5.8, 4.0.1).

## Test Results (verified locally with `COMET_PARQUET_SCAN_IMPL=native_datafusion`)

| Test Suite | Test Name | Status |
|------------|-----------|--------|
| FileDataSourceV2FallBackSuite | "Fallback Parquet V2 to V1" | ✅ **PASS** |
| BroadcastJoinSuite | "broadcast join where streamed side's output partitioning is HashPartitioning" | ✅ **PASS** |
| BroadcastJoinSuite | "broadcast join where streamed side's output partitioning is PartitioningCollection" | ✅ **PASS** |
| StreamingSelfUnionSuite | "self-union, DSv1, read via DataStreamReader API" | ❌ FAIL (separate issue) |
| StreamingSelfUnionSuite | "self-union, DSv1, read via table API" | ❌ FAIL (separate issue) |

The streaming tests fail because `getLastProgressWithData(q)` returns `None` - this is a streaming progress metrics issue with `CometNativeScan` that needs separate investigation.

## How are these changes tested?

Verified locally by running the Spark SQL tests with `COMET_PARQUET_SCAN_IMPL=native_datafusion`.

🤖 Generated with [Claude Code](https://claude.ai/code)