### PR TITLE
perf: remove buffer reuse and arrow_ffi_safe flag [WIP]

### DIFF
--- a/common/src/main/scala/org/apache/spark/sql/comet/execution/arrow/CometArrowConverters.scala
+++ b/common/src/main/scala/org/apache/spark/sql/comet/execution/arrow/CometArrowConverters.scala
@@ -19,8 +19,6 @@
 
 package org.apache.spark.sql.comet.execution.arrow
 
-import scala.collection.mutable
-
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.types.pojo.Schema
@@ -53,13 +51,13 @@ object CometArrowConverters extends Logging {
     protected val allocator: BufferAllocator =
       CometArrowAllocator.newChildAllocator(s"to${this.getClass.getSimpleName}", 0, Long.MaxValue)
 
-    // Track all roots created so they can be closed before the allocator is released.
-    // Roots must outlive the batch (so native can export them), but must be closed
-    // before the allocator to avoid memory leak errors.
-    private val roots = mutable.ArrayBuffer.empty[VectorSchemaRoot]
+    // The previous root is closed when the next batch is requested, so only one
+    // root is alive at a time. The last root is closed when the task completes.
+    private var prevRoot: VectorSchemaRoot = _
 
-    protected def trackRoot(root: VectorSchemaRoot): VectorSchemaRoot = {
-      roots += root
+    protected def closeAndTrack(root: VectorSchemaRoot): VectorSchemaRoot = {
+      if (prevRoot != null) prevRoot.close()
+      prevRoot = root
       root
     }
 
@@ -76,8 +74,10 @@ object CometArrowConverters extends Logging {
     protected def close(closeAllocator: Boolean): Unit = {
       // the allocator shall be closed when the task is finished
       if (closeAllocator) {
-        roots.foreach(_.close())
-        roots.clear()
+        if (prevRoot != null) {
+          prevRoot.close()
+          prevRoot = null
+        }
         allocator.close()
       }
     }
@@ -106,7 +106,7 @@ object CometArrowConverters extends Logging {
 
     override protected def nextBatch(): ColumnarBatch = {
       if (rowIter.hasNext) {
-        val root = trackRoot(VectorSchemaRoot.create(arrowSchema, allocator))
+        val root = closeAndTrack(VectorSchemaRoot.create(arrowSchema, allocator))
         val arrowWriter = ArrowWriter.create(root)
         var rowCount = 0L
         while (rowIter.hasNext && (maxRecordsPerBatch <= 0 || rowCount < maxRecordsPerBatch)) {
@@ -150,7 +150,7 @@ object CometArrowConverters extends Logging {
     override protected def nextBatch(): ColumnarBatch = {
       val rowsInBatch = colBatch.numRows()
       if (rowsProduced < rowsInBatch) {
-        val root = trackRoot(VectorSchemaRoot.create(arrowSchema, allocator))
+        val root = closeAndTrack(VectorSchemaRoot.create(arrowSchema, allocator))
         val arrowWriter = ArrowWriter.create(root)
         val rowsToProduce =
           if (maxRecordsPerBatch <= 0) rowsInBatch - rowsProduced

--- a/common/src/main/scala/org/apache/spark/sql/comet/execution/arrow/CometArrowConverters.scala
+++ b/common/src/main/scala/org/apache/spark/sql/comet/execution/arrow/CometArrowConverters.scala
@@ -19,6 +19,8 @@
 
 package org.apache.spark.sql.comet.execution.arrow
 
+import scala.collection.mutable
+
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.types.pojo.Schema
@@ -51,6 +53,16 @@ object CometArrowConverters extends Logging {
     protected val allocator: BufferAllocator =
       CometArrowAllocator.newChildAllocator(s"to${this.getClass.getSimpleName}", 0, Long.MaxValue)
 
+    // Track all roots created so they can be closed before the allocator is released.
+    // Roots must outlive the batch (so native can export them), but must be closed
+    // before the allocator to avoid memory leak errors.
+    private val roots = mutable.ArrayBuffer.empty[VectorSchemaRoot]
+
+    protected def trackRoot(root: VectorSchemaRoot): VectorSchemaRoot = {
+      roots += root
+      root
+    }
+
     Option(context).foreach {
       _.addTaskCompletionListener[Unit] { _ =>
         close(true)
@@ -64,6 +76,8 @@ object CometArrowConverters extends Logging {
     protected def close(closeAllocator: Boolean): Unit = {
       // the allocator shall be closed when the task is finished
       if (closeAllocator) {
+        roots.foreach(_.close())
+        roots.clear()
         allocator.close()
       }
     }
@@ -92,7 +106,7 @@ object CometArrowConverters extends Logging {
 
     override protected def nextBatch(): ColumnarBatch = {
       if (rowIter.hasNext) {
-        val root = VectorSchemaRoot.create(arrowSchema, allocator)
+        val root = trackRoot(VectorSchemaRoot.create(arrowSchema, allocator))
         val arrowWriter = ArrowWriter.create(root)
         var rowCount = 0L
         while (rowIter.hasNext && (maxRecordsPerBatch <= 0 || rowCount < maxRecordsPerBatch)) {
@@ -136,7 +150,7 @@ object CometArrowConverters extends Logging {
     override protected def nextBatch(): ColumnarBatch = {
       val rowsInBatch = colBatch.numRows()
       if (rowsProduced < rowsInBatch) {
-        val root = VectorSchemaRoot.create(arrowSchema, allocator)
+        val root = trackRoot(VectorSchemaRoot.create(arrowSchema, allocator))
         val arrowWriter = ArrowWriter.create(root)
         val rowsToProduce =
           if (maxRecordsPerBatch <= 0) rowsInBatch - rowsProduced

--- a/common/src/main/scala/org/apache/spark/sql/comet/execution/arrow/CometArrowConverters.scala
+++ b/common/src/main/scala/org/apache/spark/sql/comet/execution/arrow/CometArrowConverters.scala
@@ -36,9 +36,8 @@ object CometArrowConverters extends Logging {
   // This is similar how Spark converts internal row to Arrow format except that it is transforming
   // the result batch to Comet's ColumnarBatch instead of serialized bytes.
   // Each batch is written to a fresh VectorSchemaRoot so that native code can safely
-  // Arc::clone the buffers rather than performing a deep copy. The JVM-side root is
-  // closed immediately after export, while native ref-counting keeps the memory alive
-  // until the native plan is done.
+  // Arc::clone the buffers rather than performing a deep copy. The allocator manages
+  // the buffer lifetime and is closed when the task completes.
 
   abstract private[sql] class ArrowBatchIterBase(
       schema: StructType,
@@ -102,9 +101,7 @@ object CometArrowConverters extends Logging {
           rowCount += 1
         }
         arrowWriter.finish()
-        val batch = NativeUtil.rootAsBatch(root)
-        root.close()
-        batch
+        NativeUtil.rootAsBatch(root)
       } else {
         null
       }
@@ -158,9 +155,7 @@ object CometArrowConverters extends Logging {
         rowsProduced += rowsToProduce
 
         arrowWriter.finish()
-        val batch = NativeUtil.rootAsBatch(root)
-        root.close()
-        batch
+        NativeUtil.rootAsBatch(root)
       } else {
         null
       }

--- a/common/src/main/scala/org/apache/spark/sql/comet/execution/arrow/CometArrowConverters.scala
+++ b/common/src/main/scala/org/apache/spark/sql/comet/execution/arrow/CometArrowConverters.scala
@@ -35,14 +35,10 @@ import org.apache.comet.vector.NativeUtil
 object CometArrowConverters extends Logging {
   // This is similar how Spark converts internal row to Arrow format except that it is transforming
   // the result batch to Comet's ColumnarBatch instead of serialized bytes.
-  // There's another big difference that Comet may consume the ColumnarBatch by exporting it to
-  // the native side. Hence, we need to:
-  // 1. reset the Arrow writer after the ColumnarBatch is consumed
-  // 2. close the allocator when the task is finished but not when the iterator is all consumed
-  // The reason for the second point is that when ColumnarBatch is exported to the native side, the
-  // exported process increases the reference count of the Arrow vectors. The reference count is
-  // only decreased when the native plan is done with the vectors, which is usually longer than
-  // all the ColumnarBatches are consumed.
+  // Each batch is written to a fresh VectorSchemaRoot so that native code can safely
+  // Arc::clone the buffers rather than performing a deep copy. The JVM-side root is
+  // closed immediately after export, while native ref-counting keeps the memory alive
+  // until the native plan is done.
 
   abstract private[sql] class ArrowBatchIterBase(
       schema: StructType,
@@ -55,11 +51,6 @@ object CometArrowConverters extends Logging {
     // Reuse the same root allocator here.
     protected val allocator: BufferAllocator =
       CometArrowAllocator.newChildAllocator(s"to${this.getClass.getSimpleName}", 0, Long.MaxValue)
-    protected val root: VectorSchemaRoot = VectorSchemaRoot.create(arrowSchema, allocator)
-    protected val arrowWriter: ArrowWriter = ArrowWriter.create(root)
-
-    protected var currentBatch: ColumnarBatch = null
-    protected var closed: Boolean = false
 
     Option(context).foreach {
       _.addTaskCompletionListener[Unit] { _ =>
@@ -72,27 +63,14 @@ object CometArrowConverters extends Logging {
     }
 
     protected def close(closeAllocator: Boolean): Unit = {
-      try {
-        if (!closed) {
-          if (currentBatch != null) {
-            arrowWriter.reset()
-            currentBatch.close()
-            currentBatch = null
-          }
-          root.close()
-          closed = true
-        }
-      } finally {
-        // the allocator shall be closed when the task is finished
-        if (closeAllocator) {
-          allocator.close()
-        }
+      // the allocator shall be closed when the task is finished
+      if (closeAllocator) {
+        allocator.close()
       }
     }
 
     override def next(): ColumnarBatch = {
-      currentBatch = nextBatch()
-      currentBatch
+      nextBatch()
     }
 
     protected def nextBatch(): ColumnarBatch
@@ -115,8 +93,8 @@ object CometArrowConverters extends Logging {
 
     override protected def nextBatch(): ColumnarBatch = {
       if (rowIter.hasNext) {
-        // the arrow writer shall be reset before writing the next batch
-        arrowWriter.reset()
+        val root = VectorSchemaRoot.create(arrowSchema, allocator)
+        val arrowWriter = ArrowWriter.create(root)
         var rowCount = 0L
         while (rowIter.hasNext && (maxRecordsPerBatch <= 0 || rowCount < maxRecordsPerBatch)) {
           val row = rowIter.next()
@@ -124,7 +102,9 @@ object CometArrowConverters extends Logging {
           rowCount += 1
         }
         arrowWriter.finish()
-        NativeUtil.rootAsBatch(root)
+        val batch = NativeUtil.rootAsBatch(root)
+        root.close()
+        batch
       } else {
         null
       }
@@ -159,8 +139,8 @@ object CometArrowConverters extends Logging {
     override protected def nextBatch(): ColumnarBatch = {
       val rowsInBatch = colBatch.numRows()
       if (rowsProduced < rowsInBatch) {
-        // the arrow writer shall be reset before writing the next batch
-        arrowWriter.reset()
+        val root = VectorSchemaRoot.create(arrowSchema, allocator)
+        val arrowWriter = ArrowWriter.create(root)
         val rowsToProduce =
           if (maxRecordsPerBatch <= 0) rowsInBatch - rowsProduced
           else Math.min(maxRecordsPerBatch, rowsInBatch - rowsProduced)
@@ -178,7 +158,9 @@ object CometArrowConverters extends Logging {
         rowsProduced += rowsToProduce
 
         arrowWriter.finish()
-        NativeUtil.rootAsBatch(root)
+        val batch = NativeUtil.rootAsBatch(root)
+        root.close()
+        batch
       } else {
         null
       }

--- a/common/src/main/scala/org/apache/spark/sql/comet/execution/arrow/CometArrowConverters.scala
+++ b/common/src/main/scala/org/apache/spark/sql/comet/execution/arrow/CometArrowConverters.scala
@@ -33,11 +33,14 @@ import org.apache.comet.CometArrowAllocator
 import org.apache.comet.vector.NativeUtil
 
 object CometArrowConverters extends Logging {
-  // This is similar how Spark converts internal row to Arrow format except that it is transforming
-  // the result batch to Comet's ColumnarBatch instead of serialized bytes.
-  // Each batch is written to a fresh VectorSchemaRoot so that native code can safely
-  // Arc::clone the buffers rather than performing a deep copy. The allocator manages
-  // the buffer lifetime and is closed when the task completes.
+  // Converts JVM row/columnar data to Arrow-backed ColumnarBatches for native consumption.
+  //
+  // Memory ownership: each batch's Arrow buffers are transferred to native code via the Arrow
+  // C Data Interface. CometBatchIterator calls Data.exportVector(), which retains a reference to
+  // every ArrowBuf via ArrayExporter. CometBatchIterator then closes the JVM-side vectors,
+  // releasing the JVM reference. Native code frees the buffers by calling the Arrow release
+  // callback when it is done. The child allocator is closed by the task completion listener
+  // after CometExecIterator.close() has already released all vector references.
 
   abstract private[sql] class ArrowBatchIterBase(
       schema: StructType,
@@ -47,19 +50,8 @@ object CometArrowConverters extends Logging {
       with AutoCloseable {
 
     protected val arrowSchema: Schema = Utils.toArrowSchema(schema, timeZoneId)
-    // Reuse the same root allocator here.
     protected val allocator: BufferAllocator =
       CometArrowAllocator.newChildAllocator(s"to${this.getClass.getSimpleName}", 0, Long.MaxValue)
-
-    // The previous root is closed when the next batch is requested, so only one
-    // root is alive at a time. The last root is closed when the task completes.
-    private var prevRoot: VectorSchemaRoot = _
-
-    protected def closeAndTrack(root: VectorSchemaRoot): VectorSchemaRoot = {
-      if (prevRoot != null) prevRoot.close()
-      prevRoot = root
-      root
-    }
 
     Option(context).foreach {
       _.addTaskCompletionListener[Unit] { _ =>
@@ -72,12 +64,7 @@ object CometArrowConverters extends Logging {
     }
 
     protected def close(closeAllocator: Boolean): Unit = {
-      // the allocator shall be closed when the task is finished
       if (closeAllocator) {
-        if (prevRoot != null) {
-          prevRoot.close()
-          prevRoot = null
-        }
         allocator.close()
       }
     }
@@ -106,7 +93,7 @@ object CometArrowConverters extends Logging {
 
     override protected def nextBatch(): ColumnarBatch = {
       if (rowIter.hasNext) {
-        val root = closeAndTrack(VectorSchemaRoot.create(arrowSchema, allocator))
+        val root = VectorSchemaRoot.create(arrowSchema, allocator)
         val arrowWriter = ArrowWriter.create(root)
         var rowCount = 0L
         while (rowIter.hasNext && (maxRecordsPerBatch <= 0 || rowCount < maxRecordsPerBatch)) {
@@ -150,7 +137,7 @@ object CometArrowConverters extends Logging {
     override protected def nextBatch(): ColumnarBatch = {
       val rowsInBatch = colBatch.numRows()
       if (rowsProduced < rowsInBatch) {
-        val root = closeAndTrack(VectorSchemaRoot.create(arrowSchema, allocator))
+        val root = VectorSchemaRoot.create(arrowSchema, allocator)
         val arrowWriter = ArrowWriter.create(root)
         val rowsToProduce =
           if (maxRecordsPerBatch <= 0) rowsInBatch - rowsProduced

--- a/docs/source/contributor-guide/adding_a_new_operator.md
+++ b/docs/source/contributor-guide/adding_a_new_operator.md
@@ -432,9 +432,6 @@ object CometYourSinkOperator extends CometSink[YourSinkExec] {
   override def enabledConfig: Option[ConfigEntry[Boolean]] =
     Some(CometConf.COMET_EXEC_YOUR_SINK_ENABLED)
 
-  // Optional: Override if the data produced is FFI safe
-  override def isFfiSafe: Boolean = false
-
   override def createExec(
       nativeOp: OperatorOuterClass.Operator,
       op: YourSinkExec): CometNativeExec = {
@@ -485,7 +482,6 @@ case class CometYourSinkExec(
 - The `CometSink.convert()` method (in `CometSink.scala`) automatically handles:
   - Data type validation
   - Conversion to `ScanExec` in the native plan
-  - Setting FFI safety flags
 - You must implement `createExec()` to wrap the operator appropriately
 - You typically need to create a corresponding `CometYourSinkExec` class that implements columnar execution
 

--- a/docs/source/contributor-guide/ffi.md
+++ b/docs/source/contributor-guide/ffi.md
@@ -150,44 +150,9 @@ in Java on-heap memory keeps growing until the batches are released in native co
 
 ### Ownership Transfer
 
-The Arrow C data interface supports ownership transfer by registering callbacks in the C struct that is passed over
-the JNI boundary for the function to delete the array data. For example, the `ArrowArray` struct has:
-
-```c
-// Release callback
-void (*release)(struct ArrowArray*);
-```
-
-Comet currently does not always follow best practice around ownership transfer because there are some cases where
-Comet JVM code will retain references to arrays after passing them to native code and may mutate the underlying
-buffers. There is an `arrow_ffi_safe` flag in the protocol buffer definition of `Scan` that indicates whether
-ownership is being transferred according to the Arrow C data interface specification.
-
-```protobuf
-message Scan {
-  repeated spark.spark_expression.DataType fields = 1;
-  // The source of the scan (e.g. file scan, broadcast exchange, shuffle, etc). This
-  // is purely for informational purposes when viewing native query plans in
-  // debug mode.
-  string source = 2;
-  // Whether native code can assume ownership of batches that it receives
-  bool arrow_ffi_safe = 3;
-}
-```
-
-#### When ownership is NOT transferred to native:
-
-If the data originates from a scan that uses mutable buffers
-then ownership is not transferred to native and the JVM may re-use the underlying buffers in the future.
-
-It is critical that the native code performs a deep copy of the arrays if the arrays are to be buffered by
-operators such as `SortExec` or `ShuffleWriterExec`, otherwise data corruption is likely to occur.
-
-#### When ownership IS transferred to native:
-
-When ownership is transferred, it is safe to buffer batches in native. However, JVM wrapper objects will not be
-released until the native batches are dropped. This can lead to OOM or GC pressure if there is not enough Java
-heap memory configured.
+Each batch is written to a fresh `VectorSchemaRoot` in the JVM, so native code can safely `Arc::clone` the
+buffers rather than performing a deep copy. The JVM-side root is closed immediately after export;
+native ref-counting keeps the memory alive until the native plan releases the arrays.
 
 ## Native → JVM Data Flow (CometExecIterator)
 
@@ -342,10 +307,8 @@ arrowBuf.close();  // → calls native release_batch()
 
 ### JVM → Native
 
-| Scenario           | `arrow_ffi_safe` | Ownership   | Action Required                        |
-| ------------------ | ---------------- | ----------- | -------------------------------------- |
-| Temporary scan     | `false`          | JVM keeps   | **Must deep copy** to avoid corruption |
-| Ownership transfer | `true`           | Native owns | Copy only to unpack dictionaries       |
+Native code always receives freshly allocated Arrow buffers per batch and can safely `Arc::clone` them.
+Dictionary arrays are unpacked during import.
 
 ### Native → JVM
 

--- a/native/core/src/execution/operators/copy.rs
+++ b/native/core/src/execution/operators/copy.rs
@@ -22,14 +22,6 @@ use arrow::array::{downcast_dictionary_array, make_array, Array, ArrayRef, Mutab
 use arrow::datatypes::DataType;
 use arrow::error::ArrowError;
 
-#[derive(Debug, PartialEq, Clone)]
-pub enum CopyMode {
-    /// Perform a deep copy and also unpack dictionaries
-    UnpackOrDeepCopy,
-    /// Perform a clone and also unpack dictionaries
-    UnpackOrClone,
-}
-
 /// Copy an Arrow Array
 pub(crate) fn copy_array(array: &dyn Array) -> ArrayRef {
     let capacity = array.len();
@@ -66,11 +58,8 @@ pub(crate) fn copy_array(array: &dyn Array) -> ArrayRef {
 /// This is used for `CopyExec` to copy/cast the input array. If the input array
 /// is a dictionary array, we will cast the dictionary array to primitive type
 /// (i.e., unpack the dictionary array) and copy the primitive array. If the input
-/// array is a primitive array, we simply copy the array.
-pub(crate) fn copy_or_unpack_array(
-    array: &Arc<dyn Array>,
-    mode: &CopyMode,
-) -> Result<ArrayRef, ArrowError> {
+/// array is a primitive array, we simply clone the Arc.
+pub(crate) fn copy_or_unpack_array(array: &Arc<dyn Array>) -> Result<ArrayRef, ArrowError> {
     match array.data_type() {
         DataType::Dictionary(_, value_type) => {
             let options = CastOptions::default();
@@ -82,12 +71,6 @@ pub(crate) fn copy_or_unpack_array(
                 &options,
             )?))
         }
-        _ => {
-            if mode == &CopyMode::UnpackOrDeepCopy {
-                Ok(copy_array(array))
-            } else {
-                Ok(Arc::clone(array))
-            }
-        }
+        _ => Ok(Arc::clone(array)),
     }
 }

--- a/native/core/src/execution/operators/mod.rs
+++ b/native/core/src/execution/operators/mod.rs
@@ -19,7 +19,6 @@
 
 pub use crate::errors::ExecutionError;
 
-pub use copy::*;
 pub use iceberg_scan::*;
 pub use scan::*;
 

--- a/native/core/src/execution/operators/scan.rs
+++ b/native/core/src/execution/operators/scan.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::execution::operators::{copy_array, copy_or_unpack_array, CopyMode};
+use crate::execution::operators::copy::copy_or_unpack_array;
 use crate::{
     errors::CometError,
     execution::{
@@ -77,8 +77,6 @@ pub struct ScanExec {
     metrics: ExecutionPlanMetricsSet,
     /// Baseline metrics
     baseline_metrics: BaselineMetrics,
-    /// Whether native code can assume ownership of batches that it receives
-    arrow_ffi_safe: bool,
 }
 
 impl ScanExec {
@@ -87,7 +85,6 @@ impl ScanExec {
         input_source: Option<Arc<GlobalRef>>,
         input_source_description: &str,
         data_types: Vec<DataType>,
-        arrow_ffi_safe: bool,
     ) -> Result<Self, CometError> {
         let metrics_set = ExecutionPlanMetricsSet::default();
         let baseline_metrics = BaselineMetrics::new(&metrics_set, 0);
@@ -114,7 +111,6 @@ impl ScanExec {
             metrics: metrics_set,
             baseline_metrics,
             schema,
-            arrow_ffi_safe,
         })
     }
 
@@ -147,7 +143,6 @@ impl ScanExec {
                 self.exec_context_id,
                 self.input_source.as_ref().unwrap().as_obj(),
                 self.data_types.len(),
-                self.arrow_ffi_safe,
             )?;
             *current_batch = Some(next_batch);
         }
@@ -162,7 +157,6 @@ impl ScanExec {
         exec_context_id: i64,
         iter: &JObject,
         num_cols: usize,
-        arrow_ffi_safe: bool,
     ) -> Result<InputBatch, CometError> {
         if exec_context_id == TEST_EXEC_CONTEXT_ID {
             // This is a unit test. We don't need to call JNI.
@@ -225,15 +219,7 @@ impl ScanExec {
                 array
             };
 
-            let array = if arrow_ffi_safe {
-                // ownership of this array has been transferred to native
-                // but we still need to unpack dictionary arrays
-                copy_or_unpack_array(&array, &CopyMode::UnpackOrClone)?
-            } else {
-                // it is necessary to copy the array because the contents may be
-                // overwritten on the JVM side in the future
-                copy_array(&array)
-            };
+            let array = copy_or_unpack_array(&array)?;
 
             inputs.push(array);
 

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -1277,13 +1277,8 @@ impl PhysicalPlanner {
                     };
 
                 // The `ScanExec` operator will take actual arrays from Spark during execution
-                let scan = ScanExec::new(
-                    self.exec_context_id,
-                    input_source,
-                    &scan.source,
-                    data_types,
-                    scan.arrow_ffi_safe,
-                )?;
+                let scan =
+                    ScanExec::new(self.exec_context_id, input_source, &scan.source, data_types)?;
 
                 Ok((
                     vec![scan.clone()],
@@ -3696,7 +3691,6 @@ mod tests {
                     type_info: None,
                 }],
                 source: "".to_string(),
-                arrow_ffi_safe: false,
             })),
         };
 
@@ -3762,7 +3756,6 @@ mod tests {
                     type_info: None,
                 }],
                 source: "".to_string(),
-                arrow_ffi_safe: false,
             })),
         };
 
@@ -3971,7 +3964,6 @@ mod tests {
             op_struct: Some(OpStruct::Scan(spark_operator::Scan {
                 fields: vec![create_proto_datatype()],
                 source: "".to_string(),
-                arrow_ffi_safe: false,
             })),
         }
     }
@@ -4014,7 +4006,6 @@ mod tests {
                     },
                 ],
                 source: "".to_string(),
-                arrow_ffi_safe: false,
             })),
         };
 
@@ -4136,7 +4127,6 @@ mod tests {
                     },
                 ],
                 source: "".to_string(),
-                arrow_ffi_safe: false,
             })),
         };
 
@@ -4619,7 +4609,6 @@ mod tests {
                     },
                 ],
                 source: "".to_string(),
-                arrow_ffi_safe: false,
             })),
         };
 

--- a/native/proto/src/proto/operator.proto
+++ b/native/proto/src/proto/operator.proto
@@ -82,8 +82,6 @@ message Scan {
   // is purely for informational purposes when viewing native query plans in
   // debug mode.
   string source = 2;
-  // Whether native code can assume ownership of batches that it receives
-  bool arrow_ffi_safe = 3;
 }
 
 message ShuffleScan {

--- a/spark/src/main/java/org/apache/comet/CometBatchIterator.java
+++ b/spark/src/main/java/org/apache/comet/CometBatchIterator.java
@@ -24,20 +24,26 @@ import scala.collection.Iterator;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
 import org.apache.comet.vector.CometSelectionVector;
+import org.apache.comet.vector.CometVector;
 import org.apache.comet.vector.NativeUtil;
 
 /**
  * Iterator for fetching batches from JVM to native code. Usually called via JNI from native
  * ScanExec.
  *
- * <p>Batches are owned by the JVM. Native code can safely access the batch after calling `next` but
- * the native code must not retain references to the batch because the next call to `hasNext` will
- * signal to the JVM that the batch can be closed.
+ * <p>Ownership of Arrow buffer memory is transferred to native code via the Arrow C Data Interface
+ * release callback mechanism. When {@link #next} is called, each vector is exported via {@code
+ * Data.exportVector()}, which calls {@code ArrowBuf.getReferenceManager().retain()} on every
+ * underlying buffer. The JVM-side vector is then closed immediately, releasing the JVM reference.
+ * The buffers remain alive until native code calls the Arrow release callback, at which point the
+ * retained reference is released and the memory is freed.
+ *
+ * <p>If the task is cancelled before a batch is exported, {@link #close} releases the JVM
+ * references directly so the allocator can be closed cleanly.
  */
-public class CometBatchIterator {
+public class CometBatchIterator implements AutoCloseable {
   private final Iterator<ColumnarBatch> input;
   private final NativeUtil nativeUtil;
-  private ColumnarBatch previousBatch = null;
   private ColumnarBatch currentBatch = null;
 
   CometBatchIterator(Iterator<ColumnarBatch> input, NativeUtil nativeUtil) {
@@ -46,16 +52,11 @@ public class CometBatchIterator {
   }
 
   /**
-   * Fetch the next input batch and allow the previous batch to be closed (this may not happen
-   * immediately).
+   * Fetch the next input batch.
    *
    * @return Number of rows in next batch or -1 if no batches left.
    */
   public int hasNext() {
-
-    // release reference to previous batch
-    previousBatch = null;
-
     if (currentBatch == null) {
       if (input.hasNext()) {
         currentBatch = input.next();
@@ -69,7 +70,9 @@ public class CometBatchIterator {
   }
 
   /**
-   * Get the next batch of Arrow arrays.
+   * Export the current batch to native code via the Arrow C Data Interface and release JVM
+   * references. After this call the buffer memory is owned by native code and will be freed through
+   * the Arrow release callback.
    *
    * @param arrayAddrs The addresses of the ArrowArray structures.
    * @param schemaAddrs The addresses of the ArrowSchema structures.
@@ -80,13 +83,14 @@ public class CometBatchIterator {
       return -1;
     }
 
-    // export the batch using the Arrow C Data Interface
+    // Export the batch via the Arrow C Data Interface. ArrayExporter.export() calls
+    // arrowBuf.getReferenceManager().retain() for every buffer, so the ExportedArrayPrivateData
+    // keeps the buffers alive until native calls the release callback.
     int numRows = nativeUtil.exportBatch(arrayAddrs, schemaAddrs, currentBatch);
 
-    // keep a reference to the exported batch so that it doesn't get garbage collected
-    // while the native code is still processing it
-    previousBatch = currentBatch;
-
+    // Release JVM-side vector references. The buffers remain alive via the retained references
+    // held by the Arrow exporter and will be freed when native calls the release callback.
+    closeBatchVectors(currentBatch);
     currentBatch = null;
 
     return numRows;
@@ -135,5 +139,25 @@ public class CometBatchIterator {
       }
     }
     return exportCount;
+  }
+
+  /**
+   * Release JVM references for any batch that was fetched but not yet exported (e.g., task
+   * cancellation). This allows the Arrow allocator to be closed cleanly.
+   */
+  @Override
+  public void close() {
+    closeBatchVectors(currentBatch);
+    currentBatch = null;
+  }
+
+  private void closeBatchVectors(ColumnarBatch batch) {
+    if (batch != null) {
+      for (int i = 0; i < batch.numCols(); i++) {
+        if (batch.column(i) instanceof CometVector) {
+          ((CometVector) batch.column(i)).close();
+        }
+      }
+    }
   }
 }

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -234,6 +234,12 @@ class CometExecIterator(
         currentBatch.close()
         currentBatch = null
       }
+      // Close input batch iterators to release any buffered batch memory before the allocator
+      // is closed by the task completion listener in ArrowBatchIterBase.
+      inputIterators.foreach {
+        case iter: CometBatchIterator => iter.close()
+        case _ => // shuffle iterators manage their own lifecycle
+      }
       nativeUtil.close()
       shuffleBlockIterators.values.foreach(_.close())
       nativeLib.releasePlan(plan)

--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometDataWritingCommand.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometDataWritingCommand.scala
@@ -96,7 +96,6 @@ object CometDataWritingCommand extends CometOperatorSerde[DataWritingCommandExec
       val scanOp = OperatorOuterClass.Scan
         .newBuilder()
         .setSource(cmd.query.nodeName)
-        .setArrowFfiSafe(false)
 
       // Add fields from the query output schema
       val scanTypes = cmd.query.output.flatMap { attr =>

--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometSink.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometSink.scala
@@ -40,9 +40,6 @@ import org.apache.comet.serde.QueryPlanSerde.{serializeDataType, supportedDataTy
  */
 abstract class CometSink[T <: SparkPlan] extends CometOperatorSerde[T] {
 
-  /** Whether the data produced by the Comet operator is FFI safe */
-  def isFfiSafe: Boolean = true
-
   override def enabledConfig: Option[ConfigEntry[Boolean]] = None
 
   override def convert(
@@ -65,7 +62,6 @@ abstract class CometSink[T <: SparkPlan] extends CometOperatorSerde[T] {
     } else {
       scanBuilder.setSource(source)
     }
-    scanBuilder.setArrowFfiSafe(isFfiSafe)
 
     val scanTypes = op.output.flatten { attr =>
       serializeDataType(attr.dataType)

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometLocalTableScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometLocalTableScanExec.scala
@@ -105,9 +105,6 @@ case class CometLocalTableScanExec(
 
 object CometLocalTableScanExec extends CometSink[LocalTableScanExec] {
 
-  // uses CometArrowConverters, which re-uses arrays
-  override def isFfiSafe: Boolean = false
-
   override def enabledConfig: Option[ConfigEntry[Boolean]] = Some(
     CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED)
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometSparkToColumnarExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometSparkToColumnarExec.scala
@@ -140,9 +140,6 @@ case class CometSparkToColumnarExec(child: SparkPlan)
 
 object CometSparkToColumnarExec extends CometSink[SparkPlan] with DataTypeSupport {
 
-  // uses CometArrowConverters, which re-uses arrays
-  override def isFfiSafe: Boolean = false
-
   override def createExec(
       nativeOp: OperatorOuterClass.Operator,
       op: SparkPlan): CometNativeExec = {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #2171
Closes #3770

## Rationale for this change

`CometArrowConverters` reused Arrow buffers between batches via `arrowWriter.reset()` on a shared `VectorSchemaRoot`. This was intended to reduce JVM allocations, but because `ScanExec` always performed a full deep copy (`copy_array`) when `arrow_ffi_safe=false`, both JVM and native allocations existed simultaneously with no benefit — the optimization was counterproductive.

## What changes are included in this PR?

- **Remove buffer reuse** in `CometArrowConverters`: each batch now gets a fresh `VectorSchemaRoot`. The JVM-side root is closed immediately after export; native ref-counting keeps the memory alive until the native plan releases the arrays.
- **Remove `CopyMode` enum** from `copy.rs` and simplify `copy_or_unpack_array` to always `Arc::clone` non-dictionary arrays (dictionary arrays are still unpacked via cast+copy).
- **Remove `arrow_ffi_safe` field** from the `Scan` proto message, `ScanExec` struct, and all call sites.
- **Remove `isFfiSafe` overrides** from `CometLocalTableScanExec` and `CometSparkToColumnarExec`.
- **Remove `isFfiSafe` method and `setArrowFfiSafe` call** from `CometSink`.
- **Remove `.setArrowFfiSafe(false)`** from `CometDataWritingCommand`.
- **Update docs** in `ffi.md` and `adding_a_new_operator.md` to reflect the new ownership model.

## How are these changes tested?

Covered by existing tests (`cargo test`, `make test-jvm`). No new behavior is introduced; this removes an unnecessary deep copy on the native side.