### PR TITLE
docs: restore 0.13 user guide dropped in 0.17 release

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -25,6 +25,7 @@ mkdir temp
 cp -rf source/* temp/
 
 # Add user guide from published releases
+rm -rf comet-0.13
 rm -rf comet-0.14
 rm -rf comet-0.15
 rm -rf comet-0.16

--- a/docs/generate-versions.py
+++ b/docs/generate-versions.py
@@ -155,5 +155,5 @@ if __name__ == "__main__":
     print("Generating versioned user guide docs...")
     snapshot_version = get_version_from_pom()
     latest_released_version = "0.17.0"
-    previous_versions = ["0.14.0", "0.15.0", "0.16.0"]
+    previous_versions = ["0.13.0", "0.14.0", "0.15.0", "0.16.0"]
     generate_docs(snapshot_version, latest_released_version, previous_versions)

--- a/docs/source/user-guide/older-versions.md
+++ b/docs/source/user-guide/older-versions.md
@@ -28,4 +28,5 @@ These user guides are kept for reference. They are not maintained: use the
 0.16.x <0.16/index>
 0.15.x <0.15/index>
 0.14.x <0.14/index>
+0.13.x <0.13/index>
 ```


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

The documentation update for the 0.17.0 release (#4698) rolled the published user guide version window forward and inadvertently dropped the 0.13 user guide. The 0.13 docs were still being published prior to that change, so they should be retained for reference.

## What changes are included in this PR?

Restores 0.13 in the three places the 0.17 release PR removed it:

- `docs/generate-versions.py`: add `0.13.0` back to `previous_versions`
- `docs/build.sh`: restore the `rm -rf comet-0.13` cleanup
- `docs/source/user-guide/older-versions.md`: re-add the `0.13.x` entry to the older versions toctree

## How are these changes tested?

Documentation-only change. The docs build is exercised by CI.