### PR TITLE
ci: fix Spark 4.0.2/JDK 21 flake by enabling per-suite dedicated JVMs

### DIFF
--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -176,8 +176,24 @@ jobs:
         run: |
           cd apache-spark
           rm -rf /root/.m2/repository/org/apache/parquet # somehow parquet cache requires cleanups
+          # SERIAL_SBT_TESTS gates SparkParallelTestGrouping in
+          # project/SparkBuild.scala. For Spark 4.0.2 on JDK 21 we
+          # leave it unset so the grouping is installed and
+          # DEDICATED_JVM_SBT_TESTS below actually forks a dedicated
+          # JVM per listed suite, working around the V1/V2 Parquet and
+          # Orc source-suite cross-suite file-stream leak under JDK 21
+          # (issue #4327). For other rows we keep it set to reduce
+          # peak memory on standard 7 GB runners.
+          if [ "${{ matrix.config.spark-short }}" != "4.0" ] || [ "${{ matrix.config.java }}" != "21" ]; then
+            export SERIAL_SBT_TESTS=1
+          fi
+          # Cap parallel forked test JVMs at 1 so that even when
+          # SparkParallelTestGrouping is enabled we don't blow the
+          # 7 GB runner budget (each forked test JVM has -Xmx2g).
           NOLINT_ON_COMPILE=true ENABLE_COMET=true ENABLE_COMET_ONHEAP=true COMET_PARQUET_SCAN_IMPL=${{ matrix.config.scan-impl }} ENABLE_COMET_LOG_FALLBACK_REASONS=${{ github.event.inputs.collect-fallback-logs || 'false' }} \
-            build/sbt -Dsbt.log.noformat=true -mem $SBT_MEM ${{ matrix.module.args1 }} "${{ matrix.module.args2 }}"
+            build/sbt -Dsbt.log.noformat=true -mem $SBT_MEM \
+              'set Global / concurrentRestrictions := Seq(Tags.limit(Tags.ForkedTestGroup, 1))' \
+              ${{ matrix.module.args1 }} "${{ matrix.module.args2 }}"
           if [ "${{ github.event.inputs.collect-fallback-logs }}" = "true" ]; then
             find . -type f -name "unit-tests.log" -print0 | xargs -0 grep -h "Comet cannot accelerate" | sed 's/.*Comet cannot accelerate/Comet cannot accelerate/' | sort -u > fallback.log
           fi
@@ -186,9 +202,6 @@ jobs:
           # Standard GitHub runners have 7 GB RAM; cap SBT heap so forked test
           # JVMs fit alongside it.
           SBT_MEM: "3072"
-          # Disable parallel test execution to reduce peak memory usage —
-          # mirrors what apache/spark does on GitHub Actions.
-          SERIAL_SBT_TESTS: "1"
           # Mirror Spark's own JDK 21 / 25 CI workaround. apache/spark's
           # build_java21.yml and build_java25.yml set this same env var to
           # process-isolate the V1/V2 Parquet and Orc source suites because


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4327.

## Rationale for this change

The `spark-sql-auto-sql_core-1/spark-4.0.2-jdk21` job has been failing frequently with:

```
[info] ParquetFileFormatV{1,2}Suite (or OrcSourceV{1,2}Suite) *** ABORTED ***
[info]   \"There are 1 possibly leaked file streams.\" (SharedSparkSession.scala:189)
```

This is Spark's `DebugFilesystem.assertNoOpenStreams()` in `SharedSparkSession.afterEach`, retried via `eventually` for ~10s.

These four suites are flaky on JDK 21 even in apache/spark's own CI; the upstream workaround is `DEDICATED_JVM_SBT_TESTS`, which asks SBT to fork a dedicated JVM per listed suite. Comet's workflow already sets that env var for the Spark 4.0 row, but it has no effect because the workflow also unconditionally sets `SERIAL_SBT_TESTS=1` (added in #4285 to cap peak memory on standard runners). In `project/SparkBuild.scala`:

```scala
if (!sys.env.contains(\"SERIAL_SBT_TESTS\")) {
  allProjects.foreach(enable(SparkParallelTestGrouping.settings))
}
```

`SparkParallelTestGrouping.settings` is the only consumer of `DEDICATED_JVM_SBT_TESTS`, so when `SERIAL_SBT_TESTS` is set the env var is read into an unused set and every suite runs in one shared forked JVM. Cross-suite state accumulation from ~11k prior tests is what trips the file-stream leak detection.

Evidence from a failing log ([run 26004020697](https://github.com/apache/datafusion-comet/actions/runs/26004020697/job/76441382377)):
- thread-leak warning mentions `readingParquetFooters-ForkJoinPool-12260-worker-1` (high pool counter = many prior suites in this JVM)
- unrelated suites (`AnalysisConfOverrideSuite`, `TPCDSModifiedPlanStabilityWithStatsSuite`, state-store suites) appear in the same JVM right before these Parquet/ORC suites
- no SBT fork-restart markers between unrelated suites

## What changes are included in this PR?

- Drop `SERIAL_SBT_TESTS=1` only for the Spark 4.0.2/JDK 21 matrix row, so Spark's `SparkParallelTestGrouping` is installed and `DEDICATED_JVM_SBT_TESTS` actually forks a separate JVM per listed suite. Other rows keep `SERIAL_SBT_TESTS=1` so their memory profile is unchanged.
- Override `Global / concurrentRestrictions` to cap parallel forked test JVMs at 1. Spark's defaults would otherwise allow up to 4 in parallel (each `-Xmx2g`), which would exceed the 7 GB runner budget. The cap is a no-op for rows that still have `SERIAL_SBT_TESTS=1`.

## How are these changes tested?

CI on this PR will exercise the new path. A successful run for `spark-sql-auto-sql_core-1/spark-4.0.2-jdk21` confirms that the dedicated-JVM workaround is now in effect and the four problem suites no longer abort.