### PR TITLE
test: probe shaded Arrow imports for CometUDF impl in spark module [IGNORE]

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -387,6 +387,7 @@ jobs:
               org.apache.comet.expressions.conditional.CometIfSuite
               org.apache.comet.expressions.conditional.CometCoalesceSuite
               org.apache.comet.expressions.conditional.CometCaseWhenSuite
+              org.apache.comet.udf.DateFormatUdfSuite
           - name: "sql"
             value: |
               org.apache.spark.sql.CometToPrettyStringSuite

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -234,6 +234,7 @@ jobs:
               org.apache.comet.expressions.conditional.CometIfSuite
               org.apache.comet.expressions.conditional.CometCoalesceSuite
               org.apache.comet.expressions.conditional.CometCaseWhenSuite
+              org.apache.comet.udf.DateFormatUdfSuite
           - name: "sql"
             value: |
               org.apache.spark.sql.CometToPrettyStringSuite

--- a/spark/src/main/scala/org/apache/comet/udf/builtin/DateFormatUdf.scala
+++ b/spark/src/main/scala/org/apache/comet/udf/builtin/DateFormatUdf.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.udf.builtin
+
+import java.nio.charset.StandardCharsets
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+import org.apache.comet.shaded.arrow.vector.{DateDayVector, ValueVector, VarCharVector}
+
+import org.apache.comet.CometArrowAllocator
+import org.apache.comet.udf.CometUDF
+
+/**
+ * Comet JVM UDF that formats a DateType column using a literal Java SimpleDateFormat-style
+ * pattern. Inputs: (date column, literal format string). Output: VarCharVector of formatted
+ * strings.
+ *
+ * Smoke test variant: uses Comet's shaded Arrow namespace
+ * (`org.apache.comet.shaded.arrow.*`) directly in imports, instead of the unshaded
+ * `org.apache.arrow.*`. The intent is to validate whether a UDF impl in the spark module can
+ * compile against shaded class names on apache/main without the common-into-spark merge.
+ */
+class DateFormatUdf extends CometUDF {
+
+  override def evaluate(inputs: Array[ValueVector], numRows: Int): ValueVector = {
+    require(inputs.length == 2, s"DateFormatUdf expects 2 inputs, got ${inputs.length}")
+
+    val dates = inputs(0).asInstanceOf[DateDayVector]
+    val patternVec = inputs(1).asInstanceOf[VarCharVector]
+    require(patternVec.getValueCount >= 1, "format pattern vector must have at least one row")
+    val pattern = new String(patternVec.get(0), StandardCharsets.UTF_8)
+    val fmt = DateTimeFormatter.ofPattern(pattern)
+
+    val out = new VarCharVector("date_format", CometArrowAllocator)
+    out.allocateNew(numRows)
+    var i = 0
+    while (i < numRows) {
+      if (dates.isNull(i)) {
+        out.setNull(i)
+      } else {
+        val days = dates.get(i)
+        val formatted = LocalDate.ofEpochDay(days.toLong).format(fmt)
+        out.setSafe(i, formatted.getBytes(StandardCharsets.UTF_8))
+      }
+      i += 1
+    }
+    out.setValueCount(numRows)
+    out
+  }
+}

--- a/spark/src/test/scala/org/apache/comet/udf/DateFormatUdfSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/udf/DateFormatUdfSuite.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.udf
+
+import java.nio.charset.StandardCharsets
+import java.time.LocalDate
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.comet.shaded.arrow.vector.{DateDayVector, VarCharVector}
+
+import org.apache.comet.CometArrowAllocator
+import org.apache.comet.udf.builtin.DateFormatUdf
+
+/**
+ * Smoke test verifying that a `CometUDF` implementation in the spark module can directly
+ * manipulate Arrow vectors when the imports target Comet's shaded Arrow namespace
+ * (`org.apache.comet.shaded.arrow.*`).
+ */
+class DateFormatUdfSuite extends AnyFunSuite {
+
+  private def daysSinceEpoch(s: String): Int = LocalDate.parse(s).toEpochDay.toInt
+
+  test("formats dates with yyyy-MM-dd pattern, propagates nulls") {
+    val dates = new DateDayVector("d", CometArrowAllocator)
+    val pattern = new VarCharVector("p", CometArrowAllocator)
+    try {
+      dates.allocateNew(3)
+      dates.setSafe(0, daysSinceEpoch("2024-01-15"))
+      dates.setNull(1)
+      dates.setSafe(2, daysSinceEpoch("1999-12-31"))
+      dates.setValueCount(3)
+
+      pattern.allocateNew(1)
+      pattern.setSafe(0, "yyyy-MM-dd".getBytes(StandardCharsets.UTF_8))
+      pattern.setValueCount(1)
+
+      val out = new DateFormatUdf().evaluate(Array(dates, pattern), 3).asInstanceOf[VarCharVector]
+      try {
+        assert(out.getValueCount === 3)
+        assert(new String(out.get(0), StandardCharsets.UTF_8) === "2024-01-15")
+        assert(out.isNull(1))
+        assert(new String(out.get(2), StandardCharsets.UTF_8) === "1999-12-31")
+      } finally {
+        out.close()
+      }
+    } finally {
+      dates.close()
+      pattern.close()
+    }
+  }
+}


### PR DESCRIPTION
## Which issue does this PR close?

No specific issue. Experiment.

## Rationale for this change

This is the second of two parallel smoke tests for the Comet JVM UDF framework. Both add the same DateFormat \`CometUDF\` and \`ScalaTest\` suite. They differ only in *which* Arrow package the UDF imports.

- #4333 sits on top of #4325 and uses unshaded \`org.apache.arrow.*\`. That branch already passes locally.
- This PR targets \`apache/main\` directly (no refactor) and uses **shaded** imports: \`org.apache.comet.shaded.arrow.*\`.

The question the experiment answers: can a UDF author on current \`main\` sidestep the Arrow shading boundary by importing the relocated class names that the shade plugin produces at package time? The probable failure mode is that the shaded namespace does not exist in the reactor's pre-shade classpath, so the spark module fails to compile. CI will confirm.

## What changes are included in this PR?

- \`spark/src/main/scala/org/apache/comet/udf/builtin/DateFormatUdf.scala\`: \`CometUDF\` impl using \`import org.apache.comet.shaded.arrow.vector.{DateDayVector, ValueVector, VarCharVector}\`.
- \`spark/src/test/scala/org/apache/comet/udf/DateFormatUdfSuite.scala\`: ScalaTest suite that allocates shaded Arrow vectors and exercises the UDF directly.
- \`.github/workflows/pr_build_{linux,macos}.yml\`: registers the new suite under the \`expressions\` job.

## How are these changes tested?

Pushed directly to CI as a probe.