### PR TITLE
test: remove "Comet (Scan)" cases from microbenchmarks

### DIFF
--- a/.github/workflows/pr_benchmark_check.yml
+++ b/.github/workflows/pr_benchmark_check.yml
@@ -84,5 +84,9 @@ jobs:
             ${{ runner.os }}-benchmark-maven-
 
       - name: Check Scala compilation and linting
+        # Pin to spark-4.0 (Scala 2.13.16) because the default profile is now
+        # spark-4.1 / Scala 2.13.17, and semanticdb-scalac_2.13.17 is not yet
+        # published, which breaks `-Psemanticdb`. See pr_build_linux.yml for
+        # the same exclusion in the main lint matrix.
         run: |
-          ./mvnw -B compile test-compile scalafix:scalafix -Dscalafix.mode=CHECK -Psemanticdb -DskipTests
+          ./mvnw -B compile test-compile scalafix:scalafix -Dscalafix.mode=CHECK -Psemanticdb -Pspark-4.0 -DskipTests

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
@@ -97,8 +97,8 @@ trait CometBenchmarkBase
   }
 
   /**
-   * Runs an expression benchmark with standard cases: Spark, Comet (Scan), Comet (Scan + Exec).
-   * This provides a consistent benchmark structure for expression evaluation.
+   * Runs an expression benchmark with standard cases: Spark, Comet. This provides a consistent
+   * benchmark structure for expression evaluation.
    *
    * @param name
    *   Benchmark name
@@ -107,7 +107,7 @@ trait CometBenchmarkBase
    * @param query
    *   SQL query to benchmark
    * @param extraCometConfigs
-   *   Additional configurations to apply for Comet cases (optional)
+   *   Additional configurations to apply for the Comet case (optional)
    */
   final def runExpressionBenchmark(
       name: String,
@@ -118,14 +118,6 @@ trait CometBenchmarkBase
 
     benchmark.addCase("Spark") { _ =>
       withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
-        spark.sql(query).noop()
-      }
-    }
-
-    benchmark.addCase("Comet (Scan)") { _ =>
-      withSQLConf(
-        CometConf.COMET_ENABLED.key -> "true",
-        CometConf.COMET_EXEC_ENABLED.key -> "false") {
         spark.sql(query).noop()
       }
     }
@@ -158,7 +150,7 @@ trait CometBenchmarkBase
       }
     }
 
-    benchmark.addCase("Comet (Scan + Exec)") { _ =>
+    benchmark.addCase("Comet") { _ =>
       withSQLConf(cometExecConfigs.toSeq: _*) {
         spark.sql(query).noop()
       }

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometCsvExpressionBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometCsvExpressionBenchmark.scala
@@ -31,7 +31,7 @@ import org.apache.comet.CometConf
  * @param query
  *   SQL query to benchmark
  * @param extraCometConfigs
- *   Additional Comet configurations for the scan+exec case
+ *   Additional Comet configurations for the Comet case
  */
 case class CsvExprConfig(
     name: String,

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometExecBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometExecBenchmark.scala
@@ -84,13 +84,7 @@ object CometExecBenchmark extends CometBenchmarkBase {
           spark.sql("select c2 + 1, c1 + 2 from parquetV1Table where c1 + 1 > 0").noop()
         }
 
-        benchmark.addCase("SQL Parquet - Comet (Scan)") { _ =>
-          withSQLConf(CometConf.COMET_ENABLED.key -> "true") {
-            spark.sql("select c2 + 1, c1 + 2 from parquetV1Table where c1 + 1 > 0").noop()
-          }
-        }
-
-        benchmark.addCase("SQL Parquet - Comet (Scan, Exec)") { _ =>
+        benchmark.addCase("SQL Parquet - Comet") { _ =>
           withSQLConf(
             CometConf.COMET_ENABLED.key -> "true",
             CometConf.COMET_EXEC_ENABLED.key -> "true") {
@@ -128,15 +122,7 @@ object CometExecBenchmark extends CometBenchmarkBase {
               "col2, col3 FROM parquetV1Table")
         }
 
-        benchmark.addCase("SQL Parquet - Comet (Scan)") { _ =>
-          withSQLConf(CometConf.COMET_ENABLED.key -> "true") {
-            spark.sql(
-              "SELECT (SELECT max(col1) AS parquetV1Table FROM parquetV1Table) AS a, " +
-                "col2, col3 FROM parquetV1Table")
-          }
-        }
-
-        benchmark.addCase("SQL Parquet - Comet (Scan, Exec)") { _ =>
+        benchmark.addCase("SQL Parquet - Comet") { _ =>
           withSQLConf(
             CometConf.COMET_ENABLED.key -> "true",
             CometConf.COMET_EXEC_ENABLED.key -> "true",
@@ -164,13 +150,7 @@ object CometExecBenchmark extends CometBenchmarkBase {
           spark.sql("select * from parquetV1Table").sortWithinPartitions("value").noop()
         }
 
-        benchmark.addCase("SQL Parquet - Comet (Scan)") { _ =>
-          withSQLConf(CometConf.COMET_ENABLED.key -> "true") {
-            spark.sql("select * from parquetV1Table").sortWithinPartitions("value").noop()
-          }
-        }
-
-        benchmark.addCase("SQL Parquet - Comet (Scan, Exec)") { _ =>
+        benchmark.addCase("SQL Parquet - Comet") { _ =>
           withSQLConf(
             CometConf.COMET_ENABLED.key -> "true",
             CometConf.COMET_EXEC_ENABLED.key -> "true") {
@@ -199,16 +179,7 @@ object CometExecBenchmark extends CometBenchmarkBase {
             .noop()
         }
 
-        benchmark.addCase("SQL Parquet - Comet (Scan)") { _ =>
-          withSQLConf(CometConf.COMET_ENABLED.key -> "true") {
-            spark
-              .sql("SELECT col1, col2, SUM(col3) FROM parquetV1Table " +
-                "GROUP BY col1, col2 GROUPING SETS ((col1), (col2))")
-              .noop()
-          }
-        }
-
-        benchmark.addCase("SQL Parquet - Comet (Scan, Exec)") { _ =>
+        benchmark.addCase("SQL Parquet - Comet") { _ =>
           withSQLConf(
             CometConf.COMET_ENABLED.key -> "true",
             CometConf.COMET_EXEC_ENABLED.key -> "true") {
@@ -251,13 +222,7 @@ object CometExecBenchmark extends CometBenchmarkBase {
           spark.sql(query).noop()
         }
 
-        benchmark.addCase("SQL Parquet - Comet (Scan) (BloomFilterAgg)") { _ =>
-          withSQLConf(CometConf.COMET_ENABLED.key -> "true") {
-            spark.sql(query).noop()
-          }
-        }
-
-        benchmark.addCase("SQL Parquet - Comet (Scan, Exec) (BloomFilterAgg)") { _ =>
+        benchmark.addCase("SQL Parquet - Comet (BloomFilterAgg)") { _ =>
           withSQLConf(
             CometConf.COMET_ENABLED.key -> "true",
             CometConf.COMET_EXEC_ENABLED.key -> "true") {

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometJsonExpressionBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometJsonExpressionBenchmark.scala
@@ -32,7 +32,7 @@ import org.apache.comet.CometConf
  * @param query
  *   SQL query to benchmark
  * @param extraCometConfigs
- *   Additional Comet configurations for the scan+exec case
+ *   Additional Comet configurations for the Comet case
  */
 case class JsonExprConfig(
     name: String,

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometStringExpressionBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometStringExpressionBenchmark.scala
@@ -28,7 +28,7 @@ import org.apache.comet.CometConf
  * @param query
  *   SQL query to benchmark
  * @param extraCometConfigs
- *   Additional Comet configurations for the scan+exec case
+ *   Additional Comet configurations for the Comet case
  */
 case class StringExprConfig(
     name: String,


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

The "scan only" benchmark runs disabled `spark.comet.exec.enabled`, which actually disables scans now that `native_datafusion` is the default scan.

## What changes are included in this PR?

Just run Spark vs Comet, where Comet is fully enabled.

## How are these changes tested?
