### PR TITLE
chore(audit): audit json expressions across Spark 3.4.3, 3.5.8, 4.0.1, 4.1.1

### DIFF
--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -326,6 +326,11 @@
 
 - [ ] from_json
 - [x] get_json_object
+  - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.
+  - Spark 3.5.8 (audited 2026-05-27): baseline. `BinaryExpression with ExpectsInputTypes with CodegenFallback`; `inputTypes = Seq(StringType, StringType) -> StringType`. Eval is inline and uses Jackson with `RawStyle` output. Foldable paths are parsed once. Returns NULL for invalid JSON, missing paths, or `JsonProcessingException`.
+  - Spark 4.0.1 (audited 2026-05-27): the eval is extracted into a `GetJsonObjectEvaluator` helper (no behaviour change). The trait set now mixes in `DefaultStringProducingExpression`, and `inputTypes` is widened to `StringTypeWithCollation(supportsTrimCollation = true)` for both arguments.
+  - Spark 4.1.1 (audited 2026-05-27): identical to 4.0.1.
+  - Known incompatibility: Spark accepts single-quoted JSON and unescaped control characters; Comet's native parser (built on `serde_json`) rejects both, so those inputs require `spark.comet.expression.GetJsonObject.allowIncompatible=true` and may still produce different results. Non-default Spark 4.0 string collations are not propagated (https://github.com/apache/datafusion-comet/issues/2190).
 - [ ] json_array_length
 - [ ] json_object_keys
 - [ ] json_tuple

--- a/spark/src/main/scala/org/apache/comet/serde/strings.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/strings.scala
@@ -443,15 +443,14 @@ object CometStringSplit extends CometExpressionSerde[StringSplit] {
 
 object CometGetJsonObject extends CometExpressionSerde[GetJsonObject] {
 
-  override def getIncompatibleReasons(): Seq[String] = Seq(
+  private val incompatReason =
     "Spark allows single-quoted JSON and unescaped control characters which Comet does not" +
-      " support")
+      " support"
+
+  override def getIncompatibleReasons(): Seq[String] = Seq(incompatReason)
 
   override def getSupportLevel(expr: GetJsonObject): SupportLevel =
-    Incompatible(
-      Some(
-        "Spark allows single-quoted JSON and unescaped control characters " +
-          "which Comet does not support"))
+    Incompatible(Some(incompatReason))
 
   override def convert(
       expr: GetJsonObject,


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

Continuation of the per-category expression audit. Same pattern as #4469 (struct), #4461 (string), and earlier audits, using the updated `audit-comet-expression` skill in #4468 (now also covers Spark 4.1.1).

## What changes are included in this PR?

### Support-doc audit notes

Add per-version audit sub-bullets to `get_json_object` in `docs/source/contributor-guide/spark_expressions_support.md`. Spark 3.4.3 and 3.5.8 use a `BinaryExpression with CodegenFallback` with inline Jackson-based eval. Spark 4.0 extracts the eval into a `GetJsonObjectEvaluator` helper, mixes in `DefaultStringProducingExpression`, and widens `inputTypes` to `StringTypeWithCollation(supportsTrimCollation = true)`. Spark 4.1.1 is identical to 4.0.

### Support-level consistency fix (in `strings.scala`)

- `CometGetJsonObject`: extract the duplicate single-quote / control-character incompatibility reason into a shared `private val` so the doc generator and the EXPLAIN dispatcher cannot drift.

### Tracking issues filed for follow-up

None. The known incompatibilities (single-quoted JSON, unescaped control characters) are already declared via `getSupportLevel` and `getIncompatibleReasons`. Non-default Spark 4.0 string collations are covered by the umbrella #2190 (referenced from the support-doc sub-bullet).

### Audit process

Audited directly using the `audit-comet-expression` skill (4 Spark versions). One backing serde, so no parallel subagents were needed.

## How are these changes tested?

- `./mvnw test -Dsuites="org.apache.comet.CometSqlFileTestSuite string/get_json_object" -Dtest=none` (2 tests pass; existing `get_json_object.sql` already covers single-character, nested-field, wildcard, deep-nested, unicode, emoji, mixed-script, escaped-quote, and dictionary-encoded inputs).
- `make core` succeeds with the serde change.
