### PR TITLE
test: extend SPARK-43402 plan-match to CometNativeScanExec and retag to #4042

### DIFF
--- a/dev/diffs/4.0.1.diff
+++ b/dev/diffs/4.0.1.diff
@@ -1319,7 +1319,7 @@ index 0df7f806272..92390bd819f 100644
  
    test("non-matching optional group") {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
-index 2e33f6505ab..3a8b154b565 100644
+index 2e33f6505ab..8fca1231d66 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
 @@ -23,11 +23,13 @@ import org.apache.spark.SparkRuntimeException
@@ -1365,13 +1365,13 @@ index 2e33f6505ab..3a8b154b565 100644
        }
        assert(exchanges.size === 1)
      }
-@@ -2674,22 +2688,31 @@ class SubquerySuite extends QueryTest
+@@ -2674,22 +2688,36 @@ class SubquerySuite extends QueryTest
      }
    }
  
 -  test("SPARK-43402: FileSourceScanExec supports push down data filter with scalar subquery") {
 +  test("SPARK-43402: FileSourceScanExec supports push down data filter with scalar subquery",
-+    IgnoreCometNativeDataFusion("https://github.com/apache/datafusion-comet/issues/3315")) {
++    IgnoreCometNativeDataFusion("https://github.com/apache/datafusion-comet/issues/4042")) {
      def checkFileSourceScan(query: String, answer: Seq[Row]): Unit = {
        val df = sql(query)
        checkAnswer(df, answer)
@@ -1380,6 +1380,7 @@ index 2e33f6505ab..3a8b154b565 100644
 +      val dataSourceScanExec = collect(df.queryExecution.executedPlan) {
 +        case f: FileSourceScanLike => f
 +        case c: CometScanExec => c
++        case n: CometNativeScanExec => n
        }
        sparkContext.listenerBus.waitUntilEmpty()
 -      assert(fileSourceScanExec.size === 1)
@@ -1394,6 +1395,10 @@ index 2e33f6505ab..3a8b154b565 100644
 +          })
 +        case c: CometScanExec =>
 +          c.dataFilters.flatMap(_.collect {
++            case s: ScalarSubquery => s
++          })
++        case n: CometNativeScanExec =>
++          n.dataFilters.flatMap(_.collect {
 +            case s: ScalarSubquery => s
 +          })
 +      }


### PR DESCRIPTION
## Which issue does this PR close?

Related to #4042.

## Rationale for this change

In #4041 the `SubquerySuite` "SPARK-43402: FileSourceScanExec supports push down data filter with scalar subquery" test was retagged from the umbrella #3321 to the broader #3315 ("plan structure differences"). A closer look shows the first failure in this test is just a missed pattern match: the test collects `FileSourceScanLike` and `CometScanExec` but not `CometNativeScanExec`. After adding `CometNativeScanExec` to the match, that assertion passes, but the test still fails on a genuine behavior gap where the pushed scalar subquery ends up as a plain `Subquery` rather than `ReusedSubqueryExec`, so reuse does not happen. That narrower problem is now tracked in #4042.

## What changes are included in this PR?

Updates `dev/diffs/4.0.1.diff` to:

- Add a `CometNativeScanExec` branch to both pattern matches in the SPARK-43402 test (the `collect` over the executed plan, and the subsequent match extracting `dataFilters`). `CometNativeScanExec` already exposes `dataFilters`, `numFiles`, and `numOutputRows`, so the rest of the assertions work with the added case without further changes.
- Retag the `IgnoreCometNativeDataFusion` reference from #3315 to the narrower #4042.

## How are these changes tested?

Ran the test locally against Spark 4.0.1 with `native_datafusion` in auto scan mode via `ENABLE_COMET=true ENABLE_COMET_ONHEAP=true build/sbt "sql/testOnly org.apache.spark.sql.SubquerySuite -- -z \"SPARK-43402: FileSourceScanExec supports push down data filter with scalar subquery\""`. Confirmed the first assertion (`dataSourceScanExec.size === 1`) now passes with the extended match, and the remaining failure (`was not instance of org.apache.spark.sql.execution.ReusedSubqueryExec`) matches the description in #4042.