### PR TITLE
fix: repair broken rust-test build on main (init_datasource_exec arg mismatch)

### DIFF
--- a/native/core/src/parquet/parquet_exec.rs
+++ b/native/core/src/parquet/parquet_exec.rs
@@ -305,6 +305,7 @@ mod tests {
             true,
             false,
             false,
+            false,
             &session_ctx,
             false,
             false,


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

The `rust-test` CI job is currently failing on `main` with a compile error:

```
error[E0061]: this function takes 17 arguments but 16 arguments were supplied
  --> core/src/parquet/parquet_exec.rs:295:20
```

This is a semantic merge conflict between two PRs that did not conflict textually:

- #4357 added a 17th parameter, `allow_timestamp_ltz_to_ntz`, to `init_datasource_exec`.
- #4707 added a new unit test that calls `init_datasource_exec` with only 16 arguments.

#4707 was based on `main` before #4357 merged, so its test matched the 16-parameter signature and compiled on the branch. Once both landed on `main`, the test call no longer matched the signature. The non-test build does not compile that test code, so `Build Native Library` passes while `cargo test` (the `rust-test` job) fails. This blocks every open PR.

## What changes are included in this PR?

Insert the missing `allow_timestamp_ltz_to_ntz` argument (`false`) immediately before `session_ctx` in the test call site, matching the current signature and the existing production call site in `planner.rs`.

## How are these changes tested?

`cargo test -p datafusion-comet --no-run` now compiles successfully (it failed with E0061 before this change). The existing `rust-test` CI job exercises this test.