### PR TITLE
feat: opt array_intersect, array_except, array_join into codegen dispatch

### DIFF
--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -134,10 +134,10 @@ The tables below list every Spark built-in expression with its current status.
 | `array_compact` | ✅ |  |
 | `array_contains` | ✅ | NaN/signed-zero handling may differ ([details](compatibility/floating-point.md)) |
 | `array_distinct` | ✅ | NaN/signed-zero handling may differ ([details](compatibility/floating-point.md)) |
-| `array_except` | ✅ | Incompatible; falls back by default ([details](compatibility/expressions/array.md)) |
+| `array_except` | ✅ | Routes through the JVM codegen dispatcher by default; the incompatible native path is opt-in via allowIncompatible ([details](compatibility/expressions/array.md)) |
 | `array_insert` | ✅ |  |
-| `array_intersect` | ✅ | Incompatible; falls back by default ([details](compatibility/expressions/array.md)) |
-| `array_join` | ✅ | Incompatible; falls back by default ([details](compatibility/expressions/array.md)) |
+| `array_intersect` | ✅ | Routes through the JVM codegen dispatcher by default; the incompatible native path is opt-in via allowIncompatible ([details](compatibility/expressions/array.md)) |
+| `array_join` | ✅ | Routes through the JVM codegen dispatcher by default; the incompatible native path is opt-in via allowIncompatible ([details](compatibility/expressions/array.md)) |
 | `array_max` | ✅ | NaN ordering may differ ([details](compatibility/floating-point.md)) |
 | `array_min` | ✅ | NaN ordering may differ ([details](compatibility/floating-point.md)) |
 | `array_position` | ✅ | Binary/struct/map/null elements fall back |

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -191,7 +191,10 @@ object CometSortArray extends CometExpressionSerde[SortArray] {
   }
 }
 
-object CometArrayIntersect extends CometExpressionSerde[ArrayIntersect] with CometTypeShim {
+object CometArrayIntersect
+    extends CometExpressionSerde[ArrayIntersect]
+    with CometTypeShim
+    with CodegenDispatchFallback {
 
   private val incompatReason: String =
     "Result array element order may differ from Spark when the right array is longer " +
@@ -332,7 +335,10 @@ object CometArrayCompact extends CometExpressionSerde[Expression] {
   }
 }
 
-object CometArrayExcept extends CometExpressionSerde[ArrayExcept] with CometExprShim {
+object CometArrayExcept
+    extends CometExpressionSerde[ArrayExcept]
+    with CometExprShim
+    with CodegenDispatchFallback {
 
   private val incompatReason = "Null handling and ordering may differ from Spark"
 
@@ -376,7 +382,7 @@ object CometArrayExcept extends CometExpressionSerde[ArrayExcept] with CometExpr
   }
 }
 
-object CometArrayJoin extends CometExpressionSerde[ArrayJoin] {
+object CometArrayJoin extends CometExpressionSerde[ArrayJoin] with CodegenDispatchFallback {
 
   private val incompatReason = "Null handling may differ from Spark"
 

--- a/spark/src/test/resources/sql-tests/expressions/array/array_except_dispatch.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_except_dispatch.sql
@@ -15,14 +15,18 @@
 -- specific language governing permissions and limitations
 -- under the License.
 
-statement
-CREATE TABLE test_array_join(arr array<string>) USING parquet
+-- ArrayExcept mixes in CodegenDispatchFallback, so with allowIncompatible unset its Incompatible
+-- null-handling/ordering case routes through the JVM codegen dispatcher and matches Spark exactly,
+-- including the literal/literal case the native path could not handle.
 
 statement
-INSERT INTO test_array_join VALUES (array('a', 'b', 'c')), (array('hello', 'world')), (array()), (NULL), (array('a', NULL, 'c'))
+CREATE TABLE test_ae_dispatch(a array<int>, b array<int>) USING parquet
+
+statement
+INSERT INTO test_ae_dispatch VALUES (array(1, 2, 3), array(2, 3, 4)), (array(1, 2), array()), (array(), array(1)), (NULL, array(1)), (array(1, NULL), array(NULL))
 
 query
-SELECT array_join(arr, ',') FROM test_array_join
+SELECT array_except(a, b) FROM test_ae_dispatch
 
 query
-SELECT array_join(arr, ',', 'NULL') FROM test_array_join
+SELECT array_except(array(1, 2, 3), array(2, 3, 4)), array_except(array(1, 2), array()), array_except(array(), array(1)), array_except(cast(NULL as array<int>), array(1))

--- a/spark/src/test/resources/sql-tests/expressions/array/array_intersect_dispatch.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_intersect_dispatch.sql
@@ -15,14 +15,19 @@
 -- specific language governing permissions and limitations
 -- under the License.
 
-statement
-CREATE TABLE test_array_join(arr array<string>) USING parquet
+-- ArrayIntersect mixes in CodegenDispatchFallback, so with allowIncompatible unset its
+-- Incompatible element-order case routes through the JVM codegen dispatcher and matches Spark
+-- exactly, including the right-longer-than-left case the native path orders differently (no
+-- sort_array workaround needed here).
 
 statement
-INSERT INTO test_array_join VALUES (array('a', 'b', 'c')), (array('hello', 'world')), (array()), (NULL), (array('a', NULL, 'c'))
+CREATE TABLE test_ai_dispatch(a array<int>, b array<int>) USING parquet
+
+statement
+INSERT INTO test_ai_dispatch VALUES (array(2, 1), array(3, 1, 2)), (array(3, 1), array(1, 2, 3, 4)), (array(1, NULL), array(NULL, 2)), (NULL, array(1))
 
 query
-SELECT array_join(arr, ',') FROM test_array_join
+SELECT array_intersect(a, b) FROM test_ai_dispatch
 
 query
-SELECT array_join(arr, ',', 'NULL') FROM test_array_join
+SELECT array_intersect(array(2, 1), array(3, 1, 2)), array_intersect(array(3, 1), array(1, 2, 3, 4))


### PR DESCRIPTION
## Which issue does this PR close?

Part of #4596 (the array group: `array_intersect`, `array_except`, `array_join`).

## Rationale for this change

These three expressions report `Incompatible` (null handling and element ordering can diverge from DataFusion's native implementation), so with `allowIncompatible` unset they fall the whole projection back to Spark. They all have a real Spark `doGenCode` and supported input/output types, so they are eligible for the `CodegenDispatchFallback` path introduced in #4538: route the `Incompatible` result through the JVM codegen dispatcher (Spark's own `doGenCode` inside the Comet pipeline) so the projection stays native while matching Spark exactly.

## What changes are included in this PR?

* `CometArrayIntersect`, `CometArrayExcept`, `CometArrayJoin` mix in `CodegenDispatchFallback`. `ArrayIntersect`'s `Unsupported` collation case is unchanged (still falls back); only the `Incompatible` case dispatches.
* `docs/source/user-guide/latest/expressions.md` notes updated: these now route through the dispatcher by default, with the native incompatible path opt-in via `allowIncompatible`.

The native opt-in path (`allowIncompatible=true`) is unchanged.

## How are these changes tested?

* `array_join.sql`: upgraded from `spark_answer_only` to `query` so it now asserts native execution matching Spark, including the `array('a', NULL, 'c')` null case.
* New `array_intersect_dispatch.sql` and `array_except_dispatch.sql`: exercise the dispatch path with `allowIncompatible` unset over the exact inputs the native path handles incompatibly (the right-longer-than-left ordering case for intersect, and the literal/literal case for except that the native path could not handle). Both assert native execution matching Spark with no `sort_array` workaround.
* The existing `array_intersect.sql` / `array_except.sql` tests (native `allowIncompatible=true` path) still pass.

All run with `CometSqlFileTestSuite` on Spark 3.5 and pass.
