### PR TITLE
fix: log shuffle-manager-missing warning once per session

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -114,6 +114,14 @@ class CometSparkSessionExtensions
 object CometSparkSessionExtensions extends Logging {
   lazy val isBigEndian: Boolean = ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN)
 
+  // isCometLoaded is invoked once per plan rule application, so the shuffle-manager
+  // warning would otherwise fire many times per session. Track SQLConf identities we
+  // have already warned for; the weak map drops entries when the session is GC'd.
+  private val warnedMissingShuffleManager: java.util.Set[SQLConf] =
+    java.util.Collections.synchronizedSet(
+      java.util.Collections.newSetFromMap(
+        new java.util.WeakHashMap[SQLConf, java.lang.Boolean]()))
+
   /**
    * Checks whether Comet extension should be loaded for Spark.
    */
@@ -128,12 +136,14 @@ object CometSparkSessionExtensions extends Logging {
     }
 
     if (COMET_EXEC_SHUFFLE_ENABLED.get(conf) && !isCometShuffleManagerEnabled(conf)) {
-      logWarning(
-        "Comet extension is disabled because spark.shuffle.manager is not set to " +
-          "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager. " +
-          "Comet provides limited benefit without its shuffle manager. " +
-          s"Set ${COMET_EXEC_SHUFFLE_ENABLED.key}=false to keep Comet enabled with " +
-          "Spark's default shuffle manager.")
+      if (warnedMissingShuffleManager.add(conf)) {
+        logWarning(
+          "Comet extension is disabled because spark.shuffle.manager is not set to " +
+            "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager. " +
+            "Comet provides limited benefit without its shuffle manager. " +
+            s"Set ${COMET_EXEC_SHUFFLE_ENABLED.key}=false to keep Comet enabled with " +
+            "Spark's default shuffle manager.")
+      }
       return false
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

Refs #4377.

## Rationale for this change

`CometSparkSessionExtensions.isCometLoaded` runs from `CometScanRule._apply` and `CometExecRule._apply`, i.e. on every plan rule application. The warning added in #4328 therefore fires many times per query for any session that does not register `CometShuffleManager`. In the Spark SQL CI matrix this surfaces as hundreds of duplicate `WARN` lines per affected suite (e.g. `BroadcastJoinSuiteAE` emitted ~304 in a single 4.1.1 run).

Whether those suites should be running with the Comet shuffle manager is a separate question tracked in #4377. This PR addresses the log-spam side of the regression so the warning is still useful as a once-per-session signal.

## What changes are included in this PR?

- Add a synchronized weak set keyed by `SQLConf` in `CometSparkSessionExtensions`.
- `isCometLoaded` now only emits the warning the first time it observes a given session missing the shuffle manager. Entries are dropped when the `SQLConf` is GC'd, so this cannot grow unboundedly across test JVMs.
- Return value behavior is unchanged.

## How are these changes tested?

- `CometSparkSessionExtensionsSuite` — both `isCometLoaded` tests still pass (they assert boolean return values, which are unchanged).