### PR TITLE
fix: correct stale unix_timestamp NTZ and date_format codegen-default doc text (#4502)

### DIFF
--- a/native/spark-expr/src/datetime_funcs/date_diff.rs
+++ b/native/spark-expr/src/datetime_funcs/date_diff.rs
@@ -100,14 +100,67 @@ impl ScalarUDFImpl for SparkDateDiff {
                 )
             })?;
 
-        // Date32 stores days since epoch, so difference is just subtraction
-        let result: Int32Array =
-            binary(end_date_array, start_date_array, |end, start| end - start)?;
+        // Date32 stores days since epoch, so difference is just subtraction. Use wrapping_sub
+        // to match Spark, whose JVM int subtraction wraps on overflow; a plain `i32 -` would
+        // panic in debug builds on extreme inputs.
+        let result: Int32Array = binary(end_date_array, start_date_array, |end, start| {
+            end.wrapping_sub(start)
+        })?;
 
         Ok(ColumnarValue::Array(Arc::new(result)))
     }
 
     fn aliases(&self) -> &[String] {
         &self.aliases
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::Field;
+    use datafusion::config::ConfigOptions;
+
+    fn date_diff(end: i32, start: i32) -> i32 {
+        let udf = SparkDateDiff::new();
+        let return_field = Arc::new(Field::new("date_diff", DataType::Int32, true));
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Array(Arc::new(Date32Array::from(vec![Some(end)]))),
+                ColumnarValue::Array(Arc::new(Date32Array::from(vec![Some(start)]))),
+            ],
+            number_rows: 1,
+            return_field,
+            config_options: Arc::new(ConfigOptions::default()),
+            arg_fields: vec![],
+        };
+        match udf.invoke_with_args(args).unwrap() {
+            ColumnarValue::Array(array) => array
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap()
+                .value(0),
+            _ => panic!("expected array result"),
+        }
+    }
+
+    #[test]
+    fn test_date_diff_basic() {
+        // 2020-01-02 (18263) minus 2020-01-01 (18262) = 1 day
+        assert_eq!(date_diff(18263, 18262), 1);
+        assert_eq!(date_diff(18262, 18263), -1);
+    }
+
+    #[test]
+    fn test_date_diff_wraps_on_overflow() {
+        // Extreme inputs overflow i32; Spark's JVM int subtraction wraps rather than panicking.
+        assert_eq!(
+            date_diff(i32::MAX, i32::MIN),
+            i32::MAX.wrapping_sub(i32::MIN)
+        );
+        assert_eq!(
+            date_diff(i32::MIN, i32::MAX),
+            i32::MIN.wrapping_sub(i32::MAX)
+        );
     }
 }

--- a/spark/src/main/scala/org/apache/comet/serde/datetime.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/datetime.scala
@@ -292,9 +292,7 @@ object CometSecond extends CometExpressionSerde[Second] with CodegenDispatchFall
 object CometUnixTimestamp extends CometExpressionSerde[UnixTimestamp] {
 
   override def getUnsupportedReasons(): Seq[String] = Seq(
-    "Only `TimestampType` and `DateType` inputs are supported." +
-      " `TimestampNTZType` is not supported because Comet incorrectly applies timezone" +
-      " conversion to TimestampNTZ values.")
+    "Only `DateType`, `TimestampType`, and `TimestampNTZType` inputs are supported.")
 
   private def isSupportedInputType(expr: UnixTimestamp): Boolean = {
     expr.children.head.dataType match {
@@ -695,9 +693,8 @@ object CometDateFormat extends CometExpressionSerde[DateFormatClass] {
     "Format strings in a curated allow-list run natively via DataFusion's `to_char` for UTC " +
       "sessions. Other format strings (including non-literal formats), as well as non-UTC " +
       "sessions, route through Spark's own `DateFormatClass.doGenCode` via the Arrow-direct " +
-      "codegen dispatcher when `spark.comet.exec.scalaUDF.codegen.enabled=true`. When the " +
-      "codegen dispatcher is disabled (default) the operator falls back to Spark in those " +
-      "cases.")
+      "codegen dispatcher when `spark.comet.exec.scalaUDF.codegen.enabled=true` (the default). " +
+      "When the codegen dispatcher is disabled the operator falls back to Spark in those cases.")
 
   override def convert(
       expr: DateFormatClass,

--- a/spark/src/test/resources/sql-tests/expressions/datetime/date_diff.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/date_diff.sql
@@ -35,3 +35,16 @@ SELECT datediff(date('2024-01-20'), d2) FROM test_datediff
 -- literal + literal
 query
 SELECT datediff(date('2024-01-15'), date('2024-01-10')), datediff(date('2024-01-10'), date('2024-01-15')), datediff(NULL, date('2024-01-15'))
+
+-- Dates whose day difference overflows a 32-bit int. Spark's DateDiff does plain JVM int
+-- subtraction, which wraps; the native path must wrap to match rather than panic in debug builds.
+-- date_add materializes day values near +/- 2e9 (2000000000 - (-2000000000) = 4000000000, which
+-- wraps to -294967296).
+statement
+CREATE TABLE test_datediff_overflow(d1 date, d2 date) USING parquet
+
+statement
+INSERT INTO test_datediff_overflow VALUES (date_add(date('1970-01-01'), 2000000000), date_add(date('1970-01-01'), -2000000000)), (date_add(date('1970-01-01'), -2000000000), date_add(date('1970-01-01'), 2000000000))
+
+query
+SELECT datediff(d1, d2) FROM test_datediff_overflow

--- a/spark/src/test/resources/sql-tests/expressions/datetime/date_diff.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/date_diff.sql
@@ -39,12 +39,10 @@ SELECT datediff(date('2024-01-15'), date('2024-01-10')), datediff(date('2024-01-
 -- Dates whose day difference overflows a 32-bit int. Spark's DateDiff does plain JVM int
 -- subtraction, which wraps; the native path must wrap to match rather than panic in debug builds.
 -- date_add materializes day values near +/- 2e9 (2000000000 - (-2000000000) = 4000000000, which
--- wraps to -294967296).
-statement
-CREATE TABLE test_datediff_overflow(d1 date, d2 date) USING parquet
-
-statement
-INSERT INTO test_datediff_overflow VALUES (date_add(date('1970-01-01'), 2000000000), date_add(date('1970-01-01'), -2000000000)), (date_add(date('1970-01-01'), -2000000000), date_add(date('1970-01-01'), 2000000000))
-
+-- wraps to -294967296). The dates are computed inline as literals rather than written to a
+-- Parquet table: a day value of -2000000000 is a date before 1582-10-15, which Spark refuses to
+-- write to Parquet (INCONSISTENT_BEHAVIOR_CROSS_VERSION.WRITE_ANCIENT_DATETIME). Constant folding
+-- is disabled in this suite, so the native date_diff path still runs on these literals.
 query
-SELECT datediff(d1, d2) FROM test_datediff_overflow
+SELECT datediff(date_add(date('1970-01-01'), 2000000000), date_add(date('1970-01-01'), -2000000000)),
+       datediff(date_add(date('1970-01-01'), -2000000000), date_add(date('1970-01-01'), 2000000000))


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4502 (date/time expression audit follow-ups). The remaining open work, gating non-default `StringTypeWithCollation` inputs on Spark 4.0 datetime expressions (item 5), is carved out into #4646.

## Rationale for this change

The high-priority items in #4502 break down as follows after the codegen-dispatch migration and `spark.comet.exec.scalaUDF.codegen.enabled` defaulting to `true`:

1. `CometUnixTimestamp.getUnsupportedReasons` claimed `TimestampNTZType` is unsupported "because Comet incorrectly applies timezone conversion to TimestampNTZ values". The native `unix_timestamp` path has a dedicated `Timestamp(Microsecond, None)` branch that divides raw microseconds by `1_000_000` with no timezone conversion, matching Spark (`ToTimestamp.eval` does raw `micros / MICROS_PER_SECOND` for both `TimestampType` and `TimestampNTZType`). The predicate (`isSupportedInputType`) and `getSupportLevel` already treat `TimestampNTZType` as supported; only the reason text was out of date.

2. `CometDateFormat.getCompatibleNotes` described the codegen dispatcher as "disabled (default)". The flag now defaults to `true`, so the note was inaccurate.

6. The native `date_diff` subtracted Date32 day values with a plain `i32 -`, which panics in debug builds when the result overflows. Spark computes the difference with JVM int subtraction, which wraps. This is practically unreachable for valid `DateType` inputs but is an unmasked panic path.

Items 2, 3, and 4 are obsolete after the codegen-dispatch migration and are intentionally not changed (details below).

## What changes are included in this PR?

- `CometUnixTimestamp.getUnsupportedReasons` now reads "Only `DateType`, `TimestampType`, and `TimestampNTZType` inputs are supported.", consistent with `isSupportedInputType` and `getSupportLevel`.
- `CometDateFormat.getCompatibleNotes` now states that `spark.comet.exec.scalaUDF.codegen.enabled=true` is the default.
- Native `date_diff` uses `wrapping_sub` to match Spark's wrapping int subtraction and remove the debug-only panic path, with regression tests for basic and overflow inputs.

Intentionally not changed (obsolete after the codegen-dispatch migration and the `scalaUDF.codegen.enabled` default flipping to `true`):

- Item 2 (move `CometDateFormat` gating into `getSupportLevel`): marking non-UTC + whitelisted formats `Incompatible` would now route them to full Spark fallback under the default config instead of through the dispatcher, which produces Spark-identical results. That is a regression, not a fix.
- Item 3 (mark Group A expressions `Incompatible` / surface the dispatcher flag in `getCompatibleNotes`): `CometCodegenDispatch` deliberately reports `Compatible()` and omits the flag note, which is accurate now that the dispatcher is on by default. When it is disabled, `convert` returns `None` with a `withFallbackReason` that shows up in EXPLAIN. The only stale artifact was the `CometDateFormat` note fixed above.
- Item 4 (`CometMakeTimestamp` ANSI): `CometMakeTimestamp` is now `CometCodegenDispatch[MakeTimestamp]`, so Spark's own `doGenCode` (which honors `failOnError`) runs in the kernel and throws under ANSI mode; when the dispatcher is disabled it falls back to Spark. ANSI behavior is correct in both configurations.

## How are these changes tested?

- The `getUnsupportedReasons` / `getCompatibleNotes` corrections are EXPLAIN/compatibility-doc text with no behavior change. The native `unix_timestamp` TimestampNTZ path the corrected text describes is covered by existing Rust unit tests in `native/spark-expr/src/datetime_funcs/unix_timestamp.rs`. `mvnw compile` is clean for the `spark` module.
- The `date_diff` change adds `test_date_diff_basic` and `test_date_diff_wraps_on_overflow` in `native/spark-expr/src/datetime_funcs/date_diff.rs`, both passing. `cargo build` and `cargo clippy -D warnings` are clean for the `datafusion-comet-spark-expr` crate.
