### PR TITLE
feat: support TimestampNTZ inputs natively for hour/minute/second

### DIFF
--- a/native/spark-expr/src/datetime_funcs/extract_date_part.rs
+++ b/native/spark-expr/src/datetime_funcs/extract_date_part.rs
@@ -24,6 +24,17 @@ use datafusion::logical_expr::{
 };
 use std::fmt::Debug;
 
+/// Returns true when the type is a timestamp without a timezone (Spark's TimestampNTZType),
+/// including when wrapped in a dictionary. Such values store local wall-clock time and must not
+/// have any session timezone offset applied when extracting date parts.
+fn is_timestamp_ntz(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::Timestamp(_, None) => true,
+        DataType::Dictionary(_, value_type) => is_timestamp_ntz(value_type),
+        _ => false,
+    }
+}
+
 macro_rules! extract_date_part {
     ($struct_name:ident, $fn_name:expr, $date_part_variant:ident) => {
         #[derive(Debug, PartialEq, Eq, Hash)]
@@ -71,14 +82,21 @@ macro_rules! extract_date_part {
 
                 match args {
                     [ColumnarValue::Array(array)] => {
-                        let array = array_with_timezone(
-                            array,
-                            self.timezone.clone(),
-                            Some(&DataType::Timestamp(
-                                Microsecond,
-                                Some(self.timezone.clone().into()),
-                            )),
-                        )?;
+                        // TimestampNTZ values are stored as local wall-clock time, so the date
+                        // part is extracted directly. Timezone-aware timestamps are stored in UTC
+                        // and must be shifted to the session timezone first.
+                        let array = if is_timestamp_ntz(array.data_type()) {
+                            array
+                        } else {
+                            array_with_timezone(
+                                array,
+                                self.timezone.clone(),
+                                Some(&DataType::Timestamp(
+                                    Microsecond,
+                                    Some(self.timezone.clone().into()),
+                                )),
+                            )?
+                        };
                         let result = date_part(&array, DatePart::$date_part_variant)?;
                         Ok(ColumnarValue::Array(result))
                     }
@@ -98,3 +116,128 @@ macro_rules! extract_date_part {
 extract_date_part!(SparkHour, "hour", Hour);
 extract_date_part!(SparkMinute, "minute", Minute);
 extract_date_part!(SparkSecond, "second", Second);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{ArrayRef, Int32Array, TimestampMicrosecondArray};
+    use arrow::datatypes::{Field, Int8Type, TimeUnit};
+    use datafusion::config::ConfigOptions;
+    use std::sync::Arc;
+
+    // 2024-01-15 18:30:45 UTC, in microseconds since the epoch.
+    const MICROS: i64 = 1_705_343_445_000_000;
+
+    /// Invokes a single-argument date-part UDF on `array` and returns the first extracted value.
+    fn invoke<U: ScalarUDFImpl>(udf: &U, array: ArrayRef) -> i32 {
+        let return_field = Arc::new(Field::new("v", DataType::Int32, true));
+        let args = ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(array)],
+            number_rows: 1,
+            return_field,
+            config_options: Arc::new(ConfigOptions::default()),
+            arg_fields: vec![],
+        };
+        match udf.invoke_with_args(args).unwrap() {
+            ColumnarValue::Array(arr) => {
+                arr.as_any().downcast_ref::<Int32Array>().unwrap().value(0)
+            }
+            _ => panic!("Expected array"),
+        }
+    }
+
+    fn ntz_array() -> ArrayRef {
+        Arc::new(TimestampMicrosecondArray::from(vec![Some(MICROS)]))
+    }
+
+    #[test]
+    fn timestamp_with_timezone_converts_to_session_timezone() {
+        // A timezone-aware timestamp stores the absolute UTC instant. In a Los Angeles session
+        // (UTC-8 in January) the local hour is 18 - 8 = 10.
+        let udf = SparkHour::new("America/Los_Angeles".to_string());
+        let array = TimestampMicrosecondArray::from(vec![Some(MICROS)]).with_timezone("UTC");
+        assert_eq!(invoke(&udf, Arc::new(array)), 10);
+    }
+
+    #[test]
+    fn timestamp_ntz_extracts_local_time_without_conversion() {
+        // TimestampNTZ stores local wall-clock time, so the hour is extracted directly (18) with
+        // no session timezone offset applied (issue #3180).
+        let udf = SparkHour::new("America/Los_Angeles".to_string());
+        assert_eq!(invoke(&udf, ntz_array()), 18);
+    }
+
+    #[test]
+    fn timestamp_ntz_result_is_independent_of_session_timezone() {
+        // The extracted hour must be the same regardless of the session timezone.
+        for tz in ["UTC", "America/Los_Angeles", "Asia/Tokyo"] {
+            let udf = SparkHour::new(tz.to_string());
+            assert_eq!(invoke(&udf, ntz_array()), 18);
+        }
+    }
+
+    #[test]
+    fn minute_and_second_on_timestamp_ntz() {
+        assert_eq!(
+            invoke(&SparkMinute::new("Asia/Tokyo".to_string()), ntz_array()),
+            30
+        );
+        assert_eq!(
+            invoke(&SparkSecond::new("Asia/Tokyo".to_string()), ntz_array()),
+            45
+        );
+    }
+
+    #[test]
+    fn is_timestamp_ntz_detects_plain_and_dictionary_wrapped() {
+        assert!(is_timestamp_ntz(&DataType::Timestamp(
+            TimeUnit::Microsecond,
+            None
+        )));
+        assert!(is_timestamp_ntz(&DataType::Dictionary(
+            Box::new(DataType::Int8),
+            Box::new(DataType::Timestamp(TimeUnit::Microsecond, None)),
+        )));
+        // Timezone-aware timestamps and dictionaries of them are not NTZ.
+        assert!(!is_timestamp_ntz(&DataType::Timestamp(
+            TimeUnit::Microsecond,
+            Some("UTC".into()),
+        )));
+        assert!(!is_timestamp_ntz(&DataType::Dictionary(
+            Box::new(DataType::Int8),
+            Box::new(DataType::Timestamp(
+                TimeUnit::Microsecond,
+                Some("UTC".into())
+            )),
+        )));
+    }
+
+    #[test]
+    fn timestamp_ntz_dictionary_input_extracts_local_time() {
+        use arrow::array::{DictionaryArray, Int8Array};
+        let values = Arc::new(TimestampMicrosecondArray::from(vec![Some(MICROS)])) as ArrayRef;
+        let keys = Int8Array::from(vec![0i8]);
+        let dict = DictionaryArray::<Int8Type>::new(keys, values);
+        let udf = SparkHour::new("America/Los_Angeles".to_string());
+        let return_field = Arc::new(Field::new(
+            "hour",
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Int32)),
+            true,
+        ));
+        let args = ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(dict))],
+            number_rows: 1,
+            return_field,
+            config_options: Arc::new(ConfigOptions::default()),
+            arg_fields: vec![],
+        };
+        let arr = match udf.invoke_with_args(args).unwrap() {
+            ColumnarValue::Array(arr) => arr,
+            _ => panic!("Expected array"),
+        };
+        // Decode to a plain Int32Array regardless of whether the kernel kept the dictionary.
+        let decoded = arrow::compute::cast(&arr, &DataType::Int32).unwrap();
+        let int_arr = decoded.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(int_arr.value(0), 18);
+    }
+}

--- a/native/spark-expr/src/datetime_funcs/extract_date_part.rs
+++ b/native/spark-expr/src/datetime_funcs/extract_date_part.rs
@@ -121,7 +121,7 @@ extract_date_part!(SparkSecond, "second", Second);
 mod tests {
     use super::*;
     use arrow::array::{ArrayRef, Int32Array, TimestampMicrosecondArray};
-    use arrow::datatypes::{Field, Int8Type, TimeUnit};
+    use arrow::datatypes::{Field, TimeUnit};
     use datafusion::config::ConfigOptions;
     use std::sync::Arc;
 
@@ -214,10 +214,13 @@ mod tests {
 
     #[test]
     fn timestamp_ntz_dictionary_input_extracts_local_time() {
-        use arrow::array::{DictionaryArray, Int8Array};
+        use arrow::array::{DictionaryArray, Int32Array};
+        use arrow::datatypes::Int32Type;
+        // Comet only emits Int32-keyed dictionaries, so the test mirrors that production shape and
+        // the declared Dictionary(Int32, Int32) return type.
         let values = Arc::new(TimestampMicrosecondArray::from(vec![Some(MICROS)])) as ArrayRef;
-        let keys = Int8Array::from(vec![0i8]);
-        let dict = DictionaryArray::<Int8Type>::new(keys, values);
+        let keys = Int32Array::from(vec![0i32]);
+        let dict = DictionaryArray::<Int32Type>::new(keys, values);
         let udf = SparkHour::new("America/Los_Angeles".to_string());
         let return_field = Arc::new(Field::new(
             "hour",
@@ -235,9 +238,22 @@ mod tests {
             ColumnarValue::Array(arr) => arr,
             _ => panic!("Expected array"),
         };
-        // Decode to a plain Int32Array regardless of whether the kernel kept the dictionary.
-        let decoded = arrow::compute::cast(&arr, &DataType::Int32).unwrap();
-        let int_arr = decoded.as_any().downcast_ref::<Int32Array>().unwrap();
-        assert_eq!(int_arr.value(0), 18);
+        // The kernel preserves the Int32 key type, so the result keeps the declared dictionary shape.
+        assert_eq!(
+            arr.data_type(),
+            &DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Int32))
+        );
+        let dict = arr
+            .as_any()
+            .downcast_ref::<DictionaryArray<Int32Type>>()
+            .unwrap();
+        let key = dict.keys().value(0) as usize;
+        let extracted = dict
+            .values()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+            .value(key);
+        assert_eq!(extracted, 18);
     }
 }

--- a/spark/src/main/scala/org/apache/comet/serde/datetime.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/datetime.scala
@@ -23,7 +23,7 @@ import java.util.Locale
 
 import org.apache.spark.sql.catalyst.expressions.{AddMonths, Attribute, ConvertTimezone, DateAdd, DateDiff, DateFormatClass, DateFromUnixDate, DateSub, DayOfMonth, DayOfWeek, DayOfYear, Days, FromUTCTimestamp, GetDateField, GetTimestamp, Hour, Hours, LastDay, Literal, MakeDate, MakeTimestamp, MicrosToTimestamp, MillisToTimestamp, Minute, Month, MonthsBetween, NextDay, Quarter, Second, SecondsToTimestamp, ToUnixTimestamp, ToUTCTimestamp, TruncDate, TruncTimestamp, UnixDate, UnixMicros, UnixMillis, UnixSeconds, UnixTimestamp, WeekDay, WeekOfYear, Year}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{DataType, DateType, DoubleType, FloatType, IntegerType, LongType, StringType, TimestampNTZType, TimestampType}
+import org.apache.spark.sql.types.{DateType, DoubleType, FloatType, IntegerType, LongType, StringType, TimestampNTZType, TimestampType}
 import org.apache.spark.unsafe.types.UTF8String
 
 import org.apache.comet.CometConf

--- a/spark/src/main/scala/org/apache/comet/serde/datetime.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/datetime.scala
@@ -200,24 +200,7 @@ object CometQuarter extends CometExpressionSerde[Quarter] with CometExprGetDateF
   }
 }
 
-private object TimeFieldSerde {
-  val timestampNtzIncompatReason: String =
-    "Incorrectly applies timezone conversion to TimestampNTZ inputs" +
-      " (https://github.com/apache/datafusion-comet/issues/3180)"
-
-  def supportLevelForChild(childType: DataType): SupportLevel = childType match {
-    case TimestampNTZType => Incompatible(Some(timestampNtzIncompatReason))
-    case _ => Compatible()
-  }
-}
-
-object CometHour extends CometExpressionSerde[Hour] with CodegenDispatchFallback {
-
-  override def getIncompatibleReasons(): Seq[String] =
-    Seq(TimeFieldSerde.timestampNtzIncompatReason)
-
-  override def getSupportLevel(expr: Hour): SupportLevel =
-    TimeFieldSerde.supportLevelForChild(expr.child.dataType)
+object CometHour extends CometExpressionSerde[Hour] {
 
   override def convert(
       expr: Hour,
@@ -244,13 +227,7 @@ object CometHour extends CometExpressionSerde[Hour] with CodegenDispatchFallback
   }
 }
 
-object CometMinute extends CometExpressionSerde[Minute] with CodegenDispatchFallback {
-
-  override def getIncompatibleReasons(): Seq[String] =
-    Seq(TimeFieldSerde.timestampNtzIncompatReason)
-
-  override def getSupportLevel(expr: Minute): SupportLevel =
-    TimeFieldSerde.supportLevelForChild(expr.child.dataType)
+object CometMinute extends CometExpressionSerde[Minute] {
 
   override def convert(
       expr: Minute,
@@ -277,13 +254,7 @@ object CometMinute extends CometExpressionSerde[Minute] with CodegenDispatchFall
   }
 }
 
-object CometSecond extends CometExpressionSerde[Second] with CodegenDispatchFallback {
-
-  override def getIncompatibleReasons(): Seq[String] =
-    Seq(TimeFieldSerde.timestampNtzIncompatReason)
-
-  override def getSupportLevel(expr: Second): SupportLevel =
-    TimeFieldSerde.supportLevelForChild(expr.child.dataType)
+object CometSecond extends CometExpressionSerde[Second] {
 
   override def convert(
       expr: Second,

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1032,17 +1032,20 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
 
   test("native opt-in hint shown for codegen-dispatch path") {
     withTempDir { dir =>
-      // _5 column is TIMESTAMP(MICROS,false) = TimestampNTZ, which triggers Incompatible in CometHour
+      // _4 column is TIMESTAMP(MICROS,true) = TimestampType. FromUTCTimestamp is Incompatible
+      // (its native timezone parser is stricter than Spark's), so with allowIncompatible=false it
+      // rides the codegen dispatcher and surfaces the native opt-in hint.
       val path = new Path(dir.toURI.toString, "hint_test.parquet")
       makeRawTimeParquetFile(path, dictionaryEnabled = false, n = 5)
-      withSQLConf("spark.comet.expression.Hour.allowIncompatible" -> "false") {
-        val df = spark.read.parquet(path.toString).selectExpr("hour(_5) as h")
+      withSQLConf("spark.comet.expression.FromUTCTimestamp.allowIncompatible" -> "false") {
+        val df =
+          spark.read.parquet(path.toString).selectExpr("from_utc_timestamp(_4, 'UTC') as t")
         val explain =
           new ExtendedExplainInfo().generateExtendedInfo(df.queryExecution.executedPlan)
         assert(explain.contains("[COMET-INFO:"), s"Expected [COMET-INFO: in: $explain")
         assert(
-          explain.contains("native implementation of Hour"),
-          s"Expected 'native implementation of Hour' in: $explain")
+          explain.contains("native implementation of FromUTCTimestamp"),
+          s"Expected 'native implementation of FromUTCTimestamp' in: $explain")
       }
     }
   }

--- a/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
@@ -212,11 +212,9 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
   }
 
   test("hour/minute/second - timestamp_ntz input") {
-    // TimestampNTZ extracts time components directly from the stored local time,
-    // so the result should be the same regardless of session timezone.
-    // The native path is Incompatible for TimestampNTZ inputs
-    // (https://github.com/apache/datafusion-comet/issues/3180), so Comet routes these
-    // through the codegen dispatcher and stays native while matching Spark exactly.
+    // TimestampNTZ extracts time components directly from the stored local time, so the native
+    // path applies no timezone conversion and the result is the same regardless of session
+    // timezone (https://github.com/apache/datafusion-comet/issues/3180).
     val r = new Random(42)
     val ntzSchema = StructType(Seq(StructField("ts_ntz", DataTypes.TimestampNTZType, true)))
     val ntzDF = FuzzDataGenerator.generateDataFrame(r, spark, ntzSchema, 100, DataGenOptions())
@@ -225,41 +223,6 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
       withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> tz) {
         checkSparkAnswerAndOperator(
           "SELECT ts_ntz, hour(ts_ntz), minute(ts_ntz), second(ts_ntz) from ntz_tbl order by ts_ntz")
-      }
-    }
-  }
-
-  test("hour/minute/second - timestamp_ntz falls back when codegen dispatcher disabled") {
-    // The native path is Incompatible for TimestampNTZ inputs (#3180). With the dispatcher
-    // disabled there is no native path, so the expression falls back to Spark.
-    val r = new Random(42)
-    val ntzSchema = StructType(Seq(StructField("ts_ntz", DataTypes.TimestampNTZType, true)))
-    val ntzDF = FuzzDataGenerator.generateDataFrame(r, spark, ntzSchema, 100, DataGenOptions())
-    ntzDF.createOrReplaceTempView("ntz_tbl")
-    withSQLConf(CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "false") {
-      checkSparkAnswerAndFallbackReason(
-        "SELECT ts_ntz, hour(ts_ntz) from ntz_tbl order by ts_ntz",
-        CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key)
-    }
-  }
-
-  test("hour/minute/second - timestamp_ntz takes native path when allowIncompatible is enabled") {
-    val r = new Random(42)
-    val ntzSchema = StructType(Seq(StructField("ts_ntz", DataTypes.TimestampNTZType, true)))
-    val ntzDF = FuzzDataGenerator.generateDataFrame(r, spark, ntzSchema, 100, DataGenOptions())
-    ntzDF.createOrReplaceTempView("ntz_tbl")
-    for (tz <- crossTimezones) {
-      withSQLConf(
-        SQLConf.SESSION_LOCAL_TIMEZONE.key -> tz,
-        "spark.comet.expression.Hour.allowIncompatible" -> "true",
-        "spark.comet.expression.Minute.allowIncompatible" -> "true",
-        "spark.comet.expression.Second.allowIncompatible" -> "true") {
-        // Native results may diverge from Spark for TimestampNTZ inputs (#3180, the reason the
-        // codegen dispatcher is the default), so we only check that execution stays inside Comet.
-        // ORDER BY is omitted to keep the plan free of AQEShuffleRead.
-        val df = sql("SELECT ts_ntz, hour(ts_ntz), minute(ts_ntz), second(ts_ntz) from ntz_tbl")
-        df.collect()
-        checkCometOperators(stripAQEPlan(df.queryExecution.executedPlan))
       }
     }
   }
@@ -357,9 +320,9 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
               "SELECT ts_ntz, CAST(ts_ntz AS DATE) FROM ntz_cross_tz ORDER BY ts_ntz")
             checkSparkAnswerAndOperator(
               "SELECT ts_ntz, unix_timestamp(ts_ntz) FROM ntz_cross_tz ORDER BY ts_ntz")
-            // hour/minute/second are Incompatible for NTZ (issue #3180) and date_trunc is
-            // Incompatible when the session timezone is non-UTC (issue #2649), so both ride
-            // the codegen dispatcher and stay native while matching Spark.
+            // hour/minute/second run natively for NTZ without timezone conversion (issue #3180),
+            // and date_trunc is Incompatible when the session timezone is non-UTC (issue #2649),
+            // so the latter rides the codegen dispatcher; both stay native while matching Spark.
             checkSparkAnswerAndOperator(
               "SELECT ts_ntz, hour(ts_ntz), minute(ts_ntz), second(ts_ntz) FROM ntz_cross_tz ORDER BY ts_ntz")
             checkSparkAnswerAndOperator(


### PR DESCRIPTION
## Which issue does this PR close?

Closes #3180.

## Rationale for this change

The native `hour`, `minute`, and `second` implementations applied a session timezone offset to every input. That conversion is correct for timezone-aware timestamps (stored in UTC) but wrong for TimestampNTZ values, which already hold local wall-clock time. As a short-term fix these expressions were marked `Incompatible` for TimestampNTZ inputs so they fell back to Spark.

This PR implements the follow-up enhancement tracked in the issue: handling TimestampNTZ correctly on the native path so the expressions run in Comet for all supported input types.

## What changes are included in this PR?

- Native (`extract_date_part.rs`): detect TimestampNTZ inputs (including dictionary-encoded) and extract the date part directly with no timezone conversion. Timezone-aware timestamps keep the existing UTC to session-timezone shift.
- Scala serde: `CometHour`, `CometMinute`, and `CometSecond` no longer special-case TimestampNTZ. They are `Compatible` for all supported input types and no longer need the `Incompatible` reason or the codegen-dispatch fallback.
- Retargeted the `native opt-in hint shown for codegen-dispatch path` test in `CometExpressionSuite` to use `from_utc_timestamp`, since `Hour` is no longer `Incompatible` for any input.

## How are these changes tested?

- New Rust unit tests in `extract_date_part.rs` covering: timezone-aware conversion, TimestampNTZ direct extraction, timezone independence of the NTZ result, `minute`/`second` on NTZ, the NTZ-detection helper, and dictionary-encoded NTZ input.
- `CometTemporalExpressionSuite` `hour/minute/second - timestamp_ntz input` now verifies native execution and Spark-identical results across UTC, America/Los_Angeles, Europe/London, and Asia/Tokyo. Two tests that only covered the previous fallback and `allowIncompatible` behavior were removed as obsolete.