### PR TITLE
refactor: gate CometUnaryMinus input types in getSupportLevel

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/arithmetic.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arithmetic.scala
@@ -334,7 +334,10 @@ object CometRound extends CometExpressionSerde[Round] {
 
   }
 }
-object CometUnaryMinus extends CometExpressionSerde[UnaryMinus] {
+object CometUnaryMinus extends CometExpressionSerde[UnaryMinus] with MathBase {
+
+  override def getSupportLevel(expr: UnaryMinus): SupportLevel =
+    mathDataTypeSupportLevel(expr.child.dataType)
 
   override def convert(
       expr: UnaryMinus,

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1738,6 +1738,17 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("unary minus across numeric types") {
+    // UnaryMinus gates input types in getSupportLevel: every Spark NumericType (incl. decimal)
+    // must stay native; interval types are unsupported and fall back to Spark.
+    withParquetTable(
+      (1 to 5).map(i =>
+        (i.toByte, i.toShort, i, i.toLong, i.toFloat, i.toDouble, BigDecimal(i * 3, 2))),
+      "umt") {
+      checkSparkAnswerAndOperator("SELECT -_1, -_2, -_3, -_4, -_5, -_6, -_7 FROM umt")
+    }
+  }
+
   test("basic arithmetic") {
     withSQLConf("parquet.enable.dictionary" -> "false") {
       withParquetTable((1 until 10).map(i => (i, i + 1)), "tbl", false) {

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1749,6 +1749,37 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("unary minus on float/double special values and nulls") {
+    // Negation is an IEEE sign flip, so NaN, +/-Infinity, signed zero, the float/double range
+    // limits, and null must all match Spark. (Integer Max/MinValue overflow is covered by the
+    // "unary negative integer overflow test".)
+    val floats: Seq[Option[Float]] = Seq(
+      Some(Float.NaN),
+      Some(Float.PositiveInfinity),
+      Some(Float.NegativeInfinity),
+      Some(0.0f),
+      Some(-0.0f),
+      Some(Float.MinPositiveValue),
+      Some(Float.MaxValue),
+      Some(Float.MinValue),
+      None)
+    val doubles: Seq[Option[Double]] = Seq(
+      Some(Double.NaN),
+      Some(Double.PositiveInfinity),
+      Some(Double.NegativeInfinity),
+      Some(0.0d),
+      Some(-0.0d),
+      Some(Double.MinPositiveValue),
+      Some(Double.MaxValue),
+      Some(Double.MinValue),
+      None)
+    Seq(false, true).foreach { dictionary =>
+      withParquetTable(floats.zip(doubles), "umt_special", withDictionary = dictionary) {
+        checkSparkAnswerAndOperator("SELECT -_1, -_2 FROM umt_special")
+      }
+    }
+  }
+
   test("basic arithmetic") {
     withSQLConf("parquet.enable.dictionary" -> "false") {
       withParquetTable((1 until 10).map(i => (i, i + 1)), "tbl", false) {


### PR DESCRIPTION
## Which issue does this PR close?

Relates to #4500 (item 1: lift `convert`-time fallbacks in `arithmetic.scala` into `getSupportLevel`).

## Rationale for this change

PR #4674 moved the arithmetic and math support checks into `getSupportLevel` so that unsupported input types are reported at planning time, where the reason surfaces in EXPLAIN output and is picked up by the generated compatibility docs. `CometUnaryMinus` was the only arithmetic serde left relying on a `convert`-time fallback for unsupported input types: an interval input would serialize its child, fail, and fall back with a generic child-level reason rather than a clear datatype reason.

This change completes that pattern for `UnaryMinus`.

## What changes are included in this PR?

- `CometUnaryMinus` now mixes in `MathBase` and overrides `getSupportLevel` with `mathDataTypeSupportLevel(expr.child.dataType)`, matching the other arithmetic serdes. Every Spark `NumericType` (including decimal) stays native; interval types are reported as `Unsupported` with a datatype reason and fall back to Spark.
- Added a `CometExpressionSuite` regression test covering unary minus over byte, short, int, long, float, double, and decimal.

## How are these changes tested?

New test `unary minus across numeric types` in `CometExpressionSuite`, passing on Spark 3.5 and 4.0. Behavior was validated with the `audit-comet-expression` skill: numeric types (including decimal) run natively and match Spark, while day-time and year-month interval inputs fall back to Spark.