### PR TITLE
fix: [iceberg] Keep deep copy for Iceberg Java integration scan path

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometSink.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometSink.scala
@@ -37,7 +37,7 @@ import org.apache.comet.serde.QueryPlanSerde.{serializeDataType, supportedDataTy
 abstract class CometSink[T <: SparkPlan] extends CometOperatorSerde[T] {
 
   /** Whether the data produced by the Comet operator is FFI safe */
-  def isFfiSafe: Boolean = false
+  def isFfiSafe(op: T): Boolean = false
 
   override def enabledConfig: Option[ConfigEntry[Boolean]] = None
 
@@ -61,7 +61,7 @@ abstract class CometSink[T <: SparkPlan] extends CometOperatorSerde[T] {
     } else {
       scanBuilder.setSource(source)
     }
-    scanBuilder.setArrowFfiSafe(isFfiSafe)
+    scanBuilder.setArrowFfiSafe(isFfiSafe(op))
 
     val scanTypes = op.output.flatten { attr =>
       serializeDataType(attr.dataType)
@@ -93,7 +93,7 @@ object CometExchangeSink extends CometSink[SparkPlan] {
    *
    * Source of shuffle exchange batches is NativeBatchDecoderIterator.
    */
-  override def isFfiSafe: Boolean = true
+  override def isFfiSafe(op: SparkPlan): Boolean = true
 
   override def createExec(nativeOp: Operator, op: SparkPlan): CometNativeExec =
     CometSinkPlaceHolder(nativeOp, op, op)

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometBroadcastExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometBroadcastExchangeExec.scala
@@ -271,7 +271,7 @@ object CometBroadcastExchangeExec extends CometSink[BroadcastExchangeExec] {
    *
    * Source of broadcast exchange batches is ArrowStreamReader.
    */
-  override def isFfiSafe: Boolean = true
+  override def isFfiSafe(op: BroadcastExchangeExec): Boolean = true
 
   override def enabledConfig: Option[ConfigEntry[Boolean]] = Some(
     CometConf.COMET_EXEC_BROADCAST_EXCHANGE_ENABLED)

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -2072,6 +2072,13 @@ case class CometSortMergeJoinExec(
 }
 
 object CometScanWrapper extends CometSink[SparkPlan] {
+  override def isFfiSafe(op: SparkPlan): Boolean = op match {
+    // CometScanExec (native_iceberg_compat) uses immutable Arrow readers
+    case _: CometScanExec => true
+    // CometBatchScanExec (Iceberg Java integration) still uses mutable buffers
+    case _ => false
+  }
+
   override def createExec(nativeOp: Operator, op: SparkPlan): CometNativeExec = {
     CometScanWrapper(nativeOp, op)
   }


### PR DESCRIPTION
## Summary

- Make `CometSink.isFfiSafe` take the operator as a parameter so FFI safety can be determined per-scan
- `CometScanWrapper.isFfiSafe` now returns `true` only for `CometScanExec` (native_iceberg_compat, which uses immutable Arrow readers after #3411), and `false` for `CometBatchScanExec` (Iceberg Java integration via SupportsComet, which still uses mutable buffers)
- Remove stale `hasScanUsingMutableBuffers` check for `CometScanExec` since #3411 replaced mutable buffers with `ArrowConstantColumnReader`

## Test plan

- [ ] Iceberg integration tests pass (triggered by `[iceberg]` in title)
- [ ] Existing scan tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)