### PR TITLE
fix: array_size returns -1 instead of null for null input

### DIFF
--- a/docs/source/contributor-guide/expression-audits/collection_funcs.md
+++ b/docs/source/contributor-guide/expression-audits/collection_funcs.md
@@ -23,7 +23,7 @@
 
 ## array_size
 
-- Native via `size`; returns -1 instead of NULL for NULL input (https://github.com/apache/datafusion-comet/issues/4560).
+- Native via `size`. `array_size` lowers to `Size(child, legacySizeOfNull = false)`, so it returns NULL for NULL input. `CometSize` now reads `expr.legacySizeOfNull` (the per-expression flag) rather than the session conf (https://github.com/apache/datafusion-comet/issues/4560).
 
 ## concat
 

--- a/docs/source/contributor-guide/expression-audits/collection_funcs.md
+++ b/docs/source/contributor-guide/expression-audits/collection_funcs.md
@@ -23,7 +23,7 @@
 
 ## array_size
 
-- Native via `size`. `array_size` lowers to `Size(child, legacySizeOfNull = false)`, so it returns NULL for NULL input. `CometSize` now reads `expr.legacySizeOfNull` (the per-expression flag) rather than the session conf (https://github.com/apache/datafusion-comet/issues/4560).
+- Native via `size`. `array_size` lowers to `Size(child, legacySizeOfNull = false)`, so it returns NULL for NULL input. `CometSize` reads the per-expression `legacySizeOfNull` flag.
 
 ## concat
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -180,13 +180,13 @@ The tables below list every Spark built-in expression with its current status.
 
 ## collection_funcs
 
-| Function      | Status | Notes                                                                                                       |
-| ------------- | ------ | ----------------------------------------------------------------------------------------------------------- |
-| `array_size`  | ✅     |                                                                                                             |
-| `cardinality` | ✅     | MapType input falls back                                                                                    |
-| `concat`      | ✅     | Binary/array children fall back                                                                             |
-| `reverse`     | ✅     | Binary-element arrays fall back (Incompatible) ([details](compatibility/expressions/array.md))              |
-| `size`        | ✅     | MapType input falls back                                                                                    |
+| Function      | Status | Notes                                                                                          |
+| ------------- | ------ | ---------------------------------------------------------------------------------------------- |
+| `array_size`  | ✅     |                                                                                                |
+| `cardinality` | ✅     | MapType input falls back                                                                       |
+| `concat`      | ✅     | Binary/array children fall back                                                                |
+| `reverse`     | ✅     | Binary-element arrays fall back (Incompatible) ([details](compatibility/expressions/array.md)) |
+| `size`        | ✅     | MapType input falls back                                                                       |
 
 ---
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -182,7 +182,7 @@ The tables below list every Spark built-in expression with its current status.
 
 | Function      | Status | Notes                                                                                                       |
 | ------------- | ------ | ----------------------------------------------------------------------------------------------------------- |
-| `array_size`  | ⚠️     | Returns -1 instead of NULL for NULL input ([#4560](https://github.com/apache/datafusion-comet/issues/4560)) |
+| `array_size`  | ✅     |                                                                                                             |
 | `cardinality` | ✅     | MapType input falls back                                                                                    |
 | `concat`      | ✅     | Binary/array children fall back                                                                             |
 | `reverse`     | ✅     | Binary-element arrays fall back (Incompatible) ([details](compatibility/expressions/array.md))              |

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -688,7 +688,7 @@ object CometSize extends CometExpressionSerde[Size] {
     for {
       isNotNullExprProto <- createIsNotNullExprProto(expr, inputs, binding)
       sizeScalarExprProto <- scalarFunctionExprToProto("size", arrayExprProto)
-      emptyLiteralExprProto <- createLiteralExprProto(SQLConf.get.legacySizeOfNull)
+      emptyLiteralExprProto <- createLiteralExprProto(expr.legacySizeOfNull)
     } yield {
       val caseWhenExpr = ExprOuterClass.CaseWhen
         .newBuilder()

--- a/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
@@ -1008,6 +1008,24 @@ class CometArrayExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelp
     }
   }
 
+  // https://github.com/apache/datafusion-comet/issues/4560
+  test("array_size returns null for null input") {
+    val table = "t1"
+    withTable(table) {
+      sql(s"create table $table(col array<int>) using parquet")
+      sql(s"insert into $table values(array(1, 2, 3)), (array()), (null)")
+      // array_size lowers to Size(child, legacySizeOfNull = false), so it must return null
+      // for a null input regardless of the legacySizeOfNull conf.
+      Seq("false", "true").foreach { legacy =>
+        withSQLConf(
+          SQLConf.LEGACY_SIZE_OF_NULL.key -> legacy,
+          SQLConf.ANSI_ENABLED.key -> "false") {
+          checkSparkAnswerAndOperator(sql(s"select array_size(col) from $table"))
+        }
+      }
+    }
+  }
+
   // https://github.com/apache/datafusion-comet/issues/3375
   test("(ansi) array access out of bounds - GetArrayItem") {
     withSQLConf(


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4560.

## Rationale for this change

`array_size(NULL)` should return `NULL`, but Comet returned `-1`.

`array_size` is `RuntimeReplaceable` and lowers to `Size(child, legacySizeOfNull = false)`. With `legacySizeOfNull = false`, Spark returns `NULL` for a `NULL` input; with `legacySizeOfNull = true` it returns `-1`.

Comet's `Size` serde built the `else` branch of its `CASE WHEN` from the session conf `SQLConf.get.legacySizeOfNull` rather than from the expression's own `legacySizeOfNull` field. Since `spark.sql.legacy.sizeOfNull` defaults to `true`, the `else` literal became `-1` even though `array_size` had explicitly set the expression flag to `false`. The query runs natively via `CometProject`, so it did not fall back: it just returned the wrong value.

## What changes are included in this PR?

`CometSize.convert` now reads `expr.legacySizeOfNull` instead of `SQLConf.get.legacySizeOfNull`. This honors the flag baked into each `Size` instance, which already accounts for both the `array_size` override (always `false`) and the ANSI handling Spark applies when constructing the expression. The regular `size` and `cardinality` paths are unaffected because their expressions carry the resolved session value.

## How are these changes tested?

Added a test in `CometArrayExpressionSuite` asserting `array_size` returns `NULL` for a `NULL` array input under both `spark.sql.legacy.sizeOfNull=false` and `true`. The existing `size - respect to legacySizeOfNull` test continues to pass, confirming the `size` path is unchanged.
