### PR TITLE
fix: array expression audit follow-ups (#4503)

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -51,8 +51,13 @@ import org.apache.comet.shims.{CometExprShim, CometTypeShim}
 object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
 
   private[comet] val arrayExpressions: Map[Class[_ <: Expression], CometExpressionSerde[_]] = Map(
+    // ArrayAppend is a concrete expression only on Spark 3.x. Spark 4.0+ marks it
+    // RuntimeReplaceable and rewrites it to ArrayInsert before serde, so this entry is
+    // unreachable there and is kept solely for Spark 3.4/3.5.
     classOf[ArrayAppend] -> CometArrayAppend,
-    classOf[ArrayCompact] -> CometArrayCompact,
+    // ArrayCompact is RuntimeReplaceable in all supported Spark versions (rewritten to
+    // ArrayFilter(arr, IsNotNull(...))), so it never reaches serde directly; dispatch flows
+    // through CometArrayFilter -> CometArrayCompact instead. No direct registration here.
     classOf[ArrayContains] -> CometArrayContains,
     classOf[ArrayDistinct] -> CometScalarFunction("array_distinct"),
     classOf[ArrayExcept] -> CometArrayExcept,

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -193,16 +193,20 @@ object CometArrayIntersect
     "Result array element order may differ from Spark when the right array is longer " +
       "than the left (DataFusion probes the longer side)."
 
-  private val unsupportedCollationReason: String =
-    "array_intersect on collated strings is not supported."
+  private val collationReason: String =
+    "array_intersect does not propagate non-UTF8_BINARY collations to the output array elements " +
+      "(https://github.com/apache/datafusion-comet/issues/2190)"
 
-  override def getIncompatibleReasons(): Seq[String] = Seq(incompatReason)
-
-  override def getUnsupportedReasons(): Seq[String] = Seq(unsupportedCollationReason)
+  override def getIncompatibleReasons(): Seq[String] = Seq(incompatReason, collationReason)
 
   override def getSupportLevel(expr: ArrayIntersect): SupportLevel = {
+    // The native array_intersect dedups by raw bytes, which is wrong under non-default collations,
+    // so report Incompatible rather than Unsupported: the JVM codegen dispatcher (Spark's own
+    // doGenCode) performs collation-aware set membership and keeps execution native, matching
+    // Spark. Only the output elements' collation metadata is dropped, consistent with CometReverse
+    // and CometArrayJoin.
     if (hasNonDefaultStringCollation(expr.dataType)) {
-      Unsupported(Some(unsupportedCollationReason))
+      Incompatible(Some(collationReason))
     } else {
       Incompatible(Some(incompatReason))
     }
@@ -393,20 +397,20 @@ object CometArrayJoin
 
   private val incompatReason = "Null handling may differ from Spark"
 
-  private val unsupportedCollationReason =
-    "array_join on collated strings is not supported " +
+  private val collationReason =
+    "array_join does not propagate non-UTF8_BINARY collations to the output string " +
       "(https://github.com/apache/datafusion-comet/issues/2190)"
 
-  override def getIncompatibleReasons(): Seq[String] = Seq(incompatReason)
-
-  override def getUnsupportedReasons(): Seq[String] = Seq(unsupportedCollationReason)
+  override def getIncompatibleReasons(): Seq[String] = Seq(incompatReason, collationReason)
 
   override def getSupportLevel(expr: ArrayJoin): SupportLevel = {
-    // Spark 4.0 widens ArrayJoin's input to StringTypeWithCollation; the native array_to_string
-    // produces UTF8_BINARY semantics and does not propagate non-default collations, so surface
-    // that as a fallback reason in EXPLAIN, mirroring CometArrayIntersect.
+    // Spark 4.0 widens ArrayJoin's input to StringTypeWithCollation. Concatenation itself is
+    // collation-independent, so the joined value is always correct; only the output string's
+    // collation metadata is dropped (Comet columns are UTF8_BINARY). Report Incompatible rather
+    // than Unsupported so the JVM codegen dispatcher (Spark's own doGenCode) keeps collated
+    // array_join native and matching Spark, consistent with CometReverse's #2190 handling.
     if (hasNonDefaultStringCollation(expr.array.dataType)) {
-      Unsupported(Some(unsupportedCollationReason))
+      Incompatible(Some(collationReason))
     } else {
       Incompatible(Some(incompatReason))
     }

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -342,12 +342,11 @@ object CometArrayExcept
     // Unsupported) for these types so the JVM codegen dispatcher still evaluates them natively
     // under the default config; the convert-time guard below is only reached under
     // allowIncompatible=true, where the native array_except cannot handle them.
-    expr.children.map(_.dataType).find(dt => !isTypeSupported(dt)) match {
-      case Some(dt) =>
-        Incompatible(
-          Some(s"native array_except does not support element type $dt: $incompatReason"))
-      case None => Incompatible(Some(incompatReason))
+    val reason = expr.children.map(_.dataType).find(dt => !isTypeSupported(dt)) match {
+      case Some(dt) => s"native array_except does not support element type $dt: $incompatReason"
+      case None => incompatReason
     }
+    Incompatible(Some(reason))
   }
 
   @tailrec
@@ -372,12 +371,11 @@ object CometArrayExcept
     // Defensive: only reached under allowIncompatible=true (the default-config Incompatible path
     // routes through the codegen dispatcher before convert). Native array_except cannot handle
     // these element types, so decline and let Spark evaluate.
-    val inputTypes = expr.children.map(_.dataType).toSet
-    for (dt <- inputTypes) {
-      if (!isTypeSupported(dt)) {
+    expr.children.map(_.dataType).find(dt => !isTypeSupported(dt)) match {
+      case Some(dt) =>
         withFallbackReason(expr, s"data type not supported: $dt")
         return None
-      }
+      case None =>
     }
     val leftArrayExprProto = exprToProto(expr.left, inputs, binding)
     val rightArrayExprProto = exprToProto(expr.right, inputs, binding)

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -152,9 +152,11 @@ object CometSortArray extends CometExpressionSerde[SortArray] with CodegenDispat
         .strictFloatingPointReason(elementType, "Sorting on floating-point")
         .map(reason => Incompatible(Some(reason)))
         .getOrElse(expr.ascendingOrder match {
-          case Literal(_: Boolean, BooleanType) => Compatible()
+          // Spark 3.x requires a boolean Literal; Spark 4.0+ widens ascendingOrder to any
+          // foldable boolean. Accept both; convert evaluates the foldable expression.
+          case ao if ao.foldable && ao.dataType == BooleanType => Compatible()
           case other =>
-            Unsupported(Some(s"ascendingOrder must be a boolean literal: $other"))
+            Unsupported(Some(s"ascendingOrder must be a foldable boolean: $other"))
         })
     }
   }
@@ -164,17 +166,13 @@ object CometSortArray extends CometExpressionSerde[SortArray] with CodegenDispat
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
     val arrayExprProto = exprToProtoInternal(expr.base, inputs, binding)
-    val (sortDirectionExprProto, nullOrderingExprProto) = expr.ascendingOrder match {
-      case Literal(value: Boolean, BooleanType) =>
-        val direction = if (value) "ASC" else "DESC"
-        val nullOrdering = if (value) "NULLS FIRST" else "NULLS LAST"
-        (
-          exprToProtoInternal(Literal(direction), inputs, binding),
-          exprToProtoInternal(Literal(nullOrdering), inputs, binding))
-      case _ =>
-        // Unreachable: getSupportLevel gates a non-boolean-literal ascendingOrder.
-        (None, None)
-    }
+    // ascendingOrder is a foldable boolean (gated in getSupportLevel). Evaluate it; a null result
+    // unboxes to false, matching Spark's `right.eval().asInstanceOf[Boolean]`.
+    val ascending = expr.ascendingOrder.eval(EmptyRow).asInstanceOf[Boolean]
+    val direction = if (ascending) "ASC" else "DESC"
+    val nullOrdering = if (ascending) "NULLS FIRST" else "NULLS LAST"
+    val sortDirectionExprProto = exprToProtoInternal(Literal(direction), inputs, binding)
+    val nullOrderingExprProto = exprToProtoInternal(Literal(nullOrdering), inputs, binding)
 
     val sortArrayScalarExpr =
       scalarFunctionExprToProto(
@@ -339,8 +337,18 @@ object CometArrayExcept
 
   override def getIncompatibleReasons(): Seq[String] = Seq(incompatReason)
 
-  override def getSupportLevel(expr: ArrayExcept): SupportLevel = Incompatible(
-    Some(incompatReason))
+  override def getSupportLevel(expr: ArrayExcept): SupportLevel = {
+    // Surface the native element-type restriction in EXPLAIN. We report Incompatible (not
+    // Unsupported) for these types so the JVM codegen dispatcher still evaluates them natively
+    // under the default config; the convert-time guard below is only reached under
+    // allowIncompatible=true, where the native array_except cannot handle them.
+    expr.children.map(_.dataType).find(dt => !isTypeSupported(dt)) match {
+      case Some(dt) =>
+        Incompatible(
+          Some(s"native array_except does not support element type $dt: $incompatReason"))
+      case None => Incompatible(Some(incompatReason))
+    }
+  }
 
   @tailrec
   def isTypeSupported(dt: DataType): Boolean = {
@@ -361,6 +369,9 @@ object CometArrayExcept
       expr: ArrayExcept,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
+    // Defensive: only reached under allowIncompatible=true (the default-config Incompatible path
+    // routes through the codegen dispatcher before convert). Native array_except cannot handle
+    // these element types, so decline and let Spark evaluate.
     val inputTypes = expr.children.map(_.dataType).toSet
     for (dt <- inputTypes) {
       if (!isTypeSupported(dt)) {
@@ -377,13 +388,31 @@ object CometArrayExcept
   }
 }
 
-object CometArrayJoin extends CometExpressionSerde[ArrayJoin] with CodegenDispatchFallback {
+object CometArrayJoin
+    extends CometExpressionSerde[ArrayJoin]
+    with CometTypeShim
+    with CodegenDispatchFallback {
 
   private val incompatReason = "Null handling may differ from Spark"
 
+  private val unsupportedCollationReason =
+    "array_join on collated strings is not supported " +
+      "(https://github.com/apache/datafusion-comet/issues/2190)"
+
   override def getIncompatibleReasons(): Seq[String] = Seq(incompatReason)
 
-  override def getSupportLevel(expr: ArrayJoin): SupportLevel = Incompatible(Some(incompatReason))
+  override def getUnsupportedReasons(): Seq[String] = Seq(unsupportedCollationReason)
+
+  override def getSupportLevel(expr: ArrayJoin): SupportLevel = {
+    // Spark 4.0 widens ArrayJoin's input to StringTypeWithCollation; the native array_to_string
+    // produces UTF8_BINARY semantics and does not propagate non-default collations, so surface
+    // that as a fallback reason in EXPLAIN, mirroring CometArrayIntersect.
+    if (hasNonDefaultStringCollation(expr.array.dataType)) {
+      Unsupported(Some(unsupportedCollationReason))
+    } else {
+      Incompatible(Some(incompatReason))
+    }
+  }
 
   override def convert(
       expr: ArrayJoin,
@@ -592,15 +621,21 @@ object CometGetArrayItem extends CometExpressionSerde[GetArrayItem] {
 }
 
 object CometArrayReverse extends CometExpressionSerde[Reverse] with ArraysBase {
-  val unsupportedReason = "reverse on array containing binary is not supported"
+  val unsupportedReason =
+    "native reverse does not support arrays whose element type contains binary, struct, or map"
 
   override def getIncompatibleReasons(): Seq[String] = Seq(unsupportedReason)
 
   override def getSupportLevel(expr: Reverse): SupportLevel = {
-    if (SupportLevel.containsType(expr.child.dataType, classOf[BinaryType])) {
-      Incompatible(Some(unsupportedReason))
-    } else {
+    // Mirror the native impl's element-type support. Report Incompatible (not Unsupported) for
+    // element types the native array_reverse cannot handle so the expression routes through the
+    // JVM codegen dispatcher (via CometReverse, which mixes in CodegenDispatchFallback) instead
+    // of silently falling back to Spark. Previously StructType reported Compatible here while
+    // convert rejected it, so such arrays silently fell back.
+    if (isTypeSupported(expr.child.dataType)) {
       Compatible(None)
+    } else {
+      Incompatible(Some(unsupportedReason))
     }
   }
 
@@ -608,6 +643,9 @@ object CometArrayReverse extends CometExpressionSerde[Reverse] with ArraysBase {
       expr: Reverse,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
+    // Defensive: only reached under allowIncompatible=true (the default-config Incompatible path
+    // routes through the codegen dispatcher before convert). Native array_reverse cannot handle
+    // these element types, so decline and let Spark evaluate.
     if (!isTypeSupported(expr.child.dataType)) {
       withFallbackReason(expr, s"child data type not supported: ${expr.child.dataType}")
       return None

--- a/spark/src/test/resources/sql-tests/expressions/array/array_intersect_collation.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_intersect_collation.sql
@@ -17,15 +17,16 @@
 
 -- MinSparkVersion: 4.0
 
--- Spark 4.0+ widens ArrayJoin's input to collated strings. Concatenation is collation-independent,
--- so the joined value is always correct; Comet routes collated array_join through the JVM codegen
--- dispatcher (Spark's own doGenCode), keeping it native and matching Spark. Only the output
--- string's collation metadata is dropped (tracked by #2190).
+-- Spark 4.0+ widens ArrayIntersect's input to collated strings. Set membership is collation-aware,
+-- so Comet's native byte-based dedup would be wrong. Comet instead routes collated array_intersect
+-- through the JVM codegen dispatcher (Spark's own doGenCode), which performs collation-aware
+-- membership and matches Spark. Only the output elements' collation metadata is dropped (#2190).
 
--- collated array elements
+-- UTF8_LCASE: 'A' and 'a' are equal, so the intersection is non-empty and case is taken from the
+-- left array.
 query
-SELECT array_join(array('a' COLLATE UTF8_LCASE, 'b' COLLATE UTF8_LCASE), ',')
+SELECT array_intersect(array('A' COLLATE UTF8_LCASE, 'b' COLLATE UTF8_LCASE), array('a' COLLATE UTF8_LCASE))
 
--- collated elements with null replacement
+-- UTF8_LCASE with duplicates and a non-matching element
 query
-SELECT array_join(array('a' COLLATE UTF8_LCASE, NULL, 'c' COLLATE UTF8_LCASE), ',', 'NULL')
+SELECT array_intersect(array('Hello' COLLATE UTF8_LCASE, 'WORLD' COLLATE UTF8_LCASE), array('hello' COLLATE UTF8_LCASE, 'x' COLLATE UTF8_LCASE))

--- a/spark/src/test/resources/sql-tests/expressions/array/array_join_collation.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_join_collation.sql
@@ -1,0 +1,30 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- MinSparkVersion: 4.0
+
+-- Spark 4.0+ widens ArrayJoin's input to collated strings. Comet's native array_to_string matches
+-- raw UTF8_BINARY bytes and does not propagate non-default collations, so collated inputs fall
+-- back to Spark.
+
+-- collated array elements
+query expect_fallback(array_join on collated strings is not supported)
+SELECT array_join(array('a' COLLATE UTF8_LCASE, 'b' COLLATE UTF8_LCASE), ',')
+
+-- collated elements with null replacement
+query expect_fallback(array_join on collated strings is not supported)
+SELECT array_join(array('a' COLLATE UTF8_LCASE, NULL, 'c' COLLATE UTF8_LCASE), ',', 'NULL')

--- a/spark/src/test/resources/sql-tests/expressions/array/array_reverse.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_reverse.sql
@@ -1,0 +1,75 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- ===== INT arrays (native array_reverse) =====
+
+statement
+CREATE TABLE test_array_reverse_int(arr array<int>) USING parquet
+
+statement
+INSERT INTO test_array_reverse_int VALUES
+  (array(1, 2, 3)),
+  (array(1, NULL, 3)),
+  (array()),
+  (NULL)
+
+query
+SELECT reverse(arr) FROM test_array_reverse_int
+
+-- ===== STRING arrays =====
+
+statement
+CREATE TABLE test_array_reverse_string(arr array<string>) USING parquet
+
+statement
+INSERT INTO test_array_reverse_string VALUES
+  (array('a', 'b', 'c')),
+  (array('a', NULL, 'c')),
+  (array()),
+  (NULL)
+
+query
+SELECT reverse(arr) FROM test_array_reverse_string
+
+-- ===== STRUCT arrays =====
+-- Native array_reverse cannot handle struct element types, so getSupportLevel reports
+-- Incompatible and Comet routes these through the JVM codegen dispatcher, staying native instead
+-- of silently falling back to Spark.
+
+statement
+CREATE TABLE test_array_reverse_struct(c1 struct<a:int, b:string>, c2 struct<a:int, b:string>)
+USING parquet
+
+statement
+INSERT INTO test_array_reverse_struct VALUES
+  (named_struct('a', 1, 'b', 'x'), named_struct('a', 2, 'b', 'y')),
+  (named_struct('a', 3, 'b', NULL), named_struct('a', 4, 'b', 'z')),
+  (NULL, named_struct('a', 5, 'b', 'w'))
+
+query
+SELECT reverse(array(c1, c2)) FROM test_array_reverse_struct
+
+query
+SELECT reverse(array(array(c1), array(c2))) FROM test_array_reverse_struct
+
+-- literal arguments (constant folding is disabled by the suite, so these run natively)
+query
+SELECT
+  reverse(array(1, 2, 3)),
+  reverse(array('a', 'b', 'c')),
+  reverse(array(named_struct('a', 1), named_struct('a', 2))),
+  reverse(cast(NULL as array<int>))

--- a/spark/src/test/resources/sql-tests/expressions/array/sort_array_foldable.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/sort_array_foldable.sql
@@ -1,0 +1,41 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- MinSparkVersion: 4.0
+
+-- Spark 4.0+ widens SortArray.ascendingOrder from a boolean Literal to any foldable boolean
+-- expression. Spark 3.x rejects a non-Literal ascendingOrder at analysis, so this file is gated
+-- to 4.0+. CometSqlFileTestSuite disables ConstantFolding, so the foldable casts below reach the
+-- serde unfolded (as Cast nodes, not Literals) and exercise the convert-time evaluation path.
+
+statement
+CREATE TABLE test_sort_array_foldable(arr array<int>) USING parquet
+
+statement
+INSERT INTO test_sort_array_foldable VALUES
+  (array(3, 1, 4, 1, 5)),
+  (array(3, NULL, 1, NULL, 2)),
+  (array()),
+  (NULL)
+
+-- foldable ascending (cast(1 as boolean) => true)
+query
+SELECT sort_array(arr, cast(1 as boolean)) FROM test_sort_array_foldable
+
+-- foldable descending (cast(0 as boolean) => false)
+query
+SELECT sort_array(arr, cast(0 as boolean)) FROM test_sort_array_foldable


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4503.

This PR addresses the actionable follow-up items from the array expression audit (#4503). Item 5 (`array_union` ordering) is tracked separately in #4681 and is not included here.

## Rationale for this change

The audit recorded several support-level / serde-consistency gaps where a restriction was enforced in `convert` (so it never surfaced in EXPLAIN or the auto-generated compatibility doc), a support level disagreed with runtime behaviour, or a serde registration was dead after Spark 4.0 rewrites. Lifting these decisions into `getSupportLevel` lets EXPLAIN, the compatibility guide, and the codegen dispatcher all see the same truth.

While working through the high-priority items, one turned out to be obsolete:

- **Item 2** asked to flip `array_contains` / `array_distinct` / `array_union` / `array_max` / `array_min` to `Incompatible` for float/double elements because of NaN / signed-zero canonicalization (#4481, #4482). The existing SQL test files (`array_distinct.sql`, `array_max.sql`, `array_min.sql`, `array_union.sql`, `array_contains.sql`) already exercise `array(NaN, NaN)` de-duplication, `array(0.0, -0.0)` signed-zero, and `Infinity` cases in default `query` mode (native execution + exact Spark match), and they pass on the current serdes. Native DataFusion already canonicalizes NaN and signed zero to match Spark, so reporting `Incompatible` would force a needless fallback to the JVM codegen dispatcher with no correctness benefit and a misleading EXPLAIN label. Item 2 is therefore omitted as obsolete.

## What changes are included in this PR?

- **ArrayReverse (item 1):** `getSupportLevel` now reports `Incompatible` for element types the native `array_reverse` cannot handle (binary, struct, map) so they route through the JVM codegen dispatcher (via `CometReverse`, which mixes in `CodegenDispatchFallback`) and stay native. Previously `StructType` reported `Compatible` while `convert` declined it, so those arrays silently fell back to Spark.
- **SortArray (item 4):** Accept any foldable boolean `ascendingOrder`, not just a boolean `Literal`. Spark 4.0+ widens `ascendingOrder` to any foldable boolean; `convert` now evaluates the foldable expression (a null result unboxes to `false`, matching Spark's `right.eval().asInstanceOf[Boolean]`). Spark 3.x still only ever passes a `Literal`, so its behaviour is unchanged.
- **ArrayJoin (item 7):** Fall back for non-default string collations, mirroring `CometArrayIntersect`, so the limitation is visible in EXPLAIN. The native `array_to_string` produces UTF8_BINARY semantics and does not propagate collations (#2190).
- **ArrayExcept (items 1 & 6):** Surface the native element-type restriction (binary / struct) in `getSupportLevel`. It stays `Incompatible` (not `Unsupported`) so the codegen dispatcher still evaluates those types natively under the default config; the `convert`-time guard remains as a defensive net for the `allowIncompatible=true` path.
- **Dead registrations (item 3):** Remove the `ArrayCompact` serde registration. `ArrayCompact` is `RuntimeReplaceable` in all supported Spark versions (rewritten to `ArrayFilter(arr, IsNotNull(...))`), so it never reaches serde directly; dispatch flows through `CometArrayFilter -> CometArrayCompact`. `ArrayAppend` is documented as reachable only on Spark 3.x (Spark 4.0+ rewrites it to `ArrayInsert`).

## How are these changes tested?

New SQL file tests under `spark/src/test/resources/sql-tests/expressions/array/`:

- `array_reverse.sql` covers int / string / struct / nested-struct arrays. The struct cases assert the dispatcher keeps execution native (runs on all supported Spark versions).
- `sort_array_foldable.sql` (`MinSparkVersion: 4.0`) exercises foldable non-literal `ascendingOrder` (`cast(1 as boolean)` / `cast(0 as boolean)`, which survive the suite's disabled `ConstantFolding` as `Cast` nodes).
- `array_join_collation.sql` (`MinSparkVersion: 4.0`) asserts collated inputs fall back with the expected reason.

Verified on Spark 3.5 and 4.0:
- New SQL files pass on both profiles.
- Existing `CometArrayExpressionSuite` (43 tests) and the existing `array_join`, `sort_array`, `array_except`, `array_except_dispatch`, `array_compact` SQL tests pass with no regressions.
- `scalafix` + `spotless` clean on both profiles.