### PR TITLE
docs: render captioned sidebar sections for versioned user guides

### DIFF
--- a/docs/source/_templates/docs-sidebar.html
+++ b/docs/source/_templates/docs-sidebar.html
@@ -18,10 +18,11 @@ under the License.
 -->
 
 {# Start the sidebar from the deepest captioned section the page lives under:
-   - user-guide/latest/* lives under user-guide/index.md → user-guide/latest/index.rst, so start at depth 2
+   - user-guide/<version>/* (latest or a released version like 0.17) lives under
+     user-guide/index.md → user-guide/<version>/index.rst, so start at depth 2
    - contributor-guide/* lives under contributor-guide/index.md, so start at depth 1
    - root and orphan pages (search, genindex) fall back to the global toctree (depth 0). #}
-{% if pagename.startswith("user-guide/latest/") and not suppress_sidebar_toctree(startdepth=2, includehidden=True) %}
+{% if pagename.startswith("user-guide/") and pagename.split("/")|length > 2 and not suppress_sidebar_toctree(startdepth=2, includehidden=True) %}
   {% set sidebar_startdepth = 2 %}
 {% elif not suppress_sidebar_toctree(startdepth=1, includehidden=True) %}
   {% set sidebar_startdepth = 1 %}


### PR DESCRIPTION
## Which issue does this PR close?

N/A. Follow-on to #4698 (0.17.0 documentation links).

## Rationale for this change

The published 0.17 user guide does not render its left-sidebar navigation as captioned sections (Getting Started, What Comet Supports, Compatibility, etc.) the way the development snapshot (`latest`) does. Everything is flattened under a single "User Guide" heading.

The cause is in the custom sidebar template `docs/source/_templates/docs-sidebar.html`. It only starts the sidebar toctree at depth 2 for pages under `user-guide/latest/`. Released-version directories such as `user-guide/0.17/` are not matched, so they fall back to depth 1, which roots the navigation at the parent `user-guide/index.md` ("User Guide" caption) and pushes the version's own captioned sub-toctrees one level deeper. Sphinx does not render `:caption:` for those deeper toctrees, so the section headings disappear and the entries flatten.

This only began to show with 0.17 because it is the first released version whose frozen `index.rst` uses the captioned multi-section layout (added in #4424, after 0.16 was branched). Versions 0.13 through 0.16 are legitimately flat.

## What changes are included in this PR?

Generalize the depth-2 condition in `docs/source/_templates/docs-sidebar.html` to match any user-guide version subdirectory (`latest` or a numbered release like `0.17`) rather than only `user-guide/latest/`. The wrapper pages `user-guide/index` and `user-guide/older-versions` remain at depth 1 since they are only two path segments deep.

## How are these changes tested?

Built the docs locally and compared the rendered `user-guide/0.17/index.html` against `user-guide/latest/index.html`. Before the change, 0.17 rendered a single "User Guide" caption with its content at `toctree-l2`; after the change, 0.17 renders the six section captions with content at `toctree-l1`, matching `latest`. The `latest` navigation is unchanged.