### PR TITLE
feat: Stage based fallback

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -348,6 +348,7 @@ jobs:
               org.apache.comet.rules.CometScanRuleSuite
               org.apache.comet.rules.CometScanSchemeFallbackSuite
               org.apache.comet.rules.CometExecRuleSuite
+              org.apache.comet.rules.RevertNativeForTransitionHeavyStagesSuite
               org.apache.spark.sql.CometTPCDSQuerySuite
               org.apache.spark.sql.CometTPCDSQueryTestSuite
               org.apache.spark.sql.CometTPCHQuerySuite

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -164,6 +164,7 @@ jobs:
               org.apache.comet.rules.CometScanRuleSuite
               org.apache.comet.rules.CometScanSchemeFallbackSuite
               org.apache.comet.rules.CometExecRuleSuite
+              org.apache.comet.rules.RevertNativeForTransitionHeavyStagesSuite
               org.apache.spark.sql.CometTPCDSQuerySuite
               org.apache.spark.sql.CometTPCDSQueryTestSuite
               org.apache.spark.sql.CometTPCHQuerySuite

--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -474,7 +474,7 @@ object CometConf extends ShimCometConf {
           "Only effective when spark.comet.exec.transitionRevert.enabled is true.")
       .intConf
       .checkValue(_ >= 0, "Must be >= 0.")
-      .createWithDefault(5)
+      .createWithDefault(2)
 
   val COMET_EXEC_SHUFFLE_COMPRESSION_CODEC: ConfigEntry[String] =
     conf(s"$COMET_EXEC_CONFIG_PREFIX.shuffle.compression.codec")

--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -450,6 +450,33 @@ object CometConf extends ShimCometConf {
       .booleanConf
       .createWithDefault(true)
 
+  val COMET_EXEC_TRANSITION_REVERT_ENABLED: ConfigEntry[Boolean] =
+    conf(s"$COMET_EXEC_CONFIG_PREFIX.transitionRevert.enabled")
+      .category(CATEGORY_EXEC)
+      .doc(
+        "When enabled, Comet reverts a query stage to Spark row-based execution if the number " +
+          "of columnar-to-row and row-to-columnar transition pairs exceeds the configured " +
+          "threshold. This avoids the overhead of repeated format conversions in stages where " +
+          "many operators fall back to row-based execution.")
+      .booleanConf
+      .createWithDefault(true)
+
+  val COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS: ConfigEntry[Int] =
+    conf(s"$COMET_EXEC_CONFIG_PREFIX.transitionRevert.maxTransitions")
+      .category(CATEGORY_EXEC)
+      .doc(
+        "The maximum number of columnar-to-row (C2R) transitions allowed in a single query " +
+          "stage before Comet reverts the entire stage to Spark row-based execution. When " +
+          "columnar shuffle is enabled, each C2R has a corresponding row-to-columnar (R2C) " +
+          "conversion to feed back into the columnar shuffle, so the count reflects full " +
+          "round-trips. Minimum value is 2 because reverting a stage that feeds a columnar " +
+          "shuffle still requires at least one R2C at the shuffle boundary. " +
+          "Only effective when spark.comet.exec.transitionRevert.enabled is true.")
+      .intConf
+      .checkValue(_ >= 2, "Must be >= 2. A reverted stage still requires at least one " +
+        "R2C at the columnar shuffle boundary.")
+      .createWithDefault(2)
+
   val COMET_EXEC_SHUFFLE_COMPRESSION_CODEC: ConfigEntry[String] =
     conf(s"$COMET_EXEC_CONFIG_PREFIX.shuffle.compression.codec")
       .category(CATEGORY_SHUFFLE)

--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -469,15 +469,11 @@ object CometConf extends ShimCometConf {
           "stage before Comet reverts the entire stage to Spark row-based execution. When " +
           "columnar shuffle is enabled, each C2R has a corresponding row-to-columnar (R2C) " +
           "conversion to feed back into the columnar shuffle, so the count reflects full " +
-          "round-trips. Minimum value is 2 because reverting a stage that feeds a columnar " +
-          "shuffle still requires at least one R2C at the shuffle boundary. " +
+          "round-trips. Set to 0 to revert any stage with transitions. " +
           "Only effective when spark.comet.exec.transitionRevert.enabled is true.")
       .intConf
-      .checkValue(
-        _ >= 2,
-        "Must be >= 2. A reverted stage still requires at least one " +
-          "R2C at the columnar shuffle boundary.")
-      .createWithDefault(2)
+      .checkValue(_ >= 0, "Must be >= 0.")
+      .createWithDefault(5)
 
   val COMET_EXEC_SHUFFLE_COMPRESSION_CODEC: ConfigEntry[String] =
     conf(s"$COMET_EXEC_CONFIG_PREFIX.shuffle.compression.codec")

--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -455,9 +455,9 @@ object CometConf extends ShimCometConf {
       .category(CATEGORY_EXEC)
       .doc(
         "When enabled, Comet reverts a query stage to Spark row-based execution if the number " +
-          "of columnar-to-row and row-to-columnar transition pairs exceeds the configured " +
-          "threshold. This avoids the overhead of repeated format conversions in stages where " +
-          "many operators fall back to row-based execution.")
+          "of columnar-to-row (C2R) transitions in the stage exceeds the configured threshold. " +
+          "This avoids the overhead of repeated format conversions in stages where many " +
+          "operators fall back to row-based execution.")
       .booleanConf
       .createWithDefault(false)
 
@@ -467,9 +467,10 @@ object CometConf extends ShimCometConf {
       .doc(
         "The maximum number of columnar-to-row (C2R) transitions allowed in a single query " +
           "stage before Comet reverts the entire stage to Spark row-based execution. When " +
-          "columnar shuffle is enabled, each C2R has a corresponding row-to-columnar (R2C) " +
-          "conversion to feed back into the columnar shuffle, so the count reflects full " +
-          "round-trips. Set to 0 to revert any stage with transitions. " +
+          "columnar shuffle is enabled, each such C2R typically implies a corresponding " +
+          "row-to-columnar conversion to feed back into the columnar shuffle, so each counted " +
+          "C2R is a useful proxy for the conversion overhead in the stage. Set to 0 to revert " +
+          "any stage with transitions. " +
           "Only effective when spark.comet.exec.transitionRevert.enabled is true.")
       .intConf
       .checkValue(_ >= 0, "Must be >= 0.")

--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -473,8 +473,10 @@ object CometConf extends ShimCometConf {
           "shuffle still requires at least one R2C at the shuffle boundary. " +
           "Only effective when spark.comet.exec.transitionRevert.enabled is true.")
       .intConf
-      .checkValue(_ >= 2, "Must be >= 2. A reverted stage still requires at least one " +
-        "R2C at the columnar shuffle boundary.")
+      .checkValue(
+        _ >= 2,
+        "Must be >= 2. A reverted stage still requires at least one " +
+          "R2C at the columnar shuffle boundary.")
       .createWithDefault(2)
 
   val COMET_EXEC_SHUFFLE_COMPRESSION_CODEC: ConfigEntry[String] =

--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -459,7 +459,7 @@ object CometConf extends ShimCometConf {
           "threshold. This avoids the overhead of repeated format conversions in stages where " +
           "many operators fall back to row-based execution.")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS: ConfigEntry[Int] =
     conf(s"$COMET_EXEC_CONFIG_PREFIX.transitionRevert.maxTransitions")

--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.execution._
 import org.apache.spark.sql.internal.SQLConf
 
 import org.apache.comet.CometConf._
-import org.apache.comet.rules.{CometExecRule, CometPlanAdaptiveDynamicPruningFilters, CometReuseSubquery, CometScanRule, CometSpark34AqeDppFallbackRule, EliminateRedundantTransitions}
+import org.apache.comet.rules.{CometExecRule, CometPlanAdaptiveDynamicPruningFilters, CometReuseSubquery, CometScanRule, CometSpark34AqeDppFallbackRule, EliminateRedundantTransitions, RevertNativeForTransitionHeavyStages}
 import org.apache.comet.shims.ShimCometSparkSessionExtensions
 
 /**
@@ -106,8 +106,12 @@ class CometSparkSessionExtensions
   case class CometExecColumnar(session: SparkSession) extends ColumnarRule {
     override def preColumnarTransitions: Rule[SparkPlan] = CometExecRule(session)
 
-    override def postColumnarTransitions: Rule[SparkPlan] =
-      EliminateRedundantTransitions(session)
+    override def postColumnarTransitions: Rule[SparkPlan] = {
+      val rules = Seq(
+        EliminateRedundantTransitions(session),
+        RevertNativeForTransitionHeavyStages(session))
+      plan => rules.foldLeft(plan) { case (p, rule) => rule(p) }
+    }
   }
 }
 

--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -107,9 +107,8 @@ class CometSparkSessionExtensions
     override def preColumnarTransitions: Rule[SparkPlan] = CometExecRule(session)
 
     override def postColumnarTransitions: Rule[SparkPlan] = {
-      val rules = Seq(
-        EliminateRedundantTransitions(session),
-        RevertNativeForTransitionHeavyStages(session))
+      val rules =
+        Seq(EliminateRedundantTransitions(session), RevertNativeForTransitionHeavyStages(session))
       plan => rules.foldLeft(plan) { case (p, rule) => rule(p) }
     }
   }

--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -51,7 +51,8 @@ import org.apache.comet.shims.ShimCometSparkSessionExtensions
  *         - CometExecRule.convertSubqueryBroadcasts converts SubqueryBroadcastExec to
  *           CometSubqueryBroadcastExec for exchange reuse with Comet broadcasts
  *      b. insertTransitions:        ColumnarToRow/RowToColumnar added
- *      c. postColumnarTransitions:  EliminateRedundantTransitions
+ *      c. postColumnarTransitions:  RevertNativeForTransitionHeavyStages,
+ *                                   EliminateRedundantTransitions
  *   5. ReuseExchangeAndSubquery     -- Spark deduplicates subqueries (sees Comet nodes)
  * }}}
  *
@@ -74,7 +75,8 @@ import org.apache.comet.shims.ShimCometSparkSessionExtensions
  *     2. postStageCreationRules -> ApplyColumnarRulesAndInsertTransitions:
  *        a. preColumnarTransitions: CometScanRule, CometExecRule (no-ops, already converted)
  *        b. insertTransitions
- *        c. postColumnarTransitions: EliminateRedundantTransitions
+ *        c. postColumnarTransitions: RevertNativeForTransitionHeavyStages,
+ *                                    EliminateRedundantTransitions
  * }}}
  *
  * On Spark 3.4, injectQueryStageOptimizerRule is unavailable. CometExecRule does not wrap SABs,
@@ -108,7 +110,7 @@ class CometSparkSessionExtensions
 
     override def postColumnarTransitions: Rule[SparkPlan] = {
       val rules =
-        Seq(EliminateRedundantTransitions(session), RevertNativeForTransitionHeavyStages(session))
+        Seq(RevertNativeForTransitionHeavyStages(session), EliminateRedundantTransitions(session))
       plan => rules.foldLeft(plan) { case (p, rule) => rule(p) }
     }
   }

--- a/spark/src/main/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStages.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStages.scala
@@ -109,8 +109,11 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
     count
   }
 
-  // Two passes: strip transitions first (they assert child.supportsColumnar in constructors),
-  // then revert Comet operators to row-based Spark equivalents.
+  // Three passes:
+  // 1. Strip existing transitions (they assert child.supportsColumnar in constructors)
+  // 2. Revert Comet operators to row-based Spark equivalents
+  // 3. Re-insert ColumnarToRowExec where a columnar child feeds a row-based parent
+  //    (e.g. QueryStageExec from a prior CometShuffleExchangeExec stage)
   private[rules] def revertToSpark(plan: SparkPlan): SparkPlan = {
     val stripped = plan.transformDown {
       case CometNativeColumnarToRowExec(child) => child
@@ -119,7 +122,7 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
       case sparkToColumnar: CometSparkToColumnarExec => sparkToColumnar.child
       case RowToColumnarExec(child) => child
     }
-    stripped.transformUp {
+    val reverted = stripped.transformUp {
       case cometShuffle: CometShuffleExchangeExec =>
         cometShuffle.originalPlan.withNewChildren(Seq(cometShuffle.child))
       case cometExec: CometExec =>
@@ -128,6 +131,17 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
         } else {
           cometExec.originalPlan
         }
+    }
+    insertTransitions(reverted)
+  }
+
+  private def insertTransitions(plan: SparkPlan): SparkPlan = {
+    plan.transformUp {
+      case node if !node.isInstanceOf[QueryStageExec] && !node.supportsColumnar =>
+        val newChildren = node.children.map { child =>
+          if (child.supportsColumnar) ColumnarToRowExec(child) else child
+        }
+        if (newChildren != node.children) node.withNewChildren(newChildren) else node
     }
   }
 }

--- a/spark/src/main/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStages.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStages.scala
@@ -34,7 +34,6 @@ import org.apache.comet.CometConf
  * Reverts a query stage to Spark row-based execution when it has too many columnar-to-row (C2R)
  * transitions. Each C2R indicates Comet could not keep execution columnar and had to fall back.
  * With columnar shuffle enabled, each C2R implies a corresponding R2C round-trip.
- *
  */
 case class RevertNativeForTransitionHeavyStages(session: SparkSession)
     extends Rule[SparkPlan]
@@ -66,15 +65,16 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
   }
 
   private def applyForNonAQE(plan: SparkPlan): SparkPlan = {
-    plan.transformUp {
-      case exchange: ShuffleExchangeLike =>
-        revertStageIfNeeded(exchange.child, exchange.supportsColumnar)
-          .map(reverted => exchange.withNewChildren(Seq(reverted)))
-          .getOrElse(exchange)
+    plan.transformUp { case exchange: ShuffleExchangeLike =>
+      revertStageIfNeeded(exchange.child, exchange.supportsColumnar)
+        .map(reverted => exchange.withNewChildren(Seq(reverted)))
+        .getOrElse(exchange)
     }
   }
 
-  /** Reverts the stage if C2R count exceeds threshold. Wraps in R2C if exchange needs columnar. */
+  /**
+   * Reverts the stage if C2R count exceeds threshold. Wraps in R2C if exchange needs columnar.
+   */
   private def revertStageIfNeeded(
       stagePlan: SparkPlan,
       outputColumnar: Boolean): Option[SparkPlan] = {
@@ -93,7 +93,6 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
     }
     Some(result)
   }
-
 
   /** Counts C2R transitions within this stage, stopping at stage boundaries. */
   private[rules] def countTransitions(plan: SparkPlan): Int = {

--- a/spark/src/main/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStages.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStages.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.execution.adaptive.QueryStageExec
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeLike, ShuffleExchangeLike}
 
 import org.apache.comet.CometConf
+import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
 
 /**
  * Reverts a query stage to Spark row-based execution when it has too many columnar-to-row (C2R)
@@ -82,15 +83,14 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
     val transitionCount = countTransitions(stagePlan)
     if (transitionCount <= maxTransitions) return None
 
-    logInfo(
-      s"Reverting Comet native execution for stage with $transitionCount C2R transitions " +
-        s"(threshold: $maxTransitions).")
+    val reason =
+      s"Stage reverted: $transitionCount C2R transitions exceed threshold $maxTransitions"
 
     val reverted = revertToSpark(stagePlan)
     val result = if (outputColumnar && !reverted.supportsColumnar) {
-      RowToColumnarExec(reverted)
+      RowToColumnarExec(withFallbackReason(reverted, reason))
     } else {
-      reverted
+      withFallbackReason(reverted, reason)
     }
     Some(result)
   }
@@ -123,7 +123,7 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
         cometExec.originalPlan.withNewChildren(cometExec.children)
       } else {
         logWarning(
-          s"Comet plan and original have different child count for " +
+          "Comet plan and original have different child count for " +
             s"${cometExec.getClass.getSimpleName}, using originalPlan as-is.")
         cometExec.originalPlan
       }

--- a/spark/src/main/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStages.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStages.scala
@@ -60,6 +60,8 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
           .map(reverted => exchange.withNewChildren(Seq(reverted)))
           .getOrElse(plan)
       case _ =>
+        // Result stage: its output is collected as rows, so no consumer requires columnar input
+        // and the reverted stage needs no trailing R2C.
         revertStageIfNeeded(plan, outputColumnar = false).getOrElse(plan)
     }
   }
@@ -95,11 +97,43 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
     Some(result)
   }
 
+  /**
+   * A node that marks the boundary between this stage and an adjacent one.
+   */
+  private def isStageBoundary(plan: SparkPlan): Boolean = plan match {
+    case _: QueryStageExec | _: ShuffleExchangeLike | _: BroadcastExchangeLike => true
+    case _ => false
+  }
+
+  /**
+   * Like `transformDown`, never descends stage-boundary children.
+   */
+  private def transformStageDown(plan: SparkPlan)(
+      rule: PartialFunction[SparkPlan, SparkPlan]): SparkPlan = {
+    val transformed = rule.applyOrElse(plan, identity[SparkPlan])
+    val newChildren = transformed.children.map { child =>
+      if (isStageBoundary(child)) child else transformStageDown(child)(rule)
+    }
+    if (newChildren == transformed.children) transformed
+    else transformed.withNewChildren(newChildren)
+  }
+
+  /** Like `transformUp`, never descends stage-boundary children. */
+  private def transformStageUp(plan: SparkPlan)(
+      rule: PartialFunction[SparkPlan, SparkPlan]): SparkPlan = {
+    val newChildren = plan.children.map { child =>
+      if (isStageBoundary(child)) child else transformStageUp(child)(rule)
+    }
+    val withNewChildren =
+      if (newChildren == plan.children) plan else plan.withNewChildren(newChildren)
+    rule.applyOrElse(withNewChildren, identity[SparkPlan])
+  }
+
   /** Counts C2R transitions within this stage, stopping at stage boundaries. */
   private[rules] def countTransitions(plan: SparkPlan): Int = {
     var count = 0
     def visit(node: SparkPlan): Unit = node match {
-      case _: QueryStageExec | _: ShuffleExchangeLike | _: BroadcastExchangeLike => ()
+      case _ if isStageBoundary(node) => ()
       case _: ColumnarToRowTransition =>
         count += 1
         node.children.foreach(visit)
@@ -111,14 +145,14 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
   }
 
   private[rules] def revertToSpark(plan: SparkPlan): SparkPlan = {
-    val stripped = plan.transformDown {
+    val stripped = transformStageDown(plan) {
       case CometNativeColumnarToRowExec(child) => child
       case CometColumnarToRowExec(child) => child
       case ColumnarToRowExec(child) => child
       case sparkToColumnar: CometSparkToColumnarExec => sparkToColumnar.child
       case RowToColumnarExec(child) => child
     }
-    val reverted = stripped.transformUp { case cometExec: CometExec =>
+    val reverted = transformStageUp(stripped) { case cometExec: CometExec =>
       if (cometExec.originalPlan.children.size == cometExec.children.size) {
         cometExec.originalPlan.withNewChildren(cometExec.children)
       } else {
@@ -132,7 +166,7 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
   }
 
   private def insertTransitions(plan: SparkPlan): SparkPlan = {
-    plan.transformUp {
+    transformStageUp(plan) {
       case node if !node.isInstanceOf[QueryStageExec] && !node.supportsColumnar =>
         val newChildren = node.children.map { child =>
           if (child.supportsColumnar) ColumnarToRowExec(child) else child

--- a/spark/src/main/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStages.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStages.scala
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.rules
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.comet.{CometColumnarToRowExec, CometExec, CometNativeColumnarToRowExec, CometSparkToColumnarExec}
+import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
+import org.apache.spark.sql.execution.{ColumnarToRowExec, ColumnarToRowTransition, RowToColumnarExec, SparkPlan}
+import org.apache.spark.sql.execution.adaptive.QueryStageExec
+import org.apache.spark.sql.execution.exchange.{BroadcastExchangeLike, ShuffleExchangeLike}
+
+import org.apache.comet.CometConf
+
+/**
+ * Reverts a query stage to Spark row-based execution when it has too many columnar-to-row (C2R)
+ * transitions. Each C2R indicates Comet could not keep execution columnar and had to fall back.
+ * With columnar shuffle enabled, each C2R implies a corresponding R2C round-trip.
+ *
+ */
+case class RevertNativeForTransitionHeavyStages(session: SparkSession)
+    extends Rule[SparkPlan]
+    with Logging {
+
+  private lazy val enabled = CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.get()
+  private lazy val maxTransitions = CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.get()
+
+  override def apply(plan: SparkPlan): SparkPlan = {
+    if (!enabled) return plan
+
+    if (session.sessionState.conf.adaptiveExecutionEnabled) {
+      applyForAQE(plan)
+    } else {
+      applyForNonAQE(plan)
+    }
+  }
+
+  private def applyForAQE(plan: SparkPlan): SparkPlan = {
+    plan match {
+      case _: BroadcastExchangeLike => plan
+      case exchange: ShuffleExchangeLike =>
+        revertStageIfNeeded(exchange.child, exchange.supportsColumnar)
+          .map(reverted => exchange.withNewChildren(Seq(reverted)))
+          .getOrElse(plan)
+      case _ =>
+        revertStageIfNeeded(plan, outputColumnar = false).getOrElse(plan)
+    }
+  }
+
+  private def applyForNonAQE(plan: SparkPlan): SparkPlan = {
+    plan.transformUp {
+      case exchange: ShuffleExchangeLike =>
+        revertStageIfNeeded(exchange.child, exchange.supportsColumnar)
+          .map(reverted => exchange.withNewChildren(Seq(reverted)))
+          .getOrElse(exchange)
+    }
+  }
+
+  /** Reverts the stage if C2R count exceeds threshold. Wraps in R2C if exchange needs columnar. */
+  private def revertStageIfNeeded(
+      stagePlan: SparkPlan,
+      outputColumnar: Boolean): Option[SparkPlan] = {
+    val transitionCount = countTransitions(stagePlan)
+    if (transitionCount <= maxTransitions) return None
+
+    logInfo(
+      s"Reverting Comet native execution for stage with $transitionCount C2R transitions " +
+        s"(threshold: $maxTransitions).")
+
+    val reverted = revertToSpark(stagePlan)
+    val result = if (outputColumnar && !reverted.supportsColumnar) {
+      RowToColumnarExec(reverted)
+    } else {
+      reverted
+    }
+    Some(result)
+  }
+
+
+  /** Counts C2R transitions within this stage, stopping at stage boundaries. */
+  private[rules] def countTransitions(plan: SparkPlan): Int = {
+    var count = 0
+    def visit(node: SparkPlan): Unit = node match {
+      case _: QueryStageExec | _: ShuffleExchangeLike => ()
+      case _: ColumnarToRowTransition =>
+        count += 1
+        node.children.foreach(visit)
+      case _ =>
+        node.children.foreach(visit)
+    }
+    visit(plan)
+    count
+  }
+
+  // Two passes: strip transitions first (they assert child.supportsColumnar in constructors),
+  // then revert Comet operators to row-based Spark equivalents.
+  private[rules] def revertToSpark(plan: SparkPlan): SparkPlan = {
+    val stripped = plan.transformDown {
+      case CometNativeColumnarToRowExec(child) => child
+      case CometColumnarToRowExec(child) => child
+      case ColumnarToRowExec(child) => child
+      case sparkToColumnar: CometSparkToColumnarExec => sparkToColumnar.child
+      case RowToColumnarExec(child) => child
+    }
+    stripped.transformUp {
+      case cometShuffle: CometShuffleExchangeExec =>
+        cometShuffle.originalPlan.withNewChildren(Seq(cometShuffle.child))
+      case cometExec: CometExec =>
+        if (cometExec.originalPlan.children.size == cometExec.children.size) {
+          cometExec.originalPlan.withNewChildren(cometExec.children)
+        } else {
+          cometExec.originalPlan
+        }
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStages.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStages.scala
@@ -23,7 +23,6 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.comet.{CometColumnarToRowExec, CometExec, CometNativeColumnarToRowExec, CometSparkToColumnarExec}
-import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 import org.apache.spark.sql.execution.{ColumnarToRowExec, ColumnarToRowTransition, RowToColumnarExec, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.QueryStageExec
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeLike, ShuffleExchangeLike}
@@ -65,11 +64,13 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
   }
 
   private def applyForNonAQE(plan: SparkPlan): SparkPlan = {
-    plan.transformUp { case exchange: ShuffleExchangeLike =>
+    val withRevertedStages = plan.transformUp { case exchange: ShuffleExchangeLike =>
       revertStageIfNeeded(exchange.child, exchange.supportsColumnar)
         .map(reverted => exchange.withNewChildren(Seq(reverted)))
         .getOrElse(exchange)
     }
+    revertStageIfNeeded(withRevertedStages, outputColumnar = false)
+      .getOrElse(withRevertedStages)
   }
 
   /**
@@ -98,7 +99,7 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
   private[rules] def countTransitions(plan: SparkPlan): Int = {
     var count = 0
     def visit(node: SparkPlan): Unit = node match {
-      case _: QueryStageExec | _: ShuffleExchangeLike => ()
+      case _: QueryStageExec | _: ShuffleExchangeLike | _: BroadcastExchangeLike => ()
       case _: ColumnarToRowTransition =>
         count += 1
         node.children.foreach(visit)
@@ -109,11 +110,6 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
     count
   }
 
-  // Three passes:
-  // 1. Strip existing transitions (they assert child.supportsColumnar in constructors)
-  // 2. Revert Comet operators to row-based Spark equivalents
-  // 3. Re-insert ColumnarToRowExec where a columnar child feeds a row-based parent
-  //    (e.g. QueryStageExec from a prior CometShuffleExchangeExec stage)
   private[rules] def revertToSpark(plan: SparkPlan): SparkPlan = {
     val stripped = plan.transformDown {
       case CometNativeColumnarToRowExec(child) => child
@@ -122,15 +118,15 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
       case sparkToColumnar: CometSparkToColumnarExec => sparkToColumnar.child
       case RowToColumnarExec(child) => child
     }
-    val reverted = stripped.transformUp {
-      case cometShuffle: CometShuffleExchangeExec =>
-        cometShuffle.originalPlan.withNewChildren(Seq(cometShuffle.child))
-      case cometExec: CometExec =>
-        if (cometExec.originalPlan.children.size == cometExec.children.size) {
-          cometExec.originalPlan.withNewChildren(cometExec.children)
-        } else {
-          cometExec.originalPlan
-        }
+    val reverted = stripped.transformUp { case cometExec: CometExec =>
+      if (cometExec.originalPlan.children.size == cometExec.children.size) {
+        cometExec.originalPlan.withNewChildren(cometExec.children)
+      } else {
+        logWarning(
+          s"Comet plan and original have different child count for " +
+            s"${cometExec.getClass.getSimpleName}, using originalPlan as-is.")
+        cometExec.originalPlan
+      }
     }
     insertTransitions(reverted)
   }

--- a/spark/src/main/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStages.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStages.scala
@@ -39,8 +39,8 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
     extends Rule[SparkPlan]
     with Logging {
 
-  private lazy val enabled = CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.get()
-  private lazy val maxTransitions = CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.get()
+  private def enabled = CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.get()
+  private def maxTransitions = CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.get()
 
   override def apply(plan: SparkPlan): SparkPlan = {
     if (!enabled) return plan
@@ -166,8 +166,10 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
   }
 
   private def insertTransitions(plan: SparkPlan): SparkPlan = {
+    // transformStageUp never descends into stage-boundary nodes (QueryStageExec, exchanges), so
+    // this only needs to bridge row nodes that still have a columnar child within the stage.
     transformStageUp(plan) {
-      case node if !node.isInstanceOf[QueryStageExec] && !node.supportsColumnar =>
+      case node if !node.supportsColumnar =>
         val newChildren = node.children.map { child =>
           if (child.supportsColumnar) ColumnarToRowExec(child) else child
         }

--- a/spark/src/test/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStagesSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStagesSuite.scala
@@ -1,0 +1,271 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.rules
+
+import org.apache.spark.sql.comet._
+import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+
+import org.apache.comet.CometConf
+import org.apache.spark.sql.CometTestBase
+
+class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
+
+  private def createSparkPlan(sql: String): SparkPlan = {
+    var plan: SparkPlan = null
+    withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
+      plan = spark.sql(sql).queryExecution.executedPlan
+    }
+    stripAQEPlan(plan)
+  }
+
+  private def applyCometExecRule(plan: SparkPlan): SparkPlan = {
+    CometExecRule(spark).apply(plan)
+  }
+
+  private def applyFullColumnarPipeline(plan: SparkPlan): SparkPlan = {
+    val cometPlan = CometScanRule(spark).apply(plan)
+    val execPlan = CometExecRule(spark).apply(cometPlan)
+    val withTransitions = ApplyColumnarRulesAndInsertTransitions(Seq.empty, false).apply(execPlan)
+    EliminateRedundantTransitions(spark).apply(withTransitions)
+  }
+
+  private def countCometExecs(plan: SparkPlan): Int = {
+    plan.collect { case _: CometExec => true }.size
+  }
+
+  private def countC2RNodes(plan: SparkPlan): Int = {
+    plan.collect { case _: ColumnarToRowTransition => true }.size
+  }
+
+  test("rule is a no-op when disabled") {
+    withSQLConf(
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "false") {
+      val rule = RevertNativeForTransitionHeavyStages(spark)
+      val sparkPlan = createSparkPlan("SELECT 1")
+      val cometPlan = applyCometExecRule(sparkPlan)
+      val result = rule.apply(cometPlan)
+      assert(result eq cometPlan, "Rule should be a no-op when disabled")
+    }
+  }
+
+  test("rule does not revert plan below threshold") {
+    withSQLConf(
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "10") {
+      withTempView("test_data") {
+        spark.range(10).toDF("id").createOrReplaceTempView("test_data")
+        val sparkPlan = createSparkPlan("SELECT id, id * 2 as doubled FROM test_data WHERE id > 5")
+        val cometPlan = applyCometExecRule(sparkPlan)
+
+        val rule = RevertNativeForTransitionHeavyStages(spark)
+        val result = rule.apply(cometPlan)
+        assert(result eq cometPlan, "Plan should be unchanged when below threshold")
+      }
+    }
+  }
+
+  test("countTransitions counts non-root C2R correctly") {
+    withSQLConf(
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ENABLED.key -> "true") {
+      val rule = RevertNativeForTransitionHeavyStages(spark)
+
+      withTempView("test_data") {
+        spark.range(10).toDF("id").createOrReplaceTempView("test_data")
+        val sparkPlan = createSparkPlan("SELECT id FROM test_data")
+        val cometPlan = applyFullColumnarPipeline(sparkPlan)
+
+        val count = rule.countTransitions(cometPlan)
+        // A simple scan+project plan should have 0 or 1 transitions
+        assert(count >= 0, s"Transition count should be non-negative, got $count")
+      }
+    }
+  }
+
+  test("countTransitions counts all C2R nodes including root") {
+    withSQLConf(
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ENABLED.key -> "true") {
+      val rule = RevertNativeForTransitionHeavyStages(spark)
+
+      withTempView("test_data") {
+        spark.range(10).toDF("id").createOrReplaceTempView("test_data")
+        val sparkPlan = createSparkPlan("SELECT id FROM test_data")
+        val cometPlan = applyCometExecRule(sparkPlan)
+
+        // Wrap in a ColumnarToRow (simulating a terminal output)
+        val planWithRootC2R = ColumnarToRowExec(cometPlan)
+        val count = rule.countTransitions(planWithRootC2R)
+        assert(count == 1, s"Should count the C2R node, got $count")
+      }
+    }
+  }
+
+  test("revertToSpark removes CometExec operators") {
+    withSQLConf(
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true") {
+
+      withTempView("test_data") {
+        spark.range(10).toDF("id").createOrReplaceTempView("test_data")
+        val sparkPlan =
+          createSparkPlan("SELECT id, id * 2 as doubled FROM test_data WHERE id > 5")
+        val cometPlan = applyCometExecRule(sparkPlan)
+
+        assert(countCometExecs(cometPlan) > 0, "Should have CometExec nodes before revert")
+
+        val rule = RevertNativeForTransitionHeavyStages(spark)
+        val reverted = rule.revertToSpark(cometPlan)
+
+        assert(countCometExecs(reverted) == 0,
+          s"Should have no CometExec nodes after revert, plan:\n${reverted.treeString}")
+      }
+    }
+  }
+
+  test("revertToSpark preserves plan structure") {
+    withSQLConf(
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true") {
+
+      withTempView("test_data") {
+        spark.range(10).toDF("id").createOrReplaceTempView("test_data")
+        val sparkPlan =
+          createSparkPlan("SELECT id, id * 2 as doubled FROM test_data WHERE id > 5")
+        val cometPlan = applyCometExecRule(sparkPlan)
+        val rule = RevertNativeForTransitionHeavyStages(spark)
+        val reverted = rule.revertToSpark(cometPlan)
+
+        // Reverted plan should have same output schema
+        assert(reverted.output.map(_.name) == cometPlan.output.map(_.name),
+          "Output schema should be preserved after revert")
+      }
+    }
+  }
+
+  test("revertToSpark removes all Comet operators from a plan with transitions") {
+    withSQLConf(
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "true") {
+
+      withTempView("test_data") {
+        spark.range(10).toDF("id").createOrReplaceTempView("test_data")
+        val sparkPlan =
+          createSparkPlan("SELECT id, id * 2 as doubled FROM test_data WHERE id > 5")
+        val cometPlan = applyFullColumnarPipeline(sparkPlan)
+
+        val rule = RevertNativeForTransitionHeavyStages(spark)
+        val result = rule.revertToSpark(cometPlan)
+        assert(countCometExecs(result) == 0,
+          s"All CometExec should be reverted. Plan:\n${result.treeString}")
+      }
+    }
+  }
+
+  test("CometShuffleExchangeExec is reverted by revertToSpark") {
+    withSQLConf(
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_SHUFFLE_ENABLED.key -> "true",
+      "spark.sql.adaptive.enabled" -> "false") {
+
+      withTempView("test_data") {
+        spark.range(10).toDF("id").createOrReplaceTempView("test_data")
+        val sparkPlan = createSparkPlan("SELECT id FROM test_data DISTRIBUTE BY id")
+        val cometPlan = applyCometExecRule(sparkPlan)
+
+        val cometShuffles = cometPlan.collect { case s: CometShuffleExchangeExec => s }
+        if (cometShuffles.nonEmpty) {
+          val rule = RevertNativeForTransitionHeavyStages(spark)
+          val reverted = rule.revertToSpark(cometPlan)
+          val remainingCometShuffles = reverted.collect {
+            case s: CometShuffleExchangeExec => s
+          }
+          assert(remainingCometShuffles.isEmpty,
+            "CometShuffleExchangeExec should be reverted to ShuffleExchangeExec")
+          val sparkShuffles = reverted.collect { case s: ShuffleExchangeExec => s }
+          assert(sparkShuffles.nonEmpty,
+            "Should have ShuffleExchangeExec after revert")
+        }
+      }
+    }
+  }
+
+  test("non-AQE path applies rule per-stage via transformUp") {
+    withSQLConf(
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_SHUFFLE_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "10",
+      "spark.sql.adaptive.enabled" -> "false") {
+
+      withTempView("test_data") {
+        spark.range(10).selectExpr("id", "id % 3 as grp")
+          .createOrReplaceTempView("test_data")
+        val sparkPlan = createSparkPlan(
+          "SELECT grp, count(*) FROM test_data GROUP BY grp")
+        val cometPlan = applyCometExecRule(sparkPlan)
+
+        // With high threshold, the non-AQE path should not revert anything
+        val rule = RevertNativeForTransitionHeavyStages(spark)
+        val result = rule.apply(cometPlan)
+        assert(result eq cometPlan,
+          "Non-AQE path should not revert when below threshold")
+      }
+    }
+  }
+
+  test("default threshold of 2 allows stages with up to 2 transition pairs") {
+    withSQLConf(
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "2") {
+      val rule = RevertNativeForTransitionHeavyStages(spark)
+
+      withTempView("test_data") {
+        spark.range(10).toDF("id").createOrReplaceTempView("test_data")
+        val sparkPlan = createSparkPlan("SELECT id FROM test_data")
+        val cometPlan = applyFullColumnarPipeline(sparkPlan)
+
+        val pairs = rule.countTransitions(cometPlan)
+        val result = rule.apply(cometPlan)
+        if (pairs <= 2) {
+          assert(result eq cometPlan,
+            s"Plan with $pairs pairs should NOT be reverted at threshold 2")
+        } else {
+          assert(countCometExecs(result) == 0,
+            s"Plan with $pairs pairs should be reverted at threshold 2")
+        }
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStagesSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStagesSuite.scala
@@ -21,6 +21,7 @@ package org.apache.comet.rules
 
 import org.apache.spark.sql.CometTestBase
 import org.apache.spark.sql.comet._
+import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 import org.apache.spark.sql.execution._
 
 import org.apache.comet.CometConf
@@ -52,6 +53,21 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
 
   private def countC2RNodes(plan: SparkPlan): Int = {
     plan.collect { case _: ColumnarToRowTransition => true }.size
+  }
+
+  /**
+   * Returns every node that produces a columnar output but consumes a row-based child without a
+   * RowToColumnar transition. Such a node is an invalid columnar/row boundary: a columnar parent
+   * (e.g. a native CometShuffleExchangeExec) requires columnar input. RowToColumnarExec and
+   * CometSparkToColumnarExec are the legitimate row->columnar bridges and are excluded.
+   */
+  private def invalidColumnarBoundaries(plan: SparkPlan): Seq[SparkPlan] = {
+    plan.collect {
+      case n
+          if n.supportsColumnar && !n.isInstanceOf[RowToColumnarTransition] &&
+            n.children.exists(c => !c.supportsColumnar) =>
+        n
+    }
   }
 
   test("rule is a no-op when disabled") {
@@ -206,4 +222,61 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
     }
   }
 
+  test("revertToSpark must not revert native operators across a shuffle stage boundary") {
+    withSQLConf("spark.sql.adaptive.enabled" -> "false") {
+      withParquetTable((0 until 100).map(i => (i, i % 10)), "tbl") {
+        // A GROUP BY produces partial-agg -> native shuffle -> final-agg, i.e. two stages.
+        val df = sql("SELECT _2, count(*) FROM tbl GROUP BY _2")
+        df.collect()
+        val cometPlan = stripAQEPlan(df.queryExecution.executedPlan)
+
+        val shuffles = cometPlan.collect { case s: CometShuffleExchangeExec => s }
+        assume(shuffles.nonEmpty, "test requires a native CometShuffleExchangeExec")
+        assert(
+          shuffles.map(s => countCometExecs(s.child)).sum > 0,
+          "expected native CometExec operators below the shuffle")
+        assert(
+          invalidColumnarBoundaries(cometPlan).isEmpty,
+          s"precondition: original plan should be valid:\n${cometPlan.treeString}")
+
+        val rule = RevertNativeForTransitionHeavyStages(spark)
+        val reverted = rule.revertToSpark(cometPlan)
+
+        val invalid = invalidColumnarBoundaries(reverted)
+        assert(
+          invalid.isEmpty,
+          s"revertToSpark produced invalid columnar/row boundaries " +
+            s"(${invalid.map(_.nodeName).mkString(", ")}):\n${reverted.treeString}")
+      }
+    }
+  }
+
+  test("non-AQE apply must not produce an invalid plan when the result stage reverts") {
+    withSQLConf(
+      CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "true",
+      // Threshold 0 forces the result stage (above the topmost shuffle) to revert.
+      CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "0",
+      "spark.sql.adaptive.enabled" -> "false") {
+      withParquetTable((0 until 100).map(i => (i, i % 10)), "tbl") {
+        val cometPlan =
+          withSQLConf(CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "false") {
+            val df = sql("SELECT _2, count(*) FROM tbl GROUP BY _2")
+            df.collect()
+            stripAQEPlan(df.queryExecution.executedPlan)
+          }
+        assume(
+          cometPlan.collect { case s: CometShuffleExchangeExec => s }.nonEmpty,
+          "test requires a native CometShuffleExchangeExec")
+
+        val rule = RevertNativeForTransitionHeavyStages(spark)
+        val result = rule.apply(cometPlan)
+
+        val invalid = invalidColumnarBoundaries(result)
+        assert(
+          invalid.isEmpty,
+          s"rule.apply produced invalid columnar/row boundaries " +
+            s"(${invalid.map(_.nodeName).mkString(", ")}):\n${result.treeString}")
+      }
+    }
+  }
 }

--- a/spark/src/test/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStagesSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStagesSuite.scala
@@ -71,6 +71,7 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
 
   test("rule does not revert plan below threshold") {
     withSQLConf(
+      CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "true",
       CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "10",
       "spark.comet.exec.project.enabled" -> "false") {
       withTempView("test_data") {
@@ -82,7 +83,7 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
         val rule = RevertNativeForTransitionHeavyStages(spark)
         val transitions = rule.countTransitions(cometPlan)
         assert(transitions > 0, s"Plan should have transitions, got $transitions")
-        assert(transitions <= 10, s"Transitions should be below threshold")
+        assert(transitions <= 10, "Transitions should be below threshold")
 
         val result = rule.apply(cometPlan)
         assert(result eq cometPlan, "Plan should be unchanged when below threshold")
@@ -130,6 +131,7 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
 
   test("non-AQE path applies rule per-stage via transformUp") {
     withSQLConf(
+      CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "true",
       CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "10",
       "spark.sql.adaptive.enabled" -> "false") {
 
@@ -145,6 +147,32 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
         val rule = RevertNativeForTransitionHeavyStages(spark)
         val result = rule.apply(cometPlan)
         assert(result eq cometPlan, "Non-AQE path should not revert when below threshold")
+      }
+    }
+  }
+
+  test("revert fires with unsupported UDF producing transitions") {
+    withParquetTable((0 until 100).map(i => (i, i % 10, s"val_$i")), "tbl") {
+      spark.udf.register("identity_udf", (x: Int) => x)
+      val query = "SELECT _2, identity_udf(_1), count(*) FROM tbl GROUP BY _2, identity_udf(_1)"
+
+      // Without revert, plan should have transitions due from UDF
+      withSQLConf(CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "false") {
+        val df = sql(query)
+        df.collect()
+        val plan = stripAQEPlan(df.queryExecution.executedPlan)
+        assert(countC2RNodes(plan) > 0, "UDF should cause C2R transitions")
+      }
+
+      // With threshold 0, stage should be reverted
+      withSQLConf(
+        CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "true",
+        CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "0") {
+        val (_, cometPlan) = checkSparkAnswer(query)
+        val executedPlan = stripAQEPlan(cometPlan)
+        assert(
+          countCometExecs(executedPlan) == 0,
+          s"Revert should have removed all CometExec nodes:\n${executedPlan.treeString}")
       }
     }
   }
@@ -166,6 +194,7 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
 
       // With revert enabled at threshold 0, all CometExec should be removed
       withSQLConf(
+        CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "true",
         CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "0",
         "spark.comet.exec.project.enabled" -> "false") {
         val (_, cometPlan) = checkSparkAnswer(query)

--- a/spark/src/test/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStagesSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStagesSuite.scala
@@ -21,9 +21,7 @@ package org.apache.comet.rules
 
 import org.apache.spark.sql.CometTestBase
 import org.apache.spark.sql.comet._
-import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 
 import org.apache.comet.CometConf
 
@@ -57,103 +55,43 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
   }
 
   test("rule is a no-op when disabled") {
-    withSQLConf(
-      CometConf.COMET_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "false") {
-      val rule = RevertNativeForTransitionHeavyStages(spark)
-      val sparkPlan = createSparkPlan("SELECT 1")
-      val cometPlan = applyCometExecRule(sparkPlan)
-      val result = rule.apply(cometPlan)
-      assert(result eq cometPlan, "Rule should be a no-op when disabled")
+    withSQLConf(CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "false") {
+      withTempView("test_data") {
+        spark.range(10).toDF("id").createOrReplaceTempView("test_data")
+        val sparkPlan = createSparkPlan("SELECT id, id * 2 FROM test_data WHERE id > 5")
+        val cometPlan = applyCometExecRule(sparkPlan)
+        assert(countCometExecs(cometPlan) > 0, "Plan should have CometExec nodes")
+
+        val rule = RevertNativeForTransitionHeavyStages(spark)
+        val result = rule.apply(cometPlan)
+        assert(result eq cometPlan, "Rule should be a no-op when disabled")
+      }
     }
   }
 
   test("rule does not revert plan below threshold") {
     withSQLConf(
-      CometConf.COMET_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "10") {
+      CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "10",
+      "spark.comet.exec.project.enabled" -> "false") {
       withTempView("test_data") {
         spark.range(10).toDF("id").createOrReplaceTempView("test_data")
         val sparkPlan =
           createSparkPlan("SELECT id, id * 2 as doubled FROM test_data WHERE id > 5")
-        val cometPlan = applyCometExecRule(sparkPlan)
+        val cometPlan = applyFullColumnarPipeline(sparkPlan)
 
         val rule = RevertNativeForTransitionHeavyStages(spark)
+        val transitions = rule.countTransitions(cometPlan)
+        assert(transitions > 0, s"Plan should have transitions, got $transitions")
+        assert(transitions <= 10, s"Transitions should be below threshold")
+
         val result = rule.apply(cometPlan)
         assert(result eq cometPlan, "Plan should be unchanged when below threshold")
       }
     }
   }
 
-  test("countTransitions counts non-root C2R correctly") {
-    withSQLConf(
-      CometConf.COMET_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_ENABLED.key -> "true") {
-      val rule = RevertNativeForTransitionHeavyStages(spark)
-
-      withTempView("test_data") {
-        spark.range(10).toDF("id").createOrReplaceTempView("test_data")
-        val sparkPlan = createSparkPlan("SELECT id FROM test_data")
-        val cometPlan = applyFullColumnarPipeline(sparkPlan)
-
-        val count = rule.countTransitions(cometPlan)
-        // A simple scan+project plan should have 0 or 1 transitions
-        assert(count >= 0, s"Transition count should be non-negative, got $count")
-      }
-    }
-  }
-
-  test("countTransitions counts all C2R nodes including root") {
-    withSQLConf(
-      CometConf.COMET_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_ENABLED.key -> "true") {
-      val rule = RevertNativeForTransitionHeavyStages(spark)
-
-      withTempView("test_data") {
-        spark.range(10).toDF("id").createOrReplaceTempView("test_data")
-        val sparkPlan = createSparkPlan("SELECT id FROM test_data")
-        val cometPlan = applyCometExecRule(sparkPlan)
-
-        // Wrap in a ColumnarToRow (simulating a terminal output)
-        val planWithRootC2R = ColumnarToRowExec(cometPlan)
-        val count = rule.countTransitions(planWithRootC2R)
-        assert(count == 1, s"Should count the C2R node, got $count")
-      }
-    }
-  }
-
-  test("revertToSpark removes CometExec operators") {
-    withSQLConf(
-      CometConf.COMET_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true") {
-
-      withTempView("test_data") {
-        spark.range(10).toDF("id").createOrReplaceTempView("test_data")
-        val sparkPlan =
-          createSparkPlan("SELECT id, id * 2 as doubled FROM test_data WHERE id > 5")
-        val cometPlan = applyCometExecRule(sparkPlan)
-
-        assert(countCometExecs(cometPlan) > 0, "Should have CometExec nodes before revert")
-
-        val rule = RevertNativeForTransitionHeavyStages(spark)
-        val reverted = rule.revertToSpark(cometPlan)
-
-        assert(
-          countCometExecs(reverted) == 0,
-          s"Should have no CometExec nodes after revert, plan:\n${reverted.treeString}")
-      }
-    }
-  }
-
   test("revertToSpark preserves plan structure") {
-    withSQLConf(
-      CometConf.COMET_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true") {
+    withSQLConf(CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true") {
 
       withTempView("test_data") {
         spark.range(10).toDF("id").createOrReplaceTempView("test_data")
@@ -172,17 +110,14 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
   }
 
   test("revertToSpark removes all Comet operators from a plan with transitions") {
-    withSQLConf(
-      CometConf.COMET_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "true") {
+    withSQLConf(CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true") {
 
       withTempView("test_data") {
         spark.range(10).toDF("id").createOrReplaceTempView("test_data")
         val sparkPlan =
           createSparkPlan("SELECT id, id * 2 as doubled FROM test_data WHERE id > 5")
         val cometPlan = applyFullColumnarPipeline(sparkPlan)
+        assert(countCometExecs(cometPlan) > 0, "Should have CometExec nodes before revert")
 
         val rule = RevertNativeForTransitionHeavyStages(spark)
         val result = rule.revertToSpark(cometPlan)
@@ -193,41 +128,8 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
     }
   }
 
-  test("CometShuffleExchangeExec is reverted by revertToSpark") {
-    withSQLConf(
-      CometConf.COMET_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_SHUFFLE_ENABLED.key -> "true",
-      "spark.sql.adaptive.enabled" -> "false") {
-
-      withTempView("test_data") {
-        spark.range(10).toDF("id").createOrReplaceTempView("test_data")
-        val sparkPlan = createSparkPlan("SELECT id FROM test_data DISTRIBUTE BY id")
-        val cometPlan = applyCometExecRule(sparkPlan)
-
-        val cometShuffles = cometPlan.collect { case s: CometShuffleExchangeExec => s }
-        if (cometShuffles.nonEmpty) {
-          val rule = RevertNativeForTransitionHeavyStages(spark)
-          val reverted = rule.revertToSpark(cometPlan)
-          val remainingCometShuffles = reverted.collect { case s: CometShuffleExchangeExec =>
-            s
-          }
-          assert(
-            remainingCometShuffles.isEmpty,
-            "CometShuffleExchangeExec should be reverted to ShuffleExchangeExec")
-          val sparkShuffles = reverted.collect { case s: ShuffleExchangeExec => s }
-          assert(sparkShuffles.nonEmpty, "Should have ShuffleExchangeExec after revert")
-        }
-      }
-    }
-  }
-
   test("non-AQE path applies rule per-stage via transformUp") {
     withSQLConf(
-      CometConf.COMET_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_SHUFFLE_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "true",
       CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "10",
       "spark.sql.adaptive.enabled" -> "false") {
 
@@ -247,31 +149,32 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
     }
   }
 
-  test("default threshold of 2 allows stages with up to 2 transition pairs") {
-    withSQLConf(
-      CometConf.COMET_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "2") {
-      val rule = RevertNativeForTransitionHeavyStages(spark)
+  test("revert fires and produces correct results when transitions exceed threshold") {
+    withParquetTable((0 until 100).map(i => (i, i % 10, s"val_$i")), "tbl") {
+      val query = "SELECT _2, count(*), sum(_1) FROM tbl GROUP BY _2"
 
-      withTempView("test_data") {
-        spark.range(10).toDF("id").createOrReplaceTempView("test_data")
-        val sparkPlan = createSparkPlan("SELECT id FROM test_data")
-        val cometPlan = applyFullColumnarPipeline(sparkPlan)
+      // Without revert, plan should have CometExec nodes with transitions
+      withSQLConf(
+        CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "false",
+        "spark.comet.exec.project.enabled" -> "false") {
+        val df = sql(query)
+        df.collect()
+        val plan = stripAQEPlan(df.queryExecution.executedPlan)
+        assert(countCometExecs(plan) > 0, "Plan without revert should have CometExec nodes")
+        assert(countC2RNodes(plan) > 0, "Plan without revert should have C2R transitions")
+      }
 
-        val pairs = rule.countTransitions(cometPlan)
-        val result = rule.apply(cometPlan)
-        if (pairs <= 2) {
-          assert(
-            result eq cometPlan,
-            s"Plan with $pairs pairs should NOT be reverted at threshold 2")
-        } else {
-          assert(
-            countCometExecs(result) == 0,
-            s"Plan with $pairs pairs should be reverted at threshold 2")
-        }
+      // With revert enabled at threshold 0, all CometExec should be removed
+      withSQLConf(
+        CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "0",
+        "spark.comet.exec.project.enabled" -> "false") {
+        val (_, cometPlan) = checkSparkAnswer(query)
+        val executedPlan = stripAQEPlan(cometPlan)
+        assert(
+          countCometExecs(executedPlan) == 0,
+          s"Revert should have removed all CometExec nodes:\n${executedPlan.treeString}")
       }
     }
   }
+
 }

--- a/spark/src/test/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStagesSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStagesSuite.scala
@@ -245,7 +245,7 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
         val invalid = invalidColumnarBoundaries(reverted)
         assert(
           invalid.isEmpty,
-          s"revertToSpark produced invalid columnar/row boundaries " +
+          "revertToSpark produced invalid columnar/row boundaries " +
             s"(${invalid.map(_.nodeName).mkString(", ")}):\n${reverted.treeString}")
       }
     }
@@ -258,12 +258,12 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
       CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "0",
       "spark.sql.adaptive.enabled" -> "false") {
       withParquetTable((0 until 100).map(i => (i, i % 10)), "tbl") {
-        val cometPlan =
-          withSQLConf(CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "false") {
-            val df = sql("SELECT _2, count(*) FROM tbl GROUP BY _2")
-            df.collect()
-            stripAQEPlan(df.queryExecution.executedPlan)
-          }
+        var cometPlan: SparkPlan = null
+        withSQLConf(CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "false") {
+          val df = sql("SELECT _2, count(*) FROM tbl GROUP BY _2")
+          df.collect()
+          cometPlan = stripAQEPlan(df.queryExecution.executedPlan)
+        }
         assume(
           cometPlan.collect { case s: CometShuffleExchangeExec => s }.nonEmpty,
           "test requires a native CometShuffleExchangeExec")
@@ -274,7 +274,7 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
         val invalid = invalidColumnarBoundaries(result)
         assert(
           invalid.isEmpty,
-          s"rule.apply produced invalid columnar/row boundaries " +
+          "rule.apply produced invalid columnar/row boundaries " +
             s"(${invalid.map(_.nodeName).mkString(", ")}):\n${result.treeString}")
       }
     }

--- a/spark/src/test/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStagesSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStagesSuite.scala
@@ -19,13 +19,13 @@
 
 package org.apache.comet.rules
 
+import org.apache.spark.sql.CometTestBase
 import org.apache.spark.sql.comet._
 import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 
 import org.apache.comet.CometConf
-import org.apache.spark.sql.CometTestBase
 
 class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
 
@@ -77,7 +77,8 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
       CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "10") {
       withTempView("test_data") {
         spark.range(10).toDF("id").createOrReplaceTempView("test_data")
-        val sparkPlan = createSparkPlan("SELECT id, id * 2 as doubled FROM test_data WHERE id > 5")
+        val sparkPlan =
+          createSparkPlan("SELECT id, id * 2 as doubled FROM test_data WHERE id > 5")
         val cometPlan = applyCometExecRule(sparkPlan)
 
         val rule = RevertNativeForTransitionHeavyStages(spark)
@@ -141,7 +142,8 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
         val rule = RevertNativeForTransitionHeavyStages(spark)
         val reverted = rule.revertToSpark(cometPlan)
 
-        assert(countCometExecs(reverted) == 0,
+        assert(
+          countCometExecs(reverted) == 0,
           s"Should have no CometExec nodes after revert, plan:\n${reverted.treeString}")
       }
     }
@@ -162,7 +164,8 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
         val reverted = rule.revertToSpark(cometPlan)
 
         // Reverted plan should have same output schema
-        assert(reverted.output.map(_.name) == cometPlan.output.map(_.name),
+        assert(
+          reverted.output.map(_.name) == cometPlan.output.map(_.name),
           "Output schema should be preserved after revert")
       }
     }
@@ -183,7 +186,8 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
 
         val rule = RevertNativeForTransitionHeavyStages(spark)
         val result = rule.revertToSpark(cometPlan)
-        assert(countCometExecs(result) == 0,
+        assert(
+          countCometExecs(result) == 0,
           s"All CometExec should be reverted. Plan:\n${result.treeString}")
       }
     }
@@ -205,14 +209,14 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
         if (cometShuffles.nonEmpty) {
           val rule = RevertNativeForTransitionHeavyStages(spark)
           val reverted = rule.revertToSpark(cometPlan)
-          val remainingCometShuffles = reverted.collect {
-            case s: CometShuffleExchangeExec => s
+          val remainingCometShuffles = reverted.collect { case s: CometShuffleExchangeExec =>
+            s
           }
-          assert(remainingCometShuffles.isEmpty,
+          assert(
+            remainingCometShuffles.isEmpty,
             "CometShuffleExchangeExec should be reverted to ShuffleExchangeExec")
           val sparkShuffles = reverted.collect { case s: ShuffleExchangeExec => s }
-          assert(sparkShuffles.nonEmpty,
-            "Should have ShuffleExchangeExec after revert")
+          assert(sparkShuffles.nonEmpty, "Should have ShuffleExchangeExec after revert")
         }
       }
     }
@@ -228,17 +232,17 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
       "spark.sql.adaptive.enabled" -> "false") {
 
       withTempView("test_data") {
-        spark.range(10).selectExpr("id", "id % 3 as grp")
+        spark
+          .range(10)
+          .selectExpr("id", "id % 3 as grp")
           .createOrReplaceTempView("test_data")
-        val sparkPlan = createSparkPlan(
-          "SELECT grp, count(*) FROM test_data GROUP BY grp")
+        val sparkPlan = createSparkPlan("SELECT grp, count(*) FROM test_data GROUP BY grp")
         val cometPlan = applyCometExecRule(sparkPlan)
 
         // With high threshold, the non-AQE path should not revert anything
         val rule = RevertNativeForTransitionHeavyStages(spark)
         val result = rule.apply(cometPlan)
-        assert(result eq cometPlan,
-          "Non-AQE path should not revert when below threshold")
+        assert(result eq cometPlan, "Non-AQE path should not revert when below threshold")
       }
     }
   }
@@ -259,10 +263,12 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
         val pairs = rule.countTransitions(cometPlan)
         val result = rule.apply(cometPlan)
         if (pairs <= 2) {
-          assert(result eq cometPlan,
+          assert(
+            result eq cometPlan,
             s"Plan with $pairs pairs should NOT be reverted at threshold 2")
         } else {
-          assert(countCometExecs(result) == 0,
+          assert(
+            countCometExecs(result) == 0,
             s"Plan with $pairs pairs should be reverted at threshold 2")
         }
       }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4518 .

## Rationale for this change

Introduces a stage-aware fallback that reverts stages to Spark row-based execution when the number of C2R transitions exceeds a threshold.

## What changes are included in this PR?

  - `RevertNativeForTransitionHeavyStages` — `postColumnarTransitions` rule that counts C2R transitions per stage and reverts via `CometExec.originalPlan` when threshold exceeded
  - Configs: `spark.comet.exec.transitionRevert.enabled` (default: true), `spark.comet.exec.transitionRevert.maxTransitions` (default: 2, min: 2)
  - Works for both AQE and non-AQE paths
  - 
## How are these changes tested?

Unit tests added