### PR TITLE
CI: Add workflow to verify release candidate on multiple systems

### DIFF
--- a/.github/workflows/verify-release-candidate.yml
+++ b/.github/workflows/verify-release-candidate.yml
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Verify Release Candidate
+
+# NOTE: This workflow is intended to be run manually via workflow_dispatch.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version number (e.g., 52.0.0)
+        required: true
+        type: string
+      rc_number:
+        description: Release candidate number (e.g., 0)
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify RC (${{ matrix.os }}-${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux
+          - os: linux
+            arch: x64
+            runner: ubuntu-latest
+          - os: linux
+            arch: arm64
+            runner: ubuntu-24.04-arm
+
+          # macOS
+          - os: macos
+            arch: arm64
+            runner: macos-latest
+          - os: macos
+            arch: x64
+            runner: macos-15-intel
+
+          # Windows
+          - os: windows
+            arch: x64
+            runner: windows-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.4"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run release candidate verification
+        shell: bash
+        run: ./dev/release/verify-release-candidate.sh "${{ inputs.version }}" "${{ inputs.rc_number }}"

--- a/.github/workflows/verify-release-candidate.yml
+++ b/.github/workflows/verify-release-candidate.yml
@@ -78,6 +78,11 @@ jobs:
           version: "27.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set RUSTFLAGS for Windows GNU linker
+        if: matrix.os == 'windows'
+        shell: bash
+        run: echo "RUSTFLAGS=-C link-arg=-Wl,--exclude-libs=ALL" >> "$GITHUB_ENV"
+
       - name: Run release candidate verification
         shell: bash
         run: ./dev/release/verify-release-candidate.sh "${INPUTS_VERSION}" "${INPUTS_RC_NUMBER}"

--- a/.github/workflows/verify-release-candidate.yml
+++ b/.github/workflows/verify-release-candidate.yml
@@ -85,20 +85,23 @@ jobs:
           distribution: zulu
           java-version: 11
 
-      - name: Set RUSTFLAGS for Windows GNU linker
+      - name: Set Windows build flags
         if: matrix.os == 'windows'
         shell: bash
-        run: echo "RUSTFLAGS=-C link-arg=-Wl,--exclude-libs=ALL" >> "$GITHUB_ENV"
+        run: |
+          echo "RUSTFLAGS=-C link-arg=-Wl,--exclude-libs=ALL" >> "$GITHUB_ENV"
+          # Use --no-default-features on Windows to avoid building hdrs which
+          # does not support Windows.
+          echo "COMET_CARGO_BUILD_ARGS=--no-default-features" >> "$GITHUB_ENV"
 
-      # Pin Rust to 1.85.0 on macOS arm64 to work around ring 0.17.14
-      # compile failure with Rust 1.86+. Only aarch64-apple-darwin is
-      # affected. Remove once ring ships a fix.
+      # Work around ring 0.17.14 compile failure with Rust 1.86+ on aarch64-apple-darwin.
+      # RUSTUP_TOOLCHAIN is needed to override rust-toolchain.toml in the tarball.
       - name: Pin Rust toolchain (macOS arm64)
         if: matrix.os == 'macos' && matrix.arch == 'arm64'
         shell: bash
         run: |
           rustup toolchain install 1.85.0 --profile minimal
-          rustup default 1.85.0
+          echo "RUSTUP_TOOLCHAIN=1.85.0" >> "$GITHUB_ENV"
 
       - name: Run release candidate verification
         shell: bash

--- a/.github/workflows/verify-release-candidate.yml
+++ b/.github/workflows/verify-release-candidate.yml
@@ -85,22 +85,22 @@ jobs:
           distribution: zulu
           java-version: 11
 
-      - name: Set Windows build flags
-        if: matrix.os == 'windows'
+      - name: Set platform-specific build flags
         shell: bash
         run: |
-          echo "RUSTFLAGS=-C link-arg=-Wl,--exclude-libs=ALL" >> "$GITHUB_ENV"
-          # Use --no-default-features on Windows to avoid building hdrs which
-          # does not support Windows.
-          echo "COMET_CARGO_BUILD_ARGS=--no-default-features" >> "$GITHUB_ENV"
-
-      # Work around ring 0.17.14 compile failure with Rust 1.86+ on aarch64-apple-darwin.
-      # Rust 1.86+ enables pauth/fpac target features by default, which fail ring's
-      # compile-time assertions. Disable them until ring ships a fix.
-      - name: Work around ring compile failure (macOS arm64)
-        if: matrix.os == 'macos' && matrix.arch == 'arm64'
-        shell: bash
-        run: echo "RUSTFLAGS=-C target-feature=-pauth,-fpac" >> "$GITHUB_ENV"
+          case "${{ matrix.os }}-${{ matrix.arch }}" in
+            windows-*)
+              # Without this, the MinGW GNU linker fails with too many exported symbols.
+              echo "RUSTFLAGS=-C link-arg=-Wl,--exclude-libs=ALL" >> "$GITHUB_ENV"
+              # Use --no-default-features to avoid building hdrs which does not support Windows.
+              echo "COMET_CARGO_BUILD_ARGS=--no-default-features" >> "$GITHUB_ENV"
+              ;;
+            macos-arm64)
+              # Work around ring 0.17.14 compile failure with Rust 1.86+.
+              # Disable pauth/fpac target features that fail ring's compile-time assertions.
+              echo "RUSTFLAGS=-C target-feature=-pauth,-fpac" >> "$GITHUB_ENV"
+              ;;
+          esac
 
       - name: Run release candidate verification
         shell: bash

--- a/.github/workflows/verify-release-candidate.yml
+++ b/.github/workflows/verify-release-candidate.yml
@@ -78,10 +78,27 @@ jobs:
           version: "27.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Spark 3.4 uses Scala 2.12 which requires JDK 11
+      - name: Set up JDK 11
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: zulu
+          java-version: 11
+
       - name: Set RUSTFLAGS for Windows GNU linker
         if: matrix.os == 'windows'
         shell: bash
         run: echo "RUSTFLAGS=-C link-arg=-Wl,--exclude-libs=ALL" >> "$GITHUB_ENV"
+
+      # Pin Rust to 1.85.0 on macOS arm64 to work around ring 0.17.14
+      # compile failure with Rust 1.86+. Only aarch64-apple-darwin is
+      # affected. Remove once ring ships a fix.
+      - name: Pin Rust toolchain (macOS arm64)
+        if: matrix.os == 'macos' && matrix.arch == 'arm64'
+        shell: bash
+        run: |
+          rustup toolchain install 1.85.0 --profile minimal
+          rustup default 1.85.0
 
       - name: Run release candidate verification
         shell: bash

--- a/.github/workflows/verify-release-candidate.yml
+++ b/.github/workflows/verify-release-candidate.yml
@@ -31,6 +31,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
@@ -65,14 +68,19 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           version: "27.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run release candidate verification
         shell: bash
-        run: ./dev/release/verify-release-candidate.sh "${{ inputs.version }}" "${{ inputs.rc_number }}"
+        run: ./dev/release/verify-release-candidate.sh "${INPUTS_VERSION}" "${INPUTS_RC_NUMBER}"
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
+          INPUTS_RC_NUMBER: ${{ inputs.rc_number }}

--- a/.github/workflows/verify-release-candidate.yml
+++ b/.github/workflows/verify-release-candidate.yml
@@ -95,13 +95,12 @@ jobs:
           echo "COMET_CARGO_BUILD_ARGS=--no-default-features" >> "$GITHUB_ENV"
 
       # Work around ring 0.17.14 compile failure with Rust 1.86+ on aarch64-apple-darwin.
-      # RUSTUP_TOOLCHAIN is needed to override rust-toolchain.toml in the tarball.
-      - name: Pin Rust toolchain (macOS arm64)
+      # Rust 1.86+ enables pauth/fpac target features by default, which fail ring's
+      # compile-time assertions. Disable them until ring ships a fix.
+      - name: Work around ring compile failure (macOS arm64)
         if: matrix.os == 'macos' && matrix.arch == 'arm64'
         shell: bash
-        run: |
-          rustup toolchain install 1.85.0 --profile minimal
-          echo "RUSTUP_TOOLCHAIN=1.85.0" >> "$GITHUB_ENV"
+        run: echo "RUSTFLAGS=-C target-feature=-pauth,-fpac" >> "$GITHUB_ENV"
 
       - name: Run release candidate verification
         shell: bash

--- a/.github/workflows/verify-release-candidate.yml
+++ b/.github/workflows/verify-release-candidate.yml
@@ -23,11 +23,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Version number (e.g., 52.0.0)
+        description: Version number (e.g., 0.16.0)
         required: true
         type: string
       rc_number:
-        description: Release candidate number (e.g., 0)
+        description: Release candidate number (e.g., 1)
         required: true
         type: string
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -111,7 +111,9 @@ test_source_distribution() {
     cargo build --release ${COMET_CARGO_BUILD_ARGS:-}
   popd
   # test with the latest supported version of Spark
-  ./mvnw verify -Prelease -DskipTests -P"spark-3.4" -Dmaven.gitcommitid.skip=true
+  # Skip spotless since the source was already checked before release.
+  # Spotless can fail on Windows due to CRLF line ending differences.
+  ./mvnw verify -Prelease -DskipTests -P"spark-3.4" -Dmaven.gitcommitid.skip=true -Dspotless.check.skip=true
 }
 
 TEST_SUCCESS=no

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -108,7 +108,15 @@ setup_tempdir() {
 test_source_distribution() {
   set -e
   pushd native
-    RUSTFLAGS="-Ctarget-cpu=native" cargo build --release
+    # Use --no-default-features on Windows to avoid building hdrs which
+    # does not support Windows.
+    local cargo_features=""
+    case "$(uname -s)" in
+      MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        cargo_features="--no-default-features"
+        ;;
+    esac
+    RUSTFLAGS="-Ctarget-cpu=native" cargo build --release ${cargo_features}
   popd
   # test with the latest supported version of Spark
   ./mvnw verify -Prelease -DskipTests -P"spark-3.4" -Dmaven.gitcommitid.skip=true

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -108,15 +108,7 @@ setup_tempdir() {
 test_source_distribution() {
   set -e
   pushd native
-    # Use --no-default-features on Windows to avoid building hdrs which
-    # does not support Windows.
-    local cargo_features=""
-    case "$(uname -s)" in
-      MINGW*|MSYS*|CYGWIN*|Windows_NT)
-        cargo_features="--no-default-features"
-        ;;
-    esac
-    RUSTFLAGS="-Ctarget-cpu=native" cargo build --release ${cargo_features}
+    cargo build --release ${COMET_CARGO_BUILD_ARGS:-}
   popd
   # test with the latest supported version of Spark
   ./mvnw verify -Prelease -DskipTests -P"spark-3.4" -Dmaven.gitcommitid.skip=true


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This PR adds a manually triggered GitHub Actions workflow to verify release candidates across multiple OS/architecture combinations

Copied over from datafusion-python, https://github.com/kevinjqliu/datafusion-python/blob/baf4a7a47fc30cdb759ef7b7f9e5df6c38db8a57/.github/workflows/verify-release-candidate.yml

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?
Ran manually on my fork, https://github.com/kevinjqliu/datafusion-comet/actions/runs/25614322434

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
