### PR TITLE
chore(audit): audit cast across Spark 3.4.3, 3.5.8, 4.0.1, 4.1.1

### DIFF
--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -202,6 +202,17 @@
 - [ ] binary
 - [ ] boolean
 - [x] cast
+  - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8 modulo `Cast.canUpCast` refactored to delegate to `UpCastRule.canUpCast`.
+  - Spark 3.5.8 (audited 2026-05-27): baseline. `Cast(child, dataType, timeZoneId, evalMode)`; eval modes are `LEGACY`, `ANSI`, `TRY`. The legacy `Cast.canCast` matrix and the `Cast.canAnsiCast` matrix decide acceptance per type pair. Comet routes via `CometCast` (`spark/src/main/scala/org/apache/comet/expressions/CometCast.scala`) using a per-source-type support matrix that returns `Compatible`, `Incompatible(reason)`, or `Unsupported(reason)`; literal children are short-circuited to `Compatible()` so `CometLiteral` validates them. The serialized `Cast` proto carries `datatype`, `evalMode`, `timezone` (default `UTC`), `allowIncompat` (from `spark.comet.expression.Cast.allowIncompatible`), and `isSpark4Plus`. The native side (`native/spark-expr/src/conversion_funcs/cast.rs`) implements explicit per-eval-mode branches for narrowing numeric casts that match Spark's overflow exceptions, and falls through to DataFusion `cast_with_options(safe = !ANSI)` for the rest.
+  - Spark 4.0.1 (audited 2026-05-27): `VariantType` added; `StringType` literals replaced with `_: StringType` to accommodate collated strings. `(TimestampType, ByteType|ShortType|IntegerType)` added to `canAnsiCast`. `NullIntolerant` -> `nullIntolerant: Boolean` refactor. New `ToPrettyString.BinaryFormatter` semantics for `Binary -> String` are replicated natively via `spark_binary_formatter`. Numeric-to-numeric matrix unchanged.
+  - Spark 4.1.1 (audited 2026-05-27): `TimeType` added; many `TimeType` arms in `canCast`/`canAnsiCast`. Geospatial `GeographyType` / `GeometryType` types added with their own conversion rules. Numeric-to-numeric matrix unchanged.
+  - Known divergences and gaps:
+    - `CAST(<binary> AS STRING)` uses `unsafe { String::from_utf8_unchecked }` in native code, which is undefined behaviour for non-UTF8 inputs (https://github.com/apache/datafusion-comet/issues/4488).
+    - Spark 4.0 collated `StringType` is not explicitly guarded; pattern equality is expected to keep collated-string casts falling back, but there is no test (https://github.com/apache/datafusion-comet/issues/4489; umbrella #2190).
+    - Spark 4.1 `TimeType` casts have no explicit `Unsupported` arm; they fall back implicitly but do not appear in the auto-generated compatibility doc (https://github.com/apache/datafusion-comet/issues/4490).
+    - `CAST(<map> AS <map>)` falls back to Spark even though native `cast_map_to_map` exists (https://github.com/apache/datafusion-comet/issues/4491).
+    - `spark.sql.legacy.castComplexTypesToString.enabled=true` is not honoured by Comet (https://github.com/apache/datafusion-comet/issues/4492).
+    - `CAST(<float|double> AS DECIMAL)` rounding may differ from Spark (`Incompatible`, gated by `spark.comet.expression.Cast.allowIncompatible`, tracked at https://github.com/apache/datafusion-comet/issues/1371).
 - [ ] date
 - [ ] decimal
 - [ ] double


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

Completes the per-category expression audit started in earlier PRs (#4469 struct, #4470 json, #4473 collection, #4474 misc, #4475 conditional, #4476 hash, #4478 map, #4479 bitwise, #4480 predicate, #4483 array, #4486 math), using the updated `audit-comet-expression` skill in #4468.

`cast` is the only expression in `conversion_funcs`; the other entries (`bigint`, `binary`, `boolean`, ...) are SQL-syntactic shorthands for `CAST(... AS X)` and resolve to `Cast`.

## What changes are included in this PR?

### Support-doc audit notes

Add a per-version audit sub-bullet to `cast` in `docs/source/contributor-guide/spark_expressions_support.md`. Highlights:

- `Cast(child, dataType, timeZoneId, evalMode)` signature is stable across 3.4 / 3.5 / 4.0 / 4.1; per-version `EvalMode` resolution lives in `CometExprShim`.
- Comet uses a per-source-type support matrix in `CometCast.scala` that returns `Compatible` / `Incompatible(reason)` / `Unsupported(reason)` for each (from, to) pair.
- Spark's numeric-to-numeric `canCast` matrix is unchanged across all four versions; Spark 4.0 adds `VariantType` and collated `StringType`; Spark 4.1 adds `TimeType` and geospatial types with their own arms. None of those new arms are in `CometCast`, so they fall back to Spark.

### Support-level consistency fixes

None in this PR. The audit surfaced cosmetic inconsistencies (e.g. `canCastFromFloat/Double/Decimal` ignore `evalMode`; the static `getUnsupportedReasons` / `getIncompatibleReasons` don't enumerate the per-pair reasons returned by `isSupported`; one `case _: Incompatible()` with no reason in the array-of-binary branch) but these touch a load-bearing file and are deferred to follow-ups.

### Tracking issues filed for follow-up

- #4488 `CAST(<binary> AS STRING)` uses unsafe `String::from_utf8_unchecked` (undefined behaviour for non-UTF8 inputs).
- #4489 Spark 4.0 collated-string casts are implicitly unhandled; no test asserts the fallback (umbrella #2190).
- #4490 Spark 4.1 `TimeType` casts have no explicit `Unsupported` arm; falls back implicitly but doesn't appear in the auto-generated compat doc.
- #4491 `CAST(<map> AS <map>)` falls back even though native `cast_map_to_map` exists.
- #4492 `spark.sql.legacy.castComplexTypesToString.enabled=true` is not honoured.

Existing #1371 (`CAST(float|double AS decimal)` rounding) and #2190 (Spark 4.0 collation umbrella) are also referenced from the doc sub-bullet.

### Audit process

Audited using the `audit-comet-expression` skill (4 Spark versions per #4468), driven by 3 parallel agents covering high-level + numeric, string conversions, and datetime + complex types.

## How are these changes tested?

- `make core` succeeds (no code changes; doc only).
- Existing test coverage in `CometCastSuite` and the cast-related SQL fixtures remains unchanged.
