### PR TITLE
ci: force GNU ld on Linux to fix -ljvm linker error

### DIFF
--- a/.github/workflows/iceberg_spark_test.yml
+++ b/.github/workflows/iceberg_spark_test.yml
@@ -55,6 +55,10 @@ on:
 env:
   RUST_VERSION: stable
   RUST_BACKTRACE: 1
+  # Force GNU ld on Linux: recent Rust stable defaults to rust-lld on
+  # x86_64-unknown-linux-gnu, and rust-lld cannot resolve -ljvm against the
+  # Zulu JDK layout installed by setup-java. Keep bfd for all cargo invocations.
+  RUSTFLAGS: "-Clink-arg=-fuse-ld=bfd"
 
 jobs:
   # Build native library once and share with all test jobs
@@ -88,7 +92,7 @@ jobs:
         run: |
           cd native && cargo build --profile ci
         env:
-          RUSTFLAGS: "-Ctarget-cpu=x86-64-v3"
+          RUSTFLAGS: "-Ctarget-cpu=x86-64-v3 -Clink-arg=-fuse-ld=bfd"
 
       - name: Save Cargo cache
         uses: actions/cache/save@v5

--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -49,6 +49,10 @@ on:
 env:
   RUST_VERSION: stable
   RUST_BACKTRACE: 1
+  # Force GNU ld on Linux: recent Rust stable defaults to rust-lld on
+  # x86_64-unknown-linux-gnu, and rust-lld cannot resolve -ljvm against the
+  # Zulu JDK layout installed by setup-java. Keep bfd for all cargo invocations.
+  RUSTFLAGS: "-Clink-arg=-fuse-ld=bfd"
 
 jobs:
 
@@ -166,7 +170,7 @@ jobs:
           # (no LTO, parallel codegen)
           cargo build --profile ci
         env:
-          RUSTFLAGS: "-Ctarget-cpu=x86-64-v3"
+          RUSTFLAGS: "-Ctarget-cpu=x86-64-v3 -Clink-arg=-fuse-ld=bfd"
 
       - name: Upload native library
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -89,9 +89,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             native/target
-          key: ${{ runner.os }}-cargo-ci-${{ hashFiles('native/**/Cargo.lock', 'native/**/Cargo.toml') }}-${{ hashFiles('native/**/*.rs') }}
+          key: ${{ runner.os }}-cargo-ci-v2-${{ hashFiles('native/**/Cargo.lock', 'native/**/Cargo.toml') }}-${{ hashFiles('native/**/*.rs') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-ci-${{ hashFiles('native/**/Cargo.lock', 'native/**/Cargo.toml') }}-
+            ${{ runner.os }}-cargo-ci-v2-${{ hashFiles('native/**/Cargo.lock', 'native/**/Cargo.toml') }}-
 
       - name: Build native library (CI profile)
         run: |
@@ -117,7 +117,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             native/target
-          key: ${{ runner.os }}-cargo-ci-${{ hashFiles('native/**/Cargo.lock', 'native/**/Cargo.toml') }}-${{ hashFiles('native/**/*.rs') }}
+          key: ${{ runner.os }}-cargo-ci-v2-${{ hashFiles('native/**/Cargo.lock', 'native/**/Cargo.toml') }}-${{ hashFiles('native/**/*.rs') }}
 
   macos-aarch64-test:
     needs: build-native

--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -61,6 +61,10 @@ on:
 env:
   RUST_VERSION: stable
   RUST_BACKTRACE: 1
+  # Force GNU ld on Linux: recent Rust stable defaults to rust-lld on
+  # x86_64-unknown-linux-gnu, and rust-lld cannot resolve -ljvm against the
+  # Zulu JDK layout installed by setup-java. Keep bfd for all cargo invocations.
+  RUSTFLAGS: "-Clink-arg=-fuse-ld=bfd"
 
 jobs:
 
@@ -95,7 +99,7 @@ jobs:
           cd native
           cargo build --profile ci
         env:
-          RUSTFLAGS: "-Ctarget-cpu=x86-64-v3"
+          RUSTFLAGS: "-Ctarget-cpu=x86-64-v3 -Clink-arg=-fuse-ld=bfd"
 
       - name: Upload native library
         uses: actions/upload-artifact@v7

--- a/native/fs-hdfs/build.rs
+++ b/native/fs-hdfs/build.rs
@@ -120,6 +120,12 @@ fn get_build_flags() -> Vec<String> {
 fn get_java_dependency() -> Vec<String> {
     let mut result = vec![];
 
+    // Re-run when the JDK changes. The resolved jvm_lib_location below is
+    // baked into the crate's link args, so a cache restored against a previous
+    // JDK install (e.g. CI runners where setup-java floats Zulu patch
+    // versions) would otherwise hand the linker -L paths that no longer exist.
+    println!("cargo:rerun-if-env-changed=JAVA_HOME");
+
     // Include directories
     let java_home = java_locator::locate_java_home()
         .expect("JAVA_HOME could not be found, trying setting the variable manually");


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

Linux CI has been failing on main since ~2026-04-21 20:55 UTC on every
PR with:

```
rust-lld: error: unable to find library -ljvm
collect2: error: ld returned 1 exit status
```

The failure reproduces on main at `cae101e80` and every later commit,
across `PR Build (Linux)`, `Spark SQL Tests`, and `Iceberg Spark SQL
Tests` workflows. None of the commits in that window touch native code
or build scripts, so the regression came from the environment.

Rust's `stable` channel (used by the workflows) released a version
during that window that defaults to `rust-lld` as the linker on
`x86_64-unknown-linux-gnu`. The failing linker command clearly shows
`-fuse-ld=lld`. `rust-lld` cannot resolve `-ljvm` against the Zulu
JDK 17 layout that `actions/setup-java@v4` installs under
`/__t/Java_Zulu_jdk/17.0.18-8/x64/lib/server/` — GNU `ld.bfd` resolves
it fine.

## What changes are included in this PR?

Adds `-Clink-arg=-fuse-ld=bfd` to `RUSTFLAGS` in the three Linux CI
workflows: `pr_build_linux.yml`, `spark_sql_test.yml`, and
`iceberg_spark_test.yml`.

- Set at workflow-level `env:` so every cargo invocation (including
  those inside the composite `rust-test` action, which has no explicit
  RUSTFLAGS) picks up GNU ld.
- Extended the existing step-level `RUSTFLAGS: "-Ctarget-cpu=x86-64-v3"`
  values to include the same flag, because step-level env replaces
  workflow-level env rather than appending.

macOS CI is also failing but with a different root cause
(`ld: library 'jvm' not found`, path to Zulu does not exist on the
runner). That is a separate issue and is not addressed here.

## How are these changes tested?

By running the affected workflows on this PR. If the Linux `Build Native
Library`, `ubuntu-latest/rust-test`, `Spark SQL Tests`, and
`Iceberg Spark SQL Tests` jobs all reach a normal pass/fail state
instead of failing at the linker, the fix is confirmed.