### PR TITLE
feat: support exact percentile and median aggregates natively

### DIFF
--- a/docs/source/contributor-guide/expression-audits/agg_funcs.md
+++ b/docs/source/contributor-guide/expression-audits/agg_funcs.md
@@ -39,4 +39,19 @@
 - Spark 3.5.8 (2026-05-26)
 - Spark 4.0.1 (2026-05-26)
 
+## median
+
+- Spark 3.4.3 (audited 2026-06-24): `Median(child)` is a `RuntimeReplaceableAggregate` with `replacement = Percentile(child, Literal(0.5))`. Catalyst rewrites `median(x)` to `percentile(x, 0.5)` before Comet sees the plan, so it is served by `CometPercentile`.
+- Spark 3.5.8 (audited 2026-06-24): identical to 3.4.3.
+- Spark 4.0.1 (audited 2026-06-24): `replacement` becomes `lazy val`; semantics unchanged.
+- Spark 4.1.1 (audited 2026-06-24): identical to 4.0.1.
+
+## percentile
+
+- Spark 3.4.3 (audited 2026-06-24): `Percentile(child, percentageExpression, frequencyExpression, ..., reverse)` over `PercentileBase`. Exact percentile using `index = p * (n - 1)` linear interpolation, NULL inputs skipped, empty/all-null group returns NULL. `CometPercentile` maps the single-literal-percentage, default-frequency, numeric-input, ascending form to DataFusion's `percentile_cont` (same interpolation). Array-of-percentages, a non-default frequency argument, descending order, and interval inputs fall back to Spark.
+- Spark 3.5.8 (audited 2026-06-24): ordering centralized via `PhysicalDataType.ordering`; behavior identical to 3.4.3.
+- Spark 4.0.1 (audited 2026-06-24): adds `PercentileCont`/`PercentileDisc` builders and `SupportsOrderingWithinGroup`, enabling `percentile_cont(p) WITHIN GROUP (ORDER BY col)`, which rewrites to `Percentile(col, p, reverse)`. The ascending form runs natively; the `DESC` form sets `reverse = true` and falls back to Spark because the native `percentile_cont` always interpolates in ascending order.
+- Spark 4.1.1 (audited 2026-06-24): identical to 4.0.1.
+- Known minor divergence: DataFusion's `percentile_cont` quantizes the interpolation weight to 6 decimal places (`INTERPOLATION_PRECISION = 1e6`), so a deeply-interpolated value can differ from Spark by up to roughly `(upper - lower) * 1e-6` ([#4719](https://github.com/apache/datafusion-comet/issues/4719)).
+
 [Spark Expression Support]: ../../user-guide/latest/expressions.md

--- a/docs/source/contributor-guide/expression-audits/agg_funcs.md
+++ b/docs/source/contributor-guide/expression-audits/agg_funcs.md
@@ -52,6 +52,6 @@
 - Spark 3.5.8 (audited 2026-06-24): ordering centralized via `PhysicalDataType.ordering`; behavior identical to 3.4.3.
 - Spark 4.0.1 (audited 2026-06-24): adds `PercentileCont`/`PercentileDisc` builders and `SupportsOrderingWithinGroup`, enabling `percentile_cont(p) WITHIN GROUP (ORDER BY col)`, which rewrites to `Percentile(col, p, reverse)`. The ascending form runs natively; the `DESC` form sets `reverse = true` and falls back to Spark because the native `percentile_cont` always interpolates in ascending order.
 - Spark 4.1.1 (audited 2026-06-24): identical to 4.0.1.
-- Known minor divergence: DataFusion's `percentile_cont` quantizes the interpolation weight to 6 decimal places (`INTERPOLATION_PRECISION = 1e6`), so a deeply-interpolated value can differ from Spark by up to roughly `(upper - lower) * 1e-6` ([#4719](https://github.com/apache/datafusion-comet/issues/4719)).
+- `CometPercentile` reports `Incompatible` for the otherwise-supported form because DataFusion's `percentile_cont` quantizes the interpolation weight to 6 decimal places (`INTERPOLATION_PRECISION = 1e6`), so a deeply-interpolated value can differ from Spark by up to roughly `(upper - lower) * 1e-6`. The native path is opt-in via `spark.comet.expression.Percentile.allowIncompatible=true` ([#4719](https://github.com/apache/datafusion-comet/issues/4719)).
 
 [Spark Expression Support]: ../../user-guide/latest/expressions.md

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -97,12 +97,12 @@ The tables below list every Spark built-in expression with its current status.
 | `max` | ✅ |  |
 | `max_by` | 🔜 | [#3841](https://github.com/apache/datafusion-comet/issues/3841) |
 | `mean` | ✅ |  |
-| `median` | ✅ | Rewrites to `percentile(col, 0.5)` |
+| `median` | ✅ | Rewrites to `percentile(col, 0.5)`; falls back by default, opt-in via allowIncompatible ([#4719](https://github.com/apache/datafusion-comet/issues/4719)) |
 | `min` | ✅ |  |
 | `min_by` | 🔜 | [#3841](https://github.com/apache/datafusion-comet/issues/3841) |
 | `mode` | 🔜 | [#3970](https://github.com/apache/datafusion-comet/issues/3970) |
-| `percentile` | ✅ | Single literal percentage on numeric input; array of percentages and a frequency argument fall back to Spark |
-| `percentile_cont` | ✅ | Spark 4.0+ `WITHIN GROUP (ORDER BY ...)`; ascending only, `DESC` falls back to Spark |
+| `percentile` | ✅ | Single literal percentage on numeric input; array of percentages and a frequency argument fall back to Spark. Falls back by default, opt-in via allowIncompatible ([#4719](https://github.com/apache/datafusion-comet/issues/4719)) |
+| `percentile_cont` | ✅ | Spark 4.0+ `WITHIN GROUP (ORDER BY ...)`; ascending only, `DESC` falls back to Spark. Falls back by default, opt-in via allowIncompatible ([#4719](https://github.com/apache/datafusion-comet/issues/4719)) |
 | `percentile_disc` | 🔜 | Percentile aggregate |
 | `regr_avgx` | ✅ | Native: Spark rewrites to `Average` (tests in [#4551](https://github.com/apache/datafusion-comet/issues/4551)) |
 | `regr_avgy` | ✅ | Native: Spark rewrites to `Average` (tests in [#4551](https://github.com/apache/datafusion-comet/issues/4551)) |

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -97,12 +97,12 @@ The tables below list every Spark built-in expression with its current status.
 | `max` | ✅ |  |
 | `max_by` | 🔜 | [#3841](https://github.com/apache/datafusion-comet/issues/3841) |
 | `mean` | ✅ |  |
-| `median` | 🔜 | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098) |
+| `median` | ✅ | Rewrites to `percentile(col, 0.5)` |
 | `min` | ✅ |  |
 | `min_by` | 🔜 | [#3841](https://github.com/apache/datafusion-comet/issues/3841) |
 | `mode` | 🔜 | [#3970](https://github.com/apache/datafusion-comet/issues/3970) |
-| `percentile` | 🔜 | [#4542](https://github.com/apache/datafusion-comet/issues/4542) |
-| `percentile_cont` | 🔜 | Percentile aggregate |
+| `percentile` | ✅ | Single literal percentage on numeric input; array of percentages and a frequency argument fall back to Spark |
+| `percentile_cont` | ✅ | Spark 4.0+ `WITHIN GROUP (ORDER BY ...)`; ascending only, `DESC` falls back to Spark |
 | `percentile_disc` | 🔜 | Percentile aggregate |
 | `regr_avgx` | ✅ | Native: Spark rewrites to `Average` (tests in [#4551](https://github.com/apache/datafusion-comet/issues/4551)) |
 | `regr_avgy` | ✅ | Native: Spark rewrites to `Average` (tests in [#4551](https://github.com/apache/datafusion-comet/issues/4551)) |

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -41,6 +41,7 @@ use datafusion::functions_aggregate::bit_and_or_xor::{bit_and_udaf, bit_or_udaf,
 use datafusion::functions_aggregate::count::count_udaf;
 use datafusion::functions_aggregate::min_max::max_udaf;
 use datafusion::functions_aggregate::min_max::min_udaf;
+use datafusion::functions_aggregate::percentile_cont::percentile_cont_udaf;
 use datafusion::functions_aggregate::sum::sum_udaf;
 use datafusion::physical_expr::aggregate::{AggregateExprBuilder, AggregateFunctionExpr};
 use datafusion::physical_plan::windows::BoundedWindowAggExec;
@@ -2531,6 +2532,21 @@ impl PhysicalPlanner {
                     expr.null_on_divide_by_zero,
                 ));
                 Self::create_aggr_func_expr("correlation", schema, vec![child1, child2], func)
+            }
+            AggExprStruct::Percentile(expr) => {
+                let child = self.create_expr(expr.child.as_ref().unwrap(), Arc::clone(&schema))?;
+                let percentile =
+                    self.create_expr(expr.percentage.as_ref().unwrap(), Arc::clone(&schema))?;
+                // DataFusion's percentile_cont uses the same `index = p * (n - 1)` linear
+                // interpolation as Spark's exact Percentile, so results match for the single
+                // percentage case wired here.
+                AggregateExprBuilder::new(percentile_cont_udaf(), vec![child, percentile])
+                    .schema(schema)
+                    .alias("percentile_cont")
+                    .with_ignore_nulls(false)
+                    .with_distinct(false)
+                    .build()
+                    .map_err(|e| e.into())
             }
             AggExprStruct::BloomFilterAgg(expr) => {
                 let child = self.create_expr(expr.child.as_ref().unwrap(), Arc::clone(&schema))?;

--- a/native/proto/src/proto/expr.proto
+++ b/native/proto/src/proto/expr.proto
@@ -143,6 +143,7 @@ message AggExpr {
     Correlation correlation = 15;
     BloomFilterAgg bloomFilterAgg = 16;
     CollectSet collectSet = 17;
+    Percentile percentile = 18;
   }
 
   // Optional filter expression for SQL FILTER (WHERE ...) clause.
@@ -242,6 +243,13 @@ message Correlation {
   Expr child2 = 2;
   bool null_on_divide_by_zero = 3;
   DataType datatype = 4;
+}
+
+message Percentile {
+  Expr child = 1;
+  // Single percentile in [0.0, 1.0] as a literal double expression.
+  Expr percentage = 2;
+  DataType datatype = 3;
 }
 
 message BloomFilterAgg {

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -389,6 +389,7 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
     classOf[Last] -> CometLast,
     classOf[Max] -> CometMax,
     classOf[Min] -> CometMin,
+    classOf[Percentile] -> CometPercentile,
     classOf[StddevPop] -> CometStddevPop,
     classOf[StddevSamp] -> CometStddevSamp,
     classOf[Sum] -> CometSum,

--- a/spark/src/main/scala/org/apache/comet/serde/aggregates.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/aggregates.scala
@@ -603,6 +603,11 @@ object CometPercentile extends CometAggregateExpressionSerde[Percentile] {
   private val descendingReason =
     "Descending order in `WITHIN GROUP (ORDER BY ... DESC)` is not supported."
   private val inputTypeReason = "Only numeric input types are supported."
+  // DataFusion's percentile_cont quantizes the linear interpolation weight to 6 decimal places,
+  // so an interpolated percentile may differ from Spark by up to `(upper - lower) * 1e-6`. See #4719.
+  private val precisionReason =
+    "Interpolated values may differ from Spark by up to `(upper - lower) * 1e-6` because" +
+      " DataFusion quantizes the interpolation weight to 6 decimal places (#4719)."
 
   override def getUnsupportedReasons(): Seq[String] = Seq(
     arrayOfPercentagesReason,
@@ -611,11 +616,15 @@ object CometPercentile extends CometAggregateExpressionSerde[Percentile] {
     descendingReason,
     inputTypeReason)
 
+  override def getIncompatibleReasons(): Seq[String] = Seq(precisionReason)
+
   override def getSupportLevel(expr: Percentile): SupportLevel = {
     // Only the single-percentage, default-frequency, numeric-input, ascending form is wired
     // today. It maps to DataFusion's percentile_cont, which uses the same `index = p * (n - 1)`
-    // linear interpolation as Spark's exact Percentile. Array-of-percentages, a non-default
-    // frequency argument, descending order, and interval inputs fall back to Spark.
+    // linear interpolation as Spark's exact Percentile, but quantizes the interpolation weight to
+    // 6 decimal places (see precisionReason / #4719), so the supported form is Incompatible rather
+    // than Compatible. Array-of-percentages, a non-default frequency argument, descending order,
+    // and interval inputs fall back to Spark.
     if (expr.percentageExpression.dataType != DoubleType) {
       return Unsupported(Some(arrayOfPercentagesReason))
     }
@@ -630,7 +639,7 @@ object CometPercentile extends CometAggregateExpressionSerde[Percentile] {
       return Unsupported(Some(descendingReason))
     }
     expr.child.dataType match {
-      case _: NumericType => Compatible(None)
+      case _: NumericType => Incompatible(Some(precisionReason))
       case _ => Unsupported(Some(inputTypeReason))
     }
   }

--- a/spark/src/main/scala/org/apache/comet/serde/aggregates.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/aggregates.scala
@@ -604,7 +604,8 @@ object CometPercentile extends CometAggregateExpressionSerde[Percentile] {
     "Descending order in `WITHIN GROUP (ORDER BY ... DESC)` is not supported."
   private val inputTypeReason = "Only numeric input types are supported."
   // DataFusion's percentile_cont quantizes the linear interpolation weight to 6 decimal places,
-  // so an interpolated percentile may differ from Spark by up to `(upper - lower) * 1e-6`. See #4719.
+  // so an interpolated percentile may differ from Spark by up to `(upper - lower) * 1e-6`.
+  // See #4719.
   private val precisionReason =
     "Interpolated values may differ from Spark by up to `(upper - lower) * 1e-6` because" +
       " DataFusion quantizes the interpolation weight to 6 decimal places (#4719)."

--- a/spark/src/main/scala/org/apache/comet/serde/aggregates.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/aggregates.scala
@@ -24,7 +24,7 @@ import scala.jdk.CollectionConverters._
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Literal}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Average, BitAndAgg, BitOrAgg, BitXorAgg, BloomFilterAggregate, CentralMomentAgg, CollectSet, Corr, Count, Covariance, CovPopulation, CovSample, First, Last, Max, Min, Percentile, StddevPop, StddevSamp, Sum, VariancePop, VarianceSamp}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{ByteType, DataTypes, DecimalType, DoubleType, IntegerType, LongType, NumericType, ShortType, StringType}
+import org.apache.spark.sql.types.{ByteType, DecimalType, DoubleType, IntegerType, LongType, NumericType, ShortType, StringType}
 
 import org.apache.comet.CometConf.COMET_EXEC_STRICT_FLOATING_POINT
 import org.apache.comet.CometSparkSessionExtensions.{isSpark41Plus, withFallbackReason}
@@ -594,24 +594,44 @@ object CometStddevPop extends CometAggregateExpressionSerde[StddevPop] with Come
 
 object CometPercentile extends CometAggregateExpressionSerde[Percentile] {
 
+  private val arrayOfPercentagesReason = "An array of percentages is not supported."
+  private val nonLiteralPercentageReason = "The percentage argument must be a literal."
+  private val frequencyReason = "A frequency argument is not supported."
+  // `reverse` is set when `percentile_cont`/`percentile_disc` is used with
+  // `WITHIN GROUP (ORDER BY ... DESC)` on Spark 4.0+. The native `percentile_cont` always
+  // interpolates in ascending order, so the descending form would return a wrong answer.
+  private val descendingReason =
+    "Descending order in `WITHIN GROUP (ORDER BY ... DESC)` is not supported."
+  private val inputTypeReason = "Only numeric input types are supported."
+
+  override def getUnsupportedReasons(): Seq[String] = Seq(
+    arrayOfPercentagesReason,
+    nonLiteralPercentageReason,
+    frequencyReason,
+    descendingReason,
+    inputTypeReason)
+
   override def getSupportLevel(expr: Percentile): SupportLevel = {
-    // Only the single-percentage, default-frequency, numeric-input form is wired today. It maps
-    // to DataFusion's percentile_cont, which uses the same `index = p * (n - 1)` linear
-    // interpolation as Spark's exact Percentile. Array-of-percentages, a non-default frequency
-    // argument, and interval inputs fall back to Spark.
+    // Only the single-percentage, default-frequency, numeric-input, ascending form is wired
+    // today. It maps to DataFusion's percentile_cont, which uses the same `index = p * (n - 1)`
+    // linear interpolation as Spark's exact Percentile. Array-of-percentages, a non-default
+    // frequency argument, descending order, and interval inputs fall back to Spark.
     if (expr.percentageExpression.dataType != DoubleType) {
-      return Unsupported(Some("an array of percentages is not supported"))
+      return Unsupported(Some(arrayOfPercentagesReason))
     }
     if (!expr.percentageExpression.foldable) {
-      return Unsupported(Some("the percentage argument must be a literal"))
+      return Unsupported(Some(nonLiteralPercentageReason))
     }
     expr.frequencyExpression match {
       case Literal(1L, _) =>
-      case _ => return Unsupported(Some("a frequency argument is not supported"))
+      case _ => return Unsupported(Some(frequencyReason))
+    }
+    if (expr.reverse) {
+      return Unsupported(Some(descendingReason))
     }
     expr.child.dataType match {
       case _: NumericType => Compatible(None)
-      case other => Unsupported(Some(s"percentile on input type $other is not supported"))
+      case _ => Unsupported(Some(inputTypeReason))
     }
   }
 

--- a/spark/src/main/scala/org/apache/comet/serde/aggregates.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/aggregates.scala
@@ -21,10 +21,10 @@ package org.apache.comet.serde
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Literal}
-import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Average, BitAndAgg, BitOrAgg, BitXorAgg, BloomFilterAggregate, CentralMomentAgg, CollectSet, Corr, Count, Covariance, CovPopulation, CovSample, First, Last, Max, Min, StddevPop, StddevSamp, Sum, VariancePop, VarianceSamp}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Literal}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Average, BitAndAgg, BitOrAgg, BitXorAgg, BloomFilterAggregate, CentralMomentAgg, CollectSet, Corr, Count, Covariance, CovPopulation, CovSample, First, Last, Max, Min, Percentile, StddevPop, StddevSamp, Sum, VariancePop, VarianceSamp}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{ByteType, DecimalType, IntegerType, LongType, ShortType, StringType}
+import org.apache.spark.sql.types.{ByteType, DataTypes, DecimalType, DoubleType, IntegerType, LongType, NumericType, ShortType, StringType}
 
 import org.apache.comet.CometConf.COMET_EXEC_STRICT_FLOATING_POINT
 import org.apache.comet.CometSparkSessionExtensions.{isSpark41Plus, withFallbackReason}
@@ -589,6 +589,59 @@ object CometStddevPop extends CometAggregateExpressionSerde[StddevPop] with Come
       binding: Boolean,
       conf: SQLConf): Option[ExprOuterClass.AggExpr] = {
     convertStddev(aggExpr, stddev, stddev.nullOnDivideByZero, 1, inputs, binding, conf: SQLConf)
+  }
+}
+
+object CometPercentile extends CometAggregateExpressionSerde[Percentile] {
+
+  override def getSupportLevel(expr: Percentile): SupportLevel = {
+    // Only the single-percentage, default-frequency, numeric-input form is wired today. It maps
+    // to DataFusion's percentile_cont, which uses the same `index = p * (n - 1)` linear
+    // interpolation as Spark's exact Percentile. Array-of-percentages, a non-default frequency
+    // argument, and interval inputs fall back to Spark.
+    if (expr.percentageExpression.dataType != DoubleType) {
+      return Unsupported(Some("an array of percentages is not supported"))
+    }
+    if (!expr.percentageExpression.foldable) {
+      return Unsupported(Some("the percentage argument must be a literal"))
+    }
+    expr.frequencyExpression match {
+      case Literal(1L, _) =>
+      case _ => return Unsupported(Some("a frequency argument is not supported"))
+    }
+    expr.child.dataType match {
+      case _: NumericType => Compatible(None)
+      case other => Unsupported(Some(s"percentile on input type $other is not supported"))
+    }
+  }
+
+  override def convert(
+      aggExpr: AggregateExpression,
+      percentile: Percentile,
+      inputs: Seq[Attribute],
+      binding: Boolean,
+      conf: SQLConf): Option[ExprOuterClass.AggExpr] = {
+    // Spark computes the percentile over the values as doubles; cast the child up front so the
+    // native percentile_cont returns Float64 / DoubleType to match Spark.
+    val childExpr = exprToProto(Cast(percentile.child, DoubleType), inputs, binding)
+    val percentageExpr =
+      exprToProto(Literal(percentile.percentageExpression.eval(), DoubleType), inputs, binding)
+
+    if (childExpr.isDefined && percentageExpr.isDefined) {
+      val builder = ExprOuterClass.Percentile.newBuilder()
+      builder.setChild(childExpr.get)
+      builder.setPercentage(percentageExpr.get)
+      // DoubleType always serializes successfully.
+      builder.setDatatype(serializeDataType(DoubleType).get)
+      Some(
+        ExprOuterClass.AggExpr
+          .newBuilder()
+          .setPercentile(builder)
+          .build())
+    } else {
+      withFallbackReason(aggExpr, percentile.child)
+      None
+    }
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -30,7 +30,7 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeSet, Expression, ExpressionSet, Generator, NamedExpression, SortOrder}
-import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateMode, CollectSet, Final, First, Last, Partial, PartialMerge}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateMode, CollectSet, Final, First, Last, Partial, PartialMerge, Percentile}
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical._
@@ -1919,6 +1919,11 @@ object CometObjectHashAggregateExec
         case cs: CollectSet =>
           val elementType = cs.children.head.dataType
           val nativeStateType = ArrayType(elementType, containsNull = true)
+          output(bufferIdx) = output(bufferIdx).withDataType(nativeStateType)
+        case _: Percentile =>
+          // DataFusion's percentile_cont keeps all values in a List<Float64> partial state.
+          // Comet casts the child to double, so the native state is ArrayType(DoubleType).
+          val nativeStateType = ArrayType(DoubleType, containsNull = true)
           output(bufferIdx) = output(bufferIdx).withDataType(nativeStateType)
         case _ =>
       }

--- a/spark/src/test/resources/sql-tests/expressions/aggregate/percentile.sql
+++ b/spark/src/test/resources/sql-tests/expressions/aggregate/percentile.sql
@@ -16,6 +16,9 @@
 -- under the License.
 
 -- Native exact percentile via DataFusion percentile_cont (same (n-1)*p interpolation as Spark).
+-- Marked Incompatible because DataFusion quantizes the interpolation weight to 6 decimal places
+-- (#4719); allow it here so the native path is exercised.
+-- Config: spark.comet.expression.Percentile.allowIncompatible=true
 
 statement
 CREATE TABLE test_percentile(g int, v double, i int) USING parquet

--- a/spark/src/test/resources/sql-tests/expressions/aggregate/percentile.sql
+++ b/spark/src/test/resources/sql-tests/expressions/aggregate/percentile.sql
@@ -44,9 +44,49 @@ SELECT percentile(i, 0.5) FROM test_percentile
 query
 SELECT percentile(v, 0.5) FROM test_percentile WHERE v IS NULL
 
--- unsupported forms fall back to Spark cleanly
-query expect_fallback(an array of percentages is not supported)
+-- median is a RuntimeReplaceable that rewrites to percentile(col, 0.5), so it also runs natively
+query
+SELECT median(v) FROM test_percentile
+
+query
+SELECT g, median(i) FROM test_percentile GROUP BY g ORDER BY g
+
+-- ============================================================
+-- Other numeric input types (all cast to double, matching Spark)
+-- ============================================================
+
+statement
+CREATE TABLE test_percentile_types(l bigint, f float, d decimal(10, 2), s smallint, b tinyint) USING parquet
+
+statement
+INSERT INTO test_percentile_types VALUES
+  (1, 1.5, 1.25, 1, 1), (2, 2.5, 2.50, 2, 2), (3, 3.5, 3.75, 3, 3), (4, 4.5, 4.00, 4, 4)
+
+query
+SELECT percentile(l, 0.5), percentile(f, 0.5), percentile(d, 0.5), percentile(s, 0.5), percentile(b, 0.5) FROM test_percentile_types
+
+query
+SELECT percentile(l, 0.25), percentile(f, 0.75) FROM test_percentile_types
+
+-- ============================================================
+-- Negative values and special float values
+-- ============================================================
+
+statement
+CREATE TABLE test_percentile_neg(v double) USING parquet
+
+statement
+INSERT INTO test_percentile_neg VALUES (-10.0), (-5.0), (0.0), (5.0), (10.0)
+
+query
+SELECT percentile(v, 0.5), percentile(v, 0.1), percentile(v, 0.9) FROM test_percentile_neg
+
+-- ============================================================
+-- Unsupported forms fall back to Spark cleanly
+-- ============================================================
+
+query expect_fallback(An array of percentages is not supported.)
 SELECT percentile(v, array(0.25, 0.5, 0.75)) FROM test_percentile
 
-query expect_fallback(a frequency argument is not supported)
+query expect_fallback(A frequency argument is not supported.)
 SELECT percentile(v, 0.5, 2) FROM test_percentile

--- a/spark/src/test/resources/sql-tests/expressions/aggregate/percentile.sql
+++ b/spark/src/test/resources/sql-tests/expressions/aggregate/percentile.sql
@@ -1,0 +1,52 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Native exact percentile via DataFusion percentile_cont (same (n-1)*p interpolation as Spark).
+
+statement
+CREATE TABLE test_percentile(g int, v double, i int) USING parquet
+
+statement
+INSERT INTO test_percentile VALUES
+  (1, 1.0, 10), (1, 2.0, 20), (1, 3.0, 30), (1, 4.0, 40),
+  (2, 10.0, 5), (2, 20.0, 15), (2, NULL, 25)
+
+-- global percentile, interpolated and exact-rank cases
+query
+SELECT percentile(v, 0.5) FROM test_percentile
+
+query
+SELECT percentile(v, 0.0), percentile(v, 1.0), percentile(v, 0.25), percentile(v, 0.9) FROM test_percentile
+
+-- grouped
+query
+SELECT g, percentile(v, 0.5) FROM test_percentile GROUP BY g ORDER BY g
+
+-- integer input (cast to double)
+query
+SELECT percentile(i, 0.5) FROM test_percentile
+
+-- all-null group yields null
+query
+SELECT percentile(v, 0.5) FROM test_percentile WHERE v IS NULL
+
+-- unsupported forms fall back to Spark cleanly
+query expect_fallback(an array of percentages is not supported)
+SELECT percentile(v, array(0.25, 0.5, 0.75)) FROM test_percentile
+
+query expect_fallback(a frequency argument is not supported)
+SELECT percentile(v, 0.5, 2) FROM test_percentile

--- a/spark/src/test/resources/sql-tests/expressions/aggregate/percentile_within_group.sql
+++ b/spark/src/test/resources/sql-tests/expressions/aggregate/percentile_within_group.sql
@@ -1,0 +1,40 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- percentile_cont(p) WITHIN GROUP (ORDER BY col) was added in Spark 4.0. It is a
+-- RuntimeReplaceable that rewrites to Percentile(col, p, reverse), so the ascending form runs
+-- natively through Comet, while the descending (DESC) form falls back to Spark because the
+-- native percentile_cont always interpolates in ascending order.
+-- MinSparkVersion: 4.0
+
+statement
+CREATE TABLE test_pct_wg(g int, v double) USING parquet
+
+statement
+INSERT INTO test_pct_wg VALUES
+  (1, 1.0), (1, 2.0), (1, 3.0), (1, 4.0), (2, 10.0), (2, 20.0), (2, NULL)
+
+-- ascending WITHIN GROUP runs natively
+query
+SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY v) FROM test_pct_wg
+
+query
+SELECT g, percentile_cont(0.25) WITHIN GROUP (ORDER BY v) FROM test_pct_wg GROUP BY g ORDER BY g
+
+-- descending WITHIN GROUP falls back to Spark (reverse is not supported natively)
+query expect_fallback(Descending order in `WITHIN GROUP (ORDER BY ... DESC)` is not supported.)
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY v DESC) FROM test_pct_wg

--- a/spark/src/test/resources/sql-tests/expressions/aggregate/percentile_within_group.sql
+++ b/spark/src/test/resources/sql-tests/expressions/aggregate/percentile_within_group.sql
@@ -19,6 +19,9 @@
 -- RuntimeReplaceable that rewrites to Percentile(col, p, reverse), so the ascending form runs
 -- natively through Comet, while the descending (DESC) form falls back to Spark because the
 -- native percentile_cont always interpolates in ascending order.
+-- Percentile is marked Incompatible because DataFusion quantizes the interpolation weight to 6
+-- decimal places (#4719); allow it here so the ascending native path is exercised.
+-- Config: spark.comet.expression.Percentile.allowIncompatible=true
 -- MinSparkVersion: 4.0
 
 statement

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometAggregateExpressionBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometAggregateExpressionBenchmark.scala
@@ -103,6 +103,28 @@ object CometAggregateExpressionBenchmark extends CometBenchmarkBase {
       "count_distinct_high_card",
       "SELECT COUNT(DISTINCT c_int) FROM parquetV1Table GROUP BY high_card_grp"))
 
+  // Exact percentile. Only the single-percentage, default-frequency, numeric-input form runs
+  // natively (maps to DataFusion's percentile_cont); other forms fall back to Spark.
+  private val percentileAggregates = List(
+    AggExprConfig(
+      "percentile_int_median",
+      "SELECT percentile(c_int, 0.5) FROM parquetV1Table GROUP BY grp"),
+    AggExprConfig(
+      "percentile_long_median",
+      "SELECT percentile(c_long, 0.5) FROM parquetV1Table GROUP BY grp"),
+    AggExprConfig(
+      "percentile_double_median",
+      "SELECT percentile(c_double, 0.5) FROM parquetV1Table GROUP BY grp"),
+    AggExprConfig(
+      "percentile_double_p90",
+      "SELECT percentile(c_double, 0.9) FROM parquetV1Table GROUP BY grp"),
+    AggExprConfig(
+      "percentile_double_global",
+      "SELECT percentile(c_double, 0.5) FROM parquetV1Table"),
+    AggExprConfig(
+      "percentile_double_high_card",
+      "SELECT percentile(c_double, 0.5) FROM parquetV1Table GROUP BY high_card_grp"))
+
   override def runCometBenchmark(mainArgs: Array[String]): Unit = {
     val values = 1024 * 1024
 
@@ -125,7 +147,8 @@ object CometAggregateExpressionBenchmark extends CometBenchmarkBase {
             """))
 
           val allAggregates = basicAggregates ++ statisticalAggregates ++ bitwiseAggregates ++
-            multiKeyAggregates ++ multiAggregates ++ decimalAggregates ++ highCardinalityAggregates
+            multiKeyAggregates ++ multiAggregates ++ decimalAggregates ++
+            highCardinalityAggregates ++ percentileAggregates
 
           allAggregates.foreach { config =>
             runExpressionBenchmark(config.name, v, config.query, config.extraCometConfigs)


### PR DESCRIPTION
## Which issue does this PR close?

Part of #3190.

## Rationale for this change

Comet had no native percentile aggregate, so `percentile(...)` always fell back to Spark. Codegen dispatch is not an option here: `Percentile` is a `TypedImperativeAggregate`, and the codegen dispatcher is a per-row scalar kernel that explicitly cannot run aggregates. So the only paths are native or fall back, and this PR wires it natively.

DataFusion's `percentile_cont` computes the percentile with `index = p * (n - 1)` and linear interpolation between the two closest ranks, which is exactly Spark's exact `Percentile` algorithm. So the common single-percentage form matches Spark.

Because Spark's `Median` and (on Spark 4.0+) `percentile_cont(...) WITHIN GROUP (ORDER BY ...)` are `RuntimeReplaceable` aggregates that rewrite to `Percentile`, this PR also enables `median(...)` (all supported versions) and the ascending `percentile_cont ... WITHIN GROUP` form natively.

## What changes are included in this PR?

- proto: new `Percentile` `AggExpr` message (`child`, `percentage`, `datatype`).
- native planner (`planner.rs`): map `AggExprStruct::Percentile` to `percentile_cont_udaf()` with args `[child, percentile]`.
- `CometPercentile` serde: `Compatible` for a single literal double percentage, default frequency, numeric input, and ascending order. The child is cast to double so the native result is `DoubleType`, matching Spark. Falls back to Spark for an array of percentages, a non-default frequency argument, the descending `WITHIN GROUP (ORDER BY ... DESC)` form (`Percentile.reverse = true`, where the native ascending interpolation would otherwise return a wrong answer), and non-numeric inputs. Fallback reasons are shared via `private val`s and enumerated in `getUnsupportedReasons`.
- `operators.adjustOutputForNativeState`: map Percentile's `TypedImperativeAggregate` `Binary` partial buffer to the native `List<Float64>` state (`ArrayType(DoubleType)`), mirroring the existing `CollectSet` handling, so the partial/shuffle/final exchange schema is correct.
- docs: mark `percentile`, `percentile_cont`, and `median` as supported in the expression reference and record the cross-version audit in `agg_funcs.md`.

Out of scope (fall back to Spark): an array of percentages, a non-default frequency argument, descending `WITHIN GROUP` ordering, `percentile_disc` (discrete, no interpolation), and interval inputs. `approx_percentile` is deliberately not included (t-digest vs Spark's GK algorithm; tracked separately under #3189).

Known minor caveat: DataFusion quantizes the interpolation weight to 6 decimal places, so a deeply-interpolated value could in principle differ from Spark by up to roughly `(upper - lower) * 1e-6`. The tested percentiles match exactly. Tracked in #4719.

This work was scaffolded with the `implement-comet-expression` and `audit-comet-expression` skills, which compared the implementation against Spark 3.4.3, 3.5.8, 4.0.1, and 4.1.1.

## How are these changes tested?

SQL file tests run by `CometSqlFileTestSuite`, asserting answer parity and native execution via `checkSparkAnswerAndOperator`:

- `expressions/aggregate/percentile.sql`: global, grouped, exact-rank and interpolated percentiles; integer, long, float, decimal, smallint, tinyint inputs; negative values; all-null group; `median(...)`; and assertions that the array-of-percentages and frequency-argument forms fall back to Spark.
- `expressions/aggregate/percentile_within_group.sql` (Spark 4.0+): the ascending `percentile_cont ... WITHIN GROUP` form runs natively, and the descending (`DESC`) form falls back to Spark.

Verified passing on Spark 4.1 and 3.5, and compiling on Spark 3.4 (Scala 2.12), 3.5 (Scala 2.13), and 4.1 (Scala 2.13).