### PR TITLE
docs: Add documentation on Spark 4 limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ benefits of Comet's acceleration capabilities without disrupting your Spark appl
 
 ## Getting Started
 
-Comet supports Apache Spark 3.4 and 3.5, and provides experimental support for Spark 4.0. See the
+Comet supports Apache Spark 3.4, 3.5, and 4.0. See the
 [installation guide](https://datafusion.apache.org/comet/user-guide/installation.html) for the detailed
 version, Java, and Scala compatibility matrix.
 

--- a/docs/source/contributor-guide/roadmap.md
+++ b/docs/source/contributor-guide/roadmap.md
@@ -34,8 +34,8 @@ encryption) to the reader.
 
 ### Spark 4.0 Support
 
-Comet has experimental support for Spark 4.0, but there is more work to do ([#1637]), such as enabling
-more Spark SQL tests and fully implementing ANSI support ([#313]) for all supported expressions.
+Comet fully supports Spark 4.0. There is ongoing work to fully implement ANSI support ([#313]) for all
+supported expressions and to address remaining [Spark 4.0-specific limitations](../../user-guide/latest/compatibility.md#spark-40-limitations).
 
 [#313]: https://github.com/apache/datafusion-comet/issues/313
 [#1637]: https://github.com/apache/datafusion-comet/issues/1637

--- a/docs/source/user-guide/latest/compatibility.md
+++ b/docs/source/user-guide/latest/compatibility.md
@@ -125,6 +125,23 @@ achieves the same semantic goals:
 The only difference is that Comet's partition assignments will differ from Spark's. When results are sorted,
 they will be identical to Spark. Unsorted results may have different row ordering.
 
+## Spark 4.0 Limitations
+
+The following limitations apply specifically when running Comet with Spark 4.0. These represent new Spark
+4.0 features that Comet does not yet support. Queries that use these features will fall back to Spark.
+
+### Variant Type
+
+Comet does not yet support the Variant data type introduced in Spark 4.0. All variant-related operations
+will fall back to Spark. Tracking issue: [#2209](https://github.com/apache/datafusion-comet/issues/2209)
+
+### Parquet Type Widening
+
+Comet's native Parquet reader does not support Spark 4.0's type widening feature, which allows reading
+Parquet columns whose types have been widened (e.g., `int` to `long`, `float` to `double`,
+`date` to `timestamp_ntz`). These reads will fall back to Spark.
+Tracking issue: [#3321](https://github.com/apache/datafusion-comet/issues/3321)
+
 ## Cast
 
 Cast operations in Comet fall into three levels of support:

--- a/docs/source/user-guide/latest/installation.md
+++ b/docs/source/user-guide/latest/installation.md
@@ -74,7 +74,7 @@ through the release vote. Release candidate jars can be found [here](https://rep
 - [Comet plugin for Spark 3.4 / Scala 2.13](https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.4_2.13/$COMET_VERSION/comet-spark-spark3.4_2.13-$COMET_VERSION.jar)
 - [Comet plugin for Spark 3.5 / Scala 2.12](https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.12/$COMET_VERSION/comet-spark-spark3.5_2.12-$COMET_VERSION.jar)
 - [Comet plugin for Spark 3.5 / Scala 2.13](https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.13/$COMET_VERSION/comet-spark-spark3.5_2.13-$COMET_VERSION.jar)
-- [Comet plugin for Spark 4.0 / Scala 2.13 (Experimental)](https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark4.0_2.13/$COMET_VERSION/comet-spark-spark4.0_2.13-$COMET_VERSION.jar)
+- [Comet plugin for Spark 4.0 / Scala 2.13](https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark4.0_2.13/$COMET_VERSION/comet-spark-spark4.0_2.13-$COMET_VERSION.jar)
 
 ## Building from source
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of https://github.com/apache/datafusion-comet/issues/1637

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

There has been good progress on enabling Spark SQL tests for Spark 4.

I propose that we stop saying that Spark 4 support is "experimental" and now just document the limitations.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Docs changes.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
