### PR TITLE
fix: cargo clean before release build to avoid stale native libs

### DIFF
--- a/dev/release/build-release-comet.sh
+++ b/dev/release/build-release-comet.sh
@@ -125,6 +125,13 @@ docker build --no-cache \
 # Clean previous Java build
 pushd $COMET_HOME_DIR && ./mvnw clean && popd
 
+# Clean previous native build. This is required because common/pom.xml has
+# unconditional resource entries that bundle libcomet.dylib from
+# native/target/{x86_64,aarch64}-apple-darwin/release. If a release manager
+# previously cross-compiled those targets locally, stale dylibs would leak
+# into the release jars. See https://github.com/apache/datafusion-comet/issues/2232
+pushd $COMET_HOME_DIR/native && cargo clean && popd
+
 # Run the builder container for each architecture. The entrypoint script will build the binaries
 
 # AMD64

--- a/docs/source/contributor-guide/release_process.md
+++ b/docs/source/contributor-guide/release_process.md
@@ -158,6 +158,21 @@ commit into the release branch.
 
 ### Build the jars
 
+#### A note on workspace cleanliness
+
+The `common/pom.xml` resource configuration unconditionally bundles
+`native/target/{x86_64,aarch64}-apple-darwin/release/libcomet.dylib` into the
+`common` jar when those files exist on disk. Maven's `clean` removes
+`common/target` but does not touch Cargo's `native/target` directory, so a
+stale dylib left over from a prior local `make release` or `make release-linux`
+on the release manager's workstation can silently end up in a release jar
+(see [#2232](https://github.com/apache/datafusion-comet/issues/2232) for the
+incident in 0.9.1).
+
+The `build-release-comet.sh` script now runs `cargo clean` for you, but as a
+defensive measure, prefer running the release build from a fresh clone of the
+repository rather than your day-to-day working tree.
+
 #### Setup to do the build
 
 The build process requires Docker. Download the latest Docker Desktop from https://www.docker.com/products/docker-desktop/.


### PR DESCRIPTION
## Which issue does this PR close?

Closes #2232

## Rationale for this change

Issue #2232 reported that the 0.9.1 jars were nearly twice the size of 0.9.0. Investigation showed that a stale `org/apache/comet/darwin/aarch64/libcomet.dylib` (227MB uncompressed) was bundled into the release jar, even though the release script had `HAS_MACOS_SDK=false` (the default) and was not asked to ship a darwin/aarch64 binary.

Root cause: `common/pom.xml` declares two unconditional resource entries that always bundle `libcomet.dylib` from `native/target/{x86_64,aarch64}-apple-darwin/release` whenever those files exist on disk. The release script runs `./mvnw clean`, but Maven only cleans `common/target`, not Cargo's `native/target`. If the release manager has previously run `make release-linux` (or otherwise cross-compiled to apple-darwin) in their working tree, those stale dylibs silently leak into the release jars produced by `build-release-comet.sh`.

## What changes are included in this PR?

- `dev/release/build-release-comet.sh`: run `cargo clean` after `mvnw clean` so stale cross-compiled artifacts are removed before the release build.
- `docs/source/contributor-guide/release_process.md`: add a note explaining the leakage risk and recommending release managers run from a fresh clone as a defense-in-depth measure.

## How are these changes tested?

Manual review only. The release script is exercised by release managers ahead of each release; no automated test exists for this code path.