### PR TITLE
test: add timestamp ntz array cast coverage

### DIFF
--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -1559,7 +1559,8 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       DoubleType,
       BinaryType,
       DecimalType(10, 2),
-      DecimalType(38, 18)).foreach { dt =>
+      DecimalType(38, 18),
+      DataTypes.TimestampNTZType).foreach { dt =>
       val input = generateArrays(100, dt)
       castTest(input, StringType, hasIncompatibleType = hasIncompatibleType(input.schema))
     }
@@ -1629,6 +1630,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       // cover this type fully.
       DateType,
       TimestampType,
+      DataTypes.TimestampNTZType,
       BinaryType)
     testArrayCastMatrix(types, ArrayType(_), generateArrays(100, _))
   }
@@ -1792,6 +1794,13 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
             withEdgeCaseRows(buildRows(generateTimestampLiterals())).asJava,
             stringSchema)
           .select(col("a").cast(ArrayType(TimestampType)).as("a"))
+      case dt if dt == DataTypes.TimestampNTZType =>
+        val stringSchema = StructType(Seq(StructField("a", ArrayType(StringType), true)))
+        spark
+          .createDataFrame(
+            withEdgeCaseRows(buildRows(generateTimestampLiterals())).asJava,
+            stringSchema)
+          .select(col("a").cast(ArrayType(DataTypes.TimestampNTZType)).as("a"))
       case FloatType =>
         spark.createDataFrame(
           withEdgeCaseRows(buildRows(generateSafeFloatValues())).asJava,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #4248.

## Rationale for this change

`Array(TimestampNTZ)` cast behavior should have explicit coverage for casts to `String` and to other supported array element types. The existing array cast coverage covered many primitive and temporal cases, but did not include TimestampNTZ array inputs.

## What changes are included in this PR?

- Extends `CometCastSuite` array-to-string coverage to include `Array(TimestampNTZ)`.
- Extends the `CometCastSuite` array-to-array cast matrix to include TimestampNTZ array inputs.
- Adds SQL-file coverage for `Array(TimestampNTZ)` to `String` and to `Array(String)`, `Array(Date)`, and `Array(Timestamp)` across representative timezones.

## How are these changes tested?

- `./mvnw test -Pjdk17 -Dtest=none -Dsuites="org.apache.comet.CometCastSuite cast ArrayType to StringType"`
- `./mvnw test -Pjdk17 -Dtest=none -Dsuites="org.apache.comet.CometCastSuite cast ArrayType to ArrayType"`