### PR TITLE
feat: use byte-based target batch size for shuffle IPC blocks

### DIFF
--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -537,10 +537,11 @@ object CometConf extends ShimCometConf {
   val COMET_SHUFFLE_TARGET_BATCH_BYTES: ConfigEntry[Long] =
     conf(s"$COMET_EXEC_CONFIG_PREFIX.shuffle.targetBatchBytes")
       .category(CATEGORY_SHUFFLE)
-      .doc("Target batch size in bytes for coalescing small batches before writing shuffle " +
-        "IPC blocks. Using a byte-based threshold instead of a fixed row count ensures that " +
-        "narrow schemas produce reasonably sized blocks. Larger values produce fewer, bigger " +
-        "blocks which reduces per-block schema overhead.")
+      .doc(
+        "Target batch size in bytes for coalescing small batches before writing shuffle " +
+          "IPC blocks. Using a byte-based threshold instead of a fixed row count ensures that " +
+          "narrow schemas produce reasonably sized blocks. Larger values produce fewer, bigger " +
+          "blocks which reduces per-block schema overhead.")
       .bytesConf(ByteUnit.MiB)
       .checkValue(v => v > 0, "Target batch bytes must be positive")
       .createWithDefault(1)

--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -534,6 +534,17 @@ object CometConf extends ShimCometConf {
       .checkValue(v => v > 0, "Write buffer size must be positive")
       .createWithDefault(1)
 
+  val COMET_SHUFFLE_TARGET_BATCH_BYTES: ConfigEntry[Long] =
+    conf(s"$COMET_EXEC_CONFIG_PREFIX.shuffle.targetBatchBytes")
+      .category(CATEGORY_SHUFFLE)
+      .doc("Target batch size in bytes for coalescing small batches before writing shuffle " +
+        "IPC blocks. Using a byte-based threshold instead of a fixed row count ensures that " +
+        "narrow schemas produce reasonably sized blocks. Larger values produce fewer, bigger " +
+        "blocks which reduces per-block schema overhead.")
+      .bytesConf(ByteUnit.MiB)
+      .checkValue(v => v > 0, "Target batch bytes must be positive")
+      .createWithDefault(1)
+
   val COMET_SHUFFLE_PREFER_DICTIONARY_RATIO: ConfigEntry[Double] = conf(
     "spark.comet.shuffle.preferDictionary.ratio")
     .category(CATEGORY_SHUFFLE)

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -1371,6 +1371,11 @@ impl PhysicalPlanner {
                 }?;
 
                 let write_buffer_size = writer.write_buffer_size as usize;
+                let target_batch_bytes = if writer.target_batch_bytes > 0 {
+                    writer.target_batch_bytes as usize
+                } else {
+                    datafusion_comet_shuffle::DEFAULT_TARGET_BATCH_BYTES
+                };
                 let shuffle_writer = Arc::new(ShuffleWriterExec::try_new(
                     Arc::clone(&child.native_plan),
                     partitioning,
@@ -1379,6 +1384,7 @@ impl PhysicalPlanner {
                     writer.output_index_file.clone(),
                     writer.tracing_enabled,
                     write_buffer_size,
+                    target_batch_bytes,
                 )?);
 
                 Ok((

--- a/native/proto/src/proto/operator.proto
+++ b/native/proto/src/proto/operator.proto
@@ -294,6 +294,10 @@ message ShuffleWriter {
   // Size of the write buffer in bytes used when writing shuffle data to disk.
   // Larger values may improve write performance but use more memory.
   int32 write_buffer_size = 8;
+  // Target batch size in bytes for coalescing small batches before writing IPC blocks.
+  // Larger values produce fewer, bigger blocks which reduces per-block schema overhead.
+  // A value of 0 means use the default (1 MiB).
+  int32 target_batch_bytes = 9;
 }
 
 message ParquetWriter {

--- a/native/shuffle/benches/shuffle_writer.rs
+++ b/native/shuffle/benches/shuffle_writer.rs
@@ -153,6 +153,7 @@ fn create_shuffle_writer_exec(
         "/tmp/index.out".to_string(),
         false,
         1024 * 1024,
+        1024 * 1024,
     )
     .unwrap()
 }

--- a/native/shuffle/src/bin/shuffle_bench.rs
+++ b/native/shuffle/src/bin/shuffle_bench.rs
@@ -106,6 +106,10 @@ struct Args {
     #[arg(long, default_value_t = 1048576)]
     write_buffer_size: usize,
 
+    /// Target batch size in bytes for coalescing small batches before writing IPC blocks
+    #[arg(long, default_value_t = 1048576)]
+    target_batch_bytes: usize,
+
     /// Limit rows processed per iteration (0 = no limit)
     #[arg(long, default_value_t = 0)]
     limit: usize,
@@ -410,6 +414,7 @@ fn run_shuffle_write(
             args.batch_size,
             args.memory_limit,
             args.write_buffer_size,
+            args.target_batch_bytes,
             args.limit,
             data_file.to_string(),
             index_file.to_string(),
@@ -433,6 +438,7 @@ async fn execute_shuffle_write(
     batch_size: usize,
     memory_limit: Option<usize>,
     write_buffer_size: usize,
+    target_batch_bytes: usize,
     limit: usize,
     data_file: String,
     index_file: String,
@@ -477,6 +483,7 @@ async fn execute_shuffle_write(
         index_file,
         false,
         write_buffer_size,
+        target_batch_bytes,
     )
     .expect("Failed to create ShuffleWriterExec");
 
@@ -540,6 +547,7 @@ fn run_concurrent_shuffle_writes(
             let batch_size = args.batch_size;
             let memory_limit = args.memory_limit;
             let write_buffer_size = args.write_buffer_size;
+            let target_batch_bytes = args.target_batch_bytes;
             let limit = args.limit;
 
             handles.push(tokio::spawn(async move {
@@ -550,6 +558,7 @@ fn run_concurrent_shuffle_writes(
                     batch_size,
                     memory_limit,
                     write_buffer_size,
+                    target_batch_bytes,
                     limit,
                     data_file,
                     index_file,

--- a/native/shuffle/src/lib.rs
+++ b/native/shuffle/src/lib.rs
@@ -28,3 +28,8 @@ pub use comet_partitioning::CometPartitioning;
 pub use ipc::read_ipc_compressed;
 pub use shuffle_writer::ShuffleWriterExec;
 pub use writers::{CompressionCodec, ShuffleBlockWriter};
+
+/// Default target batch size in bytes for coalescing small batches before writing
+/// shuffle IPC blocks. Using a byte-based threshold instead of a row count ensures
+/// that narrow schemas produce reasonably sized blocks.
+pub const DEFAULT_TARGET_BATCH_BYTES: usize = 1024 * 1024; // 1 MiB

--- a/native/shuffle/src/partitioners/multi_partition.rs
+++ b/native/shuffle/src/partitioners/multi_partition.rs
@@ -118,8 +118,10 @@ pub(crate) struct MultiPartitionShuffleRepartitioner {
     metrics: ShufflePartitionerMetrics,
     /// Reused scratch space for computing partition indices
     scratch: ScratchSpace,
-    /// The configured batch size
+    /// The configured batch size in rows (used for scratch space sizing and input slicing)
     batch_size: usize,
+    /// Target batch size in bytes for coalescing before writing IPC blocks
+    target_batch_bytes: usize,
     /// Reservation for repartitioning
     reservation: MemoryReservation,
     tracing_enabled: bool,
@@ -138,6 +140,7 @@ impl MultiPartitionShuffleRepartitioner {
         metrics: ShufflePartitionerMetrics,
         runtime: Arc<RuntimeEnv>,
         batch_size: usize,
+        target_batch_bytes: usize,
         codec: CompressionCodec,
         tracing_enabled: bool,
         write_buffer_size: usize,
@@ -187,6 +190,7 @@ impl MultiPartitionShuffleRepartitioner {
             metrics,
             scratch,
             batch_size,
+            target_batch_bytes,
             reservation,
             tracing_enabled,
             write_buffer_size,
@@ -441,13 +445,13 @@ impl MultiPartitionShuffleRepartitioner {
         encode_time: &Time,
         write_time: &Time,
         write_buffer_size: usize,
-        batch_size: usize,
+        target_batch_bytes: usize,
     ) -> datafusion::common::Result<()> {
         let mut buf_batch_writer = BufBatchWriter::new(
             shuffle_block_writer,
             output_data,
             write_buffer_size,
-            batch_size,
+            target_batch_bytes,
         );
         for batch in partition_iter {
             let batch = batch?;
@@ -512,7 +516,7 @@ impl MultiPartitionShuffleRepartitioner {
                     &self.runtime,
                     &self.metrics,
                     self.write_buffer_size,
-                    self.batch_size,
+                    self.target_batch_bytes,
                 )?;
             }
 
@@ -599,7 +603,7 @@ impl ShufflePartitioner for MultiPartitionShuffleRepartitioner {
                     &self.metrics.encode_time,
                     &self.metrics.write_time,
                     self.write_buffer_size,
-                    self.batch_size,
+                    self.target_batch_bytes,
                 )?;
             }
 

--- a/native/shuffle/src/partitioners/single_partition.rs
+++ b/native/shuffle/src/partitioners/single_partition.rs
@@ -28,17 +28,16 @@ use tokio::time::Instant;
 
 /// A partitioner that writes all shuffle data to a single file and a single index file
 pub(crate) struct SinglePartitionShufflePartitioner {
-    // output_data_file: File,
     output_data_writer: BufBatchWriter<ShuffleBlockWriter, File>,
     output_index_path: String,
-    /// Batches that are smaller than the batch size and to be concatenated
+    /// Batches that are smaller than the target byte size and to be concatenated
     buffered_batches: Vec<RecordBatch>,
-    /// Number of rows in the concatenating batches
-    num_buffered_rows: usize,
+    /// Accumulated byte size of buffered batches
+    buffered_bytes: usize,
     /// Metrics for the repartitioner
     metrics: ShufflePartitionerMetrics,
-    /// The configured batch size
-    batch_size: usize,
+    /// Target batch size in bytes for coalescing
+    target_batch_bytes: usize,
 }
 
 impl SinglePartitionShufflePartitioner {
@@ -47,7 +46,7 @@ impl SinglePartitionShufflePartitioner {
         output_index_path: String,
         schema: SchemaRef,
         metrics: ShufflePartitionerMetrics,
-        batch_size: usize,
+        target_batch_bytes: usize,
         codec: CompressionCodec,
         write_buffer_size: usize,
     ) -> datafusion::common::Result<Self> {
@@ -63,23 +62,23 @@ impl SinglePartitionShufflePartitioner {
             shuffle_block_writer,
             output_data_file,
             write_buffer_size,
-            batch_size,
+            target_batch_bytes,
         );
 
         Ok(Self {
             output_data_writer,
             output_index_path,
             buffered_batches: vec![],
-            num_buffered_rows: 0,
+            buffered_bytes: 0,
             metrics,
-            batch_size,
+            target_batch_bytes,
         })
     }
 
     /// Add a batch to the buffer of the partitioner, these buffered batches will be concatenated
-    /// and written to the output data file when the number of rows in the buffer reaches the batch size.
+    /// and written to the output data file when the accumulated byte size reaches the target.
     fn add_buffered_batch(&mut self, batch: RecordBatch) {
-        self.num_buffered_rows += batch.num_rows();
+        self.buffered_bytes += batch.get_array_memory_size();
         self.buffered_batches.push(batch);
     }
 
@@ -89,14 +88,14 @@ impl SinglePartitionShufflePartitioner {
             Ok(None)
         } else if self.buffered_batches.len() == 1 {
             let batch = self.buffered_batches.remove(0);
-            self.num_buffered_rows = 0;
+            self.buffered_bytes = 0;
             Ok(Some(batch))
         } else {
             let schema = &self.buffered_batches[0].schema();
             match arrow::compute::concat_batches(schema, self.buffered_batches.iter()) {
                 Ok(concatenated) => {
                     self.buffered_batches.clear();
-                    self.num_buffered_rows = 0;
+                    self.buffered_bytes = 0;
                     Ok(Some(concatenated))
                 }
                 Err(e) => Err(DataFusionError::ArrowError(
@@ -115,10 +114,13 @@ impl ShufflePartitioner for SinglePartitionShufflePartitioner {
         let num_rows = batch.num_rows();
 
         if num_rows > 0 {
-            self.metrics.data_size.add(batch.get_array_memory_size());
+            let batch_bytes = batch.get_array_memory_size();
+            self.metrics.data_size.add(batch_bytes);
             self.metrics.baseline.record_output(num_rows);
 
-            if num_rows >= self.batch_size || num_rows + self.num_buffered_rows > self.batch_size {
+            if batch_bytes >= self.target_batch_bytes
+                || batch_bytes + self.buffered_bytes > self.target_batch_bytes
+            {
                 let concatenated_batch = self.concat_buffered_batches()?;
 
                 // Write the concatenated buffered batch
@@ -130,8 +132,8 @@ impl ShufflePartitioner for SinglePartitionShufflePartitioner {
                     )?;
                 }
 
-                if num_rows >= self.batch_size {
-                    // Write the new batch
+                if batch_bytes >= self.target_batch_bytes {
+                    // Write the new batch directly
                     self.output_data_writer.write(
                         &batch,
                         &self.metrics.encode_time,

--- a/native/shuffle/src/shuffle_writer.rs
+++ b/native/shuffle/src/shuffle_writer.rs
@@ -68,6 +68,9 @@ pub struct ShuffleWriterExec {
     tracing_enabled: bool,
     /// Size of the write buffer in bytes
     write_buffer_size: usize,
+    /// Target batch size in bytes for coalescing small batches before writing IPC blocks.
+    /// Larger values produce fewer, bigger blocks which reduces per-block schema overhead.
+    target_batch_bytes: usize,
 }
 
 impl ShuffleWriterExec {
@@ -81,6 +84,7 @@ impl ShuffleWriterExec {
         output_index_file: String,
         tracing_enabled: bool,
         write_buffer_size: usize,
+        target_batch_bytes: usize,
     ) -> Result<Self> {
         let cache = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(Arc::clone(&input.schema())),
@@ -99,6 +103,7 @@ impl ShuffleWriterExec {
             codec,
             tracing_enabled,
             write_buffer_size,
+            target_batch_bytes,
         })
     }
 }
@@ -159,6 +164,7 @@ impl ExecutionPlan for ShuffleWriterExec {
                 self.output_index_file.clone(),
                 self.tracing_enabled,
                 self.write_buffer_size,
+                self.target_batch_bytes,
             )?)),
             _ => panic!("ShuffleWriterExec wrong number of children"),
         }
@@ -186,6 +192,7 @@ impl ExecutionPlan for ShuffleWriterExec {
                     self.codec.clone(),
                     self.tracing_enabled,
                     self.write_buffer_size,
+                    self.target_batch_bytes,
                 )
                 .map_err(|e| ArrowError::ExternalError(Box::new(e))),
             )
@@ -206,6 +213,7 @@ async fn external_shuffle(
     codec: CompressionCodec,
     tracing_enabled: bool,
     write_buffer_size: usize,
+    target_batch_bytes: usize,
 ) -> Result<SendableRecordBatchStream> {
     with_trace_async("external_shuffle", tracing_enabled, || async {
         let schema = input.schema();
@@ -228,7 +236,7 @@ async fn external_shuffle(
                     output_index_file,
                     Arc::clone(&schema),
                     metrics,
-                    context.session_config().batch_size(),
+                    target_batch_bytes,
                     codec,
                     write_buffer_size,
                 )?)
@@ -242,6 +250,7 @@ async fn external_shuffle(
                 metrics,
                 context.runtime_env(),
                 context.session_config().batch_size(),
+                target_batch_bytes,
                 codec,
                 tracing_enabled,
                 write_buffer_size,
@@ -366,6 +375,7 @@ mod test {
             ShufflePartitionerMetrics::new(&metrics_set, 0),
             runtime_env,
             1024,
+            1024 * 1024, // target_batch_bytes: 1MB default
             CompressionCodec::Lz4Frame,
             false,
             1024 * 1024, // write_buffer_size: 1MB default
@@ -472,7 +482,8 @@ mod test {
                 "/tmp/data.out".to_string(),
                 "/tmp/index.out".to_string(),
                 false,
-                1024 * 1024, // write_buffer_size: 1MB default
+                1024 * 1024, // write_buffer_size
+                1024 * 1024, // target_batch_bytes
             )
             .unwrap();
 
@@ -531,6 +542,7 @@ mod test {
                 data_file.clone(),
                 index_file.clone(),
                 false,
+                1024 * 1024,
                 1024 * 1024,
             )
             .unwrap();
@@ -626,7 +638,7 @@ mod test {
         let encode_time = Time::default();
         let write_time = Time::default();
 
-        // Write with coalescing (batch_size=8192)
+        // Write with coalescing (target_batch_bytes=1MB)
         let mut coalesced_output = Vec::new();
         {
             let mut writer = ShuffleBlockWriter::try_new(schema.as_ref(), codec.clone()).unwrap();
@@ -634,7 +646,7 @@ mod test {
                 &mut writer,
                 Cursor::new(&mut coalesced_output),
                 1024 * 1024,
-                8192,
+                1024 * 1024,
             );
             for batch in &small_batches {
                 buf_writer.write(batch, &encode_time, &write_time).unwrap();
@@ -642,7 +654,7 @@ mod test {
             buf_writer.flush(&encode_time, &write_time).unwrap();
         }
 
-        // Write without coalescing (batch_size=1)
+        // Write without coalescing (target_batch_bytes=1 byte forces immediate flush)
         let mut uncoalesced_output = Vec::new();
         {
             let mut writer = ShuffleBlockWriter::try_new(schema.as_ref(), codec.clone()).unwrap();
@@ -736,6 +748,7 @@ mod test {
             index_file.to_str().unwrap().to_string(),
             false,
             1024 * 1024,
+            1024 * 1024,
         )
         .unwrap();
 
@@ -823,6 +836,7 @@ mod test {
             data_file.to_str().unwrap().to_string(),
             index_file.to_str().unwrap().to_string(),
             false,
+            1024 * 1024,
             1024 * 1024,
         )
         .unwrap();

--- a/native/shuffle/src/writers/buf_batch_writer.rs
+++ b/native/shuffle/src/writers/buf_batch_writer.rs
@@ -17,7 +17,6 @@
 
 use super::ShuffleBlockWriter;
 use arrow::array::RecordBatch;
-use arrow::compute::kernels::coalesce::BatchCoalescer;
 use datafusion::physical_plan::metrics::Time;
 use std::borrow::Borrow;
 use std::io::{Cursor, Seek, SeekFrom, Write};
@@ -26,19 +25,21 @@ use std::io::{Cursor, Seek, SeekFrom, Write};
 /// The record batches were first written by ShuffleBlockWriter into an internal buffer.
 /// Once the buffer exceeds the max size, the buffer will be flushed to the writer.
 ///
-/// Small batches are coalesced using Arrow's [`BatchCoalescer`] before serialization,
-/// producing exactly `batch_size`-row output batches to reduce per-block IPC schema overhead.
-/// The coalescer is lazily initialized on the first write.
+/// Small batches are coalesced based on a byte-size threshold before serialization,
+/// producing larger output batches to reduce per-block IPC schema overhead. This is
+/// especially beneficial for narrow schemas where a fixed row count would produce
+/// tiny blocks.
 pub(crate) struct BufBatchWriter<S: Borrow<ShuffleBlockWriter>, W: Write> {
     shuffle_block_writer: S,
     writer: W,
     buffer: Vec<u8>,
     buffer_max_size: usize,
-    /// Coalesces small batches into target_batch_size before serialization.
-    /// Lazily initialized on first write to capture the schema.
-    coalescer: Option<BatchCoalescer>,
-    /// Target batch size for coalescing
-    batch_size: usize,
+    /// Batches waiting to be coalesced and written
+    pending_batches: Vec<RecordBatch>,
+    /// Total memory size of pending batches in bytes
+    pending_bytes: usize,
+    /// Target batch size in bytes for coalescing
+    target_batch_bytes: usize,
 }
 
 impl<S: Borrow<ShuffleBlockWriter>, W: Write> BufBatchWriter<S, W> {
@@ -46,15 +47,16 @@ impl<S: Borrow<ShuffleBlockWriter>, W: Write> BufBatchWriter<S, W> {
         shuffle_block_writer: S,
         writer: W,
         buffer_max_size: usize,
-        batch_size: usize,
+        target_batch_bytes: usize,
     ) -> Self {
         Self {
             shuffle_block_writer,
             writer,
             buffer: vec![],
             buffer_max_size,
-            coalescer: None,
-            batch_size,
+            pending_batches: Vec::new(),
+            pending_bytes: 0,
+            target_batch_bytes,
         }
     }
 
@@ -64,23 +66,37 @@ impl<S: Borrow<ShuffleBlockWriter>, W: Write> BufBatchWriter<S, W> {
         encode_time: &Time,
         write_time: &Time,
     ) -> datafusion::common::Result<usize> {
-        let coalescer = self
-            .coalescer
-            .get_or_insert_with(|| BatchCoalescer::new(batch.schema(), self.batch_size));
-        coalescer.push_batch(batch.clone())?;
-
-        // Drain completed batches into a local vec so the coalescer borrow ends
-        // before we call write_batch_to_buffer (which borrows &mut self).
-        let mut completed = Vec::new();
-        while let Some(batch) = coalescer.next_completed_batch() {
-            completed.push(batch);
-        }
+        let batch_bytes = batch.get_array_memory_size();
+        self.pending_bytes += batch_bytes;
+        self.pending_batches.push(batch.clone());
 
         let mut bytes_written = 0;
-        for batch in &completed {
-            bytes_written += self.write_batch_to_buffer(batch, encode_time, write_time)?;
+        if self.pending_bytes >= self.target_batch_bytes {
+            bytes_written += self.flush_pending(encode_time, write_time)?;
         }
         Ok(bytes_written)
+    }
+
+    /// Concatenate pending batches and write as a single IPC block.
+    fn flush_pending(
+        &mut self,
+        encode_time: &Time,
+        write_time: &Time,
+    ) -> datafusion::common::Result<usize> {
+        if self.pending_batches.is_empty() {
+            return Ok(0);
+        }
+
+        let batch = if self.pending_batches.len() == 1 {
+            self.pending_batches.remove(0)
+        } else {
+            let schema = self.pending_batches[0].schema();
+            arrow::compute::concat_batches(&schema, self.pending_batches.iter())?
+        };
+        self.pending_batches.clear();
+        self.pending_bytes = 0;
+
+        self.write_batch_to_buffer(&batch, encode_time, write_time)
     }
 
     /// Serialize a single batch into the byte buffer, flushing to the writer if needed.
@@ -111,17 +127,7 @@ impl<S: Borrow<ShuffleBlockWriter>, W: Write> BufBatchWriter<S, W> {
         encode_time: &Time,
         write_time: &Time,
     ) -> datafusion::common::Result<()> {
-        // Finish any remaining buffered rows in the coalescer
-        let mut remaining = Vec::new();
-        if let Some(coalescer) = &mut self.coalescer {
-            coalescer.finish_buffered_batch()?;
-            while let Some(batch) = coalescer.next_completed_batch() {
-                remaining.push(batch);
-            }
-        }
-        for batch in &remaining {
-            self.write_batch_to_buffer(batch, encode_time, write_time)?;
-        }
+        self.flush_pending(encode_time, write_time)?;
 
         // Flush the byte buffer to the underlying writer
         let mut write_timer = write_time.timer();

--- a/native/shuffle/src/writers/spill.rs
+++ b/native/shuffle/src/writers/spill.rs
@@ -81,7 +81,7 @@ impl PartitionWriter {
         runtime: &RuntimeEnv,
         metrics: &ShufflePartitionerMetrics,
         write_buffer_size: usize,
-        batch_size: usize,
+        target_batch_bytes: usize,
     ) -> datafusion::common::Result<usize> {
         if let Some(batch) = iter.next() {
             self.ensure_spill_file_created(runtime)?;
@@ -91,7 +91,7 @@ impl PartitionWriter {
                     &mut self.shuffle_block_writer,
                     &mut self.spill_file.as_mut().unwrap().file,
                     write_buffer_size,
-                    batch_size,
+                    target_batch_bytes,
                 );
                 let mut bytes_written =
                     buf_batch_writer.write(&batch?, &metrics.encode_time, &metrics.write_time)?;

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
@@ -191,7 +191,9 @@ class CometNativeShuffleWriter[K, V](
       shuffleWriterBuilder.setCompressionLevel(
         CometConf.COMET_EXEC_SHUFFLE_COMPRESSION_ZSTD_LEVEL.get)
       shuffleWriterBuilder.setWriteBufferSize(
-        CometConf.COMET_SHUFFLE_WRITE_BUFFER_SIZE.get().max(Int.MaxValue).toInt)
+        CometConf.COMET_SHUFFLE_WRITE_BUFFER_SIZE.get().min(Int.MaxValue).toInt)
+      shuffleWriterBuilder.setTargetBatchBytes(
+        CometConf.COMET_SHUFFLE_TARGET_BATCH_BYTES.get().min(Int.MaxValue).toInt)
 
       outputPartitioning match {
         case p if isSinglePartitioning(p) =>


### PR DESCRIPTION
## Which issue does this PR close?

Partial fix for #3882

## Rationale for this change

The native shuffle writer currently uses a row-based target batch size of 8192 rows for coalescing small batches before writing IPC blocks. For narrow schemas (few columns, small data types), this produces tiny blocks with disproportionate per-block IPC schema overhead.

A byte-based threshold ensures reasonably sized blocks regardless of schema width, improving shuffle write efficiency for narrow schemas without negatively impacting wide schemas.

## What changes are included in this PR?

- Replace Arrow's `BatchCoalescer` (row-based) with byte-based accumulation in `BufBatchWriter` — batches are buffered until their total memory size reaches the target, then concatenated and written as a single IPC block
- Switch `SinglePartitionShufflePartitioner` buffering from row-count to byte-size threshold
- Add `target_batch_bytes` parameter to `MultiPartitionShuffleRepartitioner`, while keeping the row-based `batch_size` for scratch space sizing and input batch slicing (which is about processing chunk limits, not output block size)
- Add `COMET_SHUFFLE_TARGET_BATCH_BYTES` config (`spark.comet.exec.shuffle.targetBatchBytes`, default 1 MiB)
- Add `target_batch_bytes` field to `ShuffleWriter` protobuf message
- Add `--target-batch-bytes` CLI arg to the standalone shuffle benchmark tool
- Fix bug: `COMET_SHUFFLE_WRITE_BUFFER_SIZE` used `.max(Int.MaxValue)` instead of `.min(Int.MaxValue)` when converting Long to Int for protobuf, which always sent 2GB regardless of the configured value

## How are these changes tested?

Existing shuffle tests (19 tests) all pass. The `test_batch_coalescing_reduces_size` test validates that byte-based coalescing still produces smaller output than no coalescing.