### PR TITLE
ci: reduce PR test matrix for Spark SQL and Iceberg

### DIFF
--- a/.github/workflows/iceberg_spark_test.yml
+++ b/.github/workflows/iceberg_spark_test.yml
@@ -114,7 +114,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        iceberg-version: [{short: '1.8', full: '1.8.1'}, {short: '1.9', full: '1.9.1'}, {short: '1.10', full: '1.10.0'}]
+        # On pull requests, test only the latest Iceberg version to reduce CI load.
+        # Pushes to main and manual workflow_dispatch runs use the full matrix.
+        iceberg-version: ${{ fromJSON(github.event_name == 'pull_request' && '[{"short":"1.10","full":"1.10.0"}]' || '[{"short":"1.8","full":"1.8.1"},{"short":"1.9","full":"1.9.1"},{"short":"1.10","full":"1.10.0"}]') }}
         spark-version: [{short: '3.4', full: '3.4.3'}, {short: '3.5', full: '3.5.8'}]
         scala-version: ['2.13']
         include:
@@ -161,7 +163,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        iceberg-version: [{short: '1.8', full: '1.8.1'}, {short: '1.9', full: '1.9.1'}, {short: '1.10', full: '1.10.0'}]
+        # On pull requests, test only the latest Iceberg version to reduce CI load.
+        # Pushes to main and manual workflow_dispatch runs use the full matrix.
+        iceberg-version: ${{ fromJSON(github.event_name == 'pull_request' && '[{"short":"1.10","full":"1.10.0"}]' || '[{"short":"1.8","full":"1.8.1"},{"short":"1.9","full":"1.9.1"},{"short":"1.10","full":"1.10.0"}]') }}
         spark-version: [{short: '3.4', full: '3.4.3'}, {short: '3.5', full: '3.5.8'}]
         scala-version: ['2.13']
         include:
@@ -208,7 +212,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        iceberg-version: [{short: '1.8', full: '1.8.1'}, {short: '1.9', full: '1.9.1'}, {short: '1.10', full: '1.10.0'}]
+        # On pull requests, test only the latest Iceberg version to reduce CI load.
+        # Pushes to main and manual workflow_dispatch runs use the full matrix.
+        iceberg-version: ${{ fromJSON(github.event_name == 'pull_request' && '[{"short":"1.10","full":"1.10.0"}]' || '[{"short":"1.8","full":"1.8.1"},{"short":"1.9","full":"1.9.1"},{"short":"1.10","full":"1.10.0"}]') }}
         spark-version: [{short: '3.4', full: '3.4.3'}, {short: '3.5', full: '3.5.8'}]
         scala-version: ['2.13']
         include:

--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -142,11 +142,9 @@ jobs:
           - {name: "sql_hive-1", args1: "", args2: "hive/testOnly * -- -l org.apache.spark.tags.ExtendedHiveTest -l org.apache.spark.tags.SlowHiveTest"}
           - {name: "sql_hive-2", args1: "", args2: "hive/testOnly * -- -n org.apache.spark.tags.ExtendedHiveTest"}
           - {name: "sql_hive-3", args1: "", args2: "hive/testOnly * -- -n org.apache.spark.tags.SlowHiveTest"}
-        config:
-          - {spark-short: '3.4', spark-full: '3.4.3', java: 11}
-          - {spark-short: '3.5', spark-full: '3.5.8', java: 11}
-          - {spark-short: '4.0', spark-full: '4.0.2', java: 21}
-          - {spark-short: '4.1', spark-full: '4.1.1', java: 17}
+        # On pull requests, test only Spark 3.5 and 4.1 to reduce CI load.
+        # Pushes to main and manual workflow_dispatch runs use the full matrix.
+        config: ${{ fromJSON(github.event_name == 'pull_request' && '[{"spark-short":"3.5","spark-full":"3.5.8","java":11},{"spark-short":"4.1","spark-full":"4.1.1","java":17}]' || '[{"spark-short":"3.4","spark-full":"3.4.3","java":11},{"spark-short":"3.5","spark-full":"3.5.8","java":11},{"spark-short":"4.0","spark-full":"4.0.2","java":21},{"spark-short":"4.1","spark-full":"4.1.1","java":17}]') }}
       fail-fast: false
     name: spark-sql-${{ matrix.module.name }}/spark-${{ matrix.config.spark-full }}-jdk${{ matrix.config.java }}
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion-comet/issues/4406

## Rationale for this change

The Spark SQL test workflow runs every Spark version (3.4, 3.5, 4.0, 4.1) on every pull request, and the Iceberg test workflows run every Iceberg version (1.8.1, 1.9.1, 1.10.0). This is valuable coverage on `main` but is expensive to run on every pull request iteration. Reducing the matrix on pull requests shortens feedback time and frees runner capacity, while pushes to `main` still get the full sweep so regressions on the less-common versions are still caught before release.

## What changes are included in this PR?

The varying matrix dimension in each workflow is now selected with a conditional `fromJSON` expression keyed on `github.event_name`:

- `spark_sql_test.yml`: pull requests test only Spark 3.5 and 4.1; pushes to `main` and manual `workflow_dispatch` runs test the full set (3.4, 3.5, 4.0, 4.1). The 7-entry `module` matrix is unchanged, so pull request runs drop from 28 jobs to 14.
- `iceberg_spark_test.yml`: pull requests test only the latest Iceberg version (1.10.0); pushes to `main` and manual `workflow_dispatch` runs test the full set (1.8.1, 1.9.1, 1.10.0). This applies to all three Iceberg jobs (`iceberg-spark`, `iceberg-spark-extensions`, `iceberg-spark-runtime`).

Manual `workflow_dispatch` runs intentionally use the full matrix so the complete sweep can still be triggered on demand.

## How are these changes tested?

These are CI configuration changes. Both modified workflows pass `actionlint` (the same check run by `validate_workflows.yml`), and the inline matrix JSON was verified to parse. The conditional matrix behavior will be observable on this pull request (reduced matrix) versus subsequent pushes to `main` (full matrix).