### PR TITLE
feat: add unsupported metadata column names to fallback reasons

### DIFF
--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -88,7 +88,7 @@ case class CometScanRule(session: SparkSession)
       case _ => false
     }
 
-    def hasMetadataCol(plan: SparkPlan): Seq[String] = {
+    def metadataCols(plan: SparkPlan): Seq[String] = {
       plan.expressions.collect {
         case a: Attribute if a.isMetadataCol => a.name
       }
@@ -125,10 +125,10 @@ case class CometScanRule(session: SparkSession)
       case scan if !CometConf.COMET_NATIVE_SCAN_ENABLED.get(conf) =>
         withFallbackReason(scan, "Comet Scan is not enabled")
 
-      case scan if hasMetadataCol(scan).nonEmpty =>
+      case scan if metadataCols(scan).nonEmpty =>
         withFallbackReason(
           scan,
-          s"Metadata column(s) ${hasMetadataCol(scan).mkString(", ")} is not supported")
+          s"Metadata column(s) ${metadataCols(scan).mkString(", ")} is not supported")
 
       // data source V1
       case scanExec: FileSourceScanExec =>

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -88,12 +88,12 @@ case class CometScanRule(session: SparkSession)
       case _ => false
     }
 
-    def hasMetadataCol(plan: SparkPlan): Boolean = {
-      plan.expressions.exists(_.exists {
+    def hasMetadataCol(plan: SparkPlan) = {
+      plan.expressions.flatMap {
         case a: Attribute =>
-          a.isMetadataCol
-        case _ => false
-      })
+          if (a.isMetadataCol) Option(a.name) else Option.empty
+        case _ => Option.empty
+      }
     }
 
     def isIcebergMetadataTable(scanExec: BatchScanExec): Boolean = {
@@ -127,8 +127,10 @@ case class CometScanRule(session: SparkSession)
       case scan if !CometConf.COMET_NATIVE_SCAN_ENABLED.get(conf) =>
         withFallbackReason(scan, "Comet Scan is not enabled")
 
-      case scan if hasMetadataCol(scan) =>
-        withFallbackReason(scan, "Metadata column is not supported")
+      case scan if hasMetadataCol(scan).nonEmpty =>
+        withFallbackReason(
+          scan,
+          s"Metadata column ${hasMetadataCol(scan).mkString(", ")} is not supported")
 
       // data source V1
       case scanExec: FileSourceScanExec =>

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -88,11 +88,9 @@ case class CometScanRule(session: SparkSession)
       case _ => false
     }
 
-    def hasMetadataCol(plan: SparkPlan) = {
-      plan.expressions.flatMap {
-        case a: Attribute =>
-          if (a.isMetadataCol) Option(a.name) else Option.empty
-        case _ => Option.empty
+    def hasMetadataCol(plan: SparkPlan): Seq[String] = {
+      plan.expressions.collect {
+        case a: Attribute if a.isMetadataCol => a.name
       }
     }
 
@@ -130,7 +128,7 @@ case class CometScanRule(session: SparkSession)
       case scan if hasMetadataCol(scan).nonEmpty =>
         withFallbackReason(
           scan,
-          s"Metadata column ${hasMetadataCol(scan).mkString(", ")} is not supported")
+          s"Metadata column(s) ${hasMetadataCol(scan).mkString(", ")} is not supported")
 
       // data source V1
       case scanExec: FileSourceScanExec =>

--- a/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
@@ -4035,7 +4035,7 @@ class CometIcebergNativeSuite
 
           checkSparkAnswerAndFallbackReason(
             s"SELECT id, value, _spec_id, _pos, _file, _partition FROM $table WHERE id >= 2 ORDER BY id",
-            "Metadata column _spec_id, _partition, _file, _pos is not supported")
+            "Metadata column(s) _spec_id, _partition, _file, _pos is not supported")
         } finally {
           spark.sql(s"DROP TABLE IF EXISTS $table PURGE")
         }

--- a/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
@@ -4009,4 +4009,37 @@ class CometIcebergNativeSuite
       }
     }
   }
+
+  test("CometScanRule should report unsupported metadata columns") {
+    withTempIcebergDir { warehouseDir =>
+      withSQLConf(
+        s"spark.sql.catalog.test_cat" -> "org.apache.iceberg.spark.SparkCatalog",
+        s"spark.sql.catalog.test_cat.type" -> "hadoop",
+        s"spark.sql.catalog.test_cat.warehouse" -> warehouseDir.getAbsolutePath,
+        CometConf.COMET_ENABLED.key -> "true",
+        CometConf.COMET_EXEC_ENABLED.key -> "true",
+        CometConf.COMET_ICEBERG_NATIVE_ENABLED.key -> "true",
+        CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "true") {
+
+        val table = "test_cat.db.test_meta_cols"
+        try {
+          spark.sql(s"""
+            CREATE TABLE $table (id INT, value DOUBLE) USING iceberg
+            TBLPROPERTIES ('format-version' = '2')
+          """)
+
+          spark.sql(s"""
+          INSERT INTO $table
+          VALUES (1, 10.5), (2, 20.3), (3, 30.7)
+        """)
+
+          checkSparkAnswerAndFallbackReason(
+            s"SELECT id, value, _spec_id, _pos, _file, _partition FROM $table WHERE id >= 2 ORDER BY id",
+            "Metadata column _spec_id, _partition, _file, _pos is not supported")
+        } finally {
+          spark.sql(s"DROP TABLE IF EXISTS $table PURGE")
+        }
+      }
+    }
+  }
 }

--- a/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
@@ -4013,9 +4013,9 @@ class CometIcebergNativeSuite
   test("CometScanRule should report unsupported metadata columns") {
     withTempIcebergDir { warehouseDir =>
       withSQLConf(
-        s"spark.sql.catalog.test_cat" -> "org.apache.iceberg.spark.SparkCatalog",
-        s"spark.sql.catalog.test_cat.type" -> "hadoop",
-        s"spark.sql.catalog.test_cat.warehouse" -> warehouseDir.getAbsolutePath,
+        "spark.sql.catalog.test_cat" -> "org.apache.iceberg.spark.SparkCatalog",
+        "spark.sql.catalog.test_cat.type" -> "hadoop",
+        "spark.sql.catalog.test_cat.warehouse" -> warehouseDir.getAbsolutePath,
         CometConf.COMET_ENABLED.key -> "true",
         CometConf.COMET_EXEC_ENABLED.key -> "true",
         CometConf.COMET_ICEBERG_NATIVE_ENABLED.key -> "true",


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4757

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

 - Comet falls back with `[COMET: Metadata column is not supported]` and users might want to know the column names that trigger the fallback.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

 - Add unsupported metadata columns name to fallback reasons.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
 - Unit test
 - Using Iceberg Spark

```shell
CometSort
+- CometSinkPlaceHolder
   +- CometColumnarExchange
      +- Project
         +- Filter
            +-  BatchScan spark_catalog.default.table [COMET: Metadata column _spec_id, _partition, _file, _pos is not supported]
```

