### PR TITLE
fix: wait for spawned tokio task before releasing native plan

### DIFF
--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -159,6 +159,8 @@ struct ExecutionContext {
     pub stream: Option<SendableRecordBatchStream>,
     /// Receives batches from a spawned tokio task (async I/O path)
     pub batch_receiver: Option<mpsc::Receiver<DataFusionResult<RecordBatch>>>,
+    /// Handle to the spawned tokio task so we can wait for it during cleanup
+    pub task_handle: Option<tokio::task::JoinHandle<()>>,
     /// Native metrics
     pub metrics: Arc<GlobalRef>,
     // The interval in milliseconds to update metrics
@@ -317,6 +319,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
                 input_sources,
                 stream: None,
                 batch_receiver: None,
+                task_handle: None,
                 metrics,
                 metrics_update_interval,
                 metrics_last_update_time: Instant::now(),
@@ -579,7 +582,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
                     // decreasing to 1 would serialize production and consumption.
                     let (tx, rx) = mpsc::channel(2);
                     let mut stream = stream;
-                    get_runtime().spawn(async move {
+                    let handle = get_runtime().spawn(async move {
                         let result = std::panic::AssertUnwindSafe(async {
                             while let Some(batch) = stream.next().await {
                                 if tx.send(batch).await.is_err() {
@@ -606,6 +609,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
                         }
                     });
                     exec_context.batch_receiver = Some(rx);
+                    exec_context.task_handle = Some(handle);
                 } else {
                     exec_context.stream = Some(stream);
                 }
@@ -700,6 +704,17 @@ pub extern "system" fn Java_org_apache_comet_Native_releasePlan(
             execution_context.memory_pool_config.pool_type,
             execution_context.task_attempt_id,
         );
+
+        // If a tokio task was spawned for async execution, wait for it to
+        // complete before dropping the context. This ensures all
+        // MemoryReservations held by the stream are released back to Spark
+        // before Spark calls cleanUpAllAllocatedMemory().
+        if let Some(handle) = execution_context.task_handle.take() {
+            // Drop the receiver first so the task sees a closed channel
+            // and exits its loop.
+            execution_context.batch_receiver.take();
+            let _ = get_runtime().block_on(handle);
+        }
 
         let _: Box<ExecutionContext> = Box::from_raw(execution_context);
         Ok(())


### PR DESCRIPTION
## Which issue does this PR close?

Closes #2453.

## Rationale for this change

When a tokio task is spawned for async execution (the path taken when there are no JVM data sources), the execution stream and its `MemoryReservation`s are owned by the tokio task. If `releasePlan` drops the `ExecutionContext` without waiting for the task to complete, the reservations are released asynchronously on the tokio thread — potentially **after** Spark has already called `cleanUpAllAllocatedMemory()`, causing:

```
WARN ExecutionMemoryPool: Internal error: release called on 917504 bytes but task only has 0 bytes of memory from the off-heap execution pool
```

The sequence that triggers this:
1. `TaskCompletionListener` calls `CometExecIterator.close()` → `releasePlan()` via JNI
2. `releasePlan` drops `ExecutionContext`, which drops `batch_receiver` — signaling the tokio task to stop
3. `releasePlan` returns to JVM before the tokio task finishes cleanup
4. Spark calls `cleanUpAllAllocatedMemory()` — zeroes out the task's allocation
5. The tokio task finally drops the stream and its `MemoryReservation`s → `release_to_spark()` → Spark sees "0 bytes"

This also fixes Source 2 of #2470 — `GlobalRef`s held by the stream are now dropped while the JVM thread is still the caller, avoiding the "Dropping a GlobalRef in a detached thread" warning.

## What changes are included in this PR?

- Add a `task_handle` field to `ExecutionContext` to store the `JoinHandle` from the spawned tokio task
- In `releasePlan`, drop the `batch_receiver` first (to signal the task to exit its loop), then `block_on` the handle to wait for the tokio task to complete before dropping the context

This guarantees all memory releases and `GlobalRef` drops happen before `releasePlan` returns to the JVM.

## How are these changes tested?

This race condition requires a full Spark executor environment where the task completion sequence (`TaskCompletionListener` → `cleanUpAllAllocatedMemory`) races with async tokio task cleanup. It is not reproducible in unit tests. The fix is verified by code inspection: `block_on(handle)` ensures the tokio task completes (dropping the stream and all reservations) before `releasePlan` returns. Clippy passes cleanly.