### PR TITLE
chore: update documentation links for 0.16.0 release

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -25,9 +25,9 @@ mkdir temp
 cp -rf source/* temp/
 
 # Add user guide from published releases
-rm -rf comet-0.12
 rm -rf comet-0.13
 rm -rf comet-0.14
+rm -rf comet-0.15
 python3 generate-versions.py
 
 # Generate dynamic content (configs, compatibility matrices) for latest docs

--- a/docs/generate-versions.py
+++ b/docs/generate-versions.py
@@ -154,6 +154,6 @@ This is **out-of-date** documentation. The latest Comet release is version {late
 if __name__ == "__main__":
     print("Generating versioned user guide docs...")
     snapshot_version = get_version_from_pom()
-    latest_released_version = "0.15.0"
-    previous_versions = ["0.12.0", "0.13.0", "0.14.0"]
+    latest_released_version = "0.16.0"
+    previous_versions = ["0.13.0", "0.14.0", "0.15.0"]
     generate_docs(snapshot_version, latest_released_version, previous_versions)

--- a/docs/source/user-guide/index.md
+++ b/docs/source/user-guide/index.md
@@ -31,9 +31,9 @@ navigation menu to view its guide.
 :caption: User Guides
 :hidden:
 
-0.16.0-SNAPSHOT <latest/index>
+0.17.0-SNAPSHOT <latest/index>
+0.16.x <0.16/index>
 0.15.x <0.15/index>
 0.14.x <0.14/index>
 0.13.x <0.13/index>
-0.12.x <0.12/index>
 ```


### PR DESCRIPTION
## Which issue does this PR close?

N/A. Routine docs prep for the 0.16.0 release, mirroring #4029 for 0.15.0.

## Rationale for this change

The 0.16.0 release is being prepared and the main-branch docs need to point at it as the latest released version, while bumping the snapshot to the next development cycle (0.17.0).

## What changes are included in this PR?

- `docs/generate-versions.py`: set `latest_released_version` to `0.16.0` and shift `previous_versions` to `["0.13.0", "0.14.0", "0.15.0"]`.
- `docs/build.sh`: drop the `comet-0.12` clean-up line and add one for `comet-0.15`.
- `docs/source/user-guide/index.md`: bump the snapshot entry to `0.17.0-SNAPSHOT`, add `0.16.x`, and drop `0.12.x`.

## How are these changes tested?

Covered by the documentation publishing workflow, which regenerates and deploys docs on merge to main.