### PR TITLE
refactor: move arithmetic and math support checks to getSupportLevel

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/arithmetic.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arithmetic.scala
@@ -83,18 +83,24 @@ trait MathBase {
       false
   }
 
+  def mathDataTypeSupportLevel(dt: DataType): SupportLevel =
+    if (supportedDataType(dt)) {
+      Compatible()
+    } else {
+      Unsupported(Some(s"Unsupported datatype $dt"))
+    }
+
 }
 
 object CometAdd extends CometExpressionSerde[Add] with MathBase {
+
+  override def getSupportLevel(expr: Add): SupportLevel =
+    mathDataTypeSupportLevel(expr.left.dataType)
 
   override def convert(
       expr: Add,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    if (!supportedDataType(expr.left.dataType)) {
-      withFallbackReason(expr, s"Unsupported datatype ${expr.left.dataType}")
-      return None
-    }
     createMathExpression(
       expr,
       expr.left,
@@ -109,14 +115,13 @@ object CometAdd extends CometExpressionSerde[Add] with MathBase {
 
 object CometSubtract extends CometExpressionSerde[Subtract] with MathBase {
 
+  override def getSupportLevel(expr: Subtract): SupportLevel =
+    mathDataTypeSupportLevel(expr.left.dataType)
+
   override def convert(
       expr: Subtract,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    if (!supportedDataType(expr.left.dataType)) {
-      withFallbackReason(expr, s"Unsupported datatype ${expr.left.dataType}")
-      return None
-    }
     createMathExpression(
       expr,
       expr.left,
@@ -131,14 +136,13 @@ object CometSubtract extends CometExpressionSerde[Subtract] with MathBase {
 
 object CometMultiply extends CometExpressionSerde[Multiply] with MathBase {
 
+  override def getSupportLevel(expr: Multiply): SupportLevel =
+    mathDataTypeSupportLevel(expr.left.dataType)
+
   override def convert(
       expr: Multiply,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    if (!supportedDataType(expr.left.dataType)) {
-      withFallbackReason(expr, s"Unsupported datatype ${expr.left.dataType}")
-      return None
-    }
     createMathExpression(
       expr,
       expr.left,
@@ -153,6 +157,9 @@ object CometMultiply extends CometExpressionSerde[Multiply] with MathBase {
 
 object CometDivide extends CometExpressionSerde[Divide] with MathBase {
 
+  override def getSupportLevel(expr: Divide): SupportLevel =
+    mathDataTypeSupportLevel(expr.left.dataType)
+
   override def convert(
       expr: Divide,
       inputs: Seq[Attribute],
@@ -162,10 +169,6 @@ object CometDivide extends CometExpressionSerde[Divide] with MathBase {
     // For now, use NullIf to swap zeros with nulls.
     val rightExpr =
       if (expr.evalMode != EvalMode.ANSI) nullIfWhenPrimitive(expr.right) else expr.right
-    if (!supportedDataType(expr.left.dataType)) {
-      withFallbackReason(expr, s"Unsupported datatype ${expr.left.dataType}")
-      return None
-    }
     val divideExpr = createMathExpression(
       expr,
       expr.left,
@@ -195,14 +198,13 @@ object CometDivide extends CometExpressionSerde[Divide] with MathBase {
 
 object CometIntegralDivide extends CometExpressionSerde[IntegralDivide] with MathBase {
 
+  override def getSupportLevel(expr: IntegralDivide): SupportLevel =
+    mathDataTypeSupportLevel(expr.left.dataType)
+
   override def convert(
       expr: IntegralDivide,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    if (!supportedDataType(expr.left.dataType)) {
-      withFallbackReason(expr, s"Unsupported datatype ${expr.left.dataType}")
-      return None
-    }
 
 //    Precision is set to 19 (max precision for a numerical data type except DecimalType)
 
@@ -259,15 +261,13 @@ object CometIntegralDivide extends CometExpressionSerde[IntegralDivide] with Mat
 
 object CometRemainder extends CometExpressionSerde[Remainder] with MathBase {
 
+  override def getSupportLevel(expr: Remainder): SupportLevel =
+    mathDataTypeSupportLevel(expr.left.dataType)
+
   override def convert(
       expr: Remainder,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    if (!supportedDataType(expr.left.dataType)) {
-      withFallbackReason(expr, s"Unsupported datatype ${expr.left.dataType}")
-      return None
-    }
-
     createMathExpression(
       expr,
       expr.left,
@@ -282,6 +282,29 @@ object CometRemainder extends CometExpressionSerde[Remainder] with MathBase {
 
 object CometRound extends CometExpressionSerde[Round] {
 
+  override def getSupportLevel(expr: Round): SupportLevel = expr.child.dataType match {
+    case t: DecimalType if t.scale < 0 => // Spark disallows negative scale SPARK-30252
+      Unsupported(Some("Decimal type has negative scale"))
+    case _: FloatType | DoubleType =>
+      // We cannot properly match with the Spark behavior for floating-point numbers.
+      // Spark uses BigDecimal for rounding float/double, and BigDecimal fist converts a
+      // double to string internally in order to create its own internal representation.
+      // The problem is BigDecimal uses java.lang.Double.toString() and it has complicated
+      // rounding algorithm. E.g. -5.81855622136895E8 is actually
+      // -581855622.13689494132995605468750. Note the 5th fractional digit is 4 instead of
+      // 5. Java(Scala)'s toString() rounds it up to -581855622.136895. This makes a
+      // difference when rounding at 5th digit, I.e. round(-5.81855622136895E8, 5) should be
+      // -5.818556221369E8, instead of -5.8185562213689E8. There is also an example that
+      // toString() does NOT round up. 6.1317116247283497E18 is 6131711624728349696. It can
+      // be rounded up to 6.13171162472835E18 that still represents the same double number.
+      // I.e. 6.13171162472835E18 == 6.1317116247283497E18. However, toString() does not.
+      // That results in round(6.1317116247283497E18, -5) == 6.1317116247282995E18 instead
+      // of 6.1317116247283999E18.
+      Unsupported(Some("Comet does not support Spark's BigDecimal rounding"))
+    case _ =>
+      Compatible()
+  }
+
   override def convert(
       r: Round,
       inputs: Seq[Attribute],
@@ -292,30 +315,10 @@ object CometRound extends CometExpressionSerde[Round] {
 
     lazy val childExpr = exprToProtoInternal(r.child, inputs, binding)
     r.child.dataType match {
-      case t: DecimalType if t.scale < 0 => // Spark disallows negative scale SPARK-30252
-        withFallbackReason(r, "Decimal type has negative scale")
-        None
       case _ if scaleV == null =>
         exprToProtoInternal(Literal(null), inputs, binding)
       case _: ByteType | ShortType | IntegerType | LongType if _scale >= 0 =>
         childExpr // _scale(I.e. decimal place) >= 0 is a no-op for integer types in Spark
-      case _: FloatType | DoubleType =>
-        // We cannot properly match with the Spark behavior for floating-point numbers.
-        // Spark uses BigDecimal for rounding float/double, and BigDecimal fist converts a
-        // double to string internally in order to create its own internal representation.
-        // The problem is BigDecimal uses java.lang.Double.toString() and it has complicated
-        // rounding algorithm. E.g. -5.81855622136895E8 is actually
-        // -581855622.13689494132995605468750. Note the 5th fractional digit is 4 instead of
-        // 5. Java(Scala)'s toString() rounds it up to -581855622.136895. This makes a
-        // difference when rounding at 5th digit, I.e. round(-5.81855622136895E8, 5) should be
-        // -5.818556221369E8, instead of -5.8185562213689E8. There is also an example that
-        // toString() does NOT round up. 6.1317116247283497E18 is 6131711624728349696. It can
-        // be rounded up to 6.13171162472835E18 that still represents the same double number.
-        // I.e. 6.13171162472835E18 == 6.1317116247283497E18. However, toString() does not.
-        // That results in round(6.1317116247283497E18, -5) == 6.1317116247282995E18 instead
-        // of 6.1317116247283999E18.
-        withFallbackReason(r, "Comet does not support Spark's BigDecimal rounding")
-        None
       case _ =>
         // `scale` must be Int64 type in DataFusion
         val scaleExpr = exprToProtoInternal(Literal(_scale.toLong, LongType), inputs, binding)

--- a/spark/src/main/scala/org/apache/comet/serde/math.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/math.scala
@@ -41,6 +41,13 @@ object CometAtan2 extends CometExpressionSerde[Atan2] {
 }
 
 object CometCeil extends CometExpressionSerde[Ceil] {
+  override def getSupportLevel(expr: Ceil): SupportLevel = expr.child.dataType match {
+    case t: DecimalType if t.scale < 0 => // Spark disallows negative scale SPARK-30252
+      Unsupported(Some(s"Decimal type $t has negative scale"))
+    case _ =>
+      Compatible()
+  }
+
   override def convert(
       expr: Ceil,
       inputs: Seq[Attribute],
@@ -49,9 +56,6 @@ object CometCeil extends CometExpressionSerde[Ceil] {
     expr.child.dataType match {
       case t: DecimalType if t.scale == 0 => // zero scale is no-op
         childExpr
-      case t: DecimalType if t.scale < 0 => // Spark disallows negative scale SPARK-30252
-        withFallbackReason(expr, s"Decimal type $t has negative scale")
-        None
       case _ =>
         val optExpr =
           scalarFunctionExprToProtoWithReturnType("ceil", expr.dataType, false, childExpr)
@@ -61,6 +65,13 @@ object CometCeil extends CometExpressionSerde[Ceil] {
 }
 
 object CometFloor extends CometExpressionSerde[Floor] {
+  override def getSupportLevel(expr: Floor): SupportLevel = expr.child.dataType match {
+    case t: DecimalType if t.scale < 0 => // Spark disallows negative scale SPARK-30252
+      Unsupported(Some(s"Decimal type $t has negative scale"))
+    case _ =>
+      Compatible()
+  }
+
   override def convert(
       expr: Floor,
       inputs: Seq[Attribute],
@@ -69,9 +80,6 @@ object CometFloor extends CometExpressionSerde[Floor] {
     expr.child.dataType match {
       case t: DecimalType if t.scale == 0 => // zero scale is no-op
         childExpr
-      case t: DecimalType if t.scale < 0 => // Spark disallows negative scale SPARK-30252
-        withFallbackReason(expr, s"Decimal type $t has negative scale")
-        None
       case _ =>
         val optExpr =
           scalarFunctionExprToProtoWithReturnType("floor", expr.dataType, false, childExpr)


### PR DESCRIPTION
## Which issue does this PR close?

Part of #4673.

## Rationale for this change

The serde framework intends that an expression declares whether it can be accelerated through `getSupportLevel`, with the central dispatcher in `QueryPlanSerde` translating `Incompatible`/`Unsupported` into the appropriate fallback. The arithmetic and math serdes instead made these decisions inside `convert` by calling `withFallbackReason` directly, even though the decisions are statically determinable from the expression. Moving them to `getSupportLevel` keeps fallback decisions declared in one place.

## What changes are included in this PR?

Move static support decisions out of `convert` and into `getSupportLevel` for the arithmetic and math expressions:

- `Add`, `Subtract`, `Multiply`, `Divide`, `IntegralDivide`, `Remainder`: the unsupported-data-type check (shared via a new `MathBase.mathDataTypeSupportLevel` helper) now returns `Unsupported`.
- `Round`: negative decimal scale and float/double (BigDecimal rounding) now return `Unsupported` from `getSupportLevel`.
- `Ceil`, `Floor`: negative decimal scale now returns `Unsupported` from `getSupportLevel`.

This is behavior-preserving: every case that previously fell back to Spark continues to fall back with the same reason. The remaining `withFallbackReason` calls in these files are child-reason rollups, which are the intended use inside `convert`.

## How are these changes tested?

Covered by existing tests in `CometExpressionSuite` (`ceil and floor`, `basic arithmetic`, `ANSI support for round function`, `decimals arithmetic and comparison`, `scalar decimal arithmetic operations`), which exercise both the supported and fallback paths.
