### PR TITLE
chore(shuffle): add interleave_time metric and specify  buffer size for output_data buffer writer

### DIFF
--- a/native/shuffle/src/bin/shuffle_bench.rs
+++ b/native/shuffle/src/bin/shuffle_bench.rs
@@ -277,6 +277,9 @@ fn print_shuffle_metrics(metrics: &MetricsSet, total_wall_time_secs: f64) {
     if let Some(nanos) = get_metric("repart_time") {
         println!("  repart time:      {}", fmt_time(nanos));
     }
+    if let Some(nanos) = get_metric("interleave_time") {
+        println!("  interleave time:  {}", fmt_time(nanos));
+    }
     if let Some(nanos) = get_metric("encode_time") {
         println!("  encode time:      {}", fmt_time(nanos));
     }

--- a/native/shuffle/src/metrics.rs
+++ b/native/shuffle/src/metrics.rs
@@ -27,6 +27,9 @@ pub(crate) struct ShufflePartitionerMetrics {
     /// Time to perform repartitioning
     pub(crate) repart_time: Time,
 
+    /// Time spent in `interleave_record_batch` gathering shuffled batches
+    pub(crate) interleave_time: Time,
+
     /// Time encoding batches to IPC format
     pub(crate) encode_time: Time,
 
@@ -51,6 +54,8 @@ impl ShufflePartitionerMetrics {
         Self {
             baseline: BaselineMetrics::new(metrics, partition),
             repart_time: MetricBuilder::new(metrics).subset_time("repart_time", partition),
+            interleave_time: MetricBuilder::new(metrics)
+                .subset_time("interleave_time", partition),
             encode_time: MetricBuilder::new(metrics).subset_time("encode_time", partition),
             write_time: MetricBuilder::new(metrics).subset_time("write_time", partition),
             input_batches: MetricBuilder::new(metrics).counter("input_batches", partition),

--- a/native/shuffle/src/metrics.rs
+++ b/native/shuffle/src/metrics.rs
@@ -54,8 +54,7 @@ impl ShufflePartitionerMetrics {
         Self {
             baseline: BaselineMetrics::new(metrics, partition),
             repart_time: MetricBuilder::new(metrics).subset_time("repart_time", partition),
-            interleave_time: MetricBuilder::new(metrics)
-                .subset_time("interleave_time", partition),
+            interleave_time: MetricBuilder::new(metrics).subset_time("interleave_time", partition),
             encode_time: MetricBuilder::new(metrics).subset_time("encode_time", partition),
             write_time: MetricBuilder::new(metrics).subset_time("write_time", partition),
             input_batches: MetricBuilder::new(metrics).counter("input_batches", partition),

--- a/native/shuffle/src/partitioners/multi_partition.rs
+++ b/native/shuffle/src/partitioners/multi_partition.rs
@@ -434,10 +434,12 @@ impl MultiPartitionShuffleRepartitioner {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn shuffle_write_partition(
         partition_iter: &mut PartitionedBatchIterator,
         shuffle_block_writer: &mut ShuffleBlockWriter,
         output_data: &mut BufWriter<File>,
+        interleave_time: &Time,
         encode_time: &Time,
         write_time: &Time,
         write_buffer_size: usize,
@@ -449,7 +451,7 @@ impl MultiPartitionShuffleRepartitioner {
             write_buffer_size,
             batch_size,
         );
-        for batch in partition_iter {
+        while let Some(batch) = partition_iter.next(interleave_time) {
             let batch = batch?;
             buf_batch_writer.write(&batch, encode_time, write_time)?;
         }
@@ -573,7 +575,7 @@ impl ShufflePartitioner for MultiPartitionShuffleRepartitioner {
                 .open(data_file)
                 .map_err(|e| DataFusionError::Execution(format!("shuffle write error: {e:?}")))?;
 
-            let mut output_data = BufWriter::new(output_data);
+            let mut output_data = BufWriter::with_capacity(self.write_buffer_size, output_data);
 
             #[allow(clippy::needless_range_loop)]
             for i in 0..num_output_partitions {
@@ -596,6 +598,7 @@ impl ShufflePartitioner for MultiPartitionShuffleRepartitioner {
                     &mut partition_iter,
                     &mut self.shuffle_block_writer,
                     &mut output_data,
+                    &self.metrics.interleave_time,
                     &self.metrics.encode_time,
                     &self.metrics.write_time,
                     self.write_buffer_size,

--- a/native/shuffle/src/partitioners/partitioned_batch_iterator.rs
+++ b/native/shuffle/src/partitioners/partitioned_batch_iterator.rs
@@ -98,8 +98,10 @@ impl<'a> PartitionedBatchIterator<'a> {
 
         let indices_end = std::cmp::min(self.pos + self.batch_size, self.indices.len());
         let indices = &self.indices[self.pos..indices_end];
-        let _timer = interleave_time.timer();
-        match interleave_record_batch(&self.record_batches, indices) {
+        let mut timer = interleave_time.timer();
+        let result = interleave_record_batch(&self.record_batches, indices);
+        timer.stop();
+        match result {
             Ok(batch) => {
                 self.pos = indices_end;
                 Some(Ok(batch))

--- a/native/shuffle/src/partitioners/partitioned_batch_iterator.rs
+++ b/native/shuffle/src/partitioners/partitioned_batch_iterator.rs
@@ -18,6 +18,7 @@
 use arrow::array::RecordBatch;
 use arrow::compute::interleave_record_batch;
 use datafusion::common::DataFusionError;
+use datafusion::physical_plan::metrics::Time;
 
 /// A helper struct to produce shuffled batches.
 /// This struct takes ownership of the buffered batches and partition indices from the
@@ -85,18 +86,19 @@ impl<'a> PartitionedBatchIterator<'a> {
             pos: 0,
         }
     }
-}
 
-impl Iterator for PartitionedBatchIterator<'_> {
-    type Item = datafusion::common::Result<RecordBatch>;
-
-    fn next(&mut self) -> Option<Self::Item> {
+    /// Returns the next shuffled batch, recording the gather cost into `interleave_time`.
+    pub(crate) fn next(
+        &mut self,
+        interleave_time: &Time,
+    ) -> Option<datafusion::common::Result<RecordBatch>> {
         if self.pos >= self.indices.len() {
             return None;
         }
 
         let indices_end = std::cmp::min(self.pos + self.batch_size, self.indices.len());
         let indices = &self.indices[self.pos..indices_end];
+        let _timer = interleave_time.timer();
         match interleave_record_batch(&self.record_batches, indices) {
             Ok(batch) => {
                 self.pos = indices_end;

--- a/native/shuffle/src/writers/spill.rs
+++ b/native/shuffle/src/writers/spill.rs
@@ -83,7 +83,7 @@ impl PartitionWriter {
         write_buffer_size: usize,
         batch_size: usize,
     ) -> datafusion::common::Result<usize> {
-        if let Some(batch) = iter.next() {
+        if let Some(batch) = iter.next(&metrics.interleave_time) {
             self.ensure_spill_file_created(runtime)?;
 
             let total_bytes_written = {
@@ -95,7 +95,7 @@ impl PartitionWriter {
                 );
                 let mut bytes_written =
                     buf_batch_writer.write(&batch?, &metrics.encode_time, &metrics.write_time)?;
-                for batch in iter {
+                while let Some(batch) = iter.next(&metrics.interleave_time) {
                     let batch = batch?;
                     bytes_written += buf_batch_writer.write(
                         &batch,


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Two improvements to the native shuffle writer:

1. Specify  buffer size for `output_data` buffer writer: `shuffle_write` uses the default 8 KB buffer size for the output data buffer writer, which can lead to excessive system calls. This change explicitly sets `write_buffer_size` to improve write efficiency.
2. Add `interleave_time` metric: `interleave_record_batch` accounts for a significant portion of the shuffle execution time, so I'd like to add metrics for it.

## What changes are included in this PR?

This PR includes the following changes:

- adds a new `interleave_time` metric to `ShufflePartitionerMetrics`
- calculate `interleave_time` during the `PartitionedBatchIterator.next` call.
- changes the final shuffle data file writer to use `BufWriter::with_capacity(self.write_buffer_size, ...)` instead of the default buffer size


## How are these changes tested?

Run shuffle benchmark locally:

```
cargo flamegraph --root --release --features shuffle-bench --bin shuffle_bench -- \
  --input benchmark_data/lineitem.parquet \
  --partitions 200 \
  --codec lz4 \
  --hash-columns 0,3 \
  --memory-limit 2147483648 \
  --output-dir comet_shuffle_bench
```

**Test for specify  buffer size for `output_data` buffer writer**
before:
```
=== Results ===
Write:
  avg time:         42.037s
  throughput:       1,426,973 rows/s (total across 1 tasks)
  output size:      3.80 GiB

Input Metrics (last iteration):
  time_elapsed_scanning_total: 239.870s
  time_elapsed_opening: 0.003s
  time_elapsed_processing: 7.355s
  metadata_load_time: 0.000s
  output_bytes: 33.88 GiB
  bloom_filter_eval_time: 0.000s
  output_rows: 119,972,104
  bytes_scanned: 2.37 GiB
  page_index_eval_time: 0.000s
  time_elapsed_scanning_until_data: 0.349s
  output_batches: 14,956
  statistics_eval_time: 0.000s
  elapsed_compute: 0.000s
  row_pushdown_eval_time: 0.000s

Shuffle Metrics (last iteration):
  input batches:    7,478
  repart time:      0.668s (1.6%)
  encode time:      13.311s (31.7%)
  write time:       16.923s (40.3%)
  spill count:      8
  spilled bytes:    3.32 GiB
  data size:        16.95 GiB
dtrace: pid 27204 has exited
writing flamegraph to "flamegraph.svg"
```

after:
```
=== Results ===
Write:
  avg time:         35.921s
  throughput:       1,669,937 rows/s (total across 1 tasks)
  output size:      3.80 GiB

Input Metrics (last iteration):
  output_bytes: 33.88 GiB
  time_elapsed_scanning_until_data: 0.265s
  metadata_load_time: 0.001s
  bytes_scanned: 2.37 GiB
  time_elapsed_scanning_total: 234.757s
  bloom_filter_eval_time: 0.000s
  time_elapsed_opening: 0.003s
  statistics_eval_time: 0.000s
  time_elapsed_processing: 5.214s
  row_pushdown_eval_time: 0.000s
  elapsed_compute: 0.000s
  output_rows: 119,972,104
  page_index_eval_time: 0.000s
  output_batches: 14,956

Shuffle Metrics (last iteration):
  input batches:    7,478
  repart time:      0.637s (1.8%)
  encode time:      13.048s (36.3%)
  write time:       11.051s (30.8%)
  spill count:      8
  spilled bytes:    3.32 GiB
  data size:        16.95 GiB
dtrace: pid 37062 has exited
writing flamegraph to "flamegraph.svg"
```

**Test for add `interleave_time` metric**
after this:
```
=== Results ===
Write:
  avg time:         32.851s
  throughput:       1,826,014 rows/s (total across 1 tasks)
  output size:      3.80 GiB

Input Metrics (last iteration):
  page_index_eval_time: 0.000s
  elapsed_compute: 0.000s
  time_elapsed_opening: 0.002s
  output_bytes: 33.88 GiB
  row_pushdown_eval_time: 0.000s
  output_batches: 14,956
  statistics_eval_time: 0.000s
  bytes_scanned: 2.37 GiB
  bloom_filter_eval_time: 0.000s
  time_elapsed_processing: 5.287s
  metadata_load_time: 0.000s
  output_rows: 119,972,104
  time_elapsed_scanning_until_data: 0.261s
  time_elapsed_scanning_total: 226.113s

Shuffle Metrics (last iteration):
  input batches:    7,478
  repart time:      0.665s (2.0%)
  interleave time:  6.796s (20.7%)
  encode time:      12.600s (38.4%)
  write time:       8.844s (26.9%)
  spill count:      8
  spilled bytes:    3.32 GiB
  data size:        16.95 GiB
dtrace: pid 39163 has exited
writing flamegraph to "flamegraph.svg"
```