### PR TITLE
ci: add fast syntactic-only scalafix gate

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -46,6 +46,32 @@ jobs:
           rustup component add rustfmt
           cd native && cargo fmt --all -- --check
 
+  # Fast syntactic-only scalafix check. Parses sources without compiling, so it
+  # surfaces version-independent style issues (e.g. RedundantSyntax) in seconds,
+  # long before the lint-java matrix finishes its ~3.5 min build. It also scans
+  # the spark-4.1 / spark-4.2 sources that lint-java skips (those profiles can't
+  # run -Psemanticdb yet), so it is the only gate covering them. The full rule
+  # set, including the semantic rules, still runs in lint-java.
+  scalafix-syntactic:
+    name: Lint Scala (syntactic)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup coursier
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:21
+
+      - name: Run syntactic scalafix check (no compile)
+        run: |
+          cs launch scalafix:0.14.6 -- \
+            --check \
+            --syntactic \
+            --config .scalafix-syntactic.conf \
+            --exclude '**/target/**' \
+            spark
+
   lint-java:
     needs: lint
     name: Lint Java (${{ matrix.profile.name }})

--- a/.scalafix-syntactic.conf
+++ b/.scalafix-syntactic.conf
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Syntactic-only subset of .scalafix.conf. These rules parse source without
+// compilation and are independent of the Spark/Scala profile, so CI can check
+// them in seconds (see the scalafix-syntactic job in pr_build_linux.yml). The
+// full set, including the semantic rules, still runs in the lint-java job.
+rules = [
+  DisableSyntax,
+  LeakingImplicitClassVal,
+  NoValInForComprehension,
+  ProcedureSyntax,
+  RedundantSyntax
+]

--- a/spark/src/test/spark-4.1/org/apache/spark/sql/comet/CometDecimalArithmeticViewSuite.scala
+++ b/spark/src/test/spark-4.1/org/apache/spark/sql/comet/CometDecimalArithmeticViewSuite.scala
@@ -56,7 +56,7 @@ class CometDecimalArithmeticViewSuite extends CometTestBase {
             assert(
               dt === add.dataType,
               s"CheckOverflow target $dt must match Add.dataType ${add.dataType}; mismatch " +
-                s"causes the decimal buffer to be re-labelled at the wrong scale.")
+                "causes the decimal buffer to be re-labelled at the wrong scale.")
           case other =>
             fail(s"Expected DecimalPrecision.promote to wrap Add in CheckOverflow, got: $other")
         }


### PR DESCRIPTION
## Which issue does this PR close?

<!-- No dedicated issue; small CI enhancement motivated by the lint failure on #4579. -->

Closes #4545

## Rationale for this change

`.scalafix.conf` mixes two kinds of rules: semantic rules (`ExplicitResultTypes`, `NoAutoTupling`, `RemoveUnused`) that require a full compile, and syntactic rules (`DisableSyntax`, `LeakingImplicitClassVal`, `NoValInForComprehension`, `ProcedureSyntax`, `RedundantSyntax`) that only parse source.

The `lint-java` job runs the whole set behind `./mvnw package -Psemanticdb` as a 4-way Spark matrix, so a trivial syntactic issue (for example the redundant `s` string interpolator that broke #4579) only surfaces after roughly 3.5 minutes of building, repeated across four matrix legs.

The syntactic rules need no compilation and are independent of the Spark/Scala profile, so they can be checked once, in seconds.

A second benefit: `lint-java` deliberately skips Spark 4.1 / 4.2 (semanticdb-scalac for those Scala patch versions is not published, so it cannot run `-Psemanticdb`). The new check scans every Scala source, so it is the only gate covering the `spark-4.1` / `spark-4.2` trees. It immediately surfaced one pre-existing `RedundantSyntax` violation in `CometDecimalArithmeticViewSuite` (a `spark-4.1` test), which is fixed here.

## What changes are included in this PR?

- New `.scalafix-syntactic.conf` containing the syntactic-only rule subset. `.scalafix.conf` is unchanged and still enforces the full set in `lint-java`.
- New `scalafix-syntactic` job in `pr_build_linux.yml` that runs the scalafix CLI (`--check --syntactic`) via coursier with no compile, no Maven, and no Spark matrix. It runs as a peer of the existing fast `lint` job and does not gate or reorder the semantic matrix.
- Fix the one pre-existing redundant `s` interpolator in `CometDecimalArithmeticViewSuite` so the new job passes on a clean tree.

## How are these changes tested?

Validated locally with the scalafix CLI against the full `spark/` source tree:

- Positive: with the fix applied, `scalafix --check --syntactic --config .scalafix-syntactic.conf --exclude '**/target/**' spark` exits 0.
- Negative: reintroducing the redundant `s` interpolator makes the same command fail (exit 32, one violation reported), confirming the gate catches the #4579 class of issue.