### PR TITLE
feat: wire mask and map (create_map) through codegen dispatch

### DIFF
--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -375,7 +375,7 @@ expression-level). The `outer` variants are wired but marked `Incompatible`; the
 | Function | Status | Notes |
 | --- | --- | --- |
 | `element_at` | ✅ | MapType input falls back |
-| `map` | 🔜 | Constructs a map |
+| `map` | ✅ | Routed through the JVM codegen dispatcher |
 | `map_concat` | ✅ |  |
 | `map_contains_key` | ✅ |  |
 | `map_entries` | ✅ |  |
@@ -561,7 +561,7 @@ expression-level). The `outer` variants are wired but marked `Incompatible`; the
 | `lpad` | ✅ |  |
 | `ltrim` | ✅ |  |
 | `luhn_check` | ✅ | Native via `StaticInvoke` (tests: luhn_check.sql) |
-| `mask` | 🔜 | Data masking |
+| `mask` | ✅ | Routed through the JVM codegen dispatcher |
 | `octet_length` | ✅ |  |
 | `overlay` | ✅ |  |
 | `position` | ✅ |  |

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -182,7 +182,8 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
       classOf[MapFilter] -> CometMapFilter,
       classOf[TransformKeys] -> CometTransformKeys,
       classOf[TransformValues] -> CometTransformValues,
-      classOf[MapZipWith] -> CometMapZipWith)
+      classOf[MapZipWith] -> CometMapZipWith,
+      classOf[CreateMap] -> CometCreateMap)
     base ++ sparkVersionSpecificMapExpressions
   }
 
@@ -253,7 +254,8 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
       classOf[StringLocate] -> CometStringLocate,
       classOf[UnBase64] -> CometUnBase64,
       classOf[ToCharacter] -> CometToCharacter,
-      classOf[ToNumber] -> CometToNumber)
+      classOf[ToNumber] -> CometToNumber,
+      classOf[Mask] -> CometMask)
     base ++ sparkVersionSpecificStringExpressions
   }
 

--- a/spark/src/main/scala/org/apache/comet/serde/maps.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/maps.scala
@@ -182,6 +182,8 @@ object CometStrToMap extends CometScalarFunction[StringToMap]("str_to_map") {
   }
 }
 
+object CometCreateMap extends CometCodegenDispatch[CreateMap]
+
 object CometMapFilter extends CometCodegenDispatch[MapFilter]
 
 object CometTransformKeys extends CometCodegenDispatch[TransformKeys]

--- a/spark/src/main/scala/org/apache/comet/serde/strings.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/strings.scala
@@ -21,7 +21,7 @@ package org.apache.comet.serde
 
 import java.util.Locale
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, BitLength, Cast, Concat, ConcatWs, Elt, Expression, FindInSet, FormatNumber, FormatString, GetJsonObject, If, InitCap, IsNull, Left, Length, Levenshtein, Like, Literal, Lower, OctetLength, Overlay, RegExpExtract, RegExpExtractAll, RegExpInStr, RegExpReplace, Right, RLike, SoundEx, StringLocate, StringLPad, StringRepeat, StringReplace, StringRPad, StringSplit, StringTranslate, Substring, SubstringIndex, ToCharacter, ToNumber, UnBase64, Upper}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, BitLength, Cast, Concat, ConcatWs, Elt, Expression, FindInSet, FormatNumber, FormatString, GetJsonObject, If, InitCap, IsNull, Left, Length, Levenshtein, Like, Literal, Lower, Mask, OctetLength, Overlay, RegExpExtract, RegExpExtractAll, RegExpInStr, RegExpReplace, Right, RLike, SoundEx, StringLocate, StringLPad, StringRepeat, StringReplace, StringRPad, StringSplit, StringTranslate, Substring, SubstringIndex, ToCharacter, ToNumber, UnBase64, Upper}
 import org.apache.spark.sql.types.{BinaryType, DataTypes, LongType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -602,3 +602,5 @@ object CometUnBase64 extends CometCodegenDispatch[UnBase64]
 object CometToCharacter extends CometCodegenDispatch[ToCharacter]
 
 object CometToNumber extends CometCodegenDispatch[ToNumber]
+
+object CometMask extends CometCodegenDispatch[Mask]

--- a/spark/src/test/resources/sql-tests/expressions/map/create_map.sql
+++ b/spark/src/test/resources/sql-tests/expressions/map/create_map.sql
@@ -1,0 +1,30 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- map(...) constructor routed through the codegen dispatcher. Map keys may not be null in Spark.
+
+statement
+CREATE TABLE test_create_map(k string, v int) USING parquet
+
+statement
+INSERT INTO test_create_map VALUES ('a', 1), ('b', 2), ('c', NULL)
+
+query
+SELECT map(k, v) FROM test_create_map
+
+query
+SELECT map(1, 'a', 2, 'b'), map('x', array(1, 2), 'y', array(3))

--- a/spark/src/test/resources/sql-tests/expressions/string/mask.sql
+++ b/spark/src/test/resources/sql-tests/expressions/string/mask.sql
@@ -1,0 +1,32 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- mask routed through the codegen dispatcher.
+
+-- MinSparkVersion: 3.5
+
+statement
+CREATE TABLE test_mask(s string) USING parquet
+
+statement
+INSERT INTO test_mask VALUES ('AbCD123-$#'), ('Spark'), (''), (NULL)
+
+query
+SELECT mask(s), s FROM test_mask
+
+query
+SELECT mask('AbCD123-$#', 'Q', 'q', 'd', 'o'), mask('Spark', 'X')


### PR DESCRIPTION
## Which issue does this PR close?

N/A. Part of expanding JVM codegen dispatch coverage.

## Rationale for this change

`mask` and `map` are scalar expressions with supported output types that were falling back to Spark even though they are eligible for the codegen dispatch path (which runs Spark's own `doGenCode` inside the Comet pipeline for Spark-exact results).

## What changes are included in this PR?

* `mask` (`Mask`): registered as `CometCodegenDispatch`.
* `map` (`CreateMap`): registered as `CometCodegenDispatch`.

`docs/source/user-guide/latest/expressions.md` flips both from Planned to Supported.

A few related expressions were deferred because they need more than a one-line registration, and I would rather land them with proper handling:

* `base64` / `encode`: on Spark 4.x these lower to `StaticInvoke` (codec object), not the `Base64` / `Encode` case classes, so they need the `StaticInvoke` allowlist in `statics.scala` extended (and the path differs across Spark versions).
* `split_part`: rewrites to `element_at(StringSplitSQL(...))`. Dispatching `StringSplitSQL` then composing with `element_at` tripped a native panic (`Arrays with inconsistent types passed to MutableArrayData`), so it needs investigation.
* `array_prepend`: `ArrayPrepend` only exists in Spark 3.5+, so it needs the version-specific expression map rather than the shared one.

## How are these changes tested?

New Comet SQL file tests `string/mask.sql` and `map/create_map.sql`, run with `CometSqlFileTestSuite` and passing (native execution plus result match against Spark). Both exercise column inputs, literals, nulls, and the multi-argument forms.
