### PR TITLE
feat: add base64 expression

### DIFF
--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -406,7 +406,10 @@
 ### string_funcs
 
 - [x] ascii
-- [ ] base64
+- [x] base64
+  - Spark 3.4.3 audited 2026-04-30 (always uses chunked `getMimeEncoder`, output differs from Comet for inputs longer than 57 bytes; requires `spark.comet.expr.allowIncompatible=true`)
+  - Spark 3.5.8 audited 2026-04-30 (chunked output is on by default via `spark.sql.chunkBase64String.enabled`; set the conf to `false` for full compatibility)
+  - Spark 4.0.1 audited 2026-04-30 (same chunking caveat as 3.5.8; default-collation result type is honored)
 - [x] bit_length
 - [x] btrim
 - [x] char

--- a/native/spark-expr/src/comet_scalar_funcs.rs
+++ b/native/spark-expr/src/comet_scalar_funcs.rs
@@ -188,6 +188,10 @@ pub fn create_comet_physical_fun_with_eval_mode(
             let func = Arc::new(crate::string_funcs::spark_split);
             make_comet_scalar_udf!("split", func, without data_type)
         }
+        "base64" => {
+            let func = Arc::new(crate::string_funcs::spark_base64);
+            make_comet_scalar_udf!("base64", func, without data_type)
+        }
         "get_json_object" => {
             let func = Arc::new(crate::string_funcs::spark_get_json_object);
             make_comet_scalar_udf!("get_json_object", func, without data_type)

--- a/native/spark-expr/src/string_funcs/base64.rs
+++ b/native/spark-expr/src/string_funcs/base64.rs
@@ -1,0 +1,131 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use arrow::array::{Array, BinaryArray, StringBuilder};
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use datafusion::common::{cast::as_binary_array, exec_err, DataFusionError, ScalarValue};
+use datafusion::logical_expr::ColumnarValue;
+
+/// Spark-compatible `base64` expression. Encodes the binary input using padded
+/// RFC 4648 base64 without line breaks. This matches Spark's behavior when
+/// `spark.sql.chunkBase64String.enabled=false`. Spark's default (chunked)
+/// output, which inserts CRLF every 76 characters, is not produced here.
+pub fn spark_base64(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
+    if args.len() != 1 {
+        return exec_err!("base64 expects 1 argument, got {}", args.len());
+    }
+
+    match &args[0] {
+        ColumnarValue::Array(array) => {
+            let binary = as_binary_array(array)?;
+            Ok(ColumnarValue::Array(encode_array(binary)))
+        }
+        ColumnarValue::Scalar(ScalarValue::Binary(Some(bytes))) => Ok(ColumnarValue::Scalar(
+            ScalarValue::Utf8(Some(STANDARD.encode(bytes))),
+        )),
+        ColumnarValue::Scalar(ScalarValue::Binary(None)) => {
+            Ok(ColumnarValue::Scalar(ScalarValue::Utf8(None)))
+        }
+        other => exec_err!(
+            "base64 expects a binary scalar or array, but got: {:?}",
+            other.data_type()
+        ),
+    }
+}
+
+fn encode_array(array: &BinaryArray) -> Arc<dyn Array> {
+    let mut builder = StringBuilder::with_capacity(array.len(), array.value_data().len() * 2);
+    for value in array.iter() {
+        match value {
+            Some(bytes) => builder.append_value(STANDARD.encode(bytes)),
+            None => builder.append_null(),
+        }
+    }
+    Arc::new(builder.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::BinaryBuilder;
+
+    #[test]
+    fn test_base64_array() {
+        let mut builder = BinaryBuilder::new();
+        builder.append_value(b"Spark SQL");
+        builder.append_null();
+        builder.append_value(b"");
+        let input = ColumnarValue::Array(Arc::new(builder.finish()));
+
+        let result = spark_base64(&[input]).unwrap();
+        match result {
+            ColumnarValue::Array(arr) => {
+                let s = arr
+                    .as_any()
+                    .downcast_ref::<arrow::array::StringArray>()
+                    .unwrap();
+                assert_eq!(s.value(0), "U3BhcmsgU1FM");
+                assert!(s.is_null(1));
+                assert_eq!(s.value(2), "");
+            }
+            _ => panic!("expected array"),
+        }
+    }
+
+    #[test]
+    fn test_base64_scalar() {
+        let input = ColumnarValue::Scalar(ScalarValue::Binary(Some(b"foo".to_vec())));
+        let result = spark_base64(&[input]).unwrap();
+        match result {
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(s))) => assert_eq!(s, "Zm9v"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_base64_null_scalar() {
+        let input = ColumnarValue::Scalar(ScalarValue::Binary(None));
+        let result = spark_base64(&[input]).unwrap();
+        match result {
+            ColumnarValue::Scalar(ScalarValue::Utf8(None)) => {}
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_base64_padded() {
+        // 1 byte of input must produce 4 characters of base64 with two `=` padding chars.
+        let mut builder = BinaryBuilder::new();
+        builder.append_value(b"a");
+        let input = ColumnarValue::Array(Arc::new(builder.finish()));
+
+        let result = spark_base64(&[input]).unwrap();
+        match result {
+            ColumnarValue::Array(arr) => {
+                let s = arr
+                    .as_any()
+                    .downcast_ref::<arrow::array::StringArray>()
+                    .unwrap();
+                assert_eq!(s.value(0), "YQ==");
+            }
+            _ => panic!("expected array"),
+        }
+    }
+}

--- a/native/spark-expr/src/string_funcs/mod.rs
+++ b/native/spark-expr/src/string_funcs/mod.rs
@@ -15,11 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
+mod base64;
 mod contains;
 mod get_json_object;
 mod split;
 mod substring;
 
+pub use base64::spark_base64;
 pub use contains::SparkContains;
 pub use get_json_object::spark_get_json_object;
 pub use split::spark_split;

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -158,6 +158,7 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
   private[comet] val stringExpressions: Map[Class[_ <: Expression], CometExpressionSerde[_]] =
     Map(
       classOf[Ascii] -> CometScalarFunction("ascii"),
+      classOf[Base64] -> CometBase64,
       classOf[BitLength] -> CometScalarFunction("bit_length"),
       classOf[Chr] -> CometScalarFunction("char"),
       classOf[ConcatWs] -> CometConcatWs,

--- a/spark/src/main/scala/org/apache/comet/serde/statics.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/statics.scala
@@ -19,7 +19,7 @@
 
 package org.apache.comet.serde
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, ExpressionImplUtils}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Base64, ExpressionImplUtils}
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.util.CharVarcharCodegenUtils
 
@@ -35,7 +35,22 @@ object CometStaticInvoke extends CometExpressionSerde[StaticInvoke] {
     Map(
       ("readSidePadding", classOf[CharVarcharCodegenUtils]) -> CometScalarFunction(
         "read_side_padding"),
-      ("isLuhnNumber", classOf[ExpressionImplUtils]) -> CometScalarFunction("luhn_check"))
+      ("isLuhnNumber", classOf[ExpressionImplUtils]) -> CometScalarFunction("luhn_check"),
+      ("encode", classOf[Base64]) -> CometBase64StaticInvoke)
+
+  override def getExprConfigName(expr: StaticInvoke): String = {
+    staticInvokeExpressions.get((expr.functionName, expr.staticObject)) match {
+      case Some(handler) => handler.getExprConfigName(expr)
+      case None => expr.getClass.getSimpleName
+    }
+  }
+
+  override def getSupportLevel(expr: StaticInvoke): SupportLevel = {
+    staticInvokeExpressions.get((expr.functionName, expr.staticObject)) match {
+      case Some(handler) => handler.getSupportLevel(expr)
+      case None => Compatible(None)
+    }
+  }
 
   override def convert(
       expr: StaticInvoke,

--- a/spark/src/main/scala/org/apache/comet/serde/strings.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/strings.scala
@@ -21,7 +21,8 @@ package org.apache.comet.serde
 
 import java.util.Locale
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Concat, ConcatWs, Expression, GetJsonObject, If, InitCap, IsNull, Left, Length, Like, Literal, Lower, RegExpReplace, Right, RLike, StringLPad, StringRepeat, StringRPad, StringSplit, Substring, Upper}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Base64, Cast, Concat, ConcatWs, Expression, GetJsonObject, If, InitCap, IsNull, Left, Length, Like, Literal, Lower, RegExpReplace, Right, RLike, StringLPad, StringRepeat, StringRPad, StringSplit, Substring, Upper}
+import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.types.{BinaryType, DataTypes, LongType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -450,6 +451,69 @@ object CometGetJsonObject extends CometExpressionSerde[GetJsonObject] {
       jsonExpr,
       pathExpr)
     optExprWithInfo(optExpr, expr, expr.json, expr.path)
+  }
+}
+
+private object Base64Common {
+
+  val incompatReason: String =
+    "Spark's default `base64` chunks output into 76-character lines via `getMimeEncoder`;" +
+      " Comet always produces unchunked output. To match Comet, set" +
+      " `spark.sql.chunkBase64String.enabled=false`."
+
+  def convert(
+      expr: Expression,
+      child: Expression,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[Expr] = {
+    val childExpr = exprToProtoInternal(child, inputs, binding)
+    val optExpr =
+      scalarFunctionExprToProtoWithReturnType("base64", expr.dataType, false, childExpr)
+    optExprWithInfo(optExpr, expr, child)
+  }
+}
+
+/**
+ * Serde for the Spark 3.4 shape of `Base64`, which is a `UnaryExpression` with no `chunkBase64`
+ * argument. Spark 3.4 always uses the chunked MIME encoder, so output differs from Comet for
+ * inputs that produce more than 76 characters of base64.
+ */
+object CometBase64 extends CometExpressionSerde[Base64] {
+
+  override def getIncompatibleReasons(): Seq[String] = Seq(Base64Common.incompatReason)
+
+  override def getSupportLevel(expr: Base64): SupportLevel =
+    Incompatible(Some(Base64Common.incompatReason))
+
+  override def convert(expr: Base64, inputs: Seq[Attribute], binding: Boolean): Option[Expr] = {
+    Base64Common.convert(expr, expr.child, inputs, binding)
+  }
+}
+
+/**
+ * Serde for the Spark 3.5+ shape of `Base64`, which is `RuntimeReplaceable` and arrives as a
+ * `StaticInvoke` to `Base64.encode(child, chunkBase64)`. When the planner can prove
+ * `chunkBase64=false`, the output is fully compatible with Spark; otherwise it is incompatible.
+ */
+object CometBase64StaticInvoke extends CometExpressionSerde[StaticInvoke] {
+
+  override def getExprConfigName(expr: StaticInvoke): String = "Base64"
+
+  override def getIncompatibleReasons(): Seq[String] = Seq(Base64Common.incompatReason)
+
+  override def getSupportLevel(expr: StaticInvoke): SupportLevel = {
+    expr.arguments match {
+      case Seq(_, Literal(false, _)) => Compatible(None)
+      case _ => Incompatible(Some(Base64Common.incompatReason))
+    }
+  }
+
+  override def convert(
+      expr: StaticInvoke,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[Expr] = {
+    val child = expr.arguments.head
+    Base64Common.convert(expr, child, inputs, binding)
   }
 }
 

--- a/spark/src/test/resources/sql-tests/expressions/string/base64.sql
+++ b/spark/src/test/resources/sql-tests/expressions/string/base64.sql
@@ -1,0 +1,64 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Comet's base64 always produces unchunked padded output. Spark's default chunks output
+-- every 76 characters, so we run with chunkBase64String.enabled=false to match. Spark 3.4
+-- always chunks regardless of the conf, so allowIncompatible=true is needed there.
+-- Config: spark.sql.chunkBase64String.enabled=false
+-- Config: spark.comet.expr.allowIncompatible=true
+
+statement
+CREATE TABLE test_base64(b binary, s string) USING parquet
+
+statement
+INSERT INTO test_base64 VALUES
+  (CAST('Spark SQL' AS binary), 'Spark SQL'),
+  (CAST('' AS binary), ''),
+  (CAST('a' AS binary), 'a'),
+  (CAST('ab' AS binary), 'ab'),
+  (CAST('abc' AS binary), 'abc'),
+  (CAST('hello world' AS binary), 'hello world'),
+  -- 58 bytes: encodes to 80 base64 chars, the SPARK-47307 chunking boundary
+  (CAST('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' AS binary),
+   'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+  -- 200 bytes: encodes to 268 base64 chars, deep into the chunked-vs-unchunked zone
+  (CAST(repeat('xy', 100) AS binary), repeat('xy', 100)),
+  -- full 0x00..0xFF byte range exercises every byte value
+  (X'000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF',
+   NULL),
+  (NULL, NULL)
+
+-- column argument (binary)
+query
+SELECT base64(b) FROM test_base64
+
+-- column argument (string is implicitly cast to binary)
+query
+SELECT base64(s) FROM test_base64
+
+-- literal arguments
+query
+SELECT base64(CAST('Spark SQL' AS binary)),
+       base64(CAST('' AS binary)),
+       base64(CAST(NULL AS binary)),
+       base64('a'),
+       base64('ab'),
+       base64('abc')
+
+-- 58-byte literal: SPARK-47307 boundary, must produce 80-char unchunked output
+query
+SELECT base64(CAST('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' AS binary))

--- a/spark/src/test/resources/sql-tests/expressions/string/base64_chunked_fallback.sql
+++ b/spark/src/test/resources/sql-tests/expressions/string/base64_chunked_fallback.sql
@@ -1,0 +1,36 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- When spark.sql.chunkBase64String.enabled=true (the Spark default) and the user has not
+-- opted in to incompatible expressions, Comet must defer to Spark instead of silently
+-- producing un-chunked output.
+-- Config: spark.sql.chunkBase64String.enabled=true
+
+-- Spark 3.4 has no chunkBase64 parameter (always chunks), so this test is only meaningful
+-- on 3.5 or newer where the conf governs behavior.
+-- MinSparkVersion: 3.5
+
+statement
+CREATE TABLE test_base64_chunked(b binary) USING parquet
+
+statement
+INSERT INTO test_base64_chunked VALUES
+  (CAST('Spark SQL' AS binary)),
+  (NULL)
+
+query expect_fallback(not fully compatible with Spark)
+SELECT base64(b) FROM test_base64_chunked


### PR DESCRIPTION
## Which issue does this PR close?

Closes #419.

## Rationale for this change

`base64` is a commonly used Spark string function. The expression coverage doc previously listed it as unsupported, so queries using it fell back to Spark.

## What changes are included in this PR?

- New native function `spark_base64` in `native/spark-expr/src/string_funcs/base64.rs` that produces padded RFC 4648 base64 (no line breaks). Wired into `create_comet_physical_fun` as `"base64"`.
- New Scala serdes in `spark/src/main/scala/org/apache/comet/serde/strings.scala`:
  - `CometBase64` for the Spark 3.4 case-class shape (`Base64(child)`). Always returns `Incompatible` because Spark 3.4 always chunks the output.
  - `CometBase64StaticInvoke` for the Spark 3.5+ shape, where `Base64` is `RuntimeReplaceable` and arrives as `StaticInvoke(classOf[Base64], "encode", Seq(child, Literal(chunkBase64)))`. Returns `Compatible` only when the literal `chunkBase64` is `false`; otherwise `Incompatible`.
- `CometStaticInvoke` now delegates `getSupportLevel` and `getExprConfigName` to its inner handler so the `Base64`-specific support level and config name (`spark.comet.expr.Base64.allowIncompatible`) take effect through the StaticInvoke dispatch path.
- Comet SQL Tests:
  - `spark/src/test/resources/sql-tests/expressions/string/base64.sql` covers binary and string columns, literals, NULL, empty input, the SPARK-47307 58-byte chunking boundary, a 200-byte input, and the full 0x00..0xFF byte range.
  - `spark/src/test/resources/sql-tests/expressions/string/base64_chunked_fallback.sql` asserts that on Spark 3.5+ Comet falls back to Spark when `spark.sql.chunkBase64String.enabled=true` and incompatible expressions have not been opted in.
- Coverage doc `docs/source/contributor-guide/spark_expressions_support.md` updated with audit annotations for Spark 3.4.3 / 3.5.8 / 4.0.1.

This change was scaffolded with the `implement-comet-expression` Claude skill and the resulting implementation was reviewed with the `audit-comet-expression` skill.

## How are these changes tested?

- New Comet SQL Tests under `spark/src/test/resources/sql-tests/expressions/string/` cover both the compatible (`chunkBase64String.enabled=false`) and the fallback (`chunkBase64String.enabled=true`) paths.
- New Rust unit tests in `native/spark-expr/src/string_funcs/base64.rs` cover array, scalar, NULL, and padding cases.
- `make format`, `cargo clippy --all-targets --workspace -- -D warnings`, and the targeted `CometSqlFileTestSuite` runs all pass locally.