### PR TITLE
docs: list date/time expressions added in #4417

### DIFF
--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -214,7 +214,7 @@
 
 ### datetime_funcs
 
-- [ ] add_months
+- [x] add_months
 - [x] convert_timezone
 - [ ] curdate
 - [ ] current_date
@@ -250,14 +250,14 @@
 - [ ] make_dt_interval
 - [ ] make_interval
 - [ ] make_time
-- [ ] make_timestamp
+- [x] make_timestamp
 - [ ] make_timestamp_ltz
 - [ ] make_timestamp_ntz
 - [ ] make_ym_interval
 - [x] minute
 - [x] month
 - [ ] monthname
-- [ ] months_between
+- [x] months_between
 - [x] next_day
 - [ ] now
 - [x] quarter
@@ -265,15 +265,15 @@
 - [ ] session_window
 - [ ] time_diff
 - [ ] time_trunc
-- [ ] timestamp_micros
-- [ ] timestamp_millis
+- [x] timestamp_micros
+- [x] timestamp_millis
 - [x] timestamp_seconds
 - [ ] to_date
 - [ ] to_time
 - [ ] to_timestamp
 - [ ] to_timestamp_ltz
 - [ ] to_timestamp_ntz
-- [ ] to_unix_timestamp
+- [x] to_unix_timestamp
 - [x] to_utc_timestamp
   - Spark 3.4.3 (audited 2026-05-12): identical to 3.5.8.
   - Spark 3.5.8 (audited 2026-05-12): baseline.
@@ -286,9 +286,9 @@
 - [ ] try_to_time
 - [ ] try_to_timestamp
 - [x] unix_date
-- [ ] unix_micros
-- [ ] unix_millis
-- [ ] unix_seconds
+- [x] unix_micros
+- [x] unix_millis
+- [x] unix_seconds
 - [x] unix_timestamp
 - [x] weekday
 - [x] weekofyear

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -99,42 +99,51 @@ of expressions that be disabled.
 
 ## Date/Time Functions
 
-| Expression       | SQL                          |
-| ---------------- | ---------------------------- |
-| ConvertTimezone  | `convert_timezone`           |
-| CurrentTimeZone  | `current_timezone`           |
-| DateAdd          | `date_add`                   |
-| DateDiff         | `datediff`                   |
-| DateFormat       | `date_format`                |
-| DateFromUnixDate | `date_from_unix_date`        |
-| DateSub          | `date_sub`                   |
-| DatePart         | `date_part(field, source)`   |
-| Days             | `days`                       |
-| Extract          | `extract(field FROM source)` |
-| FromUnixTime     | `from_unixtime`              |
-| Hour             | `hour`                       |
-| LastDay          | `last_day`                   |
-| LocalTimestamp   | `localtimestamp`             |
-| MakeDate         | `make_date`                  |
-| MakeTime         | `make_time`                  |
-| Minute           | `minute`                     |
-| NextDay          | `next_day`                   |
-| Second           | `second`                     |
-| TimestampSeconds | `timestamp_seconds`          |
-| TruncDate        | `trunc`                      |
-| TruncTimestamp   | `date_trunc`                 |
-| UnixDate         | `unix_date`                  |
-| UnixTimestamp    | `unix_timestamp`             |
-| Year             | `year`                       |
-| Month            | `month`                      |
-| DayOfMonth       | `day`/`dayofmonth`           |
-| DayOfWeek        | `dayofweek`                  |
-| WeekDay          | `weekday`                    |
-| DayOfYear        | `dayofyear`                  |
-| WeekOfYear       | `weekofyear`                 |
-| Quarter          | `quarter`                    |
-| ToTime           | `to_time`                    |
-| TryToTime        | `try_to_time`                |
+| Expression        | SQL                          |
+| ----------------- | ---------------------------- |
+| AddMonths         | `add_months`                 |
+| ConvertTimezone   | `convert_timezone`           |
+| CurrentTimeZone   | `current_timezone`           |
+| DateAdd           | `date_add`                   |
+| DateDiff          | `datediff`                   |
+| DateFormat        | `date_format`                |
+| DateFromUnixDate  | `date_from_unix_date`        |
+| DateSub           | `date_sub`                   |
+| DatePart          | `date_part(field, source)`   |
+| Days              | `days`                       |
+| Extract           | `extract(field FROM source)` |
+| FromUnixTime      | `from_unixtime`              |
+| Hour              | `hour`                       |
+| LastDay           | `last_day`                   |
+| LocalTimestamp    | `localtimestamp`             |
+| MakeDate          | `make_date`                  |
+| MakeTime          | `make_time`                  |
+| MakeTimestamp     | `make_timestamp`             |
+| MicrosToTimestamp | `timestamp_micros`           |
+| MillisToTimestamp | `timestamp_millis`           |
+| Minute            | `minute`                     |
+| MonthsBetween     | `months_between`             |
+| NextDay           | `next_day`                   |
+| Second            | `second`                     |
+| TimestampSeconds  | `timestamp_seconds`          |
+| ToUnixTimestamp   | `to_unix_timestamp`          |
+| TruncDate         | `trunc`                      |
+| TruncTimestamp    | `date_trunc`                 |
+| UnixDate          | `unix_date`                  |
+| UnixMicros        | `unix_micros`                |
+| UnixMillis        | `unix_millis`                |
+| UnixSeconds       | `unix_seconds`               |
+| UnixTimestamp     | `unix_timestamp`             |
+| Year              | `year`                       |
+| Month             | `month`                      |
+| DayOfMonth        | `day`/`dayofmonth`           |
+| DayOfWeek         | `dayofweek`                  |
+| WeekDay           | `weekday`                    |
+| DayOfYear         | `dayofyear`                  |
+| WeekOfYear        | `weekofyear`                 |
+| Quarter           | `quarter`                    |
+| ToTime            | `to_time`                    |
+| TryToTime         | `try_to_time`                |
 
 ## Math Expressions
 


### PR DESCRIPTION
## Summary

#4417 added support for `AddMonths`, `MakeTimestamp`, `MicrosToTimestamp`, `MillisToTimestamp`, `MonthsBetween`, `ToUnixTimestamp`, `UnixMicros`, `UnixMillis`, and `UnixSeconds`, but the user and contributor guide expression lists were not updated. This docs-only PR updates both.

- `docs/source/user-guide/latest/expressions.md` — adds the nine new entries in alphabetical order to the Date/Time Functions table (and widens the Expression column by one to fit `MicrosToTimestamp` / `MillisToTimestamp`).
- `docs/source/contributor-guide/spark_expressions_support.md` — flips the corresponding `[ ]` rows to `[x]` under `datetime_funcs`.

## Test plan

- [ ] Visually inspect the rendered tables on the docs preview build