### PR TITLE
fix: correct array_append return type and mark as Compatible

### DIFF
--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -232,7 +232,7 @@ Comet supports using the following aggregate functions within window contexts wi
 
 | Expression     | Spark-Compatible? | Compatibility Notes                                                                                                                                                                       |
 | -------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ArrayAppend    | No                |                                                                                                                                                                                           |
+| ArrayAppend    | Yes               |                                                                                                                                                                                           |
 | ArrayCompact   | No                |                                                                                                                                                                                           |
 | ArrayContains  | No                | Returns null instead of false for empty arrays with literal values ([#3346](https://github.com/apache/datafusion-comet/issues/3346))                                                      |
 | ArrayDistinct  | No                | Behaves differently than spark. Comet first sorts then removes duplicates while Spark preserves the original order.                                                                       |

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -100,10 +100,13 @@ object CometArrayAppend extends CometExpressionSerde[ArrayAppend] {
     val arrayExprProto = exprToProto(expr.children.head, inputs, binding)
     val keyExprProto = exprToProto(expr.children(1), inputs, binding)
 
+    // DataFusion's array_append always returns a list with nullable elements,
+    // so we must promise ArrayType(elementType, containsNull = true) here even if
+    // Spark's expr.dataType has containsNull = false (e.g. for array(1,2,3)).
     val arrayAppendScalarExpr =
       scalarFunctionExprToProtoWithReturnType(
         "array_append",
-        expr.dataType,
+        ArrayType(elementType, containsNull = true),
         false,
         arrayExprProto,
         keyExprProto)

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -88,7 +88,7 @@ object CometArrayRemove
 
 object CometArrayAppend extends CometExpressionSerde[ArrayAppend] {
 
-  override def getSupportLevel(expr: ArrayAppend): SupportLevel = Incompatible(None)
+  override def getSupportLevel(expr: ArrayAppend): SupportLevel = Compatible()
 
   override def convert(
       expr: ArrayAppend,
@@ -103,7 +103,7 @@ object CometArrayAppend extends CometExpressionSerde[ArrayAppend] {
     val arrayAppendScalarExpr =
       scalarFunctionExprToProtoWithReturnType(
         "array_append",
-        ArrayType(elementType = elementType),
+        expr.dataType,
         false,
         arrayExprProto,
         keyExprProto)

--- a/spark/src/test/resources/sql-tests/expressions/array/array_append.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_append.sql
@@ -15,6 +15,8 @@
 -- specific language governing permissions and limitations
 -- under the License.
 
+-- On Spark 4.0, array_append is a RuntimeReplaceable that rewrites to array_insert(-1),
+-- so we need to allow the incompatible array_insert to run natively there.
 -- Config: spark.comet.expression.ArrayInsert.allowIncompatible=true
 -- ConfigMatrix: parquet.enable.dictionary=false,true
 

--- a/spark/src/test/resources/sql-tests/expressions/array/array_append.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_append.sql
@@ -16,7 +16,6 @@
 -- under the License.
 
 -- Config: spark.comet.expression.ArrayInsert.allowIncompatible=true
--- Config: spark.comet.expression.ArrayAppend.allowIncompatible=true
 -- ConfigMatrix: parquet.enable.dictionary=false,true
 
 statement


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

`CometArrayAppend` had two bugs:

1. **Runtime assertion failure for literal arrays.** DataFusion's `array_append` always returns a list with `nullable: true` on the element field. But when the input array has non-null elements (e.g. `array(1, 2, 3)`), Spark's `ArrayAppend.dataType` returns `ArrayType(IntegerType, containsNull = false)`. The serde code was passing `expr.dataType` as the "promised" return type to DataFusion, which caused a runtime assertion failure:
   ```
   Assertion failed: result_data_type == *expected_type: Function 'array_append' returned value of
   type 'List(Field { data_type: Int32, nullable: true })' while the following type was promised at
   planning time and expected: 'List(Field { data_type: Int32 })'
   ```

2. **Incorrect `Incompatible` classification.** `CometArrayAppend` was marked `Incompatible(None)` with no explanation, which disabled it by default. The `CaseWhen(IsNotNull(arr), array_append(arr, elem), null)` wrapper already handles the only genuine incompatibility (DataFusion's `array_append` does not preserve null top-level array rows on its own), so the expression matches Spark's behavior fully.

## What changes are included in this PR?

- **`arrays.scala`:** Use `ArrayType(elementType, containsNull = true)` as the promised return type for `array_append`, matching what DataFusion actually returns. Change `getSupportLevel` from `Incompatible` to `Compatible`.
- **`array_append.sql`:** Remove `spark.comet.expression.ArrayAppend.allowIncompatible=true` (no longer needed now that it's `Compatible`). Add comment explaining why `ArrayInsert.allowIncompatible=true` is still needed on Spark 4.0 (where `array_append` is a `RuntimeReplaceable` that rewrites to `array_insert(-1)`).
- **`expressions.md`:** Mark `ArrayAppend` as Spark-compatible.

## How are these changes tested?

Existing SQL file test `expressions/array/array_append.sql` covers column inputs, literal inputs, NULL arrays, and NULL elements across both dictionary and non-dictionary Parquet. The literal-only query that previously triggered the assertion failure now passes.