### PR TITLE
chore(audit): audit any and expand tests

### DIFF
--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -32,6 +32,9 @@
 ### agg_funcs
 
 - [x] any
+  - Spark 3.4.3 (audited 2026-05-26): registered as a SQL alias of `BoolOr`, which extends `RuntimeReplaceableAggregate` with `replacement = Max(child)`. Catalyst rewrites `any(x)` to `max(x)` before Comet sees the plan, so `any` is served by `CometMax` on a `BooleanType` column.
+  - Spark 3.5.8 (audited 2026-05-26): identical to 3.4.3.
+  - Spark 4.0.1 (audited 2026-05-26): identical to 3.4.3.
 - [x] any_value
 - [ ] approx_count_distinct
 - [ ] approx_percentile

--- a/spark/src/test/resources/sql-tests/expressions/aggregate/any.sql
+++ b/spark/src/test/resources/sql-tests/expressions/aggregate/any.sql
@@ -1,0 +1,57 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- `any` is registered in Spark's FunctionRegistry as a SQL alias of `BoolOr`,
+-- which extends `RuntimeReplaceableAggregate` with `replacement = Max(child)`.
+-- The analyzer rewrites `any(x)`, `some(x)`, and `bool_or(x)` to `max(x)`
+-- before Comet sees the plan. These tests exercise the rewrite end-to-end.
+
+statement
+CREATE TABLE test_any(k int, v boolean) USING parquet
+
+statement
+INSERT INTO test_any VALUES
+  (1, true), (1, false),
+  (2, true),
+  (3, false), (3, NULL),
+  (4, NULL), (4, NULL),
+  (5, NULL), (5, true), (5, false)
+
+-- column argument, no grouping (mixed true/false/NULL)
+query
+SELECT any(v), some(v), bool_or(v) FROM test_any
+
+-- column argument with group-by
+query
+SELECT k, any(v), some(v), bool_or(v) FROM test_any GROUP BY k ORDER BY k
+
+-- all-NULL group (k = 4) should return NULL
+query
+SELECT any(v), some(v), bool_or(v) FROM test_any WHERE k = 4
+
+-- empty input should return NULL
+query
+SELECT any(v), some(v), bool_or(v) FROM test_any WHERE 1 = 0
+
+-- literal arguments (constant folding is disabled by CometSqlFileTestSuite,
+-- so these are evaluated by the native engine)
+query
+SELECT any(true), any(false), any(NULL)
+
+-- HAVING on the aggregate
+query
+SELECT k, any(v) FROM test_any GROUP BY k HAVING any(v) = true ORDER BY k


### PR DESCRIPTION
## Which issue does this PR close?

N/A. Autonomous audit pass.

## Rationale for this change

Audit of the `any` expression against Spark 3.4.3, 3.5.8, and 4.0.1.

`any` is registered in Spark's `FunctionRegistry` as a SQL alias of `BoolOr`, which extends `RuntimeReplaceableAggregate` with `replacement = Max(child)`. The Catalyst analyzer rewrites `any(x)` (and the siblings `some(x)` and `bool_or(x)`) to `max(x)` before Comet sees the plan, so the expression is served by `CometMax` on a `BooleanType` column. `boolAggregates.scala` is byte-identical across the three audited Spark versions, so no shim is required.

The only finding was a test-coverage gap: the existing `test bool_and/bool_or` in `CometAggregateSuite` covers a single dataset of four rows with no NULLs, no empty group, no group-by, and no `any`/`some` alias.

## What changes are included in this PR?

- Audit sub-bullets under `any` in `docs/source/contributor-guide/spark_expressions_support.md`
- New SQL-file test `spark/src/test/resources/sql-tests/expressions/aggregate/any.sql` covering column, literal, NULL, empty, all-NULL, group-by, and HAVING inputs for `any`, `some`, and `bool_or`

## How are these changes tested?

```
./mvnw test -Dsuites="org.apache.comet.CometSqlFileTestSuite any" -Dtest=none -Dscalastyle.skip=true
```

Passes locally (1 test, 0 failures).

Scaffolded by the `audit-comet-expression-autonomous` skill.
