### PR TITLE
fix: use FAILED_READ_FILE.FILE_NOT_EXIST in Spark 4.0 FileNotFound shim

### DIFF
--- a/spark/src/main/spark-4.0/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
+++ b/spark/src/main/spark-4.0/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
@@ -19,11 +19,12 @@
 
 package org.apache.spark.sql.comet.shims
 
+import java.io.FileNotFoundException
+
 import scala.util.matching.Regex
 
 import org.apache.spark.QueryContext
 import org.apache.spark.SparkException
-import org.apache.spark.SparkFileNotFoundException
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
@@ -292,17 +293,13 @@ trait ShimSparkErrorConverter {
 
       case "FileNotFound" =>
         val msg = params("message").toString
-        // Extract file path from native error message and format like Hadoop's
-        // FileNotFoundException: "File <path> does not exist"
         val path = ShimSparkErrorConverter.ObjectLocationPattern
           .findFirstMatchIn(msg)
           .map(_.group(1))
           .getOrElse(msg)
-        // readCurrentFileNotFoundError was removed in Spark 4.0; construct directly
         Some(
-          new SparkFileNotFoundException(
-            errorClass = "_LEGACY_ERROR_TEMP_2055",
-            messageParameters = Map("message" -> s"File $path does not exist")))
+          QueryExecutionErrors
+            .fileNotExistError(path, new FileNotFoundException(s"File $path does not exist")))
 
       case _ =>
         // Unknown error type - return None to trigger fallback


### PR DESCRIPTION
## Which issue does this PR close?

Related to #2946.

## Rationale for this change

The Spark 4.0 `ShimSparkErrorConverter` translates native FileNotFound errors into a `SparkFileNotFoundException` with error class `_LEGACY_ERROR_TEMP_2055`. That error class exists in Spark 3.4 and 3.5 but was removed in Spark 4.0, so Spark's `ErrorClassesJsonReader` throws an `INTERNAL_ERROR` when it tries to look up the message template ("Cannot find main error class '_LEGACY_ERROR_TEMP_2055'").

This manifests as test failures on `org.apache.spark.sql.hive.HiveMetadataCacheSuite` (and any other suite that uses `checkError`/`checkErrorMatchPVals` against `FAILED_READ_FILE.FILE_NOT_EXIST`) when run against Spark 4.0 with Comet enabled:

```
null did not equal "FAILED_READ_FILE.FILE_NOT_EXIST"
```

with underlying cause:

```
SparkException: [INTERNAL_ERROR] Cannot find main error class '_LEGACY_ERROR_TEMP_2055'
```

The previously ignored `sql_hive-1` CI job for Spark 4.0 (issue #2946) surfaces these failures once the job is re-enabled.

## What changes are included in this PR?

In the Spark 4.0 shim, delegate to `QueryExecutionErrors.fileNotExistError(path, cause)`, which is the 4.0 replacement for `readCurrentFileNotFoundError`. It produces a `SparkException` with the expected error class `FAILED_READ_FILE.FILE_NOT_EXIST` and `path` parameter that tests assert on. The 3.4 and 3.5 shims are unchanged.

## How are these changes tested?

Covered by the existing Spark test `org.apache.spark.sql.hive.HiveMetadataCacheSuite` (run in the `sql_hive-1` CI job for Spark 4.0), which previously failed on:

- `SPARK-16337 temporary view refresh`
- `view refresh`
- `partitioned table is cached when partition pruning is true`
- `partitioned table is cached when partition pruning is false`

Re-enabling that job will be handled separately.