### PR TITLE
chore(deps): align object_store_opendal with opendal

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1768,6 +1768,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
+]
+
+[[package]]
 name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,7 +2021,7 @@ dependencies = [
  "object_store",
  "object_store_opendal",
  "once_cell",
- "opendal",
+ "opendal 0.57.0",
  "parking_lot",
  "parquet",
  "paste",
@@ -2407,7 +2417,7 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "num-traits",
  "rand 0.9.4",
@@ -3648,7 +3658,7 @@ dependencies = [
  "cfg-if",
  "futures",
  "iceberg",
- "opendal",
+ "opendal 0.56.0",
  "reqsign-aws-v4",
  "reqsign-core",
  "serde",
@@ -4207,6 +4217,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-section"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "014e440054ce8170890229eeef5bcda955305e056ec713de40ed366944483f09"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4301,6 +4323,16 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -4558,10 +4590,10 @@ dependencies = [
  "humantime",
  "hyper",
  "itertools 0.14.0",
- "md-5",
+ "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
- "quick-xml 0.39.2",
+ "quick-xml 0.39.4",
  "rand 0.10.1",
  "reqwest 0.12.28",
  "ring",
@@ -4590,7 +4622,7 @@ dependencies = [
  "futures",
  "mea",
  "object_store",
- "opendal",
+ "opendal 0.56.0",
  "pin-project",
  "tokio",
 ]
@@ -4625,18 +4657,32 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b31d3d8e99a85d83b73ec26647f5607b80578ed9375810b6e44ffa3590a236"
 dependencies = [
- "ctor",
- "opendal-core",
- "opendal-layer-concurrent-limit",
- "opendal-layer-logging",
- "opendal-layer-retry",
- "opendal-layer-timeout",
+ "ctor 0.6.3",
+ "opendal-core 0.56.0",
+ "opendal-layer-concurrent-limit 0.56.0",
+ "opendal-layer-logging 0.56.0",
+ "opendal-layer-retry 0.56.0",
+ "opendal-layer-timeout 0.56.0",
  "opendal-service-azdls",
  "opendal-service-fs",
  "opendal-service-gcs",
- "opendal-service-hdfs",
  "opendal-service-oss",
  "opendal-service-s3",
+]
+
+[[package]]
+name = "opendal"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c9c85ce253ff87225e7669979d877a20c98a06604ec9d6dd5f4473e08f1ae1"
+dependencies = [
+ "ctor 1.0.7",
+ "opendal-core 0.57.0",
+ "opendal-layer-concurrent-limit 0.57.0",
+ "opendal-layer-logging 0.57.0",
+ "opendal-layer-retry 0.57.0",
+ "opendal-layer-timeout 0.57.0",
+ "opendal-service-hdfs",
 ]
 
 [[package]]
@@ -4653,10 +4699,38 @@ dependencies = [
  "http-body 1.0.1",
  "jiff",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "mea",
  "percent-encoding",
  "quick-xml 0.38.4",
+ "reqsign-core",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+ "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "opendal-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4f8607c90e2c963a91467f50fb49fbc7fb3d573f88cea219ca59ccd3740b309"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bytes",
+ "futures",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "jiff",
+ "log",
+ "md-5 0.11.0",
+ "mea",
+ "percent-encoding",
+ "quick-xml 0.39.4",
  "reqsign-core",
  "reqwest 0.13.2",
  "serde",
@@ -4676,7 +4750,19 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "mea",
- "opendal-core",
+ "opendal-core 0.56.0",
+]
+
+[[package]]
+name = "opendal-layer-concurrent-limit"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6f81ba6960e3fae1882f253b114b21d7e444e1534f209c7737a79f6243eb6f"
+dependencies = [
+ "futures",
+ "http 1.4.0",
+ "mea",
+ "opendal-core 0.57.0",
 ]
 
 [[package]]
@@ -4686,7 +4772,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2645adc988b12eda106e2679ae529facfbbaa868ceb706f6f8125c6af15c47b"
 dependencies = [
  "log",
- "opendal-core",
+ "opendal-core 0.56.0",
+]
+
+[[package]]
+name = "opendal-layer-logging"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ada45c6d81d1aa4c9305d0c7d4bc317c59c85866a0908a2d75a7a978aa5ee2"
+dependencies = [
+ "log",
+ "opendal-core 0.57.0",
 ]
 
 [[package]]
@@ -4697,7 +4793,18 @@ checksum = "4eac134ffa4ddda6131a640a84a5315996424b9416c85052f8c64c1a33b70ad4"
 dependencies = [
  "backon",
  "log",
- "opendal-core",
+ "opendal-core 0.56.0",
+]
+
+[[package]]
+name = "opendal-layer-retry"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2a25a718afb81fad81cb9a0580a1cb989221fa2317f888c6a37f8dad408eb7"
+dependencies = [
+ "backon",
+ "log",
+ "opendal-core 0.57.0",
 ]
 
 [[package]]
@@ -4706,7 +4813,17 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "619586ab7480c2e3009f6d18eabab18957bc094778fd130bcc38924970a90f4c"
 dependencies = [
- "opendal-core",
+ "opendal-core 0.56.0",
+ "tokio",
+]
+
+[[package]]
+name = "opendal-layer-timeout"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91f731724c213af81e9d03517859c8fc47b4578e64ad61ae4f099f10fe36e3"
+dependencies = [
+ "opendal-core 0.57.0",
  "tokio",
 ]
 
@@ -4719,7 +4836,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "log",
- "opendal-core",
+ "opendal-core 0.56.0",
  "opendal-service-azure-common",
  "quick-xml 0.38.4",
  "reqsign-azure-storage",
@@ -4736,7 +4853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb0e45d6c8dcf66ce2da20e241bcb80e6e540e109a4ff20f318f6c9b4c54e0c"
 dependencies = [
  "http 1.4.0",
- "opendal-core",
+ "opendal-core 0.56.0",
 ]
 
 [[package]]
@@ -4747,7 +4864,7 @@ checksum = "cf0be0417abeeb0053376d816b90fceb9ca98f20dfb54ebf1f2a282729f83663"
 dependencies = [
  "bytes",
  "log",
- "opendal-core",
+ "opendal-core 0.56.0",
  "serde",
  "tokio",
  "xattr",
@@ -4763,7 +4880,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "log",
- "opendal-core",
+ "opendal-core 0.56.0",
  "percent-encoding",
  "quick-xml 0.38.4",
  "reqsign-core",
@@ -4776,15 +4893,15 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-hdfs"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10fa31a5abe347c61c63edfb08e5c25f488dc000b0289023190b13b0c4c89b49"
+checksum = "fb51ce674ce98b8b7d9ac7d2dfc9d7fc8f1bbd1da1a5fb928ecc5f13ba7dc88a"
 dependencies = [
  "bytes",
  "futures",
  "hdrs",
  "log",
- "opendal-core",
+ "opendal-core 0.57.0",
  "serde",
  "tokio",
 ]
@@ -4798,7 +4915,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "log",
- "opendal-core",
+ "opendal-core 0.56.0",
  "quick-xml 0.38.4",
  "reqsign-aliyun-oss",
  "reqsign-core",
@@ -4817,8 +4934,8 @@ dependencies = [
  "crc32c",
  "http 1.4.0",
  "log",
- "md-5",
- "opendal-core",
+ "md-5 0.10.6",
+ "opendal-core 0.56.0",
  "quick-xml 0.38.4",
  "reqsign-aws-v4",
  "reqsign-core",
@@ -5383,9 +5500,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -5656,7 +5773,7 @@ dependencies = [
  "http 1.4.0",
  "log",
  "percent-encoding",
- "quick-xml 0.39.2",
+ "quick-xml 0.39.4",
  "reqsign-core",
  "rust-ini",
  "serde",

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -4612,9 +4612,9 @@ dependencies = [
 
 [[package]]
 name = "object_store_opendal"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08298874eee5935c95bcaa393148834f9c53d904461ca15584a041d8a1c907c2"
+checksum = "0eb12a624a41fce745838d0ef3701ff6c47797c13cd18ad3612fd2a3134fdbd8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4622,7 +4622,7 @@ dependencies = [
  "futures",
  "mea",
  "object_store",
- "opendal 0.56.0",
+ "opendal 0.57.0",
  "pin-project",
  "tokio",
 ]

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -70,7 +70,7 @@ aws-credential-types = { workspace = true }
 parking_lot = "0.12.5"
 datafusion-comet-objectstore-hdfs = { path = "../hdfs", optional = true, default-features = false, features = ["hdfs"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "http2"] }
-object_store_opendal = { version = "0.56.0", optional = true }
+object_store_opendal = { version = "0.57.0", optional = true }
 hdfs-sys = {version = "0.3", optional = true, features = ["hdfs_3_3"]}
 opendal = { version = "0.57.0", optional = true, features = ["services-hdfs"] }
 iceberg = { workspace = true }

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -72,7 +72,7 @@ datafusion-comet-objectstore-hdfs = { path = "../hdfs", optional = true, default
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "http2"] }
 object_store_opendal = { version = "0.56.0", optional = true }
 hdfs-sys = {version = "0.3", optional = true, features = ["hdfs_3_3"]}
-opendal = { version = "0.56.0", optional = true, features = ["services-hdfs"] }
+opendal = { version = "0.57.0", optional = true, features = ["services-hdfs"] }
 iceberg = { workspace = true }
 iceberg-storage-opendal = { workspace = true }
 reqsign-core = { workspace = true }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4613 

## Rationale for this change

PR #4605 bumps `opendal` to 0.57.0, but CI failed because `object_store_opendal` remained on 0.56.0. That left Comet with two incompatible OpenDAL `Operator` types in the HDFS/OpenDAL path.

Aligning `object_store_opendal` with the bumped `opendal` version fixes the Rust type mismatch.

## What changes are included in this PR?

- Bump `object_store_opendal` from 0.56.0 to 0.57.0.
- Update `native/Cargo.lock` so `object_store_opendal` depends on `opendal 0.57.0`.

## How are these changes tested?

- `cargo check -p datafusion-comet --features hdfs-opendal`
- `cargo clippy --color=never --all-targets --workspace -- -D warnings`
