### PR TITLE
fix: exclude release scratch dirs from RAT and license skill docs

### DIFF
--- a/.claude/skills/audit-comet-expression/SKILL.md
+++ b/.claude/skills/audit-comet-expression/SKILL.md
@@ -4,6 +4,25 @@ description: Audit an existing Comet expression for correctness and test coverag
 argument-hint: <expression-name>
 ---
 
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 Audit the Comet implementation of the `$ARGUMENTS` expression for correctness and test coverage.
 
 ## Overview

--- a/.claude/skills/bug-triage/SKILL.md
+++ b/.claude/skills/bug-triage/SKILL.md
@@ -3,6 +3,25 @@ name: bug-triage
 description: Triage open Comet issues marked `requires-triage` per the project bug triage guide. Applies the recommended priority and area labels, removes `requires-triage`, and files a dated summary issue listing what was done. A human reviews the summary issue and closes it when satisfied.
 ---
 
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 Run a bug triage pass for the `apache/datafusion-comet` repository.
 
 ## Overview

--- a/.claude/skills/implement-comet-expression/SKILL.md
+++ b/.claude/skills/implement-comet-expression/SKILL.md
@@ -4,6 +4,25 @@ description: Use when implementing a new Spark expression in DataFusion Comet. W
 argument-hint: <expression-name>
 ---
 
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 Implement Comet support for the `$ARGUMENTS` Spark expression.
 
 ## Background reading

--- a/.claude/skills/review-comet-pr/SKILL.md
+++ b/.claude/skills/review-comet-pr/SKILL.md
@@ -4,6 +4,25 @@ description: Review a DataFusion Comet pull request for Spark compatibility and 
 argument-hint: <pr-number>
 ---
 
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 Review Comet PR #$ARGUMENTS
 
 ## Before You Start

--- a/.claude/skills/wire-datafusion-function/SKILL.md
+++ b/.claude/skills/wire-datafusion-function/SKILL.md
@@ -4,6 +4,25 @@ description: Use when wiring an existing DataFusion or datafusion-spark function
 argument-hint: <expression-name>
 ---
 
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 Wire Comet support for the `$ARGUMENTS` Spark expression by reusing an existing DataFusion or `datafusion-spark` function. **No native Rust is written here** — if upstream coverage is missing, stop and run `implement-comet-expression`.
 
 ## Wiring patterns

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -1,12 +1,15 @@
 *.gitignore
 *.dockerignore
 .github/pull_request_template.md
+.github/workflows/README.md
 .gitmodules
 native/Cargo.lock
 native/testdata/backtrace.txt
 native/testdata/stacktrace.txt
 native/core/testdata/backtrace.txt
 native/core/testdata/stacktrace.txt
+native/jni-bridge/testdata/backtrace.txt
+native/jni-bridge/testdata/stacktrace.txt
 dev/copyright/scala-header.txt
 dev/diffs/iceberg/*.diff
 dev/release/requirements.txt

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -4,10 +4,6 @@
 .github/workflows/README.md
 .gitmodules
 native/Cargo.lock
-native/testdata/backtrace.txt
-native/testdata/stacktrace.txt
-native/core/testdata/backtrace.txt
-native/core/testdata/stacktrace.txt
 native/jni-bridge/testdata/backtrace.txt
 native/jni-bridge/testdata/stacktrace.txt
 dev/copyright/scala-header.txt

--- a/pom.xml
+++ b/pom.xml
@@ -1167,6 +1167,12 @@ under the License.
             <exclude>docs/source/contributor-guide/*.svg</exclude>
             <exclude>dev/release/rat_exclude_files.txt</exclude>
             <exclude>dev/release/requirements.txt</exclude>
+            <exclude>dev/release/venv/**</exclude>
+            <exclude>dev/release/comet-rm/workdir/**</exclude>
+            <exclude>dev/dist/**</exclude>
+            <exclude>dev/release/rat.txt</exclude>
+            <exclude>dev/release/filtered_rat.txt</exclude>
+            <exclude>dev/release/*.jar</exclude>
             <exclude>native/proto/src/generated/**</exclude>
             <exclude>benchmarks/tpc/queries/**</exclude>
             <exclude>.claude/**</exclude>


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4671.

## Rationale for this change

The `apache-rat-plugin` is bound to the Maven `verify` phase, so it runs on every `install`, including the six `./mvnw ... -DskipTests install` runs in `dev/release/build-release-comet.sh` (`-DskipTests` skips tests, not RAT). RAT scans the root module's directory tree, and the exclude list did not cover several untracked generated/scratch directories that accumulate during a release (Python virtualenv, docker build workdir, extracted release tarballs, the rat report files, and the downloaded rat jar). Once populated, each RAT pass walks a very large number of files, so the build appears to hang rather than being busy.

Separately, the bash rat check (`dev/release/run-rat.sh` + `rat_exclude_files.txt`) flagged files that the Maven RAT config already skips, so the two checks were inconsistent.

## What changes are included in this PR?

- Add excludes to the `apache-rat-plugin` configuration in `pom.xml` for the release scratch paths: `dev/release/venv/**`, `dev/release/comet-rm/workdir/**`, `dev/dist/**`, `dev/release/rat.txt`, `dev/release/filtered_rat.txt`, and `dev/release/*.jar`.
- Reconcile the bash rat exclude list (`dev/release/rat_exclude_files.txt`) with the Maven check by adding the `native/jni-bridge/testdata/` backtrace/stacktrace fixtures (these moved from `native/testdata`, whose stale paths remain listed) and `.github/workflows/README.md`.
- Add the standard ASF license header to the five checked-in `.claude/skills/*/SKILL.md` files. These ship in the release tarball (built via `git archive`), so rather than excluding them from the license check they are now properly licensed like every other markdown file in the repo. The header is placed after the YAML frontmatter (which must remain the first content for the skill loader to parse it); RAT still detects the header in that position.

## How are these changes tested?

Built a release tarball from this branch the same way `dev/release/create-tarball.sh` does (`git archive HEAD | gzip`) and ran the real `dev/release/run-rat.sh` against it, which reported "No unapproved licenses". Also confirmed with the `apache-rat-0.16.1` jar directly that a markdown file carrying the ASF header after YAML frontmatter is approved, while the same file without the header is not.