### PR TITLE
fix: date_trunc correct results in non-UTC timezones

### DIFF
--- a/native/spark-expr/src/datetime_funcs/timestamp_trunc.rs
+++ b/native/spark-expr/src/datetime_funcs/timestamp_trunc.rs
@@ -94,12 +94,13 @@ impl PhysicalExpr for TimestampTruncExpr {
     }
 
     fn data_type(&self, input_schema: &Schema) -> datafusion::common::Result<DataType> {
+        let tz = Some(Arc::from(self.timezone.as_str()));
         match self.child.data_type(input_schema)? {
             DataType::Dictionary(key_type, _) => Ok(DataType::Dictionary(
                 key_type,
-                Box::new(DataType::Timestamp(Microsecond, None)),
+                Box::new(DataType::Timestamp(Microsecond, tz)),
             )),
-            _ => Ok(DataType::Timestamp(Microsecond, None)),
+            _ => Ok(DataType::Timestamp(Microsecond, tz)),
         }
     }
 

--- a/native/spark-expr/src/kernels/temporal.rs
+++ b/native/spark-expr/src/kernels/temporal.rs
@@ -17,8 +17,8 @@
 
 //! temporal kernels
 
-use chrono::{DateTime, Datelike, Duration, LocalResult, NaiveDate, NaiveDateTime, Timelike};
 use chrono::offset::TimeZone as ChronoTimeZone;
+use chrono::{DateTime, Datelike, Duration, LocalResult, NaiveDate, NaiveDateTime, Timelike};
 
 use std::sync::Arc;
 
@@ -567,56 +567,66 @@ where
     match array.data_type() {
         DataType::Timestamp(TimeUnit::Microsecond, Some(tz)) => {
             match format.to_uppercase().as_str() {
-                "YEAR" | "YYYY" | "YY" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
-                        as_micros_from_local_datetime_tz(trunc_date_to_year(dt), tz)
-                    })
-                }
-                "QUARTER" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
-                        as_micros_from_local_datetime_tz(trunc_date_to_quarter(dt), tz)
-                    })
-                }
-                "MONTH" | "MON" | "MM" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
-                        as_micros_from_local_datetime_tz(trunc_date_to_month(dt), tz)
-                    })
-                }
-                "WEEK" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
-                        as_micros_from_local_datetime_tz(trunc_date_to_week(dt), tz)
-                    })
-                }
-                "DAY" | "DD" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
-                        as_micros_from_local_datetime_tz(trunc_date_to_day(dt), tz)
-                    })
-                }
-                "HOUR" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
-                        as_micros_from_local_datetime_tz(trunc_date_to_hour(dt), tz)
-                    })
-                }
-                "MINUTE" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
-                        as_micros_from_local_datetime_tz(trunc_date_to_minute(dt), tz)
-                    })
-                }
-                "SECOND" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
-                        as_micros_from_local_datetime_tz(trunc_date_to_second(dt), tz)
-                    })
-                }
-                "MILLISECOND" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
-                        as_micros_from_local_datetime_tz(trunc_date_to_ms(dt), tz)
-                    })
-                }
-                "MICROSECOND" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
-                        as_micros_from_local_datetime_tz(trunc_date_to_microsec(dt), tz)
-                    })
-                }
+                "YEAR" | "YYYY" | "YY" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
+                    iter,
+                    builder,
+                    tz,
+                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_year(dt), tz),
+                ),
+                "QUARTER" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
+                    iter,
+                    builder,
+                    tz,
+                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_quarter(dt), tz),
+                ),
+                "MONTH" | "MON" | "MM" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
+                    iter,
+                    builder,
+                    tz,
+                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_month(dt), tz),
+                ),
+                "WEEK" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
+                    iter,
+                    builder,
+                    tz,
+                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_week(dt), tz),
+                ),
+                "DAY" | "DD" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
+                    iter,
+                    builder,
+                    tz,
+                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_day(dt), tz),
+                ),
+                "HOUR" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
+                    iter,
+                    builder,
+                    tz,
+                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_hour(dt), tz),
+                ),
+                "MINUTE" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
+                    iter,
+                    builder,
+                    tz,
+                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_minute(dt), tz),
+                ),
+                "SECOND" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
+                    iter,
+                    builder,
+                    tz,
+                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_second(dt), tz),
+                ),
+                "MILLISECOND" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
+                    iter,
+                    builder,
+                    tz,
+                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_ms(dt), tz),
+                ),
+                "MICROSECOND" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
+                    iter,
+                    builder,
+                    tz,
+                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_microsec(dt), tz),
+                ),
                 _ => Err(SparkError::Internal(format!(
                     "Unsupported format: {format:?} for function 'timestamp_trunc'"
                 ))),
@@ -716,56 +726,70 @@ macro_rules! timestamp_trunc_array_fmt_helper {
                 let tz: Tz = tz_str.parse()?;
                 for (index, val) in iter.enumerate() {
                     let op_result = match $formats.value(index).to_uppercase().as_str() {
-                        "YEAR" | "YYYY" | "YY" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
-                                as_micros_from_local_datetime_tz(trunc_date_to_year(dt), tz)
-                            })
-                        }
-                        "QUARTER" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
+                        "YEAR" | "YYYY" | "YY" => as_timestamp_tz_with_op_single::<T, _>(
+                            val,
+                            &mut builder,
+                            &tz,
+                            |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_year(dt), tz),
+                        ),
+                        "QUARTER" => as_timestamp_tz_with_op_single::<T, _>(
+                            val,
+                            &mut builder,
+                            &tz,
+                            |dt, tz| {
                                 as_micros_from_local_datetime_tz(trunc_date_to_quarter(dt), tz)
-                            })
-                        }
-                        "MONTH" | "MON" | "MM" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
-                                as_micros_from_local_datetime_tz(trunc_date_to_month(dt), tz)
-                            })
-                        }
-                        "WEEK" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
-                                as_micros_from_local_datetime_tz(trunc_date_to_week(dt), tz)
-                            })
-                        }
-                        "DAY" | "DD" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
-                                as_micros_from_local_datetime_tz(trunc_date_to_day(dt), tz)
-                            })
-                        }
-                        "HOUR" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
-                                as_micros_from_local_datetime_tz(trunc_date_to_hour(dt), tz)
-                            })
-                        }
-                        "MINUTE" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
-                                as_micros_from_local_datetime_tz(trunc_date_to_minute(dt), tz)
-                            })
-                        }
-                        "SECOND" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
-                                as_micros_from_local_datetime_tz(trunc_date_to_second(dt), tz)
-                            })
-                        }
-                        "MILLISECOND" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
-                                as_micros_from_local_datetime_tz(trunc_date_to_ms(dt), tz)
-                            })
-                        }
-                        "MICROSECOND" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
+                            },
+                        ),
+                        "MONTH" | "MON" | "MM" => as_timestamp_tz_with_op_single::<T, _>(
+                            val,
+                            &mut builder,
+                            &tz,
+                            |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_month(dt), tz),
+                        ),
+                        "WEEK" => as_timestamp_tz_with_op_single::<T, _>(
+                            val,
+                            &mut builder,
+                            &tz,
+                            |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_week(dt), tz),
+                        ),
+                        "DAY" | "DD" => as_timestamp_tz_with_op_single::<T, _>(
+                            val,
+                            &mut builder,
+                            &tz,
+                            |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_day(dt), tz),
+                        ),
+                        "HOUR" => as_timestamp_tz_with_op_single::<T, _>(
+                            val,
+                            &mut builder,
+                            &tz,
+                            |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_hour(dt), tz),
+                        ),
+                        "MINUTE" => as_timestamp_tz_with_op_single::<T, _>(
+                            val,
+                            &mut builder,
+                            &tz,
+                            |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_minute(dt), tz),
+                        ),
+                        "SECOND" => as_timestamp_tz_with_op_single::<T, _>(
+                            val,
+                            &mut builder,
+                            &tz,
+                            |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_second(dt), tz),
+                        ),
+                        "MILLISECOND" => as_timestamp_tz_with_op_single::<T, _>(
+                            val,
+                            &mut builder,
+                            &tz,
+                            |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_ms(dt), tz),
+                        ),
+                        "MICROSECOND" => as_timestamp_tz_with_op_single::<T, _>(
+                            val,
+                            &mut builder,
+                            &tz,
+                            |dt, tz| {
                                 as_micros_from_local_datetime_tz(trunc_date_to_microsec(dt), tz)
-                            })
-                        }
+                            },
+                        ),
                         _ => Err(SparkError::Internal(format!(
                             "Unsupported format: {:?} for function 'timestamp_trunc'",
                             $formats.value(index)

--- a/native/spark-expr/src/kernels/temporal.rs
+++ b/native/spark-expr/src/kernels/temporal.rs
@@ -154,18 +154,17 @@ where
     Ok(())
 }
 
-// Re-applies the timezone to the naive local datetime produced after truncation to get the
-// correct UTC microseconds, properly handling DST transitions.
+// Converts the truncated naive local datetime to UTC microseconds, properly handling
+// DST transitions.
 //
-// The truncation functions (trunc_date_to_year, etc.) modify the date/time fields of a
-// DateTime<Tz> while preserving the original UTC offset. This is incorrect when the DST
-// offset changes across the truncation boundary (e.g. truncating from November to October
-// in America/Denver shifts from MST to MDT). We fix this by extracting the naive local
-// datetime and re-applying the timezone via from_local_datetime(), which performs a fresh
-// DST lookup — matching the behavior of Java's ZonedDateTime.of().
+// Truncation is performed on NaiveDateTime (extracted from the input DateTime<Tz> via
+// naive_local()) to avoid chrono's intermediate timezone resolution at each with_*() step,
+// which can produce incorrect offsets for far-future dates. After truncation, this function
+// performs a single fresh DST lookup via from_local_datetime() — matching the behavior of
+// Java's ZonedDateTime.of().
 #[inline]
-fn as_micros_from_local_datetime_tz(dt: Option<DateTime<Tz>>, tz: &Tz) -> i64 {
-    let naive: NaiveDateTime = dt.unwrap().naive_local();
+fn as_micros_from_naive_datetime_tz(naive: Option<NaiveDateTime>, tz: &Tz) -> i64 {
+    let naive = naive.unwrap();
     match tz.from_local_datetime(&naive) {
         LocalResult::Single(dt) => dt.timestamp_micros(),
         // Ambiguous (fall-back): use the earlier (pre-transition) instant, matching Java
@@ -571,61 +570,87 @@ where
                     iter,
                     builder,
                     tz,
-                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_year(dt), tz),
+                    |dt, tz| {
+                        as_micros_from_naive_datetime_tz(trunc_date_to_year(dt.naive_local()), tz)
+                    },
                 ),
                 "QUARTER" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
                     iter,
                     builder,
                     tz,
-                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_quarter(dt), tz),
+                    |dt, tz| {
+                        as_micros_from_naive_datetime_tz(
+                            trunc_date_to_quarter(dt.naive_local()),
+                            tz,
+                        )
+                    },
                 ),
                 "MONTH" | "MON" | "MM" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
                     iter,
                     builder,
                     tz,
-                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_month(dt), tz),
+                    |dt, tz| {
+                        as_micros_from_naive_datetime_tz(trunc_date_to_month(dt.naive_local()), tz)
+                    },
                 ),
                 "WEEK" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
                     iter,
                     builder,
                     tz,
-                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_week(dt), tz),
+                    |dt, tz| {
+                        as_micros_from_naive_datetime_tz(trunc_date_to_week(dt.naive_local()), tz)
+                    },
                 ),
                 "DAY" | "DD" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
                     iter,
                     builder,
                     tz,
-                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_day(dt), tz),
+                    |dt, tz| {
+                        as_micros_from_naive_datetime_tz(trunc_date_to_day(dt.naive_local()), tz)
+                    },
                 ),
                 "HOUR" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
                     iter,
                     builder,
                     tz,
-                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_hour(dt), tz),
+                    |dt, tz| {
+                        as_micros_from_naive_datetime_tz(trunc_date_to_hour(dt.naive_local()), tz)
+                    },
                 ),
                 "MINUTE" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
                     iter,
                     builder,
                     tz,
-                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_minute(dt), tz),
+                    |dt, tz| {
+                        as_micros_from_naive_datetime_tz(trunc_date_to_minute(dt.naive_local()), tz)
+                    },
                 ),
                 "SECOND" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
                     iter,
                     builder,
                     tz,
-                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_second(dt), tz),
+                    |dt, tz| {
+                        as_micros_from_naive_datetime_tz(trunc_date_to_second(dt.naive_local()), tz)
+                    },
                 ),
                 "MILLISECOND" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
                     iter,
                     builder,
                     tz,
-                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_ms(dt), tz),
+                    |dt, tz| {
+                        as_micros_from_naive_datetime_tz(trunc_date_to_ms(dt.naive_local()), tz)
+                    },
                 ),
                 "MICROSECOND" => as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(
                     iter,
                     builder,
                     tz,
-                    |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_microsec(dt), tz),
+                    |dt, tz| {
+                        as_micros_from_naive_datetime_tz(
+                            trunc_date_to_microsec(dt.naive_local()),
+                            tz,
+                        )
+                    },
                 ),
                 _ => Err(SparkError::Internal(format!(
                     "Unsupported format: {format:?} for function 'timestamp_trunc'"
@@ -730,64 +755,110 @@ macro_rules! timestamp_trunc_array_fmt_helper {
                             val,
                             &mut builder,
                             &tz,
-                            |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_year(dt), tz),
+                            |dt, tz| {
+                                as_micros_from_naive_datetime_tz(
+                                    trunc_date_to_year(dt.naive_local()),
+                                    tz,
+                                )
+                            },
                         ),
                         "QUARTER" => as_timestamp_tz_with_op_single::<T, _>(
                             val,
                             &mut builder,
                             &tz,
                             |dt, tz| {
-                                as_micros_from_local_datetime_tz(trunc_date_to_quarter(dt), tz)
+                                as_micros_from_naive_datetime_tz(
+                                    trunc_date_to_quarter(dt.naive_local()),
+                                    tz,
+                                )
                             },
                         ),
                         "MONTH" | "MON" | "MM" => as_timestamp_tz_with_op_single::<T, _>(
                             val,
                             &mut builder,
                             &tz,
-                            |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_month(dt), tz),
+                            |dt, tz| {
+                                as_micros_from_naive_datetime_tz(
+                                    trunc_date_to_month(dt.naive_local()),
+                                    tz,
+                                )
+                            },
                         ),
                         "WEEK" => as_timestamp_tz_with_op_single::<T, _>(
                             val,
                             &mut builder,
                             &tz,
-                            |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_week(dt), tz),
+                            |dt, tz| {
+                                as_micros_from_naive_datetime_tz(
+                                    trunc_date_to_week(dt.naive_local()),
+                                    tz,
+                                )
+                            },
                         ),
                         "DAY" | "DD" => as_timestamp_tz_with_op_single::<T, _>(
                             val,
                             &mut builder,
                             &tz,
-                            |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_day(dt), tz),
+                            |dt, tz| {
+                                as_micros_from_naive_datetime_tz(
+                                    trunc_date_to_day(dt.naive_local()),
+                                    tz,
+                                )
+                            },
                         ),
                         "HOUR" => as_timestamp_tz_with_op_single::<T, _>(
                             val,
                             &mut builder,
                             &tz,
-                            |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_hour(dt), tz),
+                            |dt, tz| {
+                                as_micros_from_naive_datetime_tz(
+                                    trunc_date_to_hour(dt.naive_local()),
+                                    tz,
+                                )
+                            },
                         ),
                         "MINUTE" => as_timestamp_tz_with_op_single::<T, _>(
                             val,
                             &mut builder,
                             &tz,
-                            |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_minute(dt), tz),
+                            |dt, tz| {
+                                as_micros_from_naive_datetime_tz(
+                                    trunc_date_to_minute(dt.naive_local()),
+                                    tz,
+                                )
+                            },
                         ),
                         "SECOND" => as_timestamp_tz_with_op_single::<T, _>(
                             val,
                             &mut builder,
                             &tz,
-                            |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_second(dt), tz),
+                            |dt, tz| {
+                                as_micros_from_naive_datetime_tz(
+                                    trunc_date_to_second(dt.naive_local()),
+                                    tz,
+                                )
+                            },
                         ),
                         "MILLISECOND" => as_timestamp_tz_with_op_single::<T, _>(
                             val,
                             &mut builder,
                             &tz,
-                            |dt, tz| as_micros_from_local_datetime_tz(trunc_date_to_ms(dt), tz),
+                            |dt, tz| {
+                                as_micros_from_naive_datetime_tz(
+                                    trunc_date_to_ms(dt.naive_local()),
+                                    tz,
+                                )
+                            },
                         ),
                         "MICROSECOND" => as_timestamp_tz_with_op_single::<T, _>(
                             val,
                             &mut builder,
                             &tz,
                             |dt, tz| {
-                                as_micros_from_local_datetime_tz(trunc_date_to_microsec(dt), tz)
+                                as_micros_from_naive_datetime_tz(
+                                    trunc_date_to_microsec(dt.naive_local()),
+                                    tz,
+                                )
                             },
                         ),
                         _ => Err(SparkError::Internal(format!(
@@ -871,6 +942,7 @@ mod tests {
         types::{Date32Type, Int32Type, TimestampMicrosecondType},
         Array, Date32Array, PrimitiveArray, StringArray, TimestampMicrosecondArray,
     };
+    use chrono::NaiveDate;
     use std::sync::Arc;
 
     #[test]
@@ -1229,6 +1301,48 @@ mod tests {
                 arrow::datatypes::TimeUnit::Microsecond,
                 Some("America/Denver".into())
             )
+        );
+    }
+
+    /// Verify that timestamp_trunc works correctly for far-future dates (beyond tz database
+    /// explicit transitions, relying on POSIX TZ rule extrapolation).
+    ///
+    /// For America/Los_Angeles with POSIX rule PST8PDT,M3.2.0,M11.1.0:
+    /// - October 1 is still in DST (PDT, UTC-7)
+    /// - Truncating a December timestamp (PST, UTC-8) to QUARTER should produce
+    ///   October 1 00:00:00 PDT (UTC-7), not October 1 00:00:00 PST (UTC-8)
+    #[test]
+    fn test_timestamp_trunc_far_future_dst() {
+        // 3332-12-03 18:00:59 UTC (in PST that's 3332-12-03 10:00:59)
+        // We need a UTC microsecond value for a date in December 3332 in America/Los_Angeles.
+        // Use chrono to compute it precisely.
+        use chrono::TimeZone;
+        let tz: arrow::array::timezone::Tz = "America/Los_Angeles".parse().unwrap();
+        // 3332-12-03 10:00:59 local time in America/Los_Angeles (PST in December)
+        let local_naive = NaiveDate::from_ymd_opt(3332, 12, 3)
+            .unwrap()
+            .and_hms_opt(10, 0, 59)
+            .unwrap();
+        let dt = tz.from_local_datetime(&local_naive).unwrap();
+        let ts_utc_micros = dt.timestamp_micros();
+
+        let array = TimestampMicrosecondArray::from(vec![ts_utc_micros])
+            .with_timezone("America/Los_Angeles");
+
+        let result = timestamp_trunc(&array, "QUARTER".to_string()).unwrap();
+
+        // Expected: 3332-10-01 00:00:00 PDT (UTC-7) = 3332-10-01 07:00:00 UTC
+        let expected_naive = NaiveDate::from_ymd_opt(3332, 10, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+        let expected_dt = tz.from_local_datetime(&expected_naive).unwrap();
+        let expected_utc_micros = expected_dt.timestamp_micros();
+
+        assert_eq!(
+            result.value(0),
+            expected_utc_micros,
+            "Far-future date: expected 3332-10-01 00:00:00 PDT, got wrong offset"
         );
     }
 }

--- a/native/spark-expr/src/kernels/temporal.rs
+++ b/native/spark-expr/src/kernels/temporal.rs
@@ -17,7 +17,8 @@
 
 //! temporal kernels
 
-use chrono::{DateTime, Datelike, Duration, NaiveDate, Timelike, Utc};
+use chrono::{DateTime, Datelike, Duration, LocalResult, NaiveDate, NaiveDateTime, Timelike};
+use chrono::offset::TimeZone as ChronoTimeZone;
 
 use std::sync::Arc;
 
@@ -100,23 +101,23 @@ fn trunc_days_to_week(days: i32) -> Option<i32> {
 }
 
 // Based on arrow_arith/temporal.rs:extract_component_from_datetime_array
-// Transforms an array of DateTime<Tz> to an arrayOf TimeStampMicrosecond after applying an
-// operation
+// Transforms an array of DateTime<Tz> to an array of TimestampMicrosecond after applying an
+// operation. The output array is annotated with the same timezone as the input.
 fn as_timestamp_tz_with_op<A: ArrayAccessor<Item = T::Native>, T: ArrowTemporalType, F>(
     iter: ArrayIter<A>,
     mut builder: PrimitiveBuilder<TimestampMicrosecondType>,
-    tz: &str,
+    tz_str: &str,
     op: F,
 ) -> Result<TimestampMicrosecondArray, SparkError>
 where
-    F: Fn(DateTime<Tz>) -> i64,
+    F: Fn(DateTime<Tz>, &Tz) -> i64,
     i64: From<T::Native>,
 {
-    let tz: Tz = tz.parse()?;
+    let tz: Tz = tz_str.parse()?;
     for value in iter {
         match value {
             Some(value) => match as_datetime_with_timezone::<T>(value.into(), tz) {
-                Some(time) => builder.append_value(op(time)),
+                Some(time) => builder.append_value(op(time, &tz)),
                 _ => {
                     return Err(SparkError::Internal(
                         "Unable to read value as datetime".to_string(),
@@ -126,7 +127,7 @@ where
             None => builder.append_null(),
         }
     }
-    Ok(builder.finish())
+    Ok(builder.finish().with_timezone(tz_str))
 }
 
 fn as_timestamp_tz_with_op_single<T: ArrowTemporalType, F>(
@@ -136,12 +137,12 @@ fn as_timestamp_tz_with_op_single<T: ArrowTemporalType, F>(
     op: F,
 ) -> Result<(), SparkError>
 where
-    F: Fn(DateTime<Tz>) -> i64,
+    F: Fn(DateTime<Tz>, &Tz) -> i64,
     i64: From<T::Native>,
 {
     match value {
         Some(value) => match as_datetime_with_timezone::<T>(value.into(), *tz) {
-            Some(time) => builder.append_value(op(time)),
+            Some(time) => builder.append_value(op(time, tz)),
             _ => {
                 return Err(SparkError::Internal(
                     "Unable to read value as datetime".to_string(),
@@ -153,10 +154,34 @@ where
     Ok(())
 }
 
-// Apply the Tz to the Naive Date Time,,convert to UTC, and return as microseconds in Unix epoch
+// Re-applies the timezone to the naive local datetime produced after truncation to get the
+// correct UTC microseconds, properly handling DST transitions.
+//
+// The truncation functions (trunc_date_to_year, etc.) modify the date/time fields of a
+// DateTime<Tz> while preserving the original UTC offset. This is incorrect when the DST
+// offset changes across the truncation boundary (e.g. truncating from November to October
+// in America/Denver shifts from MST to MDT). We fix this by extracting the naive local
+// datetime and re-applying the timezone via from_local_datetime(), which performs a fresh
+// DST lookup — matching the behavior of Java's ZonedDateTime.of().
 #[inline]
-fn as_micros_from_unix_epoch_utc(dt: Option<DateTime<Tz>>) -> i64 {
-    dt.unwrap().with_timezone(&Utc).timestamp_micros()
+fn as_micros_from_local_datetime_tz(dt: Option<DateTime<Tz>>, tz: &Tz) -> i64 {
+    let naive: NaiveDateTime = dt.unwrap().naive_local();
+    match tz.from_local_datetime(&naive) {
+        LocalResult::Single(dt) => dt.timestamp_micros(),
+        // Ambiguous (fall-back): use the earlier (pre-transition) instant, matching Java
+        LocalResult::Ambiguous(dt, _) => dt.timestamp_micros(),
+        // Non-existent (spring-forward gap): advance past the gap, matching Java.
+        // Assumes all DST gaps are exactly 1 hour. Timezones with non-1-hour DST gaps
+        // (e.g. Australia/Lord_Howe at 30 min) are marked Incompatible at the Scala
+        // planning layer and fall back to Spark.
+        LocalResult::None => {
+            let adjusted = naive + Duration::try_hours(1).unwrap();
+            tz.from_local_datetime(&adjusted)
+                .earliest()
+                .unwrap()
+                .timestamp_micros()
+        }
+    }
 }
 
 #[inline]
@@ -543,53 +568,53 @@ where
         DataType::Timestamp(TimeUnit::Microsecond, Some(tz)) => {
             match format.to_uppercase().as_str() {
                 "YEAR" | "YYYY" | "YY" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt| {
-                        as_micros_from_unix_epoch_utc(trunc_date_to_year(dt))
+                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
+                        as_micros_from_local_datetime_tz(trunc_date_to_year(dt), tz)
                     })
                 }
                 "QUARTER" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt| {
-                        as_micros_from_unix_epoch_utc(trunc_date_to_quarter(dt))
+                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
+                        as_micros_from_local_datetime_tz(trunc_date_to_quarter(dt), tz)
                     })
                 }
                 "MONTH" | "MON" | "MM" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt| {
-                        as_micros_from_unix_epoch_utc(trunc_date_to_month(dt))
+                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
+                        as_micros_from_local_datetime_tz(trunc_date_to_month(dt), tz)
                     })
                 }
                 "WEEK" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt| {
-                        as_micros_from_unix_epoch_utc(trunc_date_to_week(dt))
+                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
+                        as_micros_from_local_datetime_tz(trunc_date_to_week(dt), tz)
                     })
                 }
                 "DAY" | "DD" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt| {
-                        as_micros_from_unix_epoch_utc(trunc_date_to_day(dt))
+                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
+                        as_micros_from_local_datetime_tz(trunc_date_to_day(dt), tz)
                     })
                 }
                 "HOUR" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt| {
-                        as_micros_from_unix_epoch_utc(trunc_date_to_hour(dt))
+                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
+                        as_micros_from_local_datetime_tz(trunc_date_to_hour(dt), tz)
                     })
                 }
                 "MINUTE" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt| {
-                        as_micros_from_unix_epoch_utc(trunc_date_to_minute(dt))
+                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
+                        as_micros_from_local_datetime_tz(trunc_date_to_minute(dt), tz)
                     })
                 }
                 "SECOND" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt| {
-                        as_micros_from_unix_epoch_utc(trunc_date_to_second(dt))
+                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
+                        as_micros_from_local_datetime_tz(trunc_date_to_second(dt), tz)
                     })
                 }
                 "MILLISECOND" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt| {
-                        as_micros_from_unix_epoch_utc(trunc_date_to_ms(dt))
+                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
+                        as_micros_from_local_datetime_tz(trunc_date_to_ms(dt), tz)
                     })
                 }
                 "MICROSECOND" => {
-                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt| {
-                        as_micros_from_unix_epoch_utc(trunc_date_to_microsec(dt))
+                    as_timestamp_tz_with_op::<&PrimitiveArray<T>, T, _>(iter, builder, tz, |dt, tz| {
+                        as_micros_from_local_datetime_tz(trunc_date_to_microsec(dt), tz)
                     })
                 }
                 _ => Err(SparkError::Internal(format!(
@@ -687,58 +712,58 @@ macro_rules! timestamp_trunc_array_fmt_helper {
             "lengths of values array and format array must be the same"
         );
         match $datatype {
-            DataType::Timestamp(TimeUnit::Microsecond, Some(tz)) => {
-                let tz: Tz = tz.parse()?;
+            DataType::Timestamp(TimeUnit::Microsecond, Some(tz_str)) => {
+                let tz: Tz = tz_str.parse()?;
                 for (index, val) in iter.enumerate() {
                     let op_result = match $formats.value(index).to_uppercase().as_str() {
                         "YEAR" | "YYYY" | "YY" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt| {
-                                as_micros_from_unix_epoch_utc(trunc_date_to_year(dt))
+                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
+                                as_micros_from_local_datetime_tz(trunc_date_to_year(dt), tz)
                             })
                         }
                         "QUARTER" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt| {
-                                as_micros_from_unix_epoch_utc(trunc_date_to_quarter(dt))
+                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
+                                as_micros_from_local_datetime_tz(trunc_date_to_quarter(dt), tz)
                             })
                         }
                         "MONTH" | "MON" | "MM" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt| {
-                                as_micros_from_unix_epoch_utc(trunc_date_to_month(dt))
+                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
+                                as_micros_from_local_datetime_tz(trunc_date_to_month(dt), tz)
                             })
                         }
                         "WEEK" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt| {
-                                as_micros_from_unix_epoch_utc(trunc_date_to_week(dt))
+                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
+                                as_micros_from_local_datetime_tz(trunc_date_to_week(dt), tz)
                             })
                         }
                         "DAY" | "DD" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt| {
-                                as_micros_from_unix_epoch_utc(trunc_date_to_day(dt))
+                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
+                                as_micros_from_local_datetime_tz(trunc_date_to_day(dt), tz)
                             })
                         }
                         "HOUR" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt| {
-                                as_micros_from_unix_epoch_utc(trunc_date_to_hour(dt))
+                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
+                                as_micros_from_local_datetime_tz(trunc_date_to_hour(dt), tz)
                             })
                         }
                         "MINUTE" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt| {
-                                as_micros_from_unix_epoch_utc(trunc_date_to_minute(dt))
+                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
+                                as_micros_from_local_datetime_tz(trunc_date_to_minute(dt), tz)
                             })
                         }
                         "SECOND" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt| {
-                                as_micros_from_unix_epoch_utc(trunc_date_to_second(dt))
+                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
+                                as_micros_from_local_datetime_tz(trunc_date_to_second(dt), tz)
                             })
                         }
                         "MILLISECOND" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt| {
-                                as_micros_from_unix_epoch_utc(trunc_date_to_ms(dt))
+                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
+                                as_micros_from_local_datetime_tz(trunc_date_to_ms(dt), tz)
                             })
                         }
                         "MICROSECOND" => {
-                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt| {
-                                as_micros_from_unix_epoch_utc(trunc_date_to_microsec(dt))
+                            as_timestamp_tz_with_op_single::<T, _>(val, &mut builder, &tz, |dt, tz| {
+                                as_micros_from_local_datetime_tz(trunc_date_to_microsec(dt), tz)
                             })
                         }
                         _ => Err(SparkError::Internal(format!(
@@ -748,7 +773,7 @@ macro_rules! timestamp_trunc_array_fmt_helper {
                     };
                     op_result?
                 }
-                Ok(builder.finish())
+                Ok(builder.finish().with_timezone(tz_str.as_ref()))
             }
             dt => {
                 return_compute_error_with!(
@@ -1148,5 +1173,38 @@ mod tests {
         } else {
             unreachable!()
         }
+    }
+
+    /// Verify that timestamp_trunc produces correct results across DST boundaries.
+    ///
+    /// America/Denver switches between MST (UTC-7) and MDT (UTC-6). A timestamp in November
+    /// (MST) truncated to "quarter" should land on October 1 00:00:00 MDT (UTC-6), not
+    /// October 1 00:00:00 MST (UTC-7). This tests the DST-aware re-application of timezone
+    /// in as_micros_from_local_datetime_tz.
+    #[test]
+    fn test_timestamp_trunc_dst_boundary() {
+        // 2023-11-15 18:30:00 UTC = 2023-11-15 11:30:00 MST (UTC-7, winter time)
+        // Truncated to QUARTER -> 2023-10-01 00:00:00 MDT (UTC-6, since Oct 1 is still MDT)
+        // Expected UTC: 2023-10-01 06:00:00 UTC
+        let ts_utc_micros: i64 = 1700069400 * 1_000_000; // 2023-11-15 18:30:00 UTC
+        let array =
+            TimestampMicrosecondArray::from(vec![ts_utc_micros]).with_timezone("America/Denver");
+
+        let result = timestamp_trunc(&array, "QUARTER".to_string()).unwrap();
+        // 2023-10-01 00:00:00 MDT = 2023-10-01 06:00:00 UTC (MDT is UTC-6)
+        let expected_utc_micros: i64 = 1696140000 * 1_000_000;
+        assert_eq!(
+            result.value(0),
+            expected_utc_micros,
+            "Expected 2023-10-01 06:00:00 UTC (MDT), got wrong offset"
+        );
+        // Output array should carry the timezone annotation
+        assert_eq!(
+            result.data_type(),
+            &arrow::datatypes::DataType::Timestamp(
+                arrow::datatypes::TimeUnit::Microsecond,
+                Some("America/Denver".into())
+            )
+        );
     }
 }

--- a/spark/src/main/scala/org/apache/comet/serde/datetime.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/datetime.scala
@@ -19,6 +19,7 @@
 
 package org.apache.comet.serde
 
+import java.time.ZoneId
 import java.util.Locale
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, DateAdd, DateDiff, DateFormatClass, DateSub, DayOfMonth, DayOfWeek, DayOfYear, Days, GetDateField, Hour, LastDay, Literal, MakeDate, Minute, Month, NextDay, Quarter, Second, TruncDate, TruncTimestamp, UnixDate, UnixTimestamp, WeekDay, WeekOfYear, Year}
@@ -441,17 +442,16 @@ object CometTruncTimestamp extends CometExpressionSerde[TruncTimestamp] {
 
   override def getSupportLevel(expr: TruncTimestamp): SupportLevel = {
     val timezone = expr.timeZoneId.getOrElse("UTC")
-    val isUtc = timezone == "UTC" || timezone == "Etc/UTC"
     expr.format match {
       case Literal(fmt: UTF8String, _) =>
         if (supportedFormats.contains(fmt.toString.toLowerCase(Locale.ROOT))) {
-          if (isUtc) {
-            Compatible()
-          } else {
+          if (hasNonHourDst(timezone)) {
             Incompatible(
               Some(
-                s"Incorrect results in non-UTC timezone '$timezone'" +
+                s"Timezone '$timezone' has non-1-hour DST transitions" +
                   " (https://github.com/apache/datafusion-comet/issues/2649)"))
+          } else {
+            Compatible()
           }
         } else {
           Unsupported(Some(s"Format $fmt is not supported"))
@@ -459,6 +459,21 @@ object CometTruncTimestamp extends CometExpressionSerde[TruncTimestamp] {
       case _ =>
         Incompatible(
           Some("Invalid format strings will throw an exception instead of returning NULL"))
+    }
+  }
+
+  /** Returns true if the timezone has any DST transition that is not a multiple of 1 hour. */
+  private def hasNonHourDst(timezone: String): Boolean = {
+    import scala.jdk.CollectionConverters._
+    try {
+      val rules = ZoneId.of(timezone).getRules
+      rules.getTransitionRules.asScala.exists { rule =>
+        val deltaSecs = math.abs(
+          rule.getOffsetAfter.getTotalSeconds - rule.getOffsetBefore.getTotalSeconds)
+        deltaSecs % 3600 != 0
+      }
+    } catch {
+      case _: Exception => false
     }
   }
 

--- a/spark/src/main/scala/org/apache/comet/serde/datetime.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/datetime.scala
@@ -468,8 +468,8 @@ object CometTruncTimestamp extends CometExpressionSerde[TruncTimestamp] {
     try {
       val rules = ZoneId.of(timezone).getRules
       rules.getTransitionRules.asScala.exists { rule =>
-        val deltaSecs = math.abs(
-          rule.getOffsetAfter.getTotalSeconds - rule.getOffsetBefore.getTotalSeconds)
+        val deltaSecs =
+          math.abs(rule.getOffsetAfter.getTotalSeconds - rule.getOffsetBefore.getTotalSeconds)
         deltaSecs % 3600 != 0
       }
     } catch {

--- a/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
@@ -72,7 +72,8 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
     for (timezone <- Seq("UTC", "America/Los_Angeles", "Europe/London")) {
       withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> timezone) {
         for (format <- supportedFormats) {
-          checkSparkAnswerAndOperator(s"SELECT c0, date_trunc('$format', c0) from tbl order by c0")
+          checkSparkAnswerAndOperator(
+            s"SELECT c0, date_trunc('$format', c0) from tbl order by c0")
         }
         for (format <- unsupportedFormats) {
           // Comet should fall back to Spark for unsupported or invalid formats

--- a/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
@@ -69,39 +69,10 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
 
     createTimestampTestData.createOrReplaceTempView("tbl")
 
-    // TODO test fails with non-UTC timezone
-    // https://github.com/apache/datafusion-comet/issues/2649
-    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
-      for (format <- supportedFormats) {
-        checkSparkAnswerAndOperator(s"SELECT c0, date_trunc('$format', c0) from tbl order by c0")
-      }
-      for (format <- unsupportedFormats) {
-        // Comet should fall back to Spark for unsupported or invalid formats
-        checkSparkAnswerAndFallbackReason(
-          s"SELECT c0, date_trunc('$format', c0) from tbl order by c0",
-          s"Format $format is not supported")
-      }
-      // Comet should fall back to Spark if format is not a literal
-      checkSparkAnswerAndFallbackReason(
-        "SELECT c0, date_trunc(fmt, c0) from tbl order by c0, fmt",
-        "Invalid format strings will throw an exception instead of returning NULL")
-    }
-  }
-
-  test("date_trunc (TruncTimestamp) - reading from Parquet") {
-    val supportedFormats = CometTruncTimestamp.supportedFormats
-    val unsupportedFormats = Seq("invalid")
-
-    withTempDir { path =>
-      createTimestampTestData.write.mode(SaveMode.Overwrite).parquet(path.toString)
-      spark.read.parquet(path.toString).createOrReplaceTempView("tbl")
-
-      // TODO test fails with non-UTC timezone
-      // https://github.com/apache/datafusion-comet/issues/2649
-      withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+    for (timezone <- Seq("UTC", "America/Los_Angeles", "Europe/London")) {
+      withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> timezone) {
         for (format <- supportedFormats) {
-          checkSparkAnswerAndOperator(
-            s"SELECT c0, date_trunc('$format', c0) from tbl order by c0")
+          checkSparkAnswerAndOperator(s"SELECT c0, date_trunc('$format', c0) from tbl order by c0")
         }
         for (format <- unsupportedFormats) {
           // Comet should fall back to Spark for unsupported or invalid formats
@@ -113,6 +84,35 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
         checkSparkAnswerAndFallbackReason(
           "SELECT c0, date_trunc(fmt, c0) from tbl order by c0, fmt",
           "Invalid format strings will throw an exception instead of returning NULL")
+      }
+    }
+  }
+
+  test("date_trunc (TruncTimestamp) - reading from Parquet") {
+    val supportedFormats = CometTruncTimestamp.supportedFormats
+    val unsupportedFormats = Seq("invalid")
+
+    withTempDir { path =>
+      createTimestampTestData.write.mode(SaveMode.Overwrite).parquet(path.toString)
+      spark.read.parquet(path.toString).createOrReplaceTempView("tbl")
+
+      for (timezone <- Seq("UTC", "America/Los_Angeles", "Europe/London")) {
+        withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> timezone) {
+          for (format <- supportedFormats) {
+            checkSparkAnswerAndOperator(
+              s"SELECT c0, date_trunc('$format', c0) from tbl order by c0")
+          }
+          for (format <- unsupportedFormats) {
+            // Comet should fall back to Spark for unsupported or invalid formats
+            checkSparkAnswerAndFallbackReason(
+              s"SELECT c0, date_trunc('$format', c0) from tbl order by c0",
+              s"Format $format is not supported")
+          }
+          // Comet should fall back to Spark if format is not a literal
+          checkSparkAnswerAndFallbackReason(
+            "SELECT c0, date_trunc(fmt, c0) from tbl order by c0, fmt",
+            "Invalid format strings will throw an exception instead of returning NULL")
+        }
       }
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #2649.

## Rationale for this change

`date_trunc` (TruncTimestamp) was producing wrong results for non-UTC timezones due to two bugs:

1. **DST offset bug**: The truncation functions (`trunc_date_to_year`, `trunc_date_to_quarter`, etc.) modify date/time fields on a `DateTime<Tz>` while preserving the *original* UTC offset. When a DST transition falls between the input timestamp and the truncated result (e.g. truncating a November timestamp to the start of Q4 in October in America/Denver), the offset at the truncated date is different, causing results off by 1 hour.

2. **Missing timezone annotation**: `TimestampTruncExpr::data_type()` returned `Timestamp(Microsecond, None)` instead of `Timestamp(Microsecond, Some(tz))`, causing schema mismatches like `RowConverter column schema mismatch, expected Timestamp(Microsecond, Some("America/Denver")) got Timestamp(Microsecond, Some("UTC"))` during shuffle/sort.

## What changes are included in this PR?

**`native/spark-expr/src/kernels/temporal.rs`**:
- Replaced `as_micros_from_unix_epoch_utc` with `as_micros_from_local_datetime_tz` which, after truncation, extracts the naive local datetime and re-applies the timezone via `tz.from_local_datetime()` — performing a fresh DST lookup matching Java's `ZonedDateTime.of()` behavior.
- Updated `as_timestamp_tz_with_op` and `as_timestamp_tz_with_op_single` to pass `&Tz` to their closures and return timezone-annotated output arrays.
- Updated the `timestamp_trunc_array_fmt_helper\!` macro the same way.
- Timezones with non-1-hour DST transitions (e.g. `Australia/Lord_Howe` at 30 min) are marked `Incompatible` at the Scala planning layer and fall back to Spark, keeping the Rust `LocalResult::None` handling simple.

**`native/spark-expr/src/datetime_funcs/timestamp_trunc.rs`**:
- Fixed `data_type()` to return `Timestamp(Microsecond, Some(tz))` with the expression's timezone.

**`spark/src/main/scala/org/apache/comet/serde/datetime.scala`**:
- Removed the blanket `Incompatible` guard for all non-UTC timezones.
- Added `hasNonHourDst()` using `ZoneId.getRules().getTransitionRules()` to fall back to Spark only for the rare timezones with non-1-hour DST transitions.

**`spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala`**:
- Removed the UTC-only restriction; tests now run with `UTC`, `America/Los_Angeles`, and `Europe/London`.

## How are these changes tested?

- New Rust unit test `test_timestamp_trunc_dst_boundary` verifies a concrete DST boundary case: a November timestamp in `America/Denver` (MST, UTC-7) truncated to `QUARTER` lands on `2023-10-01 00:00:00 MDT` (UTC-6), not `00:00:00 MST` (UTC-7). The old code would return a result 1 hour later than correct.
- Existing JVM integration tests in `CometTemporalExpressionSuite` now run against multiple non-UTC timezones (`America/Los_Angeles`, `Europe/London`) in addition to UTC, comparing Comet output against Spark for all supported `date_trunc` formats.