### PR TITLE
chore: skip Iceberg and Spark SQL test workflows on test-only changes

### DIFF
--- a/.github/workflows/iceberg_spark_test.yml
+++ b/.github/workflows/iceberg_spark_test.yml
@@ -36,7 +36,6 @@ on:
       - "common/src/test/**"
       - "fuzz-testing/**"
       - "spark-integration/**"
-      - "dev/**"
   pull_request:
     paths-ignore:
       - "benchmarks/**"
@@ -49,7 +48,6 @@ on:
       - "common/src/test/**"
       - "fuzz-testing/**"
       - "spark-integration/**"
-      - "dev/**"
   # manual trigger
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:

--- a/.github/workflows/iceberg_spark_test.yml
+++ b/.github/workflows/iceberg_spark_test.yml
@@ -32,7 +32,11 @@ on:
       - "**.md"
       - "native/core/benches/**"
       - "native/spark-expr/benches/**"
-      - "spark/src/test/scala/org/apache/spark/sql/benchmark/**"
+      - "spark/src/test/**"
+      - "common/src/test/**"
+      - "fuzz-testing/**"
+      - "spark-integration/**"
+      - "dev/**"
   pull_request:
     paths-ignore:
       - "benchmarks/**"
@@ -41,7 +45,11 @@ on:
       - "**.md"
       - "native/core/benches/**"
       - "native/spark-expr/benches/**"
-      - "spark/src/test/scala/org/apache/spark/sql/benchmark/**"
+      - "spark/src/test/**"
+      - "common/src/test/**"
+      - "fuzz-testing/**"
+      - "spark-integration/**"
+      - "dev/**"
   # manual trigger
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:

--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -36,7 +36,6 @@ on:
       - "common/src/test/**"
       - "fuzz-testing/**"
       - "spark-integration/**"
-      - "dev/**"
   pull_request:
     paths-ignore:
       - "benchmarks/**"
@@ -49,7 +48,6 @@ on:
       - "common/src/test/**"
       - "fuzz-testing/**"
       - "spark-integration/**"
-      - "dev/**"
   # manual trigger
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:

--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -32,7 +32,11 @@ on:
       - "**.md"
       - "native/core/benches/**"
       - "native/spark-expr/benches/**"
-      - "spark/src/test/scala/org/apache/spark/sql/benchmark/**"
+      - "spark/src/test/**"
+      - "common/src/test/**"
+      - "fuzz-testing/**"
+      - "spark-integration/**"
+      - "dev/**"
   pull_request:
     paths-ignore:
       - "benchmarks/**"
@@ -41,7 +45,11 @@ on:
       - "**.md"
       - "native/core/benches/**"
       - "native/spark-expr/benches/**"
-      - "spark/src/test/scala/org/apache/spark/sql/benchmark/**"
+      - "spark/src/test/**"
+      - "common/src/test/**"
+      - "fuzz-testing/**"
+      - "spark-integration/**"
+      - "dev/**"
   # manual trigger
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:


### PR DESCRIPTION
## Which issue does this PR close?

N/A. Small CI chore prompted by #4021, which only added a SQL test resource file but still triggered the Iceberg and Spark SQL test workflows.

## Rationale for this change

The Iceberg and Spark SQL test workflows run the Iceberg and Spark SQL test suites against Comet as a plugin. Their behavior depends on Comet plugin code (native, common/main, spark/main), not on Comet's own test code or standalone subprojects. Today these workflows run even when a PR touches only Comet's own tests, which wastes CI time and noise.

#4021 is a concrete example: it added a single file under `spark/src/test/resources/sql-tests/...` and still fired both workflows.

## What changes are included in this PR?

Extend `paths-ignore` on the `push` and `pull_request` triggers of `iceberg_spark_test.yml` and `spark_sql_test.yml` to also skip:

- `spark/src/test/**` (Comet's own test code and SQL test resources)
- `common/src/test/**` (Comet's own common-module tests)
- `fuzz-testing/**` (standalone fuzz-testing project)
- `spark-integration/**` (standalone integration-test project)

The broader `spark/src/test/**` pattern subsumes the previous `spark/src/test/scala/org/apache/spark/sql/benchmark/**` entry, which was removed.

Note: `dev/**` is intentionally NOT added, because `dev/diffs/` contains Spark source patches that are applied to the external Spark checkout at test time and therefore do affect external-project test behavior.

`pr_build_linux.yml` and `pr_build_macos.yml` are unchanged: they run Comet's own tests, so test-only changes must still trigger them. Mixed PRs (any src change alongside test changes) still trigger the Iceberg and Spark SQL workflows, because GitHub only skips when every changed file matches the ignore list.

## How are these changes tested?

CI configuration change. The new triggers will be exercised by subsequent PRs. The YAML files were validated and the diff is limited to additions in `paths-ignore` plus the single redundant-entry removal noted above.