### PR TITLE
feat: opt timezone expressions into codegen dispatch

### DIFF
--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -230,7 +230,7 @@ The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `deci
 | Function | Status | Notes |
 | --- | --- | --- |
 | `add_months` | ✅ |  |
-| `convert_timezone` | ✅ |  |
+| `convert_timezone` | ✅ | Routes through the JVM codegen dispatcher by default (handles all timezone forms); the native path is opt-in via allowIncompatible ([details](compatibility/expressions/datetime.md)) |
 | `curdate` | ✅ | Constant-folded to a literal (alias of `current_date`) |
 | `current_date` | ✅ | Constant-folded to a literal before Comet sees the plan |
 | `current_time` | 🔜 | Blocked on Spark 4.1 TIME type support ([#4288](https://github.com/apache/datafusion-comet/issues/4288)) |
@@ -253,7 +253,7 @@ The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `deci
 | `dayofyear` | ✅ |  |
 | `extract` | ✅ |  |
 | `from_unixtime` | ✅ |  |
-| `from_utc_timestamp` | ✅ | Legacy zone forms fall back (Incompatible) ([details](compatibility/expressions/datetime.md)) |
+| `from_utc_timestamp` | ✅ | Routes through the JVM codegen dispatcher by default (handles all timezone forms); the native path is opt-in via allowIncompatible ([details](compatibility/expressions/datetime.md)) |
 | `hour` | ✅ |  |
 | `last_day` | ✅ |  |
 | `localtimestamp` | ✅ |  |
@@ -285,7 +285,7 @@ The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `deci
 | `to_timestamp_ltz` | ✅ | Rewrites to `to_timestamp` (`TimestampType`) |
 | `to_timestamp_ntz` | ✅ | Rewrites to `to_timestamp` (`TimestampNTZType`) |
 | `to_unix_timestamp` | ✅ |  |
-| `to_utc_timestamp` | ✅ | Legacy zone forms fall back (Incompatible) ([details](compatibility/expressions/datetime.md)) |
+| `to_utc_timestamp` | ✅ | Routes through the JVM codegen dispatcher by default (handles all timezone forms); the native path is opt-in via allowIncompatible ([details](compatibility/expressions/datetime.md)) |
 | `trunc` | ✅ |  |
 | `try_make_interval` | 🔜 | Produces legacy CalendarInterval; tracked by [#4540](https://github.com/apache/datafusion-comet/issues/4540) |
 | `try_make_timestamp` | ✅ |  |

--- a/spark/src/main/scala/org/apache/comet/serde/datetime.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/datetime.scala
@@ -357,7 +357,9 @@ private object UTCTimestampSerde {
       " execution time. See https://github.com/apache/datafusion-comet/issues/2013."
 }
 
-object CometFromUTCTimestamp extends CometExpressionSerde[FromUTCTimestamp] {
+object CometFromUTCTimestamp
+    extends CometExpressionSerde[FromUTCTimestamp]
+    with CodegenDispatchFallback {
 
   override def getSupportLevel(expr: FromUTCTimestamp): SupportLevel =
     Incompatible(Some(UTCTimestampSerde.tzParseIncompatReason))
@@ -375,7 +377,9 @@ object CometFromUTCTimestamp extends CometExpressionSerde[FromUTCTimestamp] {
   }
 }
 
-object CometToUTCTimestamp extends CometExpressionSerde[ToUTCTimestamp] {
+object CometToUTCTimestamp
+    extends CometExpressionSerde[ToUTCTimestamp]
+    with CodegenDispatchFallback {
 
   override def getSupportLevel(expr: ToUTCTimestamp): SupportLevel =
     Incompatible(Some(UTCTimestampSerde.tzParseIncompatReason))
@@ -393,7 +397,9 @@ object CometToUTCTimestamp extends CometExpressionSerde[ToUTCTimestamp] {
   }
 }
 
-object CometConvertTimezone extends CometExpressionSerde[ConvertTimezone] {
+object CometConvertTimezone
+    extends CometExpressionSerde[ConvertTimezone]
+    with CodegenDispatchFallback {
 
   override def getSupportLevel(expr: ConvertTimezone): SupportLevel =
     Incompatible(Some(UTCTimestampSerde.tzParseIncompatReason))

--- a/spark/src/test/resources/sql-tests/expressions/datetime/convert_timezone_dispatch.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/convert_timezone_dispatch.sql
@@ -1,0 +1,40 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- CometConvertTimezone mixes in CodegenDispatchFallback, so with allowIncompatible unset it routes
+-- through the JVM codegen dispatcher and matches Spark exactly, including the legacy timezone forms
+-- the native parser rejects. Verified across two session zones.
+-- ConfigMatrix: spark.sql.session.timeZone=UTC,America/Los_Angeles
+
+statement
+CREATE TABLE test_ct_dispatch(ts timestamp_ntz, src string, tgt string) USING parquet
+
+statement
+INSERT INTO test_ct_dispatch VALUES
+  (timestamp_ntz'2021-12-06 08:00:00', 'UTC', 'America/Los_Angeles'),
+  (timestamp_ntz'2021-07-01 12:00:00', 'America/New_York', 'Asia/Tokyo'),
+  (NULL, 'UTC', 'Asia/Tokyo')
+
+query
+SELECT convert_timezone(src, tgt, ts) FROM test_ct_dispatch
+
+query
+SELECT convert_timezone('UTC', 'America/Los_Angeles', timestamp_ntz'2021-12-06 08:00:00')
+
+-- legacy forms the native parser rejects but the dispatcher handles
+query
+SELECT convert_timezone('GMT+1', 'PST', timestamp_ntz'2021-12-06 08:00:00')

--- a/spark/src/test/resources/sql-tests/expressions/datetime/from_utc_timestamp_dispatch.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/from_utc_timestamp_dispatch.sql
@@ -1,0 +1,45 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- CometFromUTCTimestamp mixes in CodegenDispatchFallback, so with allowIncompatible unset it
+-- routes through the JVM codegen dispatcher (Spark's own doGenCode) and matches Spark exactly,
+-- including the legacy timezone forms the native parser rejects (e.g. PST, GMT+1). Verified across
+-- two session zones to confirm the resolved timeZoneId survives closure serialization.
+-- ConfigMatrix: spark.sql.session.timeZone=UTC,America/Los_Angeles
+
+statement
+CREATE TABLE test_futc_dispatch(ts timestamp) USING parquet
+
+statement
+INSERT INTO test_futc_dispatch VALUES
+  (timestamp('2015-07-24 00:00:00')),
+  (timestamp('2015-01-24 00:00:00')),
+  (timestamp('1969-12-31 23:59:59')),
+  (NULL)
+
+query
+SELECT from_utc_timestamp(ts, 'America/Los_Angeles') FROM test_futc_dispatch
+
+query
+SELECT from_utc_timestamp(ts, '+02:00') FROM test_futc_dispatch
+
+-- legacy forms the native parser rejects but the dispatcher handles
+query
+SELECT from_utc_timestamp(ts, 'PST') FROM test_futc_dispatch
+
+query
+SELECT from_utc_timestamp(timestamp('2017-07-14 02:40:00'), 'GMT+1'), from_utc_timestamp(timestamp('2017-07-14 02:40:00'), 'Etc/GMT-1')

--- a/spark/src/test/resources/sql-tests/expressions/datetime/to_utc_timestamp_dispatch.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/to_utc_timestamp_dispatch.sql
@@ -1,0 +1,44 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- CometToUTCTimestamp mixes in CodegenDispatchFallback, so with allowIncompatible unset it routes
+-- through the JVM codegen dispatcher and matches Spark exactly, including the legacy timezone forms
+-- the native parser rejects. Verified across two session zones.
+-- ConfigMatrix: spark.sql.session.timeZone=UTC,America/Los_Angeles
+
+statement
+CREATE TABLE test_tutc_dispatch(ts timestamp) USING parquet
+
+statement
+INSERT INTO test_tutc_dispatch VALUES
+  (timestamp('2015-07-24 00:00:00')),
+  (timestamp('2015-01-24 00:00:00')),
+  (timestamp('1969-12-31 23:59:59')),
+  (NULL)
+
+query
+SELECT to_utc_timestamp(ts, 'America/Los_Angeles') FROM test_tutc_dispatch
+
+query
+SELECT to_utc_timestamp(ts, '+02:00') FROM test_tutc_dispatch
+
+-- legacy forms the native parser rejects but the dispatcher handles
+query
+SELECT to_utc_timestamp(ts, 'PST') FROM test_tutc_dispatch
+
+query
+SELECT to_utc_timestamp(timestamp('2017-07-14 02:40:00'), 'GMT+1'), to_utc_timestamp(timestamp('2017-07-14 02:40:00'), 'Etc/GMT-1')


### PR DESCRIPTION
## Which issue does this PR close?

Part of #4596 (the timezone group: `from_utc_timestamp`, `to_utc_timestamp`, `convert_timezone`).

## Rationale for this change

All three report `Incompatible` for the same reason: Comet's native timezone parser does not accept Spark's legacy zone forms (`PST`, `GMT+1`, `UTC+1`, ...), so those throw a native parse error (#2013). With `allowIncompatible` unset the whole projection falls back to Spark. They have a real Spark `doGenCode` and supported input/output types, so they are eligible for the `CodegenDispatchFallback` path: route the `Incompatible` result through the JVM codegen dispatcher (Spark's own `doGenCode` inside the Comet pipeline) so the projection stays native, matches Spark exactly, and handles every timezone form.

## What changes are included in this PR?

* `CometFromUTCTimestamp`, `CometToUTCTimestamp`, `CometConvertTimezone` mix in `CodegenDispatchFallback`. The native incompatible path stays opt-in via `allowIncompatible`.
* `docs/source/user-guide/latest/expressions.md` notes updated: these route through the dispatcher by default and now handle all timezone forms.

## How are these changes tested?

New `from_utc_timestamp_dispatch.sql`, `to_utc_timestamp_dispatch.sql`, and `convert_timezone_dispatch.sql`, each with `allowIncompatible` unset and a `ConfigMatrix: spark.sql.session.timeZone=UTC,America/Los_Angeles`. They assert native execution matching Spark across both session zones (confirming the resolved `timeZoneId` survives closure serialization, the concern called out in the issue), and include the legacy `PST` / `GMT+1` forms the native path rejects but the dispatcher handles. The existing `allowIncompatible=true` native-path tests still pass. All run with `CometSqlFileTestSuite` on Spark 3.5.
