### PR TITLE
ci: use targeted path filters for codeql, miri, and missing-suites checks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths:
+      - ".github/**"
   schedule:
     - cron: '16 4 * * 1'
 

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -25,25 +25,11 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "doc/**"
-      - "docs/**"
-      - "**.md"
-      - "dev/changelog/*.md"
-      - "native/core/benches/**"
-      - "native/spark-expr/benches/**"
-      - "spark/src/test/scala/org/apache/spark/sql/benchmark/**"
-      - "spark/src/main/scala/org/apache/comet/GenerateDocs.scala"
+    paths:
+      - "native/**"
   pull_request:
-    paths-ignore:
-      - "doc/**"
-      - "docs/**"
-      - "**.md"
-      - "dev/changelog/*.md"
-      - "native/core/benches/**"
-      - "native/spark-expr/benches/**"
-      - "spark/src/test/scala/org/apache/spark/sql/benchmark/**"
-      - "spark/src/main/scala/org/apache/comet/GenerateDocs.scala"
+    paths:
+      - "native/**"
   # manual trigger
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:

--- a/.github/workflows/pr_missing_suites.yml
+++ b/.github/workflows/pr_missing_suites.yml
@@ -25,8 +25,20 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "spark/src/test/**"
+      - "common/src/test/**"
+      - ".github/workflows/pr_build_linux.yml"
+      - ".github/workflows/pr_build_macos.yml"
+      - "dev/ci/check-suites.py"
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - "spark/src/test/**"
+      - "common/src/test/**"
+      - ".github/workflows/pr_build_linux.yml"
+      - ".github/workflows/pr_build_macos.yml"
+      - "dev/ci/check-suites.py"
 
 jobs:
   check-missing-suites:


### PR DESCRIPTION
## Summary

- **codeql.yml**: Add `paths` allow-list for `.github/**` on PRs. CodeQL is configured to scan GitHub Actions only (`languages: actions`), so it doesn't need to run when non-workflow files change.
- **miri.yml**: Replace broad `paths-ignore` with a `paths` allow-list of just `native/**`. Miri only runs `cargo miri test` on Rust code in the native directory, so it doesn't need to trigger on JVM-only changes (`spark/`, `common/`, `dev/`, etc.)
- **pr_missing_suites.yml**: Add `paths` allow-list targeting only the files the check actually inspects — test suite Scala files, the PR build workflows, and the check script itself. Previously ran on every PR regardless of what changed.

## Test plan

- [ ] Verify CodeQL still runs on PRs that touch `.github/` files
- [ ] Verify miri still runs when `native/` Rust code changes
- [ ] Verify missing-suites check runs when adding/removing a `*Suite.scala` file
- [ ] Verify all three checks are skipped for unrelated changes (e.g., docs-only PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)