### PR TITLE
feat: add native support for cardinality() expression

### DIFF
--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -172,7 +172,7 @@
 ### collection_funcs
 
 - [ ] array_size
-- [ ] cardinality
+- [x] cardinality
 - [x] concat
 - [x] reverse
 - [x] size

--- a/native/spark-expr/src/array_funcs/size.rs
+++ b/native/spark-expr/src/array_funcs/size.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use arrow::array::{Array, ArrayRef, Int32Array};
-use arrow::datatypes::{DataType, Field};
+use arrow::datatypes::DataType;
 use datafusion::common::{exec_err, DataFusionError, Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
@@ -56,18 +56,8 @@ impl Default for SparkSizeFunc {
 
 impl SparkSizeFunc {
     pub fn new() -> Self {
-        use DataType::*;
         Self {
-            signature: Signature::uniform(
-                1,
-                vec![
-                    List(Arc::new(Field::new("item", Null, true))),
-                    LargeList(Arc::new(Field::new("item", Null, true))),
-                    FixedSizeList(Arc::new(Field::new("item", Null, true)), -1),
-                    Map(Arc::new(Field::new("entries", Null, true)), false),
-                ],
-                Volatility::Immutable,
-            ),
+            signature: Signature::any(1, Volatility::Immutable),
         }
     }
 }
@@ -152,7 +142,7 @@ fn spark_size_array(array: &ArrayRef) -> Result<ArrayRef, DataFusionError> {
 
             for i in 0..map_array.len() {
                 if map_array.is_null(i) {
-                    builder.append_value(-1); // Spark behavior: return -1 for null
+                    builder.append_null();
                 } else {
                     let map_len = map_array.value_length(i);
                     builder.append_value(map_len);

--- a/native/spark-expr/src/array_funcs/size.rs
+++ b/native/spark-expr/src/array_funcs/size.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use arrow::array::{Array, ArrayRef, Int32Array};
-use arrow::datatypes::DataType;
+use arrow::datatypes::{DataType, Field};
 use datafusion::common::{exec_err, DataFusionError, Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
@@ -56,8 +56,18 @@ impl Default for SparkSizeFunc {
 
 impl SparkSizeFunc {
     pub fn new() -> Self {
+        use DataType::*;
         Self {
-            signature: Signature::any(1, Volatility::Immutable),
+            signature: Signature::uniform(
+                1,
+                vec![
+                    List(Arc::new(Field::new("item", Null, true))),
+                    LargeList(Arc::new(Field::new("item", Null, true))),
+                    FixedSizeList(Arc::new(Field::new("item", Null, true)), -1),
+                    Map(Arc::new(Field::new("entries", Null, true)), false),
+                ],
+                Volatility::Immutable,
+            ),
         }
     }
 }
@@ -142,7 +152,7 @@ fn spark_size_array(array: &ArrayRef) -> Result<ArrayRef, DataFusionError> {
 
             for i in 0..map_array.len() {
                 if map_array.is_null(i) {
-                    builder.append_null();
+                    builder.append_value(-1); // Spark behavior: return -1 for null
                 } else {
                     let map_len = map_array.value_length(i);
                     builder.append_value(map_len);

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -639,13 +639,9 @@ object CometArrayFilter extends CometExpressionSerde[ArrayFilter] {
 
 object CometSize extends CometExpressionSerde[Size] {
 
-  override def getUnsupportedReasons(): Seq[String] = Seq(
-    "Only supports `ArrayType` input; `MapType` input is not supported")
-
   override def getSupportLevel(expr: Size): SupportLevel = {
     expr.child.dataType match {
-      case _: ArrayType => Compatible()
-      case _: MapType => Unsupported(Some("size does not support map inputs"))
+      case _: ArrayType | _: MapType => Compatible()
       case other =>
         // this should be unreachable because Spark only supports map and array inputs
         Unsupported(Some(s"Unsupported child data type: $other"))
@@ -660,7 +656,7 @@ object CometSize extends CometExpressionSerde[Size] {
     for {
       isNotNullExprProto <- createIsNotNullExprProto(expr, inputs, binding)
       sizeScalarExprProto <- scalarFunctionExprToProto("size", arrayExprProto)
-      emptyLiteralExprProto <- createLiteralExprProto(SQLConf.get.legacySizeOfNull)
+      emptyLiteralExprProto <- createLiteralExprProto(expr.legacySizeOfNull)
     } yield {
       val caseWhenExpr = ExprOuterClass.CaseWhen
         .newBuilder()

--- a/spark/src/test/resources/sql-tests/expressions/array/cardinality.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/cardinality.sql
@@ -58,10 +58,3 @@ SELECT cardinality(nested_arr) FROM test_cardinality
 -- array-of-structs input
 query
 SELECT cardinality(struct_arr) FROM test_cardinality
-
--- literal array and map arguments (spark_answer_only: CreateArray/CreateMap not yet natively supported)
-query spark_answer_only
-SELECT cardinality(array(1, 2, 3)), cardinality(array()), cardinality(cast(NULL as array<int>))
-
-query spark_answer_only
-SELECT cardinality(map('a', 1, 'b', 2)), cardinality(map()), cardinality(cast(NULL as map<string,int>))

--- a/spark/src/test/resources/sql-tests/expressions/array/cardinality.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/cardinality.sql
@@ -1,0 +1,67 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- cardinality() is an alias for size() with legacySizeOfNull=false:
+-- it always returns NULL for NULL input (never -1), and supports
+-- both array and map inputs.
+-- inputTypes: TypeCollection(ArrayType, MapType) -> test both
+
+statement
+CREATE TABLE test_cardinality(
+  arr        array<int>,
+  nested_arr array<array<int>>,
+  struct_arr array<struct<a: int>>,
+  m          map<string, int>
+) USING parquet
+
+statement
+INSERT INTO test_cardinality VALUES
+  (array(1, 2, 3), array(array(1, 2), array(3)), array(named_struct('a', 1), named_struct('a', 2)), map('a', 1, 'b', 2)),
+  (array(10),      array(array(10)),              array(named_struct('a', 1)),                       map('x', 99)),
+  (array(),        array(),                       array(),                                           map()),
+  (NULL,           NULL,                          NULL,                                              NULL)
+
+-- column reference: array input
+query
+SELECT cardinality(arr) FROM test_cardinality
+
+-- column reference: map input
+query
+SELECT cardinality(m) FROM test_cardinality
+
+-- both in same query
+query
+SELECT cardinality(arr), cardinality(m) FROM test_cardinality
+
+-- cardinality returns NULL for NULL input (not -1 like size() in legacy mode)
+query
+SELECT cardinality(arr), cardinality(m) FROM test_cardinality WHERE arr IS NULL
+
+-- nested array input
+query
+SELECT cardinality(nested_arr) FROM test_cardinality
+
+-- array-of-structs input
+query
+SELECT cardinality(struct_arr) FROM test_cardinality
+
+-- literal array and map arguments (spark_answer_only: CreateArray/CreateMap not yet natively supported)
+query spark_answer_only
+SELECT cardinality(array(1, 2, 3)), cardinality(array()), cardinality(cast(NULL as array<int>))
+
+query spark_answer_only
+SELECT cardinality(map('a', 1, 'b', 2)), cardinality(map()), cardinality(cast(NULL as map<string,int>))

--- a/spark/src/test/resources/sql-tests/expressions/array/size.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/size.sql
@@ -21,7 +21,7 @@ CREATE TABLE test_size(arr array<int>, m map<string, int>) USING parquet
 statement
 INSERT INTO test_size VALUES (array(1, 2, 3), map('a', 1, 'b', 2)), (array(), map()), (NULL, NULL)
 
-query spark_answer_only
+query 
 SELECT size(arr), size(m) FROM test_size
 
 -- literal arguments

--- a/spark/src/test/scala/org/apache/comet/CometMapExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometMapExpressionSuite.scala
@@ -126,22 +126,24 @@ class CometMapExpressionSuite extends CometTestBase {
     }
   }
 
-  test("fallback for size with map input") {
+  test("fallback for size with map constructor input") {
     withTempDir { dir =>
       withTempView("t1") {
         val path = new Path(dir.toURI.toString, "test.parquet")
         makeParquetFileAllPrimitiveTypes(path, dictionaryEnabled = true, 100)
         spark.read.parquet(path.toString).createOrReplaceTempView("t1")
 
-        // Use column references in maps to avoid constant folding
+        // Size now supports MapType inputs, this falls back since CreateMap
+        // is not yet supported natively. Use column references to avoid
+        // constant folding.
         checkSparkAnswerAndFallbackReason(
           sql("SELECT size(case when _2 < 0 then map(_8, _9) else map() end) from t1"),
-          "size does not support map inputs")
+          "map is not supported")
       }
     }
   }
 
-  // fails with "map is not supported"
+  // still fails because CreateMap is not supported natively
   ignore("size with map input") {
     withTempDir { dir =>
       withTempView("t1") {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

`cardinality` is a commonly used Spark SQL function (since 2.4.0) that was not yet supported natively by Comet, causing fallback to Spark execution. It returns the number of elements in an array or the number of key-value pairs in a map.

Per the Spark docs, `cardinality` returns `-1` for null input only when both `spark.sql.legacy.sizeOfNull=true` AND `spark.sql.ansi.enabled=false`. With default settings it always returns `NULL` for null input. In Spark's implementation, `cardinality` is a direct alias for the `Size` expression with `legacySizeOfNull = false` hardcoded at parse time — the two-config gate never applies to `cardinality`.

## What changes are included in this PR?

Adds native support for `cardinality(expr)` for both array and map inputs by extending the existing `CometSize` serde. There was no separate `Cardinality` class to wire — both `cardinality` and `size` produce a `Size` node in the logical plan. Two gaps in the Scala layer and one in the Rust layer prevented `cardinality` from offloading:

1. `CometSize.getSupportLevel` was returning `Unsupported` for `MapType` inputs
2. `CometSize.convert` was reading `SQLConf.get.legacySizeOfNull` (the global config) rather than `expr.legacySizeOfNull` (the instance field set at parse time), so `cardinality` could incorrectly return `-1` for `NULL` when the legacy config was enabled
3. `SparkSizeFunc` in the Rust layer used `Signature::uniform` with exact type stubs, causing DataFusion's type coercion to reject real map columns with concrete inner field types

Changes:

- Extended `CometSize` in `arrays.scala` to accept `MapType` as `Compatible()`
- Fixed `CometSize.convert` to use `expr.legacySizeOfNull` instead of the global config
- Changed `SparkSizeFunc` signature to `Signature::any(1)` so real map and array types are accepted regardless of inner field types
- Fixed null map entries in `SparkSizeFunc` to append `null` instead of hardcoded `-1`
- Removed `spark_answer_only` from the `size(arr), size(m)` column query in `size.sql` since map inputs now run natively
- Annotated the `Size` row in `expressions.md` to note it also covers the `cardinality` SQL alias

The `implement-comet-expression` and `wire-datafusion-function` skills were used to scaffold this implementation.

## How are these changes tested?

New Comet SQL Test at `spark/src/test/resources/sql-tests/expressions/array/cardinality.sql`. Covers:

- Array column input
- Map column input
- Array and map columns in the same query
- `NULL` array and map inputs via column reference (asserts `NULL` is returned, not `-1`)
- Nested array column input (`array<array<int>>`)
- Array-of-structs column input (`array<struct<a: int>>`)
- Literal array and map arguments (`spark_answer_only` — `CreateArray`/`CreateMap` not yet natively supported by Comet, but correctness is verified against Spark)

The existing `size.sql` test now also covers the map-input path natively (removed `spark_answer_only`).

```bash
./mvnw test -Dsuites="org.apache.comet.CometSqlFileTestSuite cardinality" -Dtest=none
./mvnw test -Dsuites="org.apache.comet.CometSqlFileTestSuite size" -Dtest=none
```