### PR TITLE
docs: document Spark version labels in bug triage guide

### DIFF
--- a/.claude/skills/bug-triage/SKILL.md
+++ b/.claude/skills/bug-triage/SKILL.md
@@ -65,9 +65,14 @@ For each issue, review the title and body and determine:
 2. **Area labels** (zero or more): from the area table in the guide
    (`area:writer`, `area:shuffle`, `area:aggregation`, `area:scan`,
    `area:expressions`, `area:ffi`, `area:ci`) plus the pre-existing area
-   indicators (`native_datafusion`, `native_iceberg_compat`, `spark 4`,
+   indicators (`native_datafusion`, `native_iceberg_compat`,
    `spark sql tests`).
-3. **Escalation note**: if the issue matches an escalation trigger from the
+3. **Spark version label** (zero or more): apply `spark 4.0`, `spark 4.1`,
+   and/or `spark 4.2` only when the bug is specific to that Spark version
+   (e.g., the reporter says it only reproduces on 4.1, the stack trace names a
+   4.1-only API, or the issue title/body explicitly scopes it to one version).
+   Do not apply a version label to version-agnostic bugs.
+4. **Escalation note**: if the issue matches an escalation trigger from the
    guide (e.g., a `priority:high` crash that may also produce wrong results),
    note it in the summary.
 
@@ -93,14 +98,14 @@ For each issue you classified in Step 3, apply the labels and remove
 ```bash
 gh issue edit <NUMBER> \
   --repo apache/datafusion-comet \
-  --add-label "priority:high,area:expressions" \
+  --add-label "priority:high,area:expressions,spark 4.1" \
   --remove-label "requires-triage"
 ```
 
 Notes:
 
 - Pass the labels as a single comma-separated string (no spaces around commas).
-- Quote labels that contain spaces (e.g., `"spark 4"`).
+- Quote labels that contain spaces (e.g., `"spark 4.1"`).
 - Only add labels that already exist in the repo. If a label from the guide is
   missing in the repo, skip it for that issue and record a note in the summary
   rather than creating new labels.
@@ -139,11 +144,13 @@ Body: a markdown report with these sections, in this order:
 
    - <issue title> ([#1234](https://github.com/apache/datafusion-comet/issues/1234))
      - Area labels: `area:expressions`, `area:scan`
+     - Spark version labels: `spark 4.1`
      - Rationale: one sentence tying the call to the guide
    ```
 
    The issue number (not the title) is the link target. The title is plain
-   text. If there are no area labels, write `Area labels: none`.
+   text. If there are no area labels, write `Area labels: none`. Omit the
+   `Spark version labels` line if no version label was applied.
 
 3. **Escalations to consider** (omit section if empty) — bullet per issue with
    the same `<title> ([#N](url))` form, plus a sub-bullet explaining the

--- a/docs/source/contributor-guide/bug_triage.md
+++ b/docs/source/contributor-guide/bug_triage.md
@@ -74,7 +74,22 @@ help contributors find bugs in their area of expertise.
 | `area:ci`          | CI/CD, GitHub Actions, build tooling      |
 
 The following pre-existing labels also serve as area indicators: `native_datafusion`,
-`native_iceberg_compat`, `spark 4`, `spark sql tests`.
+`native_iceberg_compat`, `spark sql tests`.
+
+## Spark Version Labels
+
+If a bug only reproduces on (or is otherwise specific to) a particular Spark version, apply the
+matching version label so the issue surfaces in version-specific queries. A bug may have multiple
+version labels if it affects more than one supported version.
+
+| Label       | Use when                                       |
+| ----------- | ---------------------------------------------- |
+| `spark 4.0` | Issue is specific to Spark 4.0                 |
+| `spark 4.1` | Issue is specific to Spark 4.1                 |
+| `spark 4.2` | Issue is specific to Spark 4.2                 |
+
+Do not apply a Spark version label to bugs that reproduce on every supported version: they belong
+to general triage, not version-specific tracking.
 
 ## Triage Process
 
@@ -92,8 +107,10 @@ When a new bug is filed:
    is more important than whether it crashes.
 3. **Apply a priority label** using the decision tree above.
 4. **Apply area labels** to indicate the affected subsystem(s).
-5. **Apply `good first issue`** if the fix is likely straightforward and well-scoped.
-6. **Remove the `requires-triage` label** to indicate triage is complete.
+5. **Apply a Spark version label** (e.g., `spark 4.1`) if the bug is specific to one or more
+   supported Spark versions.
+6. **Apply `good first issue`** if the fix is likely straightforward and well-scoped.
+7. **Remove the `requires-triage` label** to indicate triage is complete.
 
 ### For Existing Bugs
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

Comet has per-version `spark 4.0`, `spark 4.1`, and `spark 4.2` labels in the issue tracker, but the bug triage guide does not tell triagers when to apply them. Without a documented convention, version-specific bugs get filed without a version label and are harder to surface in version-scoped queries (for example, when prepping a Spark 4.1 release or auditing 4.1-only failures).

## What changes are included in this PR?

- Add a "Spark Version Labels" section to `docs/source/contributor-guide/bug_triage.md` describing when to apply `spark 4.0`, `spark 4.1`, or `spark 4.2`.
- Add a step to the "For New Issues" checklist for applying a Spark version label.
- Drop the stale `spark 4` entry from the area-indicators line since the actual labels are version-specific.
- Update the `bug-triage` Claude skill (`.claude/skills/bug-triage/SKILL.md`) to mirror the same guidance: a new classification step, an updated `gh issue edit` example, and an optional `Spark version labels:` line in the per-issue summary template.

This work was scaffolded with the `bug-triage` project skill.

## How are these changes tested?

Documentation-only change. No code is affected.