### PR TITLE
chore: fix generate-release-docs.sh for per-Spark-version doc layout

### DIFF
--- a/dev/generate-release-docs.sh
+++ b/dev/generate-release-docs.sh
@@ -16,23 +16,30 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# This script generates documentation content for a release branch.
-# It should be run once when creating a new release branch to "freeze"
-# the generated docs (configs, compatibility matrices) into the branch.
+# This script freezes generated documentation content onto a release branch.
+# It should be run once when creating a new release branch.
+#
+# On main, docs/source/user-guide/latest/ holds only template markers; CI fills them
+# at publish time via docs/build.sh. A release branch instead commits the generated
+# content so that the archived docs for the release render real tables (archived
+# versions are served from the frozen branch, not regenerated at publish).
+#
+# This mirrors the generation in docs/build.sh, except it runs against the source tree
+# (so the result can be committed) rather than a throwaway temp copy. Two kinds of
+# content are generated:
+#   - configs.md: the config reference (not per-Spark-version)
+#   - compatibility/expressions/spark-<ver>/*.md: per-Spark-version compatibility pages,
+#     generated from the _category_template/ markers. Support can differ per Spark
+#     version, so GenerateDocs runs once per profile against that profile's build.
 #
 # Usage: ./dev/generate-release-docs.sh
 #
-# This script:
-# 1. Compiles the spark module to access CometConf and CometCast
-# 2. Runs GenerateDocs to populate the template markers in the docs
-# 3. The resulting changes should be committed to the release branch
-#
-# Example workflow when cutting release 0.13.0:
-#   git checkout -b branch-0.13 main
+# Example workflow when cutting release 0.13.0 (release-branch changes go via PR):
+#   git checkout -b release-0.13-docs branch-0.13
 #   ./dev/generate-release-docs.sh
 #   git add docs/source/user-guide/latest/
 #   git commit -m "Generate docs for 0.13.0 release"
-#   git push origin branch-0.13
+#   # open a PR targeting branch-0.13
 
 set -e
 
@@ -41,13 +48,42 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 cd "${PROJECT_ROOT}"
 
+LATEST_USER_GUIDE="${PROJECT_ROOT}/docs/source/user-guide/latest"
+COMPAT_EXPR_DIR="${LATEST_USER_GUIDE}/compatibility/expressions"
+TEMPLATE_DIR="${COMPAT_EXPR_DIR}/_category_template"
+
+# Spark profiles for which we publish per-version compatibility pages. Keep this list
+# in sync with docs/build.sh. Each entry must match both a Maven profile id (-P<profile>)
+# and a source-tree subdirectory under compatibility/expressions/.
+SPARK_PROFILES=(spark-3.4 spark-3.5 spark-4.0 spark-4.1)
+
 echo "Compiling and generating documentation content..."
-./mvnw package -Pgenerate-docs -DskipTests -Dmaven.test.skip=true
+for profile in "${SPARK_PROFILES[@]}"; do
+  echo "Generating configs and compatibility pages for ${profile}..."
+  mkdir -p "${COMPAT_EXPR_DIR}/${profile}"
+  cp "${TEMPLATE_DIR}"/*.md "${COMPAT_EXPR_DIR}/${profile}/"
+  ./mvnw package -P"${profile}" -Pgenerate-docs -DskipTests -Dmaven.test.skip=true \
+    -Dexec.arguments="${LATEST_USER_GUIDE},${profile}"
+done
+
+# Format the generated Markdown. CI runs `prettier --check "**/*.md"`, and unlike
+# docs/build.sh (whose output is a throwaway temp build) this output is committed, so it
+# must pass the check. GenerateDocs wraps the config/cast tables in prettier-ignore, but
+# the surrounding generated Markdown is not guaranteed prettier-clean. prettier honors
+# .prettierignore, so excluded pages (e.g. expressions.md) are left untouched.
+if ! command -v npx >/dev/null 2>&1; then
+  echo "ERROR: npx not found. Install Node/prettier (see docs/source/contributor-guide/development.md)" >&2
+  exit 1
+fi
+echo "Formatting generated Markdown with prettier..."
+npx prettier "${LATEST_USER_GUIDE}/**/*.md" --write
 
 echo ""
 echo "Done! Generated documentation content in docs/source/user-guide/latest/"
+echo "  - configs.md (config reference)"
+echo "  - compatibility/expressions/spark-*/ (per-Spark-version compatibility pages)"
 echo ""
-echo "Next steps:"
+echo "Next steps (release-branch changes go via PR):"
 echo "  git add docs/source/user-guide/latest/"
 echo "  git commit -m 'Generate docs for release'"
-echo "  git push"
+echo "  # push to your fork and open a PR targeting the release branch"


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

`dev/generate-release-docs.sh` freezes generated docs onto a release branch. It has been broken since #4139, which split `compatibility/expressions/` into per-Spark-version subdirectories (`spark-3.4` .. `spark-4.1`) plus `_category_template/`. That PR updated the publish-time generator (`docs/build.sh`) and `GenerateDocs` but not this script, so it still called `GenerateDocs` with only the user-guide root, hit the removed flat path, and failed with `FileNotFoundException: .../compatibility/expressions/cast.md`. No release has been cut since, so it went unnoticed.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Bring the script in line with `docs/build.sh`: loop the Spark profiles, copy `_category_template/*.md` into each `spark-<ver>/`, and run `GenerateDocs` per profile with `-Dexec.arguments="<latest-user-guide>,<profile>"` to pass the subdirectory arg. Also run `prettier --write` over the output, since CI checks `prettier --check "**/*.md"` and this script (unlike `build.sh`, whose temp output is throwaway) commits its result. `_category_template/` is kept as committed source. The only difference from `build.sh` is that this runs against the source tree so the freeze can be committed. The same fix lands on `branch-0.17` bundled with the generated docs freeze; on `main` the generated docs are not committed, so this PR carries the script change alone.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Ran on a 0.17.0 release branch: `configs.md` populated, all four `spark-<ver>/` dirs contain `cast.md` plus category pages with filled tables, per-version differences land where expected (`map.md`/`misc.md` differ 3.4 vs 4.1, `misc.md` differs 3.4 vs 3.5, 4.0 == 4.1), and `prettier --check` passes.
