### PR TITLE
fix: route StringReplace through codegen dispatcher to fix empty-search divergence

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -192,7 +192,7 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
       classOf[StartsWith] -> CometScalarFunction("starts_with"),
       classOf[StringInstr] -> CometScalarFunction("instr"),
       classOf[StringRepeat] -> CometStringRepeat,
-      classOf[StringReplace] -> CometScalarFunction("replace"),
+      classOf[StringReplace] -> CometStringReplace,
       classOf[StringRPad] -> CometStringRPad,
       classOf[StringLPad] -> CometStringLPad,
       classOf[StringSpace] -> CometScalarFunction("space"),

--- a/spark/src/main/scala/org/apache/comet/serde/strings.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/strings.scala
@@ -21,7 +21,7 @@ package org.apache.comet.serde
 
 import java.util.Locale
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Concat, ConcatWs, Expression, GetJsonObject, If, InitCap, IsNull, Left, Length, Like, Literal, Lower, RegExpReplace, Right, RLike, StringLPad, StringRepeat, StringRPad, StringSplit, Substring, SubstringIndex, Upper}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Concat, ConcatWs, Expression, GetJsonObject, If, InitCap, IsNull, Left, Length, Like, Literal, Lower, RegExpReplace, Right, RLike, StringLPad, StringRepeat, StringReplace, StringRPad, StringSplit, Substring, SubstringIndex, Upper}
 import org.apache.spark.sql.types.{BinaryType, DataTypes, LongType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -99,6 +99,32 @@ object CometInitCap extends CometScalarFunction[InitCap]("initcap") {
       // Falls through to Spark when the dispatcher is disabled.
       CometScalaUDF.emitJvmCodegenDispatch(expr, inputs, binding)
     }
+  }
+}
+
+object CometStringReplace extends CometScalarFunction[StringReplace]("replace") {
+
+  override def getSupportLevel(expr: StringReplace): SupportLevel = Compatible()
+
+  override def convert(
+      expr: StringReplace,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[Expr] = {
+    if (isEmptyStringLiteral(expr.searchExpr) &&
+      !CometConf.isExprAllowIncompat(getExprConfigName(expr))) {
+      // DataFusion's `replace` inserts the replacement between every character (and at both
+      // boundaries) when the search string is empty, whereas Spark short-circuits and returns
+      // the source unchanged. Route through the codegen dispatcher so Spark's own doGenCode
+      // handles this case. https://github.com/apache/datafusion-comet/issues/4497
+      CometScalaUDF.emitJvmCodegenDispatch(expr, inputs, binding)
+    } else {
+      super.convert(expr, inputs, binding)
+    }
+  }
+
+  private def isEmptyStringLiteral(e: Expression): Boolean = e match {
+    case Literal(s: UTF8String, _: StringType) => s.numBytes() == 0
+    case _ => false
   }
 }
 

--- a/spark/src/main/scala/org/apache/comet/serde/strings.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/strings.scala
@@ -110,21 +110,16 @@ object CometStringReplace extends CometScalarFunction[StringReplace]("replace") 
       expr: StringReplace,
       inputs: Seq[Attribute],
       binding: Boolean): Option[Expr] = {
-    if (isEmptyStringLiteral(expr.searchExpr) &&
-      !CometConf.isExprAllowIncompat(getExprConfigName(expr))) {
-      // DataFusion's `replace` inserts the replacement between every character (and at both
-      // boundaries) when the search string is empty, whereas Spark short-circuits and returns
-      // the source unchanged. Route through the codegen dispatcher so Spark's own doGenCode
-      // handles this case. https://github.com/apache/datafusion-comet/issues/4497
-      CometScalaUDF.emitJvmCodegenDispatch(expr, inputs, binding)
-    } else {
+    if (CometConf.isExprAllowIncompat(getExprConfigName(expr))) {
+      // Native path: faster, but DataFusion's `replace` diverges from Spark when the search
+      // string is empty — it inserts the replacement between every character and at both
+      // boundaries, while Spark short-circuits and returns the source unchanged. Opt-in.
       super.convert(expr, inputs, binding)
+    } else {
+      // Default: route through the codegen dispatcher so Spark's own doGenCode handles the
+      // empty-search edge case. https://github.com/apache/datafusion-comet/issues/4497
+      CometScalaUDF.emitJvmCodegenDispatch(expr, inputs, binding)
     }
-  }
-
-  private def isEmptyStringLiteral(e: Expression): Boolean = e match {
-    case Literal(s: UTF8String, _: StringType) => s.numBytes() == 0
-    case _ => false
   }
 }
 

--- a/spark/src/main/scala/org/apache/comet/serde/strings.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/strings.scala
@@ -111,13 +111,13 @@ object CometStringReplace extends CometScalarFunction[StringReplace]("replace") 
       inputs: Seq[Attribute],
       binding: Boolean): Option[Expr] = {
     if (CometConf.isExprAllowIncompat(getExprConfigName(expr))) {
-      // Native path: faster, but DataFusion's `replace` diverges from Spark when the search
-      // string is empty — it inserts the replacement between every character and at both
-      // boundaries, while Spark short-circuits and returns the source unchanged. Opt-in.
+      // The native DataFusion `replace` avoids the JVM allocations of the codegen
+      // dispatcher but is not Spark-compatible for an empty search string, so it is
+      // only used when incompatibility is explicitly allowed.
       super.convert(expr, inputs, binding)
     } else {
-      // Default: route through the codegen dispatcher so Spark's own doGenCode handles the
-      // empty-search edge case. https://github.com/apache/datafusion-comet/issues/4497
+      // Run Spark's own generated code inside the Comet pipeline so the result matches Spark
+      // exactly. Falls back to Spark when the codegen dispatcher is disabled.
       CometScalaUDF.emitJvmCodegenDispatch(expr, inputs, binding)
     }
   }

--- a/spark/src/test/resources/sql-tests/expressions/string/string_replace.sql
+++ b/spark/src/test/resources/sql-tests/expressions/string/string_replace.sql
@@ -24,8 +24,22 @@ INSERT INTO test_str_replace VALUES ('hello world', 'world', 'there'), ('aaa', '
 query
 SELECT replace(s, search, replace) FROM test_str_replace
 
-query ignore(https://github.com/apache/datafusion-comet/issues/3344)
+-- Empty literal search: DataFusion's replace diverges from Spark
+-- (Spark short-circuits and returns the source unchanged). The custom
+-- CometStringReplace serde routes through the codegen dispatcher so
+-- Spark's own doGenCode handles this case.
+-- https://github.com/apache/datafusion-comet/issues/4497
+query
 SELECT replace('hello', '', 'x')
+
+query
+SELECT replace('', '', 'x')
+
+query
+SELECT replace(NULL, '', 'x')
+
+query
+SELECT replace('hello', '', NULL)
 
 -- column + literal + literal
 query

--- a/spark/src/test/resources/sql-tests/expressions/string/string_replace.sql
+++ b/spark/src/test/resources/sql-tests/expressions/string/string_replace.sql
@@ -19,7 +19,7 @@ statement
 CREATE TABLE test_str_replace(s string, search string, replace string) USING parquet
 
 statement
-INSERT INTO test_str_replace VALUES ('hello world', 'world', 'there'), ('aaa', 'a', 'bb'), ('hello', 'xyz', 'abc'), ('', 'a', 'b'), (NULL, 'a', 'b')
+INSERT INTO test_str_replace VALUES ('hello world', 'world', 'there'), ('aaa', 'a', 'bb'), ('hello', 'xyz', 'abc'), ('', 'a', 'b'), (NULL, 'a', 'b'), ('hello', '', 'x')
 
 query
 SELECT replace(s, search, replace) FROM test_str_replace


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4497.

## Rationale for this change

`replace(str, search, replacement)` diverges from Spark when the search string is empty. Spark short-circuits and returns the source unchanged (`UTF8String.replace` checks `search.numBytes == 0`). DataFusion's `replace` instead inserts the replacement between every character and at both boundaries, producing e.g. `replace('hello', '', 'x')` -> `xhxexlxlxox`. The bug applies to both literal empty searches and column-valued empty strings at runtime.

## What changes are included in this PR?

- New `CometStringReplace` serde in `spark/src/main/scala/org/apache/comet/serde/strings.scala`. By default it routes through `CometScalaUDF.emitJvmCodegenDispatch` so Spark's own `doGenCode` runs inside the Comet pipeline. Users can opt back into the native (divergent) path with `spark.comet.expression.StringReplace.allowIncompatible=true`. The pattern mirrors `CometInitCap`.
- `QueryPlanSerde` now wires `StringReplace` to `CometStringReplace` instead of the inline `CometScalarFunction("replace")`.
- `string_replace.sql` removes the `query ignore(#3344)` directive on the empty-literal case, adds rows for empty-source / NULL-source / NULL-replacement, and adds a row `('hello', '', 'x')` to the test table to exercise the column-valued empty-search case.

## Are these changes tested?

Yes. `CometSqlFileTestSuite` runs the updated `string_replace.sql` and passes on Spark 3.5. Compile verified for Spark 3.4 (Java 11), Spark 3.5 (Java 11), and Spark 4.0 (Java 17).

## Are there any user-facing changes?

The default behavior of `replace` becomes Spark-compatible for all empty-search cases. Plans that previously executed `replace` natively now route through the JVM codegen dispatcher when `spark.comet.exec.scalaUDF.codegen.enabled=true` (the default), which is slightly slower than the native path but matches Spark exactly. The native path remains available behind `spark.comet.expression.StringReplace.allowIncompatible=true`.