### PR TITLE
refactor: remove map_contains_key serde

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -175,7 +175,6 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
       classOf[MapEntries] -> CometMapEntries,
       classOf[MapValues] -> CometMapValues,
       classOf[MapFromArrays] -> CometMapFromArrays,
-      classOf[MapContainsKey] -> CometMapContainsKey,
       classOf[MapFromEntries] -> CometMapFromEntries,
       classOf[MapConcat] -> CometMapConcat,
       classOf[StringToMap] -> CometStrToMap,

--- a/spark/src/main/scala/org/apache/comet/serde/maps.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/maps.scala
@@ -117,23 +117,6 @@ object CometMapFromArrays extends CometExpressionSerde[MapFromArrays] {
   }
 }
 
-object CometMapContainsKey extends CometExpressionSerde[MapContainsKey] {
-
-  override def convert(
-      expr: MapContainsKey,
-      inputs: Seq[Attribute],
-      binding: Boolean): Option[ExprOuterClass.Expr] = {
-    // Replace with array_has(map_keys(map), key)
-    val mapExpr = exprToProtoInternal(expr.left, inputs, binding)
-    val keyExpr = exprToProtoInternal(expr.right, inputs, binding)
-
-    val mapKeysExpr = scalarFunctionExprToProto("map_keys", mapExpr)
-
-    val mapContainsKeyExpr = scalarFunctionExprToProto("array_has", mapKeysExpr, keyExpr)
-    optExprWithFallbackReason(mapContainsKeyExpr, expr, expr.children: _*)
-  }
-}
-
 object CometMapFromEntries
     extends CometScalarFunction[MapFromEntries]("map_from_entries")
     with CodegenDispatchFallback {


### PR DESCRIPTION
## Which issue does this PR close?

Part of apache/datafusion-comet#4505.

## Rationale for this change

Spark rewrites `map_contains_key` to `ArrayContains(MapKeys(...), key)` before Comet serialization. The dedicated `MapContainsKey` serde path is therefore unreachable and should not remain registered as if it were used.

## What changes are included in this PR?

- Removes the unreachable `CometMapContainsKey` serde object.
- Removes the `MapContainsKey` registry entry from `QueryPlanSerde`.

---

Co-authored-by: @codex