### PR TITLE
fix: mark non-UTF8_BINARY collations as Incompatible for concat and reverse

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/collectionOperations.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/collectionOperations.scala
@@ -23,15 +23,25 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, Reverse}
 import org.apache.spark.sql.types.ArrayType
 
 import org.apache.comet.serde.ExprOuterClass.Expr
+import org.apache.comet.shims.CometTypeShim
 
-object CometReverse extends CometScalarFunction[Reverse]("reverse") {
+object CometReverse extends CometScalarFunction[Reverse]("reverse") with CometTypeShim {
+
+  // Spark 4.0 widens the string branch of Reverse to accept collated strings and propagates the
+  // collation through dataType. The native reverse UDF reverses code units and produces UTF8
+  // (UTF8_BINARY semantics), so a non-default collation diverges from Spark.
+  private val collationReason =
+    "reverse does not support non-UTF8_BINARY collations " +
+      "(https://github.com/apache/datafusion-comet/issues/2190)"
 
   override def getIncompatibleReasons(): Seq[String] =
-    CometArrayReverse.getIncompatibleReasons()
+    CometArrayReverse.getIncompatibleReasons() :+ collationReason
 
   override def getSupportLevel(expr: Reverse): SupportLevel = {
     if (expr.child.dataType.isInstanceOf[ArrayType]) {
       CometArrayReverse.getSupportLevel(expr)
+    } else if (hasNonDefaultStringCollation(expr.child.dataType)) {
+      Incompatible(Some(collationReason))
     } else {
       Compatible()
     }

--- a/spark/src/main/scala/org/apache/comet/serde/strings.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/strings.scala
@@ -30,6 +30,7 @@ import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
 import org.apache.comet.expressions.{CometCast, CometEvalMode, RegExp}
 import org.apache.comet.serde.ExprOuterClass.Expr
 import org.apache.comet.serde.QueryPlanSerde.{createBinaryExpr, exprToProtoInternal, optExprWithFallbackReason, scalarFunctionExprToProto, scalarFunctionExprToProtoWithReturnType}
+import org.apache.comet.shims.CometTypeShim
 
 object CometStringRepeat extends CometExpressionSerde[StringRepeat] {
 
@@ -223,16 +224,32 @@ object CometRight extends CometExpressionSerde[Right] {
   }
 }
 
-object CometConcat extends CometScalarFunction[Concat]("concat") {
+object CometConcat extends CometScalarFunction[Concat]("concat") with CometTypeShim {
   private val unsupportedReason = "CONCAT supports only string input parameters"
+
+  // Spark 4.0 widens Concat to accept collated strings and preserves the collation in the merged
+  // result type. The native concat UDF always produces UTF8 (UTF8_BINARY semantics), so a
+  // non-default collation diverges from Spark.
+  private val collationReason =
+    "concat does not support non-UTF8_BINARY collations " +
+      "(https://github.com/apache/datafusion-comet/issues/2190)"
 
   override def getUnsupportedReasons(): Seq[String] = Seq(unsupportedReason)
 
+  override def getIncompatibleReasons(): Seq[String] = Seq(collationReason)
+
   override def getSupportLevel(expr: Concat): SupportLevel = {
-    if (expr.children.forall(_.dataType == DataTypes.StringType)) {
-      Compatible()
-    } else {
+    // Use isInstanceOf rather than `== DataTypes.StringType` so that collated strings (a
+    // StringType with a non-default collationId, which is not == the default StringType) are still
+    // recognised as string input and routed to the collation check below rather than reported as
+    // an unsupported input type.
+    if (!expr.children.forall(_.dataType.isInstanceOf[StringType])) {
       Unsupported(Some(unsupportedReason))
+    } else if (hasNonDefaultStringCollation(expr.dataType) ||
+      expr.children.exists(c => hasNonDefaultStringCollation(c.dataType))) {
+      Incompatible(Some(collationReason))
+    } else {
+      Compatible()
     }
   }
 }

--- a/spark/src/test/resources/sql-tests/expressions/string/collation.sql
+++ b/spark/src/test/resources/sql-tests/expressions/string/collation.sql
@@ -31,3 +31,12 @@ SELECT collation('hello' COLLATE UTF8_BINARY)
 -- collation of a NULL string
 query
 SELECT collation(CAST(NULL AS STRING))
+
+-- concat preserves a non-default collation in its result type, but Comet's native concat produces
+-- UTF8_BINARY, so it is Incompatible and falls back to Spark by default.
+query expect_fallback(concat does not support non-UTF8_BINARY collations)
+SELECT concat('Hello' COLLATE UTF8_LCASE, 'World' COLLATE UTF8_LCASE)
+
+-- reverse on a collated string is likewise Incompatible and falls back to Spark by default.
+query expect_fallback(reverse does not support non-UTF8_BINARY collations)
+SELECT reverse('Hello' COLLATE UTF8_LCASE)

--- a/spark/src/test/resources/sql-tests/expressions/string/collation.sql
+++ b/spark/src/test/resources/sql-tests/expressions/string/collation.sql
@@ -40,3 +40,11 @@ SELECT concat('Hello' COLLATE UTF8_LCASE, 'World' COLLATE UTF8_LCASE)
 -- reverse on a collated string is likewise Incompatible and falls back to Spark by default.
 query expect_fallback(reverse does not support non-UTF8_BINARY collations)
 SELECT reverse('Hello' COLLATE UTF8_LCASE)
+
+-- A standard ICU collation (UNICODE_CI) falls back the same way, confirming the gate covers
+-- any non-UTF8_BINARY collation rather than just UTF8_LCASE.
+query expect_fallback(concat does not support non-UTF8_BINARY collations)
+SELECT concat('Hello' COLLATE UNICODE_CI, 'World' COLLATE UNICODE_CI)
+
+query expect_fallback(reverse does not support non-UTF8_BINARY collations)
+SELECT reverse('Hello' COLLATE UNICODE_CI)


### PR DESCRIPTION
## Which issue does this PR close?

Addresses the collation-related items (1, 2, and 3) of #4504. The remaining medium-priority items in that tracking issue (the `array/size.sql` MapType test and the `CometSize` defensive branch) are not collation-related and are left for a separate change, so this PR does not close #4504.

## Rationale for this change

Spark 4.0 widened `Concat.allowedTypes` and the string branch of `Reverse.inputTypes` from `StringType` to `StringTypeWithCollation`, and both preserve the collation in their result type. Comet's native `concat`/`reverse` UDFs operate on raw bytes and produce `Utf8` (UTF8_BINARY semantics), so for a non-default (non-UTF8_BINARY) collation the native result silently diverges from Spark. Per the `audit-comet-expression` conventions, such Spark 4.0+ collation gaps must surface as `Incompatible(Some(reason))` so the divergence appears in EXPLAIN and the generated compatibility doc, and so the expression falls back to Spark by default.

## What changes are included in this PR?

- **`CometConcat`** (item 1): now reports `Incompatible` when any child or the result carries a non-default collation. The string-input check uses `isInstanceOf[StringType]` instead of `== DataTypes.StringType`, because a collated `StringType` is not equal to the default `StringType` and was otherwise misreported via the unsupported-input-type branch. `getIncompatibleReasons` lists the new reason.
- **`CometReverse`** (item 2): the non-array (string) branch now reports `Incompatible` when the child carries a non-default collation.
- **`CometReverse.getIncompatibleReasons`** (item 3): now appends the string-collation reason to the array-branch reason so every `Incompatible(Some(r))` branch is represented (reaches EXPLAIN and the compatibility doc).

Both reasons are concise and link to the collation tracking issue #2190.

## How are these changes tested?

Added `expect_fallback` cases to `spark/src/test/resources/sql-tests/expressions/string/collation.sql` (already gated `MinSparkVersion: 4.0`) asserting that `concat`/`reverse` on `UTF8_LCASE` strings fall back to Spark with the expected reason. Verified on Spark 4.1; confirmed `concat`/`reverse` remain `Compatible` and the existing fixtures still pass on both Spark 3.5 and 4.1, and that the collation file is correctly skipped on 3.5.