### PR TITLE
ci: use path allow list for iceberg workflow triggers

### DIFF
--- a/.github/workflows/iceberg_spark_test.yml
+++ b/.github/workflows/iceberg_spark_test.yml
@@ -25,27 +25,41 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "benchmarks/**"
-      - "doc/**"
-      - "docs/**"
-      - "**.md"
-      - "native/core/benches/**"
-      - "native/spark-expr/benches/**"
-      - "spark/src/test/**"
-      - "spark/src/main/scala/org/apache/comet/GenerateDocs.scala"
-      - "spark-integration/**"
+    paths:
+      - "native/**/src/**"
+      - "native/**/Cargo.toml"
+      - "native/Cargo.lock"
+      - "!native/hdfs/**"
+      - "!native/fs-hdfs/**"
+      - "common/src/main/**"
+      - "common/pom.xml"
+      - "spark/src/main/**"
+      - "!spark/src/main/scala/org/apache/comet/GenerateDocs.scala"
+      - "spark/pom.xml"
+      - "dev/diffs/iceberg/**"
+      - "pom.xml"
+      - "rust-toolchain.toml"
+      - ".github/workflows/iceberg_spark_test.yml"
+      - ".github/actions/setup-builder/**"
+      - ".github/actions/setup-iceberg-builder/**"
   pull_request:
-    paths-ignore:
-      - "benchmarks/**"
-      - "doc/**"
-      - "docs/**"
-      - "**.md"
-      - "native/core/benches/**"
-      - "native/spark-expr/benches/**"
-      - "spark/src/test/**"
-      - "spark/src/main/scala/org/apache/comet/GenerateDocs.scala"
-      - "spark-integration/**"
+    paths:
+      - "native/**/src/**"
+      - "native/**/Cargo.toml"
+      - "native/Cargo.lock"
+      - "!native/hdfs/**"
+      - "!native/fs-hdfs/**"
+      - "common/src/main/**"
+      - "common/pom.xml"
+      - "spark/src/main/**"
+      - "!spark/src/main/scala/org/apache/comet/GenerateDocs.scala"
+      - "spark/pom.xml"
+      - "dev/diffs/iceberg/**"
+      - "pom.xml"
+      - "rust-toolchain.toml"
+      - ".github/workflows/iceberg_spark_test.yml"
+      - ".github/actions/setup-builder/**"
+      - ".github/actions/setup-iceberg-builder/**"
   # manual trigger
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion-comet/issues/4406

## Rationale for this change

The iceberg workflow currently uses `paths-ignore` (a deny list) to decide when to run. With a deny list, every new file or directory that should not trigger iceberg CI must be added explicitly, and it is easy to forget. As a result, unrelated changes such as `dev/` scripts, release tooling, and golden-file regeneration still trigger the full iceberg test matrix.

`spark_sql_test.yml` already uses a `paths` allow list for the same reason. This PR brings the iceberg workflow in line with that approach.

## What changes are included in this PR?

Switches the `push` and `pull_request` triggers in `iceberg_spark_test.yml` from `paths-ignore` to `paths`. The allow list covers the inputs that actually affect iceberg tests:

- native library sources and Cargo manifests (excluding HDFS crates)
- `common` and `spark` main sources and POMs (excluding `GenerateDocs.scala`)
- `dev/diffs/iceberg/**`, applied by the `setup-iceberg-builder` action
- root `pom.xml` and `rust-toolchain.toml`
- the workflow file itself and the composite actions it invokes

Changes to `dev/` scripts, docs, markdown, benchmarks, tests, and `spark-integration` no longer trigger iceberg CI.

The allow list mirrors `spark_sql_test.yml`, scoped to `dev/diffs/iceberg` and the iceberg-specific workflow and setup action.

## How are these changes tested?

This is a CI configuration change. The workflow file passes `actionlint`, which is enforced by the `validate_workflows.yml` workflow.