### PR TITLE
chore: fix `ConstantFolding` rule exclusion for benchmarks

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
@@ -124,7 +124,8 @@ trait CometBenchmarkBase
     val cometExecConfigs = Map(
       CometConf.COMET_ENABLED.key -> "true",
       CometConf.COMET_EXEC_ENABLED.key -> "true",
-      "spark.sql.optimizer.constantFolding.enabled" -> "false") ++ extraCometConfigs
+      "spark.sql.optimizer.excludedRules" ->
+        "org.apache.spark.sql.catalyst.optimizer.ConstantFolding") ++ extraCometConfigs
 
     // Check that the plan is fully Comet native before running the benchmark
     withSQLConf(cometExecConfigs.toSeq: _*) {

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometRegExpBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometRegExpBenchmark.scala
@@ -100,7 +100,8 @@ object CometRegExpBenchmark extends CometBenchmarkBase {
     val baseExec = Map(
       CometConf.COMET_ENABLED.key -> "true",
       CometConf.COMET_EXEC_ENABLED.key -> "true",
-      "spark.sql.optimizer.constantFolding.enabled" -> "false")
+      "spark.sql.optimizer.excludedRules" ->
+        "org.apache.spark.sql.catalyst.optimizer.ConstantFolding")
 
     benchmark.addCase("Comet (Exec, native Rust regex)") { _ =>
       val configs = baseExec ++ Map(CometConf.getExprAllowIncompatConfigKey("RLike") -> "true")

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometRegExpExtractBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometRegExpExtractBenchmark.scala
@@ -152,7 +152,8 @@ object CometRegExpExtractBenchmark extends CometBenchmarkBase {
     val baseExec = Map(
       CometConf.COMET_ENABLED.key -> "true",
       CometConf.COMET_EXEC_ENABLED.key -> "true",
-      "spark.sql.optimizer.constantFolding.enabled" -> "false")
+      "spark.sql.optimizer.excludedRules" ->
+        "org.apache.spark.sql.catalyst.optimizer.ConstantFolding")
 
     benchmark.addCase("Comet (Exec, native Rust regex)") { _ =>
       val configs =


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4656 .

## Rationale for this change

Three Comet benchmark files set `spark.sql.optimizer.constantFolding.enabled = false`, but **this Spark config does not exist** - it is silently ignored, so constant folding has been running during these benchmarks the whole time.

 Spark has no per-rule on/off flag for `ConstantFolding`. The canonical way to disable an individual Catalyst rule `spark.sql.optimizer.excludedRules`, which takes a comma-separated list of fully-qualified rule class names (see `SQLConf.OPTIMIZER_EXCLUDED_RULES`). The rest of the Comet test suite (`CometExpressionSuite`,`CometStringExpressionSuite`, `CometArrayExpressionSuite`,`CometSqlFileTestSuite`, etc.) already uses this pattern.


<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
