### PR TITLE
fix: drop JNI GlobalRef before detaching thread in memory pool errors

### DIFF
--- a/native/core/src/execution/memory_pools/fair_pool.rs
+++ b/native/core/src/execution/memory_pools/fair_pool.rs
@@ -22,7 +22,10 @@ use std::{
 
 use jni::objects::GlobalRef;
 
-use crate::{errors::CometResult, jvm_bridge::JVMClasses};
+use crate::{
+    errors::{CometError, CometResult},
+    jvm_bridge::JVMClasses,
+};
 use datafusion::common::resources_err;
 use datafusion::execution::memory_pool::MemoryConsumer;
 use datafusion::{
@@ -74,6 +77,7 @@ impl CometFairMemoryPool {
             jni_call!(&mut env,
               comet_task_memory_manager(handle).acquire_memory(additional as i64) -> i64)
         }
+        .map_err(CometError::drop_throwable)
     }
 
     fn release(&self, size: usize) -> CometResult<()> {
@@ -82,6 +86,7 @@ impl CometFairMemoryPool {
         unsafe {
             jni_call!(&mut env, comet_task_memory_manager(handle).release_memory(size as i64) -> ())
         }
+        .map_err(CometError::drop_throwable)
     }
 }
 

--- a/native/core/src/execution/memory_pools/unified_pool.rs
+++ b/native/core/src/execution/memory_pools/unified_pool.rs
@@ -23,7 +23,10 @@ use std::{
     },
 };
 
-use crate::{errors::CometResult, jvm_bridge::JVMClasses};
+use crate::{
+    errors::{CometError, CometResult},
+    jvm_bridge::JVMClasses,
+};
 use datafusion::{
     common::{resources_datafusion_err, DataFusionError},
     execution::memory_pool::{MemoryPool, MemoryReservation},
@@ -68,6 +71,7 @@ impl CometUnifiedMemoryPool {
             jni_call!(&mut env,
               comet_task_memory_manager(handle).acquire_memory(additional as i64) -> i64)
         }
+        .map_err(CometError::drop_throwable)
     }
 
     /// Release memory to Spark's off-heap memory pool via JNI
@@ -77,6 +81,7 @@ impl CometUnifiedMemoryPool {
         unsafe {
             jni_call!(&mut env, comet_task_memory_manager(handle).release_memory(size as i64) -> ())
         }
+        .map_err(CometError::drop_throwable)
     }
 }
 

--- a/native/jni-bridge/src/errors.rs
+++ b/native/jni-bridge/src/errors.rs
@@ -171,6 +171,25 @@ pub enum CometError {
     },
 }
 
+impl CometError {
+    /// Convert a `JavaException` into an `Internal` error, dropping the JNI
+    /// `GlobalRef` while the current thread is still attached to the JVM.
+    ///
+    /// Call this on errors returned from JNI helper methods that may execute on
+    /// threads not permanently attached to the JVM (e.g. tokio worker threads
+    /// used by the memory pool). Without this, the `GlobalRef` can outlive the
+    /// `AttachGuard` and be dropped on a detached thread, which triggers a
+    /// warning and an expensive temporary attach/detach cycle.
+    pub fn drop_throwable(self) -> Self {
+        match self {
+            CometError::JavaException { class, msg, .. } => {
+                CometError::Internal(format!("{class}: {msg}"))
+            }
+            other => other,
+        }
+    }
+}
+
 pub fn init() {
     std::panic::set_hook(Box::new(|panic_info| {
         // Log the panic message and location to stderr so it is visible in CI logs


### PR DESCRIPTION
## Which issue does this PR close?

Closes #2470.

## Rationale for this change

When running with reduced off-heap memory, JNI `GlobalRef` objects inside `JavaException` errors can be dropped on tokio worker threads that are not attached to the JVM. This triggers warnings from the `jni` crate (`"Dropping a GlobalRef in a detached thread"`) and causes expensive temporary attach/detach cycles.

The root cause: memory pool methods (`acquire_memory`/`release_memory`) call JNI via a temporary `AttachGuard`. If the JNI call throws a Java exception, a `CometError::JavaException` is created containing a `GlobalRef` to the throwable. When the method returns, the `AttachGuard` drops and detaches the thread — but the `GlobalRef` inside the error outlives it. As the error propagates through DataFusion on the now-detached tokio thread and is eventually converted to `DataFusionError::Execution(String)`, the `GlobalRef` is dropped on the detached thread, triggering the warning.

## What changes are included in this PR?

- Add `CometError::drop_throwable()` which converts `JavaException` errors (containing a `GlobalRef`) into string-only `Internal` errors, ensuring the `GlobalRef` is dropped while the thread is still JVM-attached.
- Apply `.map_err(CometError::drop_throwable)` in all four memory pool JNI methods: `acquire_from_spark`, `release_to_spark` (unified pool), `acquire`, `release` (fair pool).

The `GlobalRef` is safe to drop early here because these errors always propagate through `DataFusionError::Execution(String)` which stringifies the error anyway — the throwable reference is never used to re-throw the original Java exception from this path.

## How are these changes tested?

This is difficult to test in a unit test since it requires a full Spark executor environment with memory pressure on tokio worker threads. The fix is verified by code inspection: `map_err` executes while the `AttachGuard` (`env`) is still in scope, so the `GlobalRef` is released on an attached thread. Clippy passes cleanly.