### PR TITLE
chore: update documentation links for 0.15.0 release

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -25,9 +25,9 @@ mkdir temp
 cp -rf source/* temp/
 
 # Add user guide from published releases
-rm -rf comet-0.11
 rm -rf comet-0.12
 rm -rf comet-0.13
+rm -rf comet-0.14
 python3 generate-versions.py
 
 # Generate dynamic content (configs, compatibility matrices) for latest docs

--- a/docs/generate-versions.py
+++ b/docs/generate-versions.py
@@ -104,6 +104,6 @@ This is **out-of-date** documentation. The latest Comet release is version {late
 if __name__ == "__main__":
     print("Generating versioned user guide docs...")
     snapshot_version = get_version_from_pom()
-    latest_released_version = "0.14.0"
-    previous_versions = ["0.11.0", "0.12.0", "0.13.0"]
+    latest_released_version = "0.15.0"
+    previous_versions = ["0.12.0", "0.13.0", "0.14.0"]
     generate_docs(snapshot_version, latest_released_version, previous_versions)

--- a/docs/source/user-guide/index.md
+++ b/docs/source/user-guide/index.md
@@ -23,9 +23,9 @@ under the License.
 :maxdepth: 2
 :caption: User Guides
 
-0.15.0-SNAPSHOT <latest/index>
+0.16.0-SNAPSHOT <latest/index>
+0.15.x <0.15/index>
 0.14.x <0.14/index>
 0.13.x <0.13/index>
 0.12.x <0.12/index>
-0.11.x <0.11/index>
 ```


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

Update the user guide navigation and build scripts to publish documentation for the 0.15.0 release alongside previous releases.

## What changes are included in this PR?

- Bump `latest_released_version` to 0.15.0 in `docs/generate-versions.py` and shift 0.14.0 into `previous_versions`, dropping 0.11.0
- Update `docs/build.sh` to clean the matching versioned clone directories
- Update `docs/source/user-guide/index.md` toctree: bump snapshot to 0.16.0-SNAPSHOT, add 0.15.x, drop 0.11.x

## How are these changes tested?

Documentation-only change. Verified locally by comparing against the equivalent changes for the 0.14.0 release (#3716).