### PR TITLE
feat: [EXPERIMENT] Spike: convert next_day from chrono to jiff

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -2143,6 +2143,7 @@ dependencies = [
  "datafusion-comet-jni-bridge",
  "futures",
  "hex",
+ "jiff",
  "jni 0.22.4",
  "num",
  "rand 0.10.1",

--- a/native/spark-expr/Cargo.toml
+++ b/native/spark-expr/Cargo.toml
@@ -44,6 +44,9 @@ twox-hash = "2.1.2"
 rand = { workspace = true }
 hex = "0.4.3"
 base64 = "0.22.1"
+# Spike: jiff as a chrono replacement. A date-only expression (next_day) needs only the
+# civil date API, so the heavy tzdb bundle default features are disabled.
+jiff = { version = "0.2.29", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 arrow = {workspace = true}

--- a/native/spark-expr/src/datetime_funcs/next_day.rs
+++ b/native/spark-expr/src/datetime_funcs/next_day.rs
@@ -17,12 +17,13 @@
 
 use arrow::array::{Array, Date32Array, StringArray};
 use arrow::compute::cast;
-use arrow::datatypes::{DataType, Date32Type};
-use chrono::{Datelike, Duration, Weekday};
+use arrow::datatypes::DataType;
 use datafusion::common::{utils::take_function_args, DataFusionError, Result};
 use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
+use jiff::civil::{Date, Weekday};
+use jiff::ToSpan;
 use std::sync::Arc;
 
 /// Spark-compatible `next_day(start_date, day_of_week)` function.
@@ -54,17 +55,27 @@ impl Default for SparkNextDay {
     }
 }
 
+/// 1970-01-01, the anchor used to convert Arrow Date32 epoch-day values into jiff civil dates.
+/// jiff deliberately keeps its epoch-day conversion private, so we add a day span to this anchor.
+const UNIX_EPOCH: Date = Date::constant(1970, 1, 1);
+
+/// Convert an Arrow Date32 value (days since the Unix epoch) into a jiff [`Date`]. Returns None if
+/// the value falls outside jiff's supported range (years -9999..=9999).
+fn date_from_epoch_day(days: i32) -> Option<Date> {
+    UNIX_EPOCH.checked_add(days.days()).ok()
+}
+
 /// Match a day-of-week name to a [`Weekday`]. Mirrors Spark's
 /// `DateTimeUtils.getDayOfWeekFromString`: case-insensitive, but with no whitespace trimming.
 fn day_of_week_from_string(day_of_week: &str) -> Option<Weekday> {
     match day_of_week.to_uppercase().as_str() {
-        "SU" | "SUN" | "SUNDAY" => Some(Weekday::Sun),
-        "MO" | "MON" | "MONDAY" => Some(Weekday::Mon),
-        "TU" | "TUE" | "TUESDAY" => Some(Weekday::Tue),
-        "WE" | "WED" | "WEDNESDAY" => Some(Weekday::Wed),
-        "TH" | "THU" | "THURSDAY" => Some(Weekday::Thu),
-        "FR" | "FRI" | "FRIDAY" => Some(Weekday::Fri),
-        "SA" | "SAT" | "SATURDAY" => Some(Weekday::Sat),
+        "SU" | "SUN" | "SUNDAY" => Some(Weekday::Sunday),
+        "MO" | "MON" | "MONDAY" => Some(Weekday::Monday),
+        "TU" | "TUE" | "TUESDAY" => Some(Weekday::Tuesday),
+        "WE" | "WED" | "WEDNESDAY" => Some(Weekday::Wednesday),
+        "TH" | "THU" | "THURSDAY" => Some(Weekday::Thursday),
+        "FR" | "FRI" | "FRIDAY" => Some(Weekday::Friday),
+        "SA" | "SAT" | "SATURDAY" => Some(Weekday::Saturday),
         _ => None,
     }
 }
@@ -72,10 +83,14 @@ fn day_of_week_from_string(day_of_week: &str) -> Option<Weekday> {
 /// The first date strictly after `days` (days since the Unix epoch) that falls on `weekday`.
 /// Equivalent to Spark's `DateTimeUtils.getNextDateForDayOfWeek` (a same-weekday start advances a
 /// full week). Returns None only if `days` is not a representable date.
+///
+/// jiff's `Weekday::since` matches chrono's `Weekday::days_since`, so `advance` lands in 1..=7. The
+/// result is simply `days + advance`: adding N calendar days to epoch-day D yields epoch-day D + N,
+/// so no conversion back from [`Date`] to epoch-day is needed.
 fn next_date_for_day_of_week(days: i32, weekday: Weekday) -> Option<i32> {
-    let date = Date32Type::to_naive_date_opt(days)?;
-    let advance = 7 - date.weekday().days_since(weekday) as i64;
-    Some(Date32Type::from_naive_date(date + Duration::days(advance)))
+    let date = date_from_epoch_day(days)?;
+    let advance = 7 - date.weekday().since(weekday) as i32;
+    days.checked_add(advance)
 }
 
 impl ScalarUDFImpl for SparkNextDay {
@@ -163,12 +178,14 @@ impl ScalarUDFImpl for SparkNextDay {
 mod tests {
     use super::*;
 
+    use jiff::civil::date;
+
     #[test]
     fn test_day_of_week_from_string_no_trim() {
         // Recognised names match case-insensitively.
-        assert_eq!(day_of_week_from_string("mon"), Some(Weekday::Mon));
-        assert_eq!(day_of_week_from_string("MONDAY"), Some(Weekday::Mon));
-        assert_eq!(day_of_week_from_string("Su"), Some(Weekday::Sun));
+        assert_eq!(day_of_week_from_string("mon"), Some(Weekday::Monday));
+        assert_eq!(day_of_week_from_string("MONDAY"), Some(Weekday::Monday));
+        assert_eq!(day_of_week_from_string("Su"), Some(Weekday::Sunday));
         // Surrounding whitespace is NOT trimmed (Spark does not trim).
         assert_eq!(day_of_week_from_string(" MO "), None);
         assert_eq!(day_of_week_from_string("MO "), None);
@@ -177,20 +194,21 @@ mod tests {
     }
 
     #[test]
+    fn test_date_from_epoch_day() {
+        // 2024-01-01 is epoch day 19723.
+        assert_eq!(date_from_epoch_day(19723), Some(date(2024, 1, 1)));
+        assert_eq!(date_from_epoch_day(0), Some(date(1970, 1, 1)));
+        assert_eq!(date_from_epoch_day(-1), Some(date(1969, 12, 31)));
+    }
+
+    #[test]
     fn test_next_date_for_day_of_week() {
-        // 2024-01-01 is a Monday (epoch day 19723). Next Monday is 7 days later.
-        let monday =
-            Date32Type::from_naive_date(chrono::NaiveDate::from_ymd_opt(2024, 1, 1).unwrap());
-        let next_mon = next_date_for_day_of_week(monday, Weekday::Mon).unwrap();
-        assert_eq!(
-            Date32Type::to_naive_date_opt(next_mon).unwrap(),
-            chrono::NaiveDate::from_ymd_opt(2024, 1, 8).unwrap()
-        );
+        // 2024-01-01 is a Monday (epoch day 19723). Next Monday is 7 days later (19730).
+        let monday = 19723;
+        let next_mon = next_date_for_day_of_week(monday, Weekday::Monday).unwrap();
+        assert_eq!(date_from_epoch_day(next_mon).unwrap(), date(2024, 1, 8));
         // Next Tuesday after a Monday is the following day.
-        let next_tue = next_date_for_day_of_week(monday, Weekday::Tue).unwrap();
-        assert_eq!(
-            Date32Type::to_naive_date_opt(next_tue).unwrap(),
-            chrono::NaiveDate::from_ymd_opt(2024, 1, 2).unwrap()
-        );
+        let next_tue = next_date_for_day_of_week(monday, Weekday::Tuesday).unwrap();
+        assert_eq!(date_from_epoch_day(next_tue).unwrap(), date(2024, 1, 2));
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Relates to #4754.

> **Experimental spike, not intended for merge as-is.** This is a proof of concept to scope what migrating a temporal expression from `chrono` to `jiff` involves. Opening as a draft to share findings and gather direction.

## Rationale for this change

`chrono` / `chrono-tz` are expected to be deprecated, and #4754 proposes evaluating a move to `jiff`. Rather than estimate in the abstract, this spike converts one self-contained, timezone-free expression (`next_day`) end to end so we can see the concrete API mapping, the dependency implications, and any behavioral edges before committing to a broader migration.

## What changes are included in this PR?

- Rewrites `next_day.rs` to compute entirely with `jiff::civil` (`Date`, `Weekday`), removing all `chrono` usage from that file.
- Adds `jiff` to `datafusion-comet-spark-expr` with `default-features = false, features = ["std"]` (a date-only expression does not need the tzdb bundles `cargo add` enables by default).
- Translates the existing unit tests to jiff.

### API mapping observed

| chrono | jiff |
| --- | --- |
| `Weekday::Mon` .. | `Weekday::Monday` .. (full names) |
| `Date32Type::to_naive_date_opt(i32)` | `Date::constant(1970, 1, 1).checked_add(days.days())` |
| `weekday().days_since(other)` | `weekday().since(other)` (identical semantics) |
| `date + Duration::days(n)` then `from_naive_date` | `days + advance` (epoch-day arithmetic) |

### Findings

1. **arrow-rs does not need to move first.** The Arrow boundary is raw `i32` epoch days (`Date32Array::value`). The expression builds jiff types directly from the integer and bypasses Arrow's chrono-returning helpers (`to_naive_date_opt`, `date32_to_datetime`). Comet's own code can move to jiff today.
2. **`chrono` stays in the dependency tree regardless**, because `arrow` depends on it (and pulls `chrono-tz` via its feature). jiff adds a dependency; it cannot remove chrono until arrow-rs migrates. The near-term benefit is API ergonomics in Comet, not a smaller tree.
3. **jiff intentionally keeps epoch-day conversion private** (`from_unix_epoch_day` / `to_unix_epoch_day` are crate-private). The public idiom is anchor date plus a day `Span`. Expressions that genuinely need `Date` to epoch-day will use `epoch.until(date).get_days()`, which is more verbose than chrono.
4. **Narrower range.** jiff civil dates span years -9999..=9999; chrono and Date32 are wider. Out-of-range values map to NULL, preserving the existing nullable behavior. Not a concern for realistic Spark data.
5. **Timezone expressions are the real cost.** They would need jiff's tzdb features and a rework of `timezone.rs` (currently chrono-tz based). That path is deliberately out of scope here.

Suggested follow-up order if we proceed: tz-free date expressions first (next_day, day/month name, make_date) behind a shared epoch-day helper, then timestamp/timezone expressions, with full chrono removal gated on arrow-rs.

## How are these changes tested?

The existing `next_day` Rust unit tests were translated to jiff and pass, and `cargo clippy` is clean. End-to-end behavior continues to be covered by the existing JVM `next_day` tests, since the public function semantics are unchanged.
