### PR TITLE
feat: surface native parquet read failures as FAILED_READ_FILE

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -68,7 +68,8 @@ class CometExecIterator(
     partitionIndex: Int,
     broadcastedHadoopConfForEncryption: Option[Broadcast[SerializableConfiguration]] = None,
     encryptedFilePaths: Seq[String] = Seq.empty,
-    shuffleBlockIterators: Map[Int, CometShuffleBlockIterator] = Map.empty)
+    shuffleBlockIterators: Map[Int, CometShuffleBlockIterator] = Map.empty,
+    taskFilePaths: Seq[String] = Seq.empty)
     extends Iterator[ColumnarBatch]
     with Logging {
 
@@ -177,20 +178,14 @@ class CometExecIterator(
         // threw the exception, so we log the exception with taskAttemptId here
         logError(s"Native execution for task $taskAttemptId failed", e)
 
-        val parquetError: scala.util.matching.Regex =
-          """^Parquet error: (?:.*)$""".r
-        e.getMessage match {
-          case parquetError() =>
-            // See org.apache.spark.sql.errors.QueryExecutionErrors.failedToReadDataError
-            // See org.apache.parquet.hadoop.ParquetFileReader for error message.
-            // _LEGACY_ERROR_TEMP_2254 has no message placeholders; Spark 4 strict-checks
-            // parameters and raises INTERNAL_ERROR if any are passed.
-            throw new SparkException(
-              errorClass = "_LEGACY_ERROR_TEMP_2254",
-              messageParameters = Map.empty,
-              cause = new SparkException("File is not a Parquet file.", e))
-          case _ =>
-            throw e
+        if (CometExecIterator.isFileReadError(e.getMessage)) {
+          // Wrap in the FAILED_READ_FILE.NO_HINT SparkException Spark produces when its own
+          // parquet reader fails. The shim accesses spark-private APIs (InputFileBlockHolder,
+          // QueryExecutionErrors) from a Spark-package class.
+          throw org.apache.spark.sql.comet.shims.ShimSparkErrorConverter
+            .wrapNativeParquetError(e, taskFilePaths)
+        } else {
+          throw e
         }
       case e: Throwable =>
         throw e
@@ -270,6 +265,32 @@ class CometExecIterator(
 }
 
 object CometExecIterator extends Logging {
+
+  /**
+   * True when a native error message indicates a per-file read failure that Spark would surface
+   * as `FAILED_READ_FILE.NO_HINT` (so we wrap it via
+   * `ShimSparkErrorConverter.wrapNativeParquetError` for error compatibility, matching what
+   * Spark's own parquet reader produces).
+   *
+   * Covers: DataFusion's `Parquet error: ...` (corrupt footer etc.); arrow-rs's `Arrow: Parquet
+   * argument error: ...` / `External: failed to fill whole buffer` (corrupt page or column data
+   * hit during native execution); a truncated/empty or otherwise unreadable file that fails in
+   * the object_store layer before parquet parsing -- a 0-byte footer read gives "Requested range
+   * was invalid", a deleted file gives "Object at location ... not found".
+   *
+   * We match those specific phrasings rather than the broad object_store "Generic <Store> error:"
+   * prefix, because that prefix is also produced for NON-file config errors -- e.g. "Generic
+   * HadoopFileSystem error: Hdfs support is not enabled in this build" -- which must surface
+   * as-is, not masked behind FAILED_READ_FILE.
+   */
+  def isFileReadError(message: String): Boolean = {
+    if (message == null) return false
+    message.startsWith("Parquet error:") ||
+    message.contains("Parquet argument error") ||
+    message.contains("failed to fill whole buffer") ||
+    message.contains("Requested range was invalid") ||
+    (message.contains("Object at location") && message.contains("not found"))
+  }
 
   private def cometSqlConfs: Map[String, String] =
     SQLConf.get.getAllConfs.filter(_._1.startsWith(CometConf.COMET_PREFIX))

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometExecRDD.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometExecRDD.scala
@@ -36,7 +36,8 @@ import org.apache.comet.serde.OperatorOuterClass
 private[spark] class CometExecPartition(
     override val index: Int,
     val inputPartitions: Array[Partition],
-    val planDataByKey: Map[String, Array[Byte]])
+    val planDataByKey: Map[String, Array[Byte]],
+    val filePaths: Seq[String] = Seq.empty)
     extends Partition
 
 /**
@@ -66,7 +67,8 @@ private[spark] class CometExecRDD(
     subqueries: Seq[ScalarSubquery],
     broadcastedHadoopConfForEncryption: Option[Broadcast[SerializableConfiguration]] = None,
     encryptedFilePaths: Seq[String] = Seq.empty,
-    shuffleScanIndices: Set[Int] = Set.empty)
+    shuffleScanIndices: Set[Int] = Set.empty,
+    @transient perPartitionFilePaths: Array[Seq[String]] = Array.empty)
     extends RDD[ColumnarBatch](sc, inputRDDs.map(rdd => new OneToOneDependency(rdd))) {
 
   // Determine partition count: from inputs if available, otherwise from parameter
@@ -90,7 +92,9 @@ private[spark] class CometExecRDD(
     (0 until numPartitions).map { idx =>
       val inputParts = inputRDDs.map(_.partitions(idx)).toArray
       val planData = perPartitionByKey.map { case (key, arr) => key -> arr(idx) }
-      new CometExecPartition(idx, inputParts, planData)
+      val fp =
+        if (perPartitionFilePaths.length > idx) perPartitionFilePaths(idx) else Seq.empty[String]
+      new CometExecPartition(idx, inputParts, planData, fp)
     }.toArray
   }
 
@@ -130,7 +134,8 @@ private[spark] class CometExecRDD(
       partition.index,
       broadcastedHadoopConfForEncryption,
       encryptedFilePaths,
-      shuffleBlockIters)
+      shuffleBlockIters,
+      taskFilePaths = partition.filePaths)
 
     // Register ScalarSubqueries so native code can look them up
     subqueries.foreach(sub => CometScalarSubquery.setSubquery(it.id, sub))
@@ -179,7 +184,8 @@ object CometExecRDD {
       subqueries: Seq[ScalarSubquery],
       broadcastedHadoopConfForEncryption: Option[Broadcast[SerializableConfiguration]] = None,
       encryptedFilePaths: Seq[String] = Seq.empty,
-      shuffleScanIndices: Set[Int] = Set.empty): CometExecRDD = {
+      shuffleScanIndices: Set[Int] = Set.empty,
+      perPartitionFilePaths: Array[Seq[String]] = Array.empty): CometExecRDD = {
     // scalastyle:on
 
     new CometExecRDD(
@@ -194,6 +200,7 @@ object CometExecRDD {
       subqueries,
       broadcastedHadoopConfForEncryption,
       encryptedFilePaths,
-      shuffleScanIndices)
+      shuffleScanIndices,
+      perPartitionFilePaths)
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
@@ -154,7 +154,8 @@ case class CometNativeScanExec(
    * all files for all partitions in the driver, we serialize only common metadata (once) and each
    * partition's files (lazily, as tasks are scheduled).
    */
-  @transient private lazy val serializedPartitionData: (Array[Byte], Array[Array[Byte]]) = {
+  @transient private lazy val serializedPartitionData
+      : (Array[Byte], Array[Array[Byte]], Array[Seq[String]]) = {
     // Outer partitionFilters (wrapper) DPP is resolved by Spark's standard
     // prepare -> waitForSubqueries lifecycle, triggered explicitly via
     // CometLeafExec.ensureSubqueriesResolved called from
@@ -225,12 +226,19 @@ case class CometNativeScanExec(
       partitionNativeScan.toByteArray
     }.toArray
 
-    (commonBytes, perPartitionBytes)
+    // File paths per partition -- threaded through CometExecRDD to CometExecIterator so
+    // wrapNativeParquetError can populate FAILED_READ_FILE.NO_HINT exceptions with the actual
+    // file path.
+    val perPartitionPaths = filePartitions.map(_.files.map(_.filePath.toString).toSeq).toArray
+
+    (commonBytes, perPartitionBytes, perPartitionPaths)
   }
 
   def commonData: Array[Byte] = serializedPartitionData._1
 
   def perPartitionData: Array[Array[Byte]] = serializedPartitionData._2
+
+  def perPartitionFilePaths: Array[Seq[String]] = serializedPartitionData._3
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
     val nativeMetrics = CometMetricNode.fromCometPlan(this)
@@ -259,7 +267,8 @@ case class CometNativeScanExec(
       nativeMetrics,
       Seq.empty,
       broadcastedHadoopConfForEncryption,
-      encryptedFilePaths) {
+      encryptedFilePaths,
+      perPartitionFilePaths = perPartitionFilePaths) {
       override def compute(split: Partition, context: TaskContext): Iterator[ColumnarBatch] = {
         val res = super.compute(split, context)
 

--- a/spark/src/main/spark-3.5/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
+++ b/spark/src/main/spark-3.5/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
@@ -32,6 +32,28 @@ import org.apache.spark.unsafe.types.UTF8String
 
 object ShimSparkErrorConverter {
   val ObjectLocationPattern: Regex = "Object at location (.+?) not found".r
+
+  /**
+   * Wrap a native parquet/IO read failure in the FAILED_READ_FILE-shaped SparkException Spark
+   * itself produces when its own parquet reader fails. Mirrors the spark-4.x shim of the same
+   * name; `QueryExecutionErrors.cannotReadFilesError(Throwable, String)` has the same signature
+   * in Spark 3.5, so the implementation is identical.
+   */
+  def wrapNativeParquetError(
+      cause: Throwable,
+      taskFilePaths: Seq[String] = Seq.empty): Throwable = {
+    val filePath = if (taskFilePaths.nonEmpty) {
+      taskFilePaths.mkString(",")
+    } else {
+      try {
+        val p = org.apache.spark.rdd.InputFileBlockHolder.getInputFilePath
+        if (p == null) "" else p.toString
+      } catch {
+        case _: Throwable => ""
+      }
+    }
+    QueryExecutionErrors.cannotReadFilesError(cause, filePath)
+  }
 }
 
 /**

--- a/spark/src/main/spark-4.x/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
+++ b/spark/src/main/spark-4.x/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
@@ -34,6 +34,33 @@ import org.apache.comet.CometSparkSessionExtensions.isSpark41Plus
 
 object ShimSparkErrorConverter {
   val ObjectLocationPattern: Regex = "Object at location (.+?) not found".r
+
+  /**
+   * Wrap a native parquet/IO read failure in the FAILED_READ_FILE.NO_HINT SparkException Spark
+   * itself produces when its own parquet reader fails. Matches what Spark/Delta tests assert on
+   * (e.g. "Encountered error while reading file" + the path).
+   *
+   * The file path is taken from the per-task file list threaded in from `CometExecIterator` (set
+   * by `CometExecRDD` from the scan's per-partition file paths). Comet's native scan path does
+   * NOT go through Spark's `FileScanRDD`, so `InputFileBlockHolder` is typically not populated;
+   * we fall back to it for any path that does set it, and to an empty string otherwise (the
+   * static phrasing still satisfies the assertions).
+   */
+  def wrapNativeParquetError(
+      cause: Throwable,
+      taskFilePaths: Seq[String] = Seq.empty): Throwable = {
+    val filePath = if (taskFilePaths.nonEmpty) {
+      taskFilePaths.mkString(",")
+    } else {
+      try {
+        val p = org.apache.spark.rdd.InputFileBlockHolder.getInputFilePath
+        if (p == null) "" else p.toString
+      } catch {
+        case _: Throwable => ""
+      }
+    }
+    QueryExecutionErrors.cannotReadFilesError(cause, filePath)
+  }
 }
 
 /**

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -3974,6 +3974,42 @@ class CometExecSuite extends CometTestBase {
     }
   }
 
+  test("native parquet read failure surfaces as FAILED_READ_FILE with the file path") {
+    withTempDir { dir =>
+      val path = new Path(dir.toURI.toString, "corrupt.parquet")
+      makeParquetFileAllPrimitiveTypes(path, dictionaryEnabled = false, 1000)
+      // Corrupt column/page data in the middle of the file while leaving the footer intact, so
+      // Spark's JVM-side footer pre-check passes during planning and the native DataFusion reader
+      // fails during execution -- the path CometExecIterator must wrap as FAILED_READ_FILE.
+      val f = new java.io.File(new java.net.URI(path.toString))
+      val raf = new java.io.RandomAccessFile(f, "rw")
+      val len = raf.length()
+      raf.seek(8) // after the "PAR1" magic header, before the footer
+      raf.write(Array.fill[Byte](math.min(2048, (len / 2).toInt))(0xff.toByte))
+      raf.close()
+
+      withSQLConf(CometConf.COMET_ENABLED.key -> "true") {
+        val e = intercept[Throwable] {
+          spark.read.parquet(path.toString).collect()
+        }
+        // Spark reports its own per-file read failures as FAILED_READ_FILE carrying the path.
+        // Comet's native scan must do the same instead of leaking a raw CometNativeException.
+        val messages = Iterator
+          .iterate(e: Throwable)(_.getCause)
+          .takeWhile(_ != null)
+          .map(t => s"${t.getClass.getName}: ${t.getMessage}")
+          .toList
+        val chain = messages.mkString("\n  ")
+        assert(
+          messages.exists(m => m.contains("FAILED_READ_FILE")),
+          s"Expected a FAILED_READ_FILE exception in the cause chain, but got:\n  $chain")
+        assert(
+          messages.exists(m => m.contains("corrupt.parquet")),
+          s"Expected the offending file path in the cause chain, but got:\n  $chain")
+      }
+    }
+  }
+
 }
 
 case class BucketedTableTestSpec(


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4529.

## Rationale for this change

When Comet's native DataFusion scan hits a corrupt footer, corrupt page/column data, a truncated/empty file, or a deleted file, it rethrew the raw native message instead of Spark's `FAILED_READ_FILE.NO_HINT`. The native path does not go through Spark's `FileScanRDD`, so `InputFileBlockHolder` is usually unpopulated and the offending path was missing.

The prior handling matched only a `^Parquet error:` regex and rewrote to `_LEGACY_ERROR_TEMP_2254` / "File is not a Parquet file.", which both missed most file-read failures and didn't match what Spark's own reader produces.

This is a standalone error-compatibility improvement for all native Parquet scans. It was surfaced while working on the Delta Lake contrib integration (Delta's corrupt-file / broken-checkpoint suites assert the `FAILED_READ_FILE` message and path), so prioritizing it helps that effort.

## What changes are included in this PR?

- `CometExecIterator.isFileReadError` classifies file-read failures by matching the specific native phrasings: DataFusion `Parquet error:`, arrow-rs `Parquet argument error` / `failed to fill whole buffer` (corrupt page/column data hit during execution), and object_store `Requested range was invalid` (truncated/empty) and `Object at location ... not found` (deleted). It deliberately does **not** match the broad `Generic <Store> error:` prefix, which also covers non-file config errors (e.g. `Generic HadoopFileSystem error: Hdfs support is not enabled in this build`) that must surface as-is.
- `ShimSparkErrorConverter.wrapNativeParquetError` (in both the spark-3.5 and spark-4.x shims) wraps the cause via `QueryExecutionErrors.cannotReadFilesError(cause, path)`.
- Per-partition file paths are threaded from `CometNativeScanExec` → `CometExecRDD` → `CometExecIterator` so the wrapped error names the actual file, with an `InputFileBlockHolder` fallback for any path that does populate it.

Scope note: this wraps the direct native-scan execution path (`CometNativeScanExec.doExecuteColumnar`); surfacing the path when a scan is fused into a larger native block is a follow-up.

## How are these changes tested?

New test in `CometExecSuite` writes a valid parquet file, corrupts column/page data in the middle while leaving the footer intact (so Spark's JVM footer pre-check passes and the failure surfaces from the native reader during execution), reads it through Comet, and asserts the cause chain contains a `FAILED_READ_FILE` exception naming the file. The test fails on `main` (raw `CometNativeException`) and passes with this change. `CometExecSuite` passes (127/0).
