### PR TITLE
bug: no column projection should still persist row count

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -383,6 +383,7 @@ jobs:
               org.apache.spark.sql.comet.CometDppFallbackRepro3949Suite
               org.apache.spark.sql.comet.CometShuffleFallbackStickinessSuite
               org.apache.spark.sql.comet.CometDecimalArithmeticViewSuite
+              org.apache.spark.sql.comet.util.UtilsSuite
               org.apache.comet.objectstore.NativeConfigSuite
               org.apache.spark.sql.CometToPrettyStringSuite
               org.apache.spark.sql.CometCollationSuite

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -223,6 +223,7 @@ jobs:
               org.apache.spark.sql.comet.CometDppFallbackRepro3949Suite
               org.apache.spark.sql.comet.CometShuffleFallbackStickinessSuite
               org.apache.spark.sql.comet.CometDecimalArithmeticViewSuite
+              org.apache.spark.sql.comet.util.UtilsSuite
               org.apache.comet.objectstore.NativeConfigSuite
               org.apache.spark.sql.CometToPrettyStringSuite
               org.apache.spark.sql.CometCollationSuite

--- a/spark/src/main/scala/org/apache/spark/sql/comet/util/Utils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/util/Utils.scala
@@ -224,7 +224,10 @@ object Utils extends CometTypeShim with Logging {
 
       val (fieldVectors, batchProviderOpt) = getBatchFieldVectors(batch)
       val root = new VectorSchemaRoot(fieldVectors.asJava)
-      root.setRowCount(batch.numRows())
+      if (fieldVectors.isEmpty) {
+        // VSR cannot infer rowCount without field vectors
+        root.setRowCount(batch.numRows())
+      }
       val provider = batchProviderOpt.getOrElse(dictionaryProvider)
 
       val writer = new ArrowStreamWriter(root, provider, Channels.newChannel(out))
@@ -337,7 +340,10 @@ object Utils extends CometTypeShim with Logging {
           return (Array.empty, 0L, 0L)
         }
 
-        targetRoot.setRowCount(totalRows.toInt)
+        if (targetRoot.getSchema.getFields.isEmpty) {
+          // VSRAppender does not update rowCount with no columns
+          targetRoot.setRowCount(totalRows.toInt)
+        }
 
         assert(
           targetRoot.getRowCount.toLong == totalRows,

--- a/spark/src/main/scala/org/apache/spark/sql/comet/util/Utils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/util/Utils.scala
@@ -224,6 +224,7 @@ object Utils extends CometTypeShim with Logging {
 
       val (fieldVectors, batchProviderOpt) = getBatchFieldVectors(batch)
       val root = new VectorSchemaRoot(fieldVectors.asJava)
+      root.setRowCount(batch.numRows())
       val provider = batchProviderOpt.getOrElse(dictionaryProvider)
 
       val writer = new ArrowStreamWriter(root, provider, Channels.newChannel(out))
@@ -335,6 +336,8 @@ object Utils extends CometTypeShim with Logging {
         if (targetRoot == null) {
           return (Array.empty, 0L, 0L)
         }
+
+        targetRoot.setRowCount(totalRows.toInt)
 
         assert(
           targetRoot.getRowCount.toLong == totalRows,

--- a/spark/src/test/scala/org/apache/spark/sql/comet/util/UtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/util/UtilsSuite.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet.util
+
+import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+
+class UtilsSuite extends CometTestBase {
+
+  test("serializeBatches preserves row count for a zero-column batch") {
+    val numRows = 5
+    val batch = new ColumnarBatch(Array.empty[ColumnVector], numRows)
+
+    val (rowCount, buf) = Utils.serializeBatches(Iterator(batch)).next()
+    assert(rowCount == numRows)
+
+    val decoded = Utils.decodeBatches(buf, "test").toSeq
+    assert(decoded.map(_.numRows()).sum == numRows)
+  }
+
+  test("coalesceBroadcastBatches preserves row count across zero-column inputs") {
+    val numRows = 5
+    val numBatches = 3
+    val batches =
+      (0 until numBatches).map(_ => new ColumnarBatch(Array.empty[ColumnVector], numRows))
+
+    val bufs = Utils.serializeBatches(batches.iterator).map(_._2).toSeq.iterator
+    val (coalesced, batchCount, totalRows) = Utils.coalesceBroadcastBatches(bufs)
+
+    val expected = numRows.toLong * numBatches
+    assert(batchCount == numBatches)
+    assert(totalRows == expected)
+
+    val decoded = coalesced.iterator.flatMap(b => Utils.decodeBatches(b, "test")).toSeq
+    assert(decoded.map(_.numRows()).sum == expected)
+  }
+}


### PR DESCRIPTION
 ## Which issue does this PR close?

Closes : https://github.com/apache/datafusion-comet/issues/4445 discovered while implementing native `BroadcastNestedLoopJoin`.

  ## Rationale for this change

  `Utils.serializeBatches` and `Utils.coalesceBroadcastBatches` lose the row
  count when the input batch has zero columns, so a column-pruned broadcast
  relation arrives at the receiver as empty.

  Both functions build an Arrow `VectorSchemaRoot` from the batch's field
  vectors. With zero columns the VSR has nothing to infer rowCount from and
  defaults to 0; IPC then encodes `length = 0`. 
  
  Latent until now because every
  prior caller of `CometBroadcastExchangeExec` was BHJ, whose build side
  always carries join keys. Native `BroadcastNestedLoopJoin` implementation exposed this bug when build side that can broadcast a 0-column side (e.g. `SELECT count(*) FROM big,
  small`), resulting in 0 rows

  ## What changes are included in this PR?

  - `Utils.serializeBatches`: `root.setRowCount(batch.numRows())` after VSR
    construction.
  - `Utils.coalesceBroadcastBatches`: `targetRoot.setRowCount(totalRows.toInt)`

  ## How are these changes tested?

 New `UtilsSuite`  tests for 0-column batches.