### PR TITLE
chore(audit): audit conditional expressions across Spark 3.4.3, 3.5.8, 4.0.1, 4.1.1

### DIFF
--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -186,14 +186,42 @@
 ### conditional_funcs
 
 - [x] coalesce
+  - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.
+  - Spark 3.5.8 (audited 2026-05-27): baseline. `Coalesce(children) extends Expression with ComplexTypeMergingExpression`; returns the first non-null child, evaluated left-to-right with short-circuit. Result type is the merged child type. Comet routes via `CometCoalesce`, which serialises as nested `CaseWhen(IsNotNull(c1) -> c1, IsNotNull(c2) -> c2, ..., else cN)` so the native engine preserves the short-circuit semantics.
+  - Spark 4.0.1 (audited 2026-05-27): byte-for-byte identical to 3.5.8.
+  - Spark 4.1.1 (audited 2026-05-27): byte-for-byte identical to 3.5.8.
 - [x] if
+  - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.
+  - Spark 3.5.8 (audited 2026-05-27): baseline. `If(predicate, trueValue, falseValue) extends ComplexTypeMergingExpression`; standard ternary semantics with short-circuit, predicate must be `BooleanType`. Comet routes via `CometIf` to the native `IfExpr` proto.
+  - Spark 4.0.1 (audited 2026-05-27): adds an `override def withNewAlwaysEvaluatedInputs(...)` hook for the new optimizer phase; semantics unchanged. Error messages reformatted (`paramIndex` -> `ordinalNumber`).
+  - Spark 4.1.1 (audited 2026-05-27): identical to 4.0.1.
 - [x] ifnull
+  - Spark 3.4.3 (audited 2026-05-27): registry alias of `Nvl` (`expression[Nvl]("ifnull", setAlias = true)`). Same `RuntimeReplaceable` lowering as `nvl`.
+  - Spark 3.5.8 (audited 2026-05-27): identical to 3.4.3.
+  - Spark 4.0.1 (audited 2026-05-27): identical to 3.4.3.
+  - Spark 4.1.1 (audited 2026-05-27): identical to 3.4.3.
 - [ ] nanvl
 - [x] nullif
+  - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.
+  - Spark 3.5.8 (audited 2026-05-27): `NullIf(left, right, replacement) extends RuntimeReplaceable with InheritAnalysisRules`; the analyzer rewrites to `If(EqualTo(left, right), Literal(null, left.dataType), left)`. Comet handles via `CometIf` plus `CometEqualTo`.
+  - Spark 4.0.1 (audited 2026-05-27): identical to 3.5.8.
+  - Spark 4.1.1 (audited 2026-05-27): identical to 3.5.8.
 - [ ] nullifzero
 - [x] nvl
+  - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.
+  - Spark 3.5.8 (audited 2026-05-27): `Nvl(left, right, replacement) extends RuntimeReplaceable`; analyzer rewrites to `Coalesce(Seq(left, right))`. Comet handles via `CometCoalesce`.
+  - Spark 4.0.1 (audited 2026-05-27): identical to 3.5.8.
+  - Spark 4.1.1 (audited 2026-05-27): identical to 3.5.8.
 - [x] nvl2
+  - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.
+  - Spark 3.5.8 (audited 2026-05-27): `Nvl2(expr1, expr2, expr3, replacement) extends RuntimeReplaceable`; analyzer rewrites to `If(IsNotNull(expr1), expr2, expr3)`. Comet handles via `CometIf`.
+  - Spark 4.0.1 (audited 2026-05-27): identical to 3.5.8.
+  - Spark 4.1.1 (audited 2026-05-27): identical to 3.5.8.
 - [x] when
+  - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.
+  - Spark 3.5.8 (audited 2026-05-27): the `CASE WHEN ... THEN ...` SQL form lowers to `CaseWhen(branches: Seq[(Expression, Expression)], elseValue: Option[Expression])`. Spark evaluates left-to-right with short-circuit; result type is the merged branch type. Comet routes via `CometCaseWhen` to the native `CaseWhen` proto.
+  - Spark 4.0.1 (audited 2026-05-27): adds the `withNewAlwaysEvaluatedInputs` optimizer hook; semantics unchanged.
+  - Spark 4.1.1 (audited 2026-05-27): identical to 4.0.1.
 - [ ] zeroifnull
 
 ### conversion_funcs


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

Continuation of the per-category expression audit. Same pattern as #4474 (misc), #4473 (collection), #4470 (json), #4469 (struct), using the updated `audit-comet-expression` skill in #4468.

## What changes are included in this PR?

### Support-doc audit notes

Add per-version audit sub-bullets to `coalesce`, `if`, `ifnull`, `nullif`, `nvl`, `nvl2`, and `when` in `docs/source/contributor-guide/spark_expressions_support.md`. Only three Comet serdes back this entire category:

- `CometIf` handles `if`, `nvl2` (rewritten by the analyzer to `If(IsNotNull, e2, e3)`), and `nullif` (rewritten to `If(EqualTo, null, left)`).
- `CometCoalesce` handles `coalesce`, `nvl` (rewritten to `Coalesce`), and `ifnull` (registry alias of `nvl`).
- `CometCaseWhen` handles `when` / SQL `CASE WHEN`.

The Spark classes are byte-for-byte identical across all four versions for behaviour; Spark 4.0 only added the `withNewAlwaysEvaluatedInputs` optimizer hook on `If`/`CaseWhen` and reformatted error messages (no runtime change).

### Support-level consistency fixes

None. All three serdes were already clean: no `Incompatible(None)` cases, no reason-string drift, and the convert-time `withInfo` fallbacks are for child-conversion failures which (per the skill) legitimately belong in `convert` rather than `getSupportLevel`.

### Tracking issues filed for follow-up

None. No correctness divergences were found.

### Audit process

Audited directly using the `audit-comet-expression` skill (4 Spark versions per #4468). Three small serdes, no parallel subagents needed.

## How are these changes tested?

- `make core` succeeds (no code changes; only the doc was updated).
- Existing `CometExpressionSuite` and `CometSqlFileTestSuite` coverage for `if`, `case when`, `coalesce`, and their `RuntimeReplaceable` callers remains unchanged.
