### PR TITLE
fix: gate str_to_map collations

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/maps.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/maps.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 import org.apache.comet.serde.QueryPlanSerde.{createBinaryExpr, exprToProtoInternal, optExprWithFallbackReason, scalarFunctionExprToProto}
+import org.apache.comet.shims.CometTypeShim
 
 object CometMapKeys extends CometExpressionSerde[MapKeys] {
 
@@ -156,7 +157,7 @@ object CometMapFromEntries
   }
 }
 
-object CometStrToMap extends CometScalarFunction[StringToMap]("str_to_map") {
+object CometStrToMap extends CometScalarFunction[StringToMap]("str_to_map") with CometTypeShim {
 
   // Spark 4.1.1+ honours spark.sql.legacy.truncateForEmptyRegexSplit by truncating trailing
   // empty entries from the split result. Comet's native str_to_map always behaves as if the flag
@@ -164,9 +165,20 @@ object CometStrToMap extends CometScalarFunction[StringToMap]("str_to_map") {
   // resolves on older Spark versions where the config is not registered.
   private val legacyTruncateConfig = "spark.sql.legacy.truncateForEmptyRegexSplit"
 
+  private val legacyTruncateReason =
+    s"`$legacyTruncateConfig` is enabled, so trailing empty split entries may differ from Spark."
+
+  private val collationReason =
+    "`str_to_map` does not support non-UTF8_BINARY collations on the input string or delimiters."
+
+  override def getIncompatibleReasons(): Seq[String] =
+    Seq(legacyTruncateReason, collationReason)
+
   override def getSupportLevel(expr: StringToMap): SupportLevel = {
     if (SQLConf.get.getConfString(legacyTruncateConfig, "false").toBoolean) {
-      Incompatible(Some(s"$legacyTruncateConfig is enabled"))
+      Incompatible(Some(legacyTruncateReason))
+    } else if (expr.children.exists(child => hasNonDefaultStringCollation(child.dataType))) {
+      Incompatible(Some(collationReason))
     } else {
       Compatible(None)
     }

--- a/spark/src/test/resources/sql-tests/expressions/map/str_to_map_collation.sql
+++ b/spark/src/test/resources/sql-tests/expressions/map/str_to_map_collation.sql
@@ -1,0 +1,33 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- MinSparkVersion: 4.0
+
+-- Spark 4.0+ applies collation-aware delimiter matching in str_to_map. Comet's native
+-- implementation matches raw delimiter bytes, so non-UTF8_BINARY collations must fall back.
+
+-- collated input string
+query expect_fallback(`str_to_map` does not support non-UTF8_BINARY collations)
+SELECT str_to_map('a:1,b:2' COLLATE UTF8_LCASE, ',', ':')
+
+-- collated pair delimiter
+query expect_fallback(`str_to_map` does not support non-UTF8_BINARY collations)
+SELECT str_to_map('aX1,bX2', 'x' COLLATE UTF8_LCASE, ':')
+
+-- collated key-value delimiter
+query expect_fallback(`str_to_map` does not support non-UTF8_BINARY collations)
+SELECT str_to_map('aX1,bX2', ',', 'x' COLLATE UTF8_LCASE)


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of apache/datafusion-comet#4505.

## Rationale for this change

`str_to_map` should fall back to Spark when collation-aware string splitting is required. Comet's native path only matches Spark behavior for default `UTF8_BINARY` string inputs and delimiters.

## What changes are included in this PR?

- Marks `StringToMap` expressions with non-`UTF8_BINARY` collations as incompatible.
- Enumerates both collation and legacy-truncate incompatibility reasons for `str_to_map`.
- Adds Spark 4.0+ SQL fallback coverage for collated input, pair delimiters, and key-value delimiters.

## How are these changes tested?

- Adds SQL tests `str_to_map_collation.sql‎`

---

Co-authored-by: @codex
