### PR TITLE
ci: run miri nightly instead of on every push and PR

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -22,26 +22,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "doc/**"
-      - "docs/**"
-      - "**.md"
-      - "native/core/benches/**"
-      - "native/spark-expr/benches/**"
-      - "spark/src/test/scala/org/apache/spark/sql/benchmark/**"
-      - "spark/src/main/scala/org/apache/comet/GenerateDocs.scala"
-  pull_request:
-    paths-ignore:
-      - "doc/**"
-      - "docs/**"
-      - "**.md"
-      - "native/core/benches/**"
-      - "native/spark-expr/benches/**"
-      - "spark/src/test/scala/org/apache/spark/sql/benchmark/**"
-      - "spark/src/main/scala/org/apache/comet/GenerateDocs.scala"
+  # nightly safety check
+  schedule:
+    - cron: '0 4 * * *'
   # manual trigger
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
   workflow_dispatch:


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

The miri workflow currently runs on every push to `main` and on every pull request, each gated by a `paths-ignore` ignore list. Miri runs are slow, and running them on every PR adds latency to the build queue for little benefit, since memory-safety regressions in native code are rare.

It would be better to run these tests nightly.

## What changes are included in this PR?

Replaces the `on:` triggers in `.github/workflows/miri.yml`:

- Removes the `push` trigger and its `paths-ignore` list
- Removes the `pull_request` trigger and its `paths-ignore` list
- Adds a `schedule` trigger running nightly at 04:00 UTC (`cron: '0 4 * * *'`)
- Keeps `workflow_dispatch` for manual runs

The `miri` job itself is unchanged. The cron time does not collide with the existing scheduled workflows (codeql `16 4 * * 1`, stale `30 1 * * *`).

## How are these changes tested?

This is a CI configuration change. The workflow remains manually triggerable via `workflow_dispatch` to verify it runs, and the nightly schedule will exercise it on the normal cadence.