### PR TITLE
test: cover array date cast fallback

### DIFF
--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteType,
 
 import org.apache.comet.expressions.{CometCast, CometEvalMode}
 import org.apache.comet.rules.CometScanTypeChecker
-import org.apache.comet.serde.{Compatible, Incompatible}
+import org.apache.comet.serde.{Compatible, Incompatible, Unsupported}
 
 class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
 
@@ -1631,6 +1631,31 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       TimestampType,
       BinaryType)
     testArrayCastMatrix(types, ArrayType(_), generateArrays(100, _))
+  }
+
+  test("cast ArrayType(DateType) to unsupported ArrayType falls back") {
+    val fromType = ArrayType(DateType)
+    val unsupportedElementTypes =
+      Seq(BooleanType, ByteType, ShortType, LongType, FloatType, DoubleType, DecimalType(10, 2))
+    val input = generateArrays(100, DateType)
+
+    withTempPath { dir =>
+      val data = roundtripParquet(input, dir).coalesce(1)
+
+      withSQLConf(SQLConf.ANSI_ENABLED.key -> "false") {
+        unsupportedElementTypes.foreach { toElementType =>
+          val toType = ArrayType(toElementType)
+          val expectedMessage = s"Cast from $fromType to $toType is not supported"
+
+          assert(
+            CometCast.isSupported(fromType, toType, None, CometEvalMode.LEGACY) ==
+              Unsupported(Some(expectedMessage)))
+          checkSparkAnswerAndFallbackReason(
+            data.select(col("a").cast(toType).as("converted")),
+            expectedMessage)
+        }
+      }
+    }
   }
 
   // https://github.com/apache/datafusion-comet/issues/3906


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #4248 

## Rationale for this change

`CometCast.isSupported` has a special guard for `Array(DateType)` to `ArrayType(...)` casts. Scalar `DateType` can cast to many numeric/boolean targets in legacy mode, but these array casts should remain unsupported and fall back to Spark unless the destination element type is integer or string.

## What changes are included in this PR?

Added a focused negative test in `CometCastSuite` for `Array(DateType)` casts to unsupported `ArrayType` element targets such as boolean, long, float, double, and decimal.

## How are these changes tested?

- `./mvnw test -Pspark-4.1 -Pjdk17 -Dtest=none -Dsuites=org.apache.comet.CometCastSuite`

