### PR TITLE
chore(audit): audit BitAndAgg and expand tests

### DIFF
--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -41,6 +41,9 @@
 - [ ] array_agg
 - [x] avg
 - [x] bit_and
+  - Spark 3.4.3 (2026-05-26)
+  - Spark 3.5.8 (2026-05-26)
+  - Spark 4.0.1 (2026-05-26)
 - [x] bit_or
 - [x] bit_xor
 - [x] bool_and

--- a/spark/src/test/resources/sql-tests/expressions/aggregate/bit_agg.sql
+++ b/spark/src/test/resources/sql-tests/expressions/aggregate/bit_agg.sql
@@ -26,3 +26,58 @@ SELECT bit_and(i), bit_or(i), bit_xor(i) FROM test_bit_agg
 
 query
 SELECT grp, bit_and(i), bit_or(i), bit_xor(i) FROM test_bit_agg GROUP BY grp ORDER BY grp
+
+-- all integral types: tinyint, smallint, int, bigint
+statement
+CREATE TABLE test_bit_agg_types(b tinyint, s smallint, i int, l bigint, grp string) USING parquet
+
+statement
+INSERT INTO test_bit_agg_types VALUES
+  (cast(1 as tinyint), cast(1 as smallint), 1, 1L, 'a'),
+  (cast(3 as tinyint), cast(3 as smallint), 3, 3L, 'a'),
+  (cast(7 as tinyint), cast(7 as smallint), 7, 7L, 'a'),
+  (NULL, NULL, NULL, NULL, 'b'),
+  (cast(-1 as tinyint), cast(-1 as smallint), -1, -1L, 'c'),
+  (cast(0 as tinyint), cast(0 as smallint), 0, 0L, 'c')
+
+-- exercise bit_and over each integral type
+query
+SELECT bit_and(b), bit_and(s), bit_and(i), bit_and(l) FROM test_bit_agg_types
+
+-- group by including a group of all NULLs
+query
+SELECT grp, bit_and(b), bit_and(s), bit_and(i), bit_and(l)
+FROM test_bit_agg_types GROUP BY grp ORDER BY grp
+
+-- all-NULL filter, should return NULL
+query
+SELECT bit_and(i), bit_or(i), bit_xor(i) FROM test_bit_agg WHERE i IS NULL
+
+-- empty input, should return NULL
+query
+SELECT bit_and(i), bit_or(i), bit_xor(i) FROM test_bit_agg WHERE 1 = 0
+
+-- HAVING clause referencing bit_and
+query
+SELECT grp, bit_and(i) FROM test_bit_agg GROUP BY grp HAVING bit_and(i) < 7 ORDER BY grp
+
+-- DISTINCT form
+query
+SELECT bit_and(DISTINCT i), bit_or(DISTINCT i), bit_xor(DISTINCT i) FROM test_bit_agg
+
+-- boundary values: Long.MinValue, Long.MaxValue, Int.MinValue, Int.MaxValue
+statement
+CREATE TABLE test_bit_agg_bounds(i int, l bigint) USING parquet
+
+statement
+INSERT INTO test_bit_agg_bounds VALUES
+  (-2147483648, -9223372036854775808L),
+  (2147483647, 9223372036854775807L),
+  (-1, -1L)
+
+query
+SELECT bit_and(i), bit_or(i), bit_xor(i), bit_and(l), bit_or(l), bit_xor(l) FROM test_bit_agg_bounds
+
+-- literal argument
+query
+SELECT bit_and(5), bit_or(5), bit_xor(5) FROM test_bit_agg


### PR DESCRIPTION
## Which issue does this PR close?
N/A. Autonomous audit pass.

## Rationale for this change
Audit of the `bit_and` expression (`BitAndAgg`) against Spark 3.4.3, 3.5.8, and 4.0.1. The Spark source is identical across all three versions, and Comet delegates the aggregate to DataFusion's `bit_and_udaf`. Static review found no behavioural divergence and no missing `getIncompatibleReasons`/`getUnsupportedReasons` overrides. Existing SQL coverage only exercised `int` with a single nullable row; this audit expands coverage to the remaining integral types and additional edge cases.

## What changes are included in this PR?
- Audit sub-bullets in `spark_expressions_support.md` for Spark 3.4.3, 3.5.8, 4.0.1
- Expanded `expressions/aggregate/bit_agg.sql`: all integral types (tinyint, smallint, int, bigint), all-NULL group, empty input, HAVING clause, DISTINCT, boundary values (Int.MinValue/MaxValue, Long.MinValue/MaxValue), and a literal argument

## How are these changes tested?
- `./mvnw test -DwildcardSuites=CometSqlFileTestSuite -Dsuites="org.apache.comet.CometSqlFileTestSuite bit_agg" -Dtest=none -Dscalastyle.skip=true` (passes locally)

Note: the audit also drafted a `bit_and OVER (...)` window-form test, but removed it because Comet's `WindowExec` is gated behind `spark.comet.operator.WindowExec.allowIncompatible=true` due to known correctness issues unrelated to `bit_and`. That fallback path is not specific to this expression.

Scaffolded by the `audit-comet-expression-autonomous` skill.
