### PR TITLE
Revert "ci: skip workflows for PRs tagged  with skip ci

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,6 @@ permissions:
 jobs:
   analyze:
     name: Analyze Actions
-    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/iceberg_spark_test.yml
+++ b/.github/workflows/iceberg_spark_test.yml
@@ -66,7 +66,6 @@ jobs:
   # Build native library once and share with all test jobs
   build-native:
     name: Build Native Library
-    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     container:
       image: amd64/rust

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -51,7 +51,6 @@ on:
 jobs:
   miri:
     name: "Miri"
-    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr_benchmark_check.yml
+++ b/.github/workflows/pr_benchmark_check.yml
@@ -46,7 +46,6 @@ env:
 jobs:
   benchmark-check:
     name: Benchmark Compile & Lint Check
-    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     container:
       image: amd64/rust

--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -63,7 +63,6 @@ jobs:
   # Fast lint check - gates all other jobs
   lint:
     name: Lint
-    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     container:
       image: amd64/rust

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -59,7 +59,6 @@ jobs:
   # Fast lint check - gates all other jobs (runs on Linux for cost efficiency)
   lint:
     name: Lint
-    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-latest
     container:
       image: amd64/rust

--- a/.github/workflows/pr_markdown_format.yml
+++ b/.github/workflows/pr_markdown_format.yml
@@ -28,7 +28,6 @@ on:
 
 jobs:
   prettier-check:
-    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr_missing_suites.yml
+++ b/.github/workflows/pr_missing_suites.yml
@@ -30,7 +30,6 @@ on:
 
 jobs:
   check-missing-suites:
-    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr_rat_check.yml
+++ b/.github/workflows/pr_rat_check.yml
@@ -35,7 +35,6 @@ on:
 jobs:
   rat-check:
     name: RAT License Check
-    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr_title_check.yml
+++ b/.github/workflows/pr_title_check.yml
@@ -27,7 +27,6 @@ on:
 
 jobs:
   check-pr-title:
-    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -83,7 +83,6 @@ jobs:
   # Build native library once and share with all test jobs
   build-native:
     name: Build Native Library
-    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     container:
       image: amd64/rust

--- a/.github/workflows/validate_workflows.yml
+++ b/.github/workflows/validate_workflows.yml
@@ -32,7 +32,6 @@ on:
 
 jobs:
   validate:
-    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.title, '[skip ci]')) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Reverts #4291 because the `if:` conditions on jobs cause GitHub to treat skipped required status checks as passing, allowing PRs to merge without tests running.

## Follow-up

We need a different approach to allow skipping CI during iteration while still requiring tests before merge. Options include:
- Draft PR detection (`github.event.pull_request.draft == false`) combined with a gate job pattern
- A separate always-running gate job that is the required status check

🤖 Generated with [Claude Code](https://claude.com/claude-code)