### PR TITLE
perf: add metadata size hint to Parquet reader to match Iceberg path

### DIFF
--- a/native/core/src/parquet/parquet_exec.rs
+++ b/native/core/src/parquet/parquet_exec.rs
@@ -130,8 +130,9 @@ pub(crate) fn init_datasource_exec(
     let table_schema =
         TableSchema::from_file_schema(base_schema).with_table_partition_cols(partition_fields);
 
-    let mut parquet_source =
-        ParquetSource::new(table_schema).with_table_parquet_options(table_parquet_options);
+    let mut parquet_source = ParquetSource::new(table_schema)
+        .with_table_parquet_options(table_parquet_options)
+        .with_metadata_size_hint(512 * 1024); // Same as DataFusion's default
 
     if encryption_enabled {
         parquet_source = parquet_source.with_encryption_factory(


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

#3606 added the metadata size hint to the Iceberg code path, but we don't have that in the Parquet path. While trying to understand performance regressions in TPC-DS with DF 54.0, I instrumented 3 round-trips for Parquet metadata. This hint generally reduces it to 1 round-trip. We adopt the default value from DataFusion, and can add a configuration in the future.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add default `metadata_size_hint` from DataFusion.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Existing tests. I will run TPC-DS to see how it helps.
