### PR TITLE
chore(audit): audit collection expressions across Spark 3.4.3, 3.5.8, 4.0.1, 4.1.1

### DIFF
--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -180,8 +180,23 @@
 - [ ] array_size
 - [ ] cardinality
 - [x] concat
+  - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.
+  - Spark 3.5.8 (audited 2026-05-27): baseline. `Concat(children) extends ComplexTypeMergingExpression with QueryErrorsBase`; `allowedTypes = Seq(StringType, BinaryType, ArrayType)`; result type is the merged child type. Empty children is allowed and returns the empty string of the result type.
+  - Spark 4.0.1 (audited 2026-05-27): `allowedTypes` widens `StringType` to `StringTypeWithCollation(supportsTrimCollation = true)`. Error-formatting helper changes from `paramIndex` to `ordinalNumber`. Runtime semantics unchanged for `UTF8_BINARY`.
+  - Spark 4.1.1 (audited 2026-05-27): identical to 4.0.1.
+  - Known limitation: Comet only supports `StringType` children natively; `BinaryType` and `ArrayType` inputs fall back to Spark (https://github.com/apache/datafusion-comet/issues/4471). Non-default Spark 4.0 string collations are not propagated (https://github.com/apache/datafusion-comet/issues/2190).
 - [x] reverse
+  - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.
+  - Spark 3.5.8 (audited 2026-05-27): baseline. `Reverse(child) extends UnaryExpression with ImplicitCastInputTypes with NullIntolerant`; `inputTypes = Seq(TypeCollection(StringType, ArrayType))`; `dataType = child.dataType`. For string, calls `UTF8String.reverse()`; for array, reverses element order in-place via `GenericArrayData`.
+  - Spark 4.0.1 (audited 2026-05-27): `NullIntolerant` trait replaced by `override def nullIntolerant: Boolean = true`; `inputTypes` widened to `Seq(TypeCollection(StringTypeWithCollation(supportsTrimCollation = true), ArrayType))`. Semantics unchanged for `UTF8_BINARY`.
+  - Spark 4.1.1 (audited 2026-05-27): identical to 4.0.1.
+  - Known limitation: `Reverse` on an array containing `BinaryType` elements is reported as `Incompatible` and falls back unless explicitly enabled (https://github.com/apache/datafusion-comet/issues/2763).
 - [x] size
+  - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.
+  - Spark 3.5.8 (audited 2026-05-27): baseline. `Size(child, legacySizeOfNull) extends UnaryExpression with ExpectsInputTypes`; `inputTypes = Seq(TypeCollection(ArrayType, MapType)) -> IntegerType`. `legacySizeOfNull=true` returns `-1` for NULL input; `false` returns NULL. Comet routes via `CometSize`, which emits a `CaseWhen(isNotNull(child), size_scalar(child), Literal(legacySizeOfNull))`.
+  - Spark 4.0.1 (audited 2026-05-27): byte-for-byte identical to 3.5.8.
+  - Spark 4.1.1 (audited 2026-05-27): byte-for-byte identical to 3.5.8.
+  - Known limitation: `Size` over `MapType` falls back to Spark (https://github.com/apache/datafusion-comet/issues/4472).
 
 ### conditional_funcs
 

--- a/spark/src/main/scala/org/apache/comet/serde/strings.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/strings.scala
@@ -225,15 +225,15 @@ object CometRight extends CometExpressionSerde[Right] {
 }
 
 object CometConcat extends CometScalarFunction[Concat]("concat") {
-  val unsupportedReason = "CONCAT supports only string input parameters"
+  private val unsupportedReason = "CONCAT supports only string input parameters"
 
-  override def getIncompatibleReasons(): Seq[String] = Seq(unsupportedReason)
+  override def getUnsupportedReasons(): Seq[String] = Seq(unsupportedReason)
 
   override def getSupportLevel(expr: Concat): SupportLevel = {
     if (expr.children.forall(_.dataType == DataTypes.StringType)) {
       Compatible()
     } else {
-      Incompatible(Some(unsupportedReason))
+      Unsupported(Some(unsupportedReason))
     }
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

Continuation of the per-category expression audit. Same pattern as #4470 (json), #4469 (struct), #4461 (string), and earlier audits, using the updated `audit-comet-expression` skill in #4468 (now also covers Spark 4.1.1).

## What changes are included in this PR?

### Support-doc audit notes

Add per-version audit sub-bullets to `concat`, `reverse`, and `size` in `docs/source/contributor-guide/spark_expressions_support.md`. Spark `Concat` and `Reverse` widen `StringType` inputs to `StringTypeWithCollation(supportsTrimCollation = true)` in 4.0; `Size` is byte-for-byte identical across all four versions.

### Support-level consistency fix (in `strings.scala`)

- `CometConcat`: relabel the non-`StringType` branch from `Incompatible(Some(...))` to `Unsupported(Some(...))`. Spark accepts `BinaryType` and `ArrayType`, but Comet has no native path for either, so the user-observable effect is a fallback, not a wrong result. The reason string is now exposed via `getUnsupportedReasons` (rather than `getIncompatibleReasons`), and the constant is now `private val` for parity with other serdes.

### Tracking issues filed for follow-up

- #4471 `[Feature] support concat() for BinaryType and ArrayType inputs` — Spark accepts both, Comet only supports `StringType` natively.
- #4472 `[Feature] support size() for MapType inputs` — Spark accepts both `ArrayType` and `MapType`, Comet only supports `ArrayType`.

The existing #2763 already covers `reverse` on `array<binary>` and is referenced from the doc.

### Audit process

Audited directly using the `audit-comet-expression` skill (4 Spark versions per #4468). One backing serde per function, no parallel subagents needed.

## How are these changes tested?

- `./mvnw test -Dsuites="org.apache.comet.CometSqlFileTestSuite string/concat" -Dtest=none` (2 tests pass)
- `./mvnw test -Dsuites="org.apache.comet.CometSqlFileTestSuite array/array_concat" -Dtest=none` (1 test passes; uses the existing `expect_fallback(CONCAT supports only string input parameters)` directive — the reason text is preserved by the relabel, so substring matching still holds)
- `./mvnw test -Dsuites="org.apache.comet.CometSqlFileTestSuite array/size" -Dtest=none` (1 test passes)
- `./mvnw test -Dsuites="org.apache.comet.CometSqlFileTestSuite string/reverse" -Dtest=none` (1 test passes)
- `make core` succeeds with the serde change.
