### PR TITLE
ci: stop labeled events from cancelling the commit CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,13 @@
 
 name: CI
 
+# A `labeled` event (e.g. the run-spark-*-tests gates, or dependabot's automatic
+# `dependencies` label added ~1s after open) fires at the same commit as the
+# opened/synchronize run. Keying the group on the label name keeps labeled runs
+# in their own subgroup so they never cancel the real commit run; opened and
+# synchronize both map to `commit` so a new push still supersedes its predecessor.
 concurrency:
-  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}-${{ github.event.action == 'labeled' && github.event.label.name || 'commit' }}
   cancel-in-progress: true
 
 on:
@@ -44,6 +49,14 @@ jobs:
   preflight:
     name: Preflight
     runs-on: ubuntu-slim
+    # On a `labeled` event, only proceed for the gating labels. Any other label
+    # (e.g. dependabot's `dependencies`) skips the whole pipeline rather than
+    # spawning a redundant run alongside the opened/synchronize one.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'run-spark-3.4-tests' ||
+      github.event.label.name == 'run-spark-4.1-tests'
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Which issue does this PR close?

<!-- Add `Closes #XXXX` if there is a tracking issue. -->

Follow-up to #4494.

## Rationale for this change

Since #4494 unified every workflow under one `CI` workflow with a single concurrency group, deps-only PRs (and any PR that gets auto-labeled at open time) spawn a redundant CI run that the concurrency group cancels, leaving dangling cancelled `Preflight` and `Detect changes` checks on the PR.

The mechanism, observed on dependabot PR #4602:

- PR opened at `08:56:05` triggers a `CI` run (`opened` event).
- dependabot adds the `dependencies` label at `08:56:06`, triggering a second `CI` run at the same commit (`labeled` event).
- Both runs share the group `repo-headref-CI`, so `cancel-in-progress` cancels one of the pair.
- The head SHA ends up with 2 cancelled, 19 skipped, and 62 successful check runs.

Before #4494 the `run-spark-*-tests` label gates lived in separate workflow files that listened only on `pull_request: types: [labeled]`, each with its own concurrency group keyed on `github.workflow`. An `opened` event and a `labeled` event therefore never shared a group. Merging everything into one workflow removed that isolation, and GitHub cannot filter `types: labeled` by label name in the `on:` block, so dependabot's `dependencies` label triggers a full second run.

## What changes are included in this PR?

Two coordinated changes in `.github/workflows/ci.yml`:

1. Make the concurrency group label-aware. Labeled events get their own subgroup keyed on the label name, so they never cancel the real commit run. `opened` and `synchronize` both map to `commit`, so a new push still supersedes its predecessor.
2. Gate the root `preflight` job so a `labeled` event only proceeds for the `run-spark-3.4-tests` and `run-spark-4.1-tests` gates. Any other label (such as dependabot's `dependencies`) skips the whole pipeline transitively through `needs`, rather than spawning a redundant run.

Net behavior:

- `opened` / `synchronize` run one full pipeline, no competing cancellation.
- `labeled: dependencies` lands in its own subgroup, skips immediately, and does not touch the commit run.
- `labeled: run-spark-4.1-tests` lands in its own subgroup and runs the gated job.

One note for reviewers: adding a gating label re-runs the whole pipeline rather than just that Spark version, because the non-gated jobs fire on any `pull_request` event. That is pre-existing #4494 behavior, not introduced here. Fully restoring the old "label runs only that Spark version" isolation would mean pulling those two jobs back into a small dedicated `labeled`-only workflow.

## How are these changes tested?

Existing CI. The `preflight` actionlint step lints `ci.yml` on this branch.
