### PR TITLE
docs: mark dayname, monthname, and regexp_extract family as supported in expressions.md

### DIFF
--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -247,7 +247,7 @@ The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `deci
 | `datediff` | ✅ |  |
 | `datepart` | ✅ |  |
 | `day` | ✅ |  |
-| `dayname` | 🔜 | [#4544](https://github.com/apache/datafusion-comet/issues/4544) |
+| `dayname` | ✅ | Abbreviated day name (Spark 4.0+) |
 | `dayofmonth` | ✅ |  |
 | `dayofweek` | ✅ |  |
 | `dayofyear` | ✅ |  |
@@ -267,7 +267,7 @@ The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `deci
 | `make_ym_interval` | 🔜 | [#4541](https://github.com/apache/datafusion-comet/issues/4541) |
 | `minute` | ✅ |  |
 | `month` | ✅ |  |
-| `monthname` | 🔜 | [#4544](https://github.com/apache/datafusion-comet/issues/4544) |
+| `monthname` | ✅ | Abbreviated month name (Spark 4.0+) |
 | `months_between` | ✅ |  |
 | `next_day` | ✅ |  |
 | `now` | ✅ | Constant-folded to a literal (alias of `current_timestamp`) |
@@ -567,9 +567,9 @@ expression-level). The `outer` variants are wired but marked `Incompatible`; the
 | `position` | ✅ |  |
 | `printf` | ✅ |  |
 | `regexp_count` | 🔜 | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098) |
-| `regexp_extract` | 🔜 | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098) |
-| `regexp_extract_all` | 🔜 | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098) |
-| `regexp_instr` | 🔜 | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098) |
+| `regexp_extract` | ✅ | Routed through the JVM codegen dispatcher |
+| `regexp_extract_all` | ✅ | Routed through the JVM codegen dispatcher |
+| `regexp_instr` | ✅ | Routed through the JVM codegen dispatcher |
 | `regexp_replace` | ✅ |  |
 | `regexp_substr` | 🔜 | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098) |
 | `repeat` | ✅ |  |


### PR DESCRIPTION
## Which issue does this PR close?

N/A. This is a documentation correction.

## Rationale for this change

The Spark expression support reference (`expressions.md`) is maintained by hand, and several entries went stale after recent feature PRs enabled the expressions but did not flip the status in this page. EXPLAIN, the dispatcher, and users all read this table as the source of truth, so leaving these as `🔜 Planned` understates what Comet already accelerates.

## What changes are included in this PR?

Marks five expressions as ✅ Supported to match the current code:

* `dayname` / `monthname`: implemented as native Rust scalar functions and wired through the Spark 4.x expression shim in [#4544](https://github.com/apache/datafusion-comet/pull/4544). Noted as Spark 4.0+ since the `DayName` / `MonthName` classes only exist there.
* `regexp_extract` / `regexp_extract_all` / `regexp_instr`: registered as `CometCodegenDispatch` serdes that route through the JVM codegen dispatcher in [#4239](https://github.com/apache/datafusion-comet/pull/4239), so they run inside the Comet pipeline with Spark-compatible results.

The closely related `regexp_count` and `regexp_substr` remain `🔜` because they are not yet registered, and the higher-order `filter` remains `🔜` because `CometArrayFilter` still only supports the `array_compact` (`IsNotNull`) form.

## How are these changes tested?

Documentation-only change. Each flipped entry was verified against the code: the native scalar functions in `comet_scalar_funcs.rs` and the Spark 4.x shim for `dayname` / `monthname`, and the `CometCodegenDispatch` registrations in `QueryPlanSerde.scala` for the regexp family. `expressions.md` is listed in `.prettierignore`, so no formatting step applies.
