### PR TITLE
feat: support dayname and monthname natively

### DIFF
--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -407,10 +407,13 @@
 
 - [x] add_months
 - [x] convert_timezone
-- [ ] curdate
-- [ ] current_date
+- [x] curdate
+  - Alias of `current_date`; constant-folded to a literal by Spark's `ComputeCurrentTime` rule before Comet sees the plan.
+- [x] current_date
+  - Constant-folded to a literal by Spark's `ComputeCurrentTime` rule before Comet sees the plan.
 - [ ] current_time
-- [ ] current_timestamp
+- [x] current_timestamp
+  - Constant-folded to a literal by Spark's `ComputeCurrentTime` rule before Comet sees the plan.
 - [x] current_timezone
 - [x] date_add
 - [x] date_diff
@@ -423,7 +426,8 @@
 - [x] datediff
 - [x] datepart
 - [x] day
-- [ ] dayname
+- [x] dayname
+  - Spark 4.0+. Has no native lowering; routed through the codegen dispatcher (runs Spark's own `doGenCode`), gated by `spark.comet.exec.scalaUDF.codegen.enabled` (default true).
 - [x] dayofmonth
 - [x] dayofweek
 - [x] dayofyear
@@ -442,15 +446,18 @@
 - [ ] make_interval
 - [ ] make_time
 - [x] make_timestamp
-- [ ] make_timestamp_ltz
-- [ ] make_timestamp_ntz
+- [x] make_timestamp_ltz
+  - The 6-argument form rewrites to `MakeTimestamp` and runs via the codegen dispatcher. The 2-argument `(date, time)` form requires the Spark 4.1 TIME type and falls back.
+- [x] make_timestamp_ntz
+  - The 6-argument form rewrites to `MakeTimestamp` and runs via the codegen dispatcher. The 2-argument `(date, time)` form requires the Spark 4.1 TIME type and falls back.
 - [ ] make_ym_interval
 - [x] minute
 - [x] month
 - [ ] monthname
 - [x] months_between
 - [x] next_day
-- [ ] now
+- [x] now
+  - Alias of `current_timestamp`; constant-folded to a literal by Spark's `ComputeCurrentTime` rule before Comet sees the plan.
 - [x] quarter
 - [x] second
 - [ ] session_window
@@ -459,11 +466,15 @@
 - [x] timestamp_micros
 - [x] timestamp_millis
 - [x] timestamp_seconds
-- [ ] to_date
+- [x] to_date
+  - Rewrites to `Cast` (no format, native) or `Cast(GetTimestamp(...))` (with format, via the codegen dispatcher) before Comet sees the plan.
 - [ ] to_time
-- [ ] to_timestamp
-- [ ] to_timestamp_ltz
-- [ ] to_timestamp_ntz
+- [x] to_timestamp
+  - Rewrites to `Cast` (no format, native) or `GetTimestamp` (with format, via the codegen dispatcher) before Comet sees the plan.
+- [x] to_timestamp_ltz
+  - Rewrites to `to_timestamp` with `TimestampType`; same support as `to_timestamp`.
+- [x] to_timestamp_ntz
+  - Rewrites to `to_timestamp` with `TimestampNTZType`; same support as `to_timestamp`.
 - [x] to_unix_timestamp
 - [x] to_utc_timestamp
   - Spark 3.4.3 (audited 2026-05-12): identical to 3.5.8.

--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -424,7 +424,7 @@
 - [x] datepart
 - [x] day
 - [x] dayname
-  - Spark 4.0+. Has no native lowering; routed through the codegen dispatcher (runs Spark's own `doGenCode`), gated by `spark.comet.exec.scalaUDF.codegen.enabled` (default true).
+  - Spark 4.0+. Implemented natively: maps a `DateType` value to a fixed US-English abbreviated day name (`DayOfWeek.getDisplayName(TextStyle.SHORT, Locale.US)`), with no session-locale or timezone dependence.
 - [x] dayofmonth
 - [x] dayofweek
 - [x] dayofyear
@@ -449,7 +449,7 @@
 - [x] minute
 - [x] month
 - [x] monthname
-  - Spark 4.0+. Has no native lowering; routed through the codegen dispatcher (runs Spark's own `doGenCode`), gated by `spark.comet.exec.scalaUDF.codegen.enabled` (default true).
+  - Spark 4.0+. Implemented natively: maps a `DateType` value to a fixed US-English abbreviated month name (`Month.getDisplayName(TextStyle.SHORT, Locale.US)`), with no session-locale or timezone dependence.
 - [x] months_between
 - [x] next_day
 - [ ] now

--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -407,13 +407,10 @@
 
 - [x] add_months
 - [x] convert_timezone
-- [x] curdate
-  - Alias of `current_date`; constant-folded to a literal by Spark's `ComputeCurrentTime` rule before Comet sees the plan.
-- [x] current_date
-  - Constant-folded to a literal by Spark's `ComputeCurrentTime` rule before Comet sees the plan.
+- [ ] curdate
+- [ ] current_date
 - [ ] current_time
-- [x] current_timestamp
-  - Constant-folded to a literal by Spark's `ComputeCurrentTime` rule before Comet sees the plan.
+- [ ] current_timestamp
 - [x] current_timezone
 - [x] date_add
 - [x] date_diff
@@ -446,18 +443,16 @@
 - [ ] make_interval
 - [ ] make_time
 - [x] make_timestamp
-- [x] make_timestamp_ltz
-  - The 6-argument form rewrites to `MakeTimestamp` and runs via the codegen dispatcher. The 2-argument `(date, time)` form requires the Spark 4.1 TIME type and falls back.
-- [x] make_timestamp_ntz
-  - The 6-argument form rewrites to `MakeTimestamp` and runs via the codegen dispatcher. The 2-argument `(date, time)` form requires the Spark 4.1 TIME type and falls back.
+- [ ] make_timestamp_ltz
+- [ ] make_timestamp_ntz
 - [ ] make_ym_interval
 - [x] minute
 - [x] month
-- [ ] monthname
+- [x] monthname
+  - Spark 4.0+. Has no native lowering; routed through the codegen dispatcher (runs Spark's own `doGenCode`), gated by `spark.comet.exec.scalaUDF.codegen.enabled` (default true).
 - [x] months_between
 - [x] next_day
-- [x] now
-  - Alias of `current_timestamp`; constant-folded to a literal by Spark's `ComputeCurrentTime` rule before Comet sees the plan.
+- [ ] now
 - [x] quarter
 - [x] second
 - [ ] session_window
@@ -466,15 +461,11 @@
 - [x] timestamp_micros
 - [x] timestamp_millis
 - [x] timestamp_seconds
-- [x] to_date
-  - Rewrites to `Cast` (no format, native) or `Cast(GetTimestamp(...))` (with format, via the codegen dispatcher) before Comet sees the plan.
+- [ ] to_date
 - [ ] to_time
-- [x] to_timestamp
-  - Rewrites to `Cast` (no format, native) or `GetTimestamp` (with format, via the codegen dispatcher) before Comet sees the plan.
-- [x] to_timestamp_ltz
-  - Rewrites to `to_timestamp` with `TimestampType`; same support as `to_timestamp`.
-- [x] to_timestamp_ntz
-  - Rewrites to `to_timestamp` with `TimestampNTZType`; same support as `to_timestamp`.
+- [ ] to_timestamp
+- [ ] to_timestamp_ltz
+- [ ] to_timestamp_ntz
 - [x] to_unix_timestamp
 - [x] to_utc_timestamp
   - Spark 3.4.3 (audited 2026-05-12): identical to 3.5.8.

--- a/native/spark-expr/src/comet_scalar_funcs.rs
+++ b/native/spark-expr/src/comet_scalar_funcs.rs
@@ -22,12 +22,12 @@ use crate::math_funcs::checked_arithmetic::{checked_add, checked_div, checked_mu
 use crate::math_funcs::log::spark_log;
 use crate::math_funcs::modulo_expr::spark_modulo;
 use crate::{
-    spark_ceil, spark_decimal_div, spark_decimal_integral_div, spark_floor, spark_isnan,
-    spark_lpad, spark_make_decimal, spark_read_side_padding, spark_round, spark_rpad,
-    spark_to_time, spark_unhex, spark_unscaled_value, EvalMode, SparkArrayCompact,
-    SparkArrayPositionFunc, SparkArraySlice, SparkArraysOverlap, SparkContains, SparkDateDiff,
-    SparkDateFromUnixDate, SparkDateTrunc, SparkMakeDate, SparkMakeTime, SparkSecondsToTimestamp,
-    SparkSizeFunc,
+    spark_ceil, spark_day_name, spark_decimal_div, spark_decimal_integral_div, spark_floor,
+    spark_isnan, spark_lpad, spark_make_decimal, spark_month_name, spark_read_side_padding,
+    spark_round, spark_rpad, spark_to_time, spark_unhex, spark_unscaled_value, EvalMode,
+    SparkArrayCompact, SparkArrayPositionFunc, SparkArraySlice, SparkArraysOverlap, SparkContains,
+    SparkDateDiff, SparkDateFromUnixDate, SparkDateTrunc, SparkMakeDate, SparkMakeTime,
+    SparkSecondsToTimestamp, SparkSizeFunc,
 };
 use arrow::datatypes::DataType;
 use datafusion::common::{DataFusionError, Result as DataFusionResult};
@@ -115,6 +115,14 @@ pub fn create_comet_physical_fun_with_eval_mode(
         "read_side_padding" => {
             let func = Arc::new(spark_read_side_padding);
             make_comet_scalar_udf!("read_side_padding", func, without data_type)
+        }
+        "dayname" => {
+            let func = Arc::new(spark_day_name);
+            make_comet_scalar_udf!("dayname", func, without data_type)
+        }
+        "monthname" => {
+            let func = Arc::new(spark_month_name);
+            make_comet_scalar_udf!("monthname", func, without data_type)
         }
         "rpad" => {
             let func = Arc::new(spark_rpad);

--- a/native/spark-expr/src/datetime_funcs/day_month_name.rs
+++ b/native/spark-expr/src/datetime_funcs/day_month_name.rs
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Spark-compatible `dayname` and `monthname` (Spark 4.0+).
+//!
+//! Spark's `DayName` / `MonthName` call `DateTimeUtils.getDayName` / `getMonthName`, which map a
+//! `DateType` value through `DayOfWeek` / `Month` `.getDisplayName(TextStyle.SHORT, Locale.US)`.
+//! `DateFormatter.defaultLocale` is the constant `Locale.US`, so the output is a fixed set of
+//! abbreviated English names, independent of the session locale or timezone. We reproduce that
+//! exactly with the lookup tables below, computing the weekday / month from the Date32 value.
+
+use arrow::array::{Array, Date32Array, StringArray};
+use arrow::temporal_conversions::date32_to_datetime;
+use chrono::Datelike;
+use datafusion::common::{DataFusionError, Result, ScalarValue};
+use datafusion::logical_expr::ColumnarValue;
+use std::sync::Arc;
+
+// `DayOfWeek.getDisplayName(TextStyle.SHORT, Locale.US)`, indexed Monday-first to match
+// `chrono::Weekday::num_days_from_monday` (0 = Monday) and Spark's `DayOfWeek.ordinal()`.
+const DAY_NAMES: [&str; 7] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+// `Month.getDisplayName(TextStyle.SHORT, Locale.US)`, indexed by `month0` (0 = January).
+const MONTH_NAMES: [&str; 12] = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+fn day_name(days: i32) -> Option<&'static str> {
+    date32_to_datetime(days)
+        .map(|dt| DAY_NAMES[dt.date().weekday().num_days_from_monday() as usize])
+}
+
+fn month_name(days: i32) -> Option<&'static str> {
+    date32_to_datetime(days).map(|dt| MONTH_NAMES[dt.date().month0() as usize])
+}
+
+/// Spark-compatible `dayname(date)`.
+pub fn spark_day_name(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
+    day_month_name(args, "dayname", day_name)
+}
+
+/// Spark-compatible `monthname(date)`.
+pub fn spark_month_name(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
+    day_month_name(args, "monthname", month_name)
+}
+
+fn day_month_name(
+    args: &[ColumnarValue],
+    name: &str,
+    f: fn(i32) -> Option<&'static str>,
+) -> Result<ColumnarValue, DataFusionError> {
+    if args.len() != 1 {
+        return Err(DataFusionError::Execution(format!(
+            "{name} expects exactly one argument, got {}",
+            args.len()
+        )));
+    }
+    match &args[0] {
+        ColumnarValue::Array(array) => {
+            let dates = array
+                .as_any()
+                .downcast_ref::<Date32Array>()
+                .ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "{name} expects a Date32 argument, got {:?}",
+                        array.data_type()
+                    ))
+                })?;
+            let result: StringArray = dates.iter().map(|d| d.and_then(f)).collect();
+            Ok(ColumnarValue::Array(Arc::new(result)))
+        }
+        ColumnarValue::Scalar(ScalarValue::Date32(days)) => Ok(ColumnarValue::Scalar(
+            ScalarValue::Utf8(days.and_then(f).map(|s| s.to_string())),
+        )),
+        ColumnarValue::Scalar(ScalarValue::Null) => {
+            Ok(ColumnarValue::Scalar(ScalarValue::Utf8(None)))
+        }
+        other => Err(DataFusionError::Execution(format!(
+            "{name} expects a Date32 argument, got {other:?}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // 2024-01-15 is a Monday; 2024-06-30 is a Sunday; 2020-12-31 is a Thursday.
+    // Days since epoch: 2024-01-15 = 19737, 2024-06-30 = 19904, 2020-12-31 = 18627.
+    #[test]
+    fn day_names() {
+        assert_eq!(day_name(19737), Some("Mon"));
+        assert_eq!(day_name(19904), Some("Sun"));
+        assert_eq!(day_name(18627), Some("Thu"));
+        assert_eq!(day_name(0), Some("Thu")); // 1970-01-01 is a Thursday
+        assert_eq!(day_name(-1), Some("Wed")); // 1969-12-31
+    }
+
+    #[test]
+    fn month_names() {
+        assert_eq!(month_name(19737), Some("Jan"));
+        assert_eq!(month_name(19904), Some("Jun"));
+        assert_eq!(month_name(18627), Some("Dec"));
+        assert_eq!(month_name(0), Some("Jan"));
+    }
+}

--- a/native/spark-expr/src/datetime_funcs/mod.rs
+++ b/native/spark-expr/src/datetime_funcs/mod.rs
@@ -18,6 +18,7 @@
 mod date_diff;
 mod date_from_unix_date;
 mod date_trunc;
+mod day_month_name;
 mod extract_date_part;
 mod hours;
 mod make_date;
@@ -30,6 +31,7 @@ mod unix_timestamp;
 pub use date_diff::SparkDateDiff;
 pub use date_from_unix_date::SparkDateFromUnixDate;
 pub use date_trunc::SparkDateTrunc;
+pub use day_month_name::{spark_day_name, spark_month_name};
 pub use extract_date_part::SparkHour;
 pub use extract_date_part::SparkMinute;
 pub use extract_date_part::SparkSecond;

--- a/native/spark-expr/src/lib.rs
+++ b/native/spark-expr/src/lib.rs
@@ -76,9 +76,9 @@ pub use comet_scalar_funcs::{
 };
 pub use csv_funcs::*;
 pub use datetime_funcs::{
-    spark_to_time, SparkDateDiff, SparkDateFromUnixDate, SparkDateTrunc, SparkHour,
-    SparkHoursTransform, SparkMakeDate, SparkMakeTime, SparkMinute, SparkSecond,
-    SparkSecondsToTimestamp, SparkUnixTimestamp, TimestampTruncExpr,
+    spark_day_name, spark_month_name, spark_to_time, SparkDateDiff, SparkDateFromUnixDate,
+    SparkDateTrunc, SparkHour, SparkHoursTransform, SparkMakeDate, SparkMakeTime, SparkMinute,
+    SparkSecond, SparkSecondsToTimestamp, SparkUnixTimestamp, TimestampTruncExpr,
 };
 pub use error::{decimal_overflow_error, SparkError, SparkErrorWithContext, SparkResult};
 pub use hash_funcs::*;

--- a/spark/src/main/spark-4.0/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-4.0/org/apache/comet/shims/CometExprShim.scala
@@ -38,7 +38,7 @@ import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, optExprWithFa
 /**
  * `CometExprShim` acts as a shim for parsing expressions from different Spark versions.
  */
-trait CometExprShim extends CommonStringExprs {
+trait CometExprShim extends CommonStringExprs with CometExprShim4x {
   protected def evalMode(c: Cast): CometEvalMode.Value =
     CometEvalModeUtil.fromSparkEvalMode(c.evalMode)
 
@@ -183,22 +183,10 @@ trait CometExprShim extends CommonStringExprs {
           optExprWithFallbackReason(mapSortExpr, ms, ms.child)
         }
 
-      // dayname / monthname (Spark 4.0+) map a DateType value to a fixed US-English abbreviated
-      // name. Spark's DateTimeUtils.getDayName / getMonthName use DayOfWeek / Month
-      // getDisplayName(TextStyle.SHORT, Locale.US) (DateFormatter.defaultLocale is the constant
-      // Locale.US), so there is no session-locale or timezone dependence and they map directly to
-      // the native `dayname` / `monthname` scalar functions.
-      case d: DayName =>
-        val childExpr = exprToProtoInternal(d.child, inputs, binding)
-        val nameExpr =
-          scalarFunctionExprToProtoWithReturnType("dayname", d.dataType, false, childExpr)
-        optExprWithFallbackReason(nameExpr, d, d.child)
-
-      case m: MonthName =>
-        val childExpr = exprToProtoInternal(m.child, inputs, binding)
-        val nameExpr =
-          scalarFunctionExprToProtoWithReturnType("monthname", m.dataType, false, childExpr)
-        optExprWithFallbackReason(nameExpr, m, m.child)
+      // dayname / monthname (Spark 4.0+) are shared across all 4.x minor versions; see
+      // CometExprShim4x.convertDayMonthName.
+      case _: DayName | _: MonthName =>
+        convertDayMonthName(expr, inputs, binding)
 
       case _ => None
     }

--- a/spark/src/main/spark-4.0/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-4.0/org/apache/comet/shims/CometExprShim.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, DataTypes
 import org.apache.comet.{CometConf, CometExplainInfo}
 import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
 import org.apache.comet.expressions.{CometCast, CometEvalMode}
-import org.apache.comet.serde.{CometScalaUDF, CommonStringExprs, Compatible, ExprOuterClass, Incompatible, SupportLevel}
+import org.apache.comet.serde.{CommonStringExprs, Compatible, ExprOuterClass, Incompatible, SupportLevel}
 import org.apache.comet.serde.ExprOuterClass.{BinaryOutputStyle, Expr}
 import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, optExprWithFallbackReason, scalarFunctionExprToProto, scalarFunctionExprToProtoWithReturnType, supportedScalarSortElementType}
 
@@ -183,12 +183,22 @@ trait CometExprShim extends CommonStringExprs {
           optExprWithFallbackReason(mapSortExpr, ms, ms.child)
         }
 
-      // dayname / monthname (Spark 4.0+) have no native lowering. Route them through the
-      // Arrow-direct codegen dispatcher so they run Spark's own doGenCode for exact parity
-      // (including locale handling). Returns None and falls back cleanly when the dispatcher is
-      // disabled via spark.comet.exec.scalaUDF.codegen.enabled.
-      case _: DayName | _: MonthName =>
-        CometScalaUDF.emitJvmCodegenDispatch(expr, inputs, binding)
+      // dayname / monthname (Spark 4.0+) map a DateType value to a fixed US-English abbreviated
+      // name. Spark's DateTimeUtils.getDayName / getMonthName use DayOfWeek / Month
+      // getDisplayName(TextStyle.SHORT, Locale.US) (DateFormatter.defaultLocale is the constant
+      // Locale.US), so there is no session-locale or timezone dependence and they map directly to
+      // the native `dayname` / `monthname` scalar functions.
+      case d: DayName =>
+        val childExpr = exprToProtoInternal(d.child, inputs, binding)
+        val nameExpr =
+          scalarFunctionExprToProtoWithReturnType("dayname", d.dataType, false, childExpr)
+        optExprWithFallbackReason(nameExpr, d, d.child)
+
+      case m: MonthName =>
+        val childExpr = exprToProtoInternal(m.child, inputs, binding)
+        val nameExpr =
+          scalarFunctionExprToProtoWithReturnType("monthname", m.dataType, false, childExpr)
+        optExprWithFallbackReason(nameExpr, m, m.child)
 
       case _ => None
     }

--- a/spark/src/main/spark-4.0/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-4.0/org/apache/comet/shims/CometExprShim.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, DataTypes
 import org.apache.comet.{CometConf, CometExplainInfo}
 import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
 import org.apache.comet.expressions.{CometCast, CometEvalMode}
-import org.apache.comet.serde.{CommonStringExprs, Compatible, ExprOuterClass, Incompatible, SupportLevel}
+import org.apache.comet.serde.{CometScalaUDF, CommonStringExprs, Compatible, ExprOuterClass, Incompatible, SupportLevel}
 import org.apache.comet.serde.ExprOuterClass.{BinaryOutputStyle, Expr}
 import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, optExprWithFallbackReason, scalarFunctionExprToProto, scalarFunctionExprToProtoWithReturnType, supportedScalarSortElementType}
 
@@ -182,6 +182,13 @@ trait CometExprShim extends CommonStringExprs {
             childExpr)
           optExprWithFallbackReason(mapSortExpr, ms, ms.child)
         }
+
+      // dayname / monthname (Spark 4.0+) have no native lowering. Route them through the
+      // Arrow-direct codegen dispatcher so they run Spark's own doGenCode for exact parity
+      // (including locale handling). Returns None and falls back cleanly when the dispatcher is
+      // disabled via spark.comet.exec.scalaUDF.codegen.enabled.
+      case _: DayName | _: MonthName =>
+        CometScalaUDF.emitJvmCodegenDispatch(expr, inputs, binding)
 
       case _ => None
     }

--- a/spark/src/main/spark-4.1/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-4.1/org/apache/comet/shims/CometExprShim.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, DataTypes
 import org.apache.comet.{CometConf, CometExplainInfo}
 import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
 import org.apache.comet.expressions.{CometCast, CometEvalMode}
-import org.apache.comet.serde.{CommonStringExprs, Compatible, ExprOuterClass, Incompatible, SupportLevel}
+import org.apache.comet.serde.{CometScalaUDF, CommonStringExprs, Compatible, ExprOuterClass, Incompatible, SupportLevel}
 import org.apache.comet.serde.ExprOuterClass.{BinaryOutputStyle, Expr}
 import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, optExprWithFallbackReason, scalarFunctionExprToProto, scalarFunctionExprToProtoWithReturnType, supportedScalarSortElementType}
 
@@ -213,6 +213,13 @@ trait CometExprShim extends CommonStringExprs {
             childExpr)
           optExprWithFallbackReason(mapSortExpr, ms, ms.child)
         }
+
+      // dayname / monthname (Spark 4.0+) have no native lowering. Route them through the
+      // Arrow-direct codegen dispatcher so they run Spark's own doGenCode for exact parity
+      // (including locale handling). Returns None and falls back cleanly when the dispatcher is
+      // disabled via spark.comet.exec.scalaUDF.codegen.enabled.
+      case _: DayName | _: MonthName =>
+        CometScalaUDF.emitJvmCodegenDispatch(expr, inputs, binding)
 
       case _ => None
     }

--- a/spark/src/main/spark-4.1/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-4.1/org/apache/comet/shims/CometExprShim.scala
@@ -39,7 +39,7 @@ import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, optExprWithFa
 /**
  * `CometExprShim` acts as a shim for parsing expressions from different Spark versions.
  */
-trait CometExprShim extends CommonStringExprs {
+trait CometExprShim extends CommonStringExprs with CometExprShim4x {
   protected def evalMode(c: Cast): CometEvalMode.Value =
     CometEvalModeUtil.fromSparkEvalMode(c.evalMode)
 
@@ -214,22 +214,10 @@ trait CometExprShim extends CommonStringExprs {
           optExprWithFallbackReason(mapSortExpr, ms, ms.child)
         }
 
-      // dayname / monthname (Spark 4.0+) map a DateType value to a fixed US-English abbreviated
-      // name. Spark's DateTimeUtils.getDayName / getMonthName use DayOfWeek / Month
-      // getDisplayName(TextStyle.SHORT, Locale.US) (DateFormatter.defaultLocale is the constant
-      // Locale.US), so there is no session-locale or timezone dependence and they map directly to
-      // the native `dayname` / `monthname` scalar functions.
-      case d: DayName =>
-        val childExpr = exprToProtoInternal(d.child, inputs, binding)
-        val nameExpr =
-          scalarFunctionExprToProtoWithReturnType("dayname", d.dataType, false, childExpr)
-        optExprWithFallbackReason(nameExpr, d, d.child)
-
-      case m: MonthName =>
-        val childExpr = exprToProtoInternal(m.child, inputs, binding)
-        val nameExpr =
-          scalarFunctionExprToProtoWithReturnType("monthname", m.dataType, false, childExpr)
-        optExprWithFallbackReason(nameExpr, m, m.child)
+      // dayname / monthname (Spark 4.0+) are shared across all 4.x minor versions; see
+      // CometExprShim4x.convertDayMonthName.
+      case _: DayName | _: MonthName =>
+        convertDayMonthName(expr, inputs, binding)
 
       case _ => None
     }

--- a/spark/src/main/spark-4.1/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-4.1/org/apache/comet/shims/CometExprShim.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, DataTypes
 import org.apache.comet.{CometConf, CometExplainInfo}
 import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
 import org.apache.comet.expressions.{CometCast, CometEvalMode}
-import org.apache.comet.serde.{CometScalaUDF, CommonStringExprs, Compatible, ExprOuterClass, Incompatible, SupportLevel}
+import org.apache.comet.serde.{CommonStringExprs, Compatible, ExprOuterClass, Incompatible, SupportLevel}
 import org.apache.comet.serde.ExprOuterClass.{BinaryOutputStyle, Expr}
 import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, optExprWithFallbackReason, scalarFunctionExprToProto, scalarFunctionExprToProtoWithReturnType, supportedScalarSortElementType}
 
@@ -214,12 +214,22 @@ trait CometExprShim extends CommonStringExprs {
           optExprWithFallbackReason(mapSortExpr, ms, ms.child)
         }
 
-      // dayname / monthname (Spark 4.0+) have no native lowering. Route them through the
-      // Arrow-direct codegen dispatcher so they run Spark's own doGenCode for exact parity
-      // (including locale handling). Returns None and falls back cleanly when the dispatcher is
-      // disabled via spark.comet.exec.scalaUDF.codegen.enabled.
-      case _: DayName | _: MonthName =>
-        CometScalaUDF.emitJvmCodegenDispatch(expr, inputs, binding)
+      // dayname / monthname (Spark 4.0+) map a DateType value to a fixed US-English abbreviated
+      // name. Spark's DateTimeUtils.getDayName / getMonthName use DayOfWeek / Month
+      // getDisplayName(TextStyle.SHORT, Locale.US) (DateFormatter.defaultLocale is the constant
+      // Locale.US), so there is no session-locale or timezone dependence and they map directly to
+      // the native `dayname` / `monthname` scalar functions.
+      case d: DayName =>
+        val childExpr = exprToProtoInternal(d.child, inputs, binding)
+        val nameExpr =
+          scalarFunctionExprToProtoWithReturnType("dayname", d.dataType, false, childExpr)
+        optExprWithFallbackReason(nameExpr, d, d.child)
+
+      case m: MonthName =>
+        val childExpr = exprToProtoInternal(m.child, inputs, binding)
+        val nameExpr =
+          scalarFunctionExprToProtoWithReturnType("monthname", m.dataType, false, childExpr)
+        optExprWithFallbackReason(nameExpr, m, m.child)
 
       case _ => None
     }

--- a/spark/src/main/spark-4.2/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-4.2/org/apache/comet/shims/CometExprShim.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, DataTypes
 import org.apache.comet.{CometConf, CometExplainInfo}
 import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
 import org.apache.comet.expressions.{CometCast, CometEvalMode}
-import org.apache.comet.serde.{CommonStringExprs, Compatible, ExprOuterClass, Incompatible, SupportLevel}
+import org.apache.comet.serde.{CometScalaUDF, CommonStringExprs, Compatible, ExprOuterClass, Incompatible, SupportLevel}
 import org.apache.comet.serde.ExprOuterClass.{BinaryOutputStyle, Expr}
 import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, optExprWithFallbackReason, scalarFunctionExprToProto, scalarFunctionExprToProtoWithReturnType, supportedScalarSortElementType}
 
@@ -213,6 +213,13 @@ trait CometExprShim extends CommonStringExprs {
             childExpr)
           optExprWithFallbackReason(mapSortExpr, ms, ms.child)
         }
+
+      // dayname / monthname (Spark 4.0+) have no native lowering. Route them through the
+      // Arrow-direct codegen dispatcher so they run Spark's own doGenCode for exact parity
+      // (including locale handling). Returns None and falls back cleanly when the dispatcher is
+      // disabled via spark.comet.exec.scalaUDF.codegen.enabled.
+      case _: DayName | _: MonthName =>
+        CometScalaUDF.emitJvmCodegenDispatch(expr, inputs, binding)
 
       case _ => None
     }

--- a/spark/src/main/spark-4.2/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-4.2/org/apache/comet/shims/CometExprShim.scala
@@ -39,7 +39,7 @@ import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, optExprWithFa
 /**
  * `CometExprShim` acts as a shim for parsing expressions from different Spark versions.
  */
-trait CometExprShim extends CommonStringExprs {
+trait CometExprShim extends CommonStringExprs with CometExprShim4x {
   protected def evalMode(c: Cast): CometEvalMode.Value =
     CometEvalModeUtil.fromSparkEvalMode(c.evalMode)
 
@@ -214,22 +214,10 @@ trait CometExprShim extends CommonStringExprs {
           optExprWithFallbackReason(mapSortExpr, ms, ms.child)
         }
 
-      // dayname / monthname (Spark 4.0+) map a DateType value to a fixed US-English abbreviated
-      // name. Spark's DateTimeUtils.getDayName / getMonthName use DayOfWeek / Month
-      // getDisplayName(TextStyle.SHORT, Locale.US) (DateFormatter.defaultLocale is the constant
-      // Locale.US), so there is no session-locale or timezone dependence and they map directly to
-      // the native `dayname` / `monthname` scalar functions.
-      case d: DayName =>
-        val childExpr = exprToProtoInternal(d.child, inputs, binding)
-        val nameExpr =
-          scalarFunctionExprToProtoWithReturnType("dayname", d.dataType, false, childExpr)
-        optExprWithFallbackReason(nameExpr, d, d.child)
-
-      case m: MonthName =>
-        val childExpr = exprToProtoInternal(m.child, inputs, binding)
-        val nameExpr =
-          scalarFunctionExprToProtoWithReturnType("monthname", m.dataType, false, childExpr)
-        optExprWithFallbackReason(nameExpr, m, m.child)
+      // dayname / monthname (Spark 4.0+) are shared across all 4.x minor versions; see
+      // CometExprShim4x.convertDayMonthName.
+      case _: DayName | _: MonthName =>
+        convertDayMonthName(expr, inputs, binding)
 
       case _ => None
     }

--- a/spark/src/main/spark-4.2/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-4.2/org/apache/comet/shims/CometExprShim.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, DataTypes
 import org.apache.comet.{CometConf, CometExplainInfo}
 import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
 import org.apache.comet.expressions.{CometCast, CometEvalMode}
-import org.apache.comet.serde.{CometScalaUDF, CommonStringExprs, Compatible, ExprOuterClass, Incompatible, SupportLevel}
+import org.apache.comet.serde.{CommonStringExprs, Compatible, ExprOuterClass, Incompatible, SupportLevel}
 import org.apache.comet.serde.ExprOuterClass.{BinaryOutputStyle, Expr}
 import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, optExprWithFallbackReason, scalarFunctionExprToProto, scalarFunctionExprToProtoWithReturnType, supportedScalarSortElementType}
 
@@ -214,12 +214,22 @@ trait CometExprShim extends CommonStringExprs {
           optExprWithFallbackReason(mapSortExpr, ms, ms.child)
         }
 
-      // dayname / monthname (Spark 4.0+) have no native lowering. Route them through the
-      // Arrow-direct codegen dispatcher so they run Spark's own doGenCode for exact parity
-      // (including locale handling). Returns None and falls back cleanly when the dispatcher is
-      // disabled via spark.comet.exec.scalaUDF.codegen.enabled.
-      case _: DayName | _: MonthName =>
-        CometScalaUDF.emitJvmCodegenDispatch(expr, inputs, binding)
+      // dayname / monthname (Spark 4.0+) map a DateType value to a fixed US-English abbreviated
+      // name. Spark's DateTimeUtils.getDayName / getMonthName use DayOfWeek / Month
+      // getDisplayName(TextStyle.SHORT, Locale.US) (DateFormatter.defaultLocale is the constant
+      // Locale.US), so there is no session-locale or timezone dependence and they map directly to
+      // the native `dayname` / `monthname` scalar functions.
+      case d: DayName =>
+        val childExpr = exprToProtoInternal(d.child, inputs, binding)
+        val nameExpr =
+          scalarFunctionExprToProtoWithReturnType("dayname", d.dataType, false, childExpr)
+        optExprWithFallbackReason(nameExpr, d, d.child)
+
+      case m: MonthName =>
+        val childExpr = exprToProtoInternal(m.child, inputs, binding)
+        val nameExpr =
+          scalarFunctionExprToProtoWithReturnType("monthname", m.dataType, false, childExpr)
+        optExprWithFallbackReason(nameExpr, m, m.child)
 
       case _ => None
     }

--- a/spark/src/main/spark-4.x/org/apache/comet/shims/CometExprShim4x.scala
+++ b/spark/src/main/spark-4.x/org/apache/comet/shims/CometExprShim4x.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.shims
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, DayName, Expression, MonthName}
+
+import org.apache.comet.serde.ExprOuterClass.Expr
+import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, optExprWithFallbackReason, scalarFunctionExprToProtoWithReturnType}
+
+/**
+ * Expression conversions shared across all Spark 4.x minor versions, compiled from the
+ * `spark-4.x` source root. Spark 4.0+ expression classes (e.g. `DayName` / `MonthName`) do not
+ * exist in 3.x, so they cannot live in the version-agnostic serde, but they are identical across
+ * 4.0 / 4.1 / 4.2 and belong here rather than being duplicated in each per-minor-version
+ * `CometExprShim`.
+ */
+trait CometExprShim4x {
+
+  /**
+   * `dayname` / `monthname` (Spark 4.0+) map a `DateType` value to a fixed US-English abbreviated
+   * name. Spark's `DateTimeUtils.getDayName` / `getMonthName` use `DayOfWeek` / `Month`
+   * `getDisplayName(TextStyle.SHORT, Locale.US)` (`DateFormatter.defaultLocale` is the constant
+   * `Locale.US`), so there is no session-locale or timezone dependence and they map directly to
+   * the native `dayname` / `monthname` scalar functions.
+   */
+  protected def convertDayMonthName(
+      expr: Expression,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[Expr] = expr match {
+    case d: DayName =>
+      val childExpr = exprToProtoInternal(d.child, inputs, binding)
+      val nameExpr =
+        scalarFunctionExprToProtoWithReturnType("dayname", d.dataType, false, childExpr)
+      optExprWithFallbackReason(nameExpr, d, d.child)
+    case m: MonthName =>
+      val childExpr = exprToProtoInternal(m.child, inputs, binding)
+      val nameExpr =
+        scalarFunctionExprToProtoWithReturnType("monthname", m.dataType, false, childExpr)
+      optExprWithFallbackReason(nameExpr, m, m.child)
+    case _ => None
+  }
+}

--- a/spark/src/test/resources/sql-tests/expressions/datetime/dayname.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/dayname.sql
@@ -1,0 +1,39 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- dayname (Spark 4.0+) is implemented natively. It maps a date to a fixed US-English abbreviated
+-- day name (DayOfWeek.getDisplayName(TextStyle.SHORT, Locale.US)), with no session-locale or
+-- timezone dependence.
+-- MinSparkVersion: 4.0
+
+statement
+CREATE TABLE test_dayname(d date) USING parquet
+
+statement
+INSERT INTO test_dayname VALUES
+  (date('2024-01-15')),
+  (date('2024-06-30')),
+  (date('2020-12-31')),
+  (date('1970-01-01')),
+  (NULL)
+
+query
+SELECT dayname(d) FROM test_dayname
+
+-- literal argument
+query
+SELECT dayname(date('2024-02-29'))

--- a/spark/src/test/resources/sql-tests/expressions/datetime/monthname.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/monthname.sql
@@ -1,0 +1,39 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- monthname (Spark 4.0+) is implemented natively. It maps a date to a fixed US-English
+-- abbreviated month name (Month.getDisplayName(TextStyle.SHORT, Locale.US)), with no
+-- session-locale or timezone dependence.
+-- MinSparkVersion: 4.0
+
+statement
+CREATE TABLE test_monthname(d date) USING parquet
+
+statement
+INSERT INTO test_monthname VALUES
+  (date('2024-01-15')),
+  (date('2024-06-30')),
+  (date('2020-12-31')),
+  (date('1970-01-01')),
+  (NULL)
+
+query
+SELECT monthname(d) FROM test_monthname
+
+-- literal argument
+query
+SELECT monthname(date('2024-02-29'))

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -578,14 +578,25 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
-  test("dayname / monthname run via codegen dispatcher") {
+  test("dayname / monthname run natively") {
     assume(isSpark40Plus)
-    withSQLConf(CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "true") {
-      withParquetTable(
-        Seq(Tuple1("2024-01-15"), Tuple1("2024-06-30"), Tuple1("2020-12-31")),
-        "tbl") {
-        checkSparkAnswerAndOperator("SELECT dayname(CAST(_1 AS DATE)) FROM tbl")
-        checkSparkAnswerAndOperator("SELECT monthname(CAST(_1 AS DATE)) FROM tbl")
+    withParquetTable(
+      Seq(
+        Tuple1("2024-01-15"), // Monday, January
+        Tuple1("2024-06-30"), // Sunday, June
+        Tuple1("2020-12-31"), // Thursday, December
+        Tuple1(null.asInstanceOf[String]) // null date -> null name
+      ),
+      "tbl") {
+      checkSparkAnswerAndOperator("SELECT dayname(CAST(_1 AS DATE)) FROM tbl")
+      checkSparkAnswerAndOperator("SELECT monthname(CAST(_1 AS DATE)) FROM tbl")
+      // Literal path: disable constant folding so the function reaches Comet rather than being
+      // pre-evaluated by Spark.
+      withSQLConf(
+        SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+          "org.apache.spark.sql.catalyst.optimizer.ConstantFolding") {
+        checkSparkAnswerAndOperator(
+          "SELECT dayname(DATE '2024-02-29'), monthname(DATE '2024-02-29') FROM tbl")
       }
     }
   }

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -538,29 +538,6 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
-  test("dayname / monthname run natively") {
-    assume(isSpark40Plus)
-    withParquetTable(
-      Seq(
-        Tuple1("2024-01-15"), // Monday, January
-        Tuple1("2024-06-30"), // Sunday, June
-        Tuple1("2020-12-31"), // Thursday, December
-        Tuple1(null.asInstanceOf[String]) // null date -> null name
-      ),
-      "tbl") {
-      checkSparkAnswerAndOperator("SELECT dayname(CAST(_1 AS DATE)) FROM tbl")
-      checkSparkAnswerAndOperator("SELECT monthname(CAST(_1 AS DATE)) FROM tbl")
-      // Literal path: disable constant folding so the function reaches Comet rather than being
-      // pre-evaluated by Spark.
-      withSQLConf(
-        SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-          "org.apache.spark.sql.catalyst.optimizer.ConstantFolding") {
-        checkSparkAnswerAndOperator(
-          "SELECT dayname(DATE '2024-02-29'), monthname(DATE '2024-02-29') FROM tbl")
-      }
-    }
-  }
-
   test("hour on int96 timestamp column") {
     import testImplicits._
 

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -538,6 +538,70 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  // The following tests cover datetime functions that are not registered under their own name in
+  // the Comet expression maps but are still handled: Spark rewrites them to supported expressions
+  // (Cast / GetTimestamp / MakeTimestamp) before Comet sees the plan, or the codegen dispatcher
+  // runs Spark's own generated code.
+
+  test("to_date / to_timestamp without format run natively") {
+    withParquetTable(
+      Seq(("2024-01-15", "2024-01-15 10:30:45"), ("2020-12-31", "2020-12-31 23:59:59")),
+      "tbl") {
+      // These rewrite to Cast(string -> date/timestamp), which Comet supports natively.
+      checkSparkAnswerAndOperator("SELECT to_date(_1) FROM tbl")
+      checkSparkAnswerAndOperator("SELECT to_timestamp(_2) FROM tbl")
+      checkSparkAnswerAndOperator("SELECT to_timestamp_ntz(_2) FROM tbl")
+      checkSparkAnswerAndOperator("SELECT to_timestamp_ltz(_2) FROM tbl")
+      checkSparkAnswerAndOperator("SELECT try_to_timestamp(_2) FROM tbl")
+    }
+  }
+
+  test("to_date / to_timestamp with format run via codegen dispatcher") {
+    withSQLConf(CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "true") {
+      withParquetTable(
+        Seq(("2024-01-15", "2024-01-15 10:30:45"), ("2020-12-31", "2020-12-31 23:59:59")),
+        "tbl") {
+        // With a format these rewrite to GetTimestamp, which is routed through the dispatcher.
+        checkSparkAnswerAndOperator("SELECT to_date(_1, 'yyyy-MM-dd') FROM tbl")
+        checkSparkAnswerAndOperator("SELECT to_timestamp(_2, 'yyyy-MM-dd HH:mm:ss') FROM tbl")
+      }
+    }
+  }
+
+  test("make_timestamp_ntz / make_timestamp_ltz run via codegen dispatcher") {
+    withSQLConf(CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "true") {
+      withParquetTable(Seq((2024, 1, 15, 10, 30, 45), (2020, 12, 31, 23, 59, 59)), "tbl") {
+        // The 6-argument forms rewrite to MakeTimestamp, which is routed through the dispatcher.
+        checkSparkAnswerAndOperator("SELECT make_timestamp_ntz(_1, _2, _3, _4, _5, _6) FROM tbl")
+        checkSparkAnswerAndOperator("SELECT make_timestamp_ltz(_1, _2, _3, _4, _5, _6) FROM tbl")
+      }
+    }
+  }
+
+  test("dayname / monthname run via codegen dispatcher") {
+    assume(isSpark40Plus)
+    withSQLConf(CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "true") {
+      withParquetTable(
+        Seq(Tuple1("2024-01-15"), Tuple1("2024-06-30"), Tuple1("2020-12-31")),
+        "tbl") {
+        checkSparkAnswerAndOperator("SELECT dayname(CAST(_1 AS DATE)) FROM tbl")
+        checkSparkAnswerAndOperator("SELECT monthname(CAST(_1 AS DATE)) FROM tbl")
+      }
+    }
+  }
+
+  test("current_date / current_timestamp / now constant-folded before Comet") {
+    Seq("current_date()", "current_timestamp()", "now()", "current_date", "current_timestamp")
+      .foreach { fn =>
+        val plan = spark.sql(s"SELECT $fn AS r").queryExecution.optimizedPlan
+        val folded = plan.expressions.exists {
+          case Alias(_: Literal, _) => true
+          case _ => false
+        }
+        assert(folded, s"expected '$fn' to be constant-folded to a Literal before Comet")
+      }
+  }
+
   test("hour on int96 timestamp column") {
     import testImplicits._
 

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -538,46 +538,6 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
-  // The following tests cover datetime functions that are not registered under their own name in
-  // the Comet expression maps but are still handled: Spark rewrites them to supported expressions
-  // (Cast / GetTimestamp / MakeTimestamp) before Comet sees the plan, or the codegen dispatcher
-  // runs Spark's own generated code.
-
-  test("to_date / to_timestamp without format run natively") {
-    withParquetTable(
-      Seq(("2024-01-15", "2024-01-15 10:30:45"), ("2020-12-31", "2020-12-31 23:59:59")),
-      "tbl") {
-      // These rewrite to Cast(string -> date/timestamp), which Comet supports natively.
-      checkSparkAnswerAndOperator("SELECT to_date(_1) FROM tbl")
-      checkSparkAnswerAndOperator("SELECT to_timestamp(_2) FROM tbl")
-      checkSparkAnswerAndOperator("SELECT to_timestamp_ntz(_2) FROM tbl")
-      checkSparkAnswerAndOperator("SELECT to_timestamp_ltz(_2) FROM tbl")
-      checkSparkAnswerAndOperator("SELECT try_to_timestamp(_2) FROM tbl")
-    }
-  }
-
-  test("to_date / to_timestamp with format run via codegen dispatcher") {
-    withSQLConf(CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "true") {
-      withParquetTable(
-        Seq(("2024-01-15", "2024-01-15 10:30:45"), ("2020-12-31", "2020-12-31 23:59:59")),
-        "tbl") {
-        // With a format these rewrite to GetTimestamp, which is routed through the dispatcher.
-        checkSparkAnswerAndOperator("SELECT to_date(_1, 'yyyy-MM-dd') FROM tbl")
-        checkSparkAnswerAndOperator("SELECT to_timestamp(_2, 'yyyy-MM-dd HH:mm:ss') FROM tbl")
-      }
-    }
-  }
-
-  test("make_timestamp_ntz / make_timestamp_ltz run via codegen dispatcher") {
-    withSQLConf(CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "true") {
-      withParquetTable(Seq((2024, 1, 15, 10, 30, 45), (2020, 12, 31, 23, 59, 59)), "tbl") {
-        // The 6-argument forms rewrite to MakeTimestamp, which is routed through the dispatcher.
-        checkSparkAnswerAndOperator("SELECT make_timestamp_ntz(_1, _2, _3, _4, _5, _6) FROM tbl")
-        checkSparkAnswerAndOperator("SELECT make_timestamp_ltz(_1, _2, _3, _4, _5, _6) FROM tbl")
-      }
-    }
-  }
-
   test("dayname / monthname run natively") {
     assume(isSpark40Plus)
     withParquetTable(
@@ -599,18 +559,6 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
           "SELECT dayname(DATE '2024-02-29'), monthname(DATE '2024-02-29') FROM tbl")
       }
     }
-  }
-
-  test("current_date / current_timestamp / now constant-folded before Comet") {
-    Seq("current_date()", "current_timestamp()", "now()", "current_date", "current_timestamp")
-      .foreach { fn =>
-        val plan = spark.sql(s"SELECT $fn AS r").queryExecution.optimizedPlan
-        val folded = plan.expressions.exists {
-          case Alias(_: Literal, _) => true
-          case _ => false
-        }
-        assert(folded, s"expected '$fn' to be constant-folded to a Literal before Comet")
-      }
   }
 
   test("hour on int96 timestamp column") {


### PR DESCRIPTION
## Which issue does this PR close?

Part of #4418.

## Rationale for this change

`dayname` and `monthname` (Spark 4.0+) had no Comet support and forced a fallback to Spark.

## What changes are included in this PR?

This work was scaffolded with the `implement-comet-expression` skill.

`dayname` and `monthname` are implemented natively. Spark's `DayName` / `MonthName` map a `DateType` value through `DayOfWeek` / `Month` `.getDisplayName(TextStyle.SHORT, Locale.US)`. `DateFormatter.defaultLocale` is the constant `Locale.US`, so the result is a fixed set of abbreviated English names (`Mon`..`Sun`, `Jan`..`Dec`) with no session-locale or timezone dependence. The native Rust scalar function reproduces this exactly with US-English lookup tables keyed on the weekday / month computed from the Date32 value.

- A `dayname` / `monthname` scalar function in `native/spark-expr/src/datetime_funcs/day_month_name.rs`, registered in `comet_scalar_funcs`.
- Serde wiring in the spark-4.0 / 4.1 / 4.2 `CometExprShim` (these are Spark 4.0+ expression classes, so they cannot live in shared serde) that emits the scalar function proto.

These were Spark 4.0+ only, so they are kept out of the shared serde and gated to 4.0+.

The documentation-only corrections for the rewrite-backed and constant-folded datetime functions (`to_date`, `to_timestamp`, `make_timestamp_*`, `current_*`, `now`, `curdate`) are split out into #4543.

## How are these changes tested?

A native Rust unit test covers the weekday / month name mapping, including the epoch boundary and a pre-epoch date. A `CometExpressionSuite` test (gated to Spark 4.0+) uses `checkSparkAnswerAndOperator` to assert both functions execute fully in Comet (no fallback) and return Spark-identical results across column references, a null date, and a constant-folding-disabled literal. Verified locally against the Spark 4.0 profile.
