### PR TITLE
docs: fix conflicting status legend and inconsistent issue links in expressions.md

### DIFF
--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -24,9 +24,12 @@ expression. Comet accelerates expressions either with a native (Rust) implementa
 dispatching to a Spark-compatible codegen path. When an expression is not supported, Comet
 transparently falls back to Spark for that part of the plan; results are unaffected.
 
-Expressions marked ✅ Supported are enabled by default. Expressions marked ⚠️ Supported
-(caveats) include cases that are known to diverge from Spark; those cases fall back to Spark
-by default and must be opted into per expression with
+Expressions marked ✅ Supported are enabled by default and produce Spark-compatible results.
+Expressions marked ⚠️ Incorrect by default run natively by default but can return results that
+differ from Spark on some inputs; see the linked detail on each affected row.
+
+Some ✅ Supported expressions have specific incompatible cases that fall back to Spark by
+default. Those cases must be opted into per expression with
 `spark.comet.expression.EXPRNAME.allowIncompatible=true` (where `EXPRNAME` is the Spark
 expression class name, for example `Cast`). There is no global opt-in.
 
@@ -64,66 +67,66 @@ The tables below list every Spark built-in expression with its current status.
 
 ## agg_funcs
 
-| Function                | Status | Notes                                                            |
-| ----------------------- | ------ | ---------------------------------------------------------------- |
-| `any`                   | ✅     |                                                                  |
-| `any_value`             | ✅     |                                                                  |
-| `approx_count_distinct` | 🔜     | tracking #4098                                                   |
-| `array_agg`             | 🔜     | Array aggregate (related to `collect_list`, #2524)               |
-| `avg`                   | ✅     | Interval types fall back                                         |
-| `bit_and`               | ✅     |                                                                  |
-| `bit_or`                | ✅     |                                                                  |
-| `bit_xor`               | ✅     |                                                                  |
-| `bool_and`              | ✅     |                                                                  |
-| `bool_or`               | ✅     |                                                                  |
-| `collect_list`          | 🔜     | [#2524](https://github.com/apache/datafusion-comet/issues/2524)  |
-| `collect_set`           | ✅     |                                                                  |
-| `corr`                  | ✅     |                                                                  |
-| `count`                 | ✅     |                                                                  |
-| `count_if`              | ✅     |                                                                  |
-| `covar_pop`             | ✅     |                                                                  |
-| `covar_samp`            | ✅     |                                                                  |
-| `every`                 | ✅     |                                                                  |
-| `first`                 | ✅     |                                                                  |
-| `first_value`           | ✅     |                                                                  |
-| `grouping`              | 🔜     | Grouping indicator for ROLLUP/CUBE/GROUPING SETS                 |
-| `grouping_id`           | 🔜     | Grouping indicator for ROLLUP/CUBE/GROUPING SETS                 |
-| `kurtosis`              | 🔜     | tracking #4098                                                   |
-| `last`                  | ✅     |                                                                  |
-| `last_value`            | ✅     |                                                                  |
-| `listagg`               | 🔜     | String aggregation                                               |
-| `max`                   | ✅     |                                                                  |
-| `max_by`                | 🔜     | [#3841](https://github.com/apache/datafusion-comet/issues/3841)  |
-| `mean`                  | ✅     |                                                                  |
-| `median`                | 🔜     | tracking #4098                                                   |
-| `min`                   | ✅     |                                                                  |
-| `min_by`                | 🔜     | [#3841](https://github.com/apache/datafusion-comet/issues/3841)  |
-| `mode`                  | 🔜     | [#3970](https://github.com/apache/datafusion-comet/issues/3970)  |
-| `percentile`            | 🔜     | #4542                                                            |
-| `percentile_cont`       | 🔜     | Percentile aggregate                                             |
-| `percentile_disc`       | 🔜     | Percentile aggregate                                             |
-| `regr_avgx`             | ✅     | Native: Spark rewrites to `Average` (tests in #4551)             |
-| `regr_avgy`             | ✅     | Native: Spark rewrites to `Average` (tests in #4551)             |
-| `regr_count`            | ✅     | Native: Spark rewrites to `Count` (tests in #4551)               |
-| `regr_intercept`        | 🔜     | Falls back; can reuse `covar_pop`/`var_pop` accumulators (#4552) |
-| `regr_r2`               | 🔜     | Falls back; can reuse the `corr` accumulator (#4552)             |
-| `regr_slope`            | 🔜     | Falls back; can reuse `covar_pop`/`var_pop` accumulators (#4552) |
-| `regr_sxx`              | 🔜     | Falls back; can reuse `var_pop` accumulator (#4552)              |
-| `regr_sxy`              | 🔜     | Falls back; can reuse `covar_pop` accumulator (#4552)            |
-| `regr_syy`              | 🔜     | Falls back; can reuse `var_pop` accumulator (#4552)              |
-| `skewness`              | 🔜     | tracking #4098                                                   |
-| `some`                  | ✅     |                                                                  |
-| `std`                   | ✅     |                                                                  |
-| `stddev`                | ✅     |                                                                  |
-| `stddev_pop`            | ✅     |                                                                  |
-| `stddev_samp`           | ✅     |                                                                  |
-| `string_agg`            | 🔜     | String aggregation (alias of `listagg`)                          |
-| `sum`                   | ✅     |                                                                  |
-| `try_avg`               | 🔜     | tracking #4098                                                   |
-| `try_sum`               | 🔜     | tracking #4098                                                   |
-| `var_pop`               | ✅     |                                                                  |
-| `var_samp`              | ✅     |                                                                  |
-| `variance`              | ✅     |                                                                  |
+| Function                | Status | Notes                                                                                                                      |
+| ----------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `any`                   | ✅     |                                                                                                                            |
+| `any_value`             | ✅     |                                                                                                                            |
+| `approx_count_distinct` | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                   |
+| `array_agg`             | 🔜     | Array aggregate (related to `collect_list`, [#2524](https://github.com/apache/datafusion-comet/issues/2524))               |
+| `avg`                   | ✅     | Interval types fall back                                                                                                   |
+| `bit_and`               | ✅     |                                                                                                                            |
+| `bit_or`                | ✅     |                                                                                                                            |
+| `bit_xor`               | ✅     |                                                                                                                            |
+| `bool_and`              | ✅     |                                                                                                                            |
+| `bool_or`               | ✅     |                                                                                                                            |
+| `collect_list`          | 🔜     | [#2524](https://github.com/apache/datafusion-comet/issues/2524)                                                            |
+| `collect_set`           | ✅     |                                                                                                                            |
+| `corr`                  | ✅     |                                                                                                                            |
+| `count`                 | ✅     |                                                                                                                            |
+| `count_if`              | ✅     |                                                                                                                            |
+| `covar_pop`             | ✅     |                                                                                                                            |
+| `covar_samp`            | ✅     |                                                                                                                            |
+| `every`                 | ✅     |                                                                                                                            |
+| `first`                 | ✅     |                                                                                                                            |
+| `first_value`           | ✅     |                                                                                                                            |
+| `grouping`              | 🔜     | Grouping indicator for ROLLUP/CUBE/GROUPING SETS                                                                           |
+| `grouping_id`           | 🔜     | Grouping indicator for ROLLUP/CUBE/GROUPING SETS                                                                           |
+| `kurtosis`              | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                   |
+| `last`                  | ✅     |                                                                                                                            |
+| `last_value`            | ✅     |                                                                                                                            |
+| `listagg`               | 🔜     | String aggregation                                                                                                         |
+| `max`                   | ✅     |                                                                                                                            |
+| `max_by`                | 🔜     | [#3841](https://github.com/apache/datafusion-comet/issues/3841)                                                            |
+| `mean`                  | ✅     |                                                                                                                            |
+| `median`                | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                   |
+| `min`                   | ✅     |                                                                                                                            |
+| `min_by`                | 🔜     | [#3841](https://github.com/apache/datafusion-comet/issues/3841)                                                            |
+| `mode`                  | 🔜     | [#3970](https://github.com/apache/datafusion-comet/issues/3970)                                                            |
+| `percentile`            | 🔜     | [#4542](https://github.com/apache/datafusion-comet/issues/4542)                                                            |
+| `percentile_cont`       | 🔜     | Percentile aggregate                                                                                                       |
+| `percentile_disc`       | 🔜     | Percentile aggregate                                                                                                       |
+| `regr_avgx`             | ✅     | Native: Spark rewrites to `Average` (tests in [#4551](https://github.com/apache/datafusion-comet/issues/4551))             |
+| `regr_avgy`             | ✅     | Native: Spark rewrites to `Average` (tests in [#4551](https://github.com/apache/datafusion-comet/issues/4551))             |
+| `regr_count`            | ✅     | Native: Spark rewrites to `Count` (tests in [#4551](https://github.com/apache/datafusion-comet/issues/4551))               |
+| `regr_intercept`        | 🔜     | Falls back; can reuse `covar_pop`/`var_pop` accumulators ([#4552](https://github.com/apache/datafusion-comet/issues/4552)) |
+| `regr_r2`               | 🔜     | Falls back; can reuse the `corr` accumulator ([#4552](https://github.com/apache/datafusion-comet/issues/4552))             |
+| `regr_slope`            | 🔜     | Falls back; can reuse `covar_pop`/`var_pop` accumulators ([#4552](https://github.com/apache/datafusion-comet/issues/4552)) |
+| `regr_sxx`              | 🔜     | Falls back; can reuse `var_pop` accumulator ([#4552](https://github.com/apache/datafusion-comet/issues/4552))              |
+| `regr_sxy`              | 🔜     | Falls back; can reuse `covar_pop` accumulator ([#4552](https://github.com/apache/datafusion-comet/issues/4552))            |
+| `regr_syy`              | 🔜     | Falls back; can reuse `var_pop` accumulator ([#4552](https://github.com/apache/datafusion-comet/issues/4552))              |
+| `skewness`              | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                   |
+| `some`                  | ✅     |                                                                                                                            |
+| `std`                   | ✅     |                                                                                                                            |
+| `stddev`                | ✅     |                                                                                                                            |
+| `stddev_pop`            | ✅     |                                                                                                                            |
+| `stddev_samp`           | ✅     |                                                                                                                            |
+| `string_agg`            | 🔜     | String aggregation (alias of `listagg`)                                                                                    |
+| `sum`                   | ✅     |                                                                                                                            |
+| `try_avg`               | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                   |
+| `try_sum`               | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                   |
+| `var_pop`               | ✅     |                                                                                                                            |
+| `var_samp`              | ✅     |                                                                                                                            |
+| `variance`              | ✅     |                                                                                                                            |
 
 ---
 
@@ -152,9 +155,9 @@ The tables below list every Spark built-in expression with its current status.
 | `element_at`      | ✅     | MapType input falls back                                                            |
 | `flatten`         | ✅     | Binary/struct/map elements fall back                                                |
 | `get`             | ✅     |                                                                                     |
-| `sequence`        | 🔜     | #4538                                                                               |
+| `sequence`        | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                     |
 | `shuffle`         | 🔜     | Random array shuffle                                                                |
-| `slice`           | ✅     | Native (#4149)                                                                      |
+| `slice`           | ✅     | Native ([#4149](https://github.com/apache/datafusion-comet/issues/4149))            |
 | `sort_array`      | ✅     | Nested struct/null arrays fall back                                                 |
 
 ---
@@ -192,18 +195,18 @@ The tables below list every Spark built-in expression with its current status.
 
 ## conditional_funcs
 
-| Function     | Status | Notes                             |
-| ------------ | ------ | --------------------------------- |
-| `coalesce`   | ✅     |                                   |
-| `if`         | ✅     |                                   |
-| `ifnull`     | ✅     |                                   |
-| `nanvl`      | 🔜     | #4538                             |
-| `nullif`     | ✅     |                                   |
-| `nullifzero` | ✅     | Lowers to `if`/`=` (Spark 4.0+)   |
-| `nvl`        | ✅     |                                   |
-| `nvl2`       | ✅     |                                   |
-| `when`       | ✅     |                                   |
-| `zeroifnull` | ✅     | Lowers to `coalesce` (Spark 4.0+) |
+| Function     | Status | Notes                                                           |
+| ------------ | ------ | --------------------------------------------------------------- |
+| `coalesce`   | ✅     |                                                                 |
+| `if`         | ✅     |                                                                 |
+| `ifnull`     | ✅     |                                                                 |
+| `nanvl`      | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538) |
+| `nullif`     | ✅     |                                                                 |
+| `nullifzero` | ✅     | Lowers to `if`/`=` (Spark 4.0+)                                 |
+| `nvl`        | ✅     |                                                                 |
+| `nvl2`       | ✅     |                                                                 |
+| `when`       | ✅     |                                                                 |
+| `zeroifnull` | ✅     | Lowers to `coalesce` (Spark 4.0+)                               |
 
 ---
 
@@ -219,81 +222,81 @@ The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `deci
 
 ## datetime_funcs
 
-| Function              | Status | Notes                                                                                                                      |
-| --------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `add_months`          | ✅     |                                                                                                                            |
-| `convert_timezone`    | ✅     |                                                                                                                            |
-| `curdate`             | ✅     | Constant-folded to a literal (alias of `current_date`)                                                                     |
-| `current_date`        | ✅     | Constant-folded to a literal before Comet sees the plan                                                                    |
-| `current_time`        | 🔜     | Blocked on Spark 4.1 TIME type support (#4288)                                                                             |
-| `current_timestamp`   | ✅     | Constant-folded to a literal before Comet sees the plan                                                                    |
-| `current_timezone`    | ✅     |                                                                                                                            |
-| `date_add`            | ✅     |                                                                                                                            |
-| `date_diff`           | ✅     |                                                                                                                            |
-| `date_format`         | ✅     |                                                                                                                            |
-| `date_from_unix_date` | ✅     |                                                                                                                            |
-| `date_part`           | ✅     |                                                                                                                            |
-| `date_sub`            | ✅     |                                                                                                                            |
-| `date_trunc`          | ✅     |                                                                                                                            |
-| `dateadd`             | ✅     |                                                                                                                            |
-| `datediff`            | ✅     |                                                                                                                            |
-| `datepart`            | ✅     |                                                                                                                            |
-| `day`                 | ✅     |                                                                                                                            |
-| `dayname`             | 🔜     | #4544                                                                                                                      |
-| `dayofmonth`          | ✅     |                                                                                                                            |
-| `dayofweek`           | ✅     |                                                                                                                            |
-| `dayofyear`           | ✅     |                                                                                                                            |
-| `extract`             | ✅     |                                                                                                                            |
-| `from_unixtime`       | ✅     |                                                                                                                            |
-| `from_utc_timestamp`  | ✅     | Legacy zone forms fall back (Incompatible) ([details](compatibility/expressions/datetime.md))                              |
-| `hour`                | ✅     |                                                                                                                            |
-| `last_day`            | ✅     |                                                                                                                            |
-| `localtimestamp`      | ✅     |                                                                                                                            |
-| `make_date`           | ✅     |                                                                                                                            |
-| `make_dt_interval`    | 🔜     | #4541                                                                                                                      |
-| `make_interval`       | 🔜     | Produces legacy CalendarInterval; tracked by #4540                                                                         |
-| `make_time`           | 🔜     | Spark 4.1 TIME type; tracked by #4288                                                                                      |
-| `make_timestamp`      | ✅     |                                                                                                                            |
-| `make_timestamp_ltz`  | ✅     | 2-arg TIME form falls back                                                                                                 |
-| `make_timestamp_ntz`  | ✅     | 2-arg TIME form falls back                                                                                                 |
-| `make_ym_interval`    | 🔜     | #4541                                                                                                                      |
-| `minute`              | ✅     |                                                                                                                            |
-| `month`               | ✅     |                                                                                                                            |
-| `monthname`           | 🔜     | #4544                                                                                                                      |
-| `months_between`      | ✅     |                                                                                                                            |
-| `next_day`            | ✅     |                                                                                                                            |
-| `now`                 | ✅     | Constant-folded to a literal (alias of `current_timestamp`)                                                                |
-| `quarter`             | ✅     |                                                                                                                            |
-| `second`              | ✅     |                                                                                                                            |
-| `session_window`      | 🔜     | Time-window grouping; tracked by #4553                                                                                     |
-| `time_diff`           | 🔜     | Spark 4.1 TIME type; tracked by #4288                                                                                      |
-| `time_trunc`          | 🔜     | Spark 4.1 TIME type; tracked by #4288                                                                                      |
-| `timestamp_micros`    | ✅     |                                                                                                                            |
-| `timestamp_millis`    | ✅     |                                                                                                                            |
-| `timestamp_seconds`   | ✅     |                                                                                                                            |
-| `to_date`             | ✅     | Rewrites to `Cast` (or `Cast(GetTimestamp)` with a format) before Comet sees the plan                                      |
-| `to_time`             | 🔜     | Spark 4.1 TIME type; tracked by #4288                                                                                      |
-| `to_timestamp`        | ✅     | Rewrites to `Cast` (or `GetTimestamp` with a format) before Comet sees the plan                                            |
-| `to_timestamp_ltz`    | ✅     | Rewrites to `to_timestamp` (`TimestampType`)                                                                               |
-| `to_timestamp_ntz`    | ✅     | Rewrites to `to_timestamp` (`TimestampNTZType`)                                                                            |
-| `to_unix_timestamp`   | ✅     |                                                                                                                            |
-| `to_utc_timestamp`    | ✅     | Legacy zone forms fall back (Incompatible) ([details](compatibility/expressions/datetime.md))                              |
-| `trunc`               | ✅     |                                                                                                                            |
-| `try_make_interval`   | 🔜     | Produces legacy CalendarInterval; tracked by #4540                                                                         |
-| `try_make_timestamp`  | ⚠️     | Returns a wrong value instead of NULL for invalid inputs ([#4554](https://github.com/apache/datafusion-comet/issues/4554)) |
-| `try_to_date`         | 🔜     | Rewrites to `Cast`/`GetTimestamp` but currently falls back; tracked by #4556                                               |
-| `try_to_time`         | 🔜     | Spark 4.1 TIME type; tracked by #4288                                                                                      |
-| `try_to_timestamp`    | 🔜     | Rewrites to `Cast`/`GetTimestamp` but currently falls back; tracked by #4556                                               |
-| `unix_date`           | ✅     |                                                                                                                            |
-| `unix_micros`         | ✅     |                                                                                                                            |
-| `unix_millis`         | ✅     |                                                                                                                            |
-| `unix_seconds`        | ✅     |                                                                                                                            |
-| `unix_timestamp`      | ✅     |                                                                                                                            |
-| `weekday`             | ✅     |                                                                                                                            |
-| `weekofyear`          | ✅     |                                                                                                                            |
-| `window`              | 🔜     | Time-window grouping; tracked by #4553                                                                                     |
-| `window_time`         | 🔜     | Time-window grouping; tracked by #4553                                                                                     |
-| `year`                | ✅     |                                                                                                                            |
+| Function              | Status | Notes                                                                                                                                  |
+| --------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `add_months`          | ✅     |                                                                                                                                        |
+| `convert_timezone`    | ✅     |                                                                                                                                        |
+| `curdate`             | ✅     | Constant-folded to a literal (alias of `current_date`)                                                                                 |
+| `current_date`        | ✅     | Constant-folded to a literal before Comet sees the plan                                                                                |
+| `current_time`        | 🔜     | Blocked on Spark 4.1 TIME type support ([#4288](https://github.com/apache/datafusion-comet/issues/4288))                               |
+| `current_timestamp`   | ✅     | Constant-folded to a literal before Comet sees the plan                                                                                |
+| `current_timezone`    | ✅     |                                                                                                                                        |
+| `date_add`            | ✅     |                                                                                                                                        |
+| `date_diff`           | ✅     |                                                                                                                                        |
+| `date_format`         | ✅     |                                                                                                                                        |
+| `date_from_unix_date` | ✅     |                                                                                                                                        |
+| `date_part`           | ✅     |                                                                                                                                        |
+| `date_sub`            | ✅     |                                                                                                                                        |
+| `date_trunc`          | ✅     |                                                                                                                                        |
+| `dateadd`             | ✅     |                                                                                                                                        |
+| `datediff`            | ✅     |                                                                                                                                        |
+| `datepart`            | ✅     |                                                                                                                                        |
+| `day`                 | ✅     |                                                                                                                                        |
+| `dayname`             | 🔜     | [#4544](https://github.com/apache/datafusion-comet/issues/4544)                                                                        |
+| `dayofmonth`          | ✅     |                                                                                                                                        |
+| `dayofweek`           | ✅     |                                                                                                                                        |
+| `dayofyear`           | ✅     |                                                                                                                                        |
+| `extract`             | ✅     |                                                                                                                                        |
+| `from_unixtime`       | ✅     |                                                                                                                                        |
+| `from_utc_timestamp`  | ✅     | Legacy zone forms fall back (Incompatible) ([details](compatibility/expressions/datetime.md))                                          |
+| `hour`                | ✅     |                                                                                                                                        |
+| `last_day`            | ✅     |                                                                                                                                        |
+| `localtimestamp`      | ✅     |                                                                                                                                        |
+| `make_date`           | ✅     |                                                                                                                                        |
+| `make_dt_interval`    | 🔜     | [#4541](https://github.com/apache/datafusion-comet/issues/4541)                                                                        |
+| `make_interval`       | 🔜     | Produces legacy CalendarInterval; tracked by [#4540](https://github.com/apache/datafusion-comet/issues/4540)                           |
+| `make_time`           | 🔜     | Spark 4.1 TIME type; tracked by [#4288](https://github.com/apache/datafusion-comet/issues/4288)                                        |
+| `make_timestamp`      | ✅     |                                                                                                                                        |
+| `make_timestamp_ltz`  | ✅     | 2-arg TIME form falls back                                                                                                             |
+| `make_timestamp_ntz`  | ✅     | 2-arg TIME form falls back                                                                                                             |
+| `make_ym_interval`    | 🔜     | [#4541](https://github.com/apache/datafusion-comet/issues/4541)                                                                        |
+| `minute`              | ✅     |                                                                                                                                        |
+| `month`               | ✅     |                                                                                                                                        |
+| `monthname`           | 🔜     | [#4544](https://github.com/apache/datafusion-comet/issues/4544)                                                                        |
+| `months_between`      | ✅     |                                                                                                                                        |
+| `next_day`            | ✅     |                                                                                                                                        |
+| `now`                 | ✅     | Constant-folded to a literal (alias of `current_timestamp`)                                                                            |
+| `quarter`             | ✅     |                                                                                                                                        |
+| `second`              | ✅     |                                                                                                                                        |
+| `session_window`      | 🔜     | Time-window grouping; tracked by [#4553](https://github.com/apache/datafusion-comet/issues/4553)                                       |
+| `time_diff`           | 🔜     | Spark 4.1 TIME type; tracked by [#4288](https://github.com/apache/datafusion-comet/issues/4288)                                        |
+| `time_trunc`          | 🔜     | Spark 4.1 TIME type; tracked by [#4288](https://github.com/apache/datafusion-comet/issues/4288)                                        |
+| `timestamp_micros`    | ✅     |                                                                                                                                        |
+| `timestamp_millis`    | ✅     |                                                                                                                                        |
+| `timestamp_seconds`   | ✅     |                                                                                                                                        |
+| `to_date`             | ✅     | Rewrites to `Cast` (or `Cast(GetTimestamp)` with a format) before Comet sees the plan                                                  |
+| `to_time`             | 🔜     | Spark 4.1 TIME type; tracked by [#4288](https://github.com/apache/datafusion-comet/issues/4288)                                        |
+| `to_timestamp`        | ✅     | Rewrites to `Cast` (or `GetTimestamp` with a format) before Comet sees the plan                                                        |
+| `to_timestamp_ltz`    | ✅     | Rewrites to `to_timestamp` (`TimestampType`)                                                                                           |
+| `to_timestamp_ntz`    | ✅     | Rewrites to `to_timestamp` (`TimestampNTZType`)                                                                                        |
+| `to_unix_timestamp`   | ✅     |                                                                                                                                        |
+| `to_utc_timestamp`    | ✅     | Legacy zone forms fall back (Incompatible) ([details](compatibility/expressions/datetime.md))                                          |
+| `trunc`               | ✅     |                                                                                                                                        |
+| `try_make_interval`   | 🔜     | Produces legacy CalendarInterval; tracked by [#4540](https://github.com/apache/datafusion-comet/issues/4540)                           |
+| `try_make_timestamp`  | ⚠️     | Returns a wrong value instead of NULL for invalid inputs ([#4554](https://github.com/apache/datafusion-comet/issues/4554))             |
+| `try_to_date`         | 🔜     | Rewrites to `Cast`/`GetTimestamp` but currently falls back; tracked by [#4556](https://github.com/apache/datafusion-comet/issues/4556) |
+| `try_to_time`         | 🔜     | Spark 4.1 TIME type; tracked by [#4288](https://github.com/apache/datafusion-comet/issues/4288)                                        |
+| `try_to_timestamp`    | 🔜     | Rewrites to `Cast`/`GetTimestamp` but currently falls back; tracked by [#4556](https://github.com/apache/datafusion-comet/issues/4556) |
+| `unix_date`           | ✅     |                                                                                                                                        |
+| `unix_micros`         | ✅     |                                                                                                                                        |
+| `unix_millis`         | ✅     |                                                                                                                                        |
+| `unix_seconds`        | ✅     |                                                                                                                                        |
+| `unix_timestamp`      | ✅     |                                                                                                                                        |
+| `weekday`             | ✅     |                                                                                                                                        |
+| `weekofyear`          | ✅     |                                                                                                                                        |
+| `window`              | 🔜     | Time-window grouping; tracked by [#4553](https://github.com/apache/datafusion-comet/issues/4553)                                       |
+| `window_time`         | 🔜     | Time-window grouping; tracked by [#4553](https://github.com/apache/datafusion-comet/issues/4553)                                       |
+| `year`                | ✅     |                                                                                                                                        |
 
 ---
 
@@ -335,7 +338,7 @@ expression-level). The `outer` variants are wired but marked `Incompatible`; the
 | ------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------- |
 | `from_json`         | ✅     | Falls back by default; opt-in via allowIncompatible ([audit](../../contributor-guide/expression-audits/json_funcs.md#from_json)) |
 | `get_json_object`   | ✅     | Some inputs need allowIncompatible ([audit](../../contributor-guide/expression-audits/json_funcs.md#get_json_object))            |
-| `json_array_length` | 🔜     | tracking #4098                                                                                                                   |
+| `json_array_length` | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                         |
 | `json_object_keys`  | 🔜     | [#3161](https://github.com/apache/datafusion-comet/issues/3161)                                                                  |
 | `json_tuple`        | 🔜     | [#3160](https://github.com/apache/datafusion-comet/issues/3160)                                                                  |
 | `schema_of_json`    | 🔜     | [#3163](https://github.com/apache/datafusion-comet/issues/3163)                                                                  |
@@ -384,111 +387,111 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 
 ## math_funcs
 
-| Function       | Status | Notes                                                              |
-| -------------- | ------ | ------------------------------------------------------------------ |
-| `%`            | ✅     | try_mod (TRY mode) falls back                                      |
-| `*`            | ✅     | Interval multiplication falls back                                 |
-| `+`            | ✅     |                                                                    |
-| `-`            | ✅     |                                                                    |
-| `/`            | ✅     |                                                                    |
-| `abs`          | ✅     | Interval types fall back                                           |
-| `acos`         | ✅     |                                                                    |
-| `acosh`        | ✅     |                                                                    |
-| `asin`         | ✅     |                                                                    |
-| `asinh`        | ✅     |                                                                    |
-| `atan`         | ✅     |                                                                    |
-| `atan2`        | ✅     |                                                                    |
-| `atanh`        | ✅     |                                                                    |
-| `bin`          | ✅     |                                                                    |
-| `bround`       | 🔜     | #4538                                                              |
-| `cbrt`         | ✅     |                                                                    |
-| `ceil`         | ✅     | Two-arg form falls back                                            |
-| `ceiling`      | ✅     |                                                                    |
-| `conv`         | 🔜     | #4538                                                              |
-| `cos`          | ✅     |                                                                    |
-| `cosh`         | ✅     |                                                                    |
-| `cot`          | ✅     |                                                                    |
-| `csc`          | ✅     |                                                                    |
-| `degrees`      | ✅     |                                                                    |
-| `div`          | ✅     |                                                                    |
-| `e`            | ✅     | Folds to a literal (like `pi`)                                     |
-| `exp`          | ✅     |                                                                    |
-| `expm1`        | ✅     |                                                                    |
-| `factorial`    | ✅     |                                                                    |
-| `floor`        | ✅     | Two-arg form falls back                                            |
-| `greatest`     | ✅     |                                                                    |
-| `hex`          | ✅     |                                                                    |
-| `hypot`        | 🔜     | #4538                                                              |
-| `least`        | ✅     |                                                                    |
-| `ln`           | ✅     |                                                                    |
-| `log`          | ✅     |                                                                    |
-| `log10`        | ✅     |                                                                    |
-| `log1p`        | 🔜     | #4538                                                              |
-| `log2`         | ✅     |                                                                    |
-| `mod`          | ✅     |                                                                    |
-| `negative`     | ✅     |                                                                    |
-| `pi`           | ✅     |                                                                    |
-| `pmod`         | 🔜     | #4538                                                              |
-| `positive`     | ✅     |                                                                    |
-| `pow`          | ✅     |                                                                    |
-| `power`        | ✅     |                                                                    |
-| `radians`      | ✅     |                                                                    |
-| `rand`         | ✅     |                                                                    |
-| `randn`        | ✅     |                                                                    |
-| `random`       | ✅     | Alias for `rand` (Spark 4.0+); seed must be a literal              |
-| `randstr`      | 🔜     | Random string (Spark 4.0+)                                         |
-| `rint`         | ✅     |                                                                    |
-| `round`        | ✅     | Float/double inputs fall back                                      |
-| `sec`          | ✅     |                                                                    |
-| `shiftleft`    | ✅     |                                                                    |
-| `sign`         | ✅     |                                                                    |
-| `signum`       | ✅     |                                                                    |
-| `sin`          | ✅     |                                                                    |
-| `sinh`         | ✅     |                                                                    |
-| `sqrt`         | ✅     |                                                                    |
-| `tan`          | ✅     |                                                                    |
-| `tanh`         | ✅     |                                                                    |
-| `try_add`      | ✅     | Datetime/interval form falls back                                  |
-| `try_divide`   | ✅     |                                                                    |
-| `try_mod`      | 🔜     | Lowers to `Remainder` with TRY eval mode, which falls back (#4484) |
-| `try_multiply` | ✅     |                                                                    |
-| `try_subtract` | ✅     |                                                                    |
-| `unhex`        | ✅     |                                                                    |
-| `uniform`      | ✅     | Constant-folded; literal arguments only (Spark 4.0+)               |
-| `width_bucket` | ✅     |                                                                    |
+| Function       | Status | Notes                                                                                                                        |
+| -------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `%`            | ✅     | try_mod (TRY mode) falls back                                                                                                |
+| `*`            | ✅     | Interval multiplication falls back                                                                                           |
+| `+`            | ✅     |                                                                                                                              |
+| `-`            | ✅     |                                                                                                                              |
+| `/`            | ✅     |                                                                                                                              |
+| `abs`          | ✅     | Interval types fall back                                                                                                     |
+| `acos`         | ✅     |                                                                                                                              |
+| `acosh`        | ✅     |                                                                                                                              |
+| `asin`         | ✅     |                                                                                                                              |
+| `asinh`        | ✅     |                                                                                                                              |
+| `atan`         | ✅     |                                                                                                                              |
+| `atan2`        | ✅     |                                                                                                                              |
+| `atanh`        | ✅     |                                                                                                                              |
+| `bin`          | ✅     |                                                                                                                              |
+| `bround`       | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                              |
+| `cbrt`         | ✅     |                                                                                                                              |
+| `ceil`         | ✅     | Two-arg form falls back                                                                                                      |
+| `ceiling`      | ✅     |                                                                                                                              |
+| `conv`         | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                              |
+| `cos`          | ✅     |                                                                                                                              |
+| `cosh`         | ✅     |                                                                                                                              |
+| `cot`          | ✅     |                                                                                                                              |
+| `csc`          | ✅     |                                                                                                                              |
+| `degrees`      | ✅     |                                                                                                                              |
+| `div`          | ✅     |                                                                                                                              |
+| `e`            | ✅     | Folds to a literal (like `pi`)                                                                                               |
+| `exp`          | ✅     |                                                                                                                              |
+| `expm1`        | ✅     |                                                                                                                              |
+| `factorial`    | ✅     |                                                                                                                              |
+| `floor`        | ✅     | Two-arg form falls back                                                                                                      |
+| `greatest`     | ✅     |                                                                                                                              |
+| `hex`          | ✅     |                                                                                                                              |
+| `hypot`        | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                              |
+| `least`        | ✅     |                                                                                                                              |
+| `ln`           | ✅     |                                                                                                                              |
+| `log`          | ✅     |                                                                                                                              |
+| `log10`        | ✅     |                                                                                                                              |
+| `log1p`        | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                              |
+| `log2`         | ✅     |                                                                                                                              |
+| `mod`          | ✅     |                                                                                                                              |
+| `negative`     | ✅     |                                                                                                                              |
+| `pi`           | ✅     |                                                                                                                              |
+| `pmod`         | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                              |
+| `positive`     | ✅     |                                                                                                                              |
+| `pow`          | ✅     |                                                                                                                              |
+| `power`        | ✅     |                                                                                                                              |
+| `radians`      | ✅     |                                                                                                                              |
+| `rand`         | ✅     |                                                                                                                              |
+| `randn`        | ✅     |                                                                                                                              |
+| `random`       | ✅     | Alias for `rand` (Spark 4.0+); seed must be a literal                                                                        |
+| `randstr`      | 🔜     | Random string (Spark 4.0+)                                                                                                   |
+| `rint`         | ✅     |                                                                                                                              |
+| `round`        | ✅     | Float/double inputs fall back                                                                                                |
+| `sec`          | ✅     |                                                                                                                              |
+| `shiftleft`    | ✅     |                                                                                                                              |
+| `sign`         | ✅     |                                                                                                                              |
+| `signum`       | ✅     |                                                                                                                              |
+| `sin`          | ✅     |                                                                                                                              |
+| `sinh`         | ✅     |                                                                                                                              |
+| `sqrt`         | ✅     |                                                                                                                              |
+| `tan`          | ✅     |                                                                                                                              |
+| `tanh`         | ✅     |                                                                                                                              |
+| `try_add`      | ✅     | Datetime/interval form falls back                                                                                            |
+| `try_divide`   | ✅     |                                                                                                                              |
+| `try_mod`      | 🔜     | Lowers to `Remainder` with TRY eval mode, which falls back ([#4484](https://github.com/apache/datafusion-comet/issues/4484)) |
+| `try_multiply` | ✅     |                                                                                                                              |
+| `try_subtract` | ✅     |                                                                                                                              |
+| `unhex`        | ✅     |                                                                                                                              |
+| `uniform`      | ✅     | Constant-folded; literal arguments only (Spark 4.0+)                                                                         |
+| `width_bucket` | ✅     |                                                                                                                              |
 
 ---
 
 ## misc_funcs
 
-| Function                      | Status | Notes                                                                            |
-| ----------------------------- | ------ | -------------------------------------------------------------------------------- |
-| `aes_decrypt`                 | 🔜     | Falls back; `StaticInvoke` not allowlisted; planned via codegen dispatch (#4558) |
-| `aes_encrypt`                 | 🔜     | Falls back; planned via codegen dispatch (#4558); nondeterministic IV by default |
-| `assert_true`                 | 🔜     | Lowers to `RaiseError`, which falls back                                         |
-| `current_catalog`             | ✅     | Resolved to a literal by the analyzer (`ReplaceCurrentLike`)                     |
-| `current_database`            | ✅     | Resolved to a literal by the analyzer (`ReplaceCurrentLike`)                     |
-| `current_schema`              | ✅     | Alias of `current_database`; resolved to a literal by the analyzer               |
-| `current_user`                | ✅     | Resolved to a literal by the analyzer; same as `user`                            |
-| `equal_null`                  | ✅     | Lowers to `<=>` (`EqualNullSafe`)                                                |
-| `is_variant_null`             | 🔜     | tracking #4098                                                                   |
-| `monotonically_increasing_id` | ✅     |                                                                                  |
-| `parse_json`                  | 🔜     | tracking #4098                                                                   |
-| `raise_error`                 | 🔜     | Raises a runtime error                                                           |
-| `rand`                        | ✅     | Seed must be a literal                                                           |
-| `randn`                       | ✅     | Seed must be a literal                                                           |
-| `schema_of_variant`           | 🔜     | tracking #4098                                                                   |
-| `schema_of_variant_agg`       | 🔜     | tracking #4098                                                                   |
-| `session_user`                | ✅     | Alias of `current_user`; resolved to a literal by the analyzer                   |
-| `spark_partition_id`          | ✅     |                                                                                  |
-| `to_variant_object`           | 🔜     | tracking #4098                                                                   |
-| `try_aes_decrypt`             | 🔜     | Falls back; planned via codegen dispatch (#4558)                                 |
-| `try_parse_json`              | 🔜     | tracking #4098                                                                   |
-| `try_variant_get`             | 🔜     | tracking #4098                                                                   |
-| `typeof`                      | ✅     | Foldable; resolved to a literal before Comet sees the plan                       |
-| `user`                        | ✅     | Resolved to a literal by the Spark analyzer before reaching Comet                |
-| `uuid`                        | 🔜     | Nondeterministic random UUID                                                     |
-| `variant_get`                 | 🔜     | tracking #4098                                                                   |
+| Function                      | Status | Notes                                                                                                                                      |
+| ----------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `aes_decrypt`                 | 🔜     | Falls back; `StaticInvoke` not allowlisted; planned via codegen dispatch ([#4558](https://github.com/apache/datafusion-comet/issues/4558)) |
+| `aes_encrypt`                 | 🔜     | Falls back; planned via codegen dispatch ([#4558](https://github.com/apache/datafusion-comet/issues/4558)); nondeterministic IV by default |
+| `assert_true`                 | 🔜     | Lowers to `RaiseError`, which falls back                                                                                                   |
+| `current_catalog`             | ✅     | Resolved to a literal by the analyzer (`ReplaceCurrentLike`)                                                                               |
+| `current_database`            | ✅     | Resolved to a literal by the analyzer (`ReplaceCurrentLike`)                                                                               |
+| `current_schema`              | ✅     | Alias of `current_database`; resolved to a literal by the analyzer                                                                         |
+| `current_user`                | ✅     | Resolved to a literal by the analyzer; same as `user`                                                                                      |
+| `equal_null`                  | ✅     | Lowers to `<=>` (`EqualNullSafe`)                                                                                                          |
+| `is_variant_null`             | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                                   |
+| `monotonically_increasing_id` | ✅     |                                                                                                                                            |
+| `parse_json`                  | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                                   |
+| `raise_error`                 | 🔜     | Raises a runtime error                                                                                                                     |
+| `rand`                        | ✅     | Seed must be a literal                                                                                                                     |
+| `randn`                       | ✅     | Seed must be a literal                                                                                                                     |
+| `schema_of_variant`           | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                                   |
+| `schema_of_variant_agg`       | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                                   |
+| `session_user`                | ✅     | Alias of `current_user`; resolved to a literal by the analyzer                                                                             |
+| `spark_partition_id`          | ✅     |                                                                                                                                            |
+| `to_variant_object`           | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                                   |
+| `try_aes_decrypt`             | 🔜     | Falls back; planned via codegen dispatch ([#4558](https://github.com/apache/datafusion-comet/issues/4558))                                 |
+| `try_parse_json`              | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                                   |
+| `try_variant_get`             | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                                   |
+| `typeof`                      | ✅     | Foldable; resolved to a literal before Comet sees the plan                                                                                 |
+| `user`                        | ✅     | Resolved to a literal by the Spark analyzer before reaching Comet                                                                          |
+| `uuid`                        | 🔜     | Nondeterministic random UUID                                                                                                               |
+| `variant_get`                 | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                                   |
 
 ---
 
@@ -522,74 +525,74 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 
 ## string_funcs
 
-| Function             | Status | Notes                                                                            |
-| -------------------- | ------ | -------------------------------------------------------------------------------- |
-| `ascii`              | ✅     |                                                                                  |
-| `base64`             | 🔜     | Lowers to `StaticInvoke(encode)` (not allowlisted); falls back                   |
-| `bit_length`         | ✅     |                                                                                  |
-| `btrim`              | ✅     |                                                                                  |
-| `char`               | ✅     |                                                                                  |
-| `char_length`        | ✅     |                                                                                  |
-| `character_length`   | ✅     |                                                                                  |
-| `chr`                | ✅     |                                                                                  |
-| `collate`            | 🔜     | Spark collation (umbrella #2190)                                                 |
-| `collation`          | ✅     | Constant-folded to a literal (Spark 4.0+)                                        |
-| `concat_ws`          | ✅     |                                                                                  |
-| `contains`           | ✅     |                                                                                  |
-| `decode`             | ✅     |                                                                                  |
-| `elt`                | 🔜     | #4538                                                                            |
-| `encode`             | 🔜     | Lowers to `StaticInvoke(encode)` (not allowlisted); falls back                   |
-| `endswith`           | ✅     |                                                                                  |
-| `find_in_set`        | 🔜     | #4538                                                                            |
-| `format_number`      | 🔜     | #4538                                                                            |
-| `format_string`      | 🔜     | #4538                                                                            |
-| `initcap`            | ✅     |                                                                                  |
-| `instr`              | ✅     |                                                                                  |
-| `lcase`              | ✅     |                                                                                  |
-| `left`               | ✅     |                                                                                  |
-| `len`                | ✅     |                                                                                  |
-| `length`             | ✅     |                                                                                  |
-| `levenshtein`        | 🔜     | #4538                                                                            |
-| `locate`             | 🔜     | #4538                                                                            |
-| `lower`              | ✅     |                                                                                  |
-| `lpad`               | ✅     |                                                                                  |
-| `ltrim`              | ✅     |                                                                                  |
-| `luhn_check`         | ✅     | Native via `StaticInvoke` (tests: luhn_check.sql)                                |
-| `mask`               | 🔜     | Data masking                                                                     |
-| `octet_length`       | ✅     |                                                                                  |
-| `overlay`            | 🔜     | #4538                                                                            |
-| `position`           | 🔜     | #4538                                                                            |
-| `printf`             | 🔜     | #4538                                                                            |
-| `regexp_count`       | 🔜     | tracking #4098                                                                   |
-| `regexp_extract`     | 🔜     | tracking #4098                                                                   |
-| `regexp_extract_all` | 🔜     | tracking #4098                                                                   |
-| `regexp_instr`       | 🔜     | tracking #4098                                                                   |
-| `regexp_replace`     | ✅     |                                                                                  |
-| `regexp_substr`      | 🔜     | tracking #4098                                                                   |
-| `repeat`             | ✅     |                                                                                  |
-| `replace`            | ✅     |                                                                                  |
-| `right`              | ✅     |                                                                                  |
-| `rpad`               | ✅     |                                                                                  |
-| `rtrim`              | ✅     |                                                                                  |
-| `soundex`            | 🔜     | #4538                                                                            |
-| `space`              | ✅     |                                                                                  |
-| `split`              | ✅     |                                                                                  |
-| `split_part`         | 🔜     | Lowers to `element_at(StringSplitSQL(...))`; `StringSplitSQL` falls back (#4561) |
-| `startswith`         | ✅     |                                                                                  |
-| `substr`             | ✅     |                                                                                  |
-| `substring`          | ✅     |                                                                                  |
-| `substring_index`    | ✅     |                                                                                  |
-| `to_binary`          | ✅     | Hex form accelerated; other formats fall back                                    |
-| `to_char`            | 🔜     | #4538                                                                            |
-| `to_number`          | 🔜     | #4538                                                                            |
-| `to_varchar`         | 🔜     | #4538                                                                            |
-| `translate`          | ✅     |                                                                                  |
-| `trim`               | ✅     |                                                                                  |
-| `try_to_binary`      | 🔜     | Lowers to `TryEval(...)`, which falls back                                       |
-| `try_to_number`      | 🔜     | TRY variant of `to_number`                                                       |
-| `ucase`              | ✅     |                                                                                  |
-| `unbase64`           | 🔜     | #4538                                                                            |
-| `upper`              | ✅     |                                                                                  |
+| Function             | Status | Notes                                                                                                                                      |
+| -------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ascii`              | ✅     |                                                                                                                                            |
+| `base64`             | 🔜     | Lowers to `StaticInvoke(encode)` (not allowlisted); falls back                                                                             |
+| `bit_length`         | ✅     |                                                                                                                                            |
+| `btrim`              | ✅     |                                                                                                                                            |
+| `char`               | ✅     |                                                                                                                                            |
+| `char_length`        | ✅     |                                                                                                                                            |
+| `character_length`   | ✅     |                                                                                                                                            |
+| `chr`                | ✅     |                                                                                                                                            |
+| `collate`            | 🔜     | Spark collation (umbrella [#2190](https://github.com/apache/datafusion-comet/issues/2190))                                                 |
+| `collation`          | ✅     | Constant-folded to a literal (Spark 4.0+)                                                                                                  |
+| `concat_ws`          | ✅     |                                                                                                                                            |
+| `contains`           | ✅     |                                                                                                                                            |
+| `decode`             | ✅     |                                                                                                                                            |
+| `elt`                | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                                            |
+| `encode`             | 🔜     | Lowers to `StaticInvoke(encode)` (not allowlisted); falls back                                                                             |
+| `endswith`           | ✅     |                                                                                                                                            |
+| `find_in_set`        | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                                            |
+| `format_number`      | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                                            |
+| `format_string`      | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                                            |
+| `initcap`            | ✅     |                                                                                                                                            |
+| `instr`              | ✅     |                                                                                                                                            |
+| `lcase`              | ✅     |                                                                                                                                            |
+| `left`               | ✅     |                                                                                                                                            |
+| `len`                | ✅     |                                                                                                                                            |
+| `length`             | ✅     |                                                                                                                                            |
+| `levenshtein`        | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                                            |
+| `locate`             | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                                            |
+| `lower`              | ✅     |                                                                                                                                            |
+| `lpad`               | ✅     |                                                                                                                                            |
+| `ltrim`              | ✅     |                                                                                                                                            |
+| `luhn_check`         | ✅     | Native via `StaticInvoke` (tests: luhn_check.sql)                                                                                          |
+| `mask`               | 🔜     | Data masking                                                                                                                               |
+| `octet_length`       | ✅     |                                                                                                                                            |
+| `overlay`            | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                                            |
+| `position`           | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                                            |
+| `printf`             | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                                            |
+| `regexp_count`       | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                                   |
+| `regexp_extract`     | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                                   |
+| `regexp_extract_all` | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                                   |
+| `regexp_instr`       | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                                   |
+| `regexp_replace`     | ✅     |                                                                                                                                            |
+| `regexp_substr`      | 🔜     | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098)                                                                   |
+| `repeat`             | ✅     |                                                                                                                                            |
+| `replace`            | ✅     |                                                                                                                                            |
+| `right`              | ✅     |                                                                                                                                            |
+| `rpad`               | ✅     |                                                                                                                                            |
+| `rtrim`              | ✅     |                                                                                                                                            |
+| `soundex`            | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                                            |
+| `space`              | ✅     |                                                                                                                                            |
+| `split`              | ✅     |                                                                                                                                            |
+| `split_part`         | 🔜     | Lowers to `element_at(StringSplitSQL(...))`; `StringSplitSQL` falls back ([#4561](https://github.com/apache/datafusion-comet/issues/4561)) |
+| `startswith`         | ✅     |                                                                                                                                            |
+| `substr`             | ✅     |                                                                                                                                            |
+| `substring`          | ✅     |                                                                                                                                            |
+| `substring_index`    | ✅     |                                                                                                                                            |
+| `to_binary`          | ✅     | Hex form accelerated; other formats fall back                                                                                              |
+| `to_char`            | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                                            |
+| `to_number`          | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                                            |
+| `to_varchar`         | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                                            |
+| `translate`          | ✅     |                                                                                                                                            |
+| `trim`               | ✅     |                                                                                                                                            |
+| `try_to_binary`      | 🔜     | Lowers to `TryEval(...)`, which falls back                                                                                                 |
+| `try_to_number`      | 🔜     | TRY variant of `to_number`                                                                                                                 |
+| `ucase`              | ✅     |                                                                                                                                            |
+| `unbase64`           | 🔜     | [#4538](https://github.com/apache/datafusion-comet/issues/4538)                                                                            |
+| `upper`              | ✅     |                                                                                                                                            |
 
 ---
 
@@ -622,17 +625,17 @@ When enabled, `lag` and `lead` are explicitly wired; aggregate window functions 
 `ntile`, `percent_rank`, `cume_dist`, `nth_value`) are not yet wired in the window serde and
 fall back to Spark.
 
-| Function       | Status | Notes                             |
-| -------------- | ------ | --------------------------------- |
-| `cume_dist`    | 🔜     | Window function; tracked by #2721 |
-| `dense_rank`   | 🔜     | Window function; tracked by #2721 |
-| `lag`          | ✅     | via `CometWindowExec`             |
-| `lead`         | ✅     | via `CometWindowExec`             |
-| `nth_value`    | 🔜     | Window function; tracked by #2721 |
-| `ntile`        | 🔜     | Window function; tracked by #2721 |
-| `percent_rank` | 🔜     | Window function; tracked by #2721 |
-| `rank`         | 🔜     | Window function; tracked by #2721 |
-| `row_number`   | 🔜     | Window function; tracked by #2721 |
+| Function       | Status | Notes                                                                                       |
+| -------------- | ------ | ------------------------------------------------------------------------------------------- |
+| `cume_dist`    | 🔜     | Window function; tracked by [#2721](https://github.com/apache/datafusion-comet/issues/2721) |
+| `dense_rank`   | 🔜     | Window function; tracked by [#2721](https://github.com/apache/datafusion-comet/issues/2721) |
+| `lag`          | ✅     | via `CometWindowExec`                                                                       |
+| `lead`         | ✅     | via `CometWindowExec`                                                                       |
+| `nth_value`    | 🔜     | Window function; tracked by [#2721](https://github.com/apache/datafusion-comet/issues/2721) |
+| `ntile`        | 🔜     | Window function; tracked by [#2721](https://github.com/apache/datafusion-comet/issues/2721) |
+| `percent_rank` | 🔜     | Window function; tracked by [#2721](https://github.com/apache/datafusion-comet/issues/2721) |
+| `rank`         | 🔜     | Window function; tracked by [#2721](https://github.com/apache/datafusion-comet/issues/2721) |
+| `row_number`   | 🔜     | Window function; tracked by [#2721](https://github.com/apache/datafusion-comet/issues/2721) |
 
 ---
 


### PR DESCRIPTION
## Which issue does this PR close?

<!-- No tracking issue; small documentation consistency fix. -->

N/A

## Rationale for this change

The `expressions.md` reference page had two inconsistencies:

1. **Conflicting definition of the ⚠️ marker.** The introduction described ⚠️ as "Supported (caveats)" whose divergent cases fall back to Spark by default and must be opted into with `allowIncompatible`. The status legend (and the actual ⚠️ rows, `array_size` and `try_make_timestamp`) define ⚠️ as "Incorrect by default": Comet runs natively by default and can return results that differ from Spark. The two definitions contradicted each other. The "falls back by default + allowIncompatible opt-in" behavior actually applies to certain ✅ expressions (for example `cast`, `array_except`), not to ⚠️ expressions.

2. **Inconsistent issue and pull request references.** The Notes column mixed bare references (such as `tracking #4098` and `(#4288)`) with full Markdown links. These docs render via Sphinx, where bare `#NNNN` references do not autolink, so the bare ones were not clickable.

## What changes are included in this PR?

- Rewrote the introduction so the ⚠️ description matches the status legend ("Incorrect by default"), and described the `allowIncompatible` opt-in separately as a property of certain ✅ expressions.
- Converted every bare issue/PR reference in the tables to a full Markdown link (`[#NNNN](https://github.com/apache/datafusion-comet/issues/NNNN)`) for consistency with the references that were already linked.
- Reran `prettier` to realign the affected tables (the bulk of the line count change is column re-padding).

## How are these changes tested?

Documentation-only change. `prettier --check "**/*.md"` passes, matching the CI formatting check.