### PR TITLE
ci: disable Miri safety checks until compatibility is restored

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -28,14 +28,16 @@ on:
       - "native/core/benches/**"
       - "native/spark-expr/benches/**"
       - "spark/src/test/scala/org/apache/spark/sql/benchmark/**"
-  pull_request:
-    paths-ignore:
-      - "doc/**"
-      - "docs/**"
-      - "**.md"
-      - "native/core/benches/**"
-      - "native/spark-expr/benches/**"
-      - "spark/src/test/scala/org/apache/spark/sql/benchmark/**"
+# Disabled until Miri compatibility is restored
+# https://github.com/apache/datafusion-comet/issues/3499
+#  pull_request:
+#    paths-ignore:
+#      - "doc/**"
+#      - "docs/**"
+#      - "**.md"
+#      - "native/core/benches/**"
+#      - "native/spark-expr/benches/**"
+#      - "spark/src/test/scala/org/apache/spark/sql/benchmark/**"
   # manual trigger
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:
@@ -43,9 +45,6 @@ on:
 jobs:
   miri:
     name: "Miri"
-    # Disabled until Miri compatibility is restored
-    # https://github.com/apache/datafusion-comet/issues/3499
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -43,6 +43,9 @@ on:
 jobs:
   miri:
     name: "Miri"
+    # Disabled until Miri compatibility is restored
+    # https://github.com/apache/datafusion-comet/issues/3499
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Disables the Miri CI job (`if: false`) until compatibility with the current nightly toolchain is restored

## Related
- Closes https://github.com/apache/datafusion-comet/issues/3499

🤖 Generated with [Claude Code](https://claude.com/claude-code)