### PR TITLE
test: enable nested array cast coverage

### DIFF
--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -1786,6 +1786,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
         Row(
           Seq[Any](
             values(i % values.length),
+            // Keep every third row's middle nested-array element null.
             if (i % 3 == 0) null else values((i + 1) % values.length),
             values((i + 2) % values.length)))
       }

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -1589,7 +1589,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   // https://github.com/apache/datafusion-comet/issues/3906
-  ignore("cast nested ArrayType to nested ArrayType") {
+  test("cast nested ArrayType to nested ArrayType") {
     val types = Seq(
       BooleanType,
       StringType,
@@ -1600,14 +1600,12 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       FloatType,
       DoubleType,
       DecimalType(10, 2),
-      DecimalType(38, 18),
+      // DecimalType(38, 18) is excluded for the same reason as the one-dimensional array
+      // matrix: decimal-to-float/double casts can differ by ~1 ULP from Spark.
       DateType,
       TimestampType,
       BinaryType)
-    testArrayCastMatrix(
-      types,
-      dt => ArrayType(ArrayType(dt)),
-      dt => generateArrays(100, ArrayType(dt)))
+    testArrayCastMatrix(types, dt => ArrayType(ArrayType(dt)), dt => generateNestedArrays(20, dt))
   }
 
   // CAST from TimestampNTZType
@@ -1715,7 +1713,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   private def generateArrays(rowNum: Int, elementType: DataType): DataFrame = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val schema = StructType(Seq(StructField("a", ArrayType(elementType), true)))
     def buildRows(values: Seq[Any]): Seq[Row] = {
       Range(0, rowNum).map { i =>
@@ -1767,6 +1765,36 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       case _ =>
         spark.createDataFrame(withEdgeCaseRows(gen.generateRows(rowNum, schema)).asJava, schema)
     }
+  }
+
+  private def generateNestedArrays(rowNum: Int, elementType: DataType): DataFrame = {
+    import scala.jdk.CollectionConverters._
+    val schema = StructType(Seq(StructField("a", ArrayType(ArrayType(elementType)), true)))
+    val innerArrays = generateArrays(rowNum, elementType)
+      .collect()
+      .map { row =>
+        if (row.isNullAt(0)) {
+          null
+        } else {
+          row.getSeq[Any](0)
+        }
+      }
+      .toSeq
+
+    def buildRows(values: Seq[Seq[Any]]): Seq[Row] = {
+      Range(0, rowNum).map { i =>
+        Row(
+          Seq[Any](
+            values(i % values.length),
+            if (i % 3 == 0) null else values((i + 1) % values.length),
+            values((i + 2) % values.length)))
+      }
+    }
+
+    val sampleValue = innerArrays.find(_ != null).orNull
+    val rows = Seq(Row(Seq(sampleValue, null, sampleValue)), Row(Seq.empty[Any]), Row(null)) ++
+      buildRows(innerArrays)
+    spark.createDataFrame(rows.asJava, schema)
   }
 
   // https://github.com/apache/datafusion-comet/issues/2038


### PR DESCRIPTION
Closes #3906

## Summary
- Enable the nested `ArrayType` cast matrix in `CometCastSuite`.
- Add bounded nested array inputs to avoid recursively generated huge task results.
- Exclude `DecimalType(38,18)` from the nested matrix for the same known decimal-to-floating ULP mismatch as the one-dimensional matrix.
- Replace deprecated `JavaConverters` usage with `scala.jdk.CollectionConverters`.

## Root Cause
The previous nested test used `generateArrays(100, ArrayType(dt))`, which let Spark random data generation build very large nested arrays. The `array<array<string>>` to `array<array<boolean>>` case produced a task result around 401 MiB and failed deserialization with `unread block data`. After bounding the nested inputs, the remaining failure was the existing decimal38-to-floating precision mismatch, so the nested matrix now mirrors the one-dimensional exclusion.

## Tests
- `make core`
- `./mvnw test -Pspark-4.1 -Dtest=none -Dsuites="org.apache.comet.CometCastSuite cast nested ArrayType to nested ArrayType"`

---

Co-authored-by: @codex 
