### PR TITLE
fix: fall back for decimal SUM/AVG over sliding window frames (window audit)

### DIFF
--- a/docs/source/contributor-guide/expression-audits/window_funcs.md
+++ b/docs/source/contributor-guide/expression-audits/window_funcs.md
@@ -21,6 +21,10 @@
 
 > Audit notes for expressions in this category that have been audited. Absence of an entry means the expression has not been audited yet, not that it is unsupported. See the user guide [Spark Expression Support] for current support status.
 
+## avg (window)
+
+- 4.1.1, audited 2026-06-25: `AVG(<decimal>)` over a window falls back to Spark on Spark 4.x. Spark wraps the result as `Cast(avg(UnscaledValue(v)) / pow10 as decimal)`, a shape `CometWindowExec.convert` does not unwrap (it recognizes only `Alias(WindowExpression)` and `Alias(MakeDecimal(WindowExpression))`), so the `AvgDecimal` native window branch in `process_agg_func` is effectively dead on Spark 4.x. Results stay correct via fallback; this is a coverage gap, not a correctness divergence. Tracked by https://github.com/apache/datafusion-comet/issues/4731. Non-decimal `AVG` runs natively. Sliding-frame decimal `AVG` is additionally guarded by the same fallback as decimal `SUM` (see below) so that it cannot hit the DataFusion built-in overflow divergence once the `Cast(Divide(...))` shape is recognized.
+
 ## lag
 
 - Supported via `CometWindowExec` (operator level), not the expression serde.
@@ -28,5 +32,9 @@
 ## lead
 
 - Supported via `CometWindowExec` (operator level), not the expression serde.
+
+## sum (window)
+
+- 4.1.1, audited 2026-06-25: `SUM(<decimal>)` over a sliding window frame (lower bound not `UNBOUNDED PRECEDING`) falls back to Spark. The native sliding path would use DataFusion's built-in `sum`, which wraps on overflow rather than returning Spark's NULL, and overflow cannot be detected at plan time, so the whole sliding decimal `SUM` case falls back. Ever-expanding frames use Comet's overflow-aware `SumDecimal` UDAF and run natively, matching Spark including overflow-to-NULL. Bigint sliding `SUM` overflow matches Spark (both wrap) and stays native.
 
 [Spark Expression Support]: ../../user-guide/latest/expressions.md

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometWindowExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometWindowExec.scala
@@ -228,6 +228,40 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
 
     val f = windowExpr.windowSpec.frameSpecification
 
+    // SUM / AVG over a DECIMAL with a sliding frame (lower bound other than
+    // UNBOUNDED PRECEDING) routes to DataFusion's built-in sum / avg, whose
+    // accumulators wrap on overflow instead of returning Spark's NULL. Only
+    // the ever-expanding path uses Comet's overflow-aware SumDecimal /
+    // AvgDecimal UDAFs, so on overflow the sliding case produces a wrapped,
+    // out-of-range value rather than NULL. Whether the running value overflows
+    // can't be known at plan time, so fall back to Spark for the whole sliding
+    // decimal case, mirroring the RANGE-frame fallbacks below.
+    // https://github.com/apache/datafusion-comet/issues/4729
+    val isEverExpanding = f match {
+      case SpecifiedWindowFrame(_, UnboundedPreceding, _) => true
+      case _: SpecifiedWindowFrame => false
+      case _ => true
+    }
+    if (!isEverExpanding) {
+      windowExpr.windowFunction match {
+        case agg: AggregateExpression =>
+          agg.aggregateFunction match {
+            case s: Sum if s.dataType.isInstanceOf[DecimalType] =>
+              withFallbackReason(
+                windowExpr,
+                "SUM on DECIMAL with a sliding window frame is not supported")
+              return None
+            case a: Average if a.dataType.isInstanceOf[DecimalType] =>
+              withFallbackReason(
+                windowExpr,
+                "AVG on DECIMAL with a sliding window frame is not supported")
+              return None
+            case _ =>
+          }
+        case _ =>
+      }
+    }
+
     // Comet's native window planner ships RANGE frame offsets as
     // ScalarValue::Int64, but a couple of ORDER BY types don't tolerate that:
     //   - DATE: arrow-arith requires an Interval RHS for Date32 arithmetic,

--- a/spark/src/test/resources/sql-tests/windows/window_functions.sql
+++ b/spark/src/test/resources/sql-tests/windows/window_functions.sql
@@ -790,3 +790,48 @@ SELECT
   LAG(a, 1, c)  OVER (ORDER BY b) AS lg,
   LEAD(a, 1, c) OVER (ORDER BY b) AS ld
 FROM lag_lead_nulls
+
+-- ############################################################
+-- Section 8: decimal aggregate overflow semantics
+-- ############################################################
+-- Spark returns NULL when a decimal SUM overflows the result precision under
+-- non-ANSI semantics. Comet's native window path enforces this for
+-- ever-expanding frames (lower bound UNBOUNDED PRECEDING) via its
+-- overflow-aware SumDecimal UDAF. Sliding frames would route to DataFusion's
+-- built-in sum, whose accumulator wraps on overflow instead of returning NULL,
+-- so Comet falls back to Spark for sliding decimal SUM / AVG (#4729).
+
+statement
+CREATE TABLE dec_overflow(g int, v decimal(38,0)) USING parquet
+
+statement
+INSERT INTO dec_overflow VALUES
+  (1, 90000000000000000000000000000000000000),
+  (1, 90000000000000000000000000000000000000),
+  (1, 90000000000000000000000000000000000000)
+
+-- ============================================================
+-- 8.1: ever-expanding decimal SUM that overflows the result precision
+-- returns NULL (Comet's SumDecimal UDAF matches Spark's overflow-to-NULL).
+-- ============================================================
+
+query
+SELECT v,
+  SUM(v) OVER (PARTITION BY g ORDER BY v
+               ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS run_sum
+FROM dec_overflow
+
+-- ============================================================
+-- 8.2: sliding decimal SUM falls back to Spark. DataFusion's built-in sum
+-- wraps on overflow (producing an out-of-range Decimal128) rather than
+-- returning Spark's NULL, and overflow can't be detected at plan time, so the
+-- whole sliding decimal SUM case falls back. Re-enable native execution when
+-- the native window path enforces Spark decimal overflow semantics for
+-- sliding frames.
+-- ============================================================
+
+query expect_fallback(SUM on DECIMAL with a sliding window frame is not supported)
+SELECT v,
+  SUM(v) OVER (PARTITION BY g ORDER BY v
+               ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS tail_sum
+FROM dec_overflow


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4729

## Rationale for this change

This PR is the result of auditing the native window function support added in #4209 (covering ranking, value-shift, and standard aggregate window functions). The audit walked the Scala serde (`CometWindowExec`), the native planner (`create_window_expr` / `process_agg_func`), and the DataFusion 54 window/aggregate accumulators, and verified behavior empirically through the differential SQL-file test harness.

The audit found one correctness divergence. `SUM(<decimal>)` over a sliding window frame (a frame whose lower bound is not `UNBOUNDED PRECEDING`) routes to DataFusion's built-in `sum`, whose accumulator wraps on overflow (`add_wrapping`) instead of returning Spark's NULL. On overflow the native result is a wrapped value that can fall outside the declared decimal precision, which even breaks Spark's result decoding (`EXPRESSION_DECODING_FAILED` / `NUMERIC_VALUE_OUT_OF_RANGE`). The divergence is decimal-specific: bigint sliding `SUM` overflow matches Spark (both wrap), and ever-expanding decimal `SUM` overflow already matches Spark (Comet's `SumDecimal` UDAF returns NULL).

## What changes are included in this PR?

- Fall back to Spark for decimal `SUM` / `AVG` over a sliding window frame in `CometWindowExec`. Overflow cannot be detected at plan time, so the whole sliding decimal case falls back, mirroring the existing RANGE-frame DATE/DECIMAL fallbacks. Ever-expanding frames keep using Comet's overflow-aware `SumDecimal` / `AvgDecimal` UDAFs and continue to run natively.
- Add regression tests in `windows/window_functions.sql` (Section 8): ever-expanding decimal `SUM` overflow stays native and returns NULL, and sliding decimal `SUM` falls back.
- Record the findings in the `window_funcs` expression-audit notes.

The audit also surfaced a coverage gap that is not a correctness divergence and is tracked separately in #4731: `AVG(<decimal>)` over a window always falls back to Spark on Spark 4.x because `CometWindowExec` does not recognize the `Cast(Divide(...))` average shape, leaving the `AvgDecimal` native window branch dead there. Results stay correct via fallback. The fallback guard added here also covers `AVG` so the overflow class of bug cannot reappear once that shape is recognized.

This work was scaffolded by the `audit-comet-expression` project skill.

## How are these changes tested?

- New and existing cases in `windows/window_functions.sql` run through `CometSqlFileTestSuite`, which compares Comet against Spark.
- `CometWindowExecSuite` (49 tests) passes unchanged.
