### PR TITLE
test: add Scala test coverage for spark.sql.optimizer.nestedSchemaPruning.enabled

### DIFF
--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -34,6 +34,7 @@ Benchmarking Guide <benchmarking>
 Adding a New Operator <adding_a_new_operator>
 Adding a New Expression <adding_a_new_expression>
 Supported Spark Expressions <spark_expressions_support>
+Supported Spark Configurations <spark_configs_support>
 Tracing <tracing>
 Profiling <profiling>
 Comet SQL Tests <sql-file-tests.md>

--- a/docs/source/contributor-guide/spark_configs_support.md
+++ b/docs/source/contributor-guide/spark_configs_support.md
@@ -43,6 +43,12 @@ The status column uses these values:
   - Affected expressions: `date_format`, `from_unixtime`, `unix_timestamp`, `to_unix_timestamp`, `to_timestamp`, `to_timestamp_ntz`, `to_date`, `try_to_timestamp` (Spark 4+)
   - Spark versions checked: 3.4.3, 3.5.8, 4.0.1
   - Date: 2026-05-02
+- `spark.sql.optimizer.nestedSchemaPruning.enabled`
+  - Default: `true`
+  - Status: Supported
+  - Affected components: catalyst optimizer rules `SchemaPruning` and `NestedColumnAliasing`, datasource V2 push-down (`PushDownUtils`), Parquet readers (`ParquetReadSupport`, `ParquetFileFormat`, `ParquetScan`)
+  - Spark versions checked: 3.4.3, 3.5.8, 4.0.1
+  - Date: 2026-05-02
 
 ## Audit Notes
 
@@ -110,3 +116,45 @@ whitelist, this audit should be revisited and the policy must be honored explici
 Comet bugs were uncovered by the audit. The tests use `query spark_answer_only` so
 that result-correctness is enforced regardless of whether Comet runs the expression
 natively or falls back.
+
+### `spark.sql.optimizer.nestedSchemaPruning.enabled`
+
+**Source.** When `true`, the catalyst optimizer rewrites projections of nested
+fields so columnar readers fetch only the requested leaves of a struct, array, or
+map column. Read sites verified on Spark 3.4.3, 3.5.8, 4.0.1:
+
+- `org.apache.spark.sql.catalyst.optimizer.SchemaPruning` and
+  `org.apache.spark.sql.catalyst.optimizer.NestedColumnAliasing` -- gated by
+  `nestedSchemaPruningEnabled`; rewrite the project list to expose only the leaves
+  that downstream operators consume.
+- `org.apache.spark.sql.execution.datasources.v2.PushDownUtils.pruneColumns` --
+  pushes the pruned schema into V2 scans only when the flag is `true`.
+- `org.apache.spark.sql.execution.datasources.parquet.ParquetReadSupport`,
+  `ParquetFileFormat`, and `ParquetScan` -- propagate the flag into the Parquet
+  reader's requested schema.
+
+**Comet status.** `CometParquetFileFormat.populateConf` propagates the SQL conf
+into the Hadoop conf so the Parquet read path honors it. Comet has no other
+special handling -- native scans inherit Spark's already-pruned `requiredSchema`
+and pass it through to the native reader. The separate
+`spark.sql.optimizer.serializer.nestedSchemaPruning.enabled` (Encoder-level) is
+out of scope.
+
+**Test coverage.** `spark/src/test/scala/org/apache/comet/parquet/CometNestedSchemaPruningSuite.scala`:
+
+- One Scala test per scenario, run across both `SCAN_NATIVE_DATAFUSION` and
+  `SCAN_NATIVE_ICEBERG_COMPAT` under the V1 Parquet path. Plain Parquet V2 is not
+  Comet-accelerated (Comet's V2 scan rule covers only CSV and Iceberg) so it is
+  excluded from the matrix.
+- Each scenario inspects the executed plan via a small helper that walks Comet
+  scan execs (`CometScanExec`, `CometNativeScanExec`) and asserts the
+  `requiredSchema` matches the expected pruned (or unpruned) shape, then compares
+  results against Spark via `checkSparkAnswer`.
+- Scenarios: top-level struct field, field inside array of struct, field inside
+  map value, doubly-nested struct field, projection plus filter on nested field,
+  null at intermediate struct level. Each scenario asserts both the
+  pruning-enabled and pruning-disabled behavior, except the null-intermediate
+  case which only varies the pruning-on path.
+
+**Findings.** All 12 generated test cases pass on Spark 3.4.3, 3.5.8, and 4.0.1.
+No Comet bugs were uncovered.

--- a/docs/source/contributor-guide/spark_configs_support.md
+++ b/docs/source/contributor-guide/spark_configs_support.md
@@ -37,9 +37,12 @@ The status column uses these values:
 
 ## Audited Configurations
 
-| Config                               | Default     | Status                  | Affected expressions / operators                                                                                                                                | Spark Versions | Date       |
-| ------------------------------------ | ----------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ---------- |
-| `spark.sql.legacy.timeParserPolicy`  | `EXCEPTION` | Falls back (see notes)  | `date_format`, `from_unixtime`, `unix_timestamp`, `to_unix_timestamp`, `to_timestamp`, `to_timestamp_ntz`, `to_date`, `try_to_timestamp` (Spark 4+)              | 3.4.3, 3.5.8, 4.0.1 | 2026-05-02 |
+- `spark.sql.legacy.timeParserPolicy`
+  - Default: `EXCEPTION`
+  - Status: Falls back (see notes)
+  - Affected expressions: `date_format`, `from_unixtime`, `unix_timestamp`, `to_unix_timestamp`, `to_timestamp`, `to_timestamp_ntz`, `to_date`, `try_to_timestamp` (Spark 4+)
+  - Spark versions checked: 3.4.3, 3.5.8, 4.0.1
+  - Date: 2026-05-02
 
 ## Audit Notes
 

--- a/docs/source/contributor-guide/spark_configs_support.md
+++ b/docs/source/contributor-guide/spark_configs_support.md
@@ -1,0 +1,109 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Supported Spark Configurations
+
+This document tracks Spark SQL configurations that affect Comet's behavior. For each
+configuration we record which Comet expressions or operators are influenced, what
+verification has been performed, and any known gaps.
+
+## How to Read This Document
+
+The status column uses these values:
+
+- **Supported** -- Comet runs the affected expressions natively under every value of
+  the config, and produces results matching Spark.
+- **Partial** -- Comet runs natively for some values of the config but falls back to
+  Spark for others, or runs natively but with documented incompatibilities.
+- **Falls back** -- Comet does not run the affected expressions natively under this
+  config and always defers to Spark.
+- **Unaudited** -- the config's interaction with Comet has not yet been verified.
+
+## Audited Configurations
+
+| Config                               | Default     | Status                  | Affected expressions / operators                                                                                                                                | Spark Versions | Date       |
+| ------------------------------------ | ----------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ---------- |
+| `spark.sql.legacy.timeParserPolicy`  | `EXCEPTION` | Falls back (see notes)  | `date_format`, `from_unixtime`, `unix_timestamp`, `to_unix_timestamp`, `to_timestamp`, `to_timestamp_ntz`, `to_date`, `try_to_timestamp` (Spark 4+)              | 3.4.3, 3.5.8, 4.0.1 | 2026-05-02 |
+
+## Audit Notes
+
+### `spark.sql.legacy.timeParserPolicy`
+
+**Source.** `SQLConf.LEGACY_TIME_PARSER_POLICY` selects the formatter used by
+`TimestampFormatter` and `DateFormatter`:
+
+- `LEGACY` -- `java.text.SimpleDateFormat` / `FastDateFormat`. Lenient parsing.
+- `CORRECTED` -- `java.time.DateTimeFormatter` via `Iso8601TimestampFormatter`. Strict.
+- `EXCEPTION` (default) -- same parser as `CORRECTED`, plus
+  `DateTimeFormatterHelper.checkParsedDiff` raises `SparkUpgradeException`
+  (`INCONSISTENT_BEHAVIOR_CROSS_VERSION`) when the new parser fails on input that the
+  legacy parser would have accepted. Pattern validation also raises
+  `SparkUpgradeException` when a pattern is recognized only by the legacy formatter
+  (this check applies under both `CORRECTED` and `EXCEPTION`).
+
+**Affected expressions.** Determined by tracing `TimestampFormatterHelper`,
+`TimestampFormatter(...)`, and `DateFormatter(...)` usage in
+`sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala`
+across Spark 3.4, 3.5, 4.0, and 4.1. Three expression classes mix in
+`TimestampFormatterHelper`:
+
+- `DateFormatClass` -- `date_format`
+- `FromUnixTime` -- `from_unixtime`
+- `ToTimestamp` (abstract) -- `UnixTimestamp` (`unix_timestamp`),
+  `ToUnixTimestamp` (`to_unix_timestamp`), `GetTimestamp` (used by
+  `ParseToTimestamp` for `to_timestamp` / `to_timestamp_ntz`, `ParseToDate` for
+  `to_date`, and Spark 4's `try_to_timestamp`)
+
+`Cast` between strings and date / timestamp also reads the policy via the default
+formatters but is tested separately by `CometCastSuite` and is out of scope here.
+
+**Comet status.** None of the listed expressions consult `legacyTimeParserPolicy` in
+their Comet serde. The native implementations of `date_format`, `from_unixtime`, and
+`unix_timestamp` use a fixed strftime-style mapping that does not vary with policy;
+the remaining four (`to_unix_timestamp`, `to_timestamp`, `to_date`,
+`try_to_timestamp`) have no native implementation and fall back to Spark. Today this
+works because:
+
+- `date_format` is `Compatible` only for a small whitelist of formats under UTC; the
+  whitelisted formats happen to produce identical output under all three policies.
+- `from_unixtime` is marked `Incompatible` and falls back unless
+  `spark.comet.expression.FromUnixTime.allowIncompatible=true` is set.
+- `unix_timestamp(<timestamp_or_date>)` does not call the formatter at all; the
+  string-input overload falls back.
+
+If a Comet contributor adds native string-format parsing or extends the date_format
+whitelist, this audit should be revisited and the policy must be honored explicitly.
+
+**Test coverage.** `spark/src/test/resources/sql-tests/expressions/datetime/`:
+
+- One ConfigMatrix file per expression covering convergent inputs under
+  `LEGACY,CORRECTED,EXCEPTION` (`*_time_parser_policy.sql`).
+- Per-policy files locking in divergent behavior:
+  - `_legacy.sql` -- lenient inputs (single-digit fields, out-of-range values,
+    trailing characters) and legacy-only pattern tokens (`'aaaa'`).
+  - `_corrected.sql` -- the same inputs return null; legacy-only tokens raise
+    `INCONSISTENT_BEHAVIOR_CROSS_VERSION.DATETIME_PATTERN_RECOGNITION` at formatter
+    creation.
+  - `_exception.sql` -- the same inputs raise
+    `INCONSISTENT_BEHAVIOR_CROSS_VERSION.PARSE_DATETIME_BY_NEW_PARSER` at parse time.
+
+**Findings.** All 42 generated test cases pass on Spark 3.4.3, 3.5.8, and 4.0.1. No
+Comet bugs were uncovered by the audit. The tests use `query spark_answer_only` so
+that result-correctness is enforced regardless of whether Comet runs the expression
+natively or falls back.

--- a/spark/src/test/resources/sql-tests/expressions/datetime/date_format_time_parser_policy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/date_format_time_parser_policy.sql
@@ -1,0 +1,49 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Convergent date_format() behavior across all three timeParserPolicy values.
+-- Patterns here produce identical output under LEGACY, CORRECTED, and EXCEPTION.
+-- ConfigMatrix: spark.sql.legacy.timeParserPolicy=LEGACY,CORRECTED,EXCEPTION
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_date_format_policy(ts timestamp) USING parquet
+
+statement
+INSERT INTO test_date_format_policy VALUES (timestamp('2024-06-15 10:30:45')), (timestamp('1970-01-01 00:00:00')), (NULL)
+
+query spark_answer_only
+SELECT date_format(ts, 'yyyy-MM-dd') FROM test_date_format_policy
+
+query spark_answer_only
+SELECT date_format(ts, 'yyyy-MM-dd HH:mm:ss') FROM test_date_format_policy
+
+query spark_answer_only
+SELECT date_format(ts, 'HH:mm:ss') FROM test_date_format_policy
+
+query spark_answer_only
+SELECT date_format(ts, 'yyyyMMdd') FROM test_date_format_policy
+
+query spark_answer_only
+SELECT date_format(ts, 'yyyyMM') FROM test_date_format_policy
+
+-- literal arguments
+query spark_answer_only
+SELECT date_format(timestamp('2024-06-15 10:30:45'), 'yyyy-MM-dd')
+
+query spark_answer_only
+SELECT date_format(NULL, 'yyyy-MM-dd')

--- a/spark/src/test/resources/sql-tests/expressions/datetime/date_format_time_parser_policy_corrected.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/date_format_time_parser_policy_corrected.sql
@@ -1,0 +1,33 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- date_format() under CORRECTED timeParserPolicy.
+-- Patterns recognized only by the legacy formatter raise SparkUpgradeException at
+-- formatter creation, even under CORRECTED, because validatePatternString is called
+-- with checkLegacy=true.
+-- Config: spark.sql.legacy.timeParserPolicy=CORRECTED
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_date_format_corrected(ts timestamp) USING parquet
+
+statement
+INSERT INTO test_date_format_corrected VALUES (timestamp('2024-06-15 10:30:45'))
+
+-- 4-char am/pm marker: legacy accepts, new rejects, validation throws SparkUpgradeException.
+query expect_error(INCONSISTENT_BEHAVIOR_CROSS_VERSION)
+SELECT date_format(ts, 'yyyy-MM-dd aaaa') FROM test_date_format_corrected

--- a/spark/src/test/resources/sql-tests/expressions/datetime/date_format_time_parser_policy_exception.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/date_format_time_parser_policy_exception.sql
@@ -1,0 +1,31 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- date_format() under EXCEPTION timeParserPolicy (the default).
+-- Patterns rejected by the new formatter but accepted by legacy raise
+-- SparkUpgradeException at formatter creation.
+-- Config: spark.sql.legacy.timeParserPolicy=EXCEPTION
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_date_format_exception(ts timestamp) USING parquet
+
+statement
+INSERT INTO test_date_format_exception VALUES (timestamp('2024-06-15 10:30:45'))
+
+query expect_error(INCONSISTENT_BEHAVIOR_CROSS_VERSION)
+SELECT date_format(ts, 'yyyy-MM-dd aaaa') FROM test_date_format_exception

--- a/spark/src/test/resources/sql-tests/expressions/datetime/date_format_time_parser_policy_legacy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/date_format_time_parser_policy_legacy.sql
@@ -1,0 +1,31 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- date_format() under LEGACY timeParserPolicy.
+-- Legacy SimpleDateFormat accepts patterns that the new java.time formatter rejects.
+-- Config: spark.sql.legacy.timeParserPolicy=LEGACY
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_date_format_legacy(ts timestamp) USING parquet
+
+statement
+INSERT INTO test_date_format_legacy VALUES (timestamp('2024-06-15 10:30:45')), (timestamp('1970-01-01 00:00:00')), (NULL)
+
+-- Legacy-only token: 4-char am/pm marker is invalid in the new formatter.
+query spark_answer_only
+SELECT date_format(ts, 'yyyy-MM-dd aaaa') FROM test_date_format_legacy

--- a/spark/src/test/resources/sql-tests/expressions/datetime/from_unix_time_time_parser_policy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/from_unix_time_time_parser_policy.sql
@@ -1,0 +1,49 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Convergent from_unixtime() behavior across all three timeParserPolicy values.
+-- Patterns here produce identical output under LEGACY, CORRECTED, and EXCEPTION.
+-- ConfigMatrix: spark.sql.legacy.timeParserPolicy=LEGACY,CORRECTED,EXCEPTION
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_from_unix_time_policy(t long) USING parquet
+
+statement
+INSERT INTO test_from_unix_time_policy VALUES (0), (1718451045), (-1), (NULL), (2147483647)
+
+query spark_answer_only
+SELECT from_unixtime(t) FROM test_from_unix_time_policy
+
+query spark_answer_only
+SELECT from_unixtime(t, 'yyyy-MM-dd') FROM test_from_unix_time_policy
+
+query spark_answer_only
+SELECT from_unixtime(t, 'yyyy-MM-dd HH:mm:ss') FROM test_from_unix_time_policy
+
+query spark_answer_only
+SELECT from_unixtime(t, 'HH:mm:ss') FROM test_from_unix_time_policy
+
+-- literal arguments
+query spark_answer_only
+SELECT from_unixtime(0)
+
+query spark_answer_only
+SELECT from_unixtime(1718451045, 'yyyy-MM-dd')
+
+query spark_answer_only
+SELECT from_unixtime(NULL, 'yyyy-MM-dd')

--- a/spark/src/test/resources/sql-tests/expressions/datetime/from_unix_time_time_parser_policy_corrected.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/from_unix_time_time_parser_policy_corrected.sql
@@ -1,0 +1,31 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- from_unixtime() under CORRECTED timeParserPolicy.
+-- Patterns recognized only by the legacy formatter raise SparkUpgradeException
+-- at formatter creation, even under CORRECTED.
+-- Config: spark.sql.legacy.timeParserPolicy=CORRECTED
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_from_unix_time_corrected(t long) USING parquet
+
+statement
+INSERT INTO test_from_unix_time_corrected VALUES (1718451045)
+
+query expect_error(INCONSISTENT_BEHAVIOR_CROSS_VERSION)
+SELECT from_unixtime(t, 'yyyy-MM-dd aaaa') FROM test_from_unix_time_corrected

--- a/spark/src/test/resources/sql-tests/expressions/datetime/from_unix_time_time_parser_policy_exception.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/from_unix_time_time_parser_policy_exception.sql
@@ -1,0 +1,31 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- from_unixtime() under EXCEPTION timeParserPolicy (the default).
+-- Patterns rejected by the new formatter but accepted by legacy raise
+-- SparkUpgradeException at formatter creation.
+-- Config: spark.sql.legacy.timeParserPolicy=EXCEPTION
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_from_unix_time_exception(t long) USING parquet
+
+statement
+INSERT INTO test_from_unix_time_exception VALUES (1718451045)
+
+query expect_error(INCONSISTENT_BEHAVIOR_CROSS_VERSION)
+SELECT from_unixtime(t, 'yyyy-MM-dd aaaa') FROM test_from_unix_time_exception

--- a/spark/src/test/resources/sql-tests/expressions/datetime/from_unix_time_time_parser_policy_legacy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/from_unix_time_time_parser_policy_legacy.sql
@@ -1,0 +1,31 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- from_unixtime() under LEGACY timeParserPolicy.
+-- Legacy SimpleDateFormat accepts patterns the new java.time formatter rejects.
+-- Config: spark.sql.legacy.timeParserPolicy=LEGACY
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_from_unix_time_legacy(t long) USING parquet
+
+statement
+INSERT INTO test_from_unix_time_legacy VALUES (0), (1718451045), (NULL)
+
+-- Legacy-only token: 4-char am/pm marker formats successfully under LEGACY.
+query spark_answer_only
+SELECT from_unixtime(t, 'yyyy-MM-dd aaaa') FROM test_from_unix_time_legacy

--- a/spark/src/test/resources/sql-tests/expressions/datetime/to_date_time_parser_policy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/to_date_time_parser_policy.sql
@@ -1,0 +1,38 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Convergent to_date(string, format) behavior across all three policies.
+-- ConfigMatrix: spark.sql.legacy.timeParserPolicy=LEGACY,CORRECTED,EXCEPTION
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_to_date_policy(s string) USING parquet
+
+statement
+INSERT INTO test_to_date_policy VALUES ('2024-06-15'), ('1970-01-01'), (NULL), ('')
+
+query spark_answer_only
+SELECT to_date(s, 'yyyy-MM-dd') FROM test_to_date_policy
+
+query spark_answer_only
+SELECT to_date(s) FROM test_to_date_policy
+
+query spark_answer_only
+SELECT to_date('2024-06-15', 'yyyy-MM-dd')
+
+query spark_answer_only
+SELECT to_date(NULL, 'yyyy-MM-dd')

--- a/spark/src/test/resources/sql-tests/expressions/datetime/to_date_time_parser_policy_corrected.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/to_date_time_parser_policy_corrected.sql
@@ -1,0 +1,35 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- to_date() under CORRECTED timeParserPolicy.
+-- Strict java.time parsing returns null for inputs that legacy would accept.
+-- Config: spark.sql.legacy.timeParserPolicy=CORRECTED
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_to_date_strict(s string) USING parquet
+
+statement
+INSERT INTO test_to_date_strict VALUES
+  ('2024-1-1'),
+  ('2024-13-01'),
+  ('2024-02-30'),
+  ('2024-01-01garbage'),
+  ('2024')
+
+query spark_answer_only
+SELECT s, to_date(s, 'yyyy-MM-dd') FROM test_to_date_strict ORDER BY s

--- a/spark/src/test/resources/sql-tests/expressions/datetime/to_date_time_parser_policy_exception.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/to_date_time_parser_policy_exception.sql
@@ -1,0 +1,30 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- to_date() under EXCEPTION timeParserPolicy (the default).
+-- Inputs accepted by legacy but rejected by the new parser raise SparkUpgradeException.
+-- Config: spark.sql.legacy.timeParserPolicy=EXCEPTION
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_to_date_exception(s string) USING parquet
+
+statement
+INSERT INTO test_to_date_exception VALUES ('2024-1-1')
+
+query expect_error(INCONSISTENT_BEHAVIOR_CROSS_VERSION)
+SELECT to_date(s, 'yyyy-MM-dd') FROM test_to_date_exception

--- a/spark/src/test/resources/sql-tests/expressions/datetime/to_date_time_parser_policy_legacy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/to_date_time_parser_policy_legacy.sql
@@ -1,0 +1,35 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- to_date() under LEGACY timeParserPolicy.
+-- Lenient SimpleDateFormat parsing accepts inputs that the new formatter rejects.
+-- Config: spark.sql.legacy.timeParserPolicy=LEGACY
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_to_date_lenient(s string) USING parquet
+
+statement
+INSERT INTO test_to_date_lenient VALUES
+  ('2024-1-1'),
+  ('2024-13-01'),
+  ('2024-02-30'),
+  ('2024-01-01garbage'),
+  ('2024')
+
+query spark_answer_only
+SELECT s, to_date(s, 'yyyy-MM-dd') FROM test_to_date_lenient ORDER BY s

--- a/spark/src/test/resources/sql-tests/expressions/datetime/to_timestamp_time_parser_policy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/to_timestamp_time_parser_policy.sql
@@ -1,0 +1,47 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Convergent to_timestamp(string, format) behavior across all three policies.
+-- ConfigMatrix: spark.sql.legacy.timeParserPolicy=LEGACY,CORRECTED,EXCEPTION
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_to_ts_policy(s string) USING parquet
+
+statement
+INSERT INTO test_to_ts_policy VALUES ('2024-06-15 10:30:45'), ('1970-01-01 00:00:00'), (NULL), ('')
+
+query spark_answer_only
+SELECT to_timestamp(s, 'yyyy-MM-dd HH:mm:ss') FROM test_to_ts_policy
+
+query spark_answer_only
+SELECT to_timestamp(s) FROM test_to_ts_policy
+
+statement
+CREATE TABLE test_to_ts_date_policy(s string) USING parquet
+
+statement
+INSERT INTO test_to_ts_date_policy VALUES ('2024-06-15'), ('1970-01-01'), (NULL)
+
+query spark_answer_only
+SELECT to_timestamp(s, 'yyyy-MM-dd') FROM test_to_ts_date_policy
+
+query spark_answer_only
+SELECT to_timestamp('2024-06-15', 'yyyy-MM-dd')
+
+query spark_answer_only
+SELECT to_timestamp(NULL, 'yyyy-MM-dd')

--- a/spark/src/test/resources/sql-tests/expressions/datetime/to_timestamp_time_parser_policy_corrected.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/to_timestamp_time_parser_policy_corrected.sql
@@ -1,0 +1,35 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- to_timestamp() under CORRECTED timeParserPolicy.
+-- Strict java.time parsing returns null for inputs that legacy would accept.
+-- Config: spark.sql.legacy.timeParserPolicy=CORRECTED
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_to_ts_strict(s string) USING parquet
+
+statement
+INSERT INTO test_to_ts_strict VALUES
+  ('2024-1-1'),
+  ('2024-13-01'),
+  ('2024-02-30'),
+  ('2024-01-01garbage'),
+  ('2024')
+
+query spark_answer_only
+SELECT s, to_timestamp(s, 'yyyy-MM-dd') FROM test_to_ts_strict ORDER BY s

--- a/spark/src/test/resources/sql-tests/expressions/datetime/to_timestamp_time_parser_policy_exception.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/to_timestamp_time_parser_policy_exception.sql
@@ -1,0 +1,30 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- to_timestamp() under EXCEPTION timeParserPolicy (the default).
+-- Inputs accepted by legacy but rejected by the new parser raise SparkUpgradeException.
+-- Config: spark.sql.legacy.timeParserPolicy=EXCEPTION
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_to_ts_exception(s string) USING parquet
+
+statement
+INSERT INTO test_to_ts_exception VALUES ('2024-1-1')
+
+query expect_error(INCONSISTENT_BEHAVIOR_CROSS_VERSION)
+SELECT to_timestamp(s, 'yyyy-MM-dd') FROM test_to_ts_exception

--- a/spark/src/test/resources/sql-tests/expressions/datetime/to_timestamp_time_parser_policy_legacy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/to_timestamp_time_parser_policy_legacy.sql
@@ -1,0 +1,35 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- to_timestamp() under LEGACY timeParserPolicy.
+-- Lenient SimpleDateFormat parsing accepts inputs that the new formatter rejects.
+-- Config: spark.sql.legacy.timeParserPolicy=LEGACY
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_to_ts_lenient(s string) USING parquet
+
+statement
+INSERT INTO test_to_ts_lenient VALUES
+  ('2024-1-1'),
+  ('2024-13-01'),
+  ('2024-02-30'),
+  ('2024-01-01garbage'),
+  ('2024')
+
+query spark_answer_only
+SELECT s, to_timestamp(s, 'yyyy-MM-dd') FROM test_to_ts_lenient ORDER BY s

--- a/spark/src/test/resources/sql-tests/expressions/datetime/to_unix_timestamp_time_parser_policy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/to_unix_timestamp_time_parser_policy.sql
@@ -1,0 +1,47 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Convergent to_unix_timestamp(string, format) behavior across all three policies.
+-- ConfigMatrix: spark.sql.legacy.timeParserPolicy=LEGACY,CORRECTED,EXCEPTION
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_to_unix_ts_policy(s string) USING parquet
+
+statement
+INSERT INTO test_to_unix_ts_policy VALUES ('2024-06-15 10:30:45'), ('1970-01-01 00:00:00'), (NULL), ('')
+
+query spark_answer_only
+SELECT to_unix_timestamp(s, 'yyyy-MM-dd HH:mm:ss') FROM test_to_unix_ts_policy
+
+query spark_answer_only
+SELECT to_unix_timestamp(s) FROM test_to_unix_ts_policy
+
+statement
+CREATE TABLE test_to_unix_ts_date_policy(s string) USING parquet
+
+statement
+INSERT INTO test_to_unix_ts_date_policy VALUES ('2024-06-15'), ('1970-01-01'), (NULL)
+
+query spark_answer_only
+SELECT to_unix_timestamp(s, 'yyyy-MM-dd') FROM test_to_unix_ts_date_policy
+
+query spark_answer_only
+SELECT to_unix_timestamp('2024-06-15', 'yyyy-MM-dd')
+
+query spark_answer_only
+SELECT to_unix_timestamp(NULL, 'yyyy-MM-dd')

--- a/spark/src/test/resources/sql-tests/expressions/datetime/to_unix_timestamp_time_parser_policy_corrected.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/to_unix_timestamp_time_parser_policy_corrected.sql
@@ -1,0 +1,35 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- to_unix_timestamp() under CORRECTED timeParserPolicy.
+-- Strict java.time parsing returns null for inputs that legacy would accept.
+-- Config: spark.sql.legacy.timeParserPolicy=CORRECTED
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_to_unix_ts_strict(s string) USING parquet
+
+statement
+INSERT INTO test_to_unix_ts_strict VALUES
+  ('2024-1-1'),
+  ('2024-13-01'),
+  ('2024-02-30'),
+  ('2024-01-01garbage'),
+  ('2024')
+
+query spark_answer_only
+SELECT s, to_unix_timestamp(s, 'yyyy-MM-dd') FROM test_to_unix_ts_strict ORDER BY s

--- a/spark/src/test/resources/sql-tests/expressions/datetime/to_unix_timestamp_time_parser_policy_exception.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/to_unix_timestamp_time_parser_policy_exception.sql
@@ -1,0 +1,30 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- to_unix_timestamp() under EXCEPTION timeParserPolicy (the default).
+-- Inputs accepted by legacy but rejected by the new parser raise SparkUpgradeException.
+-- Config: spark.sql.legacy.timeParserPolicy=EXCEPTION
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_to_unix_ts_exception(s string) USING parquet
+
+statement
+INSERT INTO test_to_unix_ts_exception VALUES ('2024-1-1')
+
+query expect_error(INCONSISTENT_BEHAVIOR_CROSS_VERSION)
+SELECT to_unix_timestamp(s, 'yyyy-MM-dd') FROM test_to_unix_ts_exception

--- a/spark/src/test/resources/sql-tests/expressions/datetime/to_unix_timestamp_time_parser_policy_legacy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/to_unix_timestamp_time_parser_policy_legacy.sql
@@ -1,0 +1,35 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- to_unix_timestamp() under LEGACY timeParserPolicy.
+-- Lenient SimpleDateFormat parsing accepts inputs that the new formatter rejects.
+-- Config: spark.sql.legacy.timeParserPolicy=LEGACY
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_to_unix_ts_lenient(s string) USING parquet
+
+statement
+INSERT INTO test_to_unix_ts_lenient VALUES
+  ('2024-1-1'),
+  ('2024-13-01'),
+  ('2024-02-30'),
+  ('2024-01-01garbage'),
+  ('2024')
+
+query spark_answer_only
+SELECT s, to_unix_timestamp(s, 'yyyy-MM-dd') FROM test_to_unix_ts_lenient ORDER BY s

--- a/spark/src/test/resources/sql-tests/expressions/datetime/try_to_timestamp_time_parser_policy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/try_to_timestamp_time_parser_policy.sql
@@ -1,0 +1,48 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Convergent try_to_timestamp(string, format) behavior across all three policies.
+-- MinSparkVersion: 4.0
+-- ConfigMatrix: spark.sql.legacy.timeParserPolicy=LEGACY,CORRECTED,EXCEPTION
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_try_to_ts_policy(s string) USING parquet
+
+statement
+INSERT INTO test_try_to_ts_policy VALUES ('2024-06-15 10:30:45'), ('1970-01-01 00:00:00'), (NULL), ('')
+
+query spark_answer_only
+SELECT try_to_timestamp(s, 'yyyy-MM-dd HH:mm:ss') FROM test_try_to_ts_policy
+
+query spark_answer_only
+SELECT try_to_timestamp(s) FROM test_try_to_ts_policy
+
+statement
+CREATE TABLE test_try_to_ts_date_policy(s string) USING parquet
+
+statement
+INSERT INTO test_try_to_ts_date_policy VALUES ('2024-06-15'), ('1970-01-01'), (NULL)
+
+query spark_answer_only
+SELECT try_to_timestamp(s, 'yyyy-MM-dd') FROM test_try_to_ts_date_policy
+
+query spark_answer_only
+SELECT try_to_timestamp('2024-06-15', 'yyyy-MM-dd')
+
+query spark_answer_only
+SELECT try_to_timestamp(NULL, 'yyyy-MM-dd')

--- a/spark/src/test/resources/sql-tests/expressions/datetime/try_to_timestamp_time_parser_policy_corrected.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/try_to_timestamp_time_parser_policy_corrected.sql
@@ -1,0 +1,36 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- try_to_timestamp() under CORRECTED timeParserPolicy.
+-- Strict java.time parsing returns null for inputs that legacy would accept.
+-- MinSparkVersion: 4.0
+-- Config: spark.sql.legacy.timeParserPolicy=CORRECTED
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_try_to_ts_strict(s string) USING parquet
+
+statement
+INSERT INTO test_try_to_ts_strict VALUES
+  ('2024-1-1'),
+  ('2024-13-01'),
+  ('2024-02-30'),
+  ('2024-01-01garbage'),
+  ('2024')
+
+query spark_answer_only
+SELECT s, try_to_timestamp(s, 'yyyy-MM-dd') FROM test_try_to_ts_strict ORDER BY s

--- a/spark/src/test/resources/sql-tests/expressions/datetime/try_to_timestamp_time_parser_policy_exception.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/try_to_timestamp_time_parser_policy_exception.sql
@@ -1,0 +1,33 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- try_to_timestamp() under EXCEPTION timeParserPolicy (the default).
+-- try_to_timestamp swallows DateTimeException/ParseException, but SparkUpgradeException
+-- raised by checkParsedDiff propagates through the catch -- so the EXCEPTION case still
+-- throws on legacy/new divergent inputs.
+-- MinSparkVersion: 4.0
+-- Config: spark.sql.legacy.timeParserPolicy=EXCEPTION
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_try_to_ts_exception(s string) USING parquet
+
+statement
+INSERT INTO test_try_to_ts_exception VALUES ('2024-1-1')
+
+query expect_error(INCONSISTENT_BEHAVIOR_CROSS_VERSION)
+SELECT try_to_timestamp(s, 'yyyy-MM-dd') FROM test_try_to_ts_exception

--- a/spark/src/test/resources/sql-tests/expressions/datetime/try_to_timestamp_time_parser_policy_legacy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/try_to_timestamp_time_parser_policy_legacy.sql
@@ -1,0 +1,36 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- try_to_timestamp() under LEGACY timeParserPolicy.
+-- Lenient SimpleDateFormat parsing accepts inputs that the new formatter rejects.
+-- MinSparkVersion: 4.0
+-- Config: spark.sql.legacy.timeParserPolicy=LEGACY
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_try_to_ts_lenient(s string) USING parquet
+
+statement
+INSERT INTO test_try_to_ts_lenient VALUES
+  ('2024-1-1'),
+  ('2024-13-01'),
+  ('2024-02-30'),
+  ('2024-01-01garbage'),
+  ('2024')
+
+query spark_answer_only
+SELECT s, try_to_timestamp(s, 'yyyy-MM-dd') FROM test_try_to_ts_lenient ORDER BY s

--- a/spark/src/test/resources/sql-tests/expressions/datetime/unix_timestamp_time_parser_policy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/unix_timestamp_time_parser_policy.sql
@@ -1,0 +1,50 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Convergent unix_timestamp(string, format) behavior across all three policies.
+-- Strictly-formatted inputs parse identically under LEGACY, CORRECTED, and EXCEPTION.
+-- ConfigMatrix: spark.sql.legacy.timeParserPolicy=LEGACY,CORRECTED,EXCEPTION
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_unix_ts_policy(s string) USING parquet
+
+statement
+INSERT INTO test_unix_ts_policy VALUES ('2024-06-15 10:30:45'), ('1970-01-01 00:00:00'), (NULL), ('')
+
+query spark_answer_only
+SELECT unix_timestamp(s, 'yyyy-MM-dd HH:mm:ss') FROM test_unix_ts_policy
+
+query spark_answer_only
+SELECT unix_timestamp(s) FROM test_unix_ts_policy
+
+-- date-only input with date-only pattern
+statement
+CREATE TABLE test_unix_ts_date_policy(s string) USING parquet
+
+statement
+INSERT INTO test_unix_ts_date_policy VALUES ('2024-06-15'), ('1970-01-01'), (NULL)
+
+query spark_answer_only
+SELECT unix_timestamp(s, 'yyyy-MM-dd') FROM test_unix_ts_date_policy
+
+-- literal arguments
+query spark_answer_only
+SELECT unix_timestamp('2024-06-15', 'yyyy-MM-dd')
+
+query spark_answer_only
+SELECT unix_timestamp(NULL, 'yyyy-MM-dd')

--- a/spark/src/test/resources/sql-tests/expressions/datetime/unix_timestamp_time_parser_policy_corrected.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/unix_timestamp_time_parser_policy_corrected.sql
@@ -1,0 +1,36 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- unix_timestamp() under CORRECTED timeParserPolicy.
+-- The new java.time formatter is strict: lenient inputs return null without raising
+-- SparkUpgradeException.
+-- Config: spark.sql.legacy.timeParserPolicy=CORRECTED
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_unix_ts_strict(s string) USING parquet
+
+statement
+INSERT INTO test_unix_ts_strict VALUES
+  ('2024-1-1'),
+  ('2024-13-01'),
+  ('2024-02-30'),
+  ('2024-01-01garbage'),
+  ('2024')
+
+query spark_answer_only
+SELECT s, unix_timestamp(s, 'yyyy-MM-dd') FROM test_unix_ts_strict ORDER BY s

--- a/spark/src/test/resources/sql-tests/expressions/datetime/unix_timestamp_time_parser_policy_exception.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/unix_timestamp_time_parser_policy_exception.sql
@@ -1,0 +1,31 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- unix_timestamp() under EXCEPTION timeParserPolicy (the default).
+-- New parser fails on lenient inputs; legacy parser would have succeeded;
+-- DateTimeFormatterHelper.checkParsedDiff converts the failure to SparkUpgradeException.
+-- Config: spark.sql.legacy.timeParserPolicy=EXCEPTION
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_unix_ts_exception(s string) USING parquet
+
+statement
+INSERT INTO test_unix_ts_exception VALUES ('2024-1-1')
+
+query expect_error(INCONSISTENT_BEHAVIOR_CROSS_VERSION)
+SELECT unix_timestamp(s, 'yyyy-MM-dd') FROM test_unix_ts_exception

--- a/spark/src/test/resources/sql-tests/expressions/datetime/unix_timestamp_time_parser_policy_legacy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/unix_timestamp_time_parser_policy_legacy.sql
@@ -1,0 +1,36 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- unix_timestamp() under LEGACY timeParserPolicy.
+-- SimpleDateFormat is lenient: single-digit fields, out-of-range values, and trailing
+-- characters all parse successfully.
+-- Config: spark.sql.legacy.timeParserPolicy=LEGACY
+-- Config: spark.sql.session.timeZone=UTC
+
+statement
+CREATE TABLE test_unix_ts_lenient(s string) USING parquet
+
+statement
+INSERT INTO test_unix_ts_lenient VALUES
+  ('2024-1-1'),
+  ('2024-13-01'),
+  ('2024-02-30'),
+  ('2024-01-01garbage'),
+  ('2024')
+
+query spark_answer_only
+SELECT s, unix_timestamp(s, 'yyyy-MM-dd') FROM test_unix_ts_lenient ORDER BY s

--- a/spark/src/test/scala/org/apache/comet/parquet/CometNestedSchemaPruningSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/CometNestedSchemaPruningSuite.scala
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.parquet
+
+import org.scalactic.source.Position
+import org.scalatest.Tag
+
+import org.apache.spark.sql.{CometTestBase, DataFrame}
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
+import org.apache.spark.sql.comet.{CometNativeScanExec, CometScanExec}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StructType
+
+import org.apache.comet.CometConf
+
+/**
+ * Verifies that Comet honors `spark.sql.optimizer.nestedSchemaPruning.enabled` end-to-end: the
+ * executed plan's required schema is pruned when the flag is `true`, the full schema is read when
+ * the flag is `false`, and results match Spark in both cases.
+ *
+ * Each test runs once per Comet scan implementation (`SCAN_NATIVE_DATAFUSION`,
+ * `SCAN_NATIVE_ICEBERG_COMPAT`). The V1 datasource path is pinned because plain Parquet V2 is not
+ * Comet-accelerated (only CSV and Iceberg V2 scans are).
+ */
+class CometNestedSchemaPruningSuite extends CometTestBase with AdaptiveSparkPlanHelper {
+
+  private val scanImpls =
+    Seq(CometConf.SCAN_NATIVE_DATAFUSION, CometConf.SCAN_NATIVE_ICEBERG_COMPAT)
+
+  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit
+      pos: Position): Unit = {
+    scanImpls.foreach { scan =>
+      super.test(s"$testName - $scan", testTags: _*) {
+        withSQLConf(
+          CometConf.COMET_ENABLED.key -> "true",
+          CometConf.COMET_EXEC_ENABLED.key -> "true",
+          CometConf.COMET_EXPLAIN_FALLBACK_ENABLED.key -> "false",
+          CometConf.COMET_NATIVE_SCAN_IMPL.key -> scan,
+          SQLConf.USE_V1_SOURCE_LIST.key -> "parquet") {
+          testFun
+        }
+      }
+    }
+  }
+
+  /**
+   * Walks the executed plan, collects the required schema from any Comet scan exec, and asserts
+   * it matches `expected` (a catalyst-style schema string). Field nullability is ignored.
+   */
+  private def assertScanSchema(df: DataFrame, expected: String): Unit = {
+    val scanSchemas = collect(df.queryExecution.executedPlan) {
+      case scan: CometScanExec => scan.requiredSchema
+      case scan: CometNativeScanExec => scan.requiredSchema
+    }
+    assert(
+      scanSchemas.size == 1,
+      s"Expected exactly one Comet scan in plan, found ${scanSchemas.size}:\n" +
+        df.queryExecution.executedPlan.toString)
+    val expectedSchema = CatalystSqlParser.parseDataType(expected).asInstanceOf[StructType]
+    // Compare via catalogString which omits nullability flags so the assertions stay readable.
+    assert(
+      scanSchemas.head.catalogString == expectedSchema.catalogString,
+      s"Pruned schema mismatch.\n  expected: ${expectedSchema.catalogString}\n" +
+        s"  actual:   ${scanSchemas.head.catalogString}")
+  }
+
+  /**
+   * Writes a small `Contact` parquet dataset to a temp path and runs `body` with the path.
+   * Mirrors the case-class shape used by Spark's `SchemaPruningSuite` so the audit
+   * cross-references easily.
+   */
+  private def withContactsParquet(body: String => Unit): Unit = {
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+      import testImplicits._
+      val df = Seq(
+        Contact(
+          id = 0,
+          name = FullName("Jane", "X.", "Doe"),
+          address = "123 Main Street",
+          pets = 1,
+          friends = Array(FullName("Susan", "Z.", "Smith")),
+          relatives = Map("brother" -> FullName("John", "Y.", "Doe")),
+          employer = Employer(0, Company("abc", "123 Business Street"))),
+        Contact(
+          id = 1,
+          name = FullName("John", "Y.", "Doe"),
+          address = "321 Wall Street",
+          pets = 3,
+          friends = Array(FullName("Alice", "A.", "Jones")),
+          relatives = Map("sister" -> FullName("Jane", "X.", "Doe")),
+          employer = null)).toDF()
+      df.write.parquet(path)
+      body(path)
+    }
+  }
+
+  // Top-level field of a struct -- pruned schema retains only the projected leaf.
+  test("prune top-level struct field") {
+    withContactsParquet { path =>
+      withSQLConf(SQLConf.NESTED_SCHEMA_PRUNING_ENABLED.key -> "true") {
+        val df = spark.read.parquet(path).selectExpr("name.first")
+        assertScanSchema(df, "struct<name:struct<first:string>>")
+        checkSparkAnswer(df)
+      }
+      withSQLConf(SQLConf.NESTED_SCHEMA_PRUNING_ENABLED.key -> "false") {
+        val df = spark.read.parquet(path).selectExpr("name.first")
+        assertScanSchema(df, "struct<name:struct<first:string,middle:string,last:string>>")
+        checkSparkAnswer(df)
+      }
+    }
+  }
+
+  // Field inside an array of struct.
+  test("prune field inside array of struct") {
+    withContactsParquet { path =>
+      withSQLConf(SQLConf.NESTED_SCHEMA_PRUNING_ENABLED.key -> "true") {
+        val df = spark.read.parquet(path).selectExpr("friends.first")
+        assertScanSchema(df, "struct<friends:array<struct<first:string>>>")
+        checkSparkAnswer(df)
+      }
+      withSQLConf(SQLConf.NESTED_SCHEMA_PRUNING_ENABLED.key -> "false") {
+        val df = spark.read.parquet(path).selectExpr("friends.first")
+        assertScanSchema(
+          df,
+          "struct<friends:array<struct<first:string,middle:string,last:string>>>")
+        checkSparkAnswer(df)
+      }
+    }
+  }
+
+  // Field inside a map value.
+  test("prune field inside map value") {
+    withContactsParquet { path =>
+      withSQLConf(SQLConf.NESTED_SCHEMA_PRUNING_ENABLED.key -> "true") {
+        val df = spark.read.parquet(path).selectExpr("relatives['brother'].first")
+        assertScanSchema(df, "struct<relatives:map<string,struct<first:string>>>")
+        checkSparkAnswer(df)
+      }
+      withSQLConf(SQLConf.NESTED_SCHEMA_PRUNING_ENABLED.key -> "false") {
+        val df = spark.read.parquet(path).selectExpr("relatives['brother'].first")
+        assertScanSchema(
+          df,
+          "struct<relatives:map<string,struct<first:string,middle:string,last:string>>>")
+        checkSparkAnswer(df)
+      }
+    }
+  }
+
+  // Doubly-nested struct: only the deep leaf is required.
+  test("prune doubly-nested struct field") {
+    withContactsParquet { path =>
+      withSQLConf(SQLConf.NESTED_SCHEMA_PRUNING_ENABLED.key -> "true") {
+        val df = spark.read.parquet(path).selectExpr("employer.company.name")
+        assertScanSchema(df, "struct<employer:struct<company:struct<name:string>>>")
+        checkSparkAnswer(df)
+      }
+      withSQLConf(SQLConf.NESTED_SCHEMA_PRUNING_ENABLED.key -> "false") {
+        val df = spark.read.parquet(path).selectExpr("employer.company.name")
+        assertScanSchema(
+          df,
+          "struct<employer:struct<id:int,company:struct<name:string,address:string>>>")
+        checkSparkAnswer(df)
+      }
+    }
+  }
+
+  // Filter on a nested field plus a separate top-level projection. The required schema must
+  // include both the filtered leaf and the projected top-level column.
+  test("prune with filter on nested field") {
+    withContactsParquet { path =>
+      withSQLConf(SQLConf.NESTED_SCHEMA_PRUNING_ENABLED.key -> "true") {
+        val df = spark.read
+          .parquet(path)
+          .where("name.first = 'Jane'")
+          .selectExpr("id")
+        assertScanSchema(df, "struct<id:int,name:struct<first:string>>")
+        checkSparkAnswer(df)
+      }
+      withSQLConf(SQLConf.NESTED_SCHEMA_PRUNING_ENABLED.key -> "false") {
+        val df = spark.read
+          .parquet(path)
+          .where("name.first = 'Jane'")
+          .selectExpr("id")
+        assertScanSchema(df, "struct<id:int,name:struct<first:string,middle:string,last:string>>")
+        checkSparkAnswer(df)
+      }
+    }
+  }
+
+  // Pruning correctly returns null when the intermediate struct is null in the row.
+  // The second contact has employer = null; the projected leaf must round-trip as null and match
+  // Spark's behavior.
+  test("prune with null at intermediate struct level") {
+    withContactsParquet { path =>
+      withSQLConf(SQLConf.NESTED_SCHEMA_PRUNING_ENABLED.key -> "true") {
+        val df = spark.read.parquet(path).selectExpr("employer.company.name")
+        assertScanSchema(df, "struct<employer:struct<company:struct<name:string>>>")
+        checkSparkAnswer(df)
+      }
+    }
+  }
+}
+
+private case class FullName(first: String, middle: String, last: String)
+private case class Company(name: String, address: String)
+private case class Employer(id: Int, company: Company)
+private case class Contact(
+    id: Int,
+    name: FullName,
+    address: String,
+    pets: Int,
+    friends: Array[FullName] = Array.empty,
+    relatives: Map[String, FullName] = Map.empty,
+    employer: Employer = null)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A. Audit-driven test coverage; no behavior change.

**Stacked on #4183.** This PR's branch is based on `feat/legacy-time-parser-policy-tests`, so until #4183 merges the diff here will include those commits as well.

## Rationale for this change

`spark.sql.optimizer.nestedSchemaPruning.enabled` (default `true`) is the catalyst-level switch that lets columnar readers fetch only the leaves of a nested column. Comet propagates the flag into Hadoop conf via `CometParquetFileFormat.populateConf` and otherwise inherits Spark's already-pruned `requiredSchema`, but Comet's own test tree had no end-to-end coverage. Spark's own `ParquetSchemaPruningSuite` is patched in `dev/diffs/*.diff` to recognize Comet scans, but that only validates correctness when CI runs Spark tests, and doesn't lock in plan-level expectations from inside Comet.

A SQL-file test cannot prove pruning happened: it only checks results, and pruned-vs-unpruned reads usually return the same rows. Plan inspection is the only way to catch a regression, so this audit uses Scala tests, mirroring Spark's `checkScanSchemata` pattern.

## What changes are included in this PR?

- New suite: `spark/src/test/scala/org/apache/comet/parquet/CometNestedSchemaPruningSuite.scala`. Each scenario runs across `SCAN_NATIVE_DATAFUSION` and `SCAN_NATIVE_ICEBERG_COMPAT` under V1 Parquet. A small helper walks the executed plan, collects `requiredSchema` from any `CometScanExec`/`CometNativeScanExec`, and asserts it matches an expected catalog-string schema; results are then compared against Spark via `checkSparkAnswer`. Scenarios:
  - top-level struct field
  - field inside array of struct
  - field inside map value
  - doubly-nested struct field
  - projection plus filter on a nested field
  - null at an intermediate struct level
- Plain Parquet V2 is excluded from the matrix because Comet's V2 scan rule only covers CSV and Iceberg, so Parquet V2 stays as plain `BatchScanExec` and there's no Comet scan to inspect. Documented in the suite's class comment and the audit notes.
- Append a second entry to `docs/source/contributor-guide/spark_configs_support.md` with the full audit notes for `nestedSchemaPruning.enabled`: source semantics, current Comet status, test layout, and findings.

This PR was scaffolded with the project's `audit-comet-expression` workflow extended to a config-level audit, plus the `superpowers:brainstorming` and `superpowers:using-git-worktrees` skills.

## How are these changes tested?

- `./mvnw test -Dsuites=\"org.apache.comet.parquet.CometNestedSchemaPruningSuite\" -Dtest=none` -- 12/12 pass on Spark 3.5.8 (default).
- `./mvnw test -Pspark-3.4 -Dsuites=\"org.apache.comet.parquet.CometNestedSchemaPruningSuite\" -Dtest=none` -- 12/12 pass.
- `./mvnw test -Pspark-4.0 -Dsuites=\"org.apache.comet.parquet.CometNestedSchemaPruningSuite\" -Dtest=none` -- 12/12 pass.

No Comet bugs were uncovered by the audit.