### PR TITLE
fix: fallback NullType LocalTableScanExec to Spark

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometLocalTableScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometLocalTableScanExec.scala
@@ -27,12 +27,13 @@ import org.apache.spark.sql.comet.CometLocalTableScanExec.createMetricsIterator
 import org.apache.spark.sql.comet.execution.arrow.CometArrowConverters
 import org.apache.spark.sql.execution.{LeafExecNode, LocalTableScanExec}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.types.NullType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import com.google.common.base.Objects
 
 import org.apache.comet.{CometConf, ConfigEntry}
-import org.apache.comet.serde.OperatorOuterClass.Operator
+import org.apache.comet.serde.{Compatible, OperatorOuterClass, SupportLevel, Unsupported}
 import org.apache.comet.serde.operator.CometSink
 
 case class CometLocalTableScanExec(
@@ -112,7 +113,17 @@ object CometLocalTableScanExec extends CometSink[LocalTableScanExec] {
   override def enabledConfig: Option[ConfigEntry[Boolean]] = Some(
     CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED)
 
-  override def createExec(nativeOp: Operator, op: LocalTableScanExec): CometNativeExec = {
+  override def getSupportLevel(op: LocalTableScanExec): SupportLevel = {
+    if (op.output.exists(_.dataType == NullType)) {
+      Unsupported(Some("Unsupported data type: NullType"))
+    } else {
+      Compatible()
+    }
+  }
+
+  override def createExec(
+      nativeOp: OperatorOuterClass.Operator,
+      op: LocalTableScanExec): CometNativeExec = {
     CometScanWrapper(nativeOp, CometLocalTableScanExec(op, op.rows, op.output))
   }
 

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -3882,6 +3882,12 @@ class CometExecSuite extends CometTestBase {
     }
   }
 
+  test("LocalTableScanExec with NullType aggregate falls back without crashing") {
+    withSQLConf(CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true") {
+      checkAnswer(sql("SELECT max(col) FROM VALUES (NULL), (NULL) AS t(col)"), Seq(Row(null)))
+    }
+  }
+
   test("SparkToColumnar with timestamps in non-UTC timezone") {
     withTempDir { dir =>
       val path = new java.io.File(dir, "data").getAbsolutePath


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4457 .

## Rationale for this change

Queries containing `NullType` columns could fail when `spark.comet.exec.localTableScan.enabled=true`.

While plain `NullType` projections may execute successfully, aggregate queries can still reach native Arrow conversion paths through `CometLocalTableScanExec` and fail with an `UnsupportedOperationException`.

For example:

```sql
SELECT max(col) FROM VALUES
  (NULL),
  (NULL)
AS t(col)
````

crashes during Arrow schema conversion in `CometLocalTableScanExec`.

## What changes are included in this PR?

This PR adds an explicit support-level check for `NullType` columns in `CometLocalTableScanExec`.

When a `LocalTableScanExec` contains `NullType`, Comet now marks the operator as unsupported and falls back to Spark execution instead of attempting native Arrow conversion.

This PR intentionally uses fallback behavior instead of adding full native `NullType` support because `NullType` is currently unsupported across downstream native aggregate and shuffle paths as well. Simply allowing Arrow schema conversion would move the failure deeper into execution rather than resolving the incompatibility consistently.

A regression test has also been added for aggregate queries over `NullType` local table scans.

## How are these changes tested?

Added a regression test in `CometExecSuite` covering:

```sql
SELECT max(col) FROM VALUES (NULL), (NULL) AS t(col)
```

with:

```text
spark.comet.exec.localTableScan.enabled=true
```

Before the fix, the query failed with:

```text
java.lang.UnsupportedOperationException:
Unsupported data type: [org.apache.spark.sql.types.NullType$] void
```

After the fix, the query cleanly falls back to Spark execution and returns the expected result.

Test command used:

```bash
mvn -pl spark -DwildcardSuites=org.apache.comet.exec.CometExecSuite test
```