### PR TITLE
fix: remove spurious .flatten call that garbled SortMergeJoin fallback messages

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -2043,7 +2043,7 @@ object CometSortMergeJoinExec extends CometOperatorSerde[SortMergeJoinExec] {
     }
 
     if (errorMsgs.nonEmpty) {
-      withInfo(join, errorMsgs.flatten.mkString("\n"))
+      withInfo(join, errorMsgs.mkString("\n"))
       return None
     }
 


### PR DESCRIPTION
## Summary

Closes #1900
Closes #3967

When `SortMergeJoin` falls back to Spark due to an unsupported join key type (e.g. `TimestampType`), the fallback message was rendered as a garbled list of individual characters like `[COMET: e, s, n, j, y, T, t, ...]` instead of the expected `[COMET: Unsupported join key type TimestampType on key: <col>]`.

**Root cause:** `join.leftKeys.flatMap { ... }` already returns a `Seq[String]` (the `flatMap` unwraps the `Option[String]`). Calling `.flatten` again on a `Seq[String]` triggers Scala's implicit `String → Iterable[Char]` conversion, exploding each message string into individual characters. The fix removes the redundant `.flatten` call.

## Test plan

- [ ] Manually verify fallback message is readable when a `SortMergeJoin` has an unsupported key type such as `TimestampType`

🤖 Generated with [Claude Code](https://claude.com/claude-code)