### PR TITLE
ci: only run CodeQL on PRs that modify GitHub workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,12 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - "benchmarks/**"
+      - "doc/**"
+      - "docs/**"
+      - "**.md"
+      - "dev/changelog/*.md"
   schedule:
     - cron: '16 4 * * 1'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,12 +27,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-    paths-ignore:
-      - "benchmarks/**"
-      - "doc/**"
-      - "docs/**"
-      - "**.md"
-      - "dev/changelog/*.md"
+    paths:
+      - ".github/**"
   schedule:
     - cron: '16 4 * * 1'
 


### PR DESCRIPTION
## Summary

- The CodeQL workflow is configured to scan GitHub Actions only (`languages: actions`), so it only needs to run when workflow files are actually changed
- Replace `paths-ignore` with a `paths` allow-list targeting `.github/**` so CodeQL only triggers on PRs that modify workflow files

## Test plan

- [ ] Verify CodeQL runs on PRs that touch `.github/` files
- [ ] Verify CodeQL is skipped for PRs that don't touch `.github/` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)