### PR TITLE
fix: clean up CometCast support-level reporting (#4501)

### DIFF
--- a/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
+++ b/spark/src/main/scala/org/apache/comet/expressions/CometCast.scala
@@ -32,6 +32,10 @@ import org.apache.comet.shims.CometExprShim
 
 object CometCast extends CometExpressionSerde[Cast] with CometExprShim {
 
+  // Shared with CometCastSuite so the asserted reason cannot drift from production.
+  private[comet] val negativeScaleDecimalToStringReason: String =
+    "Negative-scale decimal requires spark.sql.legacy.allowNegativeScaleOfDecimal=true"
+
   def supportedTypes: Seq[DataType] =
     Seq(
       DataTypes.BooleanType,
@@ -48,17 +52,17 @@ object CometCast extends CometExpressionSerde[Cast] with CometExprShim {
       DataTypes.TimestampType,
       DataTypes.TimestampNTZType)
 
-  override def getIncompatibleReasons(): Seq[String] = Seq(
-    "Some cast operations between specific type pairs may produce different results than Spark." +
-      " Refer to the compatibility guide for the full matrix of supported cast operations.")
-
-  override def getUnsupportedReasons(): Seq[String] = Seq(
-    "Not all cast type combinations are supported. Unsupported casts fall back to Spark.")
+  // Note: `getIncompatibleReasons` / `getUnsupportedReasons` are intentionally not
+  // overridden here. The per-pair `isSupported` matrix is the canonical source of cast
+  // reasons: `cast.md` is generated directly from it (see `GenerateDocs.writeCastMatrixForMode`)
+  // and EXPLAIN surfaces the per-pair reason via `getSupportLevel`. A single static sentence
+  // would only duplicate the matrix and risk drifting from it.
 
   override def getSupportLevel(cast: Cast): SupportLevel = {
     if (cast.child.isInstanceOf[Literal]) {
-      // casting from literal is compatible because we delegate to Spark
-      // further data type checks will be performed by CometLiteral
+      // A cast whose child is a literal is folded by Spark at planning time via `cast.eval()`
+      // (see `convert`), so the cast never executes natively and the result matches Spark by
+      // definition. `CometLiteral` then validates the resulting literal's data type.
       Compatible()
     } else {
       isSupported(cast.child.dataType, cast.dataType, cast.timeZoneId, evalMode(cast))
@@ -254,7 +258,8 @@ object CometCast extends CometExpressionSerde[Cast] with CometExprShim {
         val allowNegativeScale = SQLConf.get
           .getConfString("spark.sql.legacy.allowNegativeScaleOfDecimal", "false")
           .toBoolean
-        if (allowNegativeScale) Compatible() else Incompatible()
+        if (allowNegativeScale) Compatible()
+        else Incompatible(Some(negativeScaleDecimalToStringReason))
       case _: DecimalType =>
         // Compatible across all eval modes: LEGACY uses cast_decimal128_to_utf8 which
         // replicates Java BigDecimal.toString() (scientific notation when adj_exp < -6);

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -787,11 +787,8 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
     withSQLConf("spark.sql.legacy.allowNegativeScaleOfDecimal" -> "false") {
       assert(
-        CometCast.isSupported(
-          negScaleType,
-          DataTypes.StringType,
-          None,
-          CometEvalMode.LEGACY) == Incompatible())
+        CometCast.isSupported(negScaleType, DataTypes.StringType, None, CometEvalMode.LEGACY) ==
+          Incompatible(Some(CometCast.negativeScaleDecimalToStringReason)))
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4501.

## Rationale for this change

#4501 collected support-level and serde consistency follow-ups deferred from the cast expression audit in #4493. While working through them, several of the issue's line references turned out to be stale against current `main`, so the fixes here reflect the current state of `CometCast.scala` and `GenerateDocs.scala`.

Findings per item:

1. The issue noted that `canCastFromFloat` / `canCastFromDouble` / `canCastFromDecimal` ignore `evalMode` while every other arm of `isSupported` threads it through, and suggested the support level should reflect the eval mode. Investigation shows there is nothing to reflect: the native code does branch on eval mode for these narrowing casts (ANSI throws on overflow/NaN, LEGACY/TRY wrap), but Comet matches Spark in every mode, and `CometCastSuite` exercises them in LEGACY, ANSI, and TRY and passes. So there is no per-mode support-level divergence, and these three helpers (like `canCastFromTimestamp`) correctly take no `evalMode`. No code change needed.

2. For `Cast`, `getIncompatibleReasons` / `getUnsupportedReasons` are never consumed. `cast.md` is generated directly from the per-pair `isSupported` matrix (`GenerateDocs.writeCastMatrixForMode`, including per-pair note annotations), and EXPLAIN surfaces the per-pair reason via `getSupportLevel`. `Cast` is not in `categoryPages`, the only caller of those static methods. The generic overrides were dead, so they are removed in favor of the matrix as the single source of truth.

3. The array-of-binary `Incompatible()` branch described in the issue no longer exists; binary to string (including arrays) is currently `Compatible()`. The only remaining bare `Incompatible()` was the negative-scale decimal to string branch, which now carries a concise reason. The separate `#4488` `from_utf8_unchecked` question for binary to string is a behavior change and is left to its own issue.

4. The literal short-circuit in `getSupportLevel` is correct: `convert()` folds literal casts via `cast.eval()` in Spark at planning time, so the cast never executes natively and the result matches Spark by definition. Only the comment was misleading; it is clarified.

## What changes are included in this PR?

- Remove the unused `getIncompatibleReasons` / `getUnsupportedReasons` overrides from `CometCast` and document that the per-pair matrix is the canonical reason source.
- Fill in the empty `Incompatible()` reason for negative-scale decimal to string, sharing the string with the test via a constant to avoid drift.
- Clarify the literal short-circuit comment in `getSupportLevel`.

## How are these changes tested?

Covered by existing `CometCastSuite` coverage, which exercises the float, double, and decimal cast paths in LEGACY, ANSI, and TRY modes. The negative-scale decimal to string test's support-level assertion is updated to reference the shared reason constant. No behavior changes, so no golden file or generated doc regeneration is required.