### PR TITLE
chore: enable ansi by default for Spark 4 tests

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -19,14 +19,15 @@
 
 package org.apache.spark.sql
 
-import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
-
 import java.util.concurrent.atomic.AtomicInteger
+
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.{Success, Try}
+
 import org.scalatest.BeforeAndAfterEach
+
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.column.ParquetProperties
 import org.apache.parquet.example.data.Group
@@ -45,7 +46,9 @@ import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.internal._
 import org.apache.spark.sql.test._
 import org.apache.spark.sql.types.{DecimalType, StructType}
+
 import org.apache.comet._
+import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
 import org.apache.comet.shims.ShimCometSparkSessionExtensions
 
 /**

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -19,15 +19,14 @@
 
 package org.apache.spark.sql
 
-import java.util.concurrent.atomic.AtomicInteger
+import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
 
+import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.{Success, Try}
-
 import org.scalatest.BeforeAndAfterEach
-
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.column.ParquetProperties
 import org.apache.parquet.example.data.Group
@@ -46,7 +45,6 @@ import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.internal._
 import org.apache.spark.sql.test._
 import org.apache.spark.sql.types.{DecimalType, StructType}
-
 import org.apache.comet._
 import org.apache.comet.shims.ShimCometSparkSessionExtensions
 
@@ -72,9 +70,7 @@ abstract class CometTestBase
     conf.set("spark.hadoop.fs.file.impl", classOf[DebugFilesystem].getName)
     conf.set("spark.ui.enabled", "false")
     conf.set(SQLConf.SHUFFLE_PARTITIONS, 10) // reduce parallelism in tests
-    val sparkMajorVersion =
-      SPARK_VERSION.split("\\.").headOption.flatMap(s => Try(s.toInt).toOption).getOrElse(0)
-    conf.set(SQLConf.ANSI_ENABLED.key, (sparkMajorVersion >= 4).toString)
+    conf.set(SQLConf.ANSI_ENABLED.key, isSpark40Plus.toString)
     conf.set(SHUFFLE_MANAGER, shuffleManager)
     conf.set(MEMORY_OFFHEAP_ENABLED.key, "true")
     conf.set(MEMORY_OFFHEAP_SIZE.key, "2g")

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -72,7 +72,9 @@ abstract class CometTestBase
     conf.set("spark.hadoop.fs.file.impl", classOf[DebugFilesystem].getName)
     conf.set("spark.ui.enabled", "false")
     conf.set(SQLConf.SHUFFLE_PARTITIONS, 10) // reduce parallelism in tests
-    conf.set(SQLConf.ANSI_ENABLED.key, "false")
+    val sparkMajorVersion =
+      SPARK_VERSION.split("\\.").headOption.flatMap(s => Try(s.toInt).toOption).getOrElse(0)
+    conf.set(SQLConf.ANSI_ENABLED.key, (sparkMajorVersion >= 4).toString)
     conf.set(SHUFFLE_MANAGER, shuffleManager)
     conf.set(MEMORY_OFFHEAP_ENABLED.key, "true")
     conf.set(MEMORY_OFFHEAP_SIZE.key, "2g")


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->


Closes #.

## Rationale for this change


  `CometTestBase` was unconditionally pinning ANSI to `false`, which meant the Spark 4.0 / 4.1 / 4.2 test profiles never actually exercised the ANSI behavior that real Spark 4 users get out of the box.
  Tests that pass under Comet today may regress in production because we never run them with the same defaults.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
