### PR TITLE
test: enable SPARK-32509 DPP test for Spark 4.0

### DIFF
--- a/dev/diffs/4.0.1.diff
+++ b/dev/diffs/4.0.1.diff
@@ -535,7 +535,7 @@ index 81713c777bc..b5f92ed9742 100644
      assert(exchanges.size == 2)
    }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
-index 2c24cc7d570..8c214e7d05c 100644
+index 2c24cc7d570..0e6aabe6d5b 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
 @@ -22,6 +22,7 @@ import org.scalatest.GivenWhenThen
@@ -595,17 +595,7 @@ index 2c24cc7d570..8c214e7d05c 100644
  
        assert(countSubqueryBroadcasts == 1)
        assert(countReusedSubqueryBroadcasts == 1)
-@@ -1215,7 +1231,8 @@ abstract class DynamicPartitionPruningSuiteBase
-   }
- 
-   test("SPARK-32509: Unused Dynamic Pruning filter shouldn't affect " +
--    "canonicalization and exchange reuse") {
-+    "canonicalization and exchange reuse",
-+    IgnoreComet("TODO: https://github.com/apache/datafusion-comet/issues/4045")) {
-     withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "true") {
-       withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
-         val df = sql(
-@@ -1424,7 +1441,8 @@ abstract class DynamicPartitionPruningSuiteBase
+@@ -1424,7 +1440,8 @@ abstract class DynamicPartitionPruningSuiteBase
      }
    }
  
@@ -615,7 +605,7 @@ index 2c24cc7d570..8c214e7d05c 100644
      withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY.key -> "true") {
        val df = sql(
          """ WITH v as (
-@@ -1578,6 +1596,7 @@ abstract class DynamicPartitionPruningSuiteBase
+@@ -1578,6 +1595,7 @@ abstract class DynamicPartitionPruningSuiteBase
  
          val subqueryBroadcastExecs = collectWithSubqueries(df.queryExecution.executedPlan) {
            case s: SubqueryBroadcastExec => s
@@ -623,7 +613,7 @@ index 2c24cc7d570..8c214e7d05c 100644
          }
          assert(subqueryBroadcastExecs.size === 1)
          subqueryBroadcastExecs.foreach { subqueryBroadcastExec =>
-@@ -1730,6 +1749,10 @@ abstract class DynamicPartitionPruningV1Suite extends DynamicPartitionPruningDat
+@@ -1730,6 +1748,10 @@ abstract class DynamicPartitionPruningV1Suite extends DynamicPartitionPruningDat
                case s: BatchScanExec =>
                  // we use f1 col for v2 tables due to schema pruning
                  s.output.exists(_.exists(_.argString(maxFields = 100).contains("f1")))


### PR DESCRIPTION
## Which issue does this PR close?

Partially addresses #4045.

## Rationale for this change

The SPARK-32509 test in `DynamicPartitionPruningSuite` was disabled across all Spark versions under issue #4045. Re-running it on Spark 4.0.1 with Comet enabled now passes in all 6 concrete suite variants (V1/V2/V2Filter × AEOff/AEOn).

## What changes are included in this PR?

Removes the `IgnoreComet` annotation from the SPARK-32509 test in `dev/diffs/4.0.1.diff`. The companion SPARK-34637 test referenced by the same `IgnoreComet` annotation remains ignored under #4045 since it still fails on Spark 4.0.1 with AQE enabled.

The test was checked on Spark 3.5.8 as well but still fails there in `DynamicPartitionPruningV1SuiteAEOn`, so the change is scoped to Spark 4.0 only.

## How are these changes tested?

Locally ran the test against the patched Spark 4.0.1 source with `ENABLE_COMET=true ENABLE_COMET_ONHEAP=true`:

```
sql/testOnly org.apache.spark.sql.DynamicPartitionPruningV1SuiteAEOff \
             org.apache.spark.sql.DynamicPartitionPruningV1SuiteAEOn \
             org.apache.spark.sql.DynamicPartitionPruningV2SuiteAEOff \
             org.apache.spark.sql.DynamicPartitionPruningV2SuiteAEOn \
             org.apache.spark.sql.DynamicPartitionPruningV2FilterSuiteAEOff \
             org.apache.spark.sql.DynamicPartitionPruningV2FilterSuiteAEOn \
  -- -z "SPARK-32509"
```

All 6 variants pass.