### PR TITLE
feat: adding math sec expression

### DIFF
--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -413,7 +413,7 @@
 - [ ] randstr
 - [ ] rint
 - [x] round
-- [ ] sec
+- [x] sec
 - [x] shiftleft
 - [x] sign
 - [x] signum

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -171,6 +171,7 @@ of expressions that be disabled.
 | Randn          | `randn`        |
 | Remainder      | `%`            |
 | Round          | `round`        |
+| Sec            | `sec`          |
 | Signum         | `signum`       |
 | Sin            | `sin`          |
 | Sinh           | `sinh`         |

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -61,6 +61,7 @@ use datafusion_spark::function::math::expm1::SparkExpm1;
 use datafusion_spark::function::math::factorial::SparkFactorial;
 use datafusion_spark::function::math::hex::SparkHex;
 use datafusion_spark::function::math::trigonometry::SparkCsc;
+use datafusion_spark::function::math::trigonometry::SparkSec;
 use datafusion_spark::function::math::width_bucket::SparkWidthBucket;
 use datafusion_spark::function::string::char::CharFunc;
 use datafusion_spark::function::string::concat::SparkConcat;
@@ -599,6 +600,7 @@ fn register_datafusion_spark_function(session_ctx: &SessionContext) {
     session_ctx.register_udf(ScalarUDF::new_from_impl(SparkTryUrlDecode::default()));
     session_ctx.register_udf(ScalarUDF::new_from_impl(SparkCsc::default()));
     session_ctx.register_udf(ScalarUDF::new_from_impl(SparkFactorial::default()));
+    session_ctx.register_udf(ScalarUDF::new_from_impl(SparkSec::default()));
 }
 
 /// Prepares arrow arrays for output.

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -126,6 +126,7 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
     classOf[Randn] -> CometRandn,
     classOf[Remainder] -> CometRemainder,
     classOf[Round] -> CometRound,
+    classOf[Sec] -> CometScalarFunction("sec"),
     classOf[Signum] -> CometScalarFunction("signum"),
     classOf[Sin] -> CometScalarFunction("sin"),
     classOf[Sinh] -> CometScalarFunction("sinh"),

--- a/spark/src/test/resources/sql-tests/expressions/math/sec.sql
+++ b/spark/src/test/resources/sql-tests/expressions/math/sec.sql
@@ -1,0 +1,25 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+statement
+CREATE TABLE test_sec(d double) USING parquet
+
+statement
+INSERT INTO test_sec VALUES (0.0), (-0.0), (1.5707963267948966), (-1.5707963267948966), (3.141592653589793), (NULL), (cast('NaN' as double)), (cast('Infinity' as double)), (cast('-Infinity' as double))
+
+query tolerance=1e-6
+SELECT sec(d) FROM test_sec


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part https://github.com/apache/datafusion-comet/issues/4150

## Rationale for this change

`sec` already has a native implementation in the `datafusion-spark` crate, but was not yet wired into Comet, so queries using it fell back to Spark.

## What changes are included in this PR?

Wires the Spark `Sec` expression to the `datafusion-spark` `SparkSec` UDF (Pattern B: register the UDF in `jni_api.rs` + one-line passthrough in `QueryPlanSerde.scala`). Also updates the supported-expression docs.

## How are these changes tested?

Added a SQL file test (`math/sec.sql`).
