### PR TITLE
bench: improve Iceberg TPC workflow and plan capture

### DIFF
--- a/benchmarks/tpc/README.md
+++ b/benchmarks/tpc/README.md
@@ -45,6 +45,7 @@ python3 run.py --engine <engine> --benchmark <tpch|tpcds> [options]
 | `--iterations`            | Number of iterations (default: 1)                                               |
 | `--output`                | Output directory (default: `.`)                                                 |
 | `--query`                 | Run a single query number                                                       |
+| `--plan-dir`              | Optional directory to write formatted physical plans per query                  |
 | `--no-restart`            | Skip Spark master/worker restart                                                |
 | `--dry-run`               | Print the spark-submit command without executing                                |
 | `--jfr`                   | Enable Java Flight Recorder profiling                                           |
@@ -54,7 +55,7 @@ python3 run.py --engine <engine> --benchmark <tpch|tpcds> [options]
 | `--async-profiler-event`  | Event type: `cpu`, `wall`, `alloc`, `lock`, etc. (default: `cpu`)               |
 | `--async-profiler-format` | Output format: `flamegraph`, `jfr`, `collapsed`, `text` (default: `flamegraph`) |
 
-Available engines: `spark`, `comet`, `comet-iceberg`, `gluten`
+Available engines: `spark`, `spark-iceberg`, `comet`, `comet-iceberg`, `gluten`
 
 ## Example usage
 
@@ -168,7 +169,7 @@ $SPARK_HOME/bin/spark-submit \
     --warehouse $ICEBERG_WAREHOUSE
 ```
 
-### Run Iceberg benchmark
+### Run Iceberg benchmarks
 
 ```shell
 export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
@@ -176,12 +177,26 @@ export COMET_JAR=/opt/comet/comet-spark-spark3.5_2.12-0.10.0.jar
 export ICEBERG_JAR=/path/to/iceberg-spark-runtime-3.5_2.12-1.8.1.jar
 export ICEBERG_WAREHOUSE=/mnt/bigdata/iceberg-warehouse
 sudo ./drop-caches.sh
+
+python3 run.py --engine spark-iceberg --benchmark tpch
 python3 run.py --engine comet-iceberg --benchmark tpch
 ```
+
+Use `spark-iceberg` as the Spark JVM Iceberg scan baseline and `comet-iceberg`
+as the Comet native Iceberg scan comparison. Both engines use `ICEBERG_JAR`,
+`ICEBERG_WAREHOUSE`, optional `ICEBERG_CATALOG`, and optional `ICEBERG_DATABASE`.
 
 The benchmark uses Comet's native iceberg-rust integration, which is enabled by default.
 Verify native scanning is active by checking for `CometIcebergNativeScanExec` in the
 physical plan output.
+
+### Plan capture
+
+Pass `--plan-dir <dir>` to write each query's formatted physical plan to
+`<dir>/<engine-name>-q<query-label>.plan.txt`. Plan capture is opt-in and
+repeated iterations overwrite the same plan files. TPC-H writes up to 22 files per engine.
+TPC-DS writes up to 103 files per engine because q14, q23, q24, and q39 each contain two
+SELECT statements.
 
 ### create-iceberg-tables.py options
 

--- a/benchmarks/tpc/create-iceberg-tables.py
+++ b/benchmarks/tpc/create-iceberg-tables.py
@@ -119,6 +119,8 @@ def main(benchmark: str, parquet_path: str, warehouse: str, catalog: str, databa
 
     for table in table_names:
         parquet_table_path = f"{parquet_path}/{table}.parquet"
+        if not os.path.exists(parquet_table_path):
+            parquet_table_path = f"{parquet_path}/{table}"
         iceberg_table = f"{catalog}.{database}.{table}"
 
         print(f"Converting {parquet_table_path} -> {iceberg_table}")

--- a/benchmarks/tpc/create-iceberg-tables.py
+++ b/benchmarks/tpc/create-iceberg-tables.py
@@ -118,9 +118,26 @@ def main(benchmark: str, parquet_path: str, warehouse: str, catalog: str, databa
         pass
 
     for table in table_names:
-        parquet_table_path = f"{parquet_path}/{table}.parquet"
-        if not os.path.exists(parquet_table_path):
-            parquet_table_path = f"{parquet_path}/{table}"
+        parquet_file_path = f"{parquet_path}/{table}.parquet"
+        parquet_dir_path = f"{parquet_path}/{table}"
+        parquet_file_exists = os.path.exists(parquet_file_path)
+        parquet_dir_exists = os.path.exists(parquet_dir_path)
+
+        if parquet_file_exists:
+            parquet_table_path = parquet_file_path
+            if parquet_dir_exists:
+                print(
+                    f"Warning: both '{parquet_file_path}' and '{parquet_dir_path}' exist; "
+                    f"using '{parquet_file_path}'",
+                    file=sys.stderr,
+                )
+        elif parquet_dir_exists:
+            parquet_table_path = parquet_dir_path
+        else:
+            raise FileNotFoundError(
+                f"Could not find Parquet data for table '{table}'. "
+                f"Expected '{parquet_file_path}' or '{parquet_dir_path}'."
+            )
         iceberg_table = f"{catalog}.{database}.{table}"
 
         print(f"Converting {parquet_table_path} -> {iceberg_table}")

--- a/benchmarks/tpc/engines/spark-iceberg.toml
+++ b/benchmarks/tpc/engines/spark-iceberg.toml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Spark + Iceberg JVM scan (no Comet).
+# Baseline for comparing against comet-iceberg (native Rust scan).
+
+[engine]
+name = "spark-iceberg"
+
+[env]
+required = ["ICEBERG_JAR", "ICEBERG_WAREHOUSE"]
+
+[env.defaults]
+ICEBERG_CATALOG = "local"
+
+[spark_submit]
+jars = ["$ICEBERG_JAR"]
+driver_class_path = ["$ICEBERG_JAR"]
+
+[spark_conf]
+"spark.driver.extraClassPath" = "$ICEBERG_JAR"
+"spark.executor.extraClassPath" = "$ICEBERG_JAR"
+"spark.sql.catalog.${ICEBERG_CATALOG}" = "org.apache.iceberg.spark.SparkCatalog"
+"spark.sql.catalog.${ICEBERG_CATALOG}.type" = "hadoop"
+"spark.sql.catalog.${ICEBERG_CATALOG}.warehouse" = "$ICEBERG_WAREHOUSE"
+"spark.sql.defaultCatalog" = "${ICEBERG_CATALOG}"
+
+[tpcbench_args]
+use_iceberg = true

--- a/benchmarks/tpc/run.py
+++ b/benchmarks/tpc/run.py
@@ -337,6 +337,9 @@ def build_spark_submit_cmd(config, benchmark, args):
     if args.query is not None:
         cmd += ["--query", str(args.query)]
 
+    if args.plan_dir is not None:
+        cmd += ["--plan-dir", args.plan_dir]
+
     if profile["format"] and not use_iceberg:
         cmd += ["--format", profile["format"]]
 
@@ -396,6 +399,10 @@ def main():
     )
     parser.add_argument(
         "--query", type=int, default=None, help="Run a single query number"
+    )
+    parser.add_argument(
+        "--plan-dir",
+        help="Optional directory to write formatted physical plans per query",
     )
     parser.add_argument(
         "--no-restart",

--- a/benchmarks/tpc/tpcbench.py
+++ b/benchmarks/tpc/tpcbench.py
@@ -56,6 +56,62 @@ def result_hash(rows):
     return h.hexdigest()
 
 
+def strip_leading_comments(sql: str) -> str:
+    lines = sql.lstrip().splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i].lstrip()
+        if not line or line.startswith("--"):
+            i += 1
+            continue
+        if line.startswith("/*"):
+            # Skip block comments at the start of the statement.
+            while i < len(lines):
+                if "*/" in lines[i]:
+                    i += 1
+                    break
+                i += 1
+            continue
+        break
+    return "\n".join(lines[i:]).lstrip()
+
+
+def is_select_statement(sql: str) -> bool:
+    sql_lower = strip_leading_comments(sql).lower()
+    return sql_lower.startswith("select") or sql_lower.startswith("with")
+
+
+def collect_execution_metrics(df):
+    """Extract execution metrics from the executed plan after df.collect().
+
+    Returns a dict with operator-level metrics including rows scanned,
+    bytes read, shuffle bytes, etc.
+    """
+    metrics = {}
+    plan = df._jdf.queryExecution().executedPlan()
+
+    def walk(node, depth=0):
+        name = node.nodeName()
+        node_metrics = {}
+        metric_map = node.metrics()
+        keys = list(metric_map.keys())
+        for k in keys:
+            m = metric_map.apply(k)
+            node_metrics[k] = m.value()
+        if node_metrics:
+            key = f"{name}_{depth}"
+            metrics[key] = node_metrics
+        children = list(node.children())
+        for child in children:
+            walk(child, depth + 1)
+
+    try:
+        walk(plan)
+    except Exception:
+        pass  # Best-effort metric extraction
+    return metrics
+
+
 def main(
     benchmark: str,
     data_path: str,
@@ -68,6 +124,8 @@ def main(
     query_num: int = None,
     write_path: str = None,
     options: Dict[str, str] = None,
+    plan_dir: str = None,
+    metrics_dir: str = None,
 ):
     if options is None:
         options = {}
@@ -164,6 +222,20 @@ def main(
                         df = spark.sql(sql)
                         df.explain("formatted")
 
+                        # Save physical plan before execution
+                        if plan_dir is not None and is_select_statement(sql):
+                            os.makedirs(plan_dir, exist_ok=True)
+                            plan_path = os.path.join(plan_dir, f"{name}-q{query}.plan.txt")
+                            try:
+                                plan_str = df._jdf.queryExecution().explainString(
+                                    spark._jvm.org.apache.spark.sql.execution
+                                    .ExplainMode.fromString("formatted"))
+                                with open(plan_path, "w") as pf:
+                                    pf.write(plan_str)
+                                print(f"Plan saved to {plan_path}")
+                            except Exception as e:
+                                print(f"Warning: could not save plan: {e}")
+
                         if write_path is not None:
                             if len(df.columns) > 0:
                                 output_path = f"{write_path}/q{query}"
@@ -175,6 +247,16 @@ def main(
                             row_count = len(rows)
                             row_hash = result_hash(rows)
                             print(f"Query {query} returned {row_count} rows, hash={row_hash}")
+
+                            # Extract execution metrics after collect()
+                            if metrics_dir is not None and is_select_statement(sql):
+                                os.makedirs(metrics_dir, exist_ok=True)
+                                metrics = collect_execution_metrics(df)
+                                metrics_path = os.path.join(
+                                    metrics_dir, f"{name}-q{query}.metrics.json")
+                                with open(metrics_path, "w") as mf:
+                                    json.dump(metrics, mf, indent=2)
+                                print(f"Metrics saved to {metrics_path}")
 
                 end_time = time.time()
                 elapsed = end_time - start_time
@@ -249,6 +331,14 @@ if __name__ == "__main__":
         help="Prefix for result file"
     )
     parser.add_argument(
+        "--plan-dir",
+        help="Optional directory to write formatted plans per query"
+    )
+    parser.add_argument(
+        "--metrics-dir",
+        help="Optional directory to write execution metrics per query"
+    )
+    parser.add_argument(
         "--query", type=int,
         help="Specific query number (1-based). If omitted, run all."
     )
@@ -270,4 +360,6 @@ if __name__ == "__main__":
         args.query,
         args.write,
         args.options,
+        args.plan_dir,
+        args.metrics_dir,
     )

--- a/benchmarks/tpc/tpcbench.py
+++ b/benchmarks/tpc/tpcbench.py
@@ -81,37 +81,6 @@ def is_select_statement(sql: str) -> bool:
     return sql_lower.startswith("select") or sql_lower.startswith("with")
 
 
-def collect_execution_metrics(df):
-    """Extract execution metrics from the executed plan after df.collect().
-
-    Returns a dict with operator-level metrics including rows scanned,
-    bytes read, shuffle bytes, etc.
-    """
-    metrics = {}
-    plan = df._jdf.queryExecution().executedPlan()
-
-    def walk(node, depth=0):
-        name = node.nodeName()
-        node_metrics = {}
-        metric_map = node.metrics()
-        keys = list(metric_map.keys())
-        for k in keys:
-            m = metric_map.apply(k)
-            node_metrics[k] = m.value()
-        if node_metrics:
-            key = f"{name}_{depth}"
-            metrics[key] = node_metrics
-        children = list(node.children())
-        for child in children:
-            walk(child, depth + 1)
-
-    try:
-        walk(plan)
-    except Exception:
-        pass  # Best-effort metric extraction
-    return metrics
-
-
 def main(
     benchmark: str,
     data_path: str,
@@ -125,7 +94,6 @@ def main(
     write_path: str = None,
     options: Dict[str, str] = None,
     plan_dir: str = None,
-    metrics_dir: str = None,
 ):
     if options is None:
         options = {}
@@ -248,15 +216,6 @@ def main(
                             row_hash = result_hash(rows)
                             print(f"Query {query} returned {row_count} rows, hash={row_hash}")
 
-                            # Extract execution metrics after collect()
-                            if metrics_dir is not None and is_select_statement(sql):
-                                os.makedirs(metrics_dir, exist_ok=True)
-                                metrics = collect_execution_metrics(df)
-                                metrics_path = os.path.join(
-                                    metrics_dir, f"{name}-q{query}.metrics.json")
-                                with open(metrics_path, "w") as mf:
-                                    json.dump(metrics, mf, indent=2)
-                                print(f"Metrics saved to {metrics_path}")
 
                 end_time = time.time()
                 elapsed = end_time - start_time
@@ -335,10 +294,6 @@ if __name__ == "__main__":
         help="Optional directory to write formatted plans per query"
     )
     parser.add_argument(
-        "--metrics-dir",
-        help="Optional directory to write execution metrics per query"
-    )
-    parser.add_argument(
         "--query", type=int,
         help="Specific query number (1-based). If omitted, run all."
     )
@@ -361,5 +316,4 @@ if __name__ == "__main__":
         args.write,
         args.options,
         args.plan_dir,
-        args.metrics_dir,
     )

--- a/benchmarks/tpc/tpcbench.py
+++ b/benchmarks/tpc/tpcbench.py
@@ -71,37 +71,6 @@ def is_select_statement(sql):
     return first_keyword(sql) in ("select", "with")
 
 
-def collect_execution_metrics(df):
-    """Extract execution metrics from the executed plan after df.collect().
-
-    Returns a dict with operator-level metrics including rows scanned,
-    bytes read, shuffle bytes, etc.
-    """
-    metrics = {}
-    plan = df._jdf.queryExecution().executedPlan()
-
-    def walk(node, depth=0):
-        name = node.nodeName()
-        node_metrics = {}
-        metric_map = node.metrics()
-        keys = list(metric_map.keys())
-        for k in keys:
-            m = metric_map.apply(k)
-            node_metrics[k] = m.value()
-        if node_metrics:
-            key = f"{name}_{depth}"
-            metrics[key] = node_metrics
-        children = list(node.children())
-        for child in children:
-            walk(child, depth + 1)
-
-    try:
-        walk(plan)
-    except Exception:
-        pass  # Best-effort metric extraction
-    return metrics
-
-
 def main(
     benchmark: str,
     data_path: str,
@@ -115,7 +84,6 @@ def main(
     write_path: str = None,
     options: Dict[str, str] = None,
     plan_dir: str = None,
-    metrics_dir: str = None,
 ):
     if options is None:
         options = {}
@@ -260,16 +228,6 @@ def main(
                             query_result["row_count"] = row_count
                             query_result["result_hash"] = row_hash
 
-                        # Save execution metrics after collect() (benchmark feature)
-                        if metrics_dir is not None:
-                            os.makedirs(metrics_dir, exist_ok=True)
-                            metrics = collect_execution_metrics(df)
-                            metrics_path = os.path.join(
-                                metrics_dir, f"{name}-q{query_label}.metrics.json")
-                            with open(metrics_path, "w") as mf:
-                                json.dump(metrics, mf, indent=2)
-                            print(f"Metrics saved to {metrics_path}")
-
         iter_end_time = time.time()
         print(f"\nIteration {iteration + 1} took {iter_end_time - iter_start_time:.2f} seconds")
 
@@ -337,10 +295,6 @@ if __name__ == "__main__":
         help="Optional directory to write formatted plans per query"
     )
     parser.add_argument(
-        "--metrics-dir",
-        help="Optional directory to write execution metrics per query"
-    )
-    parser.add_argument(
         "--query", type=int,
         help="Specific query number (1-based). If omitted, run all."
     )
@@ -363,5 +317,4 @@ if __name__ == "__main__":
         args.write,
         args.options,
         args.plan_dir,
-        args.metrics_dir,
     )

--- a/benchmarks/tpc/tpcbench.py
+++ b/benchmarks/tpc/tpcbench.py
@@ -71,6 +71,37 @@ def is_select_statement(sql):
     return first_keyword(sql) in ("select", "with")
 
 
+def collect_execution_metrics(df):
+    """Extract execution metrics from the executed plan after df.collect().
+
+    Returns a dict with operator-level metrics including rows scanned,
+    bytes read, shuffle bytes, etc.
+    """
+    metrics = {}
+    plan = df._jdf.queryExecution().executedPlan()
+
+    def walk(node, depth=0):
+        name = node.nodeName()
+        node_metrics = {}
+        metric_map = node.metrics()
+        keys = list(metric_map.keys())
+        for k in keys:
+            m = metric_map.apply(k)
+            node_metrics[k] = m.value()
+        if node_metrics:
+            key = f"{name}_{depth}"
+            metrics[key] = node_metrics
+        children = list(node.children())
+        for child in children:
+            walk(child, depth + 1)
+
+    try:
+        walk(plan)
+    except Exception:
+        pass  # Best-effort metric extraction
+    return metrics
+
+
 def main(
     benchmark: str,
     data_path: str,
@@ -83,6 +114,8 @@ def main(
     query_num: int = None,
     write_path: str = None,
     options: Dict[str, str] = None,
+    plan_dir: str = None,
+    metrics_dir: str = None,
 ):
     if options is None:
         options = {}
@@ -190,6 +223,20 @@ def main(
                 df = spark.sql(sql)
                 df.explain("formatted")
 
+                # Save formatted plan to file before execution (benchmark feature)
+                if plan_dir is not None and is_query:
+                    os.makedirs(plan_dir, exist_ok=True)
+                    plan_path = os.path.join(plan_dir, f"{name}-q{query_label}.plan.txt")
+                    try:
+                        plan_str = df._jdf.queryExecution().explainString(
+                            spark._jvm.org.apache.spark.sql.execution
+                            .ExplainMode.fromString("formatted"))
+                        with open(plan_path, "w") as pf:
+                            pf.write(plan_str)
+                        print(f"Plan saved to {plan_path}")
+                    except Exception as e:
+                        print(f"Warning: could not save plan: {e}")
+
                 if is_query and write_path is not None:
                     if len(df.columns) > 0:
                         output_path = f"{write_path}/q{query_label}"
@@ -212,6 +259,16 @@ def main(
                         if "row_count" not in query_result:
                             query_result["row_count"] = row_count
                             query_result["result_hash"] = row_hash
+
+                        # Save execution metrics after collect() (benchmark feature)
+                        if metrics_dir is not None:
+                            os.makedirs(metrics_dir, exist_ok=True)
+                            metrics = collect_execution_metrics(df)
+                            metrics_path = os.path.join(
+                                metrics_dir, f"{name}-q{query_label}.metrics.json")
+                            with open(metrics_path, "w") as mf:
+                                json.dump(metrics, mf, indent=2)
+                            print(f"Metrics saved to {metrics_path}")
 
         iter_end_time = time.time()
         print(f"\nIteration {iteration + 1} took {iter_end_time - iter_start_time:.2f} seconds")
@@ -276,6 +333,14 @@ if __name__ == "__main__":
         help="Prefix for result file"
     )
     parser.add_argument(
+        "--plan-dir",
+        help="Optional directory to write formatted plans per query"
+    )
+    parser.add_argument(
+        "--metrics-dir",
+        help="Optional directory to write execution metrics per query"
+    )
+    parser.add_argument(
         "--query", type=int,
         help="Specific query number (1-based). If omitted, run all."
     )
@@ -297,4 +362,6 @@ if __name__ == "__main__":
         args.query,
         args.write,
         args.options,
+        args.plan_dir,
+        args.metrics_dir,
     )

--- a/benchmarks/tpc/tpcbench.py
+++ b/benchmarks/tpc/tpcbench.py
@@ -191,14 +191,13 @@ def main(
                 df = spark.sql(sql)
                 df.explain("formatted")
 
-                # Save formatted plan to file before execution (benchmark feature)
                 if plan_dir is not None and is_query:
                     os.makedirs(plan_dir, exist_ok=True)
                     plan_path = os.path.join(plan_dir, f"{name}-q{query_label}.plan.txt")
                     try:
-                        plan_str = df._jdf.queryExecution().explainString(
-                            spark._jvm.org.apache.spark.sql.execution
-                            .ExplainMode.fromString("formatted"))
+                        plan_str = spark._jvm.PythonSQLUtils.explainString(
+                            df._jdf.queryExecution(), "formatted"
+                        )
                         with open(plan_path, "w") as pf:
                             pf.write(plan_str)
                         print(f"Plan saved to {plan_path}")

--- a/spark/src/main/spark-3.5/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
+++ b/spark/src/main/spark-3.5/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
@@ -140,9 +140,9 @@ trait ShimSparkErrorConverter {
         Some(QueryExecutionErrors.exceedMapSizeLimitError(params("size").toString.toInt))
 
       case "CollectionSizeLimitExceeded" =>
+        // createArrayWithElementsExceedLimitError takes (count: Any) in Spark 3.5
         Some(
           QueryExecutionErrors.createArrayWithElementsExceedLimitError(
-            "array",
             params("numElements").toString.toLong))
 
       case "NotNullAssertViolation" =>


### PR DESCRIPTION
This PR improves the Iceberg benchmarking workflow for TPC‑H/TPC‑DS in Comet by:

- adding a Spark JVM Iceberg baseline engine (spark-iceberg.toml) to compare directly against Comet native Iceberg scans
- making Iceberg table creation accept both table.parquet files and table/ directories
- adding per‑query physical plan capture in tpcbench.py for Spark vs Comet plan comparison


###  Steps to run benchmark against TPC

```
mkdir -p /tmp/comet-bench/{spark,jars}
curl -L -o /tmp/comet-bench/spark/spark-3.5.8-bin-hadoop3.tgz \
  https://dlcdn.apache.org/spark/spark-3.5.8/spark-3.5.8-bin-hadoop3.tgz
tar xzf /tmp/comet-bench/spark/spark-3.5.8-bin-hadoop3.tgz -C /tmp/comet-bench/spark

curl -L -o /tmp/comet-bench/jars/iceberg-spark-runtime-3.5_2.12-1.8.1.jar \
  https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.5_2.12/1.8.1/iceberg-spark-runtime-3.5_2.12-1.8.1.jar

# Build Comet JAR (includes native library)
cd ~/Documents/apache/datafusion-comet
make release

# Generate TPC‑H Parquet (SF1)

cd ~/Documents/apache/datafusion-comet
make benchmark-org.apache.spark.sql.GenTPCHData -- \
  --location /tmp/comet-bench/tpch-data \
  --scaleFactor 1

# Generate using DuckDB
python3 -m venv /tmp/comet-bench/duckdb-venv
/tmp/comet-bench/duckdb-venv/bin/pip install duckdb

/tmp/comet-bench/duckdb-venv/bin/python - <<'PY'
import duckdb, os
out = "/tmp/tpcds/sf1_parquet"
os.makedirs(out, exist_ok=True)

con = duckdb.connect()
con.execute("INSTALL tpcds; LOAD tpcds;")
con.execute("CALL dsdgen(sf=1);")

tables = [r[0] for r in con.execute("SHOW TABLES").fetchall()]
for t in tables:
    con.execute(f"COPY {t} TO '{out}/{t}.parquet' (FORMAT PARQUET);")
PY

# Create Iceberg Tables

export SPARK_HOME=/tmp/comet-bench/spark/spark-3.5.8-bin-hadoop3

SPARK_LOCAL_IP=127.0.0.1 $SPARK_HOME/bin/spark-submit \
  --master "local[*]" \
  --driver-class-path /tmp/comet-bench/jars/iceberg-spark-runtime-3.5_2.12-1.8.1.jar \
  --conf "spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions" \
  --conf "spark.driver.bindAddress=127.0.0.1" \
  --conf "spark.driver.host=127.0.0.1" \
  ~/Documents/apache/datafusion-comet/benchmarks/tpc/create-iceberg-tables.py \
  --benchmark tpch \
  --parquet-path /tmp/comet-bench/tpch-data/tpch/sf1_parquet \
  --warehouse /tmp/comet-bench/iceberg-warehouse

SPARK_LOCAL_IP=127.0.0.1 $SPARK_HOME/bin/spark-submit \
  --master "local[*]" \
  --driver-class-path /tmp/comet-bench/jars/iceberg-spark-runtime-3.5_2.12-1.8.1.jar \
  --conf "spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions" \
  --conf "spark.driver.bindAddress=127.0.0.1" \
  --conf "spark.driver.host=127.0.0.1" \
  ~/Documents/apache/datafusion-comet/benchmarks/tpc/create-iceberg-tables.py \
  --benchmark tpcds \
  --parquet-path /tmp/tpcds/sf1_parquet \
  --warehouse /tmp/comet-bench/iceberg-warehouse

#  Run Spark JVM (Iceberg Baseline)

SPARK_LOCAL_IP=127.0.0.1 $SPARK_HOME/bin/spark-submit \
  --master "local[*]" \
  --driver-class-path /tmp/comet-bench/jars/iceberg-spark-runtime-3.5_2.12-1.8.1.jar \
  --conf "spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog" \
  --conf "spark.sql.catalog.local.type=hadoop" \
  --conf "spark.sql.catalog.local.warehouse=/tmp/comet-bench/iceberg-warehouse" \
  --conf "spark.sql.defaultCatalog=local" \
  ~/Documents/apache/datafusion-comet/benchmarks/tpc/tpcbench.py \
  --benchmark tpch --catalog local --database tpch \
  --iterations 1 --output /tmp/comet-bench/results \
  --name spark-iceberg \
  --plan-dir /tmp/comet-bench/plans/tpch-sf1

SPARK_LOCAL_IP=127.0.0.1 $SPARK_HOME/bin/spark-submit \
  --master "local[*]" \
  --driver-class-path /tmp/comet-bench/jars/iceberg-spark-runtime-3.5_2.12-1.8.1.jar \
  --conf "spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog" \
  --conf "spark.sql.catalog.local.type=hadoop" \
  --conf "spark.sql.catalog.local.warehouse=/tmp/comet-bench/iceberg-warehouse" \
  --conf "spark.sql.defaultCatalog=local" \
  ~/Documents/apache/datafusion-comet/benchmarks/tpc/tpcbench.py \
  --benchmark tpcds --catalog local --database tpcds \
  --iterations 1 --output /tmp/comet-bench/results \
  --name spark-iceberg \
  --plan-dir /tmp/comet-bench/plans/tpcds-sf1

# Run Comet Native (Iceberg Rust Scan)

export COMET_JAR=~/Documents/apache/datafusion-comet/spark/target/comet-spark-spark3.5_2.12-0.15.0-SNAPSHOT.jar

SPARK_LOCAL_IP=127.0.0.1 $SPARK_HOME/bin/spark-submit \
  --master "local[*]" \
  --driver-class-path "$COMET_JAR:/tmp/comet-bench/jars/iceberg-spark-runtime-3.5_2.12-1.8.1.jar" \
  --jars "$COMET_JAR,/tmp/comet-bench/jars/iceberg-spark-runtime-3.5_2.12-1.8.1.jar" \
  --conf "spark.plugins=org.apache.spark.CometPlugin" \
  --conf "spark.comet.enabled=true" \
  --conf "spark.comet.exec.enabled=true" \
  --conf "spark.comet.scan.icebergNative.enabled=true" \
  --conf "spark.shuffle.manager=org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager" \
  --conf "spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog" \
  --conf "spark.sql.catalog.local.type=hadoop" \
  --conf "spark.sql.catalog.local.warehouse=/tmp/comet-bench/iceberg-warehouse" \
  --conf "spark.sql.defaultCatalog=local" \
  ~/Documents/apache/datafusion-comet/benchmarks/tpc/tpcbench.py \
  --benchmark tpch --catalog local --database tpch \
  --iterations 1 --output /tmp/comet-bench/results \
  --name comet-iceberg \
  --plan-dir /tmp/comet-bench/plans/tpch-sf1

# Generate Comparison Graphs
cd ~/Documents/apache/datafusion-comet/benchmarks/tpc

# TPC-H charts
python3 generate-comparison.py \
  --benchmark tpch \
  --labels "Spark Iceberg (JVM)" "Comet Iceberg (Native Rust)" \
  --title "TPC-H SF1: Iceberg JVM Scan vs Native Rust Scan" \
  /tmp/comet-bench/results/spark-iceberg-tpch-*.json \
  /tmp/comet-bench/results/comet-iceberg-tpch-*.json

# TPC-DS charts (Q1–Q22)
python3 generate-comparison.py \
  --benchmark tpcds \
  --labels "Spark Iceberg (JVM)" "Comet Iceberg (Native Rust)" \
  --title "TPC-DS SF1 (Q1–Q22): Iceberg JVM vs Native Rust" \
  /tmp/comet-bench/results/spark-iceberg-tpcds-q1to22-*.json \
  /tmp/comet-bench/results/comet-iceberg-tpcds-*.json
```