### PR TITLE
ci: consolidate pr_build test matrix and switch triggers to allow-list

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -22,28 +22,55 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  # Allow-list of paths that affect this workflow. A change must match a positive
+  # pattern (and not a trailing "!" exclusion) for the build to run. Editing
+  # pr_build_macos.yml does not trigger this workflow, and vice versa.
   push:
     branches:
       - main
-    paths-ignore:
-      - "benchmarks/**"
-      - "doc/**"
-      - "docs/**"
-      - "**.md"
-      - "native/core/benches/**"
-      - "native/spark-expr/benches/**"
-      - "spark/src/test/scala/org/apache/spark/sql/benchmark/**"
-      - "spark/src/main/scala/org/apache/comet/GenerateDocs.scala"
+    paths:
+      - "native/**"
+      - "common/**"
+      - "spark/**"
+      - "spark-integration/**"
+      - "pom.xml"
+      - "**/pom.xml"
+      - ".mvn/**"
+      - "mvnw"
+      - "Makefile"
+      - "rust-toolchain.toml"
+      - "dev/ci/**"
+      - ".github/workflows/pr_build_linux.yml"
+      - ".github/actions/setup-builder/**"
+      - ".github/actions/java-test/**"
+      - ".github/actions/rust-test/**"
+      - "!**.md"
+      - "!native/core/benches/**"
+      - "!native/spark-expr/benches/**"
+      - "!spark/src/test/scala/org/apache/spark/sql/benchmark/**"
+      - "!spark/src/main/scala/org/apache/comet/GenerateDocs.scala"
   pull_request:
-    paths-ignore:
-      - "benchmarks/**"
-      - "doc/**"
-      - "docs/**"
-      - "**.md"
-      - "native/core/benches/**"
-      - "native/spark-expr/benches/**"
-      - "spark/src/test/scala/org/apache/spark/sql/benchmark/**"
-      - "spark/src/main/scala/org/apache/comet/GenerateDocs.scala"
+    paths:
+      - "native/**"
+      - "common/**"
+      - "spark/**"
+      - "spark-integration/**"
+      - "pom.xml"
+      - "**/pom.xml"
+      - ".mvn/**"
+      - "mvnw"
+      - "Makefile"
+      - "rust-toolchain.toml"
+      - "dev/ci/**"
+      - ".github/workflows/pr_build_linux.yml"
+      - ".github/actions/setup-builder/**"
+      - ".github/actions/java-test/**"
+      - ".github/actions/rust-test/**"
+      - "!**.md"
+      - "!native/core/benches/**"
+      - "!native/spark-expr/benches/**"
+      - "!spark/src/test/scala/org/apache/spark/sql/benchmark/**"
+      - "!spark/src/main/scala/org/apache/comet/GenerateDocs.scala"
   # manual trigger
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:
@@ -295,28 +322,12 @@ jobs:
           - name: "Spark 4.2, JDK 17"
             java_version: "17"
             maven_opts: "-Pspark-4.2"
+        # Suites are grouped by functional area into balanced buckets so that no test
+        # job runs much longer than ~23 min. See
+        # docs/superpowers/specs/2026-05-22-pr-build-consolidation-design.md for the
+        # per-suite timing analysis behind this grouping.
         suite:
-          - name: "fuzz"
-            value: |
-              org.apache.comet.CometFuzzTestSuite
-              org.apache.comet.CometFuzzAggregateSuite
-              org.apache.comet.CometFuzzIcebergSuite
-              org.apache.comet.CometFuzzMathSuite
-              org.apache.comet.CometCodegenFuzzSuite
-              org.apache.comet.DataGeneratorSuite
-          - name: "shuffle"
-            value: |
-              org.apache.comet.exec.CometShuffleSuite
-              org.apache.comet.exec.CometShuffle4_0Suite
-              org.apache.comet.exec.CometNativeColumnarToRowSuite
-              org.apache.comet.exec.CometNativeShuffleSuite
-              org.apache.comet.exec.CometShuffleEncryptionSuite
-              org.apache.comet.exec.CometShuffleManagerSuite
-              org.apache.comet.exec.CometAsyncShuffleSuite
-              org.apache.comet.exec.DisableAQECometShuffleSuite
-              org.apache.comet.exec.DisableAQECometAsyncShuffleSuite
-              org.apache.spark.shuffle.sort.SpillSorterSuite
-          - name: "parquet"
+          - name: "scans"
             value: |
               org.apache.comet.parquet.CometParquetWriterSuite
               org.apache.comet.parquet.ParquetReadV1Suite
@@ -330,9 +341,22 @@ jobs:
               org.apache.comet.CometIcebergNativeSuite
               org.apache.comet.CometIcebergRewriteActionSuite
               org.apache.comet.iceberg.IcebergReflectionSuite
-          - name: "csv"
-            value: |
               org.apache.comet.csv.CometCsvNativeReadSuite
+              org.apache.comet.CometFuzzTestSuite
+              org.apache.comet.CometFuzzIcebergSuite
+              org.apache.comet.DataGeneratorSuite
+          - name: "shuffle"
+            value: |
+              org.apache.comet.exec.CometShuffleSuite
+              org.apache.comet.exec.CometShuffle4_0Suite
+              org.apache.comet.exec.CometNativeColumnarToRowSuite
+              org.apache.comet.exec.CometNativeShuffleSuite
+              org.apache.comet.exec.CometShuffleEncryptionSuite
+              org.apache.comet.exec.CometShuffleManagerSuite
+              org.apache.comet.exec.CometAsyncShuffleSuite
+              org.apache.comet.exec.DisableAQECometShuffleSuite
+              org.apache.comet.exec.DisableAQECometAsyncShuffleSuite
+              org.apache.spark.shuffle.sort.SpillSorterSuite
           - name: "exec"
             value: |
               org.apache.comet.exec.CometAggregateSuite
@@ -360,6 +384,9 @@ jobs:
               org.apache.spark.sql.comet.CometShuffleFallbackStickinessSuite
               org.apache.spark.sql.comet.CometDecimalArithmeticViewSuite
               org.apache.comet.objectstore.NativeConfigSuite
+              org.apache.spark.sql.CometToPrettyStringSuite
+              org.apache.spark.sql.CometCollationSuite
+              org.apache.comet.CometFuzzAggregateSuite
           - name: "expressions"
             value: |
               org.apache.comet.CometExpressionSuite
@@ -376,7 +403,6 @@ jobs:
               org.apache.comet.CometMapExpressionSuite
               org.apache.comet.CometCsvExpressionSuite
               org.apache.comet.CometJsonExpressionSuite
-              org.apache.comet.CometDateTimeUtilsSuite
               org.apache.comet.SparkErrorConverterSuite
               org.apache.comet.expressions.conditional.CometIfSuite
               org.apache.comet.expressions.conditional.CometCoalesceSuite
@@ -384,10 +410,8 @@ jobs:
               org.apache.comet.CometCodegenSuite
               org.apache.comet.CometCodegenSourceSuite
               org.apache.comet.CometCodegenHOFSuite
-          - name: "sql"
-            value: |
-              org.apache.spark.sql.CometToPrettyStringSuite
-              org.apache.spark.sql.CometCollationSuite
+              org.apache.comet.CometFuzzMathSuite
+              org.apache.comet.CometCodegenFuzzSuite
       fail-fast: false
     name: ${{ matrix.profile.name }} [${{ matrix.suite.name }}]
     runs-on: ubuntu-24.04
@@ -427,7 +451,7 @@ jobs:
         uses: ./.github/actions/java-test
         with:
           artifact_name: ${{ matrix.profile.name }}-${{ matrix.suite.name }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
-          suites: ${{ matrix.suite.name == 'sql' && matrix.profile.name == 'Spark 3.4, JDK 11, Scala 2.12' && '' || matrix.suite.value }}
+          suites: ${{ matrix.suite.value }}
           maven_opts: ${{ matrix.profile.maven_opts }}
           upload-test-reports: true
           skip-native-build: true
@@ -486,19 +510,16 @@ jobs:
         run: |
           SPARK_HOME=`pwd` SPARK_TPCH_DATA=`pwd`/tpch/sf1_parquet ./mvnw -B -Prelease -Dsuites=org.apache.spark.sql.CometTPCHQuerySuite test
 
-  # TPC-DS correctness tests - verifies benchmark queries produce correct results
+  # TPC-DS correctness tests - verifies benchmark queries produce correct results.
+  # The three join strategies run sequentially in one job so the project is built once.
   verify-benchmark-results-tpcds:
     needs: build-native
-    name: Verify TPC-DS Results (${{ matrix.join }})
+    name: Verify TPC-DS Results
     runs-on: ubuntu-24.04
     container:
       image: amd64/rust
     env:
       JAVA_TOOL_OPTIONS: --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
-    strategy:
-      matrix:
-        join: [sort_merge, broadcast, hash]
-      fail-fast: false
     steps:
       - uses: actions/checkout@v6
 
@@ -555,7 +576,6 @@ jobs:
           cd spark && MAVEN_OPTS='-Xmx20g' ../mvnw -B -Prelease exec:java -Dexec.mainClass="org.apache.spark.sql.GenTPCDSData" -Dexec.classpathScope="test" -Dexec.cleanupDaemonThreads="false" -Dexec.args="--dsdgenDir `pwd`/../tpcds-kit/tools --location `pwd`/../tpcds-sf-1 --scaleFactor 1 --numPartitions 1"
 
       - name: Run TPC-DS queries (Sort merge join)
-        if: matrix.join == 'sort_merge'
         run: |
           SPARK_HOME=`pwd` SPARK_TPCDS_DATA=`pwd`/tpcds-sf-1 ./mvnw -B -Prelease -Dsuites=org.apache.spark.sql.CometTPCDSQuerySuite test
         env:
@@ -564,7 +584,6 @@ jobs:
             spark.sql.join.preferSortMergeJoin=true
 
       - name: Run TPC-DS queries (Broadcast hash join)
-        if: matrix.join == 'broadcast'
         run: |
           SPARK_HOME=`pwd` SPARK_TPCDS_DATA=`pwd`/tpcds-sf-1 ./mvnw -B -Prelease -Dsuites=org.apache.spark.sql.CometTPCDSQuerySuite test
         env:
@@ -572,7 +591,6 @@ jobs:
             spark.sql.autoBroadcastJoinThreshold=10485760
 
       - name: Run TPC-DS queries (Shuffled hash join)
-        if: matrix.join == 'hash'
         run: |
           SPARK_HOME=`pwd` SPARK_TPCDS_DATA=`pwd`/tpcds-sf-1 ./mvnw -B -Prelease -Dsuites=org.apache.spark.sql.CometTPCDSQuerySuite test
         env:

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -22,28 +22,53 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  # Allow-list of paths that affect this workflow. A change must match a positive
+  # pattern (and not a trailing "!" exclusion) for the build to run. Editing
+  # pr_build_linux.yml does not trigger this workflow, and vice versa.
   push:
     branches:
       - main
-    paths-ignore:
-      - "benchmarks/**"
-      - "doc/**"
-      - "docs/**"
-      - "**.md"
-      - "native/core/benches/**"
-      - "native/spark-expr/benches/**"
-      - "spark/src/test/scala/org/apache/spark/sql/benchmark/**"
-      - "spark/src/main/scala/org/apache/comet/GenerateDocs.scala"
+    paths:
+      - "native/**"
+      - "common/**"
+      - "spark/**"
+      - "spark-integration/**"
+      - "pom.xml"
+      - "**/pom.xml"
+      - ".mvn/**"
+      - "mvnw"
+      - "Makefile"
+      - "rust-toolchain.toml"
+      - "dev/ci/**"
+      - ".github/workflows/pr_build_macos.yml"
+      - ".github/actions/setup-macos-builder/**"
+      - ".github/actions/java-test/**"
+      - "!**.md"
+      - "!native/core/benches/**"
+      - "!native/spark-expr/benches/**"
+      - "!spark/src/test/scala/org/apache/spark/sql/benchmark/**"
+      - "!spark/src/main/scala/org/apache/comet/GenerateDocs.scala"
   pull_request:
-    paths-ignore:
-      - "benchmarks/**"
-      - "doc/**"
-      - "docs/**"
-      - "**.md"
-      - "native/core/benches/**"
-      - "native/spark-expr/benches/**"
-      - "spark/src/test/scala/org/apache/spark/sql/benchmark/**"
-      - "spark/src/main/scala/org/apache/comet/GenerateDocs.scala"
+    paths:
+      - "native/**"
+      - "common/**"
+      - "spark/**"
+      - "spark-integration/**"
+      - "pom.xml"
+      - "**/pom.xml"
+      - ".mvn/**"
+      - "mvnw"
+      - "Makefile"
+      - "rust-toolchain.toml"
+      - "dev/ci/**"
+      - ".github/workflows/pr_build_macos.yml"
+      - ".github/actions/setup-macos-builder/**"
+      - ".github/actions/java-test/**"
+      - "!**.md"
+      - "!native/core/benches/**"
+      - "!native/spark-expr/benches/**"
+      - "!spark/src/test/scala/org/apache/spark/sql/benchmark/**"
+      - "!spark/src/main/scala/org/apache/comet/GenerateDocs.scala"
   # manual trigger
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:
@@ -148,28 +173,13 @@ jobs:
             # runtime; the scala-2.13 profile would override it back to 2.13.16 and break.
             maven_opts: "-Pspark-4.2"
 
+        # Suites are grouped by functional area into balanced buckets so that no test
+        # job runs much longer than ~23 min. See
+        # docs/superpowers/specs/2026-05-22-pr-build-consolidation-design.md for the
+        # per-suite timing analysis behind this grouping. Keep this list in sync with
+        # pr_build_linux.yml; dev/ci/check-suites.py requires every suite in both files.
         suite:
-          - name: "fuzz"
-            value: |
-              org.apache.comet.CometFuzzTestSuite
-              org.apache.comet.CometFuzzAggregateSuite
-              org.apache.comet.CometFuzzIcebergSuite
-              org.apache.comet.CometFuzzMathSuite
-              org.apache.comet.CometCodegenFuzzSuite
-              org.apache.comet.DataGeneratorSuite
-          - name: "shuffle"
-            value: |
-              org.apache.comet.exec.CometShuffleSuite
-              org.apache.comet.exec.CometShuffle4_0Suite
-              org.apache.comet.exec.CometNativeColumnarToRowSuite
-              org.apache.comet.exec.CometNativeShuffleSuite
-              org.apache.comet.exec.CometShuffleEncryptionSuite
-              org.apache.comet.exec.CometShuffleManagerSuite
-              org.apache.comet.exec.CometAsyncShuffleSuite
-              org.apache.comet.exec.DisableAQECometShuffleSuite
-              org.apache.comet.exec.DisableAQECometAsyncShuffleSuite
-              org.apache.spark.shuffle.sort.SpillSorterSuite
-          - name: "parquet"
+          - name: "scans"
             value: |
               org.apache.comet.parquet.CometParquetWriterSuite
               org.apache.comet.parquet.ParquetReadV1Suite
@@ -183,9 +193,22 @@ jobs:
               org.apache.comet.CometIcebergNativeSuite
               org.apache.comet.CometIcebergRewriteActionSuite
               org.apache.comet.iceberg.IcebergReflectionSuite
-          - name: "csv"
-            value: |
               org.apache.comet.csv.CometCsvNativeReadSuite
+              org.apache.comet.CometFuzzTestSuite
+              org.apache.comet.CometFuzzIcebergSuite
+              org.apache.comet.DataGeneratorSuite
+          - name: "shuffle"
+            value: |
+              org.apache.comet.exec.CometShuffleSuite
+              org.apache.comet.exec.CometShuffle4_0Suite
+              org.apache.comet.exec.CometNativeColumnarToRowSuite
+              org.apache.comet.exec.CometNativeShuffleSuite
+              org.apache.comet.exec.CometShuffleEncryptionSuite
+              org.apache.comet.exec.CometShuffleManagerSuite
+              org.apache.comet.exec.CometAsyncShuffleSuite
+              org.apache.comet.exec.DisableAQECometShuffleSuite
+              org.apache.comet.exec.DisableAQECometAsyncShuffleSuite
+              org.apache.spark.shuffle.sort.SpillSorterSuite
           - name: "exec"
             value: |
               org.apache.comet.exec.CometAggregateSuite
@@ -213,6 +236,9 @@ jobs:
               org.apache.spark.sql.comet.CometShuffleFallbackStickinessSuite
               org.apache.spark.sql.comet.CometDecimalArithmeticViewSuite
               org.apache.comet.objectstore.NativeConfigSuite
+              org.apache.spark.sql.CometToPrettyStringSuite
+              org.apache.spark.sql.CometCollationSuite
+              org.apache.comet.CometFuzzAggregateSuite
           - name: "expressions"
             value: |
               org.apache.comet.CometExpressionSuite
@@ -222,13 +248,13 @@ jobs:
               org.apache.comet.CometTemporalExpressionSuite
               org.apache.comet.CometArrayExpressionSuite
               org.apache.comet.CometCastSuite
+              org.apache.comet.CometDateTimeUtilsSuite
               org.apache.comet.CometMathExpressionSuite
               org.apache.comet.CometStringExpressionSuite
               org.apache.comet.CometBitwiseExpressionSuite
               org.apache.comet.CometMapExpressionSuite
-              org.apache.comet.CometJsonExpressionSuite
               org.apache.comet.CometCsvExpressionSuite
-              org.apache.comet.CometDateTimeUtilsSuite
+              org.apache.comet.CometJsonExpressionSuite
               org.apache.comet.SparkErrorConverterSuite
               org.apache.comet.expressions.conditional.CometIfSuite
               org.apache.comet.expressions.conditional.CometCoalesceSuite
@@ -236,10 +262,8 @@ jobs:
               org.apache.comet.CometCodegenSuite
               org.apache.comet.CometCodegenSourceSuite
               org.apache.comet.CometCodegenHOFSuite
-          - name: "sql"
-            value: |
-              org.apache.spark.sql.CometToPrettyStringSuite
-              org.apache.spark.sql.CometCollationSuite
+              org.apache.comet.CometFuzzMathSuite
+              org.apache.comet.CometCodegenFuzzSuite
 
       fail-fast: false
     name: ${{ matrix.os }}/${{ matrix.profile.name }} [${{ matrix.suite.name }}]


### PR DESCRIPTION
## Which issue does this PR close?

Part of #4406.

## Rationale for this change

The `pr_build_linux` and `pr_build_macos` workflows run a `profiles × suites` test matrix. Two suite buckets, `csv` and `sql`, ran only 1 and 2 test suites respectively. Every matrix job pays a fixed ~5 min overhead (checkout, toolchain setup, native-library download, and a full `mvnw install` recompile), so those buckets were almost entirely overhead: 10 near-empty jobs on Linux and 6 on macOS.

The `fuzz` bucket was organized by test type while every other bucket was organized by functional area, an inconsistency. And the triggers used `paths-ignore`, so a change to `pr_build_macos.yml` triggered `pr_build_linux.yml` and vice versa.

Per-suite timing was measured from a recent `main` run to size the new buckets so that no job runs much longer than today's ~22 min ceiling.

## What changes are included in this PR?

- Reorganize the test matrix from 7 suite buckets to 4, grouped by functional area: `scans`, `shuffle`, `exec`, `expressions`. The `fuzz`, `csv`, and `sql` buckets are dissolved into these; each fuzz suite moves next to the area it exercises (e.g. `CometFuzzAggregateSuite` into `exec`). The Linux matrix drops from 35 to 20 test jobs; macOS suites go from 7 to 4. The full suite set is unchanged, so `dev/ci/check-suites.py` still passes.
- Merge the 3-job TPC-DS verification matrix (`sort_merge`, `broadcast`, `hash`) into a single job that builds the project once and runs all three join strategies in sequence.
- Switch workflow triggers from `paths-ignore` to a `paths` allow-list covering all source trees, build tooling, and the shared composite actions. Editing `pr_build_macos.yml` no longer triggers the Linux workflow and vice versa; shared composite actions still trigger both.
- Remove the dead `Spark 3.4 + sql` special case, whose `&&` / `||` expression always evaluated to `matrix.suite.value`.

The macOS profile matrix is intentionally left untouched here; it is handled separately in #4409.

## How are these changes tested?

The workflow files were validated with `actionlint` (no new findings) and parsed as YAML. Suite coverage was checked by diffing the set of suite class names against `main`: it is identical, so no suite was dropped, and `pr_missing_suites` still passes. CI on this PR exercises the new 4-bucket matrix end to end.