### PR TITLE
ci: add dedicated RAT license check workflow for all PRs

### DIFF
--- a/.github/workflows/pr_rat_check.yml
+++ b/.github/workflows/pr_rat_check.yml
@@ -21,6 +21,9 @@ concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 # No paths-ignore: this workflow must run for ALL changes including docs
 on:
   push:

--- a/.github/workflows/pr_rat_check.yml
+++ b/.github/workflows/pr_rat_check.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   rat-check:
     name: RAT License Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v4
       - name: Set up Java

--- a/.github/workflows/pr_rat_check.yml
+++ b/.github/workflows/pr_rat_check.yml
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: RAT License Check
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+# No paths-ignore: this workflow must run for ALL changes including docs
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  rat-check:
+    name: RAT License Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+      - name: Run RAT check
+        run: ./mvnw -B -N apache-rat:check


### PR DESCRIPTION
## Summary

- Add a new lightweight CI workflow (`pr_rat_check.yml`) that runs the Apache RAT license header check on **all** PRs, including docs-only changes

## Problem

The existing build workflows (`pr_build_linux`, `spark_sql_test`, etc.) use `paths-ignore` to skip docs-only changes (matching `docs/**`, `**.md`, etc.). This also skips the RAT license check, which allowed files without Apache license headers to be merged via docs-only PRs (e.g., #3651 introduced SVG files without headers, breaking CI for unrelated PRs like #3661).

## Solution

A dedicated workflow that:
- Has **no path filters** — runs on every PR and push to main
- Only runs `./mvnw -B -N apache-rat:check` (the `-N` flag skips child module builds)
- Uses a minimal setup (just Java 11, no Rust/Spark needed)
- Completes in seconds since it only checks license headers

## Test plan

- [x] The workflow itself will be validated by CI on this PR