### PR TITLE
feat: Credential provider support

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -336,6 +336,8 @@ jobs:
               org.apache.comet.CometIcebergNativeSuite
               org.apache.comet.CometIcebergRewriteActionSuite
               org.apache.comet.iceberg.IcebergReflectionSuite
+              org.apache.comet.CometCredentialProviderSuite
+              org.apache.spark.sql.comet.CometIcebergCredentialBroadcastsSuite
           - name: "csv"
             value: |
               org.apache.comet.csv.CometCsvNativeReadSuite

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -184,6 +184,8 @@ jobs:
               org.apache.comet.CometIcebergNativeSuite
               org.apache.comet.CometIcebergRewriteActionSuite
               org.apache.comet.iceberg.IcebergReflectionSuite
+              org.apache.comet.CometCredentialProviderSuite
+              org.apache.spark.sql.comet.CometIcebergCredentialBroadcastsSuite
           - name: "csv"
             value: |
               org.apache.comet.csv.CometCsvNativeReadSuite

--- a/common/src/main/java/org/apache/comet/iceberg/CometCredentialProvider.java
+++ b/common/src/main/java/org/apache/comet/iceberg/CometCredentialProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.iceberg;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * Pluggable, catalog-scoped credential provider for Comet's native Iceberg reader.
+ *
+ * <p>Configure via: {@code spark.comet.scan.icebergNative.credentialProvider.class}
+ */
+public interface CometCredentialProvider extends Serializable {
+
+  /**
+   * Initialize this provider with catalog-level properties.
+   *
+   * @param catalogProperties the catalog-level FileIO properties
+   */
+  void initialize(Map<String, String> catalogProperties);
+
+  /**
+   * Returns {@code [accessKeyId, secretAccessKey, sessionToken, expiresAtEpochMs]}. slot 3 may be
+   * {@code "-1"} for no-expiry.
+   */
+  String[] resolveCredentials(ResolveContext context);
+}

--- a/common/src/main/java/org/apache/comet/iceberg/ResolveContext.java
+++ b/common/src/main/java/org/apache/comet/iceberg/ResolveContext.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.iceberg;
+
+import java.io.Serializable;
+
+/**
+ * Per-call context passed to {@link CometCredentialProvider#resolveCredentials(ResolveContext)}.
+ */
+public final class ResolveContext implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String tableLocation;
+
+  public ResolveContext(String tableLocation) {
+    this.tableLocation = tableLocation;
+  }
+
+  public String tableLocation() {
+    return tableLocation == null ? "" : tableLocation;
+  }
+}

--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -150,6 +150,18 @@ object CometConf extends ShimCometConf {
       .checkValue(v => v > 0, "Data file concurrency limit must be positive")
       .createWithDefault(1)
 
+  val COMET_ICEBERG_CREDENTIAL_PROVIDER_CLASS: OptionalConfigEntry[String] =
+    conf("spark.comet.scan.icebergNative.credentialProvider.class")
+      .category(CATEGORY_SCAN)
+      .doc(
+        "Fully qualified class name of a CometCredentialProvider implementation for " +
+          "dynamic S3 credential refresh during native Iceberg reads. The class must " +
+          "implement org.apache.comet.iceberg.CometCredentialProvider and have a " +
+          "no-arg constructor. When unset, static credentials extracted at plan time " +
+          "are used.")
+      .stringConf
+      .createOptional
+
   val COMET_CSV_V2_NATIVE_ENABLED: ConfigEntry[Boolean] =
     conf("spark.comet.scan.csv.v2.enabled")
       .category(CATEGORY_TESTING)

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1960,12 +1960,14 @@ dependencies = [
 name = "datafusion-comet"
 version = "0.17.0"
 dependencies = [
+ "anyhow",
  "arrow",
  "assertables",
  "async-trait",
  "aws-config",
  "aws-credential-types",
  "bytes",
+ "chrono",
  "criterion",
  "datafusion",
  "datafusion-comet-common",

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -75,6 +75,8 @@ hdfs-sys = {version = "0.3", optional = true, features = ["hdfs_3_3"]}
 opendal = { version = "0.56.0", optional = true, features = ["services-hdfs"] }
 iceberg = { workspace = true }
 iceberg-storage-opendal = { workspace = true }
+anyhow = "1"
+chrono = "0.4"
 serde_json = "1.0"
 uuid = "1.23.0"
 

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -87,6 +87,7 @@ use std::{sync::Arc, task::Poll};
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
 
+use crate::execution::jni_credential_loader::IcebergCredentialFactory;
 use crate::execution::memory_pools::{
     create_memory_pool, handle_task_shared_pool_release, parse_memory_pool_config, MemoryPoolConfig,
 };
@@ -340,6 +341,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
     task_cpus: jlong,
     key_unwrapper_obj: JObject,
     task_context_obj: JObject,
+    credential_provider_obj: JObject,
 ) -> jlong {
     try_unwrap_or_throw(&e, |env| {
         // Deserialize Spark configs
@@ -440,6 +442,16 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
                     ENCRYPTION_FACTORY_ID,
                     Arc::new(encryption_factory),
                 );
+            }
+
+            if !credential_provider_obj.is_null() {
+                let provider = Arc::new(jni_new_global_ref!(env, credential_provider_obj)?);
+                let factory = Arc::new(IcebergCredentialFactory::new(provider));
+                session
+                    .state_ref()
+                    .write()
+                    .config_mut()
+                    .set_extension(factory);
             }
 
             let session = Arc::new(session);

--- a/native/core/src/execution/jni_credential_loader.rs
+++ b/native/core/src/execution/jni_credential_loader.rs
@@ -1,0 +1,412 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! JNI-backed AWS credential loader for Comet's native Iceberg reader.
+
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use iceberg_storage_opendal::{AwsCredential, AwsCredentialLoad};
+use jni::objects::{Global, JClass, JMethodID, JObject, JObjectArray, JString, JValue};
+use jni::signature::ReturnType;
+use log::warn;
+
+use crate::execution::operators::ExecutionError;
+use crate::jvm_bridge::{check_exception, JVMClasses};
+
+const CALL_LOCAL_FRAME_CAPACITY: usize = 16;
+const CREDENTIAL_CACHE_TTL_SECS: u64 = 300;
+
+/// Session-scoped factory attached to the DataFusion `SessionConfig` extension map.
+#[derive(Debug)]
+pub(crate) struct IcebergCredentialFactory {
+    provider: Arc<Global<JObject<'static>>>,
+}
+
+impl IcebergCredentialFactory {
+    pub(crate) fn new(provider: Arc<Global<JObject<'static>>>) -> Self {
+        Self { provider }
+    }
+
+    /// Build a credential loader bound to a particular Iceberg table location.
+    pub(crate) fn loader_for(
+        &self,
+        table_location: String,
+    ) -> Result<JniAwsCredentialLoader, ExecutionError> {
+        JniAwsCredentialLoader::new(
+            Arc::clone(&self.provider),
+            table_location,
+            Duration::from_secs(CREDENTIAL_CACHE_TTL_SECS),
+        )
+    }
+}
+
+pub(crate) struct JniAwsCredentialLoader {
+    credential_provider: Arc<Global<JObject<'static>>>,
+    resolve_method_id: JMethodID,
+    resolve_context_ctor: JMethodID,
+    resolve_context_class: Global<JClass<'static>>,
+    table_location_jobj: Global<JString<'static>>,
+    table_location: String,
+    cached: RwLock<Option<CachedCredential>>,
+    min_ttl: Duration,
+}
+
+struct CachedCredential {
+    credential: AwsCredential,
+    fetched_at: std::time::Instant,
+}
+
+impl JniAwsCredentialLoader {
+    pub(crate) fn new(
+        credential_provider: Arc<Global<JObject<'static>>>,
+        table_location: String,
+        min_ttl: Duration,
+    ) -> Result<Self, ExecutionError> {
+        let (resolve_method_id, resolve_context_ctor, resolve_context_class, table_location_jobj) =
+            JVMClasses::with_env(|env| {
+                let resolve_method_id = env
+                    .get_method_id(
+                        jni::jni_str!("org/apache/comet/iceberg/CometCredentialProvider"),
+                        jni::jni_str!("resolveCredentials"),
+                        jni::jni_sig!(
+                            "(Lorg/apache/comet/iceberg/ResolveContext;)[Ljava/lang/String;"
+                        ),
+                    )
+                    .map_err(|e| {
+                        ExecutionError::GeneralError(format!(
+                            "Failed to get JNI method ID for \
+                             CometCredentialProvider.resolveCredentials(ResolveContext). \
+                             Is the provider class on the executor classpath and implementing \
+                             the current SPI? {}",
+                            e
+                        ))
+                    })?;
+
+                let context_class_local = env
+                    .find_class(jni::jni_str!("org/apache/comet/iceberg/ResolveContext"))
+                    .map_err(|e| {
+                        ExecutionError::GeneralError(format!(
+                            "Failed to find class ResolveContext: {}",
+                            e
+                        ))
+                    })?;
+
+                let ctor_id = env
+                    .get_method_id(
+                        &context_class_local,
+                        jni::jni_str!("<init>"),
+                        jni::jni_sig!("(Ljava/lang/String;)V"),
+                    )
+                    .map_err(|e| {
+                        ExecutionError::GeneralError(format!(
+                            "Failed to get JNI ctor ID for ResolveContext(String): {}",
+                            e
+                        ))
+                    })?;
+
+                let class_global = env.new_global_ref(context_class_local).map_err(|e| {
+                    ExecutionError::GeneralError(format!(
+                        "Failed to create global ref for ResolveContext class: {}",
+                        e
+                    ))
+                })?;
+
+                let table_loc_local = env.new_string(&table_location).map_err(|e| {
+                    ExecutionError::GeneralError(format!(
+                        "Failed to allocate Java String for tableLocation: {}",
+                        e
+                    ))
+                })?;
+                let table_loc_global = env.new_global_ref(table_loc_local).map_err(|e| {
+                    ExecutionError::GeneralError(format!(
+                        "Failed to create global ref for tableLocation String: {}",
+                        e
+                    ))
+                })?;
+
+                Ok::<_, ExecutionError>((
+                    resolve_method_id,
+                    ctor_id,
+                    class_global,
+                    table_loc_global,
+                ))
+            })?;
+
+        Ok(Self {
+            credential_provider,
+            resolve_method_id,
+            resolve_context_ctor,
+            resolve_context_class,
+            table_location_jobj,
+            table_location,
+            cached: RwLock::new(None),
+            min_ttl,
+        })
+    }
+
+    fn is_valid(cached: &CachedCredential, min_ttl: &Duration) -> bool {
+        match cached.credential.expires_in {
+            None => cached.fetched_at.elapsed() < *min_ttl,
+            Some(expires_at) => {
+                let now_ms = chrono::Utc::now().timestamp_millis();
+                let buffer_ms = min_ttl.as_millis() as i64;
+                expires_at.timestamp_millis() > now_ms + buffer_ms
+            }
+        }
+    }
+
+    fn call_jvm(&self) -> Result<AwsCredential, ExecutionError> {
+        JVMClasses::with_env(|env| {
+            // Run the entire per-call JNI dance inside a local reference frame so every
+            // intermediate local (ResolveContext, the result array, and each String element)
+            // is freed when we return. Without this, a long-running Iceberg scan would
+            // accumulate local refs per S3 request and eventually blow past the JVM's
+            // local-ref table limit.
+            env.with_local_frame(CALL_LOCAL_FRAME_CAPACITY, |env| {
+                Ok::<_, jni::errors::Error>(self.call_jvm_in_frame(env))
+            })
+            .map_err(|e| {
+                ExecutionError::GeneralError(format!(
+                    "Failed to push JNI local reference frame for table_location={}: {}",
+                    self.table_location, e
+                ))
+            })?
+        })
+    }
+
+    fn call_jvm_in_frame(&self, env: &mut jni::Env<'_>) -> Result<AwsCredential, ExecutionError> {
+        let instance = self.credential_provider.as_obj();
+        let table_loc_jstr = self.table_location_jobj.as_obj();
+
+        let context_obj = unsafe {
+            env.new_object_unchecked(
+                &self.resolve_context_class,
+                self.resolve_context_ctor,
+                &[JValue::Object(table_loc_jstr).as_jni()],
+            )
+        }
+        .map_err(|e| {
+            ExecutionError::GeneralError(format!(
+                "Failed to construct ResolveContext for table_location={}: {}",
+                self.table_location, e
+            ))
+        })?;
+
+        let result = unsafe {
+            env.call_method_unchecked(
+                instance,
+                self.resolve_method_id,
+                ReturnType::Array,
+                &[JValue::Object(&context_obj).as_jni()],
+            )
+        };
+
+        if let Some(exception) = check_exception(env).map_err(|e| {
+            ExecutionError::GeneralError(format!("Failed to check for Java exception: {}", e))
+        })? {
+            return Err(ExecutionError::GeneralError(format!(
+                "Java exception during credential resolution for table_location={}: {}",
+                self.table_location, exception
+            )));
+        }
+
+        let result = result.map_err(|e| {
+            ExecutionError::GeneralError(format!(
+                "JNI method call failed for resolveCredentials({}): {}",
+                self.table_location, e
+            ))
+        })?;
+
+        let result_obj = result.l().map_err(|e| {
+            ExecutionError::GeneralError(format!("Failed to extract result: {}", e))
+        })?;
+
+        let array = unsafe { JObjectArray::<JObject>::from_raw(env, result_obj.into_raw()) };
+
+        let len = array.len(env).map_err(|e| {
+            ExecutionError::GeneralError(format!("Failed to get array length: {}", e))
+        })?;
+
+        if len < 4 {
+            return Err(ExecutionError::GeneralError(format!(
+                "resolveCredentials({}) returned {} elements, expected 4",
+                self.table_location, len
+            )));
+        }
+
+        let mut get_string = |idx: usize| -> Result<String, ExecutionError> {
+            let obj: JObject = array.get_element(env, idx).map_err(|e| {
+                ExecutionError::GeneralError(format!("Failed to get array element {}: {}", idx, e))
+            })?;
+            let jstr = unsafe { JString::from_raw(env, obj.into_raw()) };
+            jstr.try_to_string(env).map_err(|e| {
+                ExecutionError::GeneralError(format!(
+                    "Failed to convert string at index {}: {}",
+                    idx, e
+                ))
+            })
+        };
+
+        let access_key_id = get_string(0)?;
+        let secret_access_key = get_string(1)?;
+        let session_token = get_string(2)?;
+        let expires_at_str = get_string(3)?;
+
+        let expires_at_ms: i64 = match expires_at_str.parse() {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(
+                    "resolveCredentials({}) returned non-numeric expires_at={:?}: {}",
+                    self.table_location, expires_at_str, e
+                );
+                -1
+            }
+        };
+
+        let session_token_opt = if session_token.is_empty() {
+            None
+        } else {
+            Some(session_token)
+        };
+
+        let expires_in = if expires_at_ms > 0 {
+            chrono::DateTime::from_timestamp_millis(expires_at_ms)
+        } else {
+            None
+        };
+
+        Ok(AwsCredential {
+            access_key_id,
+            secret_access_key,
+            session_token: session_token_opt,
+            expires_in,
+        })
+    }
+}
+
+// Safety: JNI global refs are safe to share across threads.
+// JVMClasses::with_env() handles thread attachment.
+unsafe impl Send for JniAwsCredentialLoader {}
+unsafe impl Sync for JniAwsCredentialLoader {}
+
+#[async_trait]
+impl AwsCredentialLoad for JniAwsCredentialLoader {
+    async fn load_credential(
+        &self,
+        _client: reqwest::Client,
+    ) -> anyhow::Result<Option<AwsCredential>> {
+        {
+            let guard = self
+                .cached
+                .read()
+                .map_err(|e| anyhow::anyhow!("Failed to acquire read lock: {}", e))?;
+            if let Some(ref cached) = *guard {
+                if Self::is_valid(cached, &self.min_ttl) {
+                    return Ok(Some(cached.credential.clone()));
+                }
+            }
+        }
+
+        let mut guard = self
+            .cached
+            .write()
+            .map_err(|e| anyhow::anyhow!("Failed to acquire write lock: {}", e))?;
+        if let Some(ref cached) = *guard {
+            if Self::is_valid(cached, &self.min_ttl) {
+                return Ok(Some(cached.credential.clone()));
+            }
+        }
+
+        let credential = self
+            .call_jvm()
+            .map_err(|e| anyhow::anyhow!("JNI credential refresh failed: {}", e))?;
+
+        *guard = Some(CachedCredential {
+            credential: credential.clone(),
+            fetched_at: std::time::Instant::now(),
+        });
+
+        Ok(Some(credential))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_credential(expires_in: Option<chrono::DateTime<chrono::Utc>>) -> CachedCredential {
+        CachedCredential {
+            credential: AwsCredential {
+                access_key_id: "AKIA_TEST".to_string(),
+                secret_access_key: "secret".to_string(),
+                session_token: Some("token".to_string()),
+                expires_in,
+            },
+            fetched_at: std::time::Instant::now(),
+        }
+    }
+
+    #[test]
+    fn test_is_valid_with_future_expiry() {
+        let future = chrono::Utc::now() + chrono::TimeDelta::try_hours(1).unwrap();
+        let cached = make_credential(Some(future));
+        let ttl = Duration::from_secs(300);
+        assert!(JniAwsCredentialLoader::is_valid(&cached, &ttl));
+    }
+
+    #[test]
+    fn test_is_valid_with_near_expiry() {
+        let soon = chrono::Utc::now() + chrono::TimeDelta::try_seconds(60).unwrap();
+        let cached = make_credential(Some(soon));
+        let ttl = Duration::from_secs(300); // 5 min buffer
+        assert!(!JniAwsCredentialLoader::is_valid(&cached, &ttl));
+    }
+
+    #[test]
+    fn test_is_valid_with_past_expiry() {
+        let past = chrono::Utc::now() - chrono::TimeDelta::try_hours(1).unwrap();
+        let cached = make_credential(Some(past));
+        let ttl = Duration::from_secs(300);
+        assert!(!JniAwsCredentialLoader::is_valid(&cached, &ttl));
+    }
+
+    #[test]
+    fn test_is_valid_no_expiry_within_ttl() {
+        let cached = make_credential(None);
+        let ttl = Duration::from_secs(300);
+        assert!(JniAwsCredentialLoader::is_valid(&cached, &ttl));
+    }
+
+    #[test]
+    fn test_is_valid_no_expiry_beyond_ttl() {
+        let mut cached = make_credential(None);
+        cached.fetched_at = std::time::Instant::now() - Duration::from_secs(600);
+        let ttl = Duration::from_secs(300);
+        assert!(!JniAwsCredentialLoader::is_valid(&cached, &ttl));
+    }
+
+    #[test]
+    fn test_is_valid_zero_min_ttl_with_future_expiry() {
+        // A zero buffer means "valid as long as not yet expired"; future expiries pass.
+        let future = chrono::Utc::now() + chrono::TimeDelta::try_seconds(1).unwrap();
+        let cached = make_credential(Some(future));
+        let ttl = Duration::from_secs(0);
+        assert!(JniAwsCredentialLoader::is_valid(&cached, &ttl));
+    }
+}

--- a/native/core/src/execution/mod.rs
+++ b/native/core/src/execution/mod.rs
@@ -19,6 +19,7 @@
 pub mod columnar_to_row;
 pub mod expressions;
 pub mod jni_api;
+pub(crate) mod jni_credential_loader;
 pub(crate) mod merge_as_partial;
 pub(crate) mod metrics;
 pub mod operators;

--- a/native/core/src/execution/operators/iceberg_scan.rs
+++ b/native/core/src/execution/operators/iceberg_scan.rs
@@ -40,7 +40,7 @@ use datafusion::physical_plan::{
 use futures::{Stream, StreamExt, TryStreamExt};
 use iceberg::arrow::ScanMetrics;
 use iceberg::io::{FileIO, FileIOBuilder, StorageFactory};
-use iceberg_storage_opendal::OpenDalStorageFactory;
+use iceberg_storage_opendal::{CustomAwsCredentialLoader, OpenDalStorageFactory};
 
 use crate::execution::operators::ExecutionError;
 use crate::parquet::parquet_support::SparkParquetOptions;
@@ -66,6 +66,7 @@ pub struct IcebergScanExec {
     tasks: Vec<FileScanTask>,
     /// Number of data files to read concurrently
     data_file_concurrency_limit: usize,
+    credential_loader: Option<CustomAwsCredentialLoader>,
     /// Metrics
     metrics: ExecutionPlanMetricsSet,
 }
@@ -77,6 +78,7 @@ impl IcebergScanExec {
         catalog_properties: HashMap<String, String>,
         tasks: Vec<FileScanTask>,
         data_file_concurrency_limit: usize,
+        credential_loader: Option<CustomAwsCredentialLoader>,
     ) -> Result<Self, ExecutionError> {
         let output_schema = schema;
         let plan_properties = Self::compute_properties(Arc::clone(&output_schema), 1);
@@ -90,6 +92,7 @@ impl IcebergScanExec {
             catalog_properties,
             tasks,
             data_file_concurrency_limit,
+            credential_loader,
             metrics,
         })
     }
@@ -154,7 +157,11 @@ impl IcebergScanExec {
         context: Arc<TaskContext>,
     ) -> DFResult<SendableRecordBatchStream> {
         let output_schema = Arc::clone(&self.output_schema);
-        let file_io = Self::load_file_io(&self.catalog_properties, &self.metadata_location)?;
+        let file_io = Self::load_file_io(
+            &self.catalog_properties,
+            &self.metadata_location,
+            self.credential_loader.clone(),
+        )?;
         let batch_size = context.session_config().batch_size();
 
         let metrics = IcebergScanMetrics::new(&self.metrics);
@@ -199,7 +206,10 @@ impl IcebergScanExec {
         Ok(Box::pin(wrapped_stream))
     }
 
-    fn storage_factory_for(path: &str) -> Result<Arc<dyn StorageFactory>, DataFusionError> {
+    fn storage_factory_for(
+        path: &str,
+        credential_loader: Option<CustomAwsCredentialLoader>,
+    ) -> Result<Arc<dyn StorageFactory>, DataFusionError> {
         let scheme = if path.contains("://") {
             path.split("://").next().unwrap_or("file")
         } else {
@@ -208,7 +218,7 @@ impl IcebergScanExec {
         match scheme {
             "file" => Ok(Arc::new(OpenDalStorageFactory::Fs)),
             "s3" | "s3a" => Ok(Arc::new(OpenDalStorageFactory::S3 {
-                customized_credential_load: None,
+                customized_credential_load: credential_loader,
             })),
             "gs" => Ok(Arc::new(OpenDalStorageFactory::Gcs)),
             "oss" => Ok(Arc::new(OpenDalStorageFactory::Oss)),
@@ -221,8 +231,9 @@ impl IcebergScanExec {
     fn load_file_io(
         catalog_properties: &HashMap<String, String>,
         metadata_location: &str,
+        credential_loader: Option<CustomAwsCredentialLoader>,
     ) -> Result<FileIO, DataFusionError> {
-        let factory = Self::storage_factory_for(metadata_location)?;
+        let factory = Self::storage_factory_for(metadata_location, credential_loader)?;
         let mut file_io_builder = FileIOBuilder::new(factory);
 
         for (key, value) in catalog_properties {

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -21,6 +21,7 @@ pub mod expression_registry;
 pub mod macros;
 pub mod operator_registry;
 
+use crate::execution::jni_credential_loader::IcebergCredentialFactory;
 use crate::execution::operators::init_csv_datasource_exec;
 use crate::execution::operators::IcebergScanExec;
 use crate::execution::{
@@ -1474,12 +1475,35 @@ impl PhysicalPlanner {
                 let tasks = parse_file_scan_tasks_from_common(common, &scan.file_scan_tasks)?;
                 let data_file_concurrency_limit = common.data_file_concurrency_limit as usize;
 
+                let credential_loader = self
+                    .session_ctx
+                    .state()
+                    .config()
+                    .get_extension::<IcebergCredentialFactory>()
+                    .map(|factory| {
+                        let table_location = derive_table_location(&metadata_location).to_string();
+                        factory
+                            .loader_for(table_location)
+                            .map(|loader| {
+                                iceberg_storage_opendal::CustomAwsCredentialLoader::new(Arc::new(
+                                    loader,
+                                ))
+                            })
+                            .map_err(|e| {
+                                GeneralError(format!(
+                                    "Failed to create JNI credential loader for Iceberg scan: {e}"
+                                ))
+                            })
+                    })
+                    .transpose()?;
+
                 let iceberg_scan = IcebergScanExec::new(
                     metadata_location,
                     required_schema,
                     catalog_properties,
                     tasks,
                     data_file_concurrency_limit,
+                    credential_loader,
                 )?;
 
                 Ok((
@@ -3903,6 +3927,22 @@ fn needs_fields_coercion(sig: &TypeSignature) -> bool {
     }
 }
 
+/// Strips a trailing `/metadata/<file>` segment from an Iceberg metadata URI.
+fn derive_table_location(metadata_location: &str) -> &str {
+    const SEGMENT: &str = "/metadata/";
+    match metadata_location.rfind(SEGMENT) {
+        Some(idx) if idx > 0 => {
+            let suffix = &metadata_location[idx + SEGMENT.len()..];
+            if suffix.is_empty() || suffix.contains('/') {
+                metadata_location
+            } else {
+                &metadata_location[..idx]
+            }
+        }
+        _ => metadata_location,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use futures::{poll, StreamExt};
@@ -3943,6 +3983,68 @@ mod tests {
         spark_operator::{operator::OpStruct, Operator},
     };
     use datafusion_comet_spark_expr::EvalMode;
+
+    use super::derive_table_location;
+
+    #[test]
+    fn test_derive_table_location_strips_metadata_suffix() {
+        assert_eq!(
+            derive_table_location("s3://bucket/db/table/metadata/v1.metadata.json"),
+            "s3://bucket/db/table"
+        );
+        assert_eq!(
+            derive_table_location("s3://bucket/db/table/metadata/snap-123.avro"),
+            "s3://bucket/db/table"
+        );
+    }
+
+    #[test]
+    fn test_derive_table_location_preserves_input_without_metadata_segment() {
+        assert_eq!(
+            derive_table_location("s3://bucket/db/table"),
+            "s3://bucket/db/table"
+        );
+        assert_eq!(
+            derive_table_location("/local/path/table"),
+            "/local/path/table"
+        );
+    }
+
+    #[test]
+    fn test_derive_table_location_handles_alternate_schemes() {
+        assert_eq!(
+            derive_table_location("s3a://bucket/db/table/metadata/v1.metadata.json"),
+            "s3a://bucket/db/table"
+        );
+        assert_eq!(
+            derive_table_location("file:///tmp/warehouse/table/metadata/v1.metadata.json"),
+            "file:///tmp/warehouse/table"
+        );
+    }
+
+    #[test]
+    fn test_derive_table_location_rejects_leading_metadata_segment() {
+        assert_eq!(
+            derive_table_location("/metadata/v1.metadata.json"),
+            "/metadata/v1.metadata.json"
+        );
+    }
+
+    #[test]
+    fn test_derive_table_location_strips_only_last_metadata_segment() {
+        assert_eq!(
+            derive_table_location("s3://bucket/metadata/dwh/tbl/metadata/v1.metadata.json"),
+            "s3://bucket/metadata/dwh/tbl"
+        );
+    }
+
+    #[test]
+    fn test_derive_table_location_preserves_input_with_nested_metadata_suffix() {
+        assert_eq!(
+            derive_table_location("s3://bucket/db/table/metadata/sub/v1.metadata.json"),
+            "s3://bucket/db/table/metadata/sub/v1.metadata.json"
+        );
+    }
 
     #[test]
     fn test_unpack_dictionary_primitive() {

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -68,7 +68,8 @@ class CometExecIterator(
     partitionIndex: Int,
     broadcastedHadoopConfForEncryption: Option[Broadcast[SerializableConfiguration]] = None,
     encryptedFilePaths: Seq[String] = Seq.empty,
-    shuffleBlockIterators: Map[Int, CometShuffleBlockIterator] = Map.empty)
+    shuffleBlockIterators: Map[Int, CometShuffleBlockIterator] = Map.empty,
+    credentialProvider: AnyRef = null)
     extends Iterator[ColumnarBatch]
     with Logging {
 
@@ -130,7 +131,8 @@ class CometExecIterator(
       keyUnwrapper,
       // Propagated to Tokio workers running JVM UDFs so they see this Spark task's
       // TaskContext. See CometUdfBridge.evaluate.
-      TaskContext.get())
+      TaskContext.get(),
+      credentialProvider.asInstanceOf[iceberg.CometCredentialProvider])
   }
 
   private var nextBatch: Option[ColumnarBatch] = None

--- a/spark/src/main/scala/org/apache/comet/Native.scala
+++ b/spark/src/main/scala/org/apache/comet/Native.scala
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer
 import org.apache.spark.{CometTaskMemoryManager, TaskContext}
 import org.apache.spark.sql.comet.CometMetricNode
 
+import org.apache.comet.iceberg.CometCredentialProvider
 import org.apache.comet.parquet.CometFileKeyUnwrapper
 
 class Native extends NativeBase {
@@ -70,7 +71,8 @@ class Native extends NativeBase {
       taskAttemptId: Long,
       taskCPUs: Long,
       keyUnwrapper: CometFileKeyUnwrapper,
-      taskContext: TaskContext): Long
+      taskContext: TaskContext,
+      credentialProvider: CometCredentialProvider): Long
   // scalastyle:on
 
   /**

--- a/spark/src/main/scala/org/apache/comet/iceberg/IcebergReflection.scala
+++ b/spark/src/main/scala/org/apache/comet/iceberg/IcebergReflection.scala
@@ -19,7 +19,10 @@
 
 package org.apache.comet.iceberg
 
+import scala.util.control.NonFatal
+
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
 
 /**
  * Shared reflection utilities for Iceberg operations.
@@ -323,26 +326,68 @@ object IcebergReflection extends Logging {
   }
 
   /**
+   * Returns the V2 catalog name that loaded the given Iceberg [[org.apache.iceberg.Table]].
+   * [TODO: Logic fragile. Check if there is a different way to get cat name]
+   */
+  def getCatalogName(table: Any): Option[String] =
+    getCatalogName(table, activeCatalogNames _)
+
+  /**
+   * Test seam for [[getCatalogName(table:Any)]]. The `knownCatalogNames` thunk lets tests inject
+   * a fixed catalog-name set without bootstrapping a SparkSession.
+   */
+  private[iceberg] def getCatalogName(
+      table: Any,
+      knownCatalogNames: () => Iterable[String]): Option[String] = {
+    if (table == null) return None
+    val fqn = table.toString
+    if (fqn == null || fqn.isEmpty || fqn == "null") return None
+
+    knownCatalogNames()
+      .find(name => fqn == name || fqn.startsWith(name + "."))
+      .orElse {
+        val idx = fqn.indexOf('.')
+        if (idx > 0) Some(fqn.substring(0, idx)) else None
+      }
+  }
+
+  private def activeCatalogNames(): Iterable[String] =
+    try {
+      SparkSession.active.sessionState.catalogManager.listCatalogs(None)
+    } catch {
+      case NonFatal(_) => Nil
+    }
+
+  /**
    * Gets storage properties from an Iceberg table's FileIO.
    *
    * This extracts credentials from the FileIO implementation, which is critical for REST catalog
    * credential vending. The REST catalog returns temporary S3 credentials per-table via the
    * loadTable response, stored in the table's FileIO (typically ResolvingFileIO).
    *
-   * The properties() method is not on the FileIO interface -- it exists on specific
-   * implementations like ResolvingFileIO and S3FileIO. Returns None gracefully when unavailable.
+   * `properties()` is not declared on the FileIO interface -- it exists on specific
+   * implementations like ResolvingFileIO and Iceberg's S3FileIO. Returns None gracefully when
+   * the method is not callable.
    */
   def getFileIOProperties(table: Any): Option[Map[String, String]] = {
     import scala.jdk.CollectionConverters._
     getFileIO(table).flatMap { fileIO =>
-      findMethodInHierarchy(fileIO.getClass, "properties").flatMap { propsMethod =>
-        propsMethod.invoke(fileIO) match {
-          case javaMap: java.util.Map[_, _] =>
-            val scalaMap = javaMap.asScala.collect { case (k: String, v: String) =>
-              k -> v
-            }.toMap
-            if (scalaMap.nonEmpty) Some(scalaMap) else None
-          case _ => None
+      findMethodInHierarchy(fileIO.getClass, "properties").flatMap { method =>
+        try {
+          method.invoke(fileIO) match {
+            case javaMap: java.util.Map[_, _] =>
+              val scalaMap = javaMap.asScala.collect { case (k: String, v: String) =>
+                k -> v
+              }.toMap
+              if (scalaMap.nonEmpty) Some(scalaMap) else None
+            case _ => None
+          }
+        } catch {
+          case e: Exception =>
+            logWarning(
+              s"Exception invoking ${fileIO.getClass.getName}.properties(): " +
+                s"${e.getClass.getName}: ${e.getMessage}")
+            None
         }
       }
     }
@@ -671,7 +716,14 @@ object IcebergReflection extends Logging {
  * @param globalFieldIdMapping
  *   Mapping from column names to Iceberg field IDs (built from scanSchema)
  * @param catalogProperties
- *   Catalog properties for FileIO (S3 credentials, regions, etc.)
+ *   Catalog properties for FileIO (S3 credentials, regions, etc.) - filtered to storage prefixes
+ * @param allFileIOProperties
+ *   Unfiltered FileIO properties for credential provider (includes tenant-id, refresh-id, etc.)
+ * @param catalogName
+ *   Spark V2 catalog name that loaded this table, derived from `Table.name()` and matched against
+ *   `CatalogManager.listCatalogs()`. Used as the cache key for catalog-scoped credential provider
+ *   broadcasts. None when the table has no catalog identity (e.g. HadoopTables loaded by raw
+ *   path).
  */
 case class CometIcebergNativeScanMetadata(
     table: Any,
@@ -682,6 +734,8 @@ case class CometIcebergNativeScanMetadata(
     tableSchema: Any,
     globalFieldIdMapping: Map[String, Int],
     catalogProperties: Map[String, String],
+    allFileIOProperties: Map[String, String],
+    catalogName: Option[String],
     fileFormat: String)
 
 object CometIcebergNativeScanMetadata extends Logging {
@@ -698,13 +752,16 @@ object CometIcebergNativeScanMetadata extends Logging {
    *   Path to the table metadata file (already extracted)
    * @param catalogProperties
    *   Catalog properties for FileIO (already extracted)
+   * @param allFileIOProperties
+   *   Unfiltered FileIO properties forwarded to the credential provider
    * @return
    *   Some(metadata) if all reflection succeeds, None to trigger fallback
    */
   def extract(
       scan: Any,
       metadataLocation: String,
-      catalogProperties: Map[String, String]): Option[CometIcebergNativeScanMetadata] = {
+      catalogProperties: Map[String, String],
+      allFileIOProperties: Map[String, String]): Option[CometIcebergNativeScanMetadata] = {
     import org.apache.comet.iceberg.IcebergReflection._
 
     for {
@@ -737,6 +794,8 @@ object CometIcebergNativeScanMetadata extends Logging {
         tableSchema = tableSchema,
         globalFieldIdMapping = globalFieldIdMapping,
         catalogProperties = catalogProperties,
+        allFileIOProperties = allFileIOProperties,
+        catalogName = IcebergReflection.getCatalogName(table),
         fileFormat = FileFormats.PARQUET)
     }
   }

--- a/spark/src/main/scala/org/apache/comet/iceberg/IcebergReflection.scala
+++ b/spark/src/main/scala/org/apache/comet/iceberg/IcebergReflection.scala
@@ -358,36 +358,17 @@ object IcebergReflection extends Logging {
       case NonFatal(_) => Nil
     }
 
-  /**
-   * Gets storage properties from an Iceberg table's FileIO.
-   *
-   * This extracts credentials from the FileIO implementation, which is critical for REST catalog
-   * credential vending. The REST catalog returns temporary S3 credentials per-table via the
-   * loadTable response, stored in the table's FileIO (typically ResolvingFileIO).
-   *
-   * `properties()` is not declared on the FileIO interface -- it exists on specific
-   * implementations like ResolvingFileIO and Iceberg's S3FileIO. Returns None gracefully when
-   * the method is not callable.
-   */
   def getFileIOProperties(table: Any): Option[Map[String, String]] = {
     import scala.jdk.CollectionConverters._
     getFileIO(table).flatMap { fileIO =>
-      findMethodInHierarchy(fileIO.getClass, "properties").flatMap { method =>
-        try {
-          method.invoke(fileIO) match {
-            case javaMap: java.util.Map[_, _] =>
-              val scalaMap = javaMap.asScala.collect { case (k: String, v: String) =>
-                k -> v
-              }.toMap
-              if (scalaMap.nonEmpty) Some(scalaMap) else None
-            case _ => None
-          }
-        } catch {
-          case e: Exception =>
-            logWarning(
-              s"Exception invoking ${fileIO.getClass.getName}.properties(): " +
-                s"${e.getClass.getName}: ${e.getMessage}")
-            None
+      findMethodInHierarchy(fileIO.getClass, "properties").flatMap { propsMethod =>
+        propsMethod.invoke(fileIO) match {
+          case javaMap: java.util.Map[_, _] =>
+            val scalaMap = javaMap.asScala.collect { case (k: String, v: String) =>
+              k -> v
+            }.toMap
+            if (scalaMap.nonEmpty) Some(scalaMap) else None
+          case _ => None
         }
       }
     }

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -380,15 +380,22 @@ case class CometScanRule(session: SparkSession)
             // Extract vended credentials from FileIO (REST catalog credential vending).
             // FileIO properties take precedence over Hadoop-derived properties because
             // they contain per-table credentials vended by the REST catalog.
-            val fileIOProperties = tableOpt
+            val rawFileIOProperties = tableOpt
               .flatMap(IcebergReflection.getFileIOProperties)
-              .map(CometIcebergNativeScan.filterStorageProperties)
               .getOrElse(Map.empty)
+
+            val fileIOProperties =
+              CometIcebergNativeScan.filterStorageProperties(rawFileIOProperties)
 
             val catalogProperties = hadoopDerivedProperties ++ fileIOProperties
 
-            val result = CometIcebergNativeScanMetadata
-              .extract(scanExec.scan, effectiveLocation, catalogProperties)
+            val allFileIOProperties = hadoopDerivedProperties ++ rawFileIOProperties
+
+            val result = CometIcebergNativeScanMetadata.extract(
+              scanExec.scan,
+              effectiveLocation,
+              catalogProperties,
+              allFileIOProperties)
 
             result
           } catch {
@@ -815,12 +822,14 @@ object CometScanRule extends Logging {
    * one iteration for better performance with large tables.
    */
   def validateIcebergFileScanTasks(tasks: java.util.List[_]): IcebergTaskValidationResult = {
-    // scalastyle:off classforname
-    val contentScanTaskClass = Class.forName(IcebergReflection.ClassNames.CONTENT_SCAN_TASK)
-    val contentFileClass = Class.forName(IcebergReflection.ClassNames.CONTENT_FILE)
-    val fileScanTaskClass = Class.forName(IcebergReflection.ClassNames.FILE_SCAN_TASK)
-    val unboundPredicateClass = Class.forName(IcebergReflection.ClassNames.UNBOUND_PREDICATE)
-    // scalastyle:on classforname
+    val contentScanTaskClass =
+      IcebergReflection.loadClass(IcebergReflection.ClassNames.CONTENT_SCAN_TASK)
+    val contentFileClass =
+      IcebergReflection.loadClass(IcebergReflection.ClassNames.CONTENT_FILE)
+    val fileScanTaskClass =
+      IcebergReflection.loadClass(IcebergReflection.ClassNames.FILE_SCAN_TASK)
+    val unboundPredicateClass =
+      IcebergReflection.loadClass(IcebergReflection.ClassNames.UNBOUND_PREDICATE)
 
     // Cache all method lookups outside the loop
     val fileMethod = contentScanTaskClass.getMethod("file")

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometExecRDD.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometExecRDD.scala
@@ -21,6 +21,7 @@ package org.apache.spark.sql.comet
 
 import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.comet.execution.shuffle.CometShuffledBatchRDD
 import org.apache.spark.sql.execution.ScalarSubquery
@@ -66,8 +67,10 @@ private[spark] class CometExecRDD(
     subqueries: Seq[ScalarSubquery],
     broadcastedHadoopConfForEncryption: Option[Broadcast[SerializableConfiguration]] = None,
     encryptedFilePaths: Seq[String] = Seq.empty,
-    shuffleScanIndices: Set[Int] = Set.empty)
-    extends RDD[ColumnarBatch](sc, inputRDDs.map(rdd => new OneToOneDependency(rdd))) {
+    shuffleScanIndices: Set[Int] = Set.empty,
+    credentialProviderBroadcast: Option[Broadcast[AnyRef]] = None)
+    extends RDD[ColumnarBatch](sc, inputRDDs.map(rdd => new OneToOneDependency(rdd)))
+    with Logging {
 
   // Determine partition count: from inputs if available, otherwise from parameter
   private val numPartitions: Int = if (inputRDDs.nonEmpty) {
@@ -120,6 +123,8 @@ private[spark] class CometExecRDD(
       }
     }.toMap
 
+    val credentialProvider = resolveCredentialProvider(context)
+
     val it = new CometExecIterator(
       CometExec.newIterId,
       inputs,
@@ -130,7 +135,8 @@ private[spark] class CometExecRDD(
       partition.index,
       broadcastedHadoopConfForEncryption,
       encryptedFilePaths,
-      shuffleBlockIters)
+      shuffleBlockIters,
+      credentialProvider)
 
     // Register ScalarSubqueries so native code can look them up
     subqueries.foreach(sub => CometScalarSubquery.setSubquery(it.id, sub))
@@ -153,6 +159,21 @@ private[spark] class CometExecRDD(
     // Prefer nodes where all inputs are local; fall back to any input's preferred location
     val intersection = prefs.reduce((a, b) => a.intersect(b))
     if (intersection.nonEmpty) intersection else prefs.flatten.distinct
+  }
+
+  private def resolveCredentialProvider(context: TaskContext): AnyRef = {
+    credentialProviderBroadcast match {
+      case None => null
+      case Some(broadcast) =>
+        val provider = broadcast.value
+        if (provider == null) {
+          val partitionId = if (context != null) context.partitionId() else -1
+          logWarning(
+            s"Broadcast credential provider id=${broadcast.id} returned null " +
+              s"(partition=$partitionId)")
+        }
+        provider
+    }
   }
 
   override def clearDependencies(): Unit = {
@@ -179,7 +200,8 @@ object CometExecRDD {
       subqueries: Seq[ScalarSubquery],
       broadcastedHadoopConfForEncryption: Option[Broadcast[SerializableConfiguration]] = None,
       encryptedFilePaths: Seq[String] = Seq.empty,
-      shuffleScanIndices: Set[Int] = Set.empty): CometExecRDD = {
+      shuffleScanIndices: Set[Int] = Set.empty,
+      credentialProviderBroadcast: Option[Broadcast[AnyRef]] = None): CometExecRDD = {
     // scalastyle:on
 
     new CometExecRDD(
@@ -194,6 +216,7 @@ object CometExecRDD {
       subqueries,
       broadcastedHadoopConfForEncryption,
       encryptedFilePaths,
-      shuffleScanIndices)
+      shuffleScanIndices,
+      credentialProviderBroadcast)
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometIcebergCredentialBroadcasts.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometIcebergCredentialBroadcasts.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet
+
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.SparkContext
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.internal.SQLConf
+
+import org.apache.comet.{CometConf, CometRuntimeException}
+import org.apache.comet.iceberg.{CometCredentialProvider, IcebergReflection}
+
+/**
+ * Driver-side broadcast cache for [[CometCredentialProvider]] instances.
+ */
+private[spark] object CometIcebergCredentialBroadcasts extends Logging {
+
+  private type CatalogName = String
+
+  private val cache =
+    new ConcurrentHashMap[CatalogName, Broadcast[AnyRef]]()
+
+  def getOrCreate(
+      sc: SparkContext,
+      className: String,
+      catalogName: String,
+      catalogProperties: Map[String, String]): Broadcast[AnyRef] = {
+
+    val existing = cache.get(catalogName)
+    if (existing != null) {
+      logDebug(
+        s"Reusing broadcast credential provider id=${existing.id} " +
+          s"className=$className catalogName=$catalogName")
+      return existing
+    }
+
+    cache.computeIfAbsent(
+      catalogName,
+      _ => {
+        val provider = instantiateAndInit(className, catalogProperties)
+        val broadcast = sc.broadcast[AnyRef](provider)
+        logInfo(
+          s"Broadcast credential provider created id=${broadcast.id} " +
+            s"className=$className catalogName=$catalogName")
+        broadcast
+      })
+  }
+
+  private def instantiateAndInit(
+      className: String,
+      catalogProperties: Map[String, String]): CometCredentialProvider = {
+    val provider = IcebergReflection
+      .loadClass(className)
+      .getDeclaredConstructor()
+      .newInstance()
+      .asInstanceOf[CometCredentialProvider]
+    provider.initialize(catalogProperties.asJava)
+    provider
+  }
+
+  def buildBroadcast(
+      sc: SparkContext,
+      scan: CometIcebergNativeScanExec): Option[Broadcast[AnyRef]] = {
+    val broadcast = for {
+      className <- CometConf.COMET_ICEBERG_CREDENTIAL_PROVIDER_CLASS.get(SQLConf.get)
+      catalogName <- scan.nativeIcebergScanMetadata.catalogName
+    } yield getOrCreate(
+      sc,
+      className,
+      catalogName,
+      scan.nativeIcebergScanMetadata.allFileIOProperties)
+    broadcast.foreach { b =>
+      logInfo(
+        s"Plan will use broadcast credential provider id=${b.id} " +
+          s"catalogName=${scan.nativeIcebergScanMetadata.catalogName.getOrElse("")}")
+    }
+    broadcast
+  }
+
+  /**
+   * Walks the plan, validates a single Iceberg catalog, and builds the broadcast for the first
+   * matched scan.
+   *
+   * @throws CometRuntimeException
+   *   if the plan spans more than one Iceberg catalog (only one `CometCredentialProvider` is
+   *   broadcast per plan).
+   */
+  def buildBroadcastForPlan(
+      sc: SparkContext,
+      plan: CometNativeExec): Option[Broadcast[AnyRef]] = {
+    val icebergScans = scala.collection.mutable.ArrayBuffer.empty[CometIcebergNativeScanExec]
+    plan.foreachUntilCometInput(plan) {
+      case scan: CometIcebergNativeScanExec => icebergScans += scan
+      case _ => // no-op
+    }
+    requireSingleIcebergCatalog(
+      icebergScans.flatMap(_.nativeIcebergScanMetadata.catalogName).toSeq)
+    icebergScans.headOption.flatMap(buildBroadcast(sc, _))
+  }
+
+  private[comet] def requireSingleIcebergCatalog(catalogNames: Seq[String]): Unit = {
+    val distinct = catalogNames.distinct
+    if (distinct.size > 1) {
+      throw new CometRuntimeException(
+        s"Comet plan spans multiple Iceberg catalogs (${distinct.mkString(", ")}), " +
+          s"but only one CometCredentialProvider is broadcast per plan. Multi-catalog " +
+          s"plans need a per-relation broadcast map.")
+    }
+  }
+
+  private[comet] def clear(): Unit = {
+    cache.clear()
+  }
+
+  private[comet] def cacheSize(): Int = cache.size
+}

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometIcebergNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometIcebergNativeScanExec.scala
@@ -219,6 +219,10 @@ case class CometIcebergNativeScanExec(
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
     val nativeMetrics = CometMetricNode.fromCometPlan(this)
     val serializedPlan = CometExec.serializeNativePlan(nativeOp)
+
+    val credentialProviderBroadcast =
+      CometIcebergCredentialBroadcasts.buildBroadcast(sparkContext, this)
+
     new CometExecRDD(
       sparkContext,
       inputRDDs = Seq.empty,
@@ -228,7 +232,8 @@ case class CometIcebergNativeScanExec(
       defaultNumPartitions = perPartitionData.length,
       numOutputCols = output.length,
       nativeMetrics = nativeMetrics,
-      subqueries = Seq.empty) {
+      subqueries = Seq.empty,
+      credentialProviderBroadcast = credentialProviderBroadcast) {
       override def compute(split: Partition, context: TaskContext): Iterator[ColumnarBatch] = {
         val res = super.compute(split, context)
         Option(context).foreach(nativeMetrics.reportScanInputMetrics)

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -560,6 +560,10 @@ abstract class CometNativeExec extends CometExec {
         // Unified RDD creation - CometExecRDD handles all cases
         val subqueries = collectSubqueries(this)
         val hasScanInput = sparkPlans.exists(_.isInstanceOf[CometNativeScanExec])
+
+        val credentialProviderBroadcast: Option[Broadcast[AnyRef]] =
+          CometIcebergCredentialBroadcasts.buildBroadcastForPlan(sparkContext, this)
+
         new CometExecRDD(
           sparkContext,
           inputs.toSeq,
@@ -572,7 +576,8 @@ abstract class CometNativeExec extends CometExec {
           subqueries,
           broadcastedHadoopConfForEncryption,
           encryptedFilePaths,
-          shuffleScanIndices) {
+          shuffleScanIndices,
+          credentialProviderBroadcast) {
           override def compute(
               split: Partition,
               context: TaskContext): Iterator[ColumnarBatch] = {

--- a/spark/src/test/java/org/apache/comet/iceberg/MockCometCredentialProvider.java
+++ b/spark/src/test/java/org/apache/comet/iceberg/MockCometCredentialProvider.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.iceberg;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Mock catalog-scoped credential provider for testing. Tracks initialization and call counts.
+ * Returns configurable credentials that can simulate rotation.
+ */
+public class MockCometCredentialProvider implements CometCredentialProvider {
+
+  private static final long serialVersionUID = 1L;
+
+  private static final AtomicInteger initCount = new AtomicInteger(0);
+  private static final AtomicInteger resolveCount = new AtomicInteger(0);
+  private static volatile ResolveContext lastContext;
+  private static volatile Map<String, String> lastCatalogProperties;
+
+  private String accessKeyId = "test-access-key";
+  private String secretAccessKey = "test-secret-key";
+  private String sessionToken = "test-session-token";
+
+  @Override
+  public void initialize(Map<String, String> catalogProperties) {
+    initCount.incrementAndGet();
+    lastCatalogProperties = catalogProperties;
+
+    if (catalogProperties.containsKey("s3.access-key-id")) {
+      accessKeyId = catalogProperties.get("s3.access-key-id");
+    }
+    if (catalogProperties.containsKey("s3.secret-access-key")) {
+      secretAccessKey = catalogProperties.get("s3.secret-access-key");
+    }
+    if (catalogProperties.containsKey("s3.session-token")) {
+      sessionToken = catalogProperties.get("s3.session-token");
+    }
+  }
+
+  @Override
+  public String[] resolveCredentials(ResolveContext context) {
+    resolveCount.incrementAndGet();
+    lastContext = context;
+    long expiresAt = System.currentTimeMillis() + 3600_000;
+    return new String[] {accessKeyId, secretAccessKey, sessionToken, String.valueOf(expiresAt)};
+  }
+
+  public static int getInitCount() {
+    return initCount.get();
+  }
+
+  public static int getResolveCount() {
+    return resolveCount.get();
+  }
+
+  public static String getLastTableLocation() {
+    ResolveContext ctx = lastContext;
+    return ctx == null ? null : ctx.tableLocation();
+  }
+
+  public static ResolveContext getLastContext() {
+    return lastContext;
+  }
+
+  public static Map<String, String> getLastCatalogProperties() {
+    return lastCatalogProperties;
+  }
+
+  public static void reset() {
+    initCount.set(0);
+    resolveCount.set(0);
+    lastContext = null;
+    lastCatalogProperties = null;
+  }
+}

--- a/spark/src/test/scala/org/apache/comet/CometCredentialProviderSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCredentialProviderSuite.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet
+
+import scala.jdk.CollectionConverters._
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.comet.iceberg.{CometCredentialProvider, MockCometCredentialProvider, ResolveContext}
+
+class CometCredentialProviderSuite extends AnyFunSuite {
+
+  private def ctx(loc: String): ResolveContext = new ResolveContext(loc)
+
+  test("MockCometCredentialProvider initializes and resolves") {
+    val provider = new MockCometCredentialProvider()
+    val props = Map(
+      "s3.access-key-id" -> "AKIA_TEST",
+      "s3.secret-access-key" -> "secret_TEST",
+      "s3.session-token" -> "token_TEST").asJava
+
+    provider.initialize(props)
+
+    val creds = provider.resolveCredentials(ctx("s3://my-bucket/db/my_table"))
+    assert(creds.length == 4)
+    assert(creds(0) == "AKIA_TEST")
+    assert(creds(1) == "secret_TEST")
+    assert(creds(2) == "token_TEST")
+    assert(creds(3).toLong > System.currentTimeMillis())
+  }
+
+  test("resolveCredentials returns correct format") {
+    val provider = new MockCometCredentialProvider()
+    provider.initialize(Map.empty[String, String].asJava)
+
+    val creds = provider.resolveCredentials(ctx("s3://bucket/table"))
+    assert(creds.length == 4, "Expected [accessKeyId, secretAccessKey, sessionToken, expiresAt]")
+  }
+
+  test("resolveCredentials captures the table location passed by native via ResolveContext") {
+    MockCometCredentialProvider.reset()
+    val provider = new MockCometCredentialProvider()
+    provider.initialize(Map.empty[String, String].asJava)
+
+    provider.resolveCredentials(ctx("s3://bucket/db/table_a"))
+    assert(MockCometCredentialProvider.getLastTableLocation == "s3://bucket/db/table_a")
+
+    provider.resolveCredentials(ctx("s3://bucket/db/table_b"))
+    assert(MockCometCredentialProvider.getLastTableLocation == "s3://bucket/db/table_b")
+
+    assert(MockCometCredentialProvider.getResolveCount == 2)
+  }
+
+  test("ResolveContext normalizes a null tableLocation to empty string (never null)") {
+    val c = new ResolveContext(null)
+    assert(c.tableLocation == "")
+  }
+}

--- a/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{StringType, TimestampType}
 
 import org.apache.comet.CometSparkSessionExtensions.{isSpark35Plus, isSpark42Plus}
-import org.apache.comet.iceberg.RESTCatalogHelper
+import org.apache.comet.iceberg.{MockCometCredentialProvider, RESTCatalogHelper}
 import org.apache.comet.testing.{FuzzDataGenerator, SchemaGenOptions}
 
 /**
@@ -98,6 +98,55 @@ class CometIcebergNativeSuite
         checkIcebergNativeScan("SELECT * FROM hadoop_catalog.db.test_table ORDER BY id")
 
         spark.sql("DROP TABLE hadoop_catalog.db.test_table")
+      }
+    }
+  }
+
+  test("credential provider is instantiated and called") {
+    assume(icebergAvailable, "Iceberg not available in classpath")
+
+    MockCometCredentialProvider.reset()
+
+    withTempIcebergDir { warehouseDir =>
+      val mockClass = classOf[MockCometCredentialProvider].getName
+      withSQLConf(
+        "spark.sql.catalog.cred_cat" -> "org.apache.iceberg.spark.SparkCatalog",
+        "spark.sql.catalog.cred_cat.type" -> "hadoop",
+        "spark.sql.catalog.cred_cat.warehouse" -> warehouseDir.getAbsolutePath,
+        CometConf.COMET_ENABLED.key -> "true",
+        CometConf.COMET_EXEC_ENABLED.key -> "true",
+        CometConf.COMET_ICEBERG_NATIVE_ENABLED.key -> "true",
+        CometConf.COMET_ICEBERG_CREDENTIAL_PROVIDER_CLASS.key -> mockClass) {
+
+        spark.sql("""
+          CREATE TABLE cred_cat.db.cred_test (
+            id INT, name STRING
+          ) USING iceberg
+        """)
+
+        spark.sql("""
+          INSERT INTO cred_cat.db.cred_test
+          VALUES (1, 'Alice'), (2, 'Bob')
+        """)
+
+        // Verify the native scan is in the plan -- if it fell back to
+        // Spark's regular scan, the credential provider would never fire.
+        val query = "SELECT * FROM cred_cat.db.cred_test ORDER BY id"
+        val (_, cometPlan) = checkSparkAnswer(query)
+        val icebergScans = collectIcebergNativeScans(cometPlan)
+        assert(
+          icebergScans.nonEmpty,
+          s"Expected CometIcebergNativeScanExec in plan but found none. " +
+            s"Plan:\n$cometPlan")
+
+        assert(
+          MockCometCredentialProvider.getInitCount > 0,
+          "Credential provider should have been initialized")
+        assert(
+          MockCometCredentialProvider.getLastCatalogProperties != null,
+          "Catalog properties should have been captured during initialize()")
+
+        spark.sql("DROP TABLE cred_cat.db.cred_test")
       }
     }
   }

--- a/spark/src/test/scala/org/apache/comet/IcebergReadFromS3Suite.scala
+++ b/spark/src/test/scala/org/apache/comet/IcebergReadFromS3Suite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.comet.CometIcebergNativeScanExec
 import org.apache.spark.sql.execution.SparkPlan
 
-import org.apache.comet.iceberg.RESTCatalogHelper
+import org.apache.comet.iceberg.{MockCometCredentialProvider, RESTCatalogHelper}
 
 class IcebergReadFromS3Suite extends CometS3TestBase with RESTCatalogHelper {
 
@@ -296,6 +296,55 @@ class IcebergReadFromS3Suite extends CometS3TestBase with RESTCatalogHelper {
 
           spark.sql("DROP TABLE vend_cat.db.simple")
           spark.sql("DROP NAMESPACE vend_cat.db")
+        }
+    }
+  }
+
+  test("credential provider is invoked on every native S3 scan") {
+    assume(icebergAvailable, "Iceberg not available in classpath")
+
+    // The mock provider reads its credentials from `catalogProperties` in `initialize()`, so
+    // wiring the correct MinIO creds through the REST catalog's vending payload both gets the
+    // data written and ensures the mock returns working credentials on the native read path.
+    val vendedCreds = Map(
+      "s3.access-key-id" -> userName,
+      "s3.secret-access-key" -> password,
+      "s3.endpoint" -> minioContainer.getS3URL,
+      "s3.path-style-access" -> "true")
+    val warehouse = s"s3a://$testBucketName/warehouse-cred-provider"
+    val mockClass = classOf[MockCometCredentialProvider].getName
+
+    withRESTCatalog(vendedCredentials = vendedCreds, warehouseLocation = Some(warehouse)) {
+      (restUri, _, _) =>
+        withSQLConf(
+          "spark.sql.catalog.prov_cat" -> "org.apache.iceberg.spark.SparkCatalog",
+          "spark.sql.catalog.prov_cat.catalog-impl" -> "org.apache.iceberg.rest.RESTCatalog",
+          "spark.sql.catalog.prov_cat.uri" -> restUri,
+          "spark.sql.catalog.prov_cat.warehouse" -> warehouse,
+          CometConf.COMET_ICEBERG_CREDENTIAL_PROVIDER_CLASS.key -> mockClass) {
+
+          spark.sql("CREATE NAMESPACE prov_cat.db")
+          spark.sql("CREATE TABLE prov_cat.db.cred (id INT) USING iceberg")
+          spark.sql("INSERT INTO prov_cat.db.cred VALUES (1), (2), (3)")
+
+          // Reset so we only count the read path; the provider is instantiated during
+          // broadcast build, so expect both init and resolve counts to rise.
+          MockCometCredentialProvider.reset()
+
+          checkIcebergNativeScan("SELECT * FROM prov_cat.db.cred ORDER BY id")
+
+          assert(
+            MockCometCredentialProvider.getResolveCount > 0,
+            "resolveCredentials(ResolveContext) should fire from the native side on S3 reads")
+          val lastCtx = MockCometCredentialProvider.getLastContext
+          assert(lastCtx != null, "ResolveContext should have been captured")
+          val loc = lastCtx.tableLocation()
+          assert(
+            loc.contains(s"$testBucketName/") && loc.contains("/db/cred"),
+            s"Expected tableLocation under warehouse for db.cred, got: $loc")
+
+          spark.sql("DROP TABLE prov_cat.db.cred")
+          spark.sql("DROP NAMESPACE prov_cat.db")
         }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/comet/CometIcebergCredentialBroadcastsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/CometIcebergCredentialBroadcastsSuite.scala
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+import java.util.concurrent.{Callable, Executors, TimeUnit}
+
+import scala.jdk.CollectionConverters._
+
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.{SparkConf, SparkContext}
+
+import org.apache.comet.iceberg.{CometCredentialProvider, MockCometCredentialProvider, ResolveContext}
+
+class CometIcebergCredentialBroadcastsSuite extends AnyFunSuite with BeforeAndAfterEach {
+
+  private var sc: SparkContext = _
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    val conf = new SparkConf()
+      .setAppName("CometIcebergCredentialBroadcastsSuite")
+      .setMaster("local[2]")
+    sc = new SparkContext(conf)
+    CometIcebergCredentialBroadcasts.clear()
+    MockCometCredentialProvider.reset()
+  }
+
+  override def afterEach(): Unit = {
+    if (sc != null) {
+      sc.stop()
+      sc = null
+    }
+    CometIcebergCredentialBroadcasts.clear()
+    super.afterEach()
+  }
+
+  private val mockClass = classOf[MockCometCredentialProvider].getName
+
+  test("getOrCreate builds a broadcast and initializes the provider once") {
+    val props = Map("tenant-id" -> "T1", "s3.access-key-id" -> "AKIA_T1")
+
+    val bcast = CometIcebergCredentialBroadcasts.getOrCreate(sc, mockClass, "cat_a", props)
+
+    assert(bcast != null)
+    assert(MockCometCredentialProvider.getInitCount == 1)
+    assert(CometIcebergCredentialBroadcasts.cacheSize() == 1)
+
+    val provider = bcast.value.asInstanceOf[CometCredentialProvider]
+    assert(provider != null)
+    val creds = provider.resolveCredentials(new ResolveContext("s3://bucket/db/t"))
+    assert(creds(0) == "AKIA_T1")
+  }
+
+  test("getOrCreate reuses the same broadcast for identical catalogName") {
+    val props = Map("tenant-id" -> "T1", "s3.access-key-id" -> "AKIA_T1")
+
+    val bcast1 = CometIcebergCredentialBroadcasts.getOrCreate(sc, mockClass, "cat_a", props)
+    val bcast2 = CometIcebergCredentialBroadcasts.getOrCreate(sc, mockClass, "cat_a", props)
+
+    assert(bcast1.id == bcast2.id, "Same catalog name must yield the same broadcast")
+    assert(MockCometCredentialProvider.getInitCount == 1, "initialize() called only once")
+    assert(CometIcebergCredentialBroadcasts.cacheSize() == 1)
+  }
+
+  test("getOrCreate returns DIFFERENT broadcasts for different catalogNames") {
+    val props = Map("tenant-id" -> "T_shared")
+
+    val bcastA = CometIcebergCredentialBroadcasts.getOrCreate(sc, mockClass, "cat_a", props)
+    val bcastB = CometIcebergCredentialBroadcasts.getOrCreate(sc, mockClass, "cat_b", props)
+
+    assert(bcastA.id != bcastB.id, "Different catalog names must yield different broadcasts")
+    assert(MockCometCredentialProvider.getInitCount == 2)
+    assert(CometIcebergCredentialBroadcasts.cacheSize() == 2)
+  }
+
+  test(
+    "getOrCreate REUSES broadcast when per-table FileIO props differ but catalogName matches") {
+    val tableA = Map("tenant-id" -> "T1", "table-refresh-id" -> "REFRESH_A")
+    val tableB = Map("tenant-id" -> "T1", "table-refresh-id" -> "REFRESH_B")
+
+    val bcastA = CometIcebergCredentialBroadcasts.getOrCreate(sc, mockClass, "rest_cat", tableA)
+    val bcastB = CometIcebergCredentialBroadcasts.getOrCreate(sc, mockClass, "rest_cat", tableB)
+
+    assert(
+      bcastA.id == bcastB.id,
+      "Per-table FileIO drift must not split the catalog-scoped cache")
+    assert(MockCometCredentialProvider.getInitCount == 1, "initialize() must only run once")
+    assert(CometIcebergCredentialBroadcasts.cacheSize() == 1)
+  }
+}


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4332 

## Rationale for this change

Comet's native Iceberg scan only supports static AWS credentials captured at plan time, so jobs running longer than the session-token lifetime will fail mid-scan. 
Iceberg-rust already exposes a pluggability hook  — Comet just wasn't using it. 
This PR adds a CometCredentialProvider  that the native scan calls back into via JNI when a refresh is needed.

## What changes are included in this PR?

- New interface for Credential provider
- Plumbing for Native to call into JVM via JNI to fetch credentials when needed


## How are these changes tested?
- Unit tests added.
- Tested e2e by deploying to a Spark cluster
