### PR TITLE
fix: allow EvalMode.TRY in CometRemainder to support try_mod

### DIFF
--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -389,7 +389,7 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 
 | Function | Status | Notes |
 | --- | --- | --- |
-| `%` | ✅ | try_mod (TRY mode) falls back |
+| `%` | ✅ |  |
 | `*` | ✅ | Interval multiplication falls back |
 | `+` | ✅ |  |
 | `-` | ✅ |  |
@@ -453,7 +453,7 @@ All higher-order functions are planned via [#4224](https://github.com/apache/dat
 | `tanh` | ✅ |  |
 | `try_add` | ✅ | Datetime/interval form falls back |
 | `try_divide` | ✅ |  |
-| `try_mod` | 🔜 | Lowers to `Remainder` with TRY eval mode, which falls back ([#4484](https://github.com/apache/datafusion-comet/issues/4484)) |
+| `try_mod` | ✅ |  |
 | `try_multiply` | ✅ |  |
 | `try_subtract` | ✅ |  |
 | `unhex` | ✅ |  |

--- a/spark/src/main/scala/org/apache/comet/serde/arithmetic.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arithmetic.scala
@@ -267,10 +267,6 @@ object CometRemainder extends CometExpressionSerde[Remainder] with MathBase {
       withFallbackReason(expr, s"Unsupported datatype ${expr.left.dataType}")
       return None
     }
-    if (expr.evalMode == EvalMode.TRY) {
-      withFallbackReason(expr, s"Eval mode ${expr.evalMode} is not supported")
-      return None
-    }
 
     createMathExpression(
       expr,

--- a/spark/src/test/resources/sql-tests/expressions/math/arithmetic_try.sql
+++ b/spark/src/test/resources/sql-tests/expressions/math/arithmetic_try.sql
@@ -1,0 +1,51 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- TRY mode arithmetic tests for Remainder (try_mod)
+-- try_mod returns NULL on divide-by-zero instead of throwing
+
+-- MinSparkVersion: 4.0
+
+statement
+CREATE TABLE try_mod_int(a int, b int) USING parquet
+
+statement
+INSERT INTO try_mod_int VALUES (10, 3), (10, 0), (0, 0), (NULL, 1), (10, NULL), (-10, 3), (10, -3)
+
+query
+SELECT try_mod(a, b) FROM try_mod_int
+
+query
+SELECT try_mod(10, 3)
+
+query
+SELECT try_mod(10, 0)
+
+query
+SELECT try_mod(NULL, 1)
+
+query
+SELECT try_mod(10, NULL)
+
+statement
+CREATE TABLE try_mod_long(a long, b long) USING parquet
+
+statement
+INSERT INTO try_mod_long VALUES (10L, 3L), (10L, 0L), (0L, 0L), (NULL, 1L), (10L, NULL)
+
+query
+SELECT try_mod(a, b) FROM try_mod_long


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4484

## Rationale for this change

`try_mod` (Spark 4.0+) is `RuntimeReplaceable` and rewrites to `Remainder(left, right, EvalMode.TRY)`. Comet's `CometRemainder` serde explicitly rejected `EvalMode.TRY`, causing the enclosing plan to fall back to Spark. The sibling arithmetic serdes (`CometAdd`, `CometSubtract`, `CometMultiply`, `CometDivide`, `CometIntegralDivide`) all accept `EvalMode.TRY`, and the Rust `spark_modulo` UDF already takes a `fail_on_error: bool` flag that correctly returns NULL on divide-by-zero when `fail_on_error=false` (which is the TRY mode behavior).

## What changes are included in this PR?

- Removed the `EvalMode.TRY` rejection block from `CometRemainder.convert` in `arithmetic.scala`, aligning it with the other arithmetic serdes
- Added SQL file tests for `try_mod` in `arithmetic_try.sql` (MinSparkVersion: 4.0)
- Updated `expressions.md` to mark `try_mod` as supported and remove the fallback note from `%`

## How are these changes tested?

- Existing Rust tests for `spark_modulo` (4 tests covering basic modulo, decimal modulo, divide-by-zero, and complex expressions) continue to pass
- New SQL file tests in `arithmetic_try.sql` cover `try_mod` with integer, long, divide-by-zero, NULL inputs, and column references

```bash
./mvnw test -Dsuites="org.apache.comet.CometSqlFileTestSuite arithmetic_try" -Dtest=none
```
