### PR TITLE
perf: Remove mutable buffers from scan partition/missing columns

### DIFF
--- a/common/src/main/java/org/apache/comet/parquet/ArrowConstantColumnReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/ArrowConstantColumnReader.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.parquet;
+
+import java.math.BigDecimal;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.*;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns;
+import org.apache.spark.sql.types.*;
+import org.apache.spark.unsafe.types.UTF8String;
+
+import org.apache.comet.vector.CometPlainVector;
+import org.apache.comet.vector.CometVector;
+
+/**
+ * A column reader that returns constant vectors using Arrow Java vectors directly (no native
+ * mutable buffers). Used for partition columns and missing columns in the native_iceberg_compat
+ * scan path.
+ *
+ * <p>Since the vector is constant, only a single element is stored and {@link CometPlainVector}
+ * broadcasts it to all rows.
+ */
+public class ArrowConstantColumnReader extends AbstractColumnReader {
+  private final BufferAllocator allocator = new RootAllocator();
+
+  private boolean isNull;
+  private Object value;
+  private FieldVector fieldVector;
+  private CometPlainVector vector;
+
+  /** Constructor for missing columns (default values from schema). */
+  ArrowConstantColumnReader(StructField field, int batchSize, boolean useDecimal128) {
+    super(field.dataType(), TypeUtil.convertToParquet(field), useDecimal128, false);
+    this.batchSize = batchSize;
+    this.value =
+        ResolveDefaultColumns.getExistenceDefaultValues(new StructType(new StructField[] {field}))[
+            0];
+    initVector(value);
+  }
+
+  /** Constructor for partition columns with values from a row. */
+  ArrowConstantColumnReader(
+      StructField field, int batchSize, InternalRow values, int index, boolean useDecimal128) {
+    super(field.dataType(), TypeUtil.convertToParquet(field), useDecimal128, false);
+    this.batchSize = batchSize;
+    Object v = values.get(index, field.dataType());
+    this.value = v;
+    initVector(v);
+  }
+
+  @Override
+  public void setBatchSize(int batchSize) {
+    close();
+    this.batchSize = batchSize;
+    initVector(value);
+  }
+
+  @Override
+  public void readBatch(int total) {
+    vector.setNumValues(total);
+    if (isNull) vector.setNumNulls(total);
+  }
+
+  @Override
+  public CometVector currentBatch() {
+    return vector;
+  }
+
+  @Override
+  public void close() {
+    if (vector != null) {
+      vector.close();
+      vector = null;
+    }
+    if (fieldVector != null) {
+      fieldVector.close();
+      fieldVector = null;
+    }
+  }
+
+  private void initVector(Object value) {
+    if (value == null) {
+      isNull = true;
+      fieldVector = createTypedVector();
+      fieldVector.setValueCount(1);
+    } else {
+      isNull = false;
+      fieldVector = createAndSetVector(value);
+    }
+    vector = new CometPlainVector(fieldVector, useDecimal128, false, true);
+  }
+
+  private FieldVector createTypedVector() {
+    String name = "constant";
+    if (type == DataTypes.BooleanType) {
+      return new BitVector(name, allocator);
+    } else if (type == DataTypes.ByteType) {
+      return new TinyIntVector(name, allocator);
+    } else if (type == DataTypes.ShortType) {
+      return new SmallIntVector(name, allocator);
+    } else if (type == DataTypes.IntegerType || type == DataTypes.DateType) {
+      return new IntVector(name, allocator);
+    } else if (type == DataTypes.LongType
+        || type == DataTypes.TimestampType
+        || type == TimestampNTZType$.MODULE$) {
+      return new BigIntVector(name, allocator);
+    } else if (type == DataTypes.FloatType) {
+      return new Float4Vector(name, allocator);
+    } else if (type == DataTypes.DoubleType) {
+      return new Float8Vector(name, allocator);
+    } else if (type == DataTypes.BinaryType) {
+      return new VarBinaryVector(name, allocator);
+    } else if (type == DataTypes.StringType) {
+      return new VarCharVector(name, allocator);
+    } else if (type instanceof DecimalType) {
+      DecimalType dt = (DecimalType) type;
+      if (!useDecimal128 && dt.precision() <= Decimal.MAX_INT_DIGITS()) {
+        return new IntVector(name, allocator);
+      } else if (!useDecimal128 && dt.precision() <= Decimal.MAX_LONG_DIGITS()) {
+        return new BigIntVector(name, allocator);
+      } else {
+        return new DecimalVector(name, allocator, dt.precision(), dt.scale());
+      }
+    } else {
+      throw new UnsupportedOperationException("Unsupported Spark type: " + type);
+    }
+  }
+
+  private FieldVector createAndSetVector(Object value) {
+    String name = "constant";
+    if (type == DataTypes.BooleanType) {
+      BitVector v = new BitVector(name, allocator);
+      v.allocateNew(1);
+      v.setSafe(0, (boolean) value ? 1 : 0);
+      v.setValueCount(1);
+      return v;
+    } else if (type == DataTypes.ByteType) {
+      TinyIntVector v = new TinyIntVector(name, allocator);
+      v.allocateNew(1);
+      v.setSafe(0, (byte) value);
+      v.setValueCount(1);
+      return v;
+    } else if (type == DataTypes.ShortType) {
+      SmallIntVector v = new SmallIntVector(name, allocator);
+      v.allocateNew(1);
+      v.setSafe(0, (short) value);
+      v.setValueCount(1);
+      return v;
+    } else if (type == DataTypes.IntegerType || type == DataTypes.DateType) {
+      IntVector v = new IntVector(name, allocator);
+      v.allocateNew(1);
+      v.setSafe(0, (int) value);
+      v.setValueCount(1);
+      return v;
+    } else if (type == DataTypes.LongType
+        || type == DataTypes.TimestampType
+        || type == TimestampNTZType$.MODULE$) {
+      BigIntVector v = new BigIntVector(name, allocator);
+      v.allocateNew(1);
+      v.setSafe(0, (long) value);
+      v.setValueCount(1);
+      return v;
+    } else if (type == DataTypes.FloatType) {
+      Float4Vector v = new Float4Vector(name, allocator);
+      v.allocateNew(1);
+      v.setSafe(0, (float) value);
+      v.setValueCount(1);
+      return v;
+    } else if (type == DataTypes.DoubleType) {
+      Float8Vector v = new Float8Vector(name, allocator);
+      v.allocateNew(1);
+      v.setSafe(0, (double) value);
+      v.setValueCount(1);
+      return v;
+    } else if (type == DataTypes.BinaryType) {
+      VarBinaryVector v = new VarBinaryVector(name, allocator);
+      v.allocateNew(1);
+      byte[] bytes = (byte[]) value;
+      v.setSafe(0, bytes, 0, bytes.length);
+      v.setValueCount(1);
+      return v;
+    } else if (type == DataTypes.StringType) {
+      VarCharVector v = new VarCharVector(name, allocator);
+      v.allocateNew(1);
+      byte[] bytes = ((UTF8String) value).getBytes();
+      v.setSafe(0, bytes, 0, bytes.length);
+      v.setValueCount(1);
+      return v;
+    } else if (type instanceof DecimalType) {
+      DecimalType dt = (DecimalType) type;
+      Decimal d = (Decimal) value;
+      if (!useDecimal128 && dt.precision() <= Decimal.MAX_INT_DIGITS()) {
+        IntVector v = new IntVector(name, allocator);
+        v.allocateNew(1);
+        v.setSafe(0, (int) d.toUnscaledLong());
+        v.setValueCount(1);
+        return v;
+      } else if (!useDecimal128 && dt.precision() <= Decimal.MAX_LONG_DIGITS()) {
+        BigIntVector v = new BigIntVector(name, allocator);
+        v.allocateNew(1);
+        v.setSafe(0, d.toUnscaledLong());
+        v.setValueCount(1);
+        return v;
+      } else {
+        DecimalVector v = new DecimalVector(name, allocator, dt.precision(), dt.scale());
+        v.allocateNew(1);
+        BigDecimal bd = d.toJavaBigDecimal();
+        v.setSafe(0, bd);
+        v.setValueCount(1);
+        return v;
+      }
+    } else {
+      throw new UnsupportedOperationException("Unsupported Spark type: " + type);
+    }
+  }
+}

--- a/common/src/main/java/org/apache/comet/parquet/ArrowRowIndexColumnReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/ArrowRowIndexColumnReader.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.parquet;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.spark.sql.types.*;
+
+import org.apache.comet.vector.CometPlainVector;
+import org.apache.comet.vector.CometVector;
+
+/**
+ * A column reader that computes row indices in Java and creates Arrow BigIntVectors directly (no
+ * native mutable buffers). Used for the row index metadata column in the native_iceberg_compat scan
+ * path.
+ *
+ * <p>The {@code indices} array contains alternating pairs of (start_index, count) representing
+ * ranges of sequential row indices within each row group.
+ */
+public class ArrowRowIndexColumnReader extends AbstractColumnReader {
+  private final BufferAllocator allocator = new RootAllocator();
+
+  /** Alternating (start_index, count) pairs from row groups. */
+  private final long[] indices;
+
+  /** Number of row indices consumed so far across batches. */
+  private long offset;
+
+  private BigIntVector fieldVector;
+  private CometPlainVector vector;
+
+  public ArrowRowIndexColumnReader(StructField field, int batchSize, long[] indices) {
+    super(field.dataType(), TypeUtil.convertToParquet(field), false, false);
+    this.indices = indices;
+    this.batchSize = batchSize;
+  }
+
+  @Override
+  public void setBatchSize(int batchSize) {
+    close();
+    this.batchSize = batchSize;
+  }
+
+  @Override
+  public void readBatch(int total) {
+    close();
+
+    fieldVector = new BigIntVector("row_index", allocator);
+    fieldVector.allocateNew(total);
+
+    // Port of Rust set_indices: iterate (start, count) pairs, skip offset rows, fill up to total.
+    long skipped = 0;
+    int filled = 0;
+    for (int i = 0; i < indices.length && filled < total; i += 2) {
+      long index = indices[i];
+      long count = indices[i + 1];
+      long skip = Math.min(count, offset - skipped);
+      skipped += skip;
+      if (count == skip) {
+        continue;
+      }
+      long remaining = Math.min(count - skip, total - filled);
+      for (long j = 0; j < remaining; j++) {
+        fieldVector.setSafe(filled, index + skip + j);
+        filled++;
+      }
+    }
+    offset += filled;
+
+    fieldVector.setValueCount(filled);
+    vector = new CometPlainVector(fieldVector, false, false, false);
+    vector.setNumValues(filled);
+  }
+
+  @Override
+  public CometVector currentBatch() {
+    return vector;
+  }
+
+  @Override
+  public void close() {
+    if (vector != null) {
+      vector.close();
+      vector = null;
+    }
+    if (fieldVector != null) {
+      fieldVector.close();
+      fieldVector = null;
+    }
+  }
+}

--- a/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
+++ b/common/src/main/java/org/apache/comet/parquet/NativeBatchReader.java
@@ -448,7 +448,8 @@ public class NativeBatchReader extends RecordReader<Void, ColumnarBatch> impleme
           // TODO(SPARK-40059): Allow users to include columns named
           //                    FileFormat.ROW_INDEX_TEMPORARY_COLUMN_NAME in their schemas.
           long[] rowIndices = FileReader.getRowIndices(blocks);
-          columnReaders[i] = new RowIndexColumnReader(nonPartitionFields[i], capacity, rowIndices);
+          columnReaders[i] =
+              new ArrowRowIndexColumnReader(nonPartitionFields[i], capacity, rowIndices);
           hasRowIndexColumn = true;
           missingColumns[i] = true;
         } else if (optFileField.isPresent()) {
@@ -473,8 +474,8 @@ public class NativeBatchReader extends RecordReader<Void, ColumnarBatch> impleme
                       + filePath);
             }
             if (field.isPrimitive()) {
-              ConstantColumnReader reader =
-                  new ConstantColumnReader(nonPartitionFields[i], capacity, useDecimal128);
+              ArrowConstantColumnReader reader =
+                  new ArrowConstantColumnReader(nonPartitionFields[i], capacity, useDecimal128);
               columnReaders[i] = reader;
               missingColumns[i] = true;
             } else {
@@ -492,8 +493,9 @@ public class NativeBatchReader extends RecordReader<Void, ColumnarBatch> impleme
         for (int i = fields.size(); i < columnReaders.length; i++) {
           int fieldIndex = i - fields.size();
           StructField field = partitionFields[fieldIndex];
-          ConstantColumnReader reader =
-              new ConstantColumnReader(field, capacity, partitionValues, fieldIndex, useDecimal128);
+          ArrowConstantColumnReader reader =
+              new ArrowConstantColumnReader(
+                  field, capacity, partitionValues, fieldIndex, useDecimal128);
           columnReaders[i] = reader;
         }
       }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -1904,6 +1904,8 @@ case class CometSortMergeJoinExec(
 }
 
 object CometScanWrapper extends CometSink[SparkPlan] {
+  override def isFfiSafe: Boolean = true
+
   override def createExec(nativeOp: Operator, op: SparkPlan): CometNativeExec = {
     CometScanWrapper(nativeOp, op)
   }


### PR DESCRIPTION
## Rationale

Removing the use of mutable buffers means that we can stop performing a deep copy of every single batch going through the `native_iceberg_compat` path, because we can use Arrow FFI best practices.

## Performance

These benchmark results are based on using the benchmarks in https://github.com/apache/datafusion-comet/pull/3407, comparing the main branch (Baseline) to this branch (Mutable).

There are some nice improvements in some cases because Comet no longer performs a defensive deep copy of every batch. There is a small regression in smallint case, and there is a follow on issue to improve this - https://github.com/apache/datafusion-comet/issues/3435.

### Large String Filter Benchmarks

| Benchmark | Baseline Best (ms) | Mutable Best (ms) | Change | Baseline Avg (ms) | Mutable Avg (ms) | Change |
|-----------|-------------------:|-------------------:|-------:|-------------------:|-------------------:|-------:|
| Lg Str Filter 0% | 1035 | 781 | **-24.5%** | 1175 | 784 | **-33.3%** |
| Lg Str Filter 50% | 947 | 742 | **-21.6%** | 950 | 753 | **-20.7%** |
| Lg Str Filter 99.9% | 1164 | 723 | **-37.9%** | 1165 | 745 | **-36.1%** |
| Sorted Lg Str 0% | 960 | 771 | **-19.7%** | 962 | 778 | **-19.1%** |
| Sorted Lg Str 50% | 969 | 754 | **-22.2%** | 972 | 756 | **-22.2%** |
| Sorted Lg Str 99.9% | 985 | 755 | **-23.4%** | 992 | 760 | **-23.4%** |

### String & Filter Benchmarks

| Benchmark | Baseline Best (ms) | Mutable Best (ms) | Change | Baseline Avg (ms) | Mutable Avg (ms) | Change |
|-----------|-------------------:|-------------------:|-------:|-------------------:|-------------------:|-------:|
| String Dict Encoding | 114 | 103 | **-9.6%** | 118 | 105 | **-11.0%** |
| Numeric Filter 0% | 136 | 136 | 0.0% | 140 | 140 | 0.0% |
| Numeric Filter 50% | 147 | 146 | -0.7% | 150 | 149 | -0.7% |
| Numeric Filter 95% | 107 | 104 | -2.8% | 110 | 107 | -2.7% |
| String Nulls 0% | 726 | 697 | **-4.0%** | 730 | 700 | **-4.1%** |
| String Nulls 50% | 445 | 424 | **-4.7%** | 450 | 428 | **-4.9%** |
| String Nulls 95% | 118 | 102 | **-13.6%** | 120 | 104 | **-13.3%** |
| Col from 10 | 17 | 17 | 0.0% | 20 | 19 | -5.0% |
| Col from 50 | 26 | 25 | -3.8% | 28 | 28 | 0.0% |
| Col from 100 | 39 | 37 | -5.1% | 41 | 40 | -2.4% |

### Single Column Scans (Unencrypted)
                                                                                                                                                                                                               
| Type | Baseline Best (ms) | Mutable Best (ms) | Change | Baseline Avg (ms) | Mutable Avg (ms) | Change |
|------|-------------------:|-------------------:|-------:|-------------------:|-------------------:|-------:|                                                                                                 
| BOOLEAN | 662 | 661 | -0.2% | 674 | 668 | -0.9% |
| TINYINT | 304 | 290 | **-4.6%** | 314 | 323 | +2.9% |
| SMALLINT | 383 | 426 | **+11.2%** | 386 | 441 | **+14.2%** |
| INT | 435 | 431 | -0.9% | 448 | 437 | -2.5% |
| BIGINT | 703 | 719 | +2.3% | 713 | 721 | +1.1% |
| FLOAT | 462 | 448 | **-3.0%** | 469 | 458 | -2.3% |
| DOUBLE | 717 | 705 | -1.7% | 725 | 707 | -2.5% |

### Single Column Scans (Encrypted)

| Type | Baseline Best (ms) | Mutable Best (ms) | Change | Baseline Avg (ms) | Mutable Avg (ms) | Change |
|------|-------------------:|-------------------:|-------:|-------------------:|-------------------:|-------:|
| BOOLEAN | 667 | 654 | **-1.9%** | 667 | 662 | -0.7% |
| TINYINT | 308 | 295 | **-4.2%** | 314 | 306 | -2.5% |
| SMALLINT | 512 | 562 | **+9.8%** | 515 | 565 | **+9.7%** |
| INT | 478 | 486 | +1.7% | 490 | 493 | +0.6% |
| BIGINT | 809 | 796 | -1.6% | 814 | 800 | -1.7% |
| FLOAT | 512 | 513 | +0.2% | 517 | 519 | +0.4% |
| DOUBLE | 807 | 805 | -0.2% | 811 | 807 | -0.5% |

### Decimal Column Scans

| Type | Baseline Best (ms) | Mutable Best (ms) | Change | Baseline Avg (ms) | Mutable Avg (ms) | Change |
|------|-------------------:|-------------------:|-------:|-------------------:|-------------------:|-------:|
| Decimal(5,2) | 123 | 120 | -2.4% | 126 | 123 | -2.4% |
| Decimal(18,4) | 166 | 161 | **-3.0%** | 170 | 166 | -2.4% |
| Decimal(20,8) | 258 | 255 | -1.2% | 265 | 265 | 0.0% |

## Changes in this PR

- Add `ArrowConstantColumnReader` and `ArrowRowIndexColumnReader` that create Arrow Java vectors directly instead of going through native mutable buffers
- `NativeBatchReader` now uses these new readers for partition columns, missing columns, and row index columns
- Set `isFfiSafe=true` on `CometScanWrapper` so that `ScanExec` no longer deep-copies scan data

The existing `ConstantColumnReader`, `RowIndexColumnReader`, and `MetadataColumnReader` are unchanged and still used by `BatchReader` (deprecated `native_comet` path) and Iceberg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)