### PR TITLE
chore: surface DataFusion 54 PruningMetrics and Ratio in CometNativeScan metrics

### DIFF
--- a/dev/diffs/3.4.3.diff
+++ b/dev/diffs/3.4.3.diff
@@ -2337,7 +2337,7 @@ index 240bb4e6dcb..8287ffa03ca 100644
  
    import testImplicits._
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
-index 351c6d698fc..d09a49f0482 100644
+index 351c6d698fc..3983401184a 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
 @@ -26,6 +26,7 @@ import org.apache.parquet.hadoop.{ParquetFileReader, ParquetOutputFormat}
@@ -2359,7 +2359,7 @@ index 351c6d698fc..d09a49f0482 100644
 +              numPartitions +=
 +                b.originalPlan.inputRDD.partitions.length
 +              numOutputRows +=
-+                b.metrics("numOutputRows").value
++                b.metrics("output_rows").value
              case _ =>
            }
            assert(numPartitions > 0)

--- a/dev/diffs/3.5.8.diff
+++ b/dev/diffs/3.5.8.diff
@@ -2301,7 +2301,7 @@ index 4f906411345..6cc69f7e915 100644
  
    import testImplicits._
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
-index 27c2a2148fd..b3d753b9824 100644
+index 27c2a2148fd..43ead2c81ae 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
 @@ -26,6 +26,7 @@ import org.apache.parquet.hadoop.{ParquetFileReader, ParquetOutputFormat}
@@ -2323,7 +2323,7 @@ index 27c2a2148fd..b3d753b9824 100644
 +              numPartitions +=
 +                b.originalPlan.inputRDD.partitions.length
 +              numOutputRows +=
-+                b.metrics("numOutputRows").value
++                b.metrics("output_rows").value
              case _ =>
            }
            assert(numPartitions > 0)

--- a/dev/diffs/4.0.2.diff
+++ b/dev/diffs/4.0.2.diff
@@ -1310,7 +1310,7 @@ index 0df7f806272..9cdfe8b8f46 100644
              df.collect()
            }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
-index 2e33f6505ab..fc1a2c8f964 100644
+index 2e33f6505ab..be967565303 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
 @@ -23,10 +23,11 @@ import org.apache.spark.SparkRuntimeException
@@ -1354,7 +1354,7 @@ index 2e33f6505ab..fc1a2c8f964 100644
        }
        assert(exchanges.size === 1)
      }
-@@ -2678,18 +2691,25 @@ class SubquerySuite extends QueryTest
+@@ -2678,18 +2691,29 @@ class SubquerySuite extends QueryTest
      def checkFileSourceScan(query: String, answer: Seq[Row]): Unit = {
        val df = sql(query)
        checkAnswer(df, answer)
@@ -1384,7 +1384,11 @@ index 2e33f6505ab..fc1a2c8f964 100644
 -      assert(fileSourceScanExec.head.metrics("numFiles").value === 1)
 -      assert(fileSourceScanExec.head.metrics("numOutputRows").value === answer.size)
 +      assert(dataSourceScanExec.head.metrics("numFiles").value === 1)
-+      assert(dataSourceScanExec.head.metrics("numOutputRows").value === answer.size)
++      val numOutputRows = dataSourceScanExec.head match {
++        case n: CometNativeScanExec => n.metrics("output_rows").value
++        case other => other.metrics("numOutputRows").value
++      }
++      assert(numOutputRows === answer.size)
      }
  
      withTable("t1", "t2") {
@@ -2906,7 +2910,7 @@ index 30503af0fab..1491f4bc2d5 100644
  
    import testImplicits._
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
-index 08fd8a9ecb5..306958da489 100644
+index 08fd8a9ecb5..06967aec8e1 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
 @@ -27,6 +27,7 @@ import org.apache.parquet.hadoop.ParquetWriter.DEFAULT_BLOCK_SIZE
@@ -2928,7 +2932,7 @@ index 08fd8a9ecb5..306958da489 100644
 +              numPartitions +=
 +                b.originalPlan.inputRDD.partitions.length
 +              numOutputRows +=
-+                b.metrics("numOutputRows").value
++                b.metrics("output_rows").value
              case _ =>
            }
            assert(numPartitions > 0)

--- a/dev/diffs/4.1.2.diff
+++ b/dev/diffs/4.1.2.diff
@@ -1409,7 +1409,7 @@ index 7bfc8cf4fa6..4bd387801db 100644
              df.collect()
            }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
-index 3ba48da0e32..a33e65d4420 100644
+index 3ba48da0e32..0313aaa9ec6 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
 @@ -23,10 +23,11 @@ import org.apache.spark.SparkRuntimeException
@@ -1453,7 +1453,7 @@ index 3ba48da0e32..a33e65d4420 100644
        }
        assert(exchanges.size === 1)
      }
-@@ -2678,18 +2691,25 @@ class SubquerySuite extends QueryTest
+@@ -2678,18 +2691,29 @@ class SubquerySuite extends QueryTest
      def checkFileSourceScan(query: String, answer: Seq[Row]): Unit = {
        val df = sql(query)
        checkAnswer(df, answer)
@@ -1483,7 +1483,11 @@ index 3ba48da0e32..a33e65d4420 100644
 -      assert(fileSourceScanExec.head.metrics("numFiles").value === 1)
 -      assert(fileSourceScanExec.head.metrics("numOutputRows").value === answer.size)
 +      assert(dataSourceScanExec.head.metrics("numFiles").value === 1)
-+      assert(dataSourceScanExec.head.metrics("numOutputRows").value === answer.size)
++      val numOutputRows = dataSourceScanExec.head match {
++        case n: CometNativeScanExec => n.metrics("output_rows").value
++        case other => other.metrics("numOutputRows").value
++      }
++      assert(numOutputRows === answer.size)
      }
  
      withTable("t1", "t2") {
@@ -3081,7 +3085,7 @@ index 30503af0fab..1491f4bc2d5 100644
  
    import testImplicits._
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
-index 08fd8a9ecb5..306958da489 100644
+index 08fd8a9ecb5..06967aec8e1 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
 @@ -27,6 +27,7 @@ import org.apache.parquet.hadoop.ParquetWriter.DEFAULT_BLOCK_SIZE
@@ -3103,7 +3107,7 @@ index 08fd8a9ecb5..306958da489 100644
 +              numPartitions +=
 +                b.originalPlan.inputRDD.partitions.length
 +              numOutputRows +=
-+                b.metrics("numOutputRows").value
++                b.metrics("output_rows").value
              case _ =>
            }
            assert(numPartitions > 0)

--- a/native/core/src/execution/metrics/utils.rs
+++ b/native/core/src/execution/metrics/utils.rs
@@ -79,12 +79,7 @@ pub(crate) fn to_native_metric_node(
         .unwrap_or_default()
         .aggregate_by_name()
         .iter()
-        .for_each(|m| {
-            let value = m.value();
-            native_metric_node
-                .metrics
-                .insert(value.name().to_string(), value.as_usize() as i64);
-        });
+        .for_each(|m| insert_metric_value(&mut native_metric_node.metrics, m.value()));
 
     for child_plan in children {
         let child_node = to_native_metric_node(child_plan)?;
@@ -92,4 +87,34 @@ pub(crate) fn to_native_metric_node(
     }
 
     Ok(native_metric_node)
+}
+
+/// Expand a `MetricValue` into one or more `(name, i64)` entries.
+///
+/// `MetricValue::as_usize()` returns `0` for `PruningMetrics` and `Ratio` (DF 54.0
+/// reserves their aggregation to `MetricsSet`); without expanding them every parquet
+/// scan metric of those types surfaces as `0` on the Spark side. Scala-side metrics
+/// that aren't declared by `nativeScanMetrics` are silently dropped, so the Spark
+/// layer controls what's visible.
+fn insert_metric_value(metrics: &mut HashMap<String, i64>, value: &MetricValue) {
+    match value {
+        MetricValue::PruningMetrics { name, pruning_metrics } => {
+            let pruned = name.as_ref();
+            let matched = pruned.replace("pruned", "matched");
+            metrics.insert(pruned.to_string(), pruning_metrics.pruned() as i64);
+            if matched != pruned {
+                metrics.insert(matched, pruning_metrics.matched() as i64);
+            }
+        }
+        MetricValue::Ratio { name, ratio_metrics } => {
+            // Spark's SQLMetric has no ratio type, so we expose numerator and
+            // denominator separately and let the Scala side pick what to surface.
+            let base = name.as_ref();
+            metrics.insert(format!("{base}_part"), ratio_metrics.part() as i64);
+            metrics.insert(format!("{base}_total"), ratio_metrics.total() as i64);
+        }
+        _ => {
+            metrics.insert(value.name().to_string(), value.as_usize() as i64);
+        }
+    }
 }

--- a/native/core/src/execution/metrics/utils.rs
+++ b/native/core/src/execution/metrics/utils.rs
@@ -98,7 +98,10 @@ pub(crate) fn to_native_metric_node(
 /// layer controls what's visible.
 fn insert_metric_value(metrics: &mut HashMap<String, i64>, value: &MetricValue) {
     match value {
-        MetricValue::PruningMetrics { name, pruning_metrics } => {
+        MetricValue::PruningMetrics {
+            name,
+            pruning_metrics,
+        } => {
             let pruned = name.as_ref();
             let matched = pruned.replace("pruned", "matched");
             metrics.insert(pruned.to_string(), pruning_metrics.pruned() as i64);
@@ -106,7 +109,10 @@ fn insert_metric_value(metrics: &mut HashMap<String, i64>, value: &MetricValue) 
                 metrics.insert(matched, pruning_metrics.matched() as i64);
             }
         }
-        MetricValue::Ratio { name, ratio_metrics } => {
+        MetricValue::Ratio {
+            name,
+            ratio_metrics,
+        } => {
             // Spark's SQLMetric has no ratio type, so we expose numerator and
             // denominator separately and let the Scala side pick what to surface.
             let base = name.as_ref();

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
@@ -234,11 +234,11 @@ object CometMetricNode {
       "files_ranges_pruned_statistics" ->
         SQLMetrics.createMetric(
           sc,
-          "Number of file ranges pruned by partition or file-level statistics"),
+          "Number of file ranges pruned by partition or file level statistics"),
       "files_ranges_matched_statistics" ->
         SQLMetrics.createMetric(
           sc,
-          "Number of file ranges that survived partition or file-level statistics"),
+          "Number of file ranges matched by partition or file level statistics (not pruned)"),
       "row_groups_matched_bloom_filter" ->
         SQLMetrics.createMetric(
           sc,
@@ -252,9 +252,9 @@ object CometMetricNode {
       "row_groups_pruned_statistics" ->
         SQLMetrics.createMetric(sc, "Number of row groups pruned by statistics"),
       "limit_pruned_row_groups" ->
-        SQLMetrics.createMetric(sc, "Number of row groups pruned by limit pushdown"),
+        SQLMetrics.createMetric(sc, "Number of row groups pruned due to limit pruning"),
       "limit_matched_row_groups" ->
-        SQLMetrics.createMetric(sc, "Number of row groups that survived limit pushdown"),
+        SQLMetrics.createMetric(sc, "Number of row groups matched by limit pruning (not pruned)"),
       "bytes_scanned" ->
         SQLMetrics.createSizeMetric(sc, "Number of bytes scanned"),
       "pushdown_rows_pruned" ->
@@ -276,21 +276,25 @@ object CometMetricNode {
       "page_index_pages_pruned" ->
         SQLMetrics.createMetric(sc, "Pages filtered out by parquet page index"),
       "page_index_pages_matched" ->
-        SQLMetrics.createMetric(sc, "Pages that survived parquet page index"),
+        SQLMetrics.createMetric(sc, "Pages passed through the parquet page index"),
       "page_index_eval_time" ->
         SQLMetrics.createNanoTimingMetric(sc, "Time spent evaluating parquet page index filters"),
       "metadata_load_time" ->
         SQLMetrics.createNanoTimingMetric(
           sc,
-          "Time spent reading and parsing metadata from the footer"),
+          "Total time spent reading and parsing metadata from the footer"),
       "predicate_cache_inner_records" ->
         SQLMetrics.createMetric(
           sc,
-          "Predicate cache rows decoded from the parquet file (cache misses)"),
+          "Predicate cache: rows physically read and decoded from the Parquet file (cache misses)"),
       "predicate_cache_records" ->
-        SQLMetrics.createMetric(sc, "Predicate cache rows reused from the cache"),
+        SQLMetrics.createMetric(
+          sc,
+          "Predicate cache: records read from the cache (reused after predicate evaluation)"),
       "scan_efficiency_ratio_total" ->
-        SQLMetrics.createSizeMetric(sc, "Total file size (scan efficiency denominator)"))
+        SQLMetrics.createSizeMetric(
+          sc,
+          "Total file size, denominator of scan_efficiency_ratio = bytes_scanned / total_file_size"))
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
@@ -286,7 +286,8 @@ object CometMetricNode {
       "predicate_cache_inner_records" ->
         SQLMetrics.createMetric(
           sc,
-          "Predicate cache: rows physically read and decoded from the Parquet file (cache misses)"),
+          "Predicate cache: rows physically read and decoded from the Parquet file " +
+            "(cache misses)"),
       "predicate_cache_records" ->
         SQLMetrics.createMetric(
           sc,
@@ -294,7 +295,8 @@ object CometMetricNode {
       "scan_efficiency_ratio_total" ->
         SQLMetrics.createSizeMetric(
           sc,
-          "Total file size, denominator of scan_efficiency_ratio = bytes_scanned / total_file_size"))
+          "Total file size, denominator of scan_efficiency_ratio = bytes_scanned " +
+            "/ total_file_size"))
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
@@ -217,7 +217,7 @@ object CometMetricNode {
       "time_elapsed_scanning_total" ->
         SQLMetrics.createNanoTimingMetric(
           sc,
-          "Elapsed wall clock time for for scanning " +
+          "Total elapsed wall clock time for scanning " +
             "+ record batch decompression / decoding"),
       "time_elapsed_processing" ->
         SQLMetrics.createNanoTimingMetric(
@@ -229,6 +229,16 @@ object CometMetricNode {
         SQLMetrics.createMetric(sc, "Count of errors scanning file"),
       "predicate_evaluation_errors" ->
         SQLMetrics.createMetric(sc, "Number of times the predicate could not be evaluated"),
+      "num_predicate_creation_errors" ->
+        SQLMetrics.createMetric(sc, "Number of errors building file-level predicate"),
+      "files_ranges_pruned_statistics" ->
+        SQLMetrics.createMetric(
+          sc,
+          "Number of file ranges pruned by partition or file-level statistics"),
+      "files_ranges_matched_statistics" ->
+        SQLMetrics.createMetric(
+          sc,
+          "Number of file ranges that survived partition or file-level statistics"),
       "row_groups_matched_bloom_filter" ->
         SQLMetrics.createMetric(
           sc,
@@ -241,6 +251,10 @@ object CometMetricNode {
           "Number of row groups whose statistics were checked and matched (not pruned)"),
       "row_groups_pruned_statistics" ->
         SQLMetrics.createMetric(sc, "Number of row groups pruned by statistics"),
+      "limit_pruned_row_groups" ->
+        SQLMetrics.createMetric(sc, "Number of row groups pruned by limit pushdown"),
+      "limit_matched_row_groups" ->
+        SQLMetrics.createMetric(sc, "Number of row groups that survived limit pushdown"),
       "bytes_scanned" ->
         SQLMetrics.createSizeMetric(sc, "Number of bytes scanned"),
       "pushdown_rows_pruned" ->
@@ -259,12 +273,24 @@ object CometMetricNode {
         SQLMetrics.createMetric(sc, "Rows filtered out by parquet page index"),
       "page_index_rows_matched" ->
         SQLMetrics.createMetric(sc, "Rows passed through the parquet page index"),
+      "page_index_pages_pruned" ->
+        SQLMetrics.createMetric(sc, "Pages filtered out by parquet page index"),
+      "page_index_pages_matched" ->
+        SQLMetrics.createMetric(sc, "Pages that survived parquet page index"),
       "page_index_eval_time" ->
         SQLMetrics.createNanoTimingMetric(sc, "Time spent evaluating parquet page index filters"),
       "metadata_load_time" ->
         SQLMetrics.createNanoTimingMetric(
           sc,
-          "Time spent reading and parsing metadata from the footer"))
+          "Time spent reading and parsing metadata from the footer"),
+      "predicate_cache_inner_records" ->
+        SQLMetrics.createMetric(
+          sc,
+          "Predicate cache rows decoded from the parquet file (cache misses)"),
+      "predicate_cache_records" ->
+        SQLMetrics.createMetric(sc, "Predicate cache rows reused from the cache"),
+      "scan_efficiency_ratio_total" ->
+        SQLMetrics.createSizeMetric(sc, "Total file size (scan efficiency denominator)"))
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
@@ -341,13 +341,8 @@ case class CometNativeScanExec(
       "pruningTime")
 
   override lazy val metrics: Map[String, SQLMetric] = {
-    val nativeMetrics = CometMetricNode.nativeScanMetrics(session.sparkContext)
-    // Map native metric names to Spark metric names
-    val withAlias = nativeMetrics.get("output_rows") match {
-      case Some(metric) => nativeMetrics + ("numOutputRows" -> metric)
-      case None => nativeMetrics
-    }
-    withAlias ++ scan.metrics.filterKeys(driverMetricKeys)
+    CometMetricNode.nativeScanMetrics(session.sparkContext) ++
+      scan.metrics.filter { case (k, _) => driverMetricKeys.contains(k) }
   }
 
   /**

--- a/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
@@ -865,7 +865,6 @@ class CometNativeReaderSuite extends CometTestBase with AdaptiveSparkPlanHelper 
         val nativeScans = cometPlan.collect { case n: CometNativeScanExec => n }
         assert(nativeScans.nonEmpty, "Expected a CometNativeScanExec")
         val metrics = nativeScans.head.metrics
-        metrics.toSeq.sortBy(_._1).foreach { case (k, m) => println(s"$k = ${m.value}") }
         val pruned = metrics("row_groups_pruned_statistics").value
         val matched = metrics("row_groups_matched_statistics").value
         assert(

--- a/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
@@ -864,11 +864,17 @@ class CometNativeReaderSuite extends CometTestBase with AdaptiveSparkPlanHelper 
         val (_, cometPlan) = checkSparkAnswerAndOperator(df)
         val nativeScans = cometPlan.collect { case n: CometNativeScanExec => n }
         assert(nativeScans.nonEmpty, "Expected a CometNativeScanExec")
-        val scanRows = nativeScans.head.metrics("numOutputRows").value
+        val metrics = nativeScans.head.metrics
+        metrics.toSeq.sortBy(_._1).foreach { case (k, m) => println(s"$k = ${m.value}") }
+        val pruned = metrics("row_groups_pruned_statistics").value
+        val matched = metrics("row_groups_matched_statistics").value
         assert(
-          scanRows < 1000,
-          s"Row-group statistics pruning did not fire (scan read $scanRows of 1000 rows " +
-            s"across $numRowGroups row groups)")
+          pruned + matched == numRowGroups,
+          s"pruned ($pruned) + matched ($matched) should equal numRowGroups ($numRowGroups)")
+        assert(
+          pruned > 0,
+          "Row-group statistics pruning did not fire " +
+            s"(pruned=$pruned, matched=$matched of $numRowGroups total)")
       }
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

DataFusion 54.0 introduced two composite `MetricValue` variants (`PruningMetrics` with pruned/matched/fully_matched counters, and `Ratio` with part/total). Both intentionally return `0` from `as_usize()` because the variants bundle multiple counters and aggregation is reserved for `MetricsSet`. Comet's metric bridge in `to_native_metric_node` calls `value.as_usize()` blindly, so every metric of these types silently surfaces as `0` on the Spark side. Row-group pruning, page-index pruning, bloom-filter pruning, file-range pruning, limit pruning, and scan-efficiency stats all read as zero in the Spark UI even when the underlying counters are populated correctly inside DataFusion.

The native Parquet scan also rendered "number of output rows" twice in the UI because `CometNativeScanExec.metrics` exposed the underlying `SQLMetric` under both `output_rows` and `numOutputRows`, and the description string of the metric appeared once per key. The `numOutputRows` alias has no consumers outside the class.

## What changes are included in this PR?

- `to_native_metric_node` now expands `PruningMetrics` into `<name>` (pruned count) and `s/pruned/matched/<name>` (matched count) entries, and `Ratio` into `<name>_part` and `<name>_total` entries. Other `MetricValue` variants still flow through `as_usize()` unchanged.
- `CometMetricNode.nativeScanMetrics` declares the previously-missing Scala-side metrics (`files_ranges_*`, `limit_*`, `page_index_pages_*`, `predicate_cache_*`, `num_predicate_creation_errors`, `scan_efficiency_ratio_total`). The Scala layer remains the source of truth for what's surfaced; unknown native names are silently dropped.
- `CometNativeScanExec` drops the `numOutputRows` alias, and the still-deprecated `filterKeys` call on the driver-metric subset is replaced with `filter`.
- Fix a typo (`"for for"`) and align the `time_elapsed_scanning_total` description with the DataFusion docstring.

## How are these changes tested?

`CometNativeReaderSuite`'s row-group pruning regression test reads the now-bridged `row_groups_pruned_statistics` and `row_groups_matched_statistics` directly, asserts their sum equals the row-group count reported by `ParquetFileReader`, and asserts the pruned count is greater than zero. Before this PR both metrics read `0`; after, they report `3` pruned and `5` matched across the 8 row groups in the test file.
