### PR TITLE
feat: Add statistics-based guards to SortMergeJoin-to-HashJoin rewrite [experimental]

### DIFF
--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -365,10 +365,25 @@ object CometConf extends ShimCometConf {
   val COMET_REPLACE_SMJ: ConfigEntry[Boolean] =
     conf(s"$COMET_EXEC_CONFIG_PREFIX.replaceSortMergeJoin")
       .category(CATEGORY_EXEC)
-      .doc("Experimental feature to force Spark to replace SortMergeJoin with ShuffledHashJoin " +
-        s"for improved performance. This feature is not stable yet. $TUNING_GUIDE.")
+      .doc("Experimental feature to replace SortMergeJoin with ShuffledHashJoin " +
+        "for improved performance. When enabled, Comet will only rewrite a " +
+        "SortMergeJoin to a ShuffledHashJoin if the build side is estimated to " +
+        "fit in memory (using Spark's autoBroadcastJoinThreshold * " +
+        "numShufflePartitions) and is significantly smaller than the probe side " +
+        s"(controlled by replaceSortMergeJoin.sizeRatio). $TUNING_GUIDE.")
       .booleanConf
       .createWithDefault(false)
+
+  val COMET_REPLACE_SMJ_SIZE_RATIO: ConfigEntry[Int] =
+    conf(s"$COMET_EXEC_CONFIG_PREFIX.replaceSortMergeJoin.sizeRatio")
+      .category(CATEGORY_EXEC)
+      .doc("Minimum ratio of probe side size to build side size required when " +
+        "replacing SortMergeJoin with ShuffledHashJoin. Building a hash table is " +
+        "more expensive than sorting, so the build side should be significantly " +
+        "smaller than the probe side. Matches Spark's " +
+        s"spark.sql.shuffledHashJoinFactor behavior. $TUNING_GUIDE.")
+      .intConf
+      .createWithDefault(3)
 
   val COMET_EXEC_SHUFFLE_WITH_HASH_PARTITIONING_ENABLED: ConfigEntry[Boolean] =
     conf("spark.comet.native.shuffle.partitioning.hash.enabled")


### PR DESCRIPTION
## Summary

- Add per-partition size check and size ratio check to `RewriteJoin`, mirroring Spark's own `JoinSelection` logic (`canBuildLocalHashMapBySize()` and `muchSmaller()`)
- Previously, enabling `spark.comet.exec.replaceSortMergeJoin` would unconditionally rewrite **all** SortMergeJoins to ShuffledHashJoins, risking OOM when the build side is too large
- Now the rewrite only happens when the build side is estimated to fit in memory and is significantly smaller than the probe side
- Add new config `spark.comet.exec.replaceSortMergeJoin.sizeRatio` (default: 3) matching Spark's `SHUFFLE_HASH_JOIN_FACTOR`
- Log reasons when rewrite is skipped (visible with `explainFallback.enabled=true`)

## Details

**Per-partition size check:** `buildSize < autoBroadcastJoinThreshold * numShufflePartitions`
- Reuses Spark's existing configs — no new threshold to configure
- When `autoBroadcastJoinThreshold = -1` (broadcast disabled), this check is skipped

**Size ratio check:** `buildSize * sizeRatio <= probeSize`
- Default ratio of 3 matches Spark's `spark.sql.shuffledHashJoinFactor`
- Ensures hash join is only used when it has a clear advantage over sort-merge

**Safe fallback:** When no logical plan statistics are available, the rewrite is skipped conservatively.

## Test plan

- [ ] Verify existing `CometJoinSuite` tests still pass
- [ ] Test with TPC-H/TPC-DS to confirm joins are correctly selected
- [ ] Test with `explainFallback.enabled=true` to verify skip reasons are logged
- [ ] Test edge case: `autoBroadcastJoinThreshold=-1` still allows rewrite when size ratio is met

🤖 Generated with [Claude Code](https://claude.com/claude-code)