### PR TITLE
perf: unwrap identity casts in schema adapter to enable Parquet stats pruning

### DIFF
--- a/native/core/src/parquet/schema_adapter.rs
+++ b/native/core/src/parquet/schema_adapter.rs
@@ -645,6 +645,21 @@ impl SparkPhysicalExprAdapter {
             };
             let physical_type = input_field.data_type();
 
+            // Identity cast: DataFusion's default adapter inserts a CastExpr
+            // whenever the logical and physical Arrow Fields differ in any
+            // attribute (data type, nullability, or metadata), so with identical
+            // data types but mismatched nullability or metadata, we receive a
+            // no-op cast. Unwrapping is safe because Spark `Cast` with equal
+            // source and target types is value-level identity (it does not
+            // null-strip or enforce non-null), and field nullability/metadata is
+            // informational rather than computational. Leaving the wrapper in
+            // place blocks DataFusion's pruning-predicate analyzer from
+            // recognizing the column reference, defeating row-group / page-index
+            // stats pruning.
+            if physical_type == target_type {
+                return Ok(Transformed::yes(child));
+            }
+
             // Reject reading a string/binary Parquet column as anything else. Spark's
             // `ParquetVectorUpdaterFactory.getUpdater` BINARY case allows StringType /
             // BinaryType, or DecimalType only when the column carries a

--- a/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
@@ -24,12 +24,13 @@ import org.scalatest.Tag
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import org.apache.parquet.hadoop.ParquetWriter
+import org.apache.parquet.hadoop.{ParquetFileReader, ParquetWriter}
 import org.apache.parquet.hadoop.api.WriteSupport
 import org.apache.parquet.hadoop.api.WriteSupport.WriteContext
 import org.apache.parquet.io.api.RecordConsumer
 import org.apache.parquet.schema.MessageTypeParser
 import org.apache.spark.sql.{CometTestBase, Row}
+import org.apache.spark.sql.comet.CometNativeScanExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.{array, col}
 import org.apache.spark.sql.internal.SQLConf
@@ -824,6 +825,50 @@ class CometNativeReaderSuite extends CometTestBase with AdaptiveSparkPlanHelper 
         val df = spark.read.parquet(path.toString).where("id = 0").select("id")
         val rows = df.collect()
         assert(rows.length == 1, s"Expected 1 row, got ${rows.length}: ${rows.mkString(", ")}")
+      }
+    }
+  }
+
+  test("row-group statistics pruning fires for native Parquet scan dataFilters") {
+    // Regression test for the identity-cast pruning gap. DataFusion's default
+    // PhysicalExprAdapter inserts a CastExpr around Column refs whenever the logical
+    // and physical Arrow Fields differ at all, including metadata or nullability with
+    // identical data types. Comet then translates that CastExpr into a Spark Cast,
+    // which DataFusion's pruning-predicate analyzer cannot peel back to a column,
+    // so build_pruning_predicates returns None and no row groups are pruned. The
+    // fix skips the wrap when source and target types are equal.
+    withTempPath { dir =>
+      withSQLConf(SQLConf.LEAF_NODE_DEFAULT_PARALLELISM.key -> "1") {
+        spark
+          .range(0, 1000)
+          .toDF("c1")
+          .repartition(1)
+          .write
+          .option("parquet.block.size", "1024")
+          .format("parquet")
+          .save(dir.toString)
+
+        val parquetFile = dir
+          .listFiles()
+          .find(_.getName.endsWith(".parquet"))
+          .getOrElse(fail("No parquet file was written"))
+        val reader = ParquetFileReader.open(
+          org.apache.parquet.hadoop.util.HadoopInputFile
+            .fromPath(new Path(parquetFile.getAbsolutePath), spark.sessionState.newHadoopConf()))
+        val numRowGroups =
+          try reader.getRowGroups.size()
+          finally reader.close()
+        assert(numRowGroups > 1, s"Test setup needs >1 row groups, got $numRowGroups")
+
+        val df = spark.read.parquet(dir.toString).where("c1 > 500")
+        val (_, cometPlan) = checkSparkAnswerAndOperator(df)
+        val nativeScans = cometPlan.collect { case n: CometNativeScanExec => n }
+        assert(nativeScans.nonEmpty, "Expected a CometNativeScanExec")
+        val scanRows = nativeScans.head.metrics("numOutputRows").value
+        assert(
+          scanRows < 1000,
+          s"Row-group statistics pruning did not fire (scan read $scanRows of 1000 rows " +
+            s"across $numRowGroups row groups)")
       }
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

DataFusion's default `PhysicalExprAdapter` inserts a `CastExpr` around every Column reference whenever the logical and physical Arrow Fields differ in any attribute, including metadata-only or nullability-only mismatches. DataFusion itself absorbs this because its `PruningPredicate` analyzer recognizes its own `CastExpr` and peels it to resolve the column against parquet statistics.

Comet's `SparkPhysicalExprAdapter::replace_with_spark_cast` then swaps that `CastExpr` for a `datafusion_comet_spark_expr::Cast` because Spark cast semantics diverge from arrow-cast for overflow, null handling, ANSI mode, etc. The Spark `Cast` is a different `PhysicalExpr` type that DataFusion's pruning analyzer does not understand, so `build_pruning_predicates` returns `None` at file open time and no row groups are pruned. With Spark range-derived schemas (non-nullable logical) read from Parquet (nullable physical), this fires on every column reference, silently disabling row-group and page-index stats pruning.

For identical source and target data types there is no Spark-specific cast semantics to preserve, so the swap costs us pruning for no benefit.

## What changes are included in this PR?

`SparkPhysicalExprAdapter::replace_with_spark_cast` now skips the Spark `Cast` wrap when the physical and target data types are equal. Unwrapping is safe because a `Cast` with equal source and target types is a value-level identity (it does not null-strip or enforce non-null), and Arrow field nullability and metadata are informational, not computational.

## How are these changes tested?

`CometNativeReaderSuite` adds a regression test that writes a 1000-row Parquet file with `parquet.block.size=1024`, asserts more than one row group via `ParquetFileReader`, then runs `SELECT ... WHERE c1 > 500` and asserts the scan's `numOutputRows` is strictly less than 1000. Without the fix the scan reads all rows; with the fix row groups whose max is at most 500 are pruned.