### PR TITLE
docs: Rewrite supported expressions page to show complete overview of what is and is not supported by Comet

### DIFF
--- a/docs/source/contributor-guide/adding_a_new_expression.md
+++ b/docs/source/contributor-guide/adding_a_new_expression.md
@@ -27,6 +27,10 @@ Before you start, have a look through [these slides](https://docs.google.com/pre
 
 You may have a specific expression in mind that you'd like to add, but if not, you can review the [expression coverage document](spark_expressions_support.md) to see which expressions are not yet supported.
 
+When you add or change an expression, update **both** the coverage checklist
+(`spark_expressions_support.md`) and the user-facing status in
+[Supported Spark Expressions](../user-guide/latest/expressions.md).
+
 ## Implementing the Expression
 
 Once you have the expression you'd like to add, you should take inventory of the following:

--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -106,9 +106,9 @@
 - [ ] percentile_approx
 - [ ] percentile_cont
 - [ ] percentile_disc
-- [ ] regr_avgx
-- [ ] regr_avgy
-- [ ] regr_count
+- [x] regr_avgx
+- [x] regr_avgy
+- [x] regr_count
 - [ ] regr_intercept
 - [ ] regr_r2
 - [ ] regr_slope
@@ -243,7 +243,7 @@
   - Spark 4.1.1 (audited 2026-05-27): `inputTypes` tightened to `Seq(ArrayType, IntegralType)` (analysis-time only); runtime unchanged.
 - [ ] sequence
 - [ ] shuffle
-- [ ] slice
+- [x] slice
 - [x] sort_array
   - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.
   - Spark 3.5.8 (audited 2026-05-27): baseline. `SortArray(base, ascendingOrder) extends BinaryExpression with ArraySortLike`; the second arg must be a `Literal(_: Boolean, BooleanType)`. Comet `CometSortArray` flags `Incompatible` under strict floating-point and falls back for nested arrays whose innermost element is `Struct` or `Null`.
@@ -267,7 +267,7 @@
   - Spark 3.5.8 (audited 2026-05-27): identical to 3.4.3.
   - Spark 4.0.1 (audited 2026-05-27): `>>` parses to `ShiftRight`. Comet `CometShiftRight` mirrors the same operand-cast logic as `CometShiftLeft`.
   - Spark 4.1.1 (audited 2026-05-27): identical to 4.0.1.
-- [ ] `>>>`
+- [x] `>>>`
 - [x] `^`
   - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.
   - Spark 3.5.8 (audited 2026-05-27): baseline. `BitwiseXor(left, right) extends BinaryArithmetic` over `IntegralType`. Comet routes via `CometBitwiseXor` to the proto's `bitwise_xor` binary expression.
@@ -311,8 +311,9 @@
 
 ### collection_funcs
 
-- [ ] array_size
-- [ ] cardinality
+- [x] array_size
+  - Native via `size`; returns -1 instead of NULL for NULL input (https://github.com/apache/datafusion-comet/issues/4560).
+- [x] cardinality
 - [x] concat
   - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.
   - Spark 3.5.8 (audited 2026-05-27): baseline. `Concat(children) extends ComplexTypeMergingExpression with QueryErrorsBase`; `allowedTypes = Seq(StringType, BinaryType, ArrayType)`; result type is the merged child type. Empty children is allowed and returns the empty string of the result type.
@@ -355,7 +356,7 @@
   - Spark 3.5.8 (audited 2026-05-27): `NullIf(left, right, replacement) extends RuntimeReplaceable with InheritAnalysisRules`; the analyzer rewrites to `If(EqualTo(left, right), Literal(null, left.dataType), left)`. Comet handles via `CometIf` plus `CometEqualTo`.
   - Spark 4.0.1 (audited 2026-05-27): identical to 3.5.8.
   - Spark 4.1.1 (audited 2026-05-27): identical to 3.5.8.
-- [ ] nullifzero
+- [x] nullifzero
 - [x] nvl
   - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.
   - Spark 3.5.8 (audited 2026-05-27): `Nvl(left, right, replacement) extends RuntimeReplaceable`; analyzer rewrites to `Coalesce(Seq(left, right))`. Comet handles via `CometCoalesce`.
@@ -371,7 +372,7 @@
   - Spark 3.5.8 (audited 2026-05-27): the `CASE WHEN ... THEN ...` SQL form lowers to `CaseWhen(branches: Seq[(Expression, Expression)], elseValue: Option[Expression])`. Spark evaluates left-to-right with short-circuit; result type is the merged branch type. Comet routes via `CometCaseWhen` to the native `CaseWhen` proto.
   - Spark 4.0.1 (audited 2026-05-27): adds the `withNewAlwaysEvaluatedInputs` optimizer hook; semantics unchanged.
   - Spark 4.1.1 (audited 2026-05-27): identical to 4.0.1.
-- [ ] zeroifnull
+- [x] zeroifnull
 
 ### conversion_funcs
 
@@ -486,7 +487,8 @@
   - Known divergence: Comet's native timezone parser does not accept Spark's legacy zone forms (`GMT+1`, `UTC+1`, three-letter abbreviations like `PST`). Such timezones throw a native parse error at execution.
 - [x] trunc
 - [ ] try_make_interval
-- [ ] try_make_timestamp
+- [x] try_make_timestamp
+  - Native for valid inputs; returns wrong values for invalid inputs instead of NULL (https://github.com/apache/datafusion-comet/issues/4554).
 - [ ] try_to_date
 - [ ] try_to_time
 - [ ] try_to_timestamp
@@ -505,13 +507,13 @@
 
 - [x] explode
   - Handled at the operator level as a `GenerateExec` (`CometExplodeExec`), not via the expression serde maps, so it is not auto-detected by the function-registry checkbox logic. Compatible for array inputs; map inputs fall back ([#2837](https://github.com/apache/datafusion-comet/issues/2837)).
-- [ ] explode_outer
+- [x] explode_outer
   - Same `CometExplodeExec` path as `explode`, but the `outer=true` case is `Incompatible` (empty arrays are not preserved as null outputs) and falls back unless `spark.comet.expr.allowIncompatible=true` ([datafusion#19053](https://github.com/apache/datafusion/issues/19053)).
 - [ ] inline
 - [ ] inline_outer
 - [x] posexplode
   - Handled at the operator level as a `GenerateExec` (`CometExplodeExec`), like `explode`. Compatible for array inputs; map inputs fall back ([#2837](https://github.com/apache/datafusion-comet/issues/2837)).
-- [ ] posexplode_outer
+- [x] posexplode_outer
   - Same `CometExplodeExec` path as `posexplode`, but the `outer=true` case is `Incompatible` and falls back unless `spark.comet.expr.allowIncompatible=true` ([datafusion#19053](https://github.com/apache/datafusion/issues/19053)).
 - [ ] stack
 
@@ -556,7 +558,8 @@
 
 ### json_funcs
 
-- [ ] from_json
+- [x] from_json
+  - Partial native support, marked `Incompatible` (requires explicit schema).
 - [x] get_json_object
   - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.
   - Spark 3.5.8 (audited 2026-05-27): baseline. `BinaryExpression with ExpectsInputTypes with CodegenFallback`; `inputTypes = Seq(StringType, StringType) -> StringType`. Eval is inline and uses Jackson with `RawStyle` output. Foldable paths are parsed once. Returns NULL for invalid JSON, missing paths, or `JsonProcessingException`.
@@ -567,7 +570,8 @@
 - [ ] json_object_keys
 - [ ] json_tuple
 - [ ] schema_of_json
-- [ ] to_json
+- [x] to_json
+  - Partial native support; options and map/array inputs fall back.
 
 ### lambda_funcs
 
@@ -629,7 +633,7 @@
   - Spark 3.5.8 (audited 2026-05-27): baseline. `StringToMap(text, pairDelim, keyValueDelim) extends TernaryExpression`; splits `text` on `pairDelim`, then each pair on `keyValueDelim` (default `","` and `":"`). Uses `ArrayBasedMapBuilder` for duplicate-key handling. Wired as `CometScalarFunction("str_to_map")`.
   - Spark 4.0.1 (audited 2026-05-27): `inputTypes` widened to `StringTypeNonCSAICollation`; uses `CollationAwareUTF8String.splitSQL` with a `collationId`. Runtime unchanged for `UTF8_BINARY`.
   - Spark 4.1.1 (audited 2026-05-27): adds the `legacySplitTruncate` flag (driven by `spark.sql.legacy.truncateForEmptyRegexSplit`) to both `splitSQL` calls (https://github.com/apache/datafusion-comet/issues/4477). The Comet native impl does not honour this flag; behaviour matches the non-legacy default.
-- [ ] try_element_at
+- [x] try_element_at
 
 ### math_funcs
 
@@ -729,7 +733,7 @@
   - See `misc_funcs / rand`.
 - [x] randn
   - See `misc_funcs / randn`.
-- [ ] random
+- [x] random
 - [ ] randstr
 - [x] rint
   - Spark 3.4.3, 3.5.8, 4.0.1, 4.1.1 (audited 2026-05-27): `UnaryMathExpression(math.rint, "ROUND")` with `funcName = "rint"`. Passthrough to DataFusion `rint` (round-half-to-even).
@@ -764,7 +768,7 @@
   - Spark 3.4.3, 3.5.8, 4.0.1, 4.1.1 (audited 2026-05-27): rewrites to `Subtract(.., EvalMode.TRY)`. Integer path uses `checked_sub`; decimal uses `WideDecimalBinaryExpr` as needed.
 - [x] unhex
   - Spark 3.4.3, 3.5.8, 4.0.1, 4.1.1 (audited 2026-05-27): `Unhex(child, failOnError)`. Spark 4.x widens input to `StringTypeWithCollation` and wraps the inner call in try/catch; Comet `CometUnhex` forwards `failOnError` to native `spark_unhex` but does not gate on collation.
-- [ ] uniform
+- [x] uniform
 - [x] width_bucket
   - Spark 3.5.8 (audited 2026-05-27): introduced; not available in 3.4.3.
   - Spark 4.0.1, 4.1.1 (audited 2026-05-27): same semantics; `NullIntolerant` -> `nullIntolerant: Boolean` refactor.
@@ -786,7 +790,7 @@
 - [ ] current_database
 - [ ] current_schema
 - [ ] current_user
-- [ ] equal_null
+- [x] equal_null
 - [ ] from_avro
 - [ ] from_protobuf
 - [ ] hll_sketch_estimate
@@ -940,8 +944,8 @@
   - Spark 3.5.8 (audited 2026-05-27): baseline. `Or(left, right) extends BinaryOperator with Predicate`; short-circuit left-to-right. Comet routes via `CometOr` to the proto's `or` binary expression.
   - Spark 4.0.1 (audited 2026-05-27): semantics unchanged.
   - Spark 4.1.1 (audited 2026-05-27): identical to 4.0.1.
-- [ ] regexp
-- [ ] regexp_like
+- [x] regexp
+- [x] regexp_like
 - [x] rlike
   - See `string_funcs / regexp_replace` and the `CometRLike` notes (audited in PR #4461). Uses the Rust `regex` crate, which differs from Java's `Pattern` engine; requires `spark.comet.expression.regexp.allowIncompatible=true`.
 
@@ -956,7 +960,7 @@
 - [x] character_length
 - [x] chr
 - [ ] collate
-- [ ] collation
+- [x] collation
 - [x] concat_ws
 - [x] contains
 - [x] decode
@@ -978,7 +982,7 @@
 - [x] lower
 - [x] lpad
 - [x] ltrim
-- [ ] luhn_check
+- [x] luhn_check
 - [ ] make_valid_utf8
 - [ ] mask
 - [x] octet_length
@@ -1006,7 +1010,7 @@
 - [x] substr
 - [x] substring
 - [x] substring_index
-- [ ] to_binary
+- [x] to_binary
 - [ ] to_char
 - [ ] to_number
 - [ ] to_varchar
@@ -1052,8 +1056,10 @@
 
 - [ ] cume_dist
 - [ ] dense_rank
-- [ ] lag
-- [ ] lead
+- [x] lag
+  - Supported via `CometWindowExec` (operator level), not the expression serde.
+- [x] lead
+  - Supported via `CometWindowExec` (operator level), not the expression serde.
 - [ ] nth_value
 - [ ] ntile
 - [ ] percent_rank

--- a/docs/source/contributor-guide/spark_expressions_support.md
+++ b/docs/source/contributor-guide/spark_expressions_support.md
@@ -685,7 +685,8 @@
   - Spark 3.4.3, 3.5.8, 4.0.1, 4.1.1 (audited 2026-05-27): `UnaryMathExpression(math.toDegrees, "DEGREES")` unchanged across versions.
 - [x] div
   - Spark 3.4.3, 3.5.8, 4.0.1, 4.1.1 (audited 2026-05-27): `IntegralDivide(left, right, evalMode)`. Non-decimal operands are cast to `DecimalType(19, 0)`; result is recomputed per `IntegralDivide.resultDecimalType`, wrapped in `CheckOverflow`, then cast to `Long`. ANSI overflow for `Long.MinValue div -1` and decimal-overflow ANSI cases are covered by existing tests.
-- [ ] e
+- [x] e
+  - Foldable; rewritten to a literal by ConstantFolding (like `pi`).
 - [x] exp
   - Spark 3.4.3, 3.5.8, 4.0.1, 4.1.1 (audited 2026-05-27): `UnaryMathExpression(StrictMath.exp, "EXP")` unchanged. ULP-level differences vs DataFusion `exp` are possible but unflagged.
 - [x] expm1
@@ -786,10 +787,14 @@
 - [ ] bitmap_construct_agg
 - [ ] bitmap_count
 - [ ] bitmap_or_agg
-- [ ] current_catalog
-- [ ] current_database
-- [ ] current_schema
-- [ ] current_user
+- [x] current_catalog
+  - Resolved to a literal by the analyzer (`ReplaceCurrentLike`).
+- [x] current_database
+  - Resolved to a literal by the analyzer (`ReplaceCurrentLike`).
+- [x] current_schema
+  - Alias of `current_database`; resolved to a literal by the analyzer.
+- [x] current_user
+  - Resolved to a literal by the analyzer; same as `user`.
 - [x] equal_null
 - [ ] from_avro
 - [ ] from_protobuf
@@ -823,7 +828,8 @@
 - [ ] schema_of_avro
 - [ ] schema_of_variant
 - [ ] schema_of_variant_agg
-- [ ] session_user
+- [x] session_user
+  - Alias of `current_user`; resolved to a literal by the analyzer.
 - [x] spark_partition_id
   - Spark 3.4.3 (audited 2026-05-27): byte-for-byte identical to 4.1.1. `SparkPartitionID() extends LeafExpression with Nondeterministic`; returns the integer index of the partition being processed. Comet emits an empty `SparkPartitionId` proto.
   - Spark 3.5.8 (audited 2026-05-27): identical to 3.4.3.
@@ -845,7 +851,8 @@
 - [ ] try_parse_json
 - [ ] try_reflect
 - [ ] try_variant_get
-- [ ] typeof
+- [x] typeof
+  - Foldable; resolved to a literal before Comet sees the plan.
 - [x] user
   - Spark 3.4.3 (audited 2026-05-27): `CurrentUser() extends LeafExpression with Unevaluable`; the analyzer's `ResolveCurrentLike` rule replaces it with a `StringType` literal of the current user name before Comet sees the plan. No Comet serde needed; the literal flows through `CometLiteral`.
   - Spark 3.5.8 (audited 2026-05-27): identical to 3.4.3.

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -62,34 +62,6 @@ are *not* out of scope: although approximate, they are mainstream and are planne
 
 The tables below list every Spark built-in expression with its current status.
 
-## Coverage by category
-
-| Category | Supported | Notes |
-| -------- | --------- | ----- |
-| conversion_funcs | 1 / 13 | Cast and cast aliases |
-| hash_funcs | 7 / 7 | Fully supported |
-| struct_funcs | 2 / 2 | Fully supported |
-| url_funcs | 4 / 4 | Fully supported |
-| math_funcs | 60 / 70 | Mostly supported |
-| bitwise_funcs | 11 / 12 | Mostly supported |
-| predicate_funcs | 19 / 21 | Mostly supported |
-| array_funcs | 21 / 25 | Mostly supported |
-| datetime_funcs | 45 / 73 | Mostly supported |
-| conditional_funcs | 7 / 10 | Mostly supported |
-| string_funcs | 37 / 72 | Mostly supported; regexp tail planned |
-| map_funcs | 8 / 11 | Mostly supported |
-| collection_funcs | 3 / 5 | |
-| json_funcs | 1 / 7 | Core supported; remainder planned |
-| agg_funcs | 31 / 88 | Sketch aggregates out of scope |
-| generator_funcs | 4 / 7 | explode/posexplode via operator |
-| window_funcs | 2 / 9 | Run via CometWindowExec (operator) |
-| lambda_funcs | 0 / 12 | Higher-order functions planned |
-| misc_funcs | 5 / 56 | Many niche/environment functions |
-| csv_funcs | 0 / 3 | Not yet evaluated |
-| xml_funcs | 0 / 12 | Out of scope |
-
----
-
 ## agg_funcs
 
 > 🚫 Out of scope: probabilistic sketch aggregates (`kll_sketch_*`, `hll_sketch_agg`, `hll_union_agg`, `theta_intersection_agg`, `theta_sketch_agg`, `theta_union_agg`, `count_min_sketch`, `approx_top_k`, `approx_top_k_accumulate`, `approx_top_k_combine`). See [Scope policy](#scope-policy).

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -306,10 +306,10 @@ serde but effectively fall through to the same cast path at runtime.
 | `to_utc_timestamp`    | ⚠️     | Legacy zone forms (`GMT+1`, `PST`) throw a native parse error                                          |
 | `trunc`               | ✅     |                                                                                                        |
 | `try_make_interval`   | 🔜     | Produces legacy CalendarInterval; tracked by #4540                                                     |
-| `try_make_timestamp`  | 🔜     | Rewrites to `make_timestamp`; likely accelerated, pending test                                         |
-| `try_to_date`         | 🔜     | Rewrites to `Cast`/`GetTimestamp`; likely accelerated, pending test                                    |
+| `try_make_timestamp`  | ⚠️     | Runs natively for valid inputs, but returns wrong values for invalid inputs instead of NULL (#4554)    |
+| `try_to_date`         | ❓     | Rewrites to `Cast`/`GetTimestamp`, but the rewritten form currently falls back (tests: #4555)          |
 | `try_to_time`         | 🔜     | Spark 4.1 TIME type; tracked by #4288                                                                  |
-| `try_to_timestamp`    | 🔜     | Rewrites to `Cast`/`GetTimestamp`; likely accelerated, pending test                                    |
+| `try_to_timestamp`    | ❓     | Rewrites to `Cast`/`GetTimestamp`, but the rewritten form currently falls back (tests: #4555)          |
 | `unix_date`           | ✅     |                                                                                                        |
 | `unix_micros`         | ✅     |                                                                                                        |
 | `unix_millis`         | ✅     |                                                                                                        |

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -188,7 +188,7 @@ The tables below list every Spark built-in expression with its current status.
 
 | Function      | Status | Notes                                                                                                                            |
 | ------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| `array_size`  | ❓     |                                                                                                                                  |
+| `array_size`  | ⚠️     | Lowers to `size`; accelerated, but returns -1 instead of NULL for NULL input (bug)                                               |
 | `cardinality` | ⚠️     | Alias for `size`; `MapType` input falls back ([#4472](https://github.com/apache/datafusion-comet/issues/4472))                   |
 | `concat`      | ⚠️     | Only `StringType` children; `BinaryType`/`ArrayType` fall back ([#4471](https://github.com/apache/datafusion-comet/issues/4471)) |
 | `reverse`     | ⚠️     | Array with `BinaryType` elements is `Incompatible`, flag-gated ([#2763](https://github.com/apache/datafusion-comet/issues/2763)) |
@@ -198,18 +198,18 @@ The tables below list every Spark built-in expression with its current status.
 
 ## conditional_funcs
 
-| Function     | Status | Notes |
-| ------------ | ------ | ----- |
-| `coalesce`   | ✅     |       |
-| `if`         | ✅     |       |
-| `ifnull`     | ✅     |       |
-| `nanvl`      | 🔜     | #4538 |
-| `nullif`     | ✅     |       |
-| `nullifzero` | ❓     |       |
-| `nvl`        | ✅     |       |
-| `nvl2`       | ✅     |       |
-| `when`       | ✅     |       |
-| `zeroifnull` | ❓     |       |
+| Function     | Status | Notes                             |
+| ------------ | ------ | --------------------------------- |
+| `coalesce`   | ✅     |                                   |
+| `if`         | ✅     |                                   |
+| `ifnull`     | ✅     |                                   |
+| `nanvl`      | 🔜     | #4538                             |
+| `nullif`     | ✅     |                                   |
+| `nullifzero` | ✅     | Lowers to `if`/`=` (Spark 4.0+)   |
+| `nvl`        | ✅     |                                   |
+| `nvl2`       | ✅     |                                   |
+| `when`       | ✅     |                                   |
+| `zeroifnull` | ✅     | Lowers to `coalesce` (Spark 4.0+) |
 
 ---
 
@@ -404,7 +404,7 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `map_keys`         | ✅     |                                                              |
 | `map_values`       | ✅     |                                                              |
 | `str_to_map`       | ✅     |                                                              |
-| `try_element_at`   | ❓     |                                                              |
+| `try_element_at`   | ✅     | Lowers to `element_at`; array input (MapType falls back)     |
 
 ---
 
@@ -476,11 +476,11 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `tanh`         | ✅     |                                                                                                                    |
 | `try_add`      | ⚠️     | Datetime/interval form falls back; numeric form supported                                                          |
 | `try_divide`   | ✅     |                                                                                                                    |
-| `try_mod`      | ❓     |                                                                                                                    |
+| `try_mod`      | ❓     | Lowers to `Remainder` with TRY eval mode, which falls back (#4484)                                                 |
 | `try_multiply` | ✅     |                                                                                                                    |
 | `try_subtract` | ✅     |                                                                                                                    |
 | `unhex`        | ✅     |                                                                                                                    |
-| `uniform`      | ❓     |                                                                                                                    |
+| `uniform`      | ✅     | Constant-folded; literal arguments only (Spark 4.0+)                                                               |
 | `width_bucket` | ⚠️     | Wired via shim, bypasses support-level framework ([#4485](https://github.com/apache/datafusion-comet/issues/4485)) |
 
 ---
@@ -499,12 +499,12 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | ----------------------------- | ------ | -------------------------------------------------------------------------------- |
 | `aes_decrypt`                 | 🔜     | Falls back; `StaticInvoke` not allowlisted; planned via codegen dispatch (#4558) |
 | `aes_encrypt`                 | 🔜     | Falls back; planned via codegen dispatch (#4558); nondeterministic IV by default |
-| `assert_true`                 | ❓     |                                                                                  |
+| `assert_true`                 | ❓     | Lowers to `RaiseError`, which falls back                                         |
 | `current_catalog`             | ❓     |                                                                                  |
 | `current_database`            | ❓     |                                                                                  |
 | `current_schema`              | ❓     |                                                                                  |
 | `current_user`                | ❓     |                                                                                  |
-| `equal_null`                  | ❓     |                                                                                  |
+| `equal_null`                  | ✅     | Lowers to `<=>` (`EqualNullSafe`)                                                |
 | `input_file_block_length`     | ❓     |                                                                                  |
 | `input_file_block_start`      | ❓     |                                                                                  |
 | `input_file_name`             | ❓     |                                                                                  |
@@ -526,7 +526,7 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `user`                        | ✅     | Resolved to a literal by the Spark analyzer before reaching Comet                |
 | `uuid`                        | ❓     |                                                                                  |
 | `variant_get`                 | 🔜     | tracking #4098                                                                   |
-| `version`                     | ❓     |                                                                                  |
+| `version`                     | ❓     | Lowers to `StaticInvoke(getSparkVersion)`, which falls back                      |
 
 ---
 
@@ -560,80 +560,80 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 
 ## string_funcs
 
-| Function             | Status | Notes                                             |
-| -------------------- | ------ | ------------------------------------------------- |
-| `ascii`              | ✅     |                                                   |
-| `base64`             | ❓     |                                                   |
-| `bit_length`         | ✅     |                                                   |
-| `btrim`              | ✅     |                                                   |
-| `char`               | ✅     |                                                   |
-| `char_length`        | ✅     |                                                   |
-| `character_length`   | ✅     |                                                   |
-| `chr`                | ✅     |                                                   |
-| `collate`            | ❓     |                                                   |
-| `collation`          | ❓     |                                                   |
-| `concat_ws`          | ✅     |                                                   |
-| `contains`           | ✅     |                                                   |
-| `decode`             | ✅     |                                                   |
-| `elt`                | 🔜     | #4538                                             |
-| `encode`             | ❓     |                                                   |
-| `endswith`           | ✅     |                                                   |
-| `find_in_set`        | 🔜     | #4538                                             |
-| `format_number`      | 🔜     | #4538                                             |
-| `format_string`      | 🔜     | #4538                                             |
-| `initcap`            | ✅     |                                                   |
-| `instr`              | ✅     |                                                   |
-| `is_valid_utf8`      | ❓     |                                                   |
-| `lcase`              | ✅     |                                                   |
-| `left`               | ✅     |                                                   |
-| `len`                | ✅     |                                                   |
-| `length`             | ✅     |                                                   |
-| `levenshtein`        | 🔜     | #4538                                             |
-| `locate`             | 🔜     | #4538                                             |
-| `lower`              | ✅     |                                                   |
-| `lpad`               | ✅     |                                                   |
-| `ltrim`              | ✅     |                                                   |
-| `luhn_check`         | ✅     | Native via `StaticInvoke` (tests: luhn_check.sql) |
-| `make_valid_utf8`    | ❓     |                                                   |
-| `mask`               | ❓     |                                                   |
-| `octet_length`       | ✅     |                                                   |
-| `overlay`            | 🔜     | #4538                                             |
-| `position`           | 🔜     | #4538                                             |
-| `printf`             | 🔜     | #4538                                             |
-| `quote`              | ❓     |                                                   |
-| `regexp_count`       | 🔜     | tracking #4098                                    |
-| `regexp_extract`     | 🔜     | tracking #4098                                    |
-| `regexp_extract_all` | 🔜     | tracking #4098                                    |
-| `regexp_instr`       | 🔜     | tracking #4098                                    |
-| `regexp_replace`     | ✅     |                                                   |
-| `regexp_substr`      | 🔜     | tracking #4098                                    |
-| `repeat`             | ✅     |                                                   |
-| `replace`            | ✅     |                                                   |
-| `right`              | ✅     |                                                   |
-| `rpad`               | ✅     |                                                   |
-| `rtrim`              | ✅     |                                                   |
-| `sentences`          | ❓     |                                                   |
-| `soundex`            | 🔜     | #4538                                             |
-| `space`              | ✅     |                                                   |
-| `split`              | ✅     |                                                   |
-| `split_part`         | ❓     |                                                   |
-| `startswith`         | ✅     |                                                   |
-| `substr`             | ✅     |                                                   |
-| `substring`          | ✅     |                                                   |
-| `substring_index`    | ✅     |                                                   |
-| `to_binary`          | ❓     |                                                   |
-| `to_char`            | 🔜     | #4538                                             |
-| `to_number`          | 🔜     | #4538                                             |
-| `to_varchar`         | 🔜     | #4538                                             |
-| `translate`          | ✅     |                                                   |
-| `trim`               | ✅     |                                                   |
-| `try_to_binary`      | ❓     |                                                   |
-| `try_to_number`      | ❓     |                                                   |
-| `try_validate_utf8`  | ❓     |                                                   |
-| `ucase`              | ✅     |                                                   |
-| `unbase64`           | 🔜     | #4538                                             |
-| `upper`              | ✅     |                                                   |
-| `validate_utf8`      | ❓     |                                                   |
+| Function             | Status | Notes                                                                          |
+| -------------------- | ------ | ------------------------------------------------------------------------------ |
+| `ascii`              | ✅     |                                                                                |
+| `base64`             | ❓     | Lowers to `StaticInvoke(encode)` (not allowlisted); falls back                 |
+| `bit_length`         | ✅     |                                                                                |
+| `btrim`              | ✅     |                                                                                |
+| `char`               | ✅     |                                                                                |
+| `char_length`        | ✅     |                                                                                |
+| `character_length`   | ✅     |                                                                                |
+| `chr`                | ✅     |                                                                                |
+| `collate`            | ❓     |                                                                                |
+| `collation`          | ✅     | Constant-folded to a literal (Spark 4.0+)                                      |
+| `concat_ws`          | ✅     |                                                                                |
+| `contains`           | ✅     |                                                                                |
+| `decode`             | ✅     |                                                                                |
+| `elt`                | 🔜     | #4538                                                                          |
+| `encode`             | ❓     | Lowers to `StaticInvoke(encode)` (not allowlisted); falls back                 |
+| `endswith`           | ✅     |                                                                                |
+| `find_in_set`        | 🔜     | #4538                                                                          |
+| `format_number`      | 🔜     | #4538                                                                          |
+| `format_string`      | 🔜     | #4538                                                                          |
+| `initcap`            | ✅     |                                                                                |
+| `instr`              | ✅     |                                                                                |
+| `is_valid_utf8`      | ❓     | Lowers to `Invoke`, which falls back (Spark 4.0+)                              |
+| `lcase`              | ✅     |                                                                                |
+| `left`               | ✅     |                                                                                |
+| `len`                | ✅     |                                                                                |
+| `length`             | ✅     |                                                                                |
+| `levenshtein`        | 🔜     | #4538                                                                          |
+| `locate`             | 🔜     | #4538                                                                          |
+| `lower`              | ✅     |                                                                                |
+| `lpad`               | ✅     |                                                                                |
+| `ltrim`              | ✅     |                                                                                |
+| `luhn_check`         | ✅     | Native via `StaticInvoke` (tests: luhn_check.sql)                              |
+| `make_valid_utf8`    | ❓     | Lowers to `Invoke`, which falls back (Spark 4.0+)                              |
+| `mask`               | ❓     |                                                                                |
+| `octet_length`       | ✅     |                                                                                |
+| `overlay`            | 🔜     | #4538                                                                          |
+| `position`           | 🔜     | #4538                                                                          |
+| `printf`             | 🔜     | #4538                                                                          |
+| `quote`              | ❓     | Lowers to `StaticInvoke`, which falls back (Spark 4.1+)                        |
+| `regexp_count`       | 🔜     | tracking #4098                                                                 |
+| `regexp_extract`     | 🔜     | tracking #4098                                                                 |
+| `regexp_extract_all` | 🔜     | tracking #4098                                                                 |
+| `regexp_instr`       | 🔜     | tracking #4098                                                                 |
+| `regexp_replace`     | ✅     |                                                                                |
+| `regexp_substr`      | 🔜     | tracking #4098                                                                 |
+| `repeat`             | ✅     |                                                                                |
+| `replace`            | ✅     |                                                                                |
+| `right`              | ✅     |                                                                                |
+| `rpad`               | ✅     |                                                                                |
+| `rtrim`              | ✅     |                                                                                |
+| `sentences`          | ❓     | Lowers to `StaticInvoke(getSentences)`, which falls back                       |
+| `soundex`            | 🔜     | #4538                                                                          |
+| `space`              | ✅     |                                                                                |
+| `split`              | ✅     |                                                                                |
+| `split_part`         | ❓     | Lowers to `element_at(StringSplitSQL(...))`; `StringSplitSQL` falls back       |
+| `startswith`         | ✅     |                                                                                |
+| `substr`             | ✅     |                                                                                |
+| `substring`          | ✅     |                                                                                |
+| `substring_index`    | ✅     |                                                                                |
+| `to_binary`          | ⚠️     | Only the hex format is accelerated (lowers to `unhex`); UTF-8/base64 fall back |
+| `to_char`            | 🔜     | #4538                                                                          |
+| `to_number`          | 🔜     | #4538                                                                          |
+| `to_varchar`         | 🔜     | #4538                                                                          |
+| `translate`          | ✅     |                                                                                |
+| `trim`               | ✅     |                                                                                |
+| `try_to_binary`      | ❓     | Lowers to `TryEval(...)`, which falls back                                     |
+| `try_to_number`      | ❓     |                                                                                |
+| `try_validate_utf8`  | ❓     | Lowers to `StaticInvoke`, which falls back (Spark 4.0+)                        |
+| `ucase`              | ✅     |                                                                                |
+| `unbase64`           | 🔜     | #4538                                                                          |
+| `upper`              | ✅     |                                                                                |
+| `validate_utf8`      | ❓     | Lowers to `StaticInvoke`, which falls back (Spark 4.0+)                        |
 
 ---
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -188,7 +188,7 @@ The tables below list every Spark built-in expression with its current status.
 
 | Function      | Status | Notes                                                                                                                            |
 | ------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| `array_size`  | ⚠️     | Lowers to `size`; accelerated, but returns -1 instead of NULL for NULL input (bug)                                               |
+| `array_size`  | ⚠️     | Lowers to `size`; accelerated, but returns -1 instead of NULL for NULL input (#4560)                                             |
 | `cardinality` | ⚠️     | Alias for `size`; `MapType` input falls back ([#4472](https://github.com/apache/datafusion-comet/issues/4472))                   |
 | `concat`      | ⚠️     | Only `StringType` children; `BinaryType`/`ArrayType` fall back ([#4471](https://github.com/apache/datafusion-comet/issues/4471)) |
 | `reverse`     | ⚠️     | Array with `BinaryType` elements is `Incompatible`, flag-gated ([#2763](https://github.com/apache/datafusion-comet/issues/2763)) |
@@ -560,80 +560,80 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 
 ## string_funcs
 
-| Function             | Status | Notes                                                                          |
-| -------------------- | ------ | ------------------------------------------------------------------------------ |
-| `ascii`              | ✅     |                                                                                |
-| `base64`             | ❓     | Lowers to `StaticInvoke(encode)` (not allowlisted); falls back                 |
-| `bit_length`         | ✅     |                                                                                |
-| `btrim`              | ✅     |                                                                                |
-| `char`               | ✅     |                                                                                |
-| `char_length`        | ✅     |                                                                                |
-| `character_length`   | ✅     |                                                                                |
-| `chr`                | ✅     |                                                                                |
-| `collate`            | ❓     |                                                                                |
-| `collation`          | ✅     | Constant-folded to a literal (Spark 4.0+)                                      |
-| `concat_ws`          | ✅     |                                                                                |
-| `contains`           | ✅     |                                                                                |
-| `decode`             | ✅     |                                                                                |
-| `elt`                | 🔜     | #4538                                                                          |
-| `encode`             | ❓     | Lowers to `StaticInvoke(encode)` (not allowlisted); falls back                 |
-| `endswith`           | ✅     |                                                                                |
-| `find_in_set`        | 🔜     | #4538                                                                          |
-| `format_number`      | 🔜     | #4538                                                                          |
-| `format_string`      | 🔜     | #4538                                                                          |
-| `initcap`            | ✅     |                                                                                |
-| `instr`              | ✅     |                                                                                |
-| `is_valid_utf8`      | ❓     | Lowers to `Invoke`, which falls back (Spark 4.0+)                              |
-| `lcase`              | ✅     |                                                                                |
-| `left`               | ✅     |                                                                                |
-| `len`                | ✅     |                                                                                |
-| `length`             | ✅     |                                                                                |
-| `levenshtein`        | 🔜     | #4538                                                                          |
-| `locate`             | 🔜     | #4538                                                                          |
-| `lower`              | ✅     |                                                                                |
-| `lpad`               | ✅     |                                                                                |
-| `ltrim`              | ✅     |                                                                                |
-| `luhn_check`         | ✅     | Native via `StaticInvoke` (tests: luhn_check.sql)                              |
-| `make_valid_utf8`    | ❓     | Lowers to `Invoke`, which falls back (Spark 4.0+)                              |
-| `mask`               | ❓     |                                                                                |
-| `octet_length`       | ✅     |                                                                                |
-| `overlay`            | 🔜     | #4538                                                                          |
-| `position`           | 🔜     | #4538                                                                          |
-| `printf`             | 🔜     | #4538                                                                          |
-| `quote`              | ❓     | Lowers to `StaticInvoke`, which falls back (Spark 4.1+)                        |
-| `regexp_count`       | 🔜     | tracking #4098                                                                 |
-| `regexp_extract`     | 🔜     | tracking #4098                                                                 |
-| `regexp_extract_all` | 🔜     | tracking #4098                                                                 |
-| `regexp_instr`       | 🔜     | tracking #4098                                                                 |
-| `regexp_replace`     | ✅     |                                                                                |
-| `regexp_substr`      | 🔜     | tracking #4098                                                                 |
-| `repeat`             | ✅     |                                                                                |
-| `replace`            | ✅     |                                                                                |
-| `right`              | ✅     |                                                                                |
-| `rpad`               | ✅     |                                                                                |
-| `rtrim`              | ✅     |                                                                                |
-| `sentences`          | ❓     | Lowers to `StaticInvoke(getSentences)`, which falls back                       |
-| `soundex`            | 🔜     | #4538                                                                          |
-| `space`              | ✅     |                                                                                |
-| `split`              | ✅     |                                                                                |
-| `split_part`         | ❓     | Lowers to `element_at(StringSplitSQL(...))`; `StringSplitSQL` falls back       |
-| `startswith`         | ✅     |                                                                                |
-| `substr`             | ✅     |                                                                                |
-| `substring`          | ✅     |                                                                                |
-| `substring_index`    | ✅     |                                                                                |
-| `to_binary`          | ⚠️     | Only the hex format is accelerated (lowers to `unhex`); UTF-8/base64 fall back |
-| `to_char`            | 🔜     | #4538                                                                          |
-| `to_number`          | 🔜     | #4538                                                                          |
-| `to_varchar`         | 🔜     | #4538                                                                          |
-| `translate`          | ✅     |                                                                                |
-| `trim`               | ✅     |                                                                                |
-| `try_to_binary`      | ❓     | Lowers to `TryEval(...)`, which falls back                                     |
-| `try_to_number`      | ❓     |                                                                                |
-| `try_validate_utf8`  | ❓     | Lowers to `StaticInvoke`, which falls back (Spark 4.0+)                        |
-| `ucase`              | ✅     |                                                                                |
-| `unbase64`           | 🔜     | #4538                                                                          |
-| `upper`              | ✅     |                                                                                |
-| `validate_utf8`      | ❓     | Lowers to `StaticInvoke`, which falls back (Spark 4.0+)                        |
+| Function             | Status | Notes                                                                            |
+| -------------------- | ------ | -------------------------------------------------------------------------------- |
+| `ascii`              | ✅     |                                                                                  |
+| `base64`             | ❓     | Lowers to `StaticInvoke(encode)` (not allowlisted); falls back                   |
+| `bit_length`         | ✅     |                                                                                  |
+| `btrim`              | ✅     |                                                                                  |
+| `char`               | ✅     |                                                                                  |
+| `char_length`        | ✅     |                                                                                  |
+| `character_length`   | ✅     |                                                                                  |
+| `chr`                | ✅     |                                                                                  |
+| `collate`            | ❓     |                                                                                  |
+| `collation`          | ✅     | Constant-folded to a literal (Spark 4.0+)                                        |
+| `concat_ws`          | ✅     |                                                                                  |
+| `contains`           | ✅     |                                                                                  |
+| `decode`             | ✅     |                                                                                  |
+| `elt`                | 🔜     | #4538                                                                            |
+| `encode`             | ❓     | Lowers to `StaticInvoke(encode)` (not allowlisted); falls back                   |
+| `endswith`           | ✅     |                                                                                  |
+| `find_in_set`        | 🔜     | #4538                                                                            |
+| `format_number`      | 🔜     | #4538                                                                            |
+| `format_string`      | 🔜     | #4538                                                                            |
+| `initcap`            | ✅     |                                                                                  |
+| `instr`              | ✅     |                                                                                  |
+| `is_valid_utf8`      | ❓     | Lowers to `Invoke`, which falls back (Spark 4.0+)                                |
+| `lcase`              | ✅     |                                                                                  |
+| `left`               | ✅     |                                                                                  |
+| `len`                | ✅     |                                                                                  |
+| `length`             | ✅     |                                                                                  |
+| `levenshtein`        | 🔜     | #4538                                                                            |
+| `locate`             | 🔜     | #4538                                                                            |
+| `lower`              | ✅     |                                                                                  |
+| `lpad`               | ✅     |                                                                                  |
+| `ltrim`              | ✅     |                                                                                  |
+| `luhn_check`         | ✅     | Native via `StaticInvoke` (tests: luhn_check.sql)                                |
+| `make_valid_utf8`    | ❓     | Lowers to `Invoke`, which falls back (Spark 4.0+)                                |
+| `mask`               | ❓     |                                                                                  |
+| `octet_length`       | ✅     |                                                                                  |
+| `overlay`            | 🔜     | #4538                                                                            |
+| `position`           | 🔜     | #4538                                                                            |
+| `printf`             | 🔜     | #4538                                                                            |
+| `quote`              | ❓     | Lowers to `StaticInvoke`, which falls back (Spark 4.1+)                          |
+| `regexp_count`       | 🔜     | tracking #4098                                                                   |
+| `regexp_extract`     | 🔜     | tracking #4098                                                                   |
+| `regexp_extract_all` | 🔜     | tracking #4098                                                                   |
+| `regexp_instr`       | 🔜     | tracking #4098                                                                   |
+| `regexp_replace`     | ✅     |                                                                                  |
+| `regexp_substr`      | 🔜     | tracking #4098                                                                   |
+| `repeat`             | ✅     |                                                                                  |
+| `replace`            | ✅     |                                                                                  |
+| `right`              | ✅     |                                                                                  |
+| `rpad`               | ✅     |                                                                                  |
+| `rtrim`              | ✅     |                                                                                  |
+| `sentences`          | ❓     | Lowers to `StaticInvoke(getSentences)`, which falls back                         |
+| `soundex`            | 🔜     | #4538                                                                            |
+| `space`              | ✅     |                                                                                  |
+| `split`              | ✅     |                                                                                  |
+| `split_part`         | ❓     | Lowers to `element_at(StringSplitSQL(...))`; `StringSplitSQL` falls back (#4561) |
+| `startswith`         | ✅     |                                                                                  |
+| `substr`             | ✅     |                                                                                  |
+| `substring`          | ✅     |                                                                                  |
+| `substring_index`    | ✅     |                                                                                  |
+| `to_binary`          | ⚠️     | Only the hex format is accelerated (lowers to `unhex`); UTF-8/base64 fall back   |
+| `to_char`            | 🔜     | #4538                                                                            |
+| `to_number`          | 🔜     | #4538                                                                            |
+| `to_varchar`         | 🔜     | #4538                                                                            |
+| `translate`          | ✅     |                                                                                  |
+| `trim`               | ✅     |                                                                                  |
+| `try_to_binary`      | ❓     | Lowers to `TryEval(...)`, which falls back                                       |
+| `try_to_number`      | ❓     |                                                                                  |
+| `try_validate_utf8`  | ❓     | Lowers to `StaticInvoke`, which falls back (Spark 4.0+)                          |
+| `ucase`              | ✅     |                                                                                  |
+| `unbase64`           | 🔜     | #4538                                                                            |
+| `upper`              | ✅     |                                                                                  |
+| `validate_utf8`      | ❓     | Lowers to `StaticInvoke`, which falls back (Spark 4.0+)                          |
 
 ---
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -307,9 +307,9 @@ serde but effectively fall through to the same cast path at runtime.
 | `trunc`               | ✅     |                                                                                                        |
 | `try_make_interval`   | 🔜     | Produces legacy CalendarInterval; tracked by #4540                                                     |
 | `try_make_timestamp`  | ⚠️     | Runs natively for valid inputs, but returns wrong values for invalid inputs instead of NULL (#4554)    |
-| `try_to_date`         | ❓     | Rewrites to `Cast`/`GetTimestamp`, but the rewritten form currently falls back (tests: #4555)          |
+| `try_to_date`         | 🔜     | Rewrites to `Cast`/`GetTimestamp` but currently falls back; tracked by #4556                           |
 | `try_to_time`         | 🔜     | Spark 4.1 TIME type; tracked by #4288                                                                  |
-| `try_to_timestamp`    | ❓     | Rewrites to `Cast`/`GetTimestamp`, but the rewritten form currently falls back (tests: #4555)          |
+| `try_to_timestamp`    | 🔜     | Rewrites to `Cast`/`GetTimestamp` but currently falls back; tracked by #4556                           |
 | `unix_date`           | ✅     |                                                                                                        |
 | `unix_micros`         | ✅     |                                                                                                        |
 | `unix_millis`         | ✅     |                                                                                                        |

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -39,9 +39,9 @@ Most expressions can also be disabled with `spark.comet.expression.EXPRNAME.enab
 | ------ | ------- |
 | ✅ Supported | Native or codegen path; compatible with Spark by default. |
 | ⚠️ Supported (caveats) | Works, but may diverge from Spark in some cases: incompatible, flag-gated (`allowIncompatible`), or restricted to certain types. See the [Compatibility Guide](compatibility/index.md). |
-| 🚧 Planned | Intended; tracked by an open issue or pull request. |
+| 🔜 Planned | Intended; tracked by an open issue or pull request. |
 | 🚫 Out of scope | Deliberately not planned. |
-| ⬜ Not yet supported | Falls back to Spark today; not yet evaluated. |
+| ❓ Not yet supported | Falls back to Spark today; support is to be determined (not yet evaluated). |
 
 ## Scope policy
 
@@ -70,16 +70,16 @@ The tables below list every Spark built-in expression with its current status.
 | -------- | ------ | ----- |
 | `any` | ✅ | |
 | `any_value` | ✅ | |
-| `approx_count_distinct` | 🚧 | tracking #4098 |
-| `approx_percentile` | 🚧 | [#3189](https://github.com/apache/datafusion-comet/issues/3189) |
-| `array_agg` | ⬜ | |
+| `approx_count_distinct` | 🔜 | tracking #4098 |
+| `approx_percentile` | 🔜 | [#3189](https://github.com/apache/datafusion-comet/issues/3189) |
+| `array_agg` | ❓ | |
 | `avg` | ⚠️ | Interval types (YearMonth, DayTime) fall back |
 | `bit_and` | ✅ | |
 | `bit_or` | ✅ | |
 | `bit_xor` | ✅ | |
 | `bool_and` | ✅ | |
 | `bool_or` | ✅ | |
-| `collect_list` | 🚧 | [#2524](https://github.com/apache/datafusion-comet/issues/2524) |
+| `collect_list` | 🔜 | [#2524](https://github.com/apache/datafusion-comet/issues/2524) |
 | `collect_set` | ✅ | |
 | `corr` | ✅ | |
 | `count` | ✅ | |
@@ -89,43 +89,43 @@ The tables below list every Spark built-in expression with its current status.
 | `every` | ✅ | |
 | `first` | ✅ | |
 | `first_value` | ✅ | |
-| `grouping` | ⬜ | |
-| `grouping_id` | ⬜ | |
-| `histogram_numeric` | ⬜ | |
-| `kurtosis` | 🚧 | tracking #4098 |
+| `grouping` | ❓ | |
+| `grouping_id` | ❓ | |
+| `histogram_numeric` | ❓ | |
+| `kurtosis` | 🔜 | tracking #4098 |
 | `last` | ✅ | |
 | `last_value` | ✅ | |
-| `listagg` | ⬜ | |
+| `listagg` | ❓ | |
 | `max` | ✅ | |
-| `max_by` | 🚧 | [#3841](https://github.com/apache/datafusion-comet/issues/3841) |
+| `max_by` | 🔜 | [#3841](https://github.com/apache/datafusion-comet/issues/3841) |
 | `mean` | ✅ | |
-| `median` | 🚧 | tracking #4098 |
+| `median` | 🔜 | tracking #4098 |
 | `min` | ✅ | |
-| `min_by` | 🚧 | [#3841](https://github.com/apache/datafusion-comet/issues/3841) |
-| `mode` | 🚧 | [#3970](https://github.com/apache/datafusion-comet/issues/3970) |
-| `percentile` | 🚧 | #4542 |
-| `percentile_approx` | 🚧 | [#3189](https://github.com/apache/datafusion-comet/issues/3189) |
-| `percentile_cont` | ⬜ | |
-| `percentile_disc` | ⬜ | |
-| `regr_avgx` | 🚧 | tracking #4098 |
-| `regr_avgy` | 🚧 | tracking #4098 |
-| `regr_count` | 🚧 | tracking #4098 |
-| `regr_intercept` | 🚧 | tracking #4098 |
-| `regr_r2` | 🚧 | tracking #4098 |
-| `regr_slope` | 🚧 | tracking #4098 |
-| `regr_sxx` | 🚧 | tracking #4098 |
-| `regr_sxy` | 🚧 | tracking #4098 |
-| `regr_syy` | 🚧 | tracking #4098 |
-| `skewness` | 🚧 | tracking #4098 |
+| `min_by` | 🔜 | [#3841](https://github.com/apache/datafusion-comet/issues/3841) |
+| `mode` | 🔜 | [#3970](https://github.com/apache/datafusion-comet/issues/3970) |
+| `percentile` | 🔜 | #4542 |
+| `percentile_approx` | 🔜 | [#3189](https://github.com/apache/datafusion-comet/issues/3189) |
+| `percentile_cont` | ❓ | |
+| `percentile_disc` | ❓ | |
+| `regr_avgx` | 🔜 | tracking #4098 |
+| `regr_avgy` | 🔜 | tracking #4098 |
+| `regr_count` | 🔜 | tracking #4098 |
+| `regr_intercept` | 🔜 | tracking #4098 |
+| `regr_r2` | 🔜 | tracking #4098 |
+| `regr_slope` | 🔜 | tracking #4098 |
+| `regr_sxx` | 🔜 | tracking #4098 |
+| `regr_sxy` | 🔜 | tracking #4098 |
+| `regr_syy` | 🔜 | tracking #4098 |
+| `skewness` | 🔜 | tracking #4098 |
 | `some` | ✅ | |
 | `std` | ✅ | |
 | `stddev` | ✅ | |
 | `stddev_pop` | ✅ | |
 | `stddev_samp` | ✅ | |
-| `string_agg` | ⬜ | |
+| `string_agg` | ❓ | |
 | `sum` | ✅ | |
-| `try_avg` | 🚧 | tracking #4098 |
-| `try_sum` | 🚧 | tracking #4098 |
+| `try_avg` | 🔜 | tracking #4098 |
+| `try_sum` | 🔜 | tracking #4098 |
 | `var_pop` | ✅ | |
 | `var_samp` | ✅ | |
 | `variance` | ✅ | |
@@ -148,7 +148,7 @@ The tables below list every Spark built-in expression with its current status.
 | `array_max` | ⚠️ | NaN ordering may differ for float/double ([#4482](https://github.com/apache/datafusion-comet/issues/4482)) |
 | `array_min` | ⚠️ | NaN ordering may differ for float/double ([#4482](https://github.com/apache/datafusion-comet/issues/4482)) |
 | `array_position` | ⚠️ | Falls back for binary/struct/map/null element types |
-| `array_prepend` | ⬜ | |
+| `array_prepend` | ❓ | |
 | `array_remove` | ✅ | |
 | `array_repeat` | ✅ | |
 | `array_union` | ⚠️ | NaN/signed-zero canonicalization may differ ([#4481](https://github.com/apache/datafusion-comet/issues/4481)) |
@@ -157,9 +157,9 @@ The tables below list every Spark built-in expression with its current status.
 | `element_at` | ⚠️ | Only `ArrayType` input; `MapType` input falls back |
 | `flatten` | ⚠️ | Falls back for binary/struct/map child element types |
 | `get` | ✅ | |
-| `sequence` | 🚧 | #4538 |
-| `shuffle` | ⬜ | |
-| `slice` | ⬜ | |
+| `sequence` | 🔜 | #4538 |
+| `shuffle` | ❓ | |
+| `slice` | ❓ | |
 | `sort_array` | ⚠️ | Incompatible under strict floating-point; falls back for nested struct/null arrays |
 
 ---
@@ -171,7 +171,7 @@ The tables below list every Spark built-in expression with its current status.
 | `&` | ✅ | |
 | `<<` | ✅ | |
 | `>>` | ✅ | |
-| `>>>` | ⬜ | |
+| `>>>` | ❓ | |
 | `^` | ✅ | |
 | `bit_count` | ✅ | |
 | `bit_get` | ✅ | |
@@ -187,8 +187,8 @@ The tables below list every Spark built-in expression with its current status.
 
 | Function | Status | Notes |
 | -------- | ------ | ----- |
-| `array_size` | ⬜ | |
-| `cardinality` | ⬜ | |
+| `array_size` | ❓ | |
+| `cardinality` | ❓ | |
 | `concat` | ⚠️ | Only `StringType` children; `BinaryType`/`ArrayType` fall back ([#4471](https://github.com/apache/datafusion-comet/issues/4471)) |
 | `reverse` | ⚠️ | Array with `BinaryType` elements is `Incompatible`, flag-gated ([#2763](https://github.com/apache/datafusion-comet/issues/2763)) |
 | `size` | ⚠️ | `MapType` input falls back ([#4472](https://github.com/apache/datafusion-comet/issues/4472)) |
@@ -202,13 +202,13 @@ The tables below list every Spark built-in expression with its current status.
 | `coalesce` | ✅ | |
 | `if` | ✅ | |
 | `ifnull` | ✅ | |
-| `nanvl` | 🚧 | #4538 |
+| `nanvl` | 🔜 | #4538 |
 | `nullif` | ✅ | |
-| `nullifzero` | ⬜ | |
+| `nullifzero` | ❓ | |
 | `nvl` | ✅ | |
 | `nvl2` | ✅ | |
 | `when` | ✅ | |
-| `zeroifnull` | ⬜ | |
+| `zeroifnull` | ❓ | |
 
 ---
 
@@ -220,19 +220,19 @@ serde but effectively fall through to the same cast path at runtime.
 
 | Function | Status | Notes |
 | -------- | ------ | ----- |
-| `bigint` | ⬜ | Alias for `CAST(... AS BIGINT)`; see `cast` |
-| `binary` | ⬜ | Alias for `CAST(... AS BINARY)`; see `cast` |
-| `boolean` | ⬜ | Alias for `CAST(... AS BOOLEAN)`; see `cast` |
+| `bigint` | ⚠️ | Alias for `CAST(... AS BIGINT)`; see `cast` |
+| `binary` | ⚠️ | Alias for `CAST(... AS BINARY)`; see `cast` |
+| `boolean` | ⚠️ | Alias for `CAST(... AS BOOLEAN)`; see `cast` |
 | `cast` | ⚠️ | Many type pairs supported; float-to-decimal rounding may differ; see [Compatibility Guide](compatibility/index.md) |
-| `date` | ⬜ | Alias for `CAST(... AS DATE)`; see `cast` |
-| `decimal` | ⬜ | Alias for `CAST(... AS DECIMAL)`; see `cast` |
-| `double` | ⬜ | Alias for `CAST(... AS DOUBLE)`; see `cast` |
-| `float` | ⬜ | Alias for `CAST(... AS FLOAT)`; see `cast` |
-| `int` | ⬜ | Alias for `CAST(... AS INT)`; see `cast` |
-| `smallint` | ⬜ | Alias for `CAST(... AS SMALLINT)`; see `cast` |
-| `string` | ⬜ | Alias for `CAST(... AS STRING)`; see `cast` |
-| `timestamp` | ⬜ | Alias for `CAST(... AS TIMESTAMP)`; see `cast` |
-| `tinyint` | ⬜ | Alias for `CAST(... AS TINYINT)`; see `cast` |
+| `date` | ⚠️ | Alias for `CAST(... AS DATE)`; see `cast` |
+| `decimal` | ⚠️ | Alias for `CAST(... AS DECIMAL)`; see `cast` |
+| `double` | ⚠️ | Alias for `CAST(... AS DOUBLE)`; see `cast` |
+| `float` | ⚠️ | Alias for `CAST(... AS FLOAT)`; see `cast` |
+| `int` | ⚠️ | Alias for `CAST(... AS INT)`; see `cast` |
+| `smallint` | ⚠️ | Alias for `CAST(... AS SMALLINT)`; see `cast` |
+| `string` | ⚠️ | Alias for `CAST(... AS STRING)`; see `cast` |
+| `timestamp` | ⚠️ | Alias for `CAST(... AS TIMESTAMP)`; see `cast` |
+| `tinyint` | ⚠️ | Alias for `CAST(... AS TINYINT)`; see `cast` |
 
 ---
 
@@ -240,9 +240,9 @@ serde but effectively fall through to the same cast path at runtime.
 
 | Function | Status | Notes |
 | -------- | ------ | ----- |
-| `from_csv` | ⬜ | |
-| `schema_of_csv` | ⬜ | |
-| `to_csv` | ⬜ | |
+| `from_csv` | ❓ | |
+| `schema_of_csv` | ❓ | |
+| `to_csv` | ❓ | |
 
 ---
 
@@ -252,10 +252,10 @@ serde but effectively fall through to the same cast path at runtime.
 | -------- | ------ | ----- |
 | `add_months` | ✅ | |
 | `convert_timezone` | ✅ | |
-| `curdate` | ⬜ | |
-| `current_date` | ⬜ | |
-| `current_time` | ⬜ | |
-| `current_timestamp` | ⬜ | |
+| `curdate` | ✅ | Constant-folded to a literal (alias of `current_date`) |
+| `current_date` | ✅ | Constant-folded to a literal before Comet sees the plan |
+| `current_time` | ❓ | |
+| `current_timestamp` | ✅ | Constant-folded to a literal before Comet sees the plan |
 | `current_timezone` | ✅ | |
 | `date_add` | ✅ | |
 | `date_diff` | ✅ | |
@@ -268,7 +268,7 @@ serde but effectively fall through to the same cast path at runtime.
 | `datediff` | ✅ | |
 | `datepart` | ✅ | |
 | `day` | ✅ | |
-| `dayname` | 🚧 | #4544 |
+| `dayname` | 🔜 | #4544 |
 | `dayofmonth` | ✅ | |
 | `dayofweek` | ✅ | |
 | `dayofyear` | ✅ | |
@@ -279,40 +279,40 @@ serde but effectively fall through to the same cast path at runtime.
 | `last_day` | ✅ | |
 | `localtimestamp` | ✅ | |
 | `make_date` | ✅ | |
-| `make_dt_interval` | 🚧 | #4541 |
-| `make_interval` | ⬜ | |
-| `make_time` | ⬜ | |
+| `make_dt_interval` | 🔜 | #4541 |
+| `make_interval` | ❓ | |
+| `make_time` | ❓ | |
 | `make_timestamp` | ✅ | |
-| `make_timestamp_ltz` | ⬜ | |
-| `make_timestamp_ntz` | ⬜ | |
-| `make_ym_interval` | 🚧 | #4541 |
+| `make_timestamp_ltz` | ⚠️ | 6-arg form runs via the codegen dispatcher; 2-arg `(date, time)` form (Spark 4.1 TIME type) falls back |
+| `make_timestamp_ntz` | ⚠️ | 6-arg form runs via the codegen dispatcher; 2-arg `(date, time)` form (Spark 4.1 TIME type) falls back |
+| `make_ym_interval` | 🔜 | #4541 |
 | `minute` | ✅ | |
 | `month` | ✅ | |
-| `monthname` | 🚧 | #4544 |
+| `monthname` | 🔜 | #4544 |
 | `months_between` | ✅ | |
 | `next_day` | ✅ | |
-| `now` | ⬜ | |
+| `now` | ✅ | Constant-folded to a literal (alias of `current_timestamp`) |
 | `quarter` | ✅ | |
 | `second` | ✅ | |
-| `session_window` | ⬜ | |
-| `time_diff` | ⬜ | |
-| `time_trunc` | ⬜ | |
+| `session_window` | ❓ | |
+| `time_diff` | ❓ | |
+| `time_trunc` | ❓ | |
 | `timestamp_micros` | ✅ | |
 | `timestamp_millis` | ✅ | |
 | `timestamp_seconds` | ✅ | |
-| `to_date` | ⬜ | |
-| `to_time` | ⬜ | |
-| `to_timestamp` | ⬜ | |
-| `to_timestamp_ltz` | ⬜ | |
-| `to_timestamp_ntz` | ⬜ | |
+| `to_date` | ✅ | Rewrites to `Cast` (or `Cast(GetTimestamp)` with a format) before Comet sees the plan |
+| `to_time` | ❓ | |
+| `to_timestamp` | ✅ | Rewrites to `Cast` (or `GetTimestamp` with a format) before Comet sees the plan |
+| `to_timestamp_ltz` | ✅ | Rewrites to `to_timestamp` (`TimestampType`) |
+| `to_timestamp_ntz` | ✅ | Rewrites to `to_timestamp` (`TimestampNTZType`) |
 | `to_unix_timestamp` | ✅ | |
 | `to_utc_timestamp` | ⚠️ | Legacy zone forms (`GMT+1`, `PST`) throw a native parse error |
 | `trunc` | ✅ | |
-| `try_make_interval` | ⬜ | |
-| `try_make_timestamp` | ⬜ | |
-| `try_to_date` | ⬜ | |
-| `try_to_time` | ⬜ | |
-| `try_to_timestamp` | ⬜ | |
+| `try_make_interval` | ❓ | |
+| `try_make_timestamp` | ❓ | |
+| `try_to_date` | ❓ | |
+| `try_to_time` | ❓ | |
+| `try_to_timestamp` | ❓ | |
 | `unix_date` | ✅ | |
 | `unix_micros` | ✅ | |
 | `unix_millis` | ✅ | |
@@ -320,8 +320,8 @@ serde but effectively fall through to the same cast path at runtime.
 | `unix_timestamp` | ✅ | |
 | `weekday` | ✅ | |
 | `weekofyear` | ✅ | |
-| `window` | ⬜ | |
-| `window_time` | ⬜ | |
+| `window` | ❓ | |
+| `window_time` | ❓ | |
 | `year` | ✅ | |
 
 ---
@@ -336,11 +336,11 @@ expression-level). The `outer` variants are wired but marked `Incompatible`; the
 | -------- | ------ | ----- |
 | `explode` | ✅ | via `CometExplodeExec` |
 | `explode_outer` | ⚠️ | `outer=true` incompatible; needs `allowIncompatible` |
-| `inline` | ⬜ | |
-| `inline_outer` | ⬜ | |
+| `inline` | ❓ | |
+| `inline_outer` | ❓ | |
 | `posexplode` | ✅ | via `CometExplodeExec` |
 | `posexplode_outer` | ⚠️ | `outer=true` incompatible; needs `allowIncompatible` |
-| `stack` | ⬜ | |
+| `stack` | ❓ | |
 
 ---
 
@@ -362,13 +362,13 @@ expression-level). The `outer` variants are wired but marked `Incompatible`; the
 
 | Function | Status | Notes |
 | -------- | ------ | ----- |
-| `from_json` | 🚧 | [#3203](https://github.com/apache/datafusion-comet/issues/3203) |
+| `from_json` | 🔜 | [#3203](https://github.com/apache/datafusion-comet/issues/3203) |
 | `get_json_object` | ⚠️ | Single-quoted JSON and unescaped control chars require `allowIncompatible` |
-| `json_array_length` | 🚧 | tracking #4098 |
-| `json_object_keys` | 🚧 | [#3161](https://github.com/apache/datafusion-comet/issues/3161) |
-| `json_tuple` | 🚧 | [#3160](https://github.com/apache/datafusion-comet/issues/3160) |
-| `schema_of_json` | 🚧 | [#3163](https://github.com/apache/datafusion-comet/issues/3163) |
-| `to_json` | 🚧 | tracking #4098 |
+| `json_array_length` | 🔜 | tracking #4098 |
+| `json_object_keys` | 🔜 | [#3161](https://github.com/apache/datafusion-comet/issues/3161) |
+| `json_tuple` | 🔜 | [#3160](https://github.com/apache/datafusion-comet/issues/3160) |
+| `schema_of_json` | 🔜 | [#3163](https://github.com/apache/datafusion-comet/issues/3163) |
+| `to_json` | 🔜 | tracking #4098 |
 
 ---
 
@@ -378,18 +378,18 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 
 | Function | Status | Notes |
 | -------- | ------ | ----- |
-| `aggregate` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `array_sort` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `exists` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `filter` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `forall` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `map_filter` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `map_zip_with` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `reduce` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `transform` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `transform_keys` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `transform_values` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `zip_with` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `aggregate` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `array_sort` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `exists` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `filter` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `forall` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `map_filter` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `map_zip_with` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `reduce` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `transform` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `transform_keys` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `transform_values` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `zip_with` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
 
 ---
 
@@ -398,8 +398,8 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | Function | Status | Notes |
 | -------- | ------ | ----- |
 | `element_at` | ⚠️ | Only `ArrayType` input; `MapType` input falls back |
-| `map` | ⬜ | |
-| `map_concat` | ⬜ | |
+| `map` | ❓ | |
+| `map_concat` | ❓ | |
 | `map_contains_key` | ✅ | |
 | `map_entries` | ✅ | |
 | `map_from_arrays` | ✅ | |
@@ -407,7 +407,7 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `map_keys` | ✅ | |
 | `map_values` | ✅ | |
 | `str_to_map` | ✅ | |
-| `try_element_at` | ⬜ | |
+| `try_element_at` | ❓ | |
 
 ---
 
@@ -429,43 +429,43 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `atan2` | ✅ | |
 | `atanh` | ✅ | |
 | `bin` | ✅ | |
-| `bround` | 🚧 | #4538 |
+| `bround` | 🔜 | #4538 |
 | `cbrt` | ✅ | |
 | `ceil` | ⚠️ | Two-arg `ceil(expr, scale)` form falls back |
 | `ceiling` | ✅ | |
-| `conv` | 🚧 | #4538 |
+| `conv` | 🔜 | #4538 |
 | `cos` | ✅ | |
 | `cosh` | ✅ | |
 | `cot` | ✅ | |
 | `csc` | ✅ | |
 | `degrees` | ✅ | |
 | `div` | ✅ | |
-| `e` | ⬜ | |
+| `e` | ❓ | |
 | `exp` | ✅ | |
 | `expm1` | ✅ | |
 | `factorial` | ✅ | |
 | `floor` | ⚠️ | Two-arg `floor(expr, scale)` form falls back |
 | `greatest` | ✅ | |
 | `hex` | ✅ | |
-| `hypot` | 🚧 | #4538 |
+| `hypot` | 🔜 | #4538 |
 | `least` | ✅ | |
 | `ln` | ✅ | |
 | `log` | ✅ | |
 | `log10` | ✅ | |
-| `log1p` | 🚧 | #4538 |
+| `log1p` | 🔜 | #4538 |
 | `log2` | ✅ | |
 | `mod` | ✅ | |
 | `negative` | ✅ | |
 | `pi` | ✅ | |
-| `pmod` | 🚧 | #4538 |
+| `pmod` | 🔜 | #4538 |
 | `positive` | ✅ | |
 | `pow` | ✅ | |
 | `power` | ✅ | |
 | `radians` | ✅ | |
 | `rand` | ✅ | |
 | `randn` | ✅ | |
-| `random` | ⬜ | |
-| `randstr` | ⬜ | |
+| `random` | ❓ | |
+| `randstr` | ❓ | |
 | `rint` | ✅ | |
 | `round` | ⚠️ | Float/Double inputs always fall back; integer/decimal HALF_UP supported |
 | `sec` | ✅ | |
@@ -479,11 +479,11 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `tanh` | ✅ | |
 | `try_add` | ⚠️ | Datetime/interval form falls back; numeric form supported |
 | `try_divide` | ✅ | |
-| `try_mod` | ⬜ | |
+| `try_mod` | ❓ | |
 | `try_multiply` | ✅ | |
 | `try_subtract` | ✅ | |
 | `unhex` | ✅ | |
-| `uniform` | ⬜ | |
+| `uniform` | ❓ | |
 | `width_bucket` | ⚠️ | Wired via shim, bypasses support-level framework ([#4485](https://github.com/apache/datafusion-comet/issues/4485)) |
 
 ---
@@ -500,33 +500,33 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 
 | Function | Status | Notes |
 | -------- | ------ | ----- |
-| `assert_true` | ⬜ | |
-| `current_catalog` | ⬜ | |
-| `current_database` | ⬜ | |
-| `current_schema` | ⬜ | |
-| `current_user` | ⬜ | |
-| `equal_null` | ⬜ | |
-| `input_file_block_length` | ⬜ | |
-| `input_file_block_start` | ⬜ | |
-| `input_file_name` | ⬜ | |
-| `is_variant_null` | 🚧 | tracking #4098 |
+| `assert_true` | ❓ | |
+| `current_catalog` | ❓ | |
+| `current_database` | ❓ | |
+| `current_schema` | ❓ | |
+| `current_user` | ❓ | |
+| `equal_null` | ❓ | |
+| `input_file_block_length` | ❓ | |
+| `input_file_block_start` | ❓ | |
+| `input_file_name` | ❓ | |
+| `is_variant_null` | 🔜 | tracking #4098 |
 | `monotonically_increasing_id` | ✅ | |
-| `parse_json` | 🚧 | tracking #4098 |
-| `raise_error` | ⬜ | |
+| `parse_json` | 🔜 | tracking #4098 |
+| `raise_error` | ❓ | |
 | `rand` | ✅ | Seed must be a literal |
 | `randn` | ✅ | Seed must be a literal |
-| `schema_of_variant` | 🚧 | tracking #4098 |
-| `schema_of_variant_agg` | 🚧 | tracking #4098 |
-| `session_user` | ⬜ | |
+| `schema_of_variant` | 🔜 | tracking #4098 |
+| `schema_of_variant_agg` | 🔜 | tracking #4098 |
+| `session_user` | ❓ | |
 | `spark_partition_id` | ✅ | |
-| `to_variant_object` | 🚧 | tracking #4098 |
-| `try_parse_json` | 🚧 | tracking #4098 |
-| `try_variant_get` | 🚧 | tracking #4098 |
-| `typeof` | ⬜ | |
+| `to_variant_object` | 🔜 | tracking #4098 |
+| `try_parse_json` | 🔜 | tracking #4098 |
+| `try_variant_get` | 🔜 | tracking #4098 |
+| `typeof` | ❓ | |
 | `user` | ✅ | Resolved to a literal by the Spark analyzer before reaching Comet |
-| `uuid` | ⬜ | |
-| `variant_get` | 🚧 | tracking #4098 |
-| `version` | ⬜ | |
+| `uuid` | ❓ | |
+| `variant_get` | 🔜 | tracking #4098 |
+| `version` | ❓ | |
 
 ---
 
@@ -552,8 +552,8 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `like` | ✅ | |
 | `not` | ✅ | |
 | `or` | ✅ | |
-| `regexp` | 🚧 | tracking #4098 |
-| `regexp_like` | 🚧 | tracking #4098 |
+| `regexp` | 🔜 | tracking #4098 |
+| `regexp_like` | 🔜 | tracking #4098 |
 | `rlike` | ⚠️ | Uses Rust `regex` crate; requires `allowIncompatible`; results may differ from Java `Pattern` |
 
 ---
@@ -563,77 +563,77 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | Function | Status | Notes |
 | -------- | ------ | ----- |
 | `ascii` | ✅ | |
-| `base64` | ⬜ | |
+| `base64` | ❓ | |
 | `bit_length` | ✅ | |
 | `btrim` | ✅ | |
 | `char` | ✅ | |
 | `char_length` | ✅ | |
 | `character_length` | ✅ | |
 | `chr` | ✅ | |
-| `collate` | ⬜ | |
-| `collation` | ⬜ | |
+| `collate` | ❓ | |
+| `collation` | ❓ | |
 | `concat_ws` | ✅ | |
 | `contains` | ✅ | |
 | `decode` | ✅ | |
-| `elt` | 🚧 | #4538 |
-| `encode` | ⬜ | |
+| `elt` | 🔜 | #4538 |
+| `encode` | ❓ | |
 | `endswith` | ✅ | |
-| `find_in_set` | 🚧 | #4538 |
-| `format_number` | 🚧 | #4538 |
-| `format_string` | 🚧 | #4538 |
+| `find_in_set` | 🔜 | #4538 |
+| `format_number` | 🔜 | #4538 |
+| `format_string` | 🔜 | #4538 |
 | `initcap` | ✅ | |
 | `instr` | ✅ | |
-| `is_valid_utf8` | ⬜ | |
+| `is_valid_utf8` | ❓ | |
 | `lcase` | ✅ | |
 | `left` | ✅ | |
 | `len` | ✅ | |
 | `length` | ✅ | |
-| `levenshtein` | 🚧 | #4538 |
-| `locate` | 🚧 | #4538 |
+| `levenshtein` | 🔜 | #4538 |
+| `locate` | 🔜 | #4538 |
 | `lower` | ✅ | |
 | `lpad` | ✅ | |
 | `ltrim` | ✅ | |
-| `luhn_check` | ⬜ | |
-| `make_valid_utf8` | ⬜ | |
-| `mask` | ⬜ | |
+| `luhn_check` | ❓ | |
+| `make_valid_utf8` | ❓ | |
+| `mask` | ❓ | |
 | `octet_length` | ✅ | |
-| `overlay` | 🚧 | #4538 |
-| `position` | 🚧 | #4538 |
-| `printf` | 🚧 | #4538 |
-| `quote` | ⬜ | |
-| `regexp_count` | 🚧 | tracking #4098 |
-| `regexp_extract` | 🚧 | tracking #4098 |
-| `regexp_extract_all` | 🚧 | tracking #4098 |
-| `regexp_instr` | 🚧 | tracking #4098 |
+| `overlay` | 🔜 | #4538 |
+| `position` | 🔜 | #4538 |
+| `printf` | 🔜 | #4538 |
+| `quote` | ❓ | |
+| `regexp_count` | 🔜 | tracking #4098 |
+| `regexp_extract` | 🔜 | tracking #4098 |
+| `regexp_extract_all` | 🔜 | tracking #4098 |
+| `regexp_instr` | 🔜 | tracking #4098 |
 | `regexp_replace` | ✅ | |
-| `regexp_substr` | 🚧 | tracking #4098 |
+| `regexp_substr` | 🔜 | tracking #4098 |
 | `repeat` | ✅ | |
 | `replace` | ✅ | |
 | `right` | ✅ | |
 | `rpad` | ✅ | |
 | `rtrim` | ✅ | |
-| `sentences` | ⬜ | |
-| `soundex` | 🚧 | #4538 |
+| `sentences` | ❓ | |
+| `soundex` | 🔜 | #4538 |
 | `space` | ✅ | |
 | `split` | ✅ | |
-| `split_part` | ⬜ | |
+| `split_part` | ❓ | |
 | `startswith` | ✅ | |
 | `substr` | ✅ | |
 | `substring` | ✅ | |
 | `substring_index` | ✅ | |
-| `to_binary` | ⬜ | |
-| `to_char` | 🚧 | #4538 |
-| `to_number` | 🚧 | #4538 |
-| `to_varchar` | 🚧 | #4538 |
+| `to_binary` | ❓ | |
+| `to_char` | 🔜 | #4538 |
+| `to_number` | 🔜 | #4538 |
+| `to_varchar` | 🔜 | #4538 |
 | `translate` | ✅ | |
 | `trim` | ✅ | |
-| `try_to_binary` | ⬜ | |
-| `try_to_number` | ⬜ | |
-| `try_validate_utf8` | ⬜ | |
+| `try_to_binary` | ❓ | |
+| `try_to_number` | ❓ | |
+| `try_validate_utf8` | ❓ | |
 | `ucase` | ✅ | |
-| `unbase64` | 🚧 | #4538 |
+| `unbase64` | 🔜 | #4538 |
 | `upper` | ✅ | |
-| `validate_utf8` | ⬜ | |
+| `validate_utf8` | ❓ | |
 
 ---
 
@@ -668,15 +668,15 @@ fall back to Spark.
 
 | Function | Status | Notes |
 | -------- | ------ | ----- |
-| `cume_dist` | ⬜ | Not yet wired in window serde |
-| `dense_rank` | ⬜ | Not yet wired in window serde |
+| `cume_dist` | ❓ | Not yet wired in window serde |
+| `dense_rank` | ❓ | Not yet wired in window serde |
 | `lag` | ✅ | via `CometWindowExec` |
 | `lead` | ✅ | via `CometWindowExec` |
-| `nth_value` | ⬜ | Not yet wired in window serde |
-| `ntile` | ⬜ | Not yet wired in window serde |
-| `percent_rank` | ⬜ | Not yet wired in window serde |
-| `rank` | ⬜ | Not yet wired in window serde |
-| `row_number` | ⬜ | Not yet wired in window serde |
+| `nth_value` | ❓ | Not yet wired in window serde |
+| `ntile` | ❓ | Not yet wired in window serde |
+| `percent_rank` | ❓ | Not yet wired in window serde |
+| `rank` | ❓ | Not yet wired in window serde |
+| `row_number` | ❓ | Not yet wired in window serde |
 
 ---
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -35,13 +35,13 @@ Most expressions can also be disabled with `spark.comet.expression.EXPRNAME.enab
 
 ## Status legend
 
-| Status | Meaning |
-| ------ | ------- |
-| ✅ Supported | Native or codegen path; compatible with Spark by default. |
+| Status                 | Meaning                                                                                                                                                                                 |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ✅ Supported           | Native or codegen path; compatible with Spark by default.                                                                                                                               |
 | ⚠️ Supported (caveats) | Works, but may diverge from Spark in some cases: incompatible, flag-gated (`allowIncompatible`), or restricted to certain types. See the [Compatibility Guide](compatibility/index.md). |
-| 🔜 Planned | Intended; tracked by an open issue or pull request. |
-| 🚫 Out of scope | Deliberately not planned. |
-| ❓ Not yet supported | Falls back to Spark today; support is to be determined (not yet evaluated). |
+| 🔜 Planned             | Intended; tracked by an open issue or pull request.                                                                                                                                     |
+| 🚫 Out of scope        | Deliberately not planned.                                                                                                                                                               |
+| ❓ Not yet supported   | Falls back to Spark today; support is to be determined (not yet evaluated).                                                                                                             |
 
 ## Scope policy
 
@@ -59,7 +59,7 @@ are not on the roadmap:
 - **CSV functions** (`from_csv`, `to_csv`, `schema_of_csv`): row-level CSV parsing and formatting in expressions is niche and better handled at the data source layer.
 
 Note that `approx_count_distinct`, `approx_percentile` / `percentile_approx`, `median`, and `mode`
-are *not* out of scope: although approximate, they are mainstream and are planned.
+are _not_ out of scope: although approximate, they are mainstream and are planned.
 
 The tables below list every Spark built-in expression with its current status.
 
@@ -67,149 +67,149 @@ The tables below list every Spark built-in expression with its current status.
 
 > 🚫 Out of scope: probabilistic sketch aggregates (`kll_sketch_*`, `hll_sketch_agg`, `hll_union_agg`, `theta_intersection_agg`, `theta_sketch_agg`, `theta_union_agg`, `count_min_sketch`, `approx_top_k`, `approx_top_k_accumulate`, `approx_top_k_combine`). See [Scope policy](#scope-policy).
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `any` | ✅ | |
-| `any_value` | ✅ | |
-| `approx_count_distinct` | 🔜 | tracking #4098 |
-| `approx_percentile` | 🔜 | [#3189](https://github.com/apache/datafusion-comet/issues/3189) |
-| `array_agg` | ❓ | |
-| `avg` | ⚠️ | Interval types (YearMonth, DayTime) fall back |
-| `bit_and` | ✅ | |
-| `bit_or` | ✅ | |
-| `bit_xor` | ✅ | |
-| `bool_and` | ✅ | |
-| `bool_or` | ✅ | |
-| `collect_list` | 🔜 | [#2524](https://github.com/apache/datafusion-comet/issues/2524) |
-| `collect_set` | ✅ | |
-| `corr` | ✅ | |
-| `count` | ✅ | |
-| `count_if` | ✅ | |
-| `covar_pop` | ✅ | |
-| `covar_samp` | ✅ | |
-| `every` | ✅ | |
-| `first` | ✅ | |
-| `first_value` | ✅ | |
-| `grouping` | ❓ | |
-| `grouping_id` | ❓ | |
-| `histogram_numeric` | ❓ | |
-| `kurtosis` | 🔜 | tracking #4098 |
-| `last` | ✅ | |
-| `last_value` | ✅ | |
-| `listagg` | ❓ | |
-| `max` | ✅ | |
-| `max_by` | 🔜 | [#3841](https://github.com/apache/datafusion-comet/issues/3841) |
-| `mean` | ✅ | |
-| `median` | 🔜 | tracking #4098 |
-| `min` | ✅ | |
-| `min_by` | 🔜 | [#3841](https://github.com/apache/datafusion-comet/issues/3841) |
-| `mode` | 🔜 | [#3970](https://github.com/apache/datafusion-comet/issues/3970) |
-| `percentile` | 🔜 | #4542 |
-| `percentile_approx` | 🔜 | [#3189](https://github.com/apache/datafusion-comet/issues/3189) |
-| `percentile_cont` | ❓ | |
-| `percentile_disc` | ❓ | |
-| `regr_avgx` | ✅ | Native: Spark rewrites to `Average` (tests in #4551) |
-| `regr_avgy` | ✅ | Native: Spark rewrites to `Average` (tests in #4551) |
-| `regr_count` | ✅ | Native: Spark rewrites to `Count` (tests in #4551) |
-| `regr_intercept` | 🔜 | Falls back; can reuse `covar_pop`/`var_pop` accumulators (#4552) |
-| `regr_r2` | 🔜 | Falls back; can reuse the `corr` accumulator (#4552) |
-| `regr_slope` | 🔜 | Falls back; can reuse `covar_pop`/`var_pop` accumulators (#4552) |
-| `regr_sxx` | 🔜 | Falls back; can reuse `var_pop` accumulator (#4552) |
-| `regr_sxy` | 🔜 | Falls back; can reuse `covar_pop` accumulator (#4552) |
-| `regr_syy` | 🔜 | Falls back; can reuse `var_pop` accumulator (#4552) |
-| `skewness` | 🔜 | tracking #4098 |
-| `some` | ✅ | |
-| `std` | ✅ | |
-| `stddev` | ✅ | |
-| `stddev_pop` | ✅ | |
-| `stddev_samp` | ✅ | |
-| `string_agg` | ❓ | |
-| `sum` | ✅ | |
-| `try_avg` | 🔜 | tracking #4098 |
-| `try_sum` | 🔜 | tracking #4098 |
-| `var_pop` | ✅ | |
-| `var_samp` | ✅ | |
-| `variance` | ✅ | |
+| Function                | Status | Notes                                                            |
+| ----------------------- | ------ | ---------------------------------------------------------------- |
+| `any`                   | ✅     |                                                                  |
+| `any_value`             | ✅     |                                                                  |
+| `approx_count_distinct` | 🔜     | tracking #4098                                                   |
+| `approx_percentile`     | 🔜     | [#3189](https://github.com/apache/datafusion-comet/issues/3189)  |
+| `array_agg`             | ❓     |                                                                  |
+| `avg`                   | ⚠️     | Interval types (YearMonth, DayTime) fall back                    |
+| `bit_and`               | ✅     |                                                                  |
+| `bit_or`                | ✅     |                                                                  |
+| `bit_xor`               | ✅     |                                                                  |
+| `bool_and`              | ✅     |                                                                  |
+| `bool_or`               | ✅     |                                                                  |
+| `collect_list`          | 🔜     | [#2524](https://github.com/apache/datafusion-comet/issues/2524)  |
+| `collect_set`           | ✅     |                                                                  |
+| `corr`                  | ✅     |                                                                  |
+| `count`                 | ✅     |                                                                  |
+| `count_if`              | ✅     |                                                                  |
+| `covar_pop`             | ✅     |                                                                  |
+| `covar_samp`            | ✅     |                                                                  |
+| `every`                 | ✅     |                                                                  |
+| `first`                 | ✅     |                                                                  |
+| `first_value`           | ✅     |                                                                  |
+| `grouping`              | ❓     |                                                                  |
+| `grouping_id`           | ❓     |                                                                  |
+| `histogram_numeric`     | ❓     |                                                                  |
+| `kurtosis`              | 🔜     | tracking #4098                                                   |
+| `last`                  | ✅     |                                                                  |
+| `last_value`            | ✅     |                                                                  |
+| `listagg`               | ❓     |                                                                  |
+| `max`                   | ✅     |                                                                  |
+| `max_by`                | 🔜     | [#3841](https://github.com/apache/datafusion-comet/issues/3841)  |
+| `mean`                  | ✅     |                                                                  |
+| `median`                | 🔜     | tracking #4098                                                   |
+| `min`                   | ✅     |                                                                  |
+| `min_by`                | 🔜     | [#3841](https://github.com/apache/datafusion-comet/issues/3841)  |
+| `mode`                  | 🔜     | [#3970](https://github.com/apache/datafusion-comet/issues/3970)  |
+| `percentile`            | 🔜     | #4542                                                            |
+| `percentile_approx`     | 🔜     | [#3189](https://github.com/apache/datafusion-comet/issues/3189)  |
+| `percentile_cont`       | ❓     |                                                                  |
+| `percentile_disc`       | ❓     |                                                                  |
+| `regr_avgx`             | ✅     | Native: Spark rewrites to `Average` (tests in #4551)             |
+| `regr_avgy`             | ✅     | Native: Spark rewrites to `Average` (tests in #4551)             |
+| `regr_count`            | ✅     | Native: Spark rewrites to `Count` (tests in #4551)               |
+| `regr_intercept`        | 🔜     | Falls back; can reuse `covar_pop`/`var_pop` accumulators (#4552) |
+| `regr_r2`               | 🔜     | Falls back; can reuse the `corr` accumulator (#4552)             |
+| `regr_slope`            | 🔜     | Falls back; can reuse `covar_pop`/`var_pop` accumulators (#4552) |
+| `regr_sxx`              | 🔜     | Falls back; can reuse `var_pop` accumulator (#4552)              |
+| `regr_sxy`              | 🔜     | Falls back; can reuse `covar_pop` accumulator (#4552)            |
+| `regr_syy`              | 🔜     | Falls back; can reuse `var_pop` accumulator (#4552)              |
+| `skewness`              | 🔜     | tracking #4098                                                   |
+| `some`                  | ✅     |                                                                  |
+| `std`                   | ✅     |                                                                  |
+| `stddev`                | ✅     |                                                                  |
+| `stddev_pop`            | ✅     |                                                                  |
+| `stddev_samp`           | ✅     |                                                                  |
+| `string_agg`            | ❓     |                                                                  |
+| `sum`                   | ✅     |                                                                  |
+| `try_avg`               | 🔜     | tracking #4098                                                   |
+| `try_sum`               | 🔜     | tracking #4098                                                   |
+| `var_pop`               | ✅     |                                                                  |
+| `var_samp`              | ✅     |                                                                  |
+| `variance`              | ✅     |                                                                  |
 
 ---
 
 ## array_funcs
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `array` | ✅ | |
-| `array_append` | ⚠️ | On Spark 4.0+ rewrites to `array_insert`; inherits its incompatibilities |
-| `array_compact` | ✅ | |
-| `array_contains` | ⚠️ | NaN-canonicalization may differ for float/double arrays ([#4481](https://github.com/apache/datafusion-comet/issues/4481)) |
-| `array_distinct` | ⚠️ | NaN/signed-zero canonicalization may differ ([#4481](https://github.com/apache/datafusion-comet/issues/4481)) |
-| `array_except` | ⚠️ | Null handling and ordering may differ; `Incompatible`, flag-gated |
-| `array_insert` | ✅ | |
-| `array_intersect` | ⚠️ | Result element order may differ when right array is longer than left |
-| `array_join` | ⚠️ | Null handling may differ ([#3178](https://github.com/apache/datafusion-comet/issues/3178)); `Incompatible`, flag-gated |
-| `array_max` | ⚠️ | NaN ordering may differ for float/double ([#4482](https://github.com/apache/datafusion-comet/issues/4482)) |
-| `array_min` | ⚠️ | NaN ordering may differ for float/double ([#4482](https://github.com/apache/datafusion-comet/issues/4482)) |
-| `array_position` | ⚠️ | Falls back for binary/struct/map/null element types |
-| `array_prepend` | ❓ | |
-| `array_remove` | ✅ | |
-| `array_repeat` | ✅ | |
-| `array_union` | ⚠️ | NaN/signed-zero canonicalization may differ ([#4481](https://github.com/apache/datafusion-comet/issues/4481)) |
-| `arrays_overlap` | ✅ | |
-| `arrays_zip` | ✅ | |
-| `element_at` | ⚠️ | Only `ArrayType` input; `MapType` input falls back |
-| `flatten` | ⚠️ | Falls back for binary/struct/map child element types |
-| `get` | ✅ | |
-| `sequence` | 🔜 | #4538 |
-| `shuffle` | ❓ | |
-| `slice` | ✅ | Native (#4149) |
-| `sort_array` | ⚠️ | Incompatible under strict floating-point; falls back for nested struct/null arrays |
+| Function          | Status | Notes                                                                                                                     |
+| ----------------- | ------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `array`           | ✅     |                                                                                                                           |
+| `array_append`    | ⚠️     | On Spark 4.0+ rewrites to `array_insert`; inherits its incompatibilities                                                  |
+| `array_compact`   | ✅     |                                                                                                                           |
+| `array_contains`  | ⚠️     | NaN-canonicalization may differ for float/double arrays ([#4481](https://github.com/apache/datafusion-comet/issues/4481)) |
+| `array_distinct`  | ⚠️     | NaN/signed-zero canonicalization may differ ([#4481](https://github.com/apache/datafusion-comet/issues/4481))             |
+| `array_except`    | ⚠️     | Null handling and ordering may differ; `Incompatible`, flag-gated                                                         |
+| `array_insert`    | ✅     |                                                                                                                           |
+| `array_intersect` | ⚠️     | Result element order may differ when right array is longer than left                                                      |
+| `array_join`      | ⚠️     | Null handling may differ ([#3178](https://github.com/apache/datafusion-comet/issues/3178)); `Incompatible`, flag-gated    |
+| `array_max`       | ⚠️     | NaN ordering may differ for float/double ([#4482](https://github.com/apache/datafusion-comet/issues/4482))                |
+| `array_min`       | ⚠️     | NaN ordering may differ for float/double ([#4482](https://github.com/apache/datafusion-comet/issues/4482))                |
+| `array_position`  | ⚠️     | Falls back for binary/struct/map/null element types                                                                       |
+| `array_prepend`   | ❓     |                                                                                                                           |
+| `array_remove`    | ✅     |                                                                                                                           |
+| `array_repeat`    | ✅     |                                                                                                                           |
+| `array_union`     | ⚠️     | NaN/signed-zero canonicalization may differ ([#4481](https://github.com/apache/datafusion-comet/issues/4481))             |
+| `arrays_overlap`  | ✅     |                                                                                                                           |
+| `arrays_zip`      | ✅     |                                                                                                                           |
+| `element_at`      | ⚠️     | Only `ArrayType` input; `MapType` input falls back                                                                        |
+| `flatten`         | ⚠️     | Falls back for binary/struct/map child element types                                                                      |
+| `get`             | ✅     |                                                                                                                           |
+| `sequence`        | 🔜     | #4538                                                                                                                     |
+| `shuffle`         | ❓     |                                                                                                                           |
+| `slice`           | ✅     | Native (#4149)                                                                                                            |
+| `sort_array`      | ⚠️     | Incompatible under strict floating-point; falls back for nested struct/null arrays                                        |
 
 ---
 
 ## bitwise_funcs
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `&` | ✅ | |
-| `<<` | ✅ | |
-| `>>` | ✅ | |
-| `>>>` | ❓ | |
-| `^` | ✅ | |
-| `bit_count` | ✅ | |
-| `bit_get` | ✅ | |
-| `getbit` | ✅ | |
-| `shiftright` | ✅ | |
-| `shiftrightunsigned` | ✅ | |
-| `\|` | ✅ | |
-| `~` | ✅ | |
+| Function             | Status | Notes                                                |
+| -------------------- | ------ | ---------------------------------------------------- |
+| `&`                  | ✅     |                                                      |
+| `<<`                 | ✅     |                                                      |
+| `>>`                 | ✅     |                                                      |
+| `>>>`                | ✅     | Operator alias for `shiftrightunsigned` (Spark 4.0+) |
+| `^`                  | ✅     |                                                      |
+| `bit_count`          | ✅     |                                                      |
+| `bit_get`            | ✅     |                                                      |
+| `getbit`             | ✅     |                                                      |
+| `shiftright`         | ✅     |                                                      |
+| `shiftrightunsigned` | ✅     |                                                      |
+| `\|`                 | ✅     |                                                      |
+| `~`                  | ✅     |                                                      |
 
 ---
 
 ## collection_funcs
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `array_size` | ❓ | |
-| `cardinality` | ❓ | |
-| `concat` | ⚠️ | Only `StringType` children; `BinaryType`/`ArrayType` fall back ([#4471](https://github.com/apache/datafusion-comet/issues/4471)) |
-| `reverse` | ⚠️ | Array with `BinaryType` elements is `Incompatible`, flag-gated ([#2763](https://github.com/apache/datafusion-comet/issues/2763)) |
-| `size` | ⚠️ | `MapType` input falls back ([#4472](https://github.com/apache/datafusion-comet/issues/4472)) |
+| Function      | Status | Notes                                                                                                                            |
+| ------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `array_size`  | ❓     |                                                                                                                                  |
+| `cardinality` | ⚠️     | Alias for `size`; `MapType` input falls back ([#4472](https://github.com/apache/datafusion-comet/issues/4472))                   |
+| `concat`      | ⚠️     | Only `StringType` children; `BinaryType`/`ArrayType` fall back ([#4471](https://github.com/apache/datafusion-comet/issues/4471)) |
+| `reverse`     | ⚠️     | Array with `BinaryType` elements is `Incompatible`, flag-gated ([#2763](https://github.com/apache/datafusion-comet/issues/2763)) |
+| `size`        | ⚠️     | `MapType` input falls back ([#4472](https://github.com/apache/datafusion-comet/issues/4472))                                     |
 
 ---
 
 ## conditional_funcs
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `coalesce` | ✅ | |
-| `if` | ✅ | |
-| `ifnull` | ✅ | |
-| `nanvl` | 🔜 | #4538 |
-| `nullif` | ✅ | |
-| `nullifzero` | ❓ | |
-| `nvl` | ✅ | |
-| `nvl2` | ✅ | |
-| `when` | ✅ | |
-| `zeroifnull` | ❓ | |
+| Function     | Status | Notes |
+| ------------ | ------ | ----- |
+| `coalesce`   | ✅     |       |
+| `if`         | ✅     |       |
+| `ifnull`     | ✅     |       |
+| `nanvl`      | 🔜     | #4538 |
+| `nullif`     | ✅     |       |
+| `nullifzero` | ❓     |       |
+| `nvl`        | ✅     |       |
+| `nvl2`       | ✅     |       |
+| `when`       | ✅     |       |
+| `zeroifnull` | ❓     |       |
 
 ---
 
@@ -219,21 +219,21 @@ The type-alias keywords (`bigint`, `boolean`, `int`, etc.) are SQL syntax for `C
 itself is supported with caveats; the keyword aliases are not yet individually wired in Comet's
 serde but effectively fall through to the same cast path at runtime.
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `bigint` | ⚠️ | Alias for `CAST(... AS BIGINT)`; see `cast` |
-| `binary` | ⚠️ | Alias for `CAST(... AS BINARY)`; see `cast` |
-| `boolean` | ⚠️ | Alias for `CAST(... AS BOOLEAN)`; see `cast` |
-| `cast` | ⚠️ | Many type pairs supported; float-to-decimal rounding may differ; see [Compatibility Guide](compatibility/index.md) |
-| `date` | ⚠️ | Alias for `CAST(... AS DATE)`; see `cast` |
-| `decimal` | ⚠️ | Alias for `CAST(... AS DECIMAL)`; see `cast` |
-| `double` | ⚠️ | Alias for `CAST(... AS DOUBLE)`; see `cast` |
-| `float` | ⚠️ | Alias for `CAST(... AS FLOAT)`; see `cast` |
-| `int` | ⚠️ | Alias for `CAST(... AS INT)`; see `cast` |
-| `smallint` | ⚠️ | Alias for `CAST(... AS SMALLINT)`; see `cast` |
-| `string` | ⚠️ | Alias for `CAST(... AS STRING)`; see `cast` |
-| `timestamp` | ⚠️ | Alias for `CAST(... AS TIMESTAMP)`; see `cast` |
-| `tinyint` | ⚠️ | Alias for `CAST(... AS TINYINT)`; see `cast` |
+| Function    | Status | Notes                                                                                                              |
+| ----------- | ------ | ------------------------------------------------------------------------------------------------------------------ |
+| `bigint`    | ⚠️     | Alias for `CAST(... AS BIGINT)`; see `cast`                                                                        |
+| `binary`    | ⚠️     | Alias for `CAST(... AS BINARY)`; see `cast`                                                                        |
+| `boolean`   | ⚠️     | Alias for `CAST(... AS BOOLEAN)`; see `cast`                                                                       |
+| `cast`      | ⚠️     | Many type pairs supported; float-to-decimal rounding may differ; see [Compatibility Guide](compatibility/index.md) |
+| `date`      | ⚠️     | Alias for `CAST(... AS DATE)`; see `cast`                                                                          |
+| `decimal`   | ⚠️     | Alias for `CAST(... AS DECIMAL)`; see `cast`                                                                       |
+| `double`    | ⚠️     | Alias for `CAST(... AS DOUBLE)`; see `cast`                                                                        |
+| `float`     | ⚠️     | Alias for `CAST(... AS FLOAT)`; see `cast`                                                                         |
+| `int`       | ⚠️     | Alias for `CAST(... AS INT)`; see `cast`                                                                           |
+| `smallint`  | ⚠️     | Alias for `CAST(... AS SMALLINT)`; see `cast`                                                                      |
+| `string`    | ⚠️     | Alias for `CAST(... AS STRING)`; see `cast`                                                                        |
+| `timestamp` | ⚠️     | Alias for `CAST(... AS TIMESTAMP)`; see `cast`                                                                     |
+| `tinyint`   | ⚠️     | Alias for `CAST(... AS TINYINT)`; see `cast`                                                                       |
 
 ---
 
@@ -245,81 +245,81 @@ serde but effectively fall through to the same cast path at runtime.
 
 ## datetime_funcs
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `add_months` | ✅ | |
-| `convert_timezone` | ✅ | |
-| `curdate` | ✅ | Constant-folded to a literal (alias of `current_date`) |
-| `current_date` | ✅ | Constant-folded to a literal before Comet sees the plan |
-| `current_time` | ❓ | Constant-folded to a literal, but of the Spark 4.1 `TIME` type, which Comet does not support, so it falls back |
-| `current_timestamp` | ✅ | Constant-folded to a literal before Comet sees the plan |
-| `current_timezone` | ✅ | |
-| `date_add` | ✅ | |
-| `date_diff` | ✅ | |
-| `date_format` | ✅ | |
-| `date_from_unix_date` | ✅ | |
-| `date_part` | ✅ | |
-| `date_sub` | ✅ | |
-| `date_trunc` | ✅ | |
-| `dateadd` | ✅ | |
-| `datediff` | ✅ | |
-| `datepart` | ✅ | |
-| `day` | ✅ | |
-| `dayname` | 🔜 | #4544 |
-| `dayofmonth` | ✅ | |
-| `dayofweek` | ✅ | |
-| `dayofyear` | ✅ | |
-| `extract` | ✅ | |
-| `from_unixtime` | ✅ | |
-| `from_utc_timestamp` | ⚠️ | Legacy zone forms (`GMT+1`, `PST`) throw a native parse error |
-| `hour` | ✅ | |
-| `last_day` | ✅ | |
-| `localtimestamp` | ✅ | |
-| `make_date` | ✅ | |
-| `make_dt_interval` | 🔜 | #4541 |
-| `make_interval` | ❓ | |
-| `make_time` | ❓ | |
-| `make_timestamp` | ✅ | |
-| `make_timestamp_ltz` | ⚠️ | 6-arg form runs via the codegen dispatcher; 2-arg `(date, time)` form (Spark 4.1 TIME type) falls back |
-| `make_timestamp_ntz` | ⚠️ | 6-arg form runs via the codegen dispatcher; 2-arg `(date, time)` form (Spark 4.1 TIME type) falls back |
-| `make_ym_interval` | 🔜 | #4541 |
-| `minute` | ✅ | |
-| `month` | ✅ | |
-| `monthname` | 🔜 | #4544 |
-| `months_between` | ✅ | |
-| `next_day` | ✅ | |
-| `now` | ✅ | Constant-folded to a literal (alias of `current_timestamp`) |
-| `quarter` | ✅ | |
-| `second` | ✅ | |
-| `session_window` | ❓ | |
-| `time_diff` | ❓ | |
-| `time_trunc` | ❓ | |
-| `timestamp_micros` | ✅ | |
-| `timestamp_millis` | ✅ | |
-| `timestamp_seconds` | ✅ | |
-| `to_date` | ✅ | Rewrites to `Cast` (or `Cast(GetTimestamp)` with a format) before Comet sees the plan |
-| `to_time` | ❓ | |
-| `to_timestamp` | ✅ | Rewrites to `Cast` (or `GetTimestamp` with a format) before Comet sees the plan |
-| `to_timestamp_ltz` | ✅ | Rewrites to `to_timestamp` (`TimestampType`) |
-| `to_timestamp_ntz` | ✅ | Rewrites to `to_timestamp` (`TimestampNTZType`) |
-| `to_unix_timestamp` | ✅ | |
-| `to_utc_timestamp` | ⚠️ | Legacy zone forms (`GMT+1`, `PST`) throw a native parse error |
-| `trunc` | ✅ | |
-| `try_make_interval` | ❓ | |
-| `try_make_timestamp` | ❓ | |
-| `try_to_date` | ❓ | |
-| `try_to_time` | ❓ | |
-| `try_to_timestamp` | ❓ | |
-| `unix_date` | ✅ | |
-| `unix_micros` | ✅ | |
-| `unix_millis` | ✅ | |
-| `unix_seconds` | ✅ | |
-| `unix_timestamp` | ✅ | |
-| `weekday` | ✅ | |
-| `weekofyear` | ✅ | |
-| `window` | ❓ | |
-| `window_time` | ❓ | |
-| `year` | ✅ | |
+| Function              | Status | Notes                                                                                                          |
+| --------------------- | ------ | -------------------------------------------------------------------------------------------------------------- |
+| `add_months`          | ✅     |                                                                                                                |
+| `convert_timezone`    | ✅     |                                                                                                                |
+| `curdate`             | ✅     | Constant-folded to a literal (alias of `current_date`)                                                         |
+| `current_date`        | ✅     | Constant-folded to a literal before Comet sees the plan                                                        |
+| `current_time`        | ❓     | Constant-folded to a literal, but of the Spark 4.1 `TIME` type, which Comet does not support, so it falls back |
+| `current_timestamp`   | ✅     | Constant-folded to a literal before Comet sees the plan                                                        |
+| `current_timezone`    | ✅     |                                                                                                                |
+| `date_add`            | ✅     |                                                                                                                |
+| `date_diff`           | ✅     |                                                                                                                |
+| `date_format`         | ✅     |                                                                                                                |
+| `date_from_unix_date` | ✅     |                                                                                                                |
+| `date_part`           | ✅     |                                                                                                                |
+| `date_sub`            | ✅     |                                                                                                                |
+| `date_trunc`          | ✅     |                                                                                                                |
+| `dateadd`             | ✅     |                                                                                                                |
+| `datediff`            | ✅     |                                                                                                                |
+| `datepart`            | ✅     |                                                                                                                |
+| `day`                 | ✅     |                                                                                                                |
+| `dayname`             | 🔜     | #4544                                                                                                          |
+| `dayofmonth`          | ✅     |                                                                                                                |
+| `dayofweek`           | ✅     |                                                                                                                |
+| `dayofyear`           | ✅     |                                                                                                                |
+| `extract`             | ✅     |                                                                                                                |
+| `from_unixtime`       | ✅     |                                                                                                                |
+| `from_utc_timestamp`  | ⚠️     | Legacy zone forms (`GMT+1`, `PST`) throw a native parse error                                                  |
+| `hour`                | ✅     |                                                                                                                |
+| `last_day`            | ✅     |                                                                                                                |
+| `localtimestamp`      | ✅     |                                                                                                                |
+| `make_date`           | ✅     |                                                                                                                |
+| `make_dt_interval`    | 🔜     | #4541                                                                                                          |
+| `make_interval`       | ❓     |                                                                                                                |
+| `make_time`           | ❓     |                                                                                                                |
+| `make_timestamp`      | ✅     |                                                                                                                |
+| `make_timestamp_ltz`  | ⚠️     | 6-arg form runs via the codegen dispatcher; 2-arg `(date, time)` form (Spark 4.1 TIME type) falls back         |
+| `make_timestamp_ntz`  | ⚠️     | 6-arg form runs via the codegen dispatcher; 2-arg `(date, time)` form (Spark 4.1 TIME type) falls back         |
+| `make_ym_interval`    | 🔜     | #4541                                                                                                          |
+| `minute`              | ✅     |                                                                                                                |
+| `month`               | ✅     |                                                                                                                |
+| `monthname`           | 🔜     | #4544                                                                                                          |
+| `months_between`      | ✅     |                                                                                                                |
+| `next_day`            | ✅     |                                                                                                                |
+| `now`                 | ✅     | Constant-folded to a literal (alias of `current_timestamp`)                                                    |
+| `quarter`             | ✅     |                                                                                                                |
+| `second`              | ✅     |                                                                                                                |
+| `session_window`      | ❓     |                                                                                                                |
+| `time_diff`           | ❓     |                                                                                                                |
+| `time_trunc`          | ❓     |                                                                                                                |
+| `timestamp_micros`    | ✅     |                                                                                                                |
+| `timestamp_millis`    | ✅     |                                                                                                                |
+| `timestamp_seconds`   | ✅     |                                                                                                                |
+| `to_date`             | ✅     | Rewrites to `Cast` (or `Cast(GetTimestamp)` with a format) before Comet sees the plan                          |
+| `to_time`             | ❓     |                                                                                                                |
+| `to_timestamp`        | ✅     | Rewrites to `Cast` (or `GetTimestamp` with a format) before Comet sees the plan                                |
+| `to_timestamp_ltz`    | ✅     | Rewrites to `to_timestamp` (`TimestampType`)                                                                   |
+| `to_timestamp_ntz`    | ✅     | Rewrites to `to_timestamp` (`TimestampNTZType`)                                                                |
+| `to_unix_timestamp`   | ✅     |                                                                                                                |
+| `to_utc_timestamp`    | ⚠️     | Legacy zone forms (`GMT+1`, `PST`) throw a native parse error                                                  |
+| `trunc`               | ✅     |                                                                                                                |
+| `try_make_interval`   | ❓     |                                                                                                                |
+| `try_make_timestamp`  | ❓     |                                                                                                                |
+| `try_to_date`         | ❓     |                                                                                                                |
+| `try_to_time`         | ❓     |                                                                                                                |
+| `try_to_timestamp`    | ❓     |                                                                                                                |
+| `unix_date`           | ✅     |                                                                                                                |
+| `unix_micros`         | ✅     |                                                                                                                |
+| `unix_millis`         | ✅     |                                                                                                                |
+| `unix_seconds`        | ✅     |                                                                                                                |
+| `unix_timestamp`      | ✅     |                                                                                                                |
+| `weekday`             | ✅     |                                                                                                                |
+| `weekofyear`          | ✅     |                                                                                                                |
+| `window`              | ❓     |                                                                                                                |
+| `window_time`         | ❓     |                                                                                                                |
+| `year`                | ✅     |                                                                                                                |
 
 ---
 
@@ -329,43 +329,43 @@ serde but effectively fall through to the same cast path at runtime.
 expression-level). The `outer` variants are wired but marked `Incompatible`; they require
 `spark.comet.exec.explode.enabled=true` and `allowIncompatible`.
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `explode` | ✅ | via `CometExplodeExec` |
-| `explode_outer` | ⚠️ | `outer=true` incompatible; needs `allowIncompatible` |
-| `inline` | ❓ | |
-| `inline_outer` | ❓ | |
-| `posexplode` | ✅ | via `CometExplodeExec` |
-| `posexplode_outer` | ⚠️ | `outer=true` incompatible; needs `allowIncompatible` |
-| `stack` | ❓ | |
+| Function           | Status | Notes                                                |
+| ------------------ | ------ | ---------------------------------------------------- |
+| `explode`          | ✅     | via `CometExplodeExec`                               |
+| `explode_outer`    | ⚠️     | `outer=true` incompatible; needs `allowIncompatible` |
+| `inline`           | ❓     |                                                      |
+| `inline_outer`     | ❓     |                                                      |
+| `posexplode`       | ✅     | via `CometExplodeExec`                               |
+| `posexplode_outer` | ⚠️     | `outer=true` incompatible; needs `allowIncompatible` |
+| `stack`            | ❓     |                                                      |
 
 ---
 
 ## hash_funcs
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `crc32` | ✅ | |
-| `hash` | ✅ | |
-| `md5` | ✅ | |
-| `sha` | ✅ | |
-| `sha1` | ✅ | |
-| `sha2` | ✅ | |
-| `xxhash64` | ✅ | |
+| Function   | Status | Notes |
+| ---------- | ------ | ----- |
+| `crc32`    | ✅     |       |
+| `hash`     | ✅     |       |
+| `md5`      | ✅     |       |
+| `sha`      | ✅     |       |
+| `sha1`     | ✅     |       |
+| `sha2`     | ✅     |       |
+| `xxhash64` | ✅     |       |
 
 ---
 
 ## json_funcs
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `from_json` | 🔜 | [#3203](https://github.com/apache/datafusion-comet/issues/3203) |
-| `get_json_object` | ⚠️ | Single-quoted JSON and unescaped control chars require `allowIncompatible` |
-| `json_array_length` | 🔜 | tracking #4098 |
-| `json_object_keys` | 🔜 | [#3161](https://github.com/apache/datafusion-comet/issues/3161) |
-| `json_tuple` | 🔜 | [#3160](https://github.com/apache/datafusion-comet/issues/3160) |
-| `schema_of_json` | 🔜 | [#3163](https://github.com/apache/datafusion-comet/issues/3163) |
-| `to_json` | 🔜 | tracking #4098 |
+| Function            | Status | Notes                                                                                                                 |
+| ------------------- | ------ | --------------------------------------------------------------------------------------------------------------------- |
+| `from_json`         | ⚠️     | Partial native support (requires explicit schema, marked `Incompatible`); fuller support via codegen dispatch (#4305) |
+| `get_json_object`   | ⚠️     | Single-quoted JSON and unescaped control chars require `allowIncompatible`                                            |
+| `json_array_length` | 🔜     | tracking #4098                                                                                                        |
+| `json_object_keys`  | 🔜     | [#3161](https://github.com/apache/datafusion-comet/issues/3161)                                                       |
+| `json_tuple`        | 🔜     | [#3160](https://github.com/apache/datafusion-comet/issues/3160)                                                       |
+| `schema_of_json`    | 🔜     | [#3163](https://github.com/apache/datafusion-comet/issues/3163)                                                       |
+| `to_json`           | ⚠️     | Partial native support (options and map/array inputs fall back); fuller support via codegen dispatch (#4305)          |
 
 ---
 
@@ -373,115 +373,115 @@ expression-level). The `outer` variants are wired but marked `Incompatible`; the
 
 All higher-order functions are planned via [#4224](https://github.com/apache/datafusion-comet/issues/4224).
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `aggregate` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `array_sort` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `exists` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `filter` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `forall` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `map_filter` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `map_zip_with` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `reduce` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `transform` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `transform_keys` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `transform_values` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
-| `zip_with` | 🔜 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| Function           | Status | Notes                                                           |
+| ------------------ | ------ | --------------------------------------------------------------- |
+| `aggregate`        | 🔜     | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `array_sort`       | 🔜     | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `exists`           | 🔜     | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `filter`           | 🔜     | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `forall`           | 🔜     | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `map_filter`       | 🔜     | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `map_zip_with`     | 🔜     | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `reduce`           | 🔜     | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `transform`        | 🔜     | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `transform_keys`   | 🔜     | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `transform_values` | 🔜     | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `zip_with`         | 🔜     | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
 
 ---
 
 ## map_funcs
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `element_at` | ⚠️ | Only `ArrayType` input; `MapType` input falls back |
-| `map` | ❓ | |
-| `map_concat` | ❓ | |
-| `map_contains_key` | ✅ | |
-| `map_entries` | ✅ | |
-| `map_from_arrays` | ✅ | |
-| `map_from_entries` | ⚠️ | `BinaryType` key/value falls back unless `allowIncompatible` |
-| `map_keys` | ✅ | |
-| `map_values` | ✅ | |
-| `str_to_map` | ✅ | |
-| `try_element_at` | ❓ | |
+| Function           | Status | Notes                                                        |
+| ------------------ | ------ | ------------------------------------------------------------ |
+| `element_at`       | ⚠️     | Only `ArrayType` input; `MapType` input falls back           |
+| `map`              | ❓     |                                                              |
+| `map_concat`       | ❓     |                                                              |
+| `map_contains_key` | ✅     |                                                              |
+| `map_entries`      | ✅     |                                                              |
+| `map_from_arrays`  | ✅     |                                                              |
+| `map_from_entries` | ⚠️     | `BinaryType` key/value falls back unless `allowIncompatible` |
+| `map_keys`         | ✅     |                                                              |
+| `map_values`       | ✅     |                                                              |
+| `str_to_map`       | ✅     |                                                              |
+| `try_element_at`   | ❓     |                                                              |
 
 ---
 
 ## math_funcs
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `%` | ⚠️ | `try_mod` form (`EvalMode.TRY`) falls back ([#4484](https://github.com/apache/datafusion-comet/issues/4484)) |
-| `*` | ⚠️ | Interval multiplication falls back |
-| `+` | ✅ | |
-| `-` | ✅ | |
-| `/` | ✅ | |
-| `abs` | ⚠️ | Interval types fall back; ANSI overflow for integer min value |
-| `acos` | ✅ | |
-| `acosh` | ✅ | |
-| `asin` | ✅ | |
-| `asinh` | ✅ | |
-| `atan` | ✅ | |
-| `atan2` | ✅ | |
-| `atanh` | ✅ | |
-| `bin` | ✅ | |
-| `bround` | 🔜 | #4538 |
-| `cbrt` | ✅ | |
-| `ceil` | ⚠️ | Two-arg `ceil(expr, scale)` form falls back |
-| `ceiling` | ✅ | |
-| `conv` | 🔜 | #4538 |
-| `cos` | ✅ | |
-| `cosh` | ✅ | |
-| `cot` | ✅ | |
-| `csc` | ✅ | |
-| `degrees` | ✅ | |
-| `div` | ✅ | |
-| `e` | ❓ | |
-| `exp` | ✅ | |
-| `expm1` | ✅ | |
-| `factorial` | ✅ | |
-| `floor` | ⚠️ | Two-arg `floor(expr, scale)` form falls back |
-| `greatest` | ✅ | |
-| `hex` | ✅ | |
-| `hypot` | 🔜 | #4538 |
-| `least` | ✅ | |
-| `ln` | ✅ | |
-| `log` | ✅ | |
-| `log10` | ✅ | |
-| `log1p` | 🔜 | #4538 |
-| `log2` | ✅ | |
-| `mod` | ✅ | |
-| `negative` | ✅ | |
-| `pi` | ✅ | |
-| `pmod` | 🔜 | #4538 |
-| `positive` | ✅ | |
-| `pow` | ✅ | |
-| `power` | ✅ | |
-| `radians` | ✅ | |
-| `rand` | ✅ | |
-| `randn` | ✅ | |
-| `random` | ❓ | |
-| `randstr` | ❓ | |
-| `rint` | ✅ | |
-| `round` | ⚠️ | Float/Double inputs always fall back; integer/decimal HALF_UP supported |
-| `sec` | ✅ | |
-| `shiftleft` | ✅ | |
-| `sign` | ✅ | |
-| `signum` | ✅ | |
-| `sin` | ✅ | |
-| `sinh` | ✅ | |
-| `sqrt` | ✅ | |
-| `tan` | ✅ | |
-| `tanh` | ✅ | |
-| `try_add` | ⚠️ | Datetime/interval form falls back; numeric form supported |
-| `try_divide` | ✅ | |
-| `try_mod` | ❓ | |
-| `try_multiply` | ✅ | |
-| `try_subtract` | ✅ | |
-| `unhex` | ✅ | |
-| `uniform` | ❓ | |
-| `width_bucket` | ⚠️ | Wired via shim, bypasses support-level framework ([#4485](https://github.com/apache/datafusion-comet/issues/4485)) |
+| Function       | Status | Notes                                                                                                              |
+| -------------- | ------ | ------------------------------------------------------------------------------------------------------------------ |
+| `%`            | ⚠️     | `try_mod` form (`EvalMode.TRY`) falls back ([#4484](https://github.com/apache/datafusion-comet/issues/4484))       |
+| `*`            | ⚠️     | Interval multiplication falls back                                                                                 |
+| `+`            | ✅     |                                                                                                                    |
+| `-`            | ✅     |                                                                                                                    |
+| `/`            | ✅     |                                                                                                                    |
+| `abs`          | ⚠️     | Interval types fall back; ANSI overflow for integer min value                                                      |
+| `acos`         | ✅     |                                                                                                                    |
+| `acosh`        | ✅     |                                                                                                                    |
+| `asin`         | ✅     |                                                                                                                    |
+| `asinh`        | ✅     |                                                                                                                    |
+| `atan`         | ✅     |                                                                                                                    |
+| `atan2`        | ✅     |                                                                                                                    |
+| `atanh`        | ✅     |                                                                                                                    |
+| `bin`          | ✅     |                                                                                                                    |
+| `bround`       | 🔜     | #4538                                                                                                              |
+| `cbrt`         | ✅     |                                                                                                                    |
+| `ceil`         | ⚠️     | Two-arg `ceil(expr, scale)` form falls back                                                                        |
+| `ceiling`      | ✅     |                                                                                                                    |
+| `conv`         | 🔜     | #4538                                                                                                              |
+| `cos`          | ✅     |                                                                                                                    |
+| `cosh`         | ✅     |                                                                                                                    |
+| `cot`          | ✅     |                                                                                                                    |
+| `csc`          | ✅     |                                                                                                                    |
+| `degrees`      | ✅     |                                                                                                                    |
+| `div`          | ✅     |                                                                                                                    |
+| `e`            | ❓     |                                                                                                                    |
+| `exp`          | ✅     |                                                                                                                    |
+| `expm1`        | ✅     |                                                                                                                    |
+| `factorial`    | ✅     |                                                                                                                    |
+| `floor`        | ⚠️     | Two-arg `floor(expr, scale)` form falls back                                                                       |
+| `greatest`     | ✅     |                                                                                                                    |
+| `hex`          | ✅     |                                                                                                                    |
+| `hypot`        | 🔜     | #4538                                                                                                              |
+| `least`        | ✅     |                                                                                                                    |
+| `ln`           | ✅     |                                                                                                                    |
+| `log`          | ✅     |                                                                                                                    |
+| `log10`        | ✅     |                                                                                                                    |
+| `log1p`        | 🔜     | #4538                                                                                                              |
+| `log2`         | ✅     |                                                                                                                    |
+| `mod`          | ✅     |                                                                                                                    |
+| `negative`     | ✅     |                                                                                                                    |
+| `pi`           | ✅     |                                                                                                                    |
+| `pmod`         | 🔜     | #4538                                                                                                              |
+| `positive`     | ✅     |                                                                                                                    |
+| `pow`          | ✅     |                                                                                                                    |
+| `power`        | ✅     |                                                                                                                    |
+| `radians`      | ✅     |                                                                                                                    |
+| `rand`         | ✅     |                                                                                                                    |
+| `randn`        | ✅     |                                                                                                                    |
+| `random`       | ✅     | Alias for `rand` (Spark 4.0+); seed must be a literal                                                              |
+| `randstr`      | ❓     |                                                                                                                    |
+| `rint`         | ✅     |                                                                                                                    |
+| `round`        | ⚠️     | Float/Double inputs always fall back; integer/decimal HALF_UP supported                                            |
+| `sec`          | ✅     |                                                                                                                    |
+| `shiftleft`    | ✅     |                                                                                                                    |
+| `sign`         | ✅     |                                                                                                                    |
+| `signum`       | ✅     |                                                                                                                    |
+| `sin`          | ✅     |                                                                                                                    |
+| `sinh`         | ✅     |                                                                                                                    |
+| `sqrt`         | ✅     |                                                                                                                    |
+| `tan`          | ✅     |                                                                                                                    |
+| `tanh`         | ✅     |                                                                                                                    |
+| `try_add`      | ⚠️     | Datetime/interval form falls back; numeric form supported                                                          |
+| `try_divide`   | ✅     |                                                                                                                    |
+| `try_mod`      | ❓     |                                                                                                                    |
+| `try_multiply` | ✅     |                                                                                                                    |
+| `try_subtract` | ✅     |                                                                                                                    |
+| `unhex`        | ✅     |                                                                                                                    |
+| `uniform`      | ❓     |                                                                                                                    |
+| `width_bucket` | ⚠️     | Wired via shim, bypasses support-level framework ([#4485](https://github.com/apache/datafusion-comet/issues/4485)) |
 
 ---
 
@@ -495,162 +495,162 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 
 > 🚫 Out of scope: JVM reflection and cryptographic functions (`java_method`, `reflect`, `try_reflect`, `aes_encrypt`, `aes_decrypt`, `try_aes_decrypt`). See [Scope policy](#scope-policy).
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `assert_true` | ❓ | |
-| `current_catalog` | ❓ | |
-| `current_database` | ❓ | |
-| `current_schema` | ❓ | |
-| `current_user` | ❓ | |
-| `equal_null` | ❓ | |
-| `input_file_block_length` | ❓ | |
-| `input_file_block_start` | ❓ | |
-| `input_file_name` | ❓ | |
-| `is_variant_null` | 🔜 | tracking #4098 |
-| `monotonically_increasing_id` | ✅ | |
-| `parse_json` | 🔜 | tracking #4098 |
-| `raise_error` | ❓ | |
-| `rand` | ✅ | Seed must be a literal |
-| `randn` | ✅ | Seed must be a literal |
-| `schema_of_variant` | 🔜 | tracking #4098 |
-| `schema_of_variant_agg` | 🔜 | tracking #4098 |
-| `session_user` | ❓ | |
-| `spark_partition_id` | ✅ | |
-| `to_variant_object` | 🔜 | tracking #4098 |
-| `try_parse_json` | 🔜 | tracking #4098 |
-| `try_variant_get` | 🔜 | tracking #4098 |
-| `typeof` | ❓ | |
-| `user` | ✅ | Resolved to a literal by the Spark analyzer before reaching Comet |
-| `uuid` | ❓ | |
-| `variant_get` | 🔜 | tracking #4098 |
-| `version` | ❓ | |
+| Function                      | Status | Notes                                                             |
+| ----------------------------- | ------ | ----------------------------------------------------------------- |
+| `assert_true`                 | ❓     |                                                                   |
+| `current_catalog`             | ❓     |                                                                   |
+| `current_database`            | ❓     |                                                                   |
+| `current_schema`              | ❓     |                                                                   |
+| `current_user`                | ❓     |                                                                   |
+| `equal_null`                  | ❓     |                                                                   |
+| `input_file_block_length`     | ❓     |                                                                   |
+| `input_file_block_start`      | ❓     |                                                                   |
+| `input_file_name`             | ❓     |                                                                   |
+| `is_variant_null`             | 🔜     | tracking #4098                                                    |
+| `monotonically_increasing_id` | ✅     |                                                                   |
+| `parse_json`                  | 🔜     | tracking #4098                                                    |
+| `raise_error`                 | ❓     |                                                                   |
+| `rand`                        | ✅     | Seed must be a literal                                            |
+| `randn`                       | ✅     | Seed must be a literal                                            |
+| `schema_of_variant`           | 🔜     | tracking #4098                                                    |
+| `schema_of_variant_agg`       | 🔜     | tracking #4098                                                    |
+| `session_user`                | ❓     |                                                                   |
+| `spark_partition_id`          | ✅     |                                                                   |
+| `to_variant_object`           | 🔜     | tracking #4098                                                    |
+| `try_parse_json`              | 🔜     | tracking #4098                                                    |
+| `try_variant_get`             | 🔜     | tracking #4098                                                    |
+| `typeof`                      | ❓     |                                                                   |
+| `user`                        | ✅     | Resolved to a literal by the Spark analyzer before reaching Comet |
+| `uuid`                        | ❓     |                                                                   |
+| `variant_get`                 | 🔜     | tracking #4098                                                    |
+| `version`                     | ❓     |                                                                   |
 
 ---
 
 ## predicate_funcs
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `!` | ✅ | |
-| `<` | ✅ | |
-| `<=` | ✅ | |
-| `<=>` | ✅ | |
-| `=` | ✅ | |
-| `==` | ✅ | |
-| `>` | ✅ | |
-| `>=` | ✅ | |
-| `and` | ✅ | |
-| `between` | ✅ | |
-| `ilike` | ✅ | |
-| `in` | ✅ | |
-| `isnan` | ✅ | |
-| `isnotnull` | ✅ | |
-| `isnull` | ✅ | |
-| `like` | ✅ | |
-| `not` | ✅ | |
-| `or` | ✅ | |
-| `regexp` | 🔜 | tracking #4098 |
-| `regexp_like` | 🔜 | tracking #4098 |
-| `rlike` | ⚠️ | Uses Rust `regex` crate; requires `allowIncompatible`; results may differ from Java `Pattern` |
+| Function      | Status | Notes                                                                                         |
+| ------------- | ------ | --------------------------------------------------------------------------------------------- |
+| `!`           | ✅     |                                                                                               |
+| `<`           | ✅     |                                                                                               |
+| `<=`          | ✅     |                                                                                               |
+| `<=>`         | ✅     |                                                                                               |
+| `=`           | ✅     |                                                                                               |
+| `==`          | ✅     |                                                                                               |
+| `>`           | ✅     |                                                                                               |
+| `>=`          | ✅     |                                                                                               |
+| `and`         | ✅     |                                                                                               |
+| `between`     | ✅     |                                                                                               |
+| `ilike`       | ✅     |                                                                                               |
+| `in`          | ✅     |                                                                                               |
+| `isnan`       | ✅     |                                                                                               |
+| `isnotnull`   | ✅     |                                                                                               |
+| `isnull`      | ✅     |                                                                                               |
+| `like`        | ✅     |                                                                                               |
+| `not`         | ✅     |                                                                                               |
+| `or`          | ✅     |                                                                                               |
+| `regexp`      | ⚠️     | Alias for `rlike`; uses Rust `regex` crate, requires `allowIncompatible`                      |
+| `regexp_like` | ⚠️     | Alias for `rlike`; uses Rust `regex` crate, requires `allowIncompatible`                      |
+| `rlike`       | ⚠️     | Uses Rust `regex` crate; requires `allowIncompatible`; results may differ from Java `Pattern` |
 
 ---
 
 ## string_funcs
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `ascii` | ✅ | |
-| `base64` | ❓ | |
-| `bit_length` | ✅ | |
-| `btrim` | ✅ | |
-| `char` | ✅ | |
-| `char_length` | ✅ | |
-| `character_length` | ✅ | |
-| `chr` | ✅ | |
-| `collate` | ❓ | |
-| `collation` | ❓ | |
-| `concat_ws` | ✅ | |
-| `contains` | ✅ | |
-| `decode` | ✅ | |
-| `elt` | 🔜 | #4538 |
-| `encode` | ❓ | |
-| `endswith` | ✅ | |
-| `find_in_set` | 🔜 | #4538 |
-| `format_number` | 🔜 | #4538 |
-| `format_string` | 🔜 | #4538 |
-| `initcap` | ✅ | |
-| `instr` | ✅ | |
-| `is_valid_utf8` | ❓ | |
-| `lcase` | ✅ | |
-| `left` | ✅ | |
-| `len` | ✅ | |
-| `length` | ✅ | |
-| `levenshtein` | 🔜 | #4538 |
-| `locate` | 🔜 | #4538 |
-| `lower` | ✅ | |
-| `lpad` | ✅ | |
-| `ltrim` | ✅ | |
-| `luhn_check` | ❓ | |
-| `make_valid_utf8` | ❓ | |
-| `mask` | ❓ | |
-| `octet_length` | ✅ | |
-| `overlay` | 🔜 | #4538 |
-| `position` | 🔜 | #4538 |
-| `printf` | 🔜 | #4538 |
-| `quote` | ❓ | |
-| `regexp_count` | 🔜 | tracking #4098 |
-| `regexp_extract` | 🔜 | tracking #4098 |
-| `regexp_extract_all` | 🔜 | tracking #4098 |
-| `regexp_instr` | 🔜 | tracking #4098 |
-| `regexp_replace` | ✅ | |
-| `regexp_substr` | 🔜 | tracking #4098 |
-| `repeat` | ✅ | |
-| `replace` | ✅ | |
-| `right` | ✅ | |
-| `rpad` | ✅ | |
-| `rtrim` | ✅ | |
-| `sentences` | ❓ | |
-| `soundex` | 🔜 | #4538 |
-| `space` | ✅ | |
-| `split` | ✅ | |
-| `split_part` | ❓ | |
-| `startswith` | ✅ | |
-| `substr` | ✅ | |
-| `substring` | ✅ | |
-| `substring_index` | ✅ | |
-| `to_binary` | ❓ | |
-| `to_char` | 🔜 | #4538 |
-| `to_number` | 🔜 | #4538 |
-| `to_varchar` | 🔜 | #4538 |
-| `translate` | ✅ | |
-| `trim` | ✅ | |
-| `try_to_binary` | ❓ | |
-| `try_to_number` | ❓ | |
-| `try_validate_utf8` | ❓ | |
-| `ucase` | ✅ | |
-| `unbase64` | 🔜 | #4538 |
-| `upper` | ✅ | |
-| `validate_utf8` | ❓ | |
+| Function             | Status | Notes          |
+| -------------------- | ------ | -------------- |
+| `ascii`              | ✅     |                |
+| `base64`             | ❓     |                |
+| `bit_length`         | ✅     |                |
+| `btrim`              | ✅     |                |
+| `char`               | ✅     |                |
+| `char_length`        | ✅     |                |
+| `character_length`   | ✅     |                |
+| `chr`                | ✅     |                |
+| `collate`            | ❓     |                |
+| `collation`          | ❓     |                |
+| `concat_ws`          | ✅     |                |
+| `contains`           | ✅     |                |
+| `decode`             | ✅     |                |
+| `elt`                | 🔜     | #4538          |
+| `encode`             | ❓     |                |
+| `endswith`           | ✅     |                |
+| `find_in_set`        | 🔜     | #4538          |
+| `format_number`      | 🔜     | #4538          |
+| `format_string`      | 🔜     | #4538          |
+| `initcap`            | ✅     |                |
+| `instr`              | ✅     |                |
+| `is_valid_utf8`      | ❓     |                |
+| `lcase`              | ✅     |                |
+| `left`               | ✅     |                |
+| `len`                | ✅     |                |
+| `length`             | ✅     |                |
+| `levenshtein`        | 🔜     | #4538          |
+| `locate`             | 🔜     | #4538          |
+| `lower`              | ✅     |                |
+| `lpad`               | ✅     |                |
+| `ltrim`              | ✅     |                |
+| `luhn_check`         | ❓     |                |
+| `make_valid_utf8`    | ❓     |                |
+| `mask`               | ❓     |                |
+| `octet_length`       | ✅     |                |
+| `overlay`            | 🔜     | #4538          |
+| `position`           | 🔜     | #4538          |
+| `printf`             | 🔜     | #4538          |
+| `quote`              | ❓     |                |
+| `regexp_count`       | 🔜     | tracking #4098 |
+| `regexp_extract`     | 🔜     | tracking #4098 |
+| `regexp_extract_all` | 🔜     | tracking #4098 |
+| `regexp_instr`       | 🔜     | tracking #4098 |
+| `regexp_replace`     | ✅     |                |
+| `regexp_substr`      | 🔜     | tracking #4098 |
+| `repeat`             | ✅     |                |
+| `replace`            | ✅     |                |
+| `right`              | ✅     |                |
+| `rpad`               | ✅     |                |
+| `rtrim`              | ✅     |                |
+| `sentences`          | ❓     |                |
+| `soundex`            | 🔜     | #4538          |
+| `space`              | ✅     |                |
+| `split`              | ✅     |                |
+| `split_part`         | ❓     |                |
+| `startswith`         | ✅     |                |
+| `substr`             | ✅     |                |
+| `substring`          | ✅     |                |
+| `substring_index`    | ✅     |                |
+| `to_binary`          | ❓     |                |
+| `to_char`            | 🔜     | #4538          |
+| `to_number`          | 🔜     | #4538          |
+| `to_varchar`         | 🔜     | #4538          |
+| `translate`          | ✅     |                |
+| `trim`               | ✅     |                |
+| `try_to_binary`      | ❓     |                |
+| `try_to_number`      | ❓     |                |
+| `try_validate_utf8`  | ❓     |                |
+| `ucase`              | ✅     |                |
+| `unbase64`           | 🔜     | #4538          |
+| `upper`              | ✅     |                |
+| `validate_utf8`      | ❓     |                |
 
 ---
 
 ## struct_funcs
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `named_struct` | ⚠️ | Duplicate field names fall back to Spark |
-| `struct` | ✅ | |
+| Function       | Status | Notes                                    |
+| -------------- | ------ | ---------------------------------------- |
+| `named_struct` | ⚠️     | Duplicate field names fall back to Spark |
+| `struct`       | ✅     |                                          |
 
 ---
 
 ## url_funcs
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `parse_url` | ✅ | |
-| `try_url_decode` | ✅ | |
-| `url_decode` | ✅ | |
-| `url_encode` | ✅ | |
+| Function         | Status | Notes |
+| ---------------- | ------ | ----- |
+| `parse_url`      | ✅     |       |
+| `try_url_decode` | ✅     |       |
+| `url_decode`     | ✅     |       |
+| `url_encode`     | ✅     |       |
 
 ---
 
@@ -663,17 +663,17 @@ When enabled, `lag` and `lead` are explicitly wired; aggregate window functions 
 `ntile`, `percent_rank`, `cume_dist`, `nth_value`) are not yet wired in the window serde and
 fall back to Spark.
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `cume_dist` | ❓ | Not yet wired in window serde |
-| `dense_rank` | ❓ | Not yet wired in window serde |
-| `lag` | ✅ | via `CometWindowExec` |
-| `lead` | ✅ | via `CometWindowExec` |
-| `nth_value` | ❓ | Not yet wired in window serde |
-| `ntile` | ❓ | Not yet wired in window serde |
-| `percent_rank` | ❓ | Not yet wired in window serde |
-| `rank` | ❓ | Not yet wired in window serde |
-| `row_number` | ❓ | Not yet wired in window serde |
+| Function       | Status | Notes                         |
+| -------------- | ------ | ----------------------------- |
+| `cume_dist`    | ❓     | Not yet wired in window serde |
+| `dense_rank`   | ❓     | Not yet wired in window serde |
+| `lag`          | ✅     | via `CometWindowExec`         |
+| `lead`         | ✅     | via `CometWindowExec`         |
+| `nth_value`    | ❓     | Not yet wired in window serde |
+| `ntile`        | ❓     | Not yet wired in window serde |
+| `percent_rank` | ❓     | Not yet wired in window serde |
+| `rank`         | ❓     | Not yet wired in window serde |
+| `row_number`   | ❓     | Not yet wired in window serde |
 
 ---
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -57,6 +57,9 @@ are not on the roadmap:
 - **Avro / Protobuf codecs** (`from_avro`, `to_avro`, `from_protobuf`, `to_protobuf`, `schema_of_avro`): format conversion belongs at the IO layer, not expression evaluation.
 - **JVM reflection** (`java_method`, `reflect`): niche, and they invoke arbitrary JVM methods (a security concern).
 - **CSV functions** (`from_csv`, `to_csv`, `schema_of_csv`): row-level CSV parsing and formatting in expressions is niche and better handled at the data source layer.
+- **UTF-8 validation** (`is_valid_utf8`, `make_valid_utf8`, `validate_utf8`, `try_validate_utf8`): niche Spark 4.x string-validation helpers.
+- **File metadata** (`input_file_name`, `input_file_block_start`, `input_file_block_length`): require scan-internal per-row file information, outside the expression layer.
+- **Miscellaneous niche** (`histogram_numeric`, `version`, `sentences`, `quote`, `uuid`): low-value or specialized functions with little benefit from native acceleration.
 
 Note that `approx_count_distinct`, `approx_percentile` / `percentile_approx`, `median`, and `mode`
 are _not_ out of scope: although approximate, they are mainstream and are planned.
@@ -67,69 +70,69 @@ The tables below list every Spark built-in expression with its current status.
 
 > 🚫 Out of scope: probabilistic sketch aggregates (`kll_sketch_*`, `hll_sketch_agg`, `hll_union_agg`, `theta_intersection_agg`, `theta_sketch_agg`, `theta_union_agg`, `count_min_sketch`, `approx_top_k`, `approx_top_k_accumulate`, `approx_top_k_combine`). See [Out of scope](#out-of-scope).
 
-| Function                | Status | Notes                                                            |
-| ----------------------- | ------ | ---------------------------------------------------------------- |
-| `any`                   | ✅     |                                                                  |
-| `any_value`             | ✅     |                                                                  |
-| `approx_count_distinct` | 🔜     | tracking #4098                                                   |
-| `approx_percentile`     | 🔜     | [#3189](https://github.com/apache/datafusion-comet/issues/3189)  |
-| `array_agg`             | ❓     |                                                                  |
-| `avg`                   | ⚠️     | Interval types (YearMonth, DayTime) fall back                    |
-| `bit_and`               | ✅     |                                                                  |
-| `bit_or`                | ✅     |                                                                  |
-| `bit_xor`               | ✅     |                                                                  |
-| `bool_and`              | ✅     |                                                                  |
-| `bool_or`               | ✅     |                                                                  |
-| `collect_list`          | 🔜     | [#2524](https://github.com/apache/datafusion-comet/issues/2524)  |
-| `collect_set`           | ✅     |                                                                  |
-| `corr`                  | ✅     |                                                                  |
-| `count`                 | ✅     |                                                                  |
-| `count_if`              | ✅     |                                                                  |
-| `covar_pop`             | ✅     |                                                                  |
-| `covar_samp`            | ✅     |                                                                  |
-| `every`                 | ✅     |                                                                  |
-| `first`                 | ✅     |                                                                  |
-| `first_value`           | ✅     |                                                                  |
-| `grouping`              | ❓     |                                                                  |
-| `grouping_id`           | ❓     |                                                                  |
-| `histogram_numeric`     | ❓     |                                                                  |
-| `kurtosis`              | 🔜     | tracking #4098                                                   |
-| `last`                  | ✅     |                                                                  |
-| `last_value`            | ✅     |                                                                  |
-| `listagg`               | ❓     |                                                                  |
-| `max`                   | ✅     |                                                                  |
-| `max_by`                | 🔜     | [#3841](https://github.com/apache/datafusion-comet/issues/3841)  |
-| `mean`                  | ✅     |                                                                  |
-| `median`                | 🔜     | tracking #4098                                                   |
-| `min`                   | ✅     |                                                                  |
-| `min_by`                | 🔜     | [#3841](https://github.com/apache/datafusion-comet/issues/3841)  |
-| `mode`                  | 🔜     | [#3970](https://github.com/apache/datafusion-comet/issues/3970)  |
-| `percentile`            | 🔜     | #4542                                                            |
-| `percentile_approx`     | 🔜     | [#3189](https://github.com/apache/datafusion-comet/issues/3189)  |
-| `percentile_cont`       | ❓     |                                                                  |
-| `percentile_disc`       | ❓     |                                                                  |
-| `regr_avgx`             | ✅     | Native: Spark rewrites to `Average` (tests in #4551)             |
-| `regr_avgy`             | ✅     | Native: Spark rewrites to `Average` (tests in #4551)             |
-| `regr_count`            | ✅     | Native: Spark rewrites to `Count` (tests in #4551)               |
-| `regr_intercept`        | 🔜     | Falls back; can reuse `covar_pop`/`var_pop` accumulators (#4552) |
-| `regr_r2`               | 🔜     | Falls back; can reuse the `corr` accumulator (#4552)             |
-| `regr_slope`            | 🔜     | Falls back; can reuse `covar_pop`/`var_pop` accumulators (#4552) |
-| `regr_sxx`              | 🔜     | Falls back; can reuse `var_pop` accumulator (#4552)              |
-| `regr_sxy`              | 🔜     | Falls back; can reuse `covar_pop` accumulator (#4552)            |
-| `regr_syy`              | 🔜     | Falls back; can reuse `var_pop` accumulator (#4552)              |
-| `skewness`              | 🔜     | tracking #4098                                                   |
-| `some`                  | ✅     |                                                                  |
-| `std`                   | ✅     |                                                                  |
-| `stddev`                | ✅     |                                                                  |
-| `stddev_pop`            | ✅     |                                                                  |
-| `stddev_samp`           | ✅     |                                                                  |
-| `string_agg`            | ❓     |                                                                  |
-| `sum`                   | ✅     |                                                                  |
-| `try_avg`               | 🔜     | tracking #4098                                                   |
-| `try_sum`               | 🔜     | tracking #4098                                                   |
-| `var_pop`               | ✅     |                                                                  |
-| `var_samp`              | ✅     |                                                                  |
-| `variance`              | ✅     |                                                                  |
+| Function                | Status | Notes                                                                  |
+| ----------------------- | ------ | ---------------------------------------------------------------------- |
+| `any`                   | ✅     |                                                                        |
+| `any_value`             | ✅     |                                                                        |
+| `approx_count_distinct` | 🔜     | tracking #4098                                                         |
+| `approx_percentile`     | 🔜     | [#3189](https://github.com/apache/datafusion-comet/issues/3189)        |
+| `array_agg`             | 🔜     | Array aggregate (related to `collect_list`, #2524)                     |
+| `avg`                   | ⚠️     | Interval types (YearMonth, DayTime) fall back                          |
+| `bit_and`               | ✅     |                                                                        |
+| `bit_or`                | ✅     |                                                                        |
+| `bit_xor`               | ✅     |                                                                        |
+| `bool_and`              | ✅     |                                                                        |
+| `bool_or`               | ✅     |                                                                        |
+| `collect_list`          | 🔜     | [#2524](https://github.com/apache/datafusion-comet/issues/2524)        |
+| `collect_set`           | ✅     |                                                                        |
+| `corr`                  | ✅     |                                                                        |
+| `count`                 | ✅     |                                                                        |
+| `count_if`              | ✅     |                                                                        |
+| `covar_pop`             | ✅     |                                                                        |
+| `covar_samp`            | ✅     |                                                                        |
+| `every`                 | ✅     |                                                                        |
+| `first`                 | ✅     |                                                                        |
+| `first_value`           | ✅     |                                                                        |
+| `grouping`              | 🔜     | Grouping indicator for ROLLUP/CUBE/GROUPING SETS                       |
+| `grouping_id`           | 🔜     | Grouping indicator for ROLLUP/CUBE/GROUPING SETS                       |
+| `histogram_numeric`     | 🚫     | Approximate histogram aggregate (out of scope, like sketch aggregates) |
+| `kurtosis`              | 🔜     | tracking #4098                                                         |
+| `last`                  | ✅     |                                                                        |
+| `last_value`            | ✅     |                                                                        |
+| `listagg`               | 🔜     | String aggregation                                                     |
+| `max`                   | ✅     |                                                                        |
+| `max_by`                | 🔜     | [#3841](https://github.com/apache/datafusion-comet/issues/3841)        |
+| `mean`                  | ✅     |                                                                        |
+| `median`                | 🔜     | tracking #4098                                                         |
+| `min`                   | ✅     |                                                                        |
+| `min_by`                | 🔜     | [#3841](https://github.com/apache/datafusion-comet/issues/3841)        |
+| `mode`                  | 🔜     | [#3970](https://github.com/apache/datafusion-comet/issues/3970)        |
+| `percentile`            | 🔜     | #4542                                                                  |
+| `percentile_approx`     | 🔜     | [#3189](https://github.com/apache/datafusion-comet/issues/3189)        |
+| `percentile_cont`       | 🔜     | Percentile aggregate                                                   |
+| `percentile_disc`       | 🔜     | Percentile aggregate                                                   |
+| `regr_avgx`             | ✅     | Native: Spark rewrites to `Average` (tests in #4551)                   |
+| `regr_avgy`             | ✅     | Native: Spark rewrites to `Average` (tests in #4551)                   |
+| `regr_count`            | ✅     | Native: Spark rewrites to `Count` (tests in #4551)                     |
+| `regr_intercept`        | 🔜     | Falls back; can reuse `covar_pop`/`var_pop` accumulators (#4552)       |
+| `regr_r2`               | 🔜     | Falls back; can reuse the `corr` accumulator (#4552)                   |
+| `regr_slope`            | 🔜     | Falls back; can reuse `covar_pop`/`var_pop` accumulators (#4552)       |
+| `regr_sxx`              | 🔜     | Falls back; can reuse `var_pop` accumulator (#4552)                    |
+| `regr_sxy`              | 🔜     | Falls back; can reuse `covar_pop` accumulator (#4552)                  |
+| `regr_syy`              | 🔜     | Falls back; can reuse `var_pop` accumulator (#4552)                    |
+| `skewness`              | 🔜     | tracking #4098                                                         |
+| `some`                  | ✅     |                                                                        |
+| `std`                   | ✅     |                                                                        |
+| `stddev`                | ✅     |                                                                        |
+| `stddev_pop`            | ✅     |                                                                        |
+| `stddev_samp`           | ✅     |                                                                        |
+| `string_agg`            | 🔜     | String aggregation (alias of `listagg`)                                |
+| `sum`                   | ✅     |                                                                        |
+| `try_avg`               | 🔜     | tracking #4098                                                         |
+| `try_sum`               | 🔜     | tracking #4098                                                         |
+| `var_pop`               | ✅     |                                                                        |
+| `var_samp`              | ✅     |                                                                        |
+| `variance`              | ✅     |                                                                        |
 
 ---
 
@@ -149,7 +152,7 @@ The tables below list every Spark built-in expression with its current status.
 | `array_max`       | ⚠️     | NaN ordering may differ for float/double ([#4482](https://github.com/apache/datafusion-comet/issues/4482))                |
 | `array_min`       | ⚠️     | NaN ordering may differ for float/double ([#4482](https://github.com/apache/datafusion-comet/issues/4482))                |
 | `array_position`  | ⚠️     | Falls back for binary/struct/map/null element types                                                                       |
-| `array_prepend`   | ❓     |                                                                                                                           |
+| `array_prepend`   | 🔜     | Sibling of `array_append`                                                                                                 |
 | `array_remove`    | ✅     |                                                                                                                           |
 | `array_repeat`    | ✅     |                                                                                                                           |
 | `array_union`     | ⚠️     | NaN/signed-zero canonicalization may differ ([#4481](https://github.com/apache/datafusion-comet/issues/4481))             |
@@ -159,7 +162,7 @@ The tables below list every Spark built-in expression with its current status.
 | `flatten`         | ⚠️     | Falls back for binary/struct/map child element types                                                                      |
 | `get`             | ✅     |                                                                                                                           |
 | `sequence`        | 🔜     | #4538                                                                                                                     |
-| `shuffle`         | ❓     |                                                                                                                           |
+| `shuffle`         | 🔜     | Random array shuffle                                                                                                      |
 | `slice`           | ✅     | Native (#4149)                                                                                                            |
 | `sort_array`      | ⚠️     | Incompatible under strict floating-point; falls back for nested struct/null arrays                                        |
 
@@ -333,11 +336,11 @@ expression-level). The `outer` variants are wired but marked `Incompatible`; the
 | ------------------ | ------ | ---------------------------------------------------- |
 | `explode`          | ✅     | via `CometExplodeExec`                               |
 | `explode_outer`    | ⚠️     | `outer=true` incompatible; needs `allowIncompatible` |
-| `inline`           | ❓     |                                                      |
-| `inline_outer`     | ❓     |                                                      |
+| `inline`           | 🔜     | Operator-level generator (like `explode`)            |
+| `inline_outer`     | 🔜     | Operator-level generator (like `explode`)            |
 | `posexplode`       | ✅     | via `CometExplodeExec`                               |
 | `posexplode_outer` | ⚠️     | `outer=true` incompatible; needs `allowIncompatible` |
-| `stack`            | ❓     |                                                      |
+| `stack`            | 🔜     | Operator-level generator                             |
 
 ---
 
@@ -395,8 +398,8 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | Function           | Status | Notes                                                        |
 | ------------------ | ------ | ------------------------------------------------------------ |
 | `element_at`       | ⚠️     | Only `ArrayType` input; `MapType` input falls back           |
-| `map`              | ❓     |                                                              |
-| `map_concat`       | ❓     |                                                              |
+| `map`              | 🔜     | Constructs a map                                             |
+| `map_concat`       | 🔜     | Concatenates maps                                            |
 | `map_contains_key` | ✅     |                                                              |
 | `map_entries`      | ✅     |                                                              |
 | `map_from_arrays`  | ✅     |                                                              |
@@ -437,7 +440,7 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `csc`          | ✅     |                                                                                                                    |
 | `degrees`      | ✅     |                                                                                                                    |
 | `div`          | ✅     |                                                                                                                    |
-| `e`            | ❓     |                                                                                                                    |
+| `e`            | ✅     | Folds to a literal (like `pi`)                                                                                     |
 | `exp`          | ✅     |                                                                                                                    |
 | `expm1`        | ✅     |                                                                                                                    |
 | `factorial`    | ✅     |                                                                                                                    |
@@ -462,7 +465,7 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `rand`         | ✅     |                                                                                                                    |
 | `randn`        | ✅     |                                                                                                                    |
 | `random`       | ✅     | Alias for `rand` (Spark 4.0+); seed must be a literal                                                              |
-| `randstr`      | ❓     |                                                                                                                    |
+| `randstr`      | 🔜     | Random string (Spark 4.0+)                                                                                         |
 | `rint`         | ✅     |                                                                                                                    |
 | `round`        | ⚠️     | Float/Double inputs always fall back; integer/decimal HALF_UP supported                                            |
 | `sec`          | ✅     |                                                                                                                    |
@@ -476,7 +479,7 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `tanh`         | ✅     |                                                                                                                    |
 | `try_add`      | ⚠️     | Datetime/interval form falls back; numeric form supported                                                          |
 | `try_divide`   | ✅     |                                                                                                                    |
-| `try_mod`      | ❓     | Lowers to `Remainder` with TRY eval mode, which falls back (#4484)                                                 |
+| `try_mod`      | 🔜     | Lowers to `Remainder` with TRY eval mode, which falls back (#4484)                                                 |
 | `try_multiply` | ✅     |                                                                                                                    |
 | `try_subtract` | ✅     |                                                                                                                    |
 | `unhex`        | ✅     |                                                                                                                    |
@@ -499,34 +502,34 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | ----------------------------- | ------ | -------------------------------------------------------------------------------- |
 | `aes_decrypt`                 | 🔜     | Falls back; `StaticInvoke` not allowlisted; planned via codegen dispatch (#4558) |
 | `aes_encrypt`                 | 🔜     | Falls back; planned via codegen dispatch (#4558); nondeterministic IV by default |
-| `assert_true`                 | ❓     | Lowers to `RaiseError`, which falls back                                         |
-| `current_catalog`             | ❓     |                                                                                  |
-| `current_database`            | ❓     |                                                                                  |
-| `current_schema`              | ❓     |                                                                                  |
-| `current_user`                | ❓     |                                                                                  |
+| `assert_true`                 | 🔜     | Lowers to `RaiseError`, which falls back                                         |
+| `current_catalog`             | ✅     | Resolved to a literal by the analyzer (`ReplaceCurrentLike`)                     |
+| `current_database`            | ✅     | Resolved to a literal by the analyzer (`ReplaceCurrentLike`)                     |
+| `current_schema`              | ✅     | Alias of `current_database`; resolved to a literal by the analyzer               |
+| `current_user`                | ✅     | Resolved to a literal by the analyzer; same as `user`                            |
 | `equal_null`                  | ✅     | Lowers to `<=>` (`EqualNullSafe`)                                                |
-| `input_file_block_length`     | ❓     |                                                                                  |
-| `input_file_block_start`      | ❓     |                                                                                  |
-| `input_file_name`             | ❓     |                                                                                  |
+| `input_file_block_length`     | 🚫     | Requires scan-internal file metadata (out of scope)                              |
+| `input_file_block_start`      | 🚫     | Requires scan-internal file metadata (out of scope)                              |
+| `input_file_name`             | 🚫     | Requires scan-internal file metadata (out of scope)                              |
 | `is_variant_null`             | 🔜     | tracking #4098                                                                   |
 | `monotonically_increasing_id` | ✅     |                                                                                  |
 | `parse_json`                  | 🔜     | tracking #4098                                                                   |
-| `raise_error`                 | ❓     |                                                                                  |
+| `raise_error`                 | 🔜     | Raises a runtime error                                                           |
 | `rand`                        | ✅     | Seed must be a literal                                                           |
 | `randn`                       | ✅     | Seed must be a literal                                                           |
 | `schema_of_variant`           | 🔜     | tracking #4098                                                                   |
 | `schema_of_variant_agg`       | 🔜     | tracking #4098                                                                   |
-| `session_user`                | ❓     |                                                                                  |
+| `session_user`                | ✅     | Alias of `current_user`; resolved to a literal by the analyzer                   |
 | `spark_partition_id`          | ✅     |                                                                                  |
 | `to_variant_object`           | 🔜     | tracking #4098                                                                   |
 | `try_aes_decrypt`             | 🔜     | Falls back; planned via codegen dispatch (#4558)                                 |
 | `try_parse_json`              | 🔜     | tracking #4098                                                                   |
 | `try_variant_get`             | 🔜     | tracking #4098                                                                   |
-| `typeof`                      | ❓     |                                                                                  |
+| `typeof`                      | ✅     | Foldable; resolved to a literal before Comet sees the plan                       |
 | `user`                        | ✅     | Resolved to a literal by the Spark analyzer before reaching Comet                |
-| `uuid`                        | ❓     |                                                                                  |
+| `uuid`                        | 🚫     | Nondeterministic random UUID (out of scope)                                      |
 | `variant_get`                 | 🔜     | tracking #4098                                                                   |
-| `version`                     | ❓     | Lowers to `StaticInvoke(getSparkVersion)`, which falls back                      |
+| `version`                     | 🚫     | Returns the Spark version string (out of scope)                                  |
 
 ---
 
@@ -563,27 +566,27 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | Function             | Status | Notes                                                                            |
 | -------------------- | ------ | -------------------------------------------------------------------------------- |
 | `ascii`              | ✅     |                                                                                  |
-| `base64`             | ❓     | Lowers to `StaticInvoke(encode)` (not allowlisted); falls back                   |
+| `base64`             | 🔜     | Lowers to `StaticInvoke(encode)` (not allowlisted); falls back                   |
 | `bit_length`         | ✅     |                                                                                  |
 | `btrim`              | ✅     |                                                                                  |
 | `char`               | ✅     |                                                                                  |
 | `char_length`        | ✅     |                                                                                  |
 | `character_length`   | ✅     |                                                                                  |
 | `chr`                | ✅     |                                                                                  |
-| `collate`            | ❓     |                                                                                  |
+| `collate`            | 🔜     | Spark collation (umbrella #2190)                                                 |
 | `collation`          | ✅     | Constant-folded to a literal (Spark 4.0+)                                        |
 | `concat_ws`          | ✅     |                                                                                  |
 | `contains`           | ✅     |                                                                                  |
 | `decode`             | ✅     |                                                                                  |
 | `elt`                | 🔜     | #4538                                                                            |
-| `encode`             | ❓     | Lowers to `StaticInvoke(encode)` (not allowlisted); falls back                   |
+| `encode`             | 🔜     | Lowers to `StaticInvoke(encode)` (not allowlisted); falls back                   |
 | `endswith`           | ✅     |                                                                                  |
 | `find_in_set`        | 🔜     | #4538                                                                            |
 | `format_number`      | 🔜     | #4538                                                                            |
 | `format_string`      | 🔜     | #4538                                                                            |
 | `initcap`            | ✅     |                                                                                  |
 | `instr`              | ✅     |                                                                                  |
-| `is_valid_utf8`      | ❓     | Lowers to `Invoke`, which falls back (Spark 4.0+)                                |
+| `is_valid_utf8`      | 🚫     | UTF-8 validation (out of scope)                                                  |
 | `lcase`              | ✅     |                                                                                  |
 | `left`               | ✅     |                                                                                  |
 | `len`                | ✅     |                                                                                  |
@@ -594,13 +597,13 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `lpad`               | ✅     |                                                                                  |
 | `ltrim`              | ✅     |                                                                                  |
 | `luhn_check`         | ✅     | Native via `StaticInvoke` (tests: luhn_check.sql)                                |
-| `make_valid_utf8`    | ❓     | Lowers to `Invoke`, which falls back (Spark 4.0+)                                |
-| `mask`               | ❓     |                                                                                  |
+| `make_valid_utf8`    | 🚫     | UTF-8 validation (out of scope)                                                  |
+| `mask`               | 🔜     | Data masking                                                                     |
 | `octet_length`       | ✅     |                                                                                  |
 | `overlay`            | 🔜     | #4538                                                                            |
 | `position`           | 🔜     | #4538                                                                            |
 | `printf`             | 🔜     | #4538                                                                            |
-| `quote`              | ❓     | Lowers to `StaticInvoke`, which falls back (Spark 4.1+)                          |
+| `quote`              | 🚫     | Quotes a string as a SQL literal (out of scope)                                  |
 | `regexp_count`       | 🔜     | tracking #4098                                                                   |
 | `regexp_extract`     | 🔜     | tracking #4098                                                                   |
 | `regexp_extract_all` | 🔜     | tracking #4098                                                                   |
@@ -612,11 +615,11 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `right`              | ✅     |                                                                                  |
 | `rpad`               | ✅     |                                                                                  |
 | `rtrim`              | ✅     |                                                                                  |
-| `sentences`          | ❓     | Lowers to `StaticInvoke(getSentences)`, which falls back                         |
+| `sentences`          | 🚫     | Locale-aware sentence/word splitting (out of scope)                              |
 | `soundex`            | 🔜     | #4538                                                                            |
 | `space`              | ✅     |                                                                                  |
 | `split`              | ✅     |                                                                                  |
-| `split_part`         | ❓     | Lowers to `element_at(StringSplitSQL(...))`; `StringSplitSQL` falls back (#4561) |
+| `split_part`         | 🔜     | Lowers to `element_at(StringSplitSQL(...))`; `StringSplitSQL` falls back (#4561) |
 | `startswith`         | ✅     |                                                                                  |
 | `substr`             | ✅     |                                                                                  |
 | `substring`          | ✅     |                                                                                  |
@@ -627,13 +630,13 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `to_varchar`         | 🔜     | #4538                                                                            |
 | `translate`          | ✅     |                                                                                  |
 | `trim`               | ✅     |                                                                                  |
-| `try_to_binary`      | ❓     | Lowers to `TryEval(...)`, which falls back                                       |
-| `try_to_number`      | ❓     |                                                                                  |
-| `try_validate_utf8`  | ❓     | Lowers to `StaticInvoke`, which falls back (Spark 4.0+)                          |
+| `try_to_binary`      | 🔜     | Lowers to `TryEval(...)`, which falls back                                       |
+| `try_to_number`      | 🔜     | TRY variant of `to_number`                                                       |
+| `try_validate_utf8`  | 🚫     | UTF-8 validation (out of scope)                                                  |
 | `ucase`              | ✅     |                                                                                  |
 | `unbase64`           | 🔜     | #4538                                                                            |
 | `upper`              | ✅     |                                                                                  |
-| `validate_utf8`      | ❓     | Lowers to `StaticInvoke`, which falls back (Spark 4.0+)                          |
+| `validate_utf8`      | 🚫     | UTF-8 validation (out of scope)                                                  |
 
 ---
 
@@ -666,17 +669,17 @@ When enabled, `lag` and `lead` are explicitly wired; aggregate window functions 
 `ntile`, `percent_rank`, `cume_dist`, `nth_value`) are not yet wired in the window serde and
 fall back to Spark.
 
-| Function       | Status | Notes                         |
-| -------------- | ------ | ----------------------------- |
-| `cume_dist`    | ❓     | Not yet wired in window serde |
-| `dense_rank`   | ❓     | Not yet wired in window serde |
-| `lag`          | ✅     | via `CometWindowExec`         |
-| `lead`         | ✅     | via `CometWindowExec`         |
-| `nth_value`    | ❓     | Not yet wired in window serde |
-| `ntile`        | ❓     | Not yet wired in window serde |
-| `percent_rank` | ❓     | Not yet wired in window serde |
-| `rank`         | ❓     | Not yet wired in window serde |
-| `row_number`   | ❓     | Not yet wired in window serde |
+| Function       | Status | Notes                             |
+| -------------- | ------ | --------------------------------- |
+| `cume_dist`    | 🔜     | Window function; tracked by #2721 |
+| `dense_rank`   | 🔜     | Window function; tracked by #2721 |
+| `lag`          | ✅     | via `CometWindowExec`             |
+| `lead`         | ✅     | via `CometWindowExec`             |
+| `nth_value`    | 🔜     | Window function; tracked by #2721 |
+| `ntile`        | 🔜     | Window function; tracked by #2721 |
+| `percent_rank` | 🔜     | Window function; tracked by #2721 |
+| `rank`         | 🔜     | Window function; tracked by #2721 |
+| `row_number`   | 🔜     | Window function; tracked by #2721 |
 
 ---
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -26,8 +26,9 @@ transparently falls back to Spark for that part of the plan; results are unaffec
 
 Expressions marked ✅ Supported are enabled by default. Expressions marked ⚠️ Supported
 (caveats) include cases that are known to diverge from Spark; those cases fall back to Spark
-by default and must be opted into, either globally with `spark.comet.expr.allowIncompatible=true`
-or per expression with `spark.comet.expression.EXPRNAME.allowIncompatible=true`.
+by default and must be opted into per expression with
+`spark.comet.expression.EXPRNAME.allowIncompatible=true` (where `EXPRNAME` is the Spark
+expression class name, for example `Cast`). There is no global opt-in.
 
 Most expressions can also be disabled with `spark.comet.expression.EXPRNAME.enabled=false`, where
 `EXPRNAME` is the Spark expression class name (for example `Length` or `StartsWith`). See the
@@ -43,7 +44,7 @@ Most expressions can also be disabled with `spark.comet.expression.EXPRNAME.enab
 | 🚫 Out of scope        | Deliberately not planned.                                                                                                                                                               |
 | ❓ Not yet supported   | Falls back to Spark today; support is to be determined (not yet evaluated).                                                                                                             |
 
-## Scope policy
+## Out of scope
 
 Comet focuses acceleration on mainstream relational, string, datetime, math, and collection
 expressions. Some Spark function families are **out of scope**: specialized functionality with
@@ -54,8 +55,7 @@ are not on the roadmap:
 - **XML / XPath** (`from_xml`, `to_xml`, `schema_of_xml`, `xpath*`): legacy text format, rare in accelerated workloads.
 - **Geospatial** (`st_*`): brand-new Spark 4.1 functionality, specialized.
 - **Avro / Protobuf codecs** (`from_avro`, `to_avro`, `from_protobuf`, `to_protobuf`, `schema_of_avro`): format conversion belongs at the IO layer, not expression evaluation.
-- **JVM reflection** (`java_method`, `reflect`): cannot run in native code.
-- **Cryptographic functions** (`aes_encrypt`, `aes_decrypt`): niche, with correctness and security risk for marginal benefit.
+- **JVM reflection** (`java_method`, `reflect`): niche, and they invoke arbitrary JVM methods (a security concern).
 - **CSV functions** (`from_csv`, `to_csv`, `schema_of_csv`): row-level CSV parsing and formatting in expressions is niche and better handled at the data source layer.
 
 Note that `approx_count_distinct`, `approx_percentile` / `percentile_approx`, `median`, and `mode`
@@ -65,7 +65,7 @@ The tables below list every Spark built-in expression with its current status.
 
 ## agg_funcs
 
-> 🚫 Out of scope: probabilistic sketch aggregates (`kll_sketch_*`, `hll_sketch_agg`, `hll_union_agg`, `theta_intersection_agg`, `theta_sketch_agg`, `theta_union_agg`, `count_min_sketch`, `approx_top_k`, `approx_top_k_accumulate`, `approx_top_k_combine`). See [Scope policy](#scope-policy).
+> 🚫 Out of scope: probabilistic sketch aggregates (`kll_sketch_*`, `hll_sketch_agg`, `hll_union_agg`, `theta_intersection_agg`, `theta_sketch_agg`, `theta_union_agg`, `count_min_sketch`, `approx_top_k`, `approx_top_k_accumulate`, `approx_top_k_combine`). See [Out of scope](#out-of-scope).
 
 | Function                | Status | Notes                                                            |
 | ----------------------- | ------ | ---------------------------------------------------------------- |
@@ -239,7 +239,7 @@ serde but effectively fall through to the same cast path at runtime.
 
 ## csv_funcs
 
-🚫 **Out of scope.** `from_csv`, `to_csv`, and `schema_of_csv` fall back to Spark. See [Scope policy](#scope-policy).
+🚫 **Out of scope.** `from_csv`, `to_csv`, and `schema_of_csv` fall back to Spark. See [Out of scope](#out-of-scope).
 
 ---
 
@@ -487,16 +487,18 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 
 ## misc_funcs
 
-> 🚫 Out of scope: probabilistic sketch functions (`hll_sketch_estimate`, `hll_union`, `theta_difference`, `theta_intersection`, `theta_sketch_estimate`, `theta_union`, `bitmap_and_agg`, `bitmap_or_agg`, `bitmap_construct_agg`, `bitmap_count`, `bitmap_bucket_number`, `bitmap_bit_position`, `approx_top_k_estimate`). See [Scope policy](#scope-policy).
+> 🚫 Out of scope: probabilistic sketch functions (`hll_sketch_estimate`, `hll_union`, `theta_difference`, `theta_intersection`, `theta_sketch_estimate`, `theta_union`, `bitmap_and_agg`, `bitmap_or_agg`, `bitmap_construct_agg`, `bitmap_count`, `bitmap_bucket_number`, `bitmap_bit_position`, `approx_top_k_estimate`). See [Out of scope](#out-of-scope).
 
-> 🚫 Out of scope: geospatial functions (`st_asbinary`, `st_geogfromwkb`, `st_geomfromwkb`, `st_setsrid`, `st_srid`). See [Scope policy](#scope-policy).
+> 🚫 Out of scope: geospatial functions (`st_asbinary`, `st_geogfromwkb`, `st_geomfromwkb`, `st_setsrid`, `st_srid`). See [Out of scope](#out-of-scope).
 
-> 🚫 Out of scope: Avro/Protobuf codec functions (`from_avro`, `to_avro`, `schema_of_avro`, `from_protobuf`, `to_protobuf`). See [Scope policy](#scope-policy).
+> 🚫 Out of scope: Avro/Protobuf codec functions (`from_avro`, `to_avro`, `schema_of_avro`, `from_protobuf`, `to_protobuf`). See [Out of scope](#out-of-scope).
 
-> 🚫 Out of scope: JVM reflection and cryptographic functions (`java_method`, `reflect`, `try_reflect`, `aes_encrypt`, `aes_decrypt`, `try_aes_decrypt`). See [Scope policy](#scope-policy).
+> 🚫 Out of scope: JVM reflection functions (`java_method`, `reflect`, `try_reflect`). See [Out of scope](#out-of-scope).
 
 | Function                      | Status | Notes                                                             |
 | ----------------------------- | ------ | ----------------------------------------------------------------- |
+| `aes_decrypt`                 | 🔜     | Codegen-dispatch candidate (RuntimeReplaceable to `StaticInvoke`) |
+| `aes_encrypt`                 | 🔜     | Codegen-dispatch candidate; nondeterministic IV by default        |
 | `assert_true`                 | ❓     |                                                                   |
 | `current_catalog`             | ❓     |                                                                   |
 | `current_database`            | ❓     |                                                                   |
@@ -517,6 +519,7 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `session_user`                | ❓     |                                                                   |
 | `spark_partition_id`          | ✅     |                                                                   |
 | `to_variant_object`           | 🔜     | tracking #4098                                                    |
+| `try_aes_decrypt`             | 🔜     | Codegen-dispatch candidate (RuntimeReplaceable to `StaticInvoke`) |
 | `try_parse_json`              | 🔜     | tracking #4098                                                    |
 | `try_variant_get`             | 🔜     | tracking #4098                                                    |
 | `typeof`                      | ❓     |                                                                   |
@@ -679,7 +682,7 @@ fall back to Spark.
 
 ## xml_funcs
 
-🚫 **Out of scope.** `from_xml`, `to_xml`, `schema_of_xml`, and the `xpath*` family fall back to Spark. See [Scope policy](#scope-policy).
+🚫 **Out of scope.** `from_xml`, `to_xml`, `schema_of_xml`, and the `xpath*` family fall back to Spark. See [Out of scope](#out-of-scope).
 
 ---
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -107,15 +107,15 @@ The tables below list every Spark built-in expression with its current status.
 | `percentile_approx` | 🔜 | [#3189](https://github.com/apache/datafusion-comet/issues/3189) |
 | `percentile_cont` | ❓ | |
 | `percentile_disc` | ❓ | |
-| `regr_avgx` | 🔜 | Rewrites to `Average`; reuses existing aggregates (#4098) |
-| `regr_avgy` | 🔜 | Rewrites to `Average`; reuses existing aggregates (#4098) |
-| `regr_count` | 🔜 | Rewrites to `Count`; reuses existing aggregates (#4098) |
-| `regr_intercept` | 🔜 | Builds on `covar_pop`/`var_pop` accumulators (#4098) |
-| `regr_r2` | 🔜 | Builds on the `corr` accumulator (#4098) |
-| `regr_slope` | 🔜 | Builds on `covar_pop`/`var_pop` accumulators (#4098) |
-| `regr_sxx` | 🔜 | Builds on `var_pop` accumulator (#4098) |
-| `regr_sxy` | 🔜 | Builds on `covar_pop` accumulator (#4098) |
-| `regr_syy` | 🔜 | Builds on `var_pop` accumulator (#4098) |
+| `regr_avgx` | ✅ | Native: Spark rewrites to `Average` (tests in #4551) |
+| `regr_avgy` | ✅ | Native: Spark rewrites to `Average` (tests in #4551) |
+| `regr_count` | ✅ | Native: Spark rewrites to `Count` (tests in #4551) |
+| `regr_intercept` | 🔜 | Falls back; can reuse `covar_pop`/`var_pop` accumulators (#4552) |
+| `regr_r2` | 🔜 | Falls back; can reuse the `corr` accumulator (#4552) |
+| `regr_slope` | 🔜 | Falls back; can reuse `covar_pop`/`var_pop` accumulators (#4552) |
+| `regr_sxx` | 🔜 | Falls back; can reuse `var_pop` accumulator (#4552) |
+| `regr_sxy` | 🔜 | Falls back; can reuse `covar_pop` accumulator (#4552) |
+| `regr_syy` | 🔜 | Falls back; can reuse `var_pop` accumulator (#4552) |
 | `skewness` | 🔜 | tracking #4098 |
 | `some` | ✅ | |
 | `std` | ✅ | |

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -42,7 +42,6 @@ Most expressions can also be disabled with `spark.comet.expression.EXPRNAME.enab
 | ⚠️ Supported (caveats) | Works, but may diverge from Spark in some cases: incompatible, flag-gated (`allowIncompatible`), or restricted to certain types. See the [Compatibility Guide](compatibility/index.md). |
 | 🔜 Planned             | Intended; tracked by an open issue or pull request.                                                                                                                                     |
 | 🚫 Out of scope        | Deliberately not planned.                                                                                                                                                               |
-| ❓ Not yet supported   | Falls back to Spark today; support is to be determined (not yet evaluated).                                                                                                             |
 
 ## Out of scope
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -88,7 +88,7 @@ The tables below list every Spark built-in expression with its current status.
 
 ## agg_funcs
 
-> 🚫 Out of scope: probabilistic sketch aggregates (`kll_sketch_*`, `hll_sketch_agg`, `hll_union_agg`, `theta_*_agg`, `count_min_sketch`, `bitmap_*_agg`, `approx_top_k*`). See [Scope policy](#scope-policy).
+> 🚫 Out of scope: probabilistic sketch aggregates (`kll_sketch_*`, `hll_sketch_agg`, `hll_union_agg`, `theta_intersection_agg`, `theta_sketch_agg`, `theta_union_agg`, `count_min_sketch`, `approx_top_k`, `approx_top_k_accumulate`, `approx_top_k_combine`). See [Scope policy](#scope-policy).
 
 | Function | Status | Notes |
 | -------- | ------ | ----- |
@@ -514,6 +514,8 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 
 ## misc_funcs
 
+> 🚫 Out of scope: probabilistic sketch functions (`hll_sketch_estimate`, `hll_union`, `theta_difference`, `theta_intersection`, `theta_sketch_estimate`, `theta_union`, `bitmap_and_agg`, `bitmap_or_agg`, `bitmap_construct_agg`, `bitmap_count`, `bitmap_bucket_number`, `bitmap_bit_position`, `approx_top_k_estimate`). See [Scope policy](#scope-policy).
+
 > 🚫 Out of scope: geospatial functions (`st_asbinary`, `st_geogfromwkb`, `st_geomfromwkb`, `st_setsrid`, `st_srid`). See [Scope policy](#scope-policy).
 
 > 🚫 Out of scope: Avro/Protobuf codec functions (`from_avro`, `to_avro`, `schema_of_avro`, `from_protobuf`, `to_protobuf`). See [Scope policy](#scope-policy).
@@ -522,15 +524,12 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 
 | Function | Status | Notes |
 | -------- | ------ | ----- |
-| `approx_top_k_estimate` | 🚫 | Out of scope; see [Scope policy](#scope-policy) |
 | `assert_true` | ⬜ | |
 | `current_catalog` | ⬜ | |
 | `current_database` | ⬜ | |
 | `current_schema` | ⬜ | |
 | `current_user` | ⬜ | |
 | `equal_null` | ⬜ | |
-| `hll_sketch_estimate` | 🚫 | Out of scope; see [Scope policy](#scope-policy) |
-| `hll_union` | 🚫 | Out of scope; see [Scope policy](#scope-policy) |
 | `input_file_block_length` | ⬜ | |
 | `input_file_block_start` | ⬜ | |
 | `input_file_name` | ⬜ | |
@@ -544,10 +543,6 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `schema_of_variant_agg` | 🚧 | tracking #4098 |
 | `session_user` | ⬜ | |
 | `spark_partition_id` | ✅ | |
-| `theta_difference` | 🚫 | Out of scope; see [Scope policy](#scope-policy) |
-| `theta_intersection` | 🚫 | Out of scope; see [Scope policy](#scope-policy) |
-| `theta_sketch_estimate` | 🚫 | Out of scope; see [Scope policy](#scope-policy) |
-| `theta_union` | 🚫 | Out of scope; see [Scope policy](#scope-policy) |
 | `to_variant_object` | 🚧 | tracking #4098 |
 | `try_parse_json` | 🚧 | tracking #4098 |
 | `try_variant_get` | 🚧 | tracking #4098 |

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -214,25 +214,15 @@ The tables below list every Spark built-in expression with its current status.
 
 ## conversion_funcs
 
+The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `decimal`, `double`, `float`, `int`, `smallint`, `string`, `timestamp`, `tinyint`) are SQL aliases for `CAST(... AS <type>)` and share the support and caveats of `cast`.
+
 The type-alias keywords (`bigint`, `boolean`, `int`, etc.) are SQL syntax for `CAST`. `cast`
 itself is supported with caveats; the keyword aliases are not yet individually wired in Comet's
 serde but effectively fall through to the same cast path at runtime.
 
-| Function    | Status | Notes                                                                                                              |
-| ----------- | ------ | ------------------------------------------------------------------------------------------------------------------ |
-| `bigint`    | ⚠️     | Alias for `CAST(... AS BIGINT)`; see `cast`                                                                        |
-| `binary`    | ⚠️     | Alias for `CAST(... AS BINARY)`; see `cast`                                                                        |
-| `boolean`   | ⚠️     | Alias for `CAST(... AS BOOLEAN)`; see `cast`                                                                       |
-| `cast`      | ⚠️     | Many type pairs supported; float-to-decimal rounding may differ; see [Compatibility Guide](compatibility/index.md) |
-| `date`      | ⚠️     | Alias for `CAST(... AS DATE)`; see `cast`                                                                          |
-| `decimal`   | ⚠️     | Alias for `CAST(... AS DECIMAL)`; see `cast`                                                                       |
-| `double`    | ⚠️     | Alias for `CAST(... AS DOUBLE)`; see `cast`                                                                        |
-| `float`     | ⚠️     | Alias for `CAST(... AS FLOAT)`; see `cast`                                                                         |
-| `int`       | ⚠️     | Alias for `CAST(... AS INT)`; see `cast`                                                                           |
-| `smallint`  | ⚠️     | Alias for `CAST(... AS SMALLINT)`; see `cast`                                                                      |
-| `string`    | ⚠️     | Alias for `CAST(... AS STRING)`; see `cast`                                                                        |
-| `timestamp` | ⚠️     | Alias for `CAST(... AS TIMESTAMP)`; see `cast`                                                                     |
-| `tinyint`   | ⚠️     | Alias for `CAST(... AS TINYINT)`; see `cast`                                                                       |
+| Function | Status | Notes                                                                                                              |
+| -------- | ------ | ------------------------------------------------------------------------------------------------------------------ |
+| `cast`   | ⚠️     | Many type pairs supported; float-to-decimal rounding may differ; see [Compatibility Guide](compatibility/index.md) |
 
 ---
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -216,10 +216,6 @@ The tables below list every Spark built-in expression with its current status.
 
 The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `decimal`, `double`, `float`, `int`, `smallint`, `string`, `timestamp`, `tinyint`) are SQL aliases for `CAST(... AS <type>)` and share the support and caveats of `cast`.
 
-The type-alias keywords (`bigint`, `boolean`, `int`, etc.) are SQL syntax for `CAST`. `cast`
-itself is supported with caveats; the keyword aliases are not yet individually wired in Comet's
-serde but effectively fall through to the same cast path at runtime.
-
 | Function | Status | Notes                                                                                                              |
 | -------- | ------ | ------------------------------------------------------------------------------------------------------------------ |
 | `cast`   | ⚠️     | Many type pairs supported; float-to-decimal rounding may differ; see [Compatibility Guide](compatibility/index.md) |

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -24,10 +24,14 @@ expression. Comet accelerates expressions either with a native (Rust) implementa
 dispatching to a Spark-compatible codegen path. When an expression is not supported, Comet
 transparently falls back to Spark for that part of the plan; results are unaffected.
 
-All supported expressions are enabled by default. Most can be disabled with
-`spark.comet.expression.EXPRNAME.enabled=false`, where `EXPRNAME` is the Spark expression
-class name (for example `Length` or `StartsWith`). See the [Comet Configuration Guide](configs.md)
-for the full list.
+Expressions marked ✅ Supported are enabled by default. Expressions marked ⚠️ Supported
+(caveats) include cases that are known to diverge from Spark; those cases fall back to Spark
+by default and must be opted into, either globally with `spark.comet.expr.allowIncompatible=true`
+or per expression with `spark.comet.expression.EXPRNAME.allowIncompatible=true`.
+
+Most expressions can also be disabled with `spark.comet.expression.EXPRNAME.enabled=false`, where
+`EXPRNAME` is the Spark expression class name (for example `Length` or `StartsWith`). See the
+[Comet Configuration Guide](configs.md) for the full list.
 
 ## Status legend
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -495,38 +495,38 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 
 > 🚫 Out of scope: JVM reflection functions (`java_method`, `reflect`, `try_reflect`). See [Out of scope](#out-of-scope).
 
-| Function                      | Status | Notes                                                             |
-| ----------------------------- | ------ | ----------------------------------------------------------------- |
-| `aes_decrypt`                 | 🔜     | Codegen-dispatch candidate (RuntimeReplaceable to `StaticInvoke`) |
-| `aes_encrypt`                 | 🔜     | Codegen-dispatch candidate; nondeterministic IV by default        |
-| `assert_true`                 | ❓     |                                                                   |
-| `current_catalog`             | ❓     |                                                                   |
-| `current_database`            | ❓     |                                                                   |
-| `current_schema`              | ❓     |                                                                   |
-| `current_user`                | ❓     |                                                                   |
-| `equal_null`                  | ❓     |                                                                   |
-| `input_file_block_length`     | ❓     |                                                                   |
-| `input_file_block_start`      | ❓     |                                                                   |
-| `input_file_name`             | ❓     |                                                                   |
-| `is_variant_null`             | 🔜     | tracking #4098                                                    |
-| `monotonically_increasing_id` | ✅     |                                                                   |
-| `parse_json`                  | 🔜     | tracking #4098                                                    |
-| `raise_error`                 | ❓     |                                                                   |
-| `rand`                        | ✅     | Seed must be a literal                                            |
-| `randn`                       | ✅     | Seed must be a literal                                            |
-| `schema_of_variant`           | 🔜     | tracking #4098                                                    |
-| `schema_of_variant_agg`       | 🔜     | tracking #4098                                                    |
-| `session_user`                | ❓     |                                                                   |
-| `spark_partition_id`          | ✅     |                                                                   |
-| `to_variant_object`           | 🔜     | tracking #4098                                                    |
-| `try_aes_decrypt`             | 🔜     | Codegen-dispatch candidate (RuntimeReplaceable to `StaticInvoke`) |
-| `try_parse_json`              | 🔜     | tracking #4098                                                    |
-| `try_variant_get`             | 🔜     | tracking #4098                                                    |
-| `typeof`                      | ❓     |                                                                   |
-| `user`                        | ✅     | Resolved to a literal by the Spark analyzer before reaching Comet |
-| `uuid`                        | ❓     |                                                                   |
-| `variant_get`                 | 🔜     | tracking #4098                                                    |
-| `version`                     | ❓     |                                                                   |
+| Function                      | Status | Notes                                                                            |
+| ----------------------------- | ------ | -------------------------------------------------------------------------------- |
+| `aes_decrypt`                 | 🔜     | Falls back; `StaticInvoke` not allowlisted; planned via codegen dispatch (#4558) |
+| `aes_encrypt`                 | 🔜     | Falls back; planned via codegen dispatch (#4558); nondeterministic IV by default |
+| `assert_true`                 | ❓     |                                                                                  |
+| `current_catalog`             | ❓     |                                                                                  |
+| `current_database`            | ❓     |                                                                                  |
+| `current_schema`              | ❓     |                                                                                  |
+| `current_user`                | ❓     |                                                                                  |
+| `equal_null`                  | ❓     |                                                                                  |
+| `input_file_block_length`     | ❓     |                                                                                  |
+| `input_file_block_start`      | ❓     |                                                                                  |
+| `input_file_name`             | ❓     |                                                                                  |
+| `is_variant_null`             | 🔜     | tracking #4098                                                                   |
+| `monotonically_increasing_id` | ✅     |                                                                                  |
+| `parse_json`                  | 🔜     | tracking #4098                                                                   |
+| `raise_error`                 | ❓     |                                                                                  |
+| `rand`                        | ✅     | Seed must be a literal                                                           |
+| `randn`                       | ✅     | Seed must be a literal                                                           |
+| `schema_of_variant`           | 🔜     | tracking #4098                                                                   |
+| `schema_of_variant_agg`       | 🔜     | tracking #4098                                                                   |
+| `session_user`                | ❓     |                                                                                  |
+| `spark_partition_id`          | ✅     |                                                                                  |
+| `to_variant_object`           | 🔜     | tracking #4098                                                                   |
+| `try_aes_decrypt`             | 🔜     | Falls back; planned via codegen dispatch (#4558)                                 |
+| `try_parse_json`              | 🔜     | tracking #4098                                                                   |
+| `try_variant_get`             | 🔜     | tracking #4098                                                                   |
+| `typeof`                      | ❓     |                                                                                  |
+| `user`                        | ✅     | Resolved to a literal by the Spark analyzer before reaching Comet                |
+| `uuid`                        | ❓     |                                                                                  |
+| `variant_get`                 | 🔜     | tracking #4098                                                                   |
+| `version`                     | ❓     |                                                                                  |
 
 ---
 
@@ -560,80 +560,80 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 
 ## string_funcs
 
-| Function             | Status | Notes          |
-| -------------------- | ------ | -------------- |
-| `ascii`              | ✅     |                |
-| `base64`             | ❓     |                |
-| `bit_length`         | ✅     |                |
-| `btrim`              | ✅     |                |
-| `char`               | ✅     |                |
-| `char_length`        | ✅     |                |
-| `character_length`   | ✅     |                |
-| `chr`                | ✅     |                |
-| `collate`            | ❓     |                |
-| `collation`          | ❓     |                |
-| `concat_ws`          | ✅     |                |
-| `contains`           | ✅     |                |
-| `decode`             | ✅     |                |
-| `elt`                | 🔜     | #4538          |
-| `encode`             | ❓     |                |
-| `endswith`           | ✅     |                |
-| `find_in_set`        | 🔜     | #4538          |
-| `format_number`      | 🔜     | #4538          |
-| `format_string`      | 🔜     | #4538          |
-| `initcap`            | ✅     |                |
-| `instr`              | ✅     |                |
-| `is_valid_utf8`      | ❓     |                |
-| `lcase`              | ✅     |                |
-| `left`               | ✅     |                |
-| `len`                | ✅     |                |
-| `length`             | ✅     |                |
-| `levenshtein`        | 🔜     | #4538          |
-| `locate`             | 🔜     | #4538          |
-| `lower`              | ✅     |                |
-| `lpad`               | ✅     |                |
-| `ltrim`              | ✅     |                |
-| `luhn_check`         | ❓     |                |
-| `make_valid_utf8`    | ❓     |                |
-| `mask`               | ❓     |                |
-| `octet_length`       | ✅     |                |
-| `overlay`            | 🔜     | #4538          |
-| `position`           | 🔜     | #4538          |
-| `printf`             | 🔜     | #4538          |
-| `quote`              | ❓     |                |
-| `regexp_count`       | 🔜     | tracking #4098 |
-| `regexp_extract`     | 🔜     | tracking #4098 |
-| `regexp_extract_all` | 🔜     | tracking #4098 |
-| `regexp_instr`       | 🔜     | tracking #4098 |
-| `regexp_replace`     | ✅     |                |
-| `regexp_substr`      | 🔜     | tracking #4098 |
-| `repeat`             | ✅     |                |
-| `replace`            | ✅     |                |
-| `right`              | ✅     |                |
-| `rpad`               | ✅     |                |
-| `rtrim`              | ✅     |                |
-| `sentences`          | ❓     |                |
-| `soundex`            | 🔜     | #4538          |
-| `space`              | ✅     |                |
-| `split`              | ✅     |                |
-| `split_part`         | ❓     |                |
-| `startswith`         | ✅     |                |
-| `substr`             | ✅     |                |
-| `substring`          | ✅     |                |
-| `substring_index`    | ✅     |                |
-| `to_binary`          | ❓     |                |
-| `to_char`            | 🔜     | #4538          |
-| `to_number`          | 🔜     | #4538          |
-| `to_varchar`         | 🔜     | #4538          |
-| `translate`          | ✅     |                |
-| `trim`               | ✅     |                |
-| `try_to_binary`      | ❓     |                |
-| `try_to_number`      | ❓     |                |
-| `try_validate_utf8`  | ❓     |                |
-| `ucase`              | ✅     |                |
-| `unbase64`           | 🔜     | #4538          |
-| `upper`              | ✅     |                |
-| `validate_utf8`      | ❓     |                |
+| Function             | Status | Notes                                             |
+| -------------------- | ------ | ------------------------------------------------- |
+| `ascii`              | ✅     |                                                   |
+| `base64`             | ❓     |                                                   |
+| `bit_length`         | ✅     |                                                   |
+| `btrim`              | ✅     |                                                   |
+| `char`               | ✅     |                                                   |
+| `char_length`        | ✅     |                                                   |
+| `character_length`   | ✅     |                                                   |
+| `chr`                | ✅     |                                                   |
+| `collate`            | ❓     |                                                   |
+| `collation`          | ❓     |                                                   |
+| `concat_ws`          | ✅     |                                                   |
+| `contains`           | ✅     |                                                   |
+| `decode`             | ✅     |                                                   |
+| `elt`                | 🔜     | #4538                                             |
+| `encode`             | ❓     |                                                   |
+| `endswith`           | ✅     |                                                   |
+| `find_in_set`        | 🔜     | #4538                                             |
+| `format_number`      | 🔜     | #4538                                             |
+| `format_string`      | 🔜     | #4538                                             |
+| `initcap`            | ✅     |                                                   |
+| `instr`              | ✅     |                                                   |
+| `is_valid_utf8`      | ❓     |                                                   |
+| `lcase`              | ✅     |                                                   |
+| `left`               | ✅     |                                                   |
+| `len`                | ✅     |                                                   |
+| `length`             | ✅     |                                                   |
+| `levenshtein`        | 🔜     | #4538                                             |
+| `locate`             | 🔜     | #4538                                             |
+| `lower`              | ✅     |                                                   |
+| `lpad`               | ✅     |                                                   |
+| `ltrim`              | ✅     |                                                   |
+| `luhn_check`         | ✅     | Native via `StaticInvoke` (tests: luhn_check.sql) |
+| `make_valid_utf8`    | ❓     |                                                   |
+| `mask`               | ❓     |                                                   |
+| `octet_length`       | ✅     |                                                   |
+| `overlay`            | 🔜     | #4538                                             |
+| `position`           | 🔜     | #4538                                             |
+| `printf`             | 🔜     | #4538                                             |
+| `quote`              | ❓     |                                                   |
+| `regexp_count`       | 🔜     | tracking #4098                                    |
+| `regexp_extract`     | 🔜     | tracking #4098                                    |
+| `regexp_extract_all` | 🔜     | tracking #4098                                    |
+| `regexp_instr`       | 🔜     | tracking #4098                                    |
+| `regexp_replace`     | ✅     |                                                   |
+| `regexp_substr`      | 🔜     | tracking #4098                                    |
+| `repeat`             | ✅     |                                                   |
+| `replace`            | ✅     |                                                   |
+| `right`              | ✅     |                                                   |
+| `rpad`               | ✅     |                                                   |
+| `rtrim`              | ✅     |                                                   |
+| `sentences`          | ❓     |                                                   |
+| `soundex`            | 🔜     | #4538                                             |
+| `space`              | ✅     |                                                   |
+| `split`              | ✅     |                                                   |
+| `split_part`         | ❓     |                                                   |
+| `startswith`         | ✅     |                                                   |
+| `substr`             | ✅     |                                                   |
+| `substring`          | ✅     |                                                   |
+| `substring_index`    | ✅     |                                                   |
+| `to_binary`          | ❓     |                                                   |
+| `to_char`            | 🔜     | #4538                                             |
+| `to_number`          | 🔜     | #4538                                             |
+| `to_varchar`         | 🔜     | #4538                                             |
+| `translate`          | ✅     |                                                   |
+| `trim`               | ✅     |                                                   |
+| `try_to_binary`      | ❓     |                                                   |
+| `try_to_number`      | ❓     |                                                   |
+| `try_validate_utf8`  | ❓     |                                                   |
+| `ucase`              | ✅     |                                                   |
+| `unbase64`           | 🔜     | #4538                                             |
+| `upper`              | ✅     |                                                   |
+| `validate_utf8`      | ❓     |                                                   |
 
 ---
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -36,19 +36,17 @@ Most expressions can also be disabled with `spark.comet.expression.EXPRNAME.enab
 
 ## Status legend
 
-| Status                 | Meaning                                                                                                                                                                                 |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ✅ Supported           | Native or codegen path; compatible with Spark by default.                                                                                                                               |
-| ⚠️ Supported (caveats) | Works, but may diverge from Spark in some cases: incompatible, flag-gated (`allowIncompatible`), or restricted to certain types. See the [Compatibility Guide](compatibility/index.md). |
-| 🔜 Planned             | Intended; tracked by an open issue or pull request.                                                                                                                                     |
-| 🚫 Out of scope        | Deliberately not planned.                                                                                                                                                               |
+| Status                   | Meaning                                                                                                                                                                                 |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ✅ Supported             | Native or codegen path; compatible with Spark by default.                                                                                                                               |
+| ⚠️ Supported (caveats)   | Works, but may diverge from Spark in some cases: incompatible, flag-gated (`allowIncompatible`), or restricted to certain types. See the [Compatibility Guide](compatibility/index.md). |
+| 🔜 Planned               | Intended; tracked by an open issue or pull request.                                                                                                                                     |
+| 💤 Not currently planned | Not on the current roadmap; falls back to Spark and may be reconsidered later.                                                                                                          |
 
-## Out of scope
+## Not currently planned
 
 Comet focuses acceleration on mainstream relational, string, datetime, math, and collection
-expressions. Some Spark function families are **out of scope**: specialized functionality with
-narrow real-world analytics use and high implementation cost. These will fall back to Spark and
-are not on the roadmap:
+expressions. The following function families are **not currently planned** for native acceleration (they are not on the 1.0 roadmap): specialized functionality with narrow real-world analytics use and high implementation cost. They fall back to Spark and may be reconsidered based on demand:
 
 - **Probabilistic sketches and approximate top-k** (`kll_sketch_*`, `hll_*`, `theta_*`, `count_min_sketch`, `bitmap_*`, `approx_top_k*`): specialized data structures with exact-correctness traps.
 - **XML / XPath** (`from_xml`, `to_xml`, `schema_of_xml`, `xpath*`): legacy text format, rare in accelerated workloads.
@@ -58,10 +56,9 @@ are not on the roadmap:
 - **CSV functions** (`from_csv`, `to_csv`, `schema_of_csv`): row-level CSV parsing and formatting in expressions is niche and better handled at the data source layer.
 - **UTF-8 validation** (`is_valid_utf8`, `make_valid_utf8`, `validate_utf8`, `try_validate_utf8`): niche Spark 4.x string-validation helpers.
 - **File metadata** (`input_file_name`, `input_file_block_start`, `input_file_block_length`): require scan-internal per-row file information, outside the expression layer.
-- **Miscellaneous niche** (`histogram_numeric`, `version`, `sentences`, `quote`, `uuid`): low-value or specialized functions with little benefit from native acceleration.
+- **Miscellaneous niche** (`histogram_numeric`, `version`, `sentences`, `quote`): low-value or specialized functions with little benefit from native acceleration.
 
-Note that `approx_count_distinct`, `approx_percentile` / `percentile_approx`, `median`, and `mode`
-are _not_ out of scope: although approximate, they are mainstream and are planned.
+Note that `approx_count_distinct`, `median`, and `mode` are planned: they are mainstream (`median` and `mode` are exact aggregates). `approx_percentile` / `percentile_approx` are not currently planned because their approximate results cannot be made bit-identical to Spark.
 
 The tables below list every Spark built-in expression with its current status.
 
@@ -72,7 +69,6 @@ The tables below list every Spark built-in expression with its current status.
 | `any`                   | ✅     |                                                                  |
 | `any_value`             | ✅     |                                                                  |
 | `approx_count_distinct` | 🔜     | tracking #4098                                                   |
-| `approx_percentile`     | 🔜     | [#3189](https://github.com/apache/datafusion-comet/issues/3189)  |
 | `array_agg`             | 🔜     | Array aggregate (related to `collect_list`, #2524)               |
 | `avg`                   | ⚠️     | Interval types (YearMonth, DayTime) fall back                    |
 | `bit_and`               | ✅     |                                                                  |
@@ -104,7 +100,6 @@ The tables below list every Spark built-in expression with its current status.
 | `min_by`                | 🔜     | [#3841](https://github.com/apache/datafusion-comet/issues/3841)  |
 | `mode`                  | 🔜     | [#3970](https://github.com/apache/datafusion-comet/issues/3970)  |
 | `percentile`            | 🔜     | #4542                                                            |
-| `percentile_approx`     | 🔜     | [#3189](https://github.com/apache/datafusion-comet/issues/3189)  |
 | `percentile_cont`       | 🔜     | Percentile aggregate                                             |
 | `percentile_disc`       | 🔜     | Percentile aggregate                                             |
 | `regr_avgx`             | ✅     | Native: Spark rewrites to `Average` (tests in #4551)             |
@@ -492,6 +487,7 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `try_variant_get`             | 🔜     | tracking #4098                                                                   |
 | `typeof`                      | ✅     | Foldable; resolved to a literal before Comet sees the plan                       |
 | `user`                        | ✅     | Resolved to a literal by the Spark analyzer before reaching Comet                |
+| `uuid`                        | 🔜     | Nondeterministic random UUID                                                     |
 | `variant_get`                 | 🔜     | tracking #4098                                                                   |
 
 ---
@@ -639,16 +635,6 @@ fall back to Spark.
 | `row_number`   | 🔜     | Window function; tracked by #2721 |
 
 ---
-
-## Out-of-scope function list
-
-The following functions are out of scope and fall back to Spark. See [Out of scope](#out-of-scope) above for the rationale.
-
-- **agg_funcs:** `approx_top_k`, `approx_top_k_accumulate`, `approx_top_k_combine`, `count_min_sketch`, `histogram_numeric`, `hll_sketch_agg`, `hll_union_agg`, `kll_sketch_agg_bigint`, `kll_sketch_agg_double`, `kll_sketch_agg_float`, `kll_sketch_get_n_bigint`, `kll_sketch_get_n_double`, `kll_sketch_get_n_float`, `kll_sketch_get_quantile_bigint`, `kll_sketch_get_quantile_double`, `kll_sketch_get_quantile_float`, `kll_sketch_get_rank_bigint`, `kll_sketch_get_rank_double`, `kll_sketch_get_rank_float`, `kll_sketch_merge_bigint`, `kll_sketch_merge_double`, `kll_sketch_merge_float`, `kll_sketch_to_string_bigint`, `kll_sketch_to_string_double`, `kll_sketch_to_string_float`, `theta_intersection_agg`, `theta_sketch_agg`, `theta_union_agg`
-- **csv_funcs:** `from_csv`, `schema_of_csv`, `to_csv`
-- **misc_funcs:** `approx_top_k_estimate`, `bitmap_and_agg`, `bitmap_bit_position`, `bitmap_bucket_number`, `bitmap_construct_agg`, `bitmap_count`, `bitmap_or_agg`, `from_avro`, `from_protobuf`, `hll_sketch_estimate`, `hll_union`, `input_file_block_length`, `input_file_block_start`, `input_file_name`, `java_method`, `reflect`, `schema_of_avro`, `st_asbinary`, `st_geogfromwkb`, `st_geomfromwkb`, `st_setsrid`, `st_srid`, `theta_difference`, `theta_intersection`, `theta_sketch_estimate`, `theta_union`, `to_avro`, `to_protobuf`, `try_reflect`, `uuid`, `version`
-- **string_funcs:** `is_valid_utf8`, `make_valid_utf8`, `quote`, `sentences`, `try_validate_utf8`, `validate_utf8`
-- **xml_funcs:** `from_xml`, `schema_of_xml`, `to_xml`, `xpath`, `xpath_boolean`, `xpath_double`, `xpath_float`, `xpath_int`, `xpath_long`, `xpath_number`, `xpath_short`, `xpath_string`
 
 ## Beyond SQL functions
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -56,6 +56,7 @@ are not on the roadmap:
 - **Avro / Protobuf codecs** (`from_avro`, `to_avro`, `from_protobuf`, `to_protobuf`, `schema_of_avro`): format conversion belongs at the IO layer, not expression evaluation.
 - **JVM reflection** (`java_method`, `reflect`): cannot run in native code.
 - **Cryptographic functions** (`aes_encrypt`, `aes_decrypt`): niche, with correctness and security risk for marginal benefit.
+- **CSV functions** (`from_csv`, `to_csv`, `schema_of_csv`): row-level CSV parsing and formatting in expressions is niche and better handled at the data source layer.
 
 Note that `approx_count_distinct`, `approx_percentile` / `percentile_approx`, `median`, and `mode`
 are *not* out of scope: although approximate, they are mainstream and are planned.
@@ -238,11 +239,7 @@ serde but effectively fall through to the same cast path at runtime.
 
 ## csv_funcs
 
-| Function | Status | Notes |
-| -------- | ------ | ----- |
-| `from_csv` | ❓ | |
-| `schema_of_csv` | ❓ | |
-| `to_csv` | ❓ | |
+🚫 **Out of scope.** `from_csv`, `to_csv`, and `schema_of_csv` fall back to Spark. See [Scope policy](#scope-policy).
 
 ---
 
@@ -254,7 +251,7 @@ serde but effectively fall through to the same cast path at runtime.
 | `convert_timezone` | ✅ | |
 | `curdate` | ✅ | Constant-folded to a literal (alias of `current_date`) |
 | `current_date` | ✅ | Constant-folded to a literal before Comet sees the plan |
-| `current_time` | ❓ | |
+| `current_time` | ❓ | Constant-folded to a literal, but of the Spark 4.1 `TIME` type, which Comet does not support, so it falls back |
 | `current_timestamp` | ✅ | Constant-folded to a literal before Comet sees the plan |
 | `current_timezone` | ✅ | |
 | `date_add` | ✅ | |

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -245,81 +245,81 @@ serde but effectively fall through to the same cast path at runtime.
 
 ## datetime_funcs
 
-| Function              | Status | Notes                                                                                                          |
-| --------------------- | ------ | -------------------------------------------------------------------------------------------------------------- |
-| `add_months`          | ✅     |                                                                                                                |
-| `convert_timezone`    | ✅     |                                                                                                                |
-| `curdate`             | ✅     | Constant-folded to a literal (alias of `current_date`)                                                         |
-| `current_date`        | ✅     | Constant-folded to a literal before Comet sees the plan                                                        |
-| `current_time`        | ❓     | Constant-folded to a literal, but of the Spark 4.1 `TIME` type, which Comet does not support, so it falls back |
-| `current_timestamp`   | ✅     | Constant-folded to a literal before Comet sees the plan                                                        |
-| `current_timezone`    | ✅     |                                                                                                                |
-| `date_add`            | ✅     |                                                                                                                |
-| `date_diff`           | ✅     |                                                                                                                |
-| `date_format`         | ✅     |                                                                                                                |
-| `date_from_unix_date` | ✅     |                                                                                                                |
-| `date_part`           | ✅     |                                                                                                                |
-| `date_sub`            | ✅     |                                                                                                                |
-| `date_trunc`          | ✅     |                                                                                                                |
-| `dateadd`             | ✅     |                                                                                                                |
-| `datediff`            | ✅     |                                                                                                                |
-| `datepart`            | ✅     |                                                                                                                |
-| `day`                 | ✅     |                                                                                                                |
-| `dayname`             | 🔜     | #4544                                                                                                          |
-| `dayofmonth`          | ✅     |                                                                                                                |
-| `dayofweek`           | ✅     |                                                                                                                |
-| `dayofyear`           | ✅     |                                                                                                                |
-| `extract`             | ✅     |                                                                                                                |
-| `from_unixtime`       | ✅     |                                                                                                                |
-| `from_utc_timestamp`  | ⚠️     | Legacy zone forms (`GMT+1`, `PST`) throw a native parse error                                                  |
-| `hour`                | ✅     |                                                                                                                |
-| `last_day`            | ✅     |                                                                                                                |
-| `localtimestamp`      | ✅     |                                                                                                                |
-| `make_date`           | ✅     |                                                                                                                |
-| `make_dt_interval`    | 🔜     | #4541                                                                                                          |
-| `make_interval`       | ❓     |                                                                                                                |
-| `make_time`           | ❓     |                                                                                                                |
-| `make_timestamp`      | ✅     |                                                                                                                |
-| `make_timestamp_ltz`  | ⚠️     | 6-arg form runs via the codegen dispatcher; 2-arg `(date, time)` form (Spark 4.1 TIME type) falls back         |
-| `make_timestamp_ntz`  | ⚠️     | 6-arg form runs via the codegen dispatcher; 2-arg `(date, time)` form (Spark 4.1 TIME type) falls back         |
-| `make_ym_interval`    | 🔜     | #4541                                                                                                          |
-| `minute`              | ✅     |                                                                                                                |
-| `month`               | ✅     |                                                                                                                |
-| `monthname`           | 🔜     | #4544                                                                                                          |
-| `months_between`      | ✅     |                                                                                                                |
-| `next_day`            | ✅     |                                                                                                                |
-| `now`                 | ✅     | Constant-folded to a literal (alias of `current_timestamp`)                                                    |
-| `quarter`             | ✅     |                                                                                                                |
-| `second`              | ✅     |                                                                                                                |
-| `session_window`      | ❓     |                                                                                                                |
-| `time_diff`           | ❓     |                                                                                                                |
-| `time_trunc`          | ❓     |                                                                                                                |
-| `timestamp_micros`    | ✅     |                                                                                                                |
-| `timestamp_millis`    | ✅     |                                                                                                                |
-| `timestamp_seconds`   | ✅     |                                                                                                                |
-| `to_date`             | ✅     | Rewrites to `Cast` (or `Cast(GetTimestamp)` with a format) before Comet sees the plan                          |
-| `to_time`             | ❓     |                                                                                                                |
-| `to_timestamp`        | ✅     | Rewrites to `Cast` (or `GetTimestamp` with a format) before Comet sees the plan                                |
-| `to_timestamp_ltz`    | ✅     | Rewrites to `to_timestamp` (`TimestampType`)                                                                   |
-| `to_timestamp_ntz`    | ✅     | Rewrites to `to_timestamp` (`TimestampNTZType`)                                                                |
-| `to_unix_timestamp`   | ✅     |                                                                                                                |
-| `to_utc_timestamp`    | ⚠️     | Legacy zone forms (`GMT+1`, `PST`) throw a native parse error                                                  |
-| `trunc`               | ✅     |                                                                                                                |
-| `try_make_interval`   | ❓     |                                                                                                                |
-| `try_make_timestamp`  | ❓     |                                                                                                                |
-| `try_to_date`         | ❓     |                                                                                                                |
-| `try_to_time`         | ❓     |                                                                                                                |
-| `try_to_timestamp`    | ❓     |                                                                                                                |
-| `unix_date`           | ✅     |                                                                                                                |
-| `unix_micros`         | ✅     |                                                                                                                |
-| `unix_millis`         | ✅     |                                                                                                                |
-| `unix_seconds`        | ✅     |                                                                                                                |
-| `unix_timestamp`      | ✅     |                                                                                                                |
-| `weekday`             | ✅     |                                                                                                                |
-| `weekofyear`          | ✅     |                                                                                                                |
-| `window`              | ❓     |                                                                                                                |
-| `window_time`         | ❓     |                                                                                                                |
-| `year`                | ✅     |                                                                                                                |
+| Function              | Status | Notes                                                                                                  |
+| --------------------- | ------ | ------------------------------------------------------------------------------------------------------ |
+| `add_months`          | ✅     |                                                                                                        |
+| `convert_timezone`    | ✅     |                                                                                                        |
+| `curdate`             | ✅     | Constant-folded to a literal (alias of `current_date`)                                                 |
+| `current_date`        | ✅     | Constant-folded to a literal before Comet sees the plan                                                |
+| `current_time`        | 🔜     | Blocked on Spark 4.1 TIME type support (#4288)                                                         |
+| `current_timestamp`   | ✅     | Constant-folded to a literal before Comet sees the plan                                                |
+| `current_timezone`    | ✅     |                                                                                                        |
+| `date_add`            | ✅     |                                                                                                        |
+| `date_diff`           | ✅     |                                                                                                        |
+| `date_format`         | ✅     |                                                                                                        |
+| `date_from_unix_date` | ✅     |                                                                                                        |
+| `date_part`           | ✅     |                                                                                                        |
+| `date_sub`            | ✅     |                                                                                                        |
+| `date_trunc`          | ✅     |                                                                                                        |
+| `dateadd`             | ✅     |                                                                                                        |
+| `datediff`            | ✅     |                                                                                                        |
+| `datepart`            | ✅     |                                                                                                        |
+| `day`                 | ✅     |                                                                                                        |
+| `dayname`             | 🔜     | #4544                                                                                                  |
+| `dayofmonth`          | ✅     |                                                                                                        |
+| `dayofweek`           | ✅     |                                                                                                        |
+| `dayofyear`           | ✅     |                                                                                                        |
+| `extract`             | ✅     |                                                                                                        |
+| `from_unixtime`       | ✅     |                                                                                                        |
+| `from_utc_timestamp`  | ⚠️     | Legacy zone forms (`GMT+1`, `PST`) throw a native parse error                                          |
+| `hour`                | ✅     |                                                                                                        |
+| `last_day`            | ✅     |                                                                                                        |
+| `localtimestamp`      | ✅     |                                                                                                        |
+| `make_date`           | ✅     |                                                                                                        |
+| `make_dt_interval`    | 🔜     | #4541                                                                                                  |
+| `make_interval`       | 🔜     | Produces legacy CalendarInterval; tracked by #4540                                                     |
+| `make_time`           | 🔜     | Spark 4.1 TIME type; tracked by #4288                                                                  |
+| `make_timestamp`      | ✅     |                                                                                                        |
+| `make_timestamp_ltz`  | ⚠️     | 6-arg form runs via the codegen dispatcher; 2-arg `(date, time)` form (Spark 4.1 TIME type) falls back |
+| `make_timestamp_ntz`  | ⚠️     | 6-arg form runs via the codegen dispatcher; 2-arg `(date, time)` form (Spark 4.1 TIME type) falls back |
+| `make_ym_interval`    | 🔜     | #4541                                                                                                  |
+| `minute`              | ✅     |                                                                                                        |
+| `month`               | ✅     |                                                                                                        |
+| `monthname`           | 🔜     | #4544                                                                                                  |
+| `months_between`      | ✅     |                                                                                                        |
+| `next_day`            | ✅     |                                                                                                        |
+| `now`                 | ✅     | Constant-folded to a literal (alias of `current_timestamp`)                                            |
+| `quarter`             | ✅     |                                                                                                        |
+| `second`              | ✅     |                                                                                                        |
+| `session_window`      | 🔜     | Time-window grouping; tracked by #4553                                                                 |
+| `time_diff`           | 🔜     | Spark 4.1 TIME type; tracked by #4288                                                                  |
+| `time_trunc`          | 🔜     | Spark 4.1 TIME type; tracked by #4288                                                                  |
+| `timestamp_micros`    | ✅     |                                                                                                        |
+| `timestamp_millis`    | ✅     |                                                                                                        |
+| `timestamp_seconds`   | ✅     |                                                                                                        |
+| `to_date`             | ✅     | Rewrites to `Cast` (or `Cast(GetTimestamp)` with a format) before Comet sees the plan                  |
+| `to_time`             | 🔜     | Spark 4.1 TIME type; tracked by #4288                                                                  |
+| `to_timestamp`        | ✅     | Rewrites to `Cast` (or `GetTimestamp` with a format) before Comet sees the plan                        |
+| `to_timestamp_ltz`    | ✅     | Rewrites to `to_timestamp` (`TimestampType`)                                                           |
+| `to_timestamp_ntz`    | ✅     | Rewrites to `to_timestamp` (`TimestampNTZType`)                                                        |
+| `to_unix_timestamp`   | ✅     |                                                                                                        |
+| `to_utc_timestamp`    | ⚠️     | Legacy zone forms (`GMT+1`, `PST`) throw a native parse error                                          |
+| `trunc`               | ✅     |                                                                                                        |
+| `try_make_interval`   | 🔜     | Produces legacy CalendarInterval; tracked by #4540                                                     |
+| `try_make_timestamp`  | 🔜     | Rewrites to `make_timestamp`; likely accelerated, pending test                                         |
+| `try_to_date`         | 🔜     | Rewrites to `Cast`/`GetTimestamp`; likely accelerated, pending test                                    |
+| `try_to_time`         | 🔜     | Spark 4.1 TIME type; tracked by #4288                                                                  |
+| `try_to_timestamp`    | 🔜     | Rewrites to `Cast`/`GetTimestamp`; likely accelerated, pending test                                    |
+| `unix_date`           | ✅     |                                                                                                        |
+| `unix_micros`         | ✅     |                                                                                                        |
+| `unix_millis`         | ✅     |                                                                                                        |
+| `unix_seconds`        | ✅     |                                                                                                        |
+| `unix_timestamp`      | ✅     |                                                                                                        |
+| `weekday`             | ✅     |                                                                                                        |
+| `weekofyear`          | ✅     |                                                                                                        |
+| `window`              | 🔜     | Time-window grouping; tracked by #4553                                                                 |
+| `window_time`         | 🔜     | Time-window grouping; tracked by #4553                                                                 |
+| `year`                | ✅     |                                                                                                        |
 
 ---
 
@@ -682,6 +682,18 @@ fall back to Spark.
 🚫 **Out of scope.** `from_xml`, `to_xml`, `schema_of_xml`, and the `xpath*` family fall back to Spark. See [Scope policy](#scope-policy).
 
 ---
+
+## Beyond SQL functions
+
+Comet also accelerates a number of Catalyst expressions that have no Spark SQL function name and therefore do not appear in the tables above. These arise from the DataFrame API, from SQL syntax other than function calls, or from the query optimizer. They include:
+
+- **Operator and optimizer-injected expressions:** runtime bloom-filter join probes (`BloomFilterMightContain`, `BloomFilterAggregate`), optimized `IN` sets (`InSet`), scalar subqueries (`ScalarSubquery`), and floating-point normalization (`KnownFloatingPointNormalized`).
+- **Accessor expressions (subscript and field access, not functions):** struct field access (`col.field`), array element access (`arr[i]`), and map value access (`map[key]`).
+- **Internal decimal arithmetic:** `CheckOverflow`, `MakeDecimal`, and `UnscaledValue`, which the analyzer inserts around decimal operations.
+- **User-defined functions:** Scala UDFs registered through the DataFrame or SQL API.
+- **Structural expressions:** aliases, attribute references, literals, sort orders, and `CASE WHEN`.
+
+This list is illustrative, not exhaustive: the per-function tables are not the complete set of expressions Comet can accelerate.
 
 ## See also
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -77,8 +77,8 @@ The tables below list every Spark built-in expression with its current status.
 | collection_funcs | 3 / 5 | |
 | json_funcs | 1 / 7 | Core supported; remainder planned |
 | agg_funcs | 31 / 88 | Sketch aggregates out of scope |
-| generator_funcs | 0 / 7 | explode/posexplode via operator |
-| window_funcs | 0 / 9 | Run via CometWindowExec (operator) |
+| generator_funcs | 4 / 7 | explode/posexplode via operator |
+| window_funcs | 2 / 9 | Run via CometWindowExec (operator) |
 | lambda_funcs | 0 / 12 | Higher-order functions planned |
 | misc_funcs | 5 / 56 | Many niche/environment functions |
 | csv_funcs | 0 / 3 | Not yet evaluated |
@@ -127,7 +127,7 @@ The tables below list every Spark built-in expression with its current status.
 | `min` | ✅ | |
 | `min_by` | 🚧 | [#3841](https://github.com/apache/datafusion-comet/issues/3841) |
 | `mode` | 🚧 | [#3970](https://github.com/apache/datafusion-comet/issues/3970) |
-| `percentile` | ⬜ | |
+| `percentile` | 🚧 | #4542 |
 | `percentile_approx` | 🚧 | [#3189](https://github.com/apache/datafusion-comet/issues/3189) |
 | `percentile_cont` | ⬜ | |
 | `percentile_disc` | ⬜ | |
@@ -181,7 +181,7 @@ The tables below list every Spark built-in expression with its current status.
 | `element_at` | ⚠️ | Only `ArrayType` input; `MapType` input falls back |
 | `flatten` | ⚠️ | Falls back for binary/struct/map child element types |
 | `get` | ✅ | |
-| `sequence` | ⬜ | |
+| `sequence` | 🚧 | #4538 |
 | `shuffle` | ⬜ | |
 | `slice` | ⬜ | |
 | `sort_array` | ⚠️ | Incompatible under strict floating-point; falls back for nested struct/null arrays |
@@ -226,7 +226,7 @@ The tables below list every Spark built-in expression with its current status.
 | `coalesce` | ✅ | |
 | `if` | ✅ | |
 | `ifnull` | ✅ | |
-| `nanvl` | ⬜ | |
+| `nanvl` | 🚧 | #4538 |
 | `nullif` | ✅ | |
 | `nullifzero` | ⬜ | |
 | `nvl` | ✅ | |
@@ -292,7 +292,7 @@ serde but effectively fall through to the same cast path at runtime.
 | `datediff` | ✅ | |
 | `datepart` | ✅ | |
 | `day` | ✅ | |
-| `dayname` | ⬜ | |
+| `dayname` | 🚧 | #4544 |
 | `dayofmonth` | ✅ | |
 | `dayofweek` | ✅ | |
 | `dayofyear` | ✅ | |
@@ -303,16 +303,16 @@ serde but effectively fall through to the same cast path at runtime.
 | `last_day` | ✅ | |
 | `localtimestamp` | ✅ | |
 | `make_date` | ✅ | |
-| `make_dt_interval` | ⬜ | |
+| `make_dt_interval` | 🚧 | #4541 |
 | `make_interval` | ⬜ | |
 | `make_time` | ⬜ | |
 | `make_timestamp` | ✅ | |
 | `make_timestamp_ltz` | ⬜ | |
 | `make_timestamp_ntz` | ⬜ | |
-| `make_ym_interval` | ⬜ | |
+| `make_ym_interval` | 🚧 | #4541 |
 | `minute` | ✅ | |
 | `month` | ✅ | |
-| `monthname` | ⬜ | |
+| `monthname` | 🚧 | #4544 |
 | `months_between` | ✅ | |
 | `next_day` | ✅ | |
 | `now` | ⬜ | |
@@ -453,11 +453,11 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `atan2` | ✅ | |
 | `atanh` | ✅ | |
 | `bin` | ✅ | |
-| `bround` | ⬜ | |
+| `bround` | 🚧 | #4538 |
 | `cbrt` | ✅ | |
 | `ceil` | ⚠️ | Two-arg `ceil(expr, scale)` form falls back |
 | `ceiling` | ✅ | |
-| `conv` | ⬜ | |
+| `conv` | 🚧 | #4538 |
 | `cos` | ✅ | |
 | `cosh` | ✅ | |
 | `cot` | ✅ | |
@@ -471,17 +471,17 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `floor` | ⚠️ | Two-arg `floor(expr, scale)` form falls back |
 | `greatest` | ✅ | |
 | `hex` | ✅ | |
-| `hypot` | ⬜ | |
+| `hypot` | 🚧 | #4538 |
 | `least` | ✅ | |
 | `ln` | ✅ | |
 | `log` | ✅ | |
 | `log10` | ✅ | |
-| `log1p` | ⬜ | |
+| `log1p` | 🚧 | #4538 |
 | `log2` | ✅ | |
 | `mod` | ✅ | |
 | `negative` | ✅ | |
 | `pi` | ✅ | |
-| `pmod` | ⬜ | |
+| `pmod` | 🚧 | #4538 |
 | `positive` | ✅ | |
 | `pow` | ✅ | |
 | `power` | ✅ | |
@@ -599,12 +599,12 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `concat_ws` | ✅ | |
 | `contains` | ✅ | |
 | `decode` | ✅ | |
-| `elt` | ⬜ | |
+| `elt` | 🚧 | #4538 |
 | `encode` | ⬜ | |
 | `endswith` | ✅ | |
-| `find_in_set` | ⬜ | |
-| `format_number` | ⬜ | |
-| `format_string` | ⬜ | |
+| `find_in_set` | 🚧 | #4538 |
+| `format_number` | 🚧 | #4538 |
+| `format_string` | 🚧 | #4538 |
 | `initcap` | ✅ | |
 | `instr` | ✅ | |
 | `is_valid_utf8` | ⬜ | |
@@ -612,8 +612,8 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `left` | ✅ | |
 | `len` | ✅ | |
 | `length` | ✅ | |
-| `levenshtein` | ⬜ | |
-| `locate` | ⬜ | |
+| `levenshtein` | 🚧 | #4538 |
+| `locate` | 🚧 | #4538 |
 | `lower` | ✅ | |
 | `lpad` | ✅ | |
 | `ltrim` | ✅ | |
@@ -621,9 +621,9 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `make_valid_utf8` | ⬜ | |
 | `mask` | ⬜ | |
 | `octet_length` | ✅ | |
-| `overlay` | ⬜ | |
-| `position` | ⬜ | |
-| `printf` | ⬜ | |
+| `overlay` | 🚧 | #4538 |
+| `position` | 🚧 | #4538 |
+| `printf` | 🚧 | #4538 |
 | `quote` | ⬜ | |
 | `regexp_count` | 🚧 | tracking #4098 |
 | `regexp_extract` | 🚧 | tracking #4098 |
@@ -637,7 +637,7 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `rpad` | ✅ | |
 | `rtrim` | ✅ | |
 | `sentences` | ⬜ | |
-| `soundex` | ⬜ | |
+| `soundex` | 🚧 | #4538 |
 | `space` | ✅ | |
 | `split` | ✅ | |
 | `split_part` | ⬜ | |
@@ -646,16 +646,16 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `substring` | ✅ | |
 | `substring_index` | ✅ | |
 | `to_binary` | ⬜ | |
-| `to_char` | ⬜ | |
-| `to_number` | ⬜ | |
-| `to_varchar` | ⬜ | |
+| `to_char` | 🚧 | #4538 |
+| `to_number` | 🚧 | #4538 |
+| `to_varchar` | 🚧 | #4538 |
 | `translate` | ✅ | |
 | `trim` | ✅ | |
 | `try_to_binary` | ⬜ | |
 | `try_to_number` | ⬜ | |
 | `try_validate_utf8` | ⬜ | |
 | `ucase` | ✅ | |
-| `unbase64` | ⬜ | |
+| `unbase64` | 🚧 | #4538 |
 | `upper` | ✅ | |
 | `validate_utf8` | ⬜ | |
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -67,71 +67,68 @@ The tables below list every Spark built-in expression with its current status.
 
 ## agg_funcs
 
-> 🚫 Out of scope: probabilistic sketch aggregates (`kll_sketch_*`, `hll_sketch_agg`, `hll_union_agg`, `theta_intersection_agg`, `theta_sketch_agg`, `theta_union_agg`, `count_min_sketch`, `approx_top_k`, `approx_top_k_accumulate`, `approx_top_k_combine`). See [Out of scope](#out-of-scope).
-
-| Function                | Status | Notes                                                                  |
-| ----------------------- | ------ | ---------------------------------------------------------------------- |
-| `any`                   | ✅     |                                                                        |
-| `any_value`             | ✅     |                                                                        |
-| `approx_count_distinct` | 🔜     | tracking #4098                                                         |
-| `approx_percentile`     | 🔜     | [#3189](https://github.com/apache/datafusion-comet/issues/3189)        |
-| `array_agg`             | 🔜     | Array aggregate (related to `collect_list`, #2524)                     |
-| `avg`                   | ⚠️     | Interval types (YearMonth, DayTime) fall back                          |
-| `bit_and`               | ✅     |                                                                        |
-| `bit_or`                | ✅     |                                                                        |
-| `bit_xor`               | ✅     |                                                                        |
-| `bool_and`              | ✅     |                                                                        |
-| `bool_or`               | ✅     |                                                                        |
-| `collect_list`          | 🔜     | [#2524](https://github.com/apache/datafusion-comet/issues/2524)        |
-| `collect_set`           | ✅     |                                                                        |
-| `corr`                  | ✅     |                                                                        |
-| `count`                 | ✅     |                                                                        |
-| `count_if`              | ✅     |                                                                        |
-| `covar_pop`             | ✅     |                                                                        |
-| `covar_samp`            | ✅     |                                                                        |
-| `every`                 | ✅     |                                                                        |
-| `first`                 | ✅     |                                                                        |
-| `first_value`           | ✅     |                                                                        |
-| `grouping`              | 🔜     | Grouping indicator for ROLLUP/CUBE/GROUPING SETS                       |
-| `grouping_id`           | 🔜     | Grouping indicator for ROLLUP/CUBE/GROUPING SETS                       |
-| `histogram_numeric`     | 🚫     | Approximate histogram aggregate (out of scope, like sketch aggregates) |
-| `kurtosis`              | 🔜     | tracking #4098                                                         |
-| `last`                  | ✅     |                                                                        |
-| `last_value`            | ✅     |                                                                        |
-| `listagg`               | 🔜     | String aggregation                                                     |
-| `max`                   | ✅     |                                                                        |
-| `max_by`                | 🔜     | [#3841](https://github.com/apache/datafusion-comet/issues/3841)        |
-| `mean`                  | ✅     |                                                                        |
-| `median`                | 🔜     | tracking #4098                                                         |
-| `min`                   | ✅     |                                                                        |
-| `min_by`                | 🔜     | [#3841](https://github.com/apache/datafusion-comet/issues/3841)        |
-| `mode`                  | 🔜     | [#3970](https://github.com/apache/datafusion-comet/issues/3970)        |
-| `percentile`            | 🔜     | #4542                                                                  |
-| `percentile_approx`     | 🔜     | [#3189](https://github.com/apache/datafusion-comet/issues/3189)        |
-| `percentile_cont`       | 🔜     | Percentile aggregate                                                   |
-| `percentile_disc`       | 🔜     | Percentile aggregate                                                   |
-| `regr_avgx`             | ✅     | Native: Spark rewrites to `Average` (tests in #4551)                   |
-| `regr_avgy`             | ✅     | Native: Spark rewrites to `Average` (tests in #4551)                   |
-| `regr_count`            | ✅     | Native: Spark rewrites to `Count` (tests in #4551)                     |
-| `regr_intercept`        | 🔜     | Falls back; can reuse `covar_pop`/`var_pop` accumulators (#4552)       |
-| `regr_r2`               | 🔜     | Falls back; can reuse the `corr` accumulator (#4552)                   |
-| `regr_slope`            | 🔜     | Falls back; can reuse `covar_pop`/`var_pop` accumulators (#4552)       |
-| `regr_sxx`              | 🔜     | Falls back; can reuse `var_pop` accumulator (#4552)                    |
-| `regr_sxy`              | 🔜     | Falls back; can reuse `covar_pop` accumulator (#4552)                  |
-| `regr_syy`              | 🔜     | Falls back; can reuse `var_pop` accumulator (#4552)                    |
-| `skewness`              | 🔜     | tracking #4098                                                         |
-| `some`                  | ✅     |                                                                        |
-| `std`                   | ✅     |                                                                        |
-| `stddev`                | ✅     |                                                                        |
-| `stddev_pop`            | ✅     |                                                                        |
-| `stddev_samp`           | ✅     |                                                                        |
-| `string_agg`            | 🔜     | String aggregation (alias of `listagg`)                                |
-| `sum`                   | ✅     |                                                                        |
-| `try_avg`               | 🔜     | tracking #4098                                                         |
-| `try_sum`               | 🔜     | tracking #4098                                                         |
-| `var_pop`               | ✅     |                                                                        |
-| `var_samp`              | ✅     |                                                                        |
-| `variance`              | ✅     |                                                                        |
+| Function                | Status | Notes                                                            |
+| ----------------------- | ------ | ---------------------------------------------------------------- |
+| `any`                   | ✅     |                                                                  |
+| `any_value`             | ✅     |                                                                  |
+| `approx_count_distinct` | 🔜     | tracking #4098                                                   |
+| `approx_percentile`     | 🔜     | [#3189](https://github.com/apache/datafusion-comet/issues/3189)  |
+| `array_agg`             | 🔜     | Array aggregate (related to `collect_list`, #2524)               |
+| `avg`                   | ⚠️     | Interval types (YearMonth, DayTime) fall back                    |
+| `bit_and`               | ✅     |                                                                  |
+| `bit_or`                | ✅     |                                                                  |
+| `bit_xor`               | ✅     |                                                                  |
+| `bool_and`              | ✅     |                                                                  |
+| `bool_or`               | ✅     |                                                                  |
+| `collect_list`          | 🔜     | [#2524](https://github.com/apache/datafusion-comet/issues/2524)  |
+| `collect_set`           | ✅     |                                                                  |
+| `corr`                  | ✅     |                                                                  |
+| `count`                 | ✅     |                                                                  |
+| `count_if`              | ✅     |                                                                  |
+| `covar_pop`             | ✅     |                                                                  |
+| `covar_samp`            | ✅     |                                                                  |
+| `every`                 | ✅     |                                                                  |
+| `first`                 | ✅     |                                                                  |
+| `first_value`           | ✅     |                                                                  |
+| `grouping`              | 🔜     | Grouping indicator for ROLLUP/CUBE/GROUPING SETS                 |
+| `grouping_id`           | 🔜     | Grouping indicator for ROLLUP/CUBE/GROUPING SETS                 |
+| `kurtosis`              | 🔜     | tracking #4098                                                   |
+| `last`                  | ✅     |                                                                  |
+| `last_value`            | ✅     |                                                                  |
+| `listagg`               | 🔜     | String aggregation                                               |
+| `max`                   | ✅     |                                                                  |
+| `max_by`                | 🔜     | [#3841](https://github.com/apache/datafusion-comet/issues/3841)  |
+| `mean`                  | ✅     |                                                                  |
+| `median`                | 🔜     | tracking #4098                                                   |
+| `min`                   | ✅     |                                                                  |
+| `min_by`                | 🔜     | [#3841](https://github.com/apache/datafusion-comet/issues/3841)  |
+| `mode`                  | 🔜     | [#3970](https://github.com/apache/datafusion-comet/issues/3970)  |
+| `percentile`            | 🔜     | #4542                                                            |
+| `percentile_approx`     | 🔜     | [#3189](https://github.com/apache/datafusion-comet/issues/3189)  |
+| `percentile_cont`       | 🔜     | Percentile aggregate                                             |
+| `percentile_disc`       | 🔜     | Percentile aggregate                                             |
+| `regr_avgx`             | ✅     | Native: Spark rewrites to `Average` (tests in #4551)             |
+| `regr_avgy`             | ✅     | Native: Spark rewrites to `Average` (tests in #4551)             |
+| `regr_count`            | ✅     | Native: Spark rewrites to `Count` (tests in #4551)               |
+| `regr_intercept`        | 🔜     | Falls back; can reuse `covar_pop`/`var_pop` accumulators (#4552) |
+| `regr_r2`               | 🔜     | Falls back; can reuse the `corr` accumulator (#4552)             |
+| `regr_slope`            | 🔜     | Falls back; can reuse `covar_pop`/`var_pop` accumulators (#4552) |
+| `regr_sxx`              | 🔜     | Falls back; can reuse `var_pop` accumulator (#4552)              |
+| `regr_sxy`              | 🔜     | Falls back; can reuse `covar_pop` accumulator (#4552)            |
+| `regr_syy`              | 🔜     | Falls back; can reuse `var_pop` accumulator (#4552)              |
+| `skewness`              | 🔜     | tracking #4098                                                   |
+| `some`                  | ✅     |                                                                  |
+| `std`                   | ✅     |                                                                  |
+| `stddev`                | ✅     |                                                                  |
+| `stddev_pop`            | ✅     |                                                                  |
+| `stddev_samp`           | ✅     |                                                                  |
+| `string_agg`            | 🔜     | String aggregation (alias of `listagg`)                          |
+| `sum`                   | ✅     |                                                                  |
+| `try_avg`               | 🔜     | tracking #4098                                                   |
+| `try_sum`               | 🔜     | tracking #4098                                                   |
+| `var_pop`               | ✅     |                                                                  |
+| `var_samp`              | ✅     |                                                                  |
+| `variance`              | ✅     |                                                                  |
 
 ---
 
@@ -236,12 +233,6 @@ serde but effectively fall through to the same cast path at runtime.
 | `string`    | ⚠️     | Alias for `CAST(... AS STRING)`; see `cast`                                                                        |
 | `timestamp` | ⚠️     | Alias for `CAST(... AS TIMESTAMP)`; see `cast`                                                                     |
 | `tinyint`   | ⚠️     | Alias for `CAST(... AS TINYINT)`; see `cast`                                                                       |
-
----
-
-## csv_funcs
-
-🚫 **Out of scope.** `from_csv`, `to_csv`, and `schema_of_csv` fall back to Spark. See [Out of scope](#out-of-scope).
 
 ---
 
@@ -489,14 +480,6 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 
 ## misc_funcs
 
-> 🚫 Out of scope: probabilistic sketch functions (`hll_sketch_estimate`, `hll_union`, `theta_difference`, `theta_intersection`, `theta_sketch_estimate`, `theta_union`, `bitmap_and_agg`, `bitmap_or_agg`, `bitmap_construct_agg`, `bitmap_count`, `bitmap_bucket_number`, `bitmap_bit_position`, `approx_top_k_estimate`). See [Out of scope](#out-of-scope).
-
-> 🚫 Out of scope: geospatial functions (`st_asbinary`, `st_geogfromwkb`, `st_geomfromwkb`, `st_setsrid`, `st_srid`). See [Out of scope](#out-of-scope).
-
-> 🚫 Out of scope: Avro/Protobuf codec functions (`from_avro`, `to_avro`, `schema_of_avro`, `from_protobuf`, `to_protobuf`). See [Out of scope](#out-of-scope).
-
-> 🚫 Out of scope: JVM reflection functions (`java_method`, `reflect`, `try_reflect`). See [Out of scope](#out-of-scope).
-
 | Function                      | Status | Notes                                                                            |
 | ----------------------------- | ------ | -------------------------------------------------------------------------------- |
 | `aes_decrypt`                 | 🔜     | Falls back; `StaticInvoke` not allowlisted; planned via codegen dispatch (#4558) |
@@ -507,9 +490,6 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `current_schema`              | ✅     | Alias of `current_database`; resolved to a literal by the analyzer               |
 | `current_user`                | ✅     | Resolved to a literal by the analyzer; same as `user`                            |
 | `equal_null`                  | ✅     | Lowers to `<=>` (`EqualNullSafe`)                                                |
-| `input_file_block_length`     | 🚫     | Requires scan-internal file metadata (out of scope)                              |
-| `input_file_block_start`      | 🚫     | Requires scan-internal file metadata (out of scope)                              |
-| `input_file_name`             | 🚫     | Requires scan-internal file metadata (out of scope)                              |
 | `is_variant_null`             | 🔜     | tracking #4098                                                                   |
 | `monotonically_increasing_id` | ✅     |                                                                                  |
 | `parse_json`                  | 🔜     | tracking #4098                                                                   |
@@ -526,9 +506,7 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `try_variant_get`             | 🔜     | tracking #4098                                                                   |
 | `typeof`                      | ✅     | Foldable; resolved to a literal before Comet sees the plan                       |
 | `user`                        | ✅     | Resolved to a literal by the Spark analyzer before reaching Comet                |
-| `uuid`                        | 🚫     | Nondeterministic random UUID (out of scope)                                      |
 | `variant_get`                 | 🔜     | tracking #4098                                                                   |
-| `version`                     | 🚫     | Returns the Spark version string (out of scope)                                  |
 
 ---
 
@@ -585,7 +563,6 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `format_string`      | 🔜     | #4538                                                                            |
 | `initcap`            | ✅     |                                                                                  |
 | `instr`              | ✅     |                                                                                  |
-| `is_valid_utf8`      | 🚫     | UTF-8 validation (out of scope)                                                  |
 | `lcase`              | ✅     |                                                                                  |
 | `left`               | ✅     |                                                                                  |
 | `len`                | ✅     |                                                                                  |
@@ -596,13 +573,11 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `lpad`               | ✅     |                                                                                  |
 | `ltrim`              | ✅     |                                                                                  |
 | `luhn_check`         | ✅     | Native via `StaticInvoke` (tests: luhn_check.sql)                                |
-| `make_valid_utf8`    | 🚫     | UTF-8 validation (out of scope)                                                  |
 | `mask`               | 🔜     | Data masking                                                                     |
 | `octet_length`       | ✅     |                                                                                  |
 | `overlay`            | 🔜     | #4538                                                                            |
 | `position`           | 🔜     | #4538                                                                            |
 | `printf`             | 🔜     | #4538                                                                            |
-| `quote`              | 🚫     | Quotes a string as a SQL literal (out of scope)                                  |
 | `regexp_count`       | 🔜     | tracking #4098                                                                   |
 | `regexp_extract`     | 🔜     | tracking #4098                                                                   |
 | `regexp_extract_all` | 🔜     | tracking #4098                                                                   |
@@ -614,7 +589,6 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `right`              | ✅     |                                                                                  |
 | `rpad`               | ✅     |                                                                                  |
 | `rtrim`              | ✅     |                                                                                  |
-| `sentences`          | 🚫     | Locale-aware sentence/word splitting (out of scope)                              |
 | `soundex`            | 🔜     | #4538                                                                            |
 | `space`              | ✅     |                                                                                  |
 | `split`              | ✅     |                                                                                  |
@@ -631,11 +605,9 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `trim`               | ✅     |                                                                                  |
 | `try_to_binary`      | 🔜     | Lowers to `TryEval(...)`, which falls back                                       |
 | `try_to_number`      | 🔜     | TRY variant of `to_number`                                                       |
-| `try_validate_utf8`  | 🚫     | UTF-8 validation (out of scope)                                                  |
 | `ucase`              | ✅     |                                                                                  |
 | `unbase64`           | 🔜     | #4538                                                                            |
 | `upper`              | ✅     |                                                                                  |
-| `validate_utf8`      | 🚫     | UTF-8 validation (out of scope)                                                  |
 
 ---
 
@@ -682,11 +654,15 @@ fall back to Spark.
 
 ---
 
-## xml_funcs
+## Out-of-scope function list
 
-🚫 **Out of scope.** `from_xml`, `to_xml`, `schema_of_xml`, and the `xpath*` family fall back to Spark. See [Out of scope](#out-of-scope).
+The following functions are out of scope and fall back to Spark. See [Out of scope](#out-of-scope) above for the rationale.
 
----
+- **agg_funcs:** `approx_top_k`, `approx_top_k_accumulate`, `approx_top_k_combine`, `count_min_sketch`, `histogram_numeric`, `hll_sketch_agg`, `hll_union_agg`, `kll_sketch_agg_bigint`, `kll_sketch_agg_double`, `kll_sketch_agg_float`, `kll_sketch_get_n_bigint`, `kll_sketch_get_n_double`, `kll_sketch_get_n_float`, `kll_sketch_get_quantile_bigint`, `kll_sketch_get_quantile_double`, `kll_sketch_get_quantile_float`, `kll_sketch_get_rank_bigint`, `kll_sketch_get_rank_double`, `kll_sketch_get_rank_float`, `kll_sketch_merge_bigint`, `kll_sketch_merge_double`, `kll_sketch_merge_float`, `kll_sketch_to_string_bigint`, `kll_sketch_to_string_double`, `kll_sketch_to_string_float`, `theta_intersection_agg`, `theta_sketch_agg`, `theta_union_agg`
+- **csv_funcs:** `from_csv`, `schema_of_csv`, `to_csv`
+- **misc_funcs:** `approx_top_k_estimate`, `bitmap_and_agg`, `bitmap_bit_position`, `bitmap_bucket_number`, `bitmap_construct_agg`, `bitmap_count`, `bitmap_or_agg`, `from_avro`, `from_protobuf`, `hll_sketch_estimate`, `hll_union`, `input_file_block_length`, `input_file_block_start`, `input_file_name`, `java_method`, `reflect`, `schema_of_avro`, `st_asbinary`, `st_geogfromwkb`, `st_geomfromwkb`, `st_setsrid`, `st_srid`, `theta_difference`, `theta_intersection`, `theta_sketch_estimate`, `theta_union`, `to_avro`, `to_protobuf`, `try_reflect`, `uuid`, `version`
+- **string_funcs:** `is_valid_utf8`, `make_valid_utf8`, `quote`, `sentences`, `try_validate_utf8`, `validate_utf8`
+- **xml_funcs:** `from_xml`, `schema_of_xml`, `to_xml`, `xpath`, `xpath_boolean`, `xpath_double`, `xpath_float`, `xpath_int`, `xpath_long`, `xpath_number`, `xpath_short`, `xpath_string`
 
 ## Beyond SQL functions
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -159,7 +159,7 @@ The tables below list every Spark built-in expression with its current status.
 | `get` | ✅ | |
 | `sequence` | 🔜 | #4538 |
 | `shuffle` | ❓ | |
-| `slice` | ❓ | |
+| `slice` | ✅ | Native (#4149) |
 | `sort_array` | ⚠️ | Incompatible under strict floating-point; falls back for nested struct/null arrays |
 
 ---

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -107,15 +107,15 @@ The tables below list every Spark built-in expression with its current status.
 | `percentile_approx` | 🔜 | [#3189](https://github.com/apache/datafusion-comet/issues/3189) |
 | `percentile_cont` | ❓ | |
 | `percentile_disc` | ❓ | |
-| `regr_avgx` | 🔜 | tracking #4098 |
-| `regr_avgy` | 🔜 | tracking #4098 |
-| `regr_count` | 🔜 | tracking #4098 |
-| `regr_intercept` | 🔜 | tracking #4098 |
-| `regr_r2` | 🔜 | tracking #4098 |
-| `regr_slope` | 🔜 | tracking #4098 |
-| `regr_sxx` | 🔜 | tracking #4098 |
-| `regr_sxy` | 🔜 | tracking #4098 |
-| `regr_syy` | 🔜 | tracking #4098 |
+| `regr_avgx` | 🔜 | Rewrites to `Average`; reuses existing aggregates (#4098) |
+| `regr_avgy` | 🔜 | Rewrites to `Average`; reuses existing aggregates (#4098) |
+| `regr_count` | 🔜 | Rewrites to `Count`; reuses existing aggregates (#4098) |
+| `regr_intercept` | 🔜 | Builds on `covar_pop`/`var_pop` accumulators (#4098) |
+| `regr_r2` | 🔜 | Builds on the `corr` accumulator (#4098) |
+| `regr_slope` | 🔜 | Builds on `covar_pop`/`var_pop` accumulators (#4098) |
+| `regr_sxx` | 🔜 | Builds on `var_pop` accumulator (#4098) |
+| `regr_sxy` | 🔜 | Builds on `covar_pop` accumulator (#4098) |
+| `regr_syy` | 🔜 | Builds on `var_pop` accumulator (#4098) |
 | `skewness` | 🔜 | tracking #4098 |
 | `some` | ✅ | |
 | `std` | ✅ | |

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -17,354 +17,705 @@
   under the License.
 -->
 
-# Supported Spark Expressions
+# Spark Expression Support
 
-Comet supports the following Spark expressions. See the [Comet Compatibility Guide] for details on known
-incompatibilities and unsupported cases.
+This page is the complete reference for how Apache Comet handles each Spark built-in
+expression. Comet accelerates expressions either with a native (Rust) implementation or by
+dispatching to a Spark-compatible codegen path. When an expression is not supported, Comet
+transparently falls back to Spark for that part of the plan; results are unaffected.
 
-All expressions are enabled by default, but most can be disabled by setting
-`spark.comet.expression.EXPRNAME.enabled=false`, where `EXPRNAME` is the expression name as specified in
-the following tables, such as `Length`, or `StartsWith`. See the [Comet Configuration Guide] for a full list
-of expressions that be disabled.
+All supported expressions are enabled by default. Most can be disabled with
+`spark.comet.expression.EXPRNAME.enabled=false`, where `EXPRNAME` is the Spark expression
+class name (for example `Length` or `StartsWith`). See the [Comet Configuration Guide](configs.md)
+for the full list.
 
-## Conditional Expressions
+## Status legend
 
-| Expression | SQL                                         |
-| ---------- | ------------------------------------------- |
-| CaseWhen   | `CASE WHEN expr THEN expr ELSE expr END`    |
-| If         | `IF(predicate_expr, true_expr, false_expr)` |
+| Status | Meaning |
+| ------ | ------- |
+| ✅ Supported | Native or codegen path; compatible with Spark by default. |
+| ⚠️ Supported (caveats) | Works, but may diverge from Spark in some cases: incompatible, flag-gated (`allowIncompatible`), or restricted to certain types. See the [Compatibility Guide](compatibility/index.md). |
+| 🚧 Planned | Intended; tracked by an open issue or pull request. |
+| 🚫 Out of scope | Deliberately not planned. |
+| ⬜ Not yet supported | Falls back to Spark today; not yet evaluated. |
 
-## Predicate Expressions
+## Scope policy
 
-| Expression         | SQL           |
-| ------------------ | ------------- |
-| And                | `AND`         |
-| EqualTo            | `=`           |
-| EqualNullSafe      | `<=>`         |
-| GreaterThan        | `>`           |
-| GreaterThanOrEqual | `>=`          |
-| ILike              | `ILIKE`       |
-| In                 | `IN`          |
-| InSet              | `IN (...)`    |
-| IsNotNull          | `IS NOT NULL` |
-| IsNull             | `IS NULL`     |
-| LessThan           | `<`           |
-| LessThanOrEqual    | `<=`          |
-| Not                | `NOT`         |
-| Or                 | `OR`          |
+Comet focuses acceleration on mainstream relational, string, datetime, math, and collection
+expressions. Some Spark function families are **out of scope**: specialized functionality with
+narrow real-world analytics use and high implementation cost. These will fall back to Spark and
+are not on the roadmap:
 
-## String Functions
+- **Probabilistic sketches and approximate top-k** (`kll_sketch_*`, `hll_*`, `theta_*`, `count_min_sketch`, `bitmap_*`, `approx_top_k*`): specialized data structures with exact-correctness traps.
+- **XML / XPath** (`from_xml`, `to_xml`, `schema_of_xml`, `xpath*`): legacy text format, rare in accelerated workloads.
+- **Geospatial** (`st_*`): brand-new Spark 4.1 functionality, specialized.
+- **Avro / Protobuf codecs** (`from_avro`, `to_avro`, `from_protobuf`, `to_protobuf`, `schema_of_avro`): format conversion belongs at the IO layer, not expression evaluation.
+- **JVM reflection** (`java_method`, `reflect`): cannot run in native code.
+- **Cryptographic functions** (`aes_encrypt`, `aes_decrypt`): niche, with correctness and security risk for marginal benefit.
 
-| Expression      |
-| --------------- |
-| Ascii           |
-| BitLength       |
-| Chr             |
-| Concat          |
-| ConcatWs        |
-| Contains        |
-| Decode          |
-| EndsWith        |
-| InitCap         |
-| Left            |
-| Length          |
-| Like            |
-| Lower           |
-| OctetLength     |
-| Reverse         |
-| Right           |
-| RLike           |
-| Split           |
-| StartsWith      |
-| StringInstr     |
-| StringRepeat    |
-| StringReplace   |
-| StringLPad      |
-| StringRPad      |
-| StringSpace     |
-| StringTranslate |
-| StringTrim      |
-| StringTrimBoth  |
-| StringTrimLeft  |
-| StringTrimRight |
-| Substring       |
-| SubstringIndex  |
-| Upper           |
+Note that `approx_count_distinct`, `approx_percentile` / `percentile_approx`, `median`, and `mode`
+are *not* out of scope: although approximate, they are mainstream and are planned.
 
-## JSON Functions
+The tables below list every Spark built-in expression with its current status.
 
-| Expression    |
-| ------------- |
-| GetJsonObject |
+## Coverage by category
 
-## Date/Time Functions
+| Category | Supported | Notes |
+| -------- | --------- | ----- |
+| conversion_funcs | 1 / 13 | Cast and cast aliases |
+| hash_funcs | 7 / 7 | Fully supported |
+| struct_funcs | 2 / 2 | Fully supported |
+| url_funcs | 4 / 4 | Fully supported |
+| math_funcs | 60 / 70 | Mostly supported |
+| bitwise_funcs | 11 / 12 | Mostly supported |
+| predicate_funcs | 19 / 21 | Mostly supported |
+| array_funcs | 21 / 25 | Mostly supported |
+| datetime_funcs | 45 / 73 | Mostly supported |
+| conditional_funcs | 7 / 10 | Mostly supported |
+| string_funcs | 37 / 72 | Mostly supported; regexp tail planned |
+| map_funcs | 8 / 11 | Mostly supported |
+| collection_funcs | 3 / 5 | |
+| json_funcs | 1 / 7 | Core supported; remainder planned |
+| agg_funcs | 31 / 88 | Sketch aggregates out of scope |
+| generator_funcs | 0 / 7 | explode/posexplode via operator |
+| window_funcs | 0 / 9 | Run via CometWindowExec (operator) |
+| lambda_funcs | 0 / 12 | Higher-order functions planned |
+| misc_funcs | 5 / 56 | Many niche/environment functions |
+| csv_funcs | 0 / 3 | Not yet evaluated |
+| xml_funcs | 0 / 12 | Out of scope |
 
-| Expression        | SQL                          |
-| ----------------- | ---------------------------- |
-| AddMonths         | `add_months`                 |
-| ConvertTimezone   | `convert_timezone`           |
-| CurrentTimeZone   | `current_timezone`           |
-| DateAdd           | `date_add`                   |
-| DateDiff          | `datediff`                   |
-| DateFormat        | `date_format`                |
-| DateFromUnixDate  | `date_from_unix_date`        |
-| DateSub           | `date_sub`                   |
-| DatePart          | `date_part(field, source)`   |
-| Days              | `days`                       |
-| Extract           | `extract(field FROM source)` |
-| FromUnixTime      | `from_unixtime`              |
-| Hour              | `hour`                       |
-| LastDay           | `last_day`                   |
-| LocalTimestamp    | `localtimestamp`             |
-| MakeDate          | `make_date`                  |
-| MakeTime          | `make_time`                  |
-| MakeTimestamp     | `make_timestamp`             |
-| MicrosToTimestamp | `timestamp_micros`           |
-| MillisToTimestamp | `timestamp_millis`           |
-| Minute            | `minute`                     |
-| MonthsBetween     | `months_between`             |
-| NextDay           | `next_day`                   |
-| Second            | `second`                     |
-| TimestampSeconds  | `timestamp_seconds`          |
-| ToUnixTimestamp   | `to_unix_timestamp`          |
-| TruncDate         | `trunc`                      |
-| TruncTimestamp    | `date_trunc`                 |
-| UnixDate          | `unix_date`                  |
-| UnixMicros        | `unix_micros`                |
-| UnixMillis        | `unix_millis`                |
-| UnixSeconds       | `unix_seconds`               |
-| UnixTimestamp     | `unix_timestamp`             |
-| Year              | `year`                       |
-| Month             | `month`                      |
-| DayOfMonth        | `day`/`dayofmonth`           |
-| DayOfWeek         | `dayofweek`                  |
-| WeekDay           | `weekday`                    |
-| DayOfYear         | `dayofyear`                  |
-| WeekOfYear        | `weekofyear`                 |
-| Quarter           | `quarter`                    |
-| ToTime            | `to_time`                    |
-| TryToTime         | `try_to_time`                |
+---
 
-## Math Expressions
+## agg_funcs
 
-| Expression     | SQL            |
-| -------------- | -------------- |
-| Abs            | `abs`          |
-| Acos           | `acos`         |
-| Acosh          | `acosh`        |
-| Add            | `+`            |
-| Asin           | `asin`         |
-| Asinh          | `asinh`        |
-| Atan           | `atan`         |
-| Atan2          | `atan2`        |
-| Atanh          | `atanh`        |
-| Bin            | `bin`          |
-| BRound         | `bround`       |
-| Cbrt           | `cbrt`         |
-| Ceil           | `ceil`         |
-| Cos            | `cos`          |
-| Cosh           | `cosh`         |
-| Cot            | `cot`          |
-| Csc            | `csc`          |
-| Divide         | `/`            |
-| Exp            | `exp`          |
-| Expm1          | `expm1`        |
-| Factorial      | `factorial`    |
-| Floor          | `floor`        |
-| Hex            | `hex`          |
-| IntegralDivide | `div`          |
-| IsNaN          | `isnan`        |
-| Log            | `log`          |
-| Log2           | `log2`         |
-| Log10          | `log10`        |
-| Multiply       | `*`            |
-| Pi             | `pi`           |
-| Pow            | `power`        |
-| Rand           | `rand`         |
-| Randn          | `randn`        |
-| Remainder      | `%`            |
-| Rint           | `rint`         |
-| Round          | `round`        |
-| Sec            | `sec`          |
-| Signum         | `signum`       |
-| Sin            | `sin`          |
-| Sinh           | `sinh`         |
-| Sqrt           | `sqrt`         |
-| Subtract       | `-`            |
-| Tan            | `tan`          |
-| Tanh           | `tanh`         |
-| ToDegrees      | `degrees`      |
-| ToRadians      | `radians`      |
-| TryAdd         | `try_add`      |
-| TryDivide      | `try_div`      |
-| TryMultiply    | `try_mul`      |
-| TrySubtract    | `try_sub`      |
-| UnaryMinus     | `-`            |
-| Unhex          | `unhex`        |
-| WidthBucket    | `width_bucket` |
+> 🚫 Out of scope: probabilistic sketch aggregates (`kll_sketch_*`, `hll_sketch_agg`, `hll_union_agg`, `theta_*_agg`, `count_min_sketch`, `bitmap_*_agg`, `approx_top_k*`). See [Scope policy](#scope-policy).
 
-## Hashing Functions
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `any` | ✅ | |
+| `any_value` | ✅ | |
+| `approx_count_distinct` | 🚧 | tracking #4098 |
+| `approx_percentile` | 🚧 | [#3189](https://github.com/apache/datafusion-comet/issues/3189) |
+| `array_agg` | ⬜ | |
+| `avg` | ⚠️ | Interval types (YearMonth, DayTime) fall back |
+| `bit_and` | ✅ | |
+| `bit_or` | ✅ | |
+| `bit_xor` | ✅ | |
+| `bool_and` | ✅ | |
+| `bool_or` | ✅ | |
+| `collect_list` | 🚧 | [#2524](https://github.com/apache/datafusion-comet/issues/2524) |
+| `collect_set` | ✅ | |
+| `corr` | ✅ | |
+| `count` | ✅ | |
+| `count_if` | ✅ | |
+| `covar_pop` | ✅ | |
+| `covar_samp` | ✅ | |
+| `every` | ✅ | |
+| `first` | ✅ | |
+| `first_value` | ✅ | |
+| `grouping` | ⬜ | |
+| `grouping_id` | ⬜ | |
+| `histogram_numeric` | ⬜ | |
+| `kurtosis` | 🚧 | tracking #4098 |
+| `last` | ✅ | |
+| `last_value` | ✅ | |
+| `listagg` | ⬜ | |
+| `max` | ✅ | |
+| `max_by` | 🚧 | [#3841](https://github.com/apache/datafusion-comet/issues/3841) |
+| `mean` | ✅ | |
+| `median` | 🚧 | tracking #4098 |
+| `min` | ✅ | |
+| `min_by` | 🚧 | [#3841](https://github.com/apache/datafusion-comet/issues/3841) |
+| `mode` | 🚧 | [#3970](https://github.com/apache/datafusion-comet/issues/3970) |
+| `percentile` | ⬜ | |
+| `percentile_approx` | 🚧 | [#3189](https://github.com/apache/datafusion-comet/issues/3189) |
+| `percentile_cont` | ⬜ | |
+| `percentile_disc` | ⬜ | |
+| `regr_avgx` | 🚧 | tracking #4098 |
+| `regr_avgy` | 🚧 | tracking #4098 |
+| `regr_count` | 🚧 | tracking #4098 |
+| `regr_intercept` | 🚧 | tracking #4098 |
+| `regr_r2` | 🚧 | tracking #4098 |
+| `regr_slope` | 🚧 | tracking #4098 |
+| `regr_sxx` | 🚧 | tracking #4098 |
+| `regr_sxy` | 🚧 | tracking #4098 |
+| `regr_syy` | 🚧 | tracking #4098 |
+| `skewness` | 🚧 | tracking #4098 |
+| `some` | ✅ | |
+| `std` | ✅ | |
+| `stddev` | ✅ | |
+| `stddev_pop` | ✅ | |
+| `stddev_samp` | ✅ | |
+| `string_agg` | ⬜ | |
+| `sum` | ✅ | |
+| `try_avg` | 🚧 | tracking #4098 |
+| `try_sum` | 🚧 | tracking #4098 |
+| `var_pop` | ✅ | |
+| `var_samp` | ✅ | |
+| `variance` | ✅ | |
 
-| Expression  |
-| ----------- |
-| Crc32       |
-| Md5         |
-| Murmur3Hash |
-| Sha1        |
-| Sha2        |
-| XxHash64    |
+---
 
-## Bitwise Expressions
+## array_funcs
 
-| Expression         | SQL   |
-| ------------------ | ----- |
-| BitwiseAnd         | `&`   |
-| BitwiseCount       |       |
-| BitwiseGet         |       |
-| BitwiseOr          | `\|`  |
-| BitwiseNot         | `~`   |
-| BitwiseXor         | `^`   |
-| ShiftLeft          | `<<`  |
-| ShiftRight         | `>>`  |
-| ShiftRightUnsigned | `>>>` |
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `array` | ✅ | |
+| `array_append` | ⚠️ | On Spark 4.0+ rewrites to `array_insert`; inherits its incompatibilities |
+| `array_compact` | ✅ | |
+| `array_contains` | ⚠️ | NaN-canonicalization may differ for float/double arrays ([#4481](https://github.com/apache/datafusion-comet/issues/4481)) |
+| `array_distinct` | ⚠️ | NaN/signed-zero canonicalization may differ ([#4481](https://github.com/apache/datafusion-comet/issues/4481)) |
+| `array_except` | ⚠️ | Null handling and ordering may differ; `Incompatible`, flag-gated |
+| `array_insert` | ✅ | |
+| `array_intersect` | ⚠️ | Result element order may differ when right array is longer than left |
+| `array_join` | ⚠️ | Null handling may differ ([#3178](https://github.com/apache/datafusion-comet/issues/3178)); `Incompatible`, flag-gated |
+| `array_max` | ⚠️ | NaN ordering may differ for float/double ([#4482](https://github.com/apache/datafusion-comet/issues/4482)) |
+| `array_min` | ⚠️ | NaN ordering may differ for float/double ([#4482](https://github.com/apache/datafusion-comet/issues/4482)) |
+| `array_position` | ⚠️ | Falls back for binary/struct/map/null element types |
+| `array_prepend` | ⬜ | |
+| `array_remove` | ✅ | |
+| `array_repeat` | ✅ | |
+| `array_union` | ⚠️ | NaN/signed-zero canonicalization may differ ([#4481](https://github.com/apache/datafusion-comet/issues/4481)) |
+| `arrays_overlap` | ✅ | |
+| `arrays_zip` | ✅ | |
+| `element_at` | ⚠️ | Only `ArrayType` input; `MapType` input falls back |
+| `flatten` | ⚠️ | Falls back for binary/struct/map child element types |
+| `get` | ✅ | |
+| `sequence` | ⬜ | |
+| `shuffle` | ⬜ | |
+| `slice` | ⬜ | |
+| `sort_array` | ⚠️ | Incompatible under strict floating-point; falls back for nested struct/null arrays |
 
-## Aggregate Expressions
+---
 
-| Expression    | SQL        |
-| ------------- | ---------- |
-| Average       |            |
-| BitAndAgg     |            |
-| BitOrAgg      |            |
-| BitXorAgg     |            |
-| BoolAnd       | `bool_and` |
-| BoolOr        | `bool_or`  |
-| CollectSet    |            |
-| Corr          |            |
-| Count         |            |
-| CountIf       | `count_if` |
-| CovPopulation |            |
-| CovSample     |            |
-| First         |            |
-| Last          |            |
-| Max           |            |
-| Min           |            |
-| StddevPop     |            |
-| StddevSamp    |            |
-| Sum           |            |
-| VariancePop   |            |
-| VarianceSamp  |            |
+## bitwise_funcs
 
-## Window Functions
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `&` | ✅ | |
+| `<<` | ✅ | |
+| `>>` | ✅ | |
+| `>>>` | ⬜ | |
+| `^` | ✅ | |
+| `bit_count` | ✅ | |
+| `bit_get` | ✅ | |
+| `getbit` | ✅ | |
+| `shiftright` | ✅ | |
+| `shiftrightunsigned` | ✅ | |
+| `\|` | ✅ | |
+| `~` | ✅ | |
 
-```{warning}
-Window support is disabled by default due to known correctness issues. Tracking issue: [#2721](https://github.com/apache/datafusion-comet/issues/2721).
-```
+---
 
-Comet supports using the following aggregate functions within window contexts with PARTITION BY and ORDER BY clauses.
+## collection_funcs
 
-| Expression |
-| ---------- |
-| Count      |
-| Max        |
-| Min        |
-| Sum        |
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `array_size` | ⬜ | |
+| `cardinality` | ⬜ | |
+| `concat` | ⚠️ | Only `StringType` children; `BinaryType`/`ArrayType` fall back ([#4471](https://github.com/apache/datafusion-comet/issues/4471)) |
+| `reverse` | ⚠️ | Array with `BinaryType` elements is `Incompatible`, flag-gated ([#2763](https://github.com/apache/datafusion-comet/issues/2763)) |
+| `size` | ⚠️ | `MapType` input falls back ([#4472](https://github.com/apache/datafusion-comet/issues/4472)) |
 
-**Note:** Dedicated window functions such as `rank`, `dense_rank`, `row_number`, `lag`, `lead`, `ntile`, `cume_dist`, `percent_rank`, and `nth_value` are not currently supported and will fall back to Spark.
+---
 
-## Array Expressions
+## conditional_funcs
 
-| Expression     |
-| -------------- |
-| ArrayAppend    |
-| ArrayCompact   |
-| ArrayContains  |
-| ArrayDistinct  |
-| ArrayExcept    |
-| ArrayFilter    |
-| ArrayInsert    |
-| ArrayIntersect |
-| ArrayJoin      |
-| ArrayMax       |
-| ArrayMin       |
-| ArrayPosition  |
-| ArrayRemove    |
-| ArrayRepeat    |
-| ArraysZip      |
-| ArrayUnion     |
-| ArraysOverlap  |
-| CreateArray    |
-| ElementAt      |
-| Flatten        |
-| GetArrayItem   |
-| Size           |
-| SortArray      |
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `coalesce` | ✅ | |
+| `if` | ✅ | |
+| `ifnull` | ✅ | |
+| `nanvl` | ⬜ | |
+| `nullif` | ✅ | |
+| `nullifzero` | ⬜ | |
+| `nvl` | ✅ | |
+| `nvl2` | ✅ | |
+| `when` | ✅ | |
+| `zeroifnull` | ⬜ | |
 
-## Map Expressions
+---
 
-| Expression     |
-| -------------- |
-| GetMapValue    |
-| MapContainsKey |
-| MapEntries     |
-| MapFromArrays  |
-| MapFromEntries |
-| MapKeys        |
-| MapValues      |
-| StringToMap    |
+## conversion_funcs
 
-## Struct Expressions
+The type-alias keywords (`bigint`, `boolean`, `int`, etc.) are SQL syntax for `CAST`. `cast`
+itself is supported with caveats; the keyword aliases are not yet individually wired in Comet's
+serde but effectively fall through to the same cast path at runtime.
 
-| Expression           |
-| -------------------- |
-| CreateNamedStruct    |
-| GetArrayStructFields |
-| GetStructField       |
-| JsonToStructs        |
-| StructsToJson        |
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `bigint` | ⬜ | Alias for `CAST(... AS BIGINT)`; see `cast` |
+| `binary` | ⬜ | Alias for `CAST(... AS BINARY)`; see `cast` |
+| `boolean` | ⬜ | Alias for `CAST(... AS BOOLEAN)`; see `cast` |
+| `cast` | ⚠️ | Many type pairs supported; float-to-decimal rounding may differ; see [Compatibility Guide](compatibility/index.md) |
+| `date` | ⬜ | Alias for `CAST(... AS DATE)`; see `cast` |
+| `decimal` | ⬜ | Alias for `CAST(... AS DECIMAL)`; see `cast` |
+| `double` | ⬜ | Alias for `CAST(... AS DOUBLE)`; see `cast` |
+| `float` | ⬜ | Alias for `CAST(... AS FLOAT)`; see `cast` |
+| `int` | ⬜ | Alias for `CAST(... AS INT)`; see `cast` |
+| `smallint` | ⬜ | Alias for `CAST(... AS SMALLINT)`; see `cast` |
+| `string` | ⬜ | Alias for `CAST(... AS STRING)`; see `cast` |
+| `timestamp` | ⬜ | Alias for `CAST(... AS TIMESTAMP)`; see `cast` |
+| `tinyint` | ⬜ | Alias for `CAST(... AS TINYINT)`; see `cast` |
 
-## URL Functions
+---
 
-| Expression   |
-| ------------ |
-| TryUrlDecode |
-| UrlDecode    |
-| UrlEncode    |
+## csv_funcs
 
-## Conversion Expressions
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `from_csv` | ⬜ | |
+| `schema_of_csv` | ⬜ | |
+| `to_csv` | ⬜ | |
 
-| Expression |
-| ---------- |
-| Cast       |
+---
 
-## SortOrder
+## datetime_funcs
 
-| Expression |
-| ---------- |
-| NullsFirst |
-| NullsLast  |
-| Ascending  |
-| Descending |
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `add_months` | ✅ | |
+| `convert_timezone` | ✅ | |
+| `curdate` | ⬜ | |
+| `current_date` | ⬜ | |
+| `current_time` | ⬜ | |
+| `current_timestamp` | ⬜ | |
+| `current_timezone` | ✅ | |
+| `date_add` | ✅ | |
+| `date_diff` | ✅ | |
+| `date_format` | ✅ | |
+| `date_from_unix_date` | ✅ | |
+| `date_part` | ✅ | |
+| `date_sub` | ✅ | |
+| `date_trunc` | ✅ | |
+| `dateadd` | ✅ | |
+| `datediff` | ✅ | |
+| `datepart` | ✅ | |
+| `day` | ✅ | |
+| `dayname` | ⬜ | |
+| `dayofmonth` | ✅ | |
+| `dayofweek` | ✅ | |
+| `dayofyear` | ✅ | |
+| `extract` | ✅ | |
+| `from_unixtime` | ✅ | |
+| `from_utc_timestamp` | ⚠️ | Legacy zone forms (`GMT+1`, `PST`) throw a native parse error |
+| `hour` | ✅ | |
+| `last_day` | ✅ | |
+| `localtimestamp` | ✅ | |
+| `make_date` | ✅ | |
+| `make_dt_interval` | ⬜ | |
+| `make_interval` | ⬜ | |
+| `make_time` | ⬜ | |
+| `make_timestamp` | ✅ | |
+| `make_timestamp_ltz` | ⬜ | |
+| `make_timestamp_ntz` | ⬜ | |
+| `make_ym_interval` | ⬜ | |
+| `minute` | ✅ | |
+| `month` | ✅ | |
+| `monthname` | ⬜ | |
+| `months_between` | ✅ | |
+| `next_day` | ✅ | |
+| `now` | ⬜ | |
+| `quarter` | ✅ | |
+| `second` | ✅ | |
+| `session_window` | ⬜ | |
+| `time_diff` | ⬜ | |
+| `time_trunc` | ⬜ | |
+| `timestamp_micros` | ✅ | |
+| `timestamp_millis` | ✅ | |
+| `timestamp_seconds` | ✅ | |
+| `to_date` | ⬜ | |
+| `to_time` | ⬜ | |
+| `to_timestamp` | ⬜ | |
+| `to_timestamp_ltz` | ⬜ | |
+| `to_timestamp_ntz` | ⬜ | |
+| `to_unix_timestamp` | ✅ | |
+| `to_utc_timestamp` | ⚠️ | Legacy zone forms (`GMT+1`, `PST`) throw a native parse error |
+| `trunc` | ✅ | |
+| `try_make_interval` | ⬜ | |
+| `try_make_timestamp` | ⬜ | |
+| `try_to_date` | ⬜ | |
+| `try_to_time` | ⬜ | |
+| `try_to_timestamp` | ⬜ | |
+| `unix_date` | ✅ | |
+| `unix_micros` | ✅ | |
+| `unix_millis` | ✅ | |
+| `unix_seconds` | ✅ | |
+| `unix_timestamp` | ✅ | |
+| `weekday` | ✅ | |
+| `weekofyear` | ✅ | |
+| `window` | ⬜ | |
+| `window_time` | ⬜ | |
+| `year` | ✅ | |
 
-## Other
+---
 
-| Expression                   |
-| ---------------------------- |
-| Alias                        |
-| AttributeReference           |
-| BloomFilterMightContain      |
-| Coalesce                     |
-| CheckOverflow                |
-| KnownFloatingPointNormalized |
-| Literal                      |
-| MakeDecimal                  |
-| MonotonicallyIncreasingID    |
-| NormalizeNaNAndZero          |
-| PromotePrecision             |
-| RegExpReplace                |
-| ScalarSubquery               |
-| SparkPartitionID             |
-| ToPrettyString               |
-| UnscaledValue                |
+## generator_funcs
 
-[Comet Configuration Guide]: configs.md
-[Comet Compatibility Guide]: compatibility/expressions/index.md
+`explode` and `posexplode` are supported via `CometExplodeExec` (operator-level, not
+expression-level). The `outer` variants are wired but marked `Incompatible`; they require
+`spark.comet.exec.explode.enabled=true` and `allowIncompatible`.
+
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `explode` | ✅ | via `CometExplodeExec` |
+| `explode_outer` | ⚠️ | `outer=true` incompatible; needs `allowIncompatible` |
+| `inline` | ⬜ | |
+| `inline_outer` | ⬜ | |
+| `posexplode` | ✅ | via `CometExplodeExec` |
+| `posexplode_outer` | ⚠️ | `outer=true` incompatible; needs `allowIncompatible` |
+| `stack` | ⬜ | |
+
+---
+
+## hash_funcs
+
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `crc32` | ✅ | |
+| `hash` | ✅ | |
+| `md5` | ✅ | |
+| `sha` | ✅ | |
+| `sha1` | ✅ | |
+| `sha2` | ✅ | |
+| `xxhash64` | ✅ | |
+
+---
+
+## json_funcs
+
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `from_json` | 🚧 | [#3203](https://github.com/apache/datafusion-comet/issues/3203) |
+| `get_json_object` | ⚠️ | Single-quoted JSON and unescaped control chars require `allowIncompatible` |
+| `json_array_length` | 🚧 | tracking #4098 |
+| `json_object_keys` | 🚧 | [#3161](https://github.com/apache/datafusion-comet/issues/3161) |
+| `json_tuple` | 🚧 | [#3160](https://github.com/apache/datafusion-comet/issues/3160) |
+| `schema_of_json` | 🚧 | [#3163](https://github.com/apache/datafusion-comet/issues/3163) |
+| `to_json` | 🚧 | tracking #4098 |
+
+---
+
+## lambda_funcs
+
+All higher-order functions are planned via [#4224](https://github.com/apache/datafusion-comet/issues/4224).
+
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `aggregate` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `array_sort` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `exists` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `filter` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `forall` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `map_filter` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `map_zip_with` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `reduce` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `transform` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `transform_keys` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `transform_values` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+| `zip_with` | 🚧 | [#4224](https://github.com/apache/datafusion-comet/issues/4224) |
+
+---
+
+## map_funcs
+
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `element_at` | ⚠️ | Only `ArrayType` input; `MapType` input falls back |
+| `map` | ⬜ | |
+| `map_concat` | ⬜ | |
+| `map_contains_key` | ✅ | |
+| `map_entries` | ✅ | |
+| `map_from_arrays` | ✅ | |
+| `map_from_entries` | ⚠️ | `BinaryType` key/value falls back unless `allowIncompatible` |
+| `map_keys` | ✅ | |
+| `map_values` | ✅ | |
+| `str_to_map` | ✅ | |
+| `try_element_at` | ⬜ | |
+
+---
+
+## math_funcs
+
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `%` | ⚠️ | `try_mod` form (`EvalMode.TRY`) falls back ([#4484](https://github.com/apache/datafusion-comet/issues/4484)) |
+| `*` | ⚠️ | Interval multiplication falls back |
+| `+` | ✅ | |
+| `-` | ✅ | |
+| `/` | ✅ | |
+| `abs` | ⚠️ | Interval types fall back; ANSI overflow for integer min value |
+| `acos` | ✅ | |
+| `acosh` | ✅ | |
+| `asin` | ✅ | |
+| `asinh` | ✅ | |
+| `atan` | ✅ | |
+| `atan2` | ✅ | |
+| `atanh` | ✅ | |
+| `bin` | ✅ | |
+| `bround` | ⬜ | |
+| `cbrt` | ✅ | |
+| `ceil` | ⚠️ | Two-arg `ceil(expr, scale)` form falls back |
+| `ceiling` | ✅ | |
+| `conv` | ⬜ | |
+| `cos` | ✅ | |
+| `cosh` | ✅ | |
+| `cot` | ✅ | |
+| `csc` | ✅ | |
+| `degrees` | ✅ | |
+| `div` | ✅ | |
+| `e` | ⬜ | |
+| `exp` | ✅ | |
+| `expm1` | ✅ | |
+| `factorial` | ✅ | |
+| `floor` | ⚠️ | Two-arg `floor(expr, scale)` form falls back |
+| `greatest` | ✅ | |
+| `hex` | ✅ | |
+| `hypot` | ⬜ | |
+| `least` | ✅ | |
+| `ln` | ✅ | |
+| `log` | ✅ | |
+| `log10` | ✅ | |
+| `log1p` | ⬜ | |
+| `log2` | ✅ | |
+| `mod` | ✅ | |
+| `negative` | ✅ | |
+| `pi` | ✅ | |
+| `pmod` | ⬜ | |
+| `positive` | ✅ | |
+| `pow` | ✅ | |
+| `power` | ✅ | |
+| `radians` | ✅ | |
+| `rand` | ✅ | |
+| `randn` | ✅ | |
+| `random` | ⬜ | |
+| `randstr` | ⬜ | |
+| `rint` | ✅ | |
+| `round` | ⚠️ | Float/Double inputs always fall back; integer/decimal HALF_UP supported |
+| `sec` | ✅ | |
+| `shiftleft` | ✅ | |
+| `sign` | ✅ | |
+| `signum` | ✅ | |
+| `sin` | ✅ | |
+| `sinh` | ✅ | |
+| `sqrt` | ✅ | |
+| `tan` | ✅ | |
+| `tanh` | ✅ | |
+| `try_add` | ⚠️ | Datetime/interval form falls back; numeric form supported |
+| `try_divide` | ✅ | |
+| `try_mod` | ⬜ | |
+| `try_multiply` | ✅ | |
+| `try_subtract` | ✅ | |
+| `unhex` | ✅ | |
+| `uniform` | ⬜ | |
+| `width_bucket` | ⚠️ | Wired via shim, bypasses support-level framework ([#4485](https://github.com/apache/datafusion-comet/issues/4485)) |
+
+---
+
+## misc_funcs
+
+> 🚫 Out of scope: geospatial functions (`st_asbinary`, `st_geogfromwkb`, `st_geomfromwkb`, `st_setsrid`, `st_srid`). See [Scope policy](#scope-policy).
+
+> 🚫 Out of scope: Avro/Protobuf codec functions (`from_avro`, `to_avro`, `schema_of_avro`, `from_protobuf`, `to_protobuf`). See [Scope policy](#scope-policy).
+
+> 🚫 Out of scope: JVM reflection and cryptographic functions (`java_method`, `reflect`, `try_reflect`, `aes_encrypt`, `aes_decrypt`, `try_aes_decrypt`). See [Scope policy](#scope-policy).
+
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `approx_top_k_estimate` | 🚫 | Out of scope; see [Scope policy](#scope-policy) |
+| `assert_true` | ⬜ | |
+| `current_catalog` | ⬜ | |
+| `current_database` | ⬜ | |
+| `current_schema` | ⬜ | |
+| `current_user` | ⬜ | |
+| `equal_null` | ⬜ | |
+| `hll_sketch_estimate` | 🚫 | Out of scope; see [Scope policy](#scope-policy) |
+| `hll_union` | 🚫 | Out of scope; see [Scope policy](#scope-policy) |
+| `input_file_block_length` | ⬜ | |
+| `input_file_block_start` | ⬜ | |
+| `input_file_name` | ⬜ | |
+| `is_variant_null` | 🚧 | tracking #4098 |
+| `monotonically_increasing_id` | ✅ | |
+| `parse_json` | 🚧 | tracking #4098 |
+| `raise_error` | ⬜ | |
+| `rand` | ✅ | Seed must be a literal |
+| `randn` | ✅ | Seed must be a literal |
+| `schema_of_variant` | 🚧 | tracking #4098 |
+| `schema_of_variant_agg` | 🚧 | tracking #4098 |
+| `session_user` | ⬜ | |
+| `spark_partition_id` | ✅ | |
+| `theta_difference` | 🚫 | Out of scope; see [Scope policy](#scope-policy) |
+| `theta_intersection` | 🚫 | Out of scope; see [Scope policy](#scope-policy) |
+| `theta_sketch_estimate` | 🚫 | Out of scope; see [Scope policy](#scope-policy) |
+| `theta_union` | 🚫 | Out of scope; see [Scope policy](#scope-policy) |
+| `to_variant_object` | 🚧 | tracking #4098 |
+| `try_parse_json` | 🚧 | tracking #4098 |
+| `try_variant_get` | 🚧 | tracking #4098 |
+| `typeof` | ⬜ | |
+| `user` | ✅ | Resolved to a literal by the Spark analyzer before reaching Comet |
+| `uuid` | ⬜ | |
+| `variant_get` | 🚧 | tracking #4098 |
+| `version` | ⬜ | |
+
+---
+
+## predicate_funcs
+
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `!` | ✅ | |
+| `<` | ✅ | |
+| `<=` | ✅ | |
+| `<=>` | ✅ | |
+| `=` | ✅ | |
+| `==` | ✅ | |
+| `>` | ✅ | |
+| `>=` | ✅ | |
+| `and` | ✅ | |
+| `between` | ✅ | |
+| `ilike` | ✅ | |
+| `in` | ✅ | |
+| `isnan` | ✅ | |
+| `isnotnull` | ✅ | |
+| `isnull` | ✅ | |
+| `like` | ✅ | |
+| `not` | ✅ | |
+| `or` | ✅ | |
+| `regexp` | 🚧 | tracking #4098 |
+| `regexp_like` | 🚧 | tracking #4098 |
+| `rlike` | ⚠️ | Uses Rust `regex` crate; requires `allowIncompatible`; results may differ from Java `Pattern` |
+
+---
+
+## string_funcs
+
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `ascii` | ✅ | |
+| `base64` | ⬜ | |
+| `bit_length` | ✅ | |
+| `btrim` | ✅ | |
+| `char` | ✅ | |
+| `char_length` | ✅ | |
+| `character_length` | ✅ | |
+| `chr` | ✅ | |
+| `collate` | ⬜ | |
+| `collation` | ⬜ | |
+| `concat_ws` | ✅ | |
+| `contains` | ✅ | |
+| `decode` | ✅ | |
+| `elt` | ⬜ | |
+| `encode` | ⬜ | |
+| `endswith` | ✅ | |
+| `find_in_set` | ⬜ | |
+| `format_number` | ⬜ | |
+| `format_string` | ⬜ | |
+| `initcap` | ✅ | |
+| `instr` | ✅ | |
+| `is_valid_utf8` | ⬜ | |
+| `lcase` | ✅ | |
+| `left` | ✅ | |
+| `len` | ✅ | |
+| `length` | ✅ | |
+| `levenshtein` | ⬜ | |
+| `locate` | ⬜ | |
+| `lower` | ✅ | |
+| `lpad` | ✅ | |
+| `ltrim` | ✅ | |
+| `luhn_check` | ⬜ | |
+| `make_valid_utf8` | ⬜ | |
+| `mask` | ⬜ | |
+| `octet_length` | ✅ | |
+| `overlay` | ⬜ | |
+| `position` | ⬜ | |
+| `printf` | ⬜ | |
+| `quote` | ⬜ | |
+| `regexp_count` | 🚧 | tracking #4098 |
+| `regexp_extract` | 🚧 | tracking #4098 |
+| `regexp_extract_all` | 🚧 | tracking #4098 |
+| `regexp_instr` | 🚧 | tracking #4098 |
+| `regexp_replace` | ✅ | |
+| `regexp_substr` | 🚧 | tracking #4098 |
+| `repeat` | ✅ | |
+| `replace` | ✅ | |
+| `right` | ✅ | |
+| `rpad` | ✅ | |
+| `rtrim` | ✅ | |
+| `sentences` | ⬜ | |
+| `soundex` | ⬜ | |
+| `space` | ✅ | |
+| `split` | ✅ | |
+| `split_part` | ⬜ | |
+| `startswith` | ✅ | |
+| `substr` | ✅ | |
+| `substring` | ✅ | |
+| `substring_index` | ✅ | |
+| `to_binary` | ⬜ | |
+| `to_char` | ⬜ | |
+| `to_number` | ⬜ | |
+| `to_varchar` | ⬜ | |
+| `translate` | ✅ | |
+| `trim` | ✅ | |
+| `try_to_binary` | ⬜ | |
+| `try_to_number` | ⬜ | |
+| `try_validate_utf8` | ⬜ | |
+| `ucase` | ✅ | |
+| `unbase64` | ⬜ | |
+| `upper` | ✅ | |
+| `validate_utf8` | ⬜ | |
+
+---
+
+## struct_funcs
+
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `named_struct` | ⚠️ | Duplicate field names fall back to Spark |
+| `struct` | ✅ | |
+
+---
+
+## url_funcs
+
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `parse_url` | ✅ | |
+| `try_url_decode` | ✅ | |
+| `url_decode` | ✅ | |
+| `url_encode` | ✅ | |
+
+---
+
+## window_funcs
+
+Window functions run via `CometWindowExec`. Window support is disabled by default due to known
+correctness issues (tracking [#2721](https://github.com/apache/datafusion-comet/issues/2721)).
+When enabled, `lag` and `lead` are explicitly wired; aggregate window functions (`count`, `min`,
+`max`, `sum`) are also supported. Ranking functions (`rank`, `dense_rank`, `row_number`,
+`ntile`, `percent_rank`, `cume_dist`, `nth_value`) are not yet wired in the window serde and
+fall back to Spark.
+
+| Function | Status | Notes |
+| -------- | ------ | ----- |
+| `cume_dist` | ⬜ | Not yet wired in window serde |
+| `dense_rank` | ⬜ | Not yet wired in window serde |
+| `lag` | ✅ | via `CometWindowExec` |
+| `lead` | ✅ | via `CometWindowExec` |
+| `nth_value` | ⬜ | Not yet wired in window serde |
+| `ntile` | ⬜ | Not yet wired in window serde |
+| `percent_rank` | ⬜ | Not yet wired in window serde |
+| `rank` | ⬜ | Not yet wired in window serde |
+| `row_number` | ⬜ | Not yet wired in window serde |
+
+---
+
+## xml_funcs
+
+🚫 **Out of scope.** `from_xml`, `to_xml`, `schema_of_xml`, and the `xpath*` family fall back to Spark. See [Scope policy](#scope-policy).
+
+---
+
+## See also
+
+- [Comet Compatibility Guide](compatibility/index.md) - known incompatibilities and edge cases for ⚠️ expressions.
+- [Spark Expressions Support (contributor guide)](../../contributor-guide/spark_expressions_support.md) - per-version (Spark 3.4 / 3.5 / 4.0 / 4.1) audit notes for each expression.


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

- Use SQL function name rather than Spark class name - more appropriate for end users and easier to reconcile to Spark code
- Show all Spark expressions and current Comet status (supported, supported with incompatibilities, out of scope, etc)

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

See [rendered version](https://github.com/andygrove/datafusion-comet/blob/docs-expression-support-reference/docs/source/user-guide/latest/expressions.md).

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
