### PR TITLE
docs: lead README with the Arrow-native framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ under the License.
 
 <img src="docs/source/_static/images/DataFusionComet-Logo-Light.png" width="512" alt="logo"/>
 
-Apache DataFusion Comet is a high-performance accelerator for Apache Spark, built on top of the powerful
-[Apache DataFusion] query engine. Comet is designed to significantly enhance the
-performance of Apache Spark workloads while leveraging commodity hardware and seamlessly integrating with the
-Spark ecosystem without requiring any code changes.
+Apache DataFusion Comet is a high-performance accelerator for Apache Spark. Comet keeps Spark queries
+**Arrow-native end-to-end**: operators, expressions, shuffle, and broadcast all stay in Apache Arrow
+columnar format, avoiding the per-row overhead of Spark's row-based engine. Within the Arrow-native
+pipeline, operators and expressions execute as Rust code (via the [Apache DataFusion] query engine)
+or as JVM code that operates directly on Arrow batches. Comet integrates with the Spark ecosystem
+without requiring any code changes.
 
 **Comet provides a ~2x speedup for TPC-DS @ SF 1000 (1TB), resulting in ~50% cost savings.**
 
@@ -58,17 +60,22 @@ See the [Comet Benchmarking Guide](https://datafusion.apache.org/comet/contribut
 
 ## What Comet Accelerates
 
-Comet replaces Spark operators and expressions with native Rust implementations that run on Apache DataFusion.
-It uses Apache Arrow for zero-copy data transfer between the JVM and native code.
+Comet replaces Spark operators and expressions with implementations that consume and produce Apache Arrow
+batches. Most run as native Rust code on top of Apache DataFusion; some run as JVM code over Arrow batches.
+Either way the work stays in the Comet pipeline without falling back to Spark's row-based engine.
 
 - **Parquet scans**: native Parquet reader integrated with Spark's query planner
 - **Apache Iceberg**: accelerated Parquet scans when reading Iceberg tables from Spark
   (see the [Iceberg guide](https://datafusion.apache.org/comet/user-guide/iceberg.html))
-- **Shuffle**: native columnar shuffle with support for hash and range partitioning
+- **Shuffle**: Arrow-IPC columnar shuffle with support for hash and range partitioning, in a native Rust
+  implementation paired with a JVM fallback for unsupported partition key types
 - **Expressions**: hundreds of supported Spark expressions across math, string, datetime, array,
   map, JSON, hash, and predicate categories
 - **Aggregations**: hash aggregate with support for `FILTER (WHERE ...)` clauses
 - **Joins**: hash join, sort-merge join, and broadcast join
+- **Scala/Java UDFs**: experimental support for keeping Scala/Java scalar UDFs in the Comet pipeline
+  via Spark's whole-stage codegen (see the
+  [Scala UDF guide](https://datafusion.apache.org/comet/user-guide/scala_java_udfs.html))
 
 For the authoritative lists, see the [supported expressions](https://datafusion.apache.org/comet/user-guide/expressions.html)
 and [supported operators](https://datafusion.apache.org/comet/user-guide/operators.html) pages.

--- a/README.md
+++ b/README.md
@@ -60,9 +60,7 @@ See the [Comet Benchmarking Guide](https://datafusion.apache.org/comet/contribut
 
 ## What Comet Accelerates
 
-Comet replaces Spark operators and expressions with implementations that consume and produce Apache Arrow
-batches. Most run as native Rust code on top of Apache DataFusion; some run as JVM code over Arrow batches.
-Either way, query execution stays in the Comet pipeline without falling back to Spark's row-based engine.
+Comet accelerates Spark workloads by replacing Spark operators and expressions with high-performance implementations that process Apache Arrow columnar data directly. Most operators are powered by native Rust execution built on Apache DataFusion, while others run efficiently in the JVM on Arrow batches. This unified columnar execution model keeps processing within the Comet engine end-to-end, reducing overhead and delivering faster, more efficient query execution without reverting to Spark's traditional row-based engine.
 
 - **Parquet scans**: native Parquet reader integrated with Spark's query planner
 - **Apache Iceberg**: accelerated Parquet scans when reading Iceberg tables from Spark

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Either way, query execution stays in the Comet pipeline without falling back to 
   map, JSON, hash, and predicate categories
 - **Aggregations**: hash aggregate with support for `FILTER (WHERE ...)` clauses
 - **Joins**: hash join, sort-merge join, and broadcast join
-- **Scala/Java UDFs**: experimental support for keeping Scala/Java scalar UDFs in the Comet pipeline
+- **Scala/Java UDFs**: support for keeping Scala/Java scalar UDFs in the Comet pipeline
   via Spark's whole-stage codegen (see the
   [Scala UDF guide](https://datafusion.apache.org/comet/user-guide/scala_java_udfs.html))
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See the [Comet Benchmarking Guide](https://datafusion.apache.org/comet/contribut
 
 Comet replaces Spark operators and expressions with implementations that consume and produce Apache Arrow
 batches. Most run as native Rust code on top of Apache DataFusion; some run as JVM code over Arrow batches.
-Either way the work stays in the Comet pipeline without falling back to Spark's row-based engine.
+Either way, query execution stays in the Comet pipeline without falling back to Spark's row-based engine.
 
 - **Parquet scans**: native Parquet reader integrated with Spark's query planner
 - **Apache Iceberg**: accelerated Parquet scans when reading Iceberg tables from Spark


### PR DESCRIPTION
## Which issue does this PR close?

Part of #4419 (the documentation-only phase, first slice).

## Rationale for this change

Comet's documentation conflates several distinct ideas under the word "native": implementation language (Rust vs JVM), pipeline membership (handled by Comet vs falls back to Spark), and data format (Arrow columnar vs Spark rows). Issue #4419 spells out a clearer vocabulary so the docs stop overloading "native" and can scale to a roadmap where some JVM code paths (today Scala UDF codegen; soon Arrow UDFs and hybrid impls) also live inside the Comet pipeline.

The original version of this PR rolled the new vocabulary into ~20 files at once. This revision narrows the scope to a **single file** — the top-level `README.md` — so reviewers can sign off on the framing first. The user-guide and contributor-guide sweeps will follow as separate PRs.

## What changes are included in this PR?

`README.md` only. The two top paragraphs and the "What Comet Accelerates" list are rewritten:

- The opening paragraph leads with the Arrow-native pipeline (operators, expressions, shuffle, and broadcast all stay in Apache Arrow columnar format) rather than "native Rust implementations on Apache DataFusion."
- The intro to "What Comet Accelerates" makes the Rust-vs-JVM split explicit: most operators and expressions run as Rust on DataFusion; some run as JVM code over Arrow batches. Either way the work stays in the Comet pipeline.
- The shuffle bullet upgrades from "native columnar shuffle with support for hash and range partitioning" to "Arrow-IPC columnar shuffle ... in a native Rust implementation paired with a JVM fallback for unsupported partition key types."
- A new bullet introduces the experimental Scala/Java UDF support and links to the existing user-guide page.

No other docs files are touched. Operator renames (`CometExchange` → `CometNativeShuffleExchange`, etc.) and the user-guide / contributor-guide vocabulary sweep are explicitly out of scope here and will land in follow-on PRs.

## How are these changes tested?

Documentation only. Verified that the README renders correctly on GitHub and that the new wording matches the vocabulary rules in #4419.
