### PR TITLE
refactor: move string expression support checks to getSupportLevel

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/strings.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/strings.scala
@@ -152,6 +152,11 @@ object CometStringReplace extends CometScalarFunction[StringReplace]("replace") 
 
 object CometSubstring extends CometExpressionSerde[Substring] {
 
+  override def getSupportLevel(expr: Substring): SupportLevel = (expr.pos, expr.len) match {
+    case (_: Literal, _: Literal) => Compatible()
+    case _ => Unsupported(Some("Substring pos and len must be literals"))
+  }
+
   override def convert(
       expr: Substring,
       inputs: Seq[Attribute],
@@ -170,7 +175,7 @@ object CometSubstring extends CometExpressionSerde[Substring] {
             None
         }
       case _ =>
-        withFallbackReason(expr, "Substring pos and len must be literals")
+        // Unreachable: getSupportLevel gates non-literal pos/len.
         None
     }
   }
@@ -213,14 +218,18 @@ object CometLeft extends CometExpressionSerde[Left] {
             None
         }
       case _ =>
-        withFallbackReason(expr, "LEFT len must be a literal")
+        // Unreachable: getSupportLevel gates a non-literal length.
         None
     }
   }
 
   override def getSupportLevel(expr: Left): SupportLevel = {
     expr.str.dataType match {
-      case _: BinaryType | _: StringType => Compatible()
+      case _: BinaryType | _: StringType =>
+        expr.len match {
+          case _: Literal => Compatible()
+          case _ => Unsupported(Some("LEFT len must be a literal"))
+        }
       case _ => Unsupported(Some(s"LEFT does not support ${expr.str.dataType}"))
     }
   }
@@ -256,7 +265,7 @@ object CometRight extends CometExpressionSerde[Right] {
           }
         }
       case _ =>
-        withFallbackReason(expr, "RIGHT len must be a literal")
+        // Unreachable: getSupportLevel gates a non-literal length.
         None
     }
   }
@@ -265,7 +274,11 @@ object CometRight extends CometExpressionSerde[Right] {
 
   override def getSupportLevel(expr: Right): SupportLevel = {
     expr.str.dataType match {
-      case _: StringType => Compatible()
+      case _: StringType =>
+        expr.len match {
+          case _: Literal => Compatible()
+          case _ => Unsupported(Some("RIGHT len must be a literal"))
+        }
       case _ => Unsupported(Some(s"RIGHT does not support ${expr.str.dataType}"))
     }
   }
@@ -303,17 +316,21 @@ object CometConcat extends CometScalarFunction[Concat]("concat") with CometTypeS
 
 object CometConcatWs extends CometExpressionSerde[ConcatWs] {
 
+  override def getSupportLevel(expr: ConcatWs): SupportLevel = expr.children.headOption match {
+    // A NULL separator converts directly to a NULL result, so it stays supported.
+    case Some(Literal(null, _)) => Compatible()
+    // Fall back to Spark for all-literal args so ConstantFolding can handle it.
+    case _ if expr.children.forall(_.foldable) =>
+      Unsupported(Some("all arguments are foldable"))
+    case _ => Compatible()
+  }
+
   override def convert(expr: ConcatWs, inputs: Seq[Attribute], binding: Boolean): Option[Expr] = {
     expr.children.headOption match {
       // Match Spark behavior: when the separator is NULL, the result of concat_ws is NULL.
       case Some(Literal(null, _)) =>
         val nullLiteral = Literal.create(null, expr.dataType)
         exprToProtoInternal(nullLiteral, inputs, binding)
-
-      case _ if expr.children.forall(_.foldable) =>
-        // Fall back to Spark for all-literal args so ConstantFolding can handle it
-        withFallbackReason(expr, "all arguments are foldable")
-        None
 
       case _ =>
         // For all other cases, use the generic scalar function implementation.
@@ -324,21 +341,22 @@ object CometConcatWs extends CometExpressionSerde[ConcatWs] {
 
 object CometLike extends CometExpressionSerde[Like] {
 
-  override def convert(expr: Like, inputs: Seq[Attribute], binding: Boolean): Option[Expr] = {
+  override def getSupportLevel(expr: Like): SupportLevel = {
     if (expr.escapeChar == '\\') {
-      createBinaryExpr(
-        expr,
-        expr.left,
-        expr.right,
-        inputs,
-        binding,
-        (builder, binaryExpr) => builder.setLike(binaryExpr))
+      Compatible()
     } else {
-      withFallbackReason(
-        expr,
-        s"custom escape character ${expr.escapeChar} not supported in LIKE")
-      None
+      Unsupported(Some(s"custom escape character ${expr.escapeChar} not supported in LIKE"))
     }
+  }
+
+  override def convert(expr: Like, inputs: Seq[Attribute], binding: Boolean): Option[Expr] = {
+    createBinaryExpr(
+      expr,
+      expr.left,
+      expr.right,
+      inputs,
+      binding,
+      (builder, binaryExpr) => builder.setLike(binaryExpr))
   }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

Part of #4673.

## Rationale for this change

The serde framework intends that an expression declares whether it can be accelerated through `getSupportLevel`, with the central dispatcher in `QueryPlanSerde` translating `Incompatible`/`Unsupported` into the appropriate fallback. Several string serdes instead made these decisions inside `convert` by calling `withFallbackReason` directly, even though the decisions are statically determinable from the expression.

## What changes are included in this PR?

Move static support decisions out of `convert` and into `getSupportLevel` for the string expressions:

- `Substring`: `pos` and `len` must be literals.
- `Left`, `Right`: the length argument must be a literal (folded into the existing `getSupportLevel`).
- `ConcatWs`: all-foldable arguments fall back so Spark's `ConstantFolding` can handle them. The NULL-separator case still converts directly to a NULL result, so the precedence is preserved in `getSupportLevel`.
- `Like`: a custom escape character is unsupported.

This is behavior-preserving: every case that previously fell back to Spark continues to fall back with the same reason. The remaining `withFallbackReason` calls in this file are child-reason rollups, which are the intended use inside `convert`.

## How are these changes tested?

Covered by existing tests: `CometStringExpressionSuite` (33 tests, including `concat_ws`, `left`, `right`) and `CometExpressionSuite` (`like with custom escape`, `string type and substring`, `substring with start < 1`), which exercise both the supported and fallback paths.
