### PR TITLE
perf: avoid excessive timer calls

### DIFF
--- a/native/core/src/execution/operators/scan.rs
+++ b/native/core/src/execution/operators/scan.rs
@@ -116,16 +116,15 @@ impl ScanExec {
             // This is a unit test. Input batches are seeded via `set_input_batch`.
             return Ok(());
         }
-        let mut timer = self.baseline_metrics.elapsed_compute().timer();
 
         let mut current_batch = self.batch.try_lock().unwrap();
         if current_batch.is_none() {
+            let mut timer = self.baseline_metrics.elapsed_compute().timer();
             let next_batch =
                 ScanExec::pull_next(self.exec_context_id, self.input_source.as_ref().unwrap())?;
             *current_batch = Some(next_batch);
+            timer.stop();
         }
-
-        timer.stop();
 
         Ok(())
     }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4738.

## Rationale for this change

Avoid excessive timer calls in `ScanExec::get_next_batch`

## What changes are included in this PR?

Move `timer` into the `if current_batch.is_none() {`.

## How are these changes tested?

before this:
<img width="1834" height="429" alt="image" src="https://github.com/user-attachments/assets/e5be3707-73e6-4c67-b576-c6d58afae8dd" />

after this:
<img width="1827" height="469" alt="image" src="https://github.com/user-attachments/assets/f491108e-90df-43bf-b26c-cdcc037025fe" />

