### PR TITLE
fix: size Iceberg delete files in the native scan to avoid dropping deletes

### DIFF
--- a/native/core/src/execution/operators/iceberg_scan.rs
+++ b/native/core/src/execution/operators/iceberg_scan.rs
@@ -168,6 +168,13 @@ impl IcebergScanExec {
             &self.metadata_location,
             &self.catalog_name,
         )?;
+
+        // The JVM serializer leaves delete-file sizes as 0 (it cannot reliably stat them with the
+        // FileIO it reconstructs). iceberg-rust needs the true size to locate each delete file's
+        // Parquet footer, so fill them here with the same FileIO the reader uses, before reading.
+        let mut tasks = tasks;
+        get_runtime().block_on(Self::fill_delete_file_sizes(&mut tasks, &file_io))?;
+
         let batch_size = context.session_config().batch_size();
 
         let metrics = IcebergScanMetrics::new(&self.metrics);
@@ -241,6 +248,77 @@ impl IcebergScanExec {
                 "Unsupported storage scheme: {scheme}"
             ))),
         }
+    }
+
+    /// Populates delete-file sizes that the JVM serializer left as 0.
+    ///
+    /// iceberg-rust uses `file_size_in_bytes` to seek the Parquet footer of each delete file, so a
+    /// 0 (or otherwise wrong) value makes metadata loading fail. We do not size delete files on the
+    /// JVM side because the FileIO reconstructed there may not resolve every delete path (e.g.
+    /// Trino-written tables on S3); see CometIcebergNativeScan.scala. Instead we stat each unique
+    /// delete file here, in parallel, with the same FileIO the reader uses.
+    ///
+    /// A stat failure is fatal: applying only some deletes would silently leak deleted rows, so we
+    /// propagate the error rather than read with missing deletes.
+    async fn fill_delete_file_sizes(
+        tasks: &mut [FileScanTask],
+        file_io: &FileIO,
+    ) -> Result<(), DataFusionError> {
+        use datafusion::common::{HashMap, HashSet};
+
+        // Unique delete-file paths still missing a size. Deduplicate so a delete file shared by
+        // many tasks is statted once. Owns the paths so no borrow of `tasks` is held into the
+        // mutable write-back below.
+        let mut needed: HashSet<String> = HashSet::new();
+        for task in tasks.iter() {
+            for delete in &task.deletes {
+                if delete.file_size_in_bytes == 0 {
+                    needed.insert(delete.file_path.clone());
+                }
+            }
+        }
+        if needed.is_empty() {
+            return Ok(());
+        }
+
+        let sizes = futures::future::try_join_all(needed.into_iter().map(|path| {
+            let file_io = file_io.clone();
+            async move {
+                let size = file_io
+                    .new_input(&path)
+                    .map_err(|e| {
+                        DataFusionError::Execution(format!(
+                            "Failed to open delete file '{path}' to read its size: {e}"
+                        ))
+                    })?
+                    .metadata()
+                    .await
+                    .map_err(|e| {
+                        DataFusionError::Execution(format!(
+                            "Failed to stat delete file '{path}' to read its size: {e}"
+                        ))
+                    })?
+                    .size;
+                Ok::<(String, u64), DataFusionError>((path, size))
+            }
+        }))
+        .await?;
+
+        let size_map: HashMap<String, u64> = sizes.into_iter().collect();
+        for task in tasks.iter_mut() {
+            for delete in task.deletes.iter_mut() {
+                if delete.file_size_in_bytes == 0 {
+                    delete.file_size_in_bytes =
+                        *size_map.get(&delete.file_path).ok_or_else(|| {
+                            DataFusionError::Execution(format!(
+                                "Missing computed size for delete file '{}'",
+                                delete.file_path
+                            ))
+                        })?;
+                }
+            }
+        }
+        Ok(())
     }
 
     fn load_file_io(
@@ -519,4 +597,99 @@ fn adapt_batch_with_expressions(
         .collect::<DFResult<Vec<_>>>()?;
 
     RecordBatch::try_new(Arc::clone(target_schema), columns).map_err(|e| e.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::sync::Arc;
+
+    use iceberg::io::{FileIO, FileIOBuilder};
+    use iceberg::scan::{FileScanTask, FileScanTaskDeleteFile};
+    use iceberg::spec::{DataContentType, DataFileFormat, Schema};
+    use iceberg_storage_opendal::OpenDalStorageFactory;
+
+    use super::IcebergScanExec;
+
+    fn fs_file_io() -> FileIO {
+        FileIOBuilder::new(Arc::new(OpenDalStorageFactory::Fs)).build()
+    }
+
+    fn task_with_deletes(deletes: Vec<FileScanTaskDeleteFile>) -> FileScanTask {
+        FileScanTask {
+            file_size_in_bytes: 0,
+            start: 0,
+            length: 0,
+            record_count: None,
+            data_file_path: "data.parquet".to_string(),
+            data_file_format: DataFileFormat::Parquet,
+            schema: Arc::new(Schema::builder().build().unwrap()),
+            project_field_ids: vec![],
+            predicate: None,
+            deletes,
+            partition: None,
+            partition_spec: None,
+            name_mapping: None,
+            case_sensitive: false,
+        }
+    }
+
+    fn delete_file(path: &str) -> FileScanTaskDeleteFile {
+        FileScanTaskDeleteFile {
+            file_path: path.to_string(),
+            file_type: DataContentType::PositionDeletes,
+            file_size_in_bytes: 0,
+            partition_spec_id: 0,
+            equality_ids: None,
+        }
+    }
+
+    // A delete file we cannot stat must fail the scan, not be silently read with a missing/0 size.
+    // That silent drop is the #4723 corruption: deleted rows would leak through.
+    #[tokio::test]
+    async fn fill_delete_file_sizes_errors_on_unreadable_delete_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing-delete.parquet");
+        let mut tasks = vec![task_with_deletes(vec![delete_file(
+            missing.to_str().unwrap(),
+        )])];
+
+        let result = IcebergScanExec::fill_delete_file_sizes(&mut tasks, &fs_file_io()).await;
+
+        assert!(
+            result.is_err(),
+            "expected an error when a delete file cannot be statted"
+        );
+        assert_eq!(tasks[0].deletes[0].file_size_in_bytes, 0);
+    }
+
+    // The real on-disk size is filled in from the FileIO, replacing the 0 placeholder.
+    #[tokio::test]
+    async fn fill_delete_file_sizes_populates_real_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("delete.parquet");
+        let bytes = b"these bytes stand in for a delete file";
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(bytes).unwrap();
+        f.flush().unwrap();
+
+        let mut tasks = vec![task_with_deletes(vec![delete_file(path.to_str().unwrap())])];
+        IcebergScanExec::fill_delete_file_sizes(&mut tasks, &fs_file_io())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            tasks[0].deletes[0].file_size_in_bytes,
+            bytes.len() as u64
+        );
+    }
+
+    // No deletes means no stats and no error.
+    #[tokio::test]
+    async fn fill_delete_file_sizes_noop_without_deletes() {
+        let mut tasks = vec![task_with_deletes(vec![])];
+        IcebergScanExec::fill_delete_file_sizes(&mut tasks, &fs_file_io())
+            .await
+            .unwrap();
+    }
 }

--- a/native/core/src/execution/operators/iceberg_scan.rs
+++ b/native/core/src/execution/operators/iceberg_scan.rs
@@ -40,6 +40,7 @@ use futures::{Stream, StreamExt, TryStreamExt};
 use iceberg::arrow::ScanMetrics;
 use iceberg::io::{FileIO, FileIOBuilder, StorageFactory};
 use iceberg::Runtime as IcebergRuntime;
+use iceberg::{Error, ErrorKind};
 use iceberg_storage_opendal::CustomAwsCredentialLoader;
 use iceberg_storage_opendal::OpenDalStorageFactory;
 
@@ -159,7 +160,7 @@ impl IcebergScanExec {
     /// deletes via iceberg-rust's ArrowReader.
     fn execute_with_tasks(
         &self,
-        mut tasks: Vec<FileScanTask>,
+        tasks: Vec<FileScanTask>,
         context: Arc<TaskContext>,
     ) -> DFResult<SendableRecordBatchStream> {
         let output_schema = Arc::clone(&self.output_schema);
@@ -168,18 +169,22 @@ impl IcebergScanExec {
             &self.metadata_location,
             &self.catalog_name,
         )?;
-
-        // Delete-file sizes arrive as 0 (not serialized); fill them before reading (see
-        // fill_delete_file_sizes).
-        get_runtime().block_on(Self::fill_delete_file_sizes(&mut tasks, &file_io))?;
-
         let batch_size = context.session_config().batch_size();
 
         let metrics = IcebergScanMetrics::new(&self.metrics);
-        let num_tasks = tasks.len();
-        metrics.num_splits.add(num_tasks);
+        metrics.num_splits.add(tasks.len());
 
-        let task_stream = futures::stream::iter(tasks.into_iter().map(Ok)).boxed();
+        // Fill delete-file sizes as the first step of the task stream so the stats run on the
+        // iceberg runtime alongside the reads, not on the calling executor thread (see
+        // fill_delete_file_sizes).
+        let fill_io = file_io.clone();
+        let task_stream = futures::stream::once(async move {
+            let mut tasks = tasks;
+            Self::fill_delete_file_sizes(&mut tasks, &fill_io).await?;
+            Ok::<_, Error>(futures::stream::iter(tasks.into_iter().map(Ok::<_, Error>)))
+        })
+        .try_flatten()
+        .boxed();
 
         // iceberg-rust's ArrowReader spawns IO/CPU work onto an iceberg::Runtime. execute() runs
         // on the JVM-called thread outside any tokio context, so Runtime::current() would panic;
@@ -256,16 +261,20 @@ impl IcebergScanExec {
     async fn fill_delete_file_sizes(
         tasks: &mut [FileScanTask],
         file_io: &FileIO,
-    ) -> Result<(), DataFusionError> {
+    ) -> Result<(), Error> {
         use datafusion::common::{HashMap, HashSet};
 
-        // Owns the paths so no borrow of `tasks` is held into the mutable write-back below.
+        // Dedup: the JVM pools delete-file lists, not individual files, so the same delete file
+        // recurs across the tasks that share it. Owning the paths also avoids holding a borrow of
+        // `tasks` into the mutable write-back below.
         let mut needed: HashSet<String> = HashSet::new();
         for task in tasks.iter() {
             for delete in &task.deletes {
-                if delete.file_size_in_bytes == 0 {
-                    needed.insert(delete.file_path.clone());
-                }
+                // Delete-file sizes are never serialized, so they always arrive as 0. If we ever
+                // trust manifest sizes (pending the unreleased apache/iceberg#12554 fix), skip
+                // already-sized files here instead of asserting.
+                debug_assert_eq!(delete.file_size_in_bytes, 0);
+                needed.insert(delete.file_path.clone());
             }
         }
         if needed.is_empty() {
@@ -276,21 +285,18 @@ impl IcebergScanExec {
             let file_io = file_io.clone();
             async move {
                 let size = file_io
-                    .new_input(&path)
-                    .map_err(|e| {
-                        DataFusionError::Execution(format!(
-                            "Failed to open delete file '{path}' to read its size: {e}"
-                        ))
-                    })?
+                    .new_input(&path)?
                     .metadata()
                     .await
                     .map_err(|e| {
-                        DataFusionError::Execution(format!(
-                            "Failed to stat delete file '{path}' to read its size: {e}"
-                        ))
+                        Error::new(
+                            ErrorKind::Unexpected,
+                            format!("Failed to stat delete file '{path}'"),
+                        )
+                        .with_source(e)
                     })?
                     .size;
-                Ok::<(String, u64), DataFusionError>((path, size))
+                Ok::<(String, u64), Error>((path, size))
             }
         }))
         .await?;

--- a/native/core/src/execution/operators/iceberg_scan.rs
+++ b/native/core/src/execution/operators/iceberg_scan.rs
@@ -636,7 +636,6 @@ mod tests {
     }
 
     // A delete file we cannot stat must fail the scan, not be silently read with a missing/0 size.
-    // That silent drop is the #4723 corruption: deleted rows would leak through.
     #[tokio::test]
     async fn fill_delete_file_sizes_errors_on_unreadable_delete_file() {
         let dir = tempfile::tempdir().unwrap();

--- a/native/core/src/execution/operators/iceberg_scan.rs
+++ b/native/core/src/execution/operators/iceberg_scan.rs
@@ -57,6 +57,14 @@ use iceberg::scan::FileScanTask;
 /// catalog's `s3.*` property bag.
 const ICEBERG_PROVIDER_CLASS_PROPERTY: &str = "s3.comet.credential.provider.class";
 
+/// A valid Parquet file ends with at least an 8-byte footer (4-byte metadata length + "PAR1").
+/// A delete file that stats below this cannot be read, so we reject it in the fill step. opendal
+/// returns size 0 from a successful HEAD whose response carries no Content-Length header (some
+/// S3-compatible endpoints/proxies, or a path-style mismatch), and for a genuinely empty object;
+/// neither errors at the stat layer, so without this floor the 0 would flow into the Parquet
+/// reader and surface as an opaque "file size of 0 is less than footer".
+const MIN_PARQUET_FILE_SIZE: u64 = 8;
+
 /// Iceberg table scan operator that uses iceberg-rust to read Iceberg tables.
 ///
 /// Executes pre-planned FileScanTasks for efficient parallel scanning.
@@ -305,6 +313,17 @@ impl IcebergScanExec {
                         .with_source(e)
                     })?
                     .size;
+                if size < MIN_PARQUET_FILE_SIZE {
+                    return Err(Error::new(
+                        ErrorKind::Unexpected,
+                        format!(
+                            "Delete file '{path}' statted to {size} bytes, below the \
+                             {MIN_PARQUET_FILE_SIZE}-byte Parquet minimum. The object is empty or \
+                             truncated, or the stat returned no Content-Length (check the object \
+                             store endpoint, TLS, and path-style config)."
+                        ),
+                    ));
+                }
                 Ok::<(String, u64), Error>((path, size))
             }
         }))
@@ -680,6 +699,25 @@ mod tests {
             .unwrap();
 
         assert_eq!(tasks[0].deletes[0].file_size_in_bytes, bytes.len() as u64);
+    }
+
+    // A present-but-undersized delete file (0-byte object, truncated write, or a HEAD with no
+    // Content-Length that opendal reports as size 0) must fail loudly rather than passing a
+    // sub-footer size into the Parquet reader.
+    #[tokio::test]
+    async fn fill_delete_file_sizes_errors_on_subfooter_delete_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty-delete.parquet");
+        std::fs::File::create(&path).unwrap(); // 0 bytes on disk
+
+        let mut tasks = vec![task_with_deletes(vec![delete_file(path.to_str().unwrap())])];
+        let result = IcebergScanExec::fill_delete_file_sizes(&mut tasks, &fs_file_io(), 4).await;
+
+        assert!(
+            result.is_err(),
+            "expected an error when a delete file is below the Parquet footer minimum"
+        );
+        assert_eq!(tasks[0].deletes[0].file_size_in_bytes, 0);
     }
 
     // No deletes means no stats and no error.

--- a/native/core/src/execution/operators/iceberg_scan.rs
+++ b/native/core/src/execution/operators/iceberg_scan.rs
@@ -159,7 +159,7 @@ impl IcebergScanExec {
     /// deletes via iceberg-rust's ArrowReader.
     fn execute_with_tasks(
         &self,
-        tasks: Vec<FileScanTask>,
+        mut tasks: Vec<FileScanTask>,
         context: Arc<TaskContext>,
     ) -> DFResult<SendableRecordBatchStream> {
         let output_schema = Arc::clone(&self.output_schema);
@@ -169,10 +169,8 @@ impl IcebergScanExec {
             &self.catalog_name,
         )?;
 
-        // The JVM serializer leaves delete-file sizes as 0 (it cannot reliably stat them with the
-        // FileIO it reconstructs). iceberg-rust needs the true size to locate each delete file's
-        // Parquet footer, so fill them here with the same FileIO the reader uses, before reading.
-        let mut tasks = tasks;
+        // Delete-file sizes arrive as 0 (not serialized); fill them before reading (see
+        // fill_delete_file_sizes).
         get_runtime().block_on(Self::fill_delete_file_sizes(&mut tasks, &file_io))?;
 
         let batch_size = context.session_config().batch_size();
@@ -250,25 +248,18 @@ impl IcebergScanExec {
         }
     }
 
-    /// Populates delete-file sizes that the JVM serializer left as 0.
+    /// Stats each unique delete file to fill its `file_size_in_bytes` (0 on arrival, since it is
+    /// not serialized).
     ///
-    /// iceberg-rust uses `file_size_in_bytes` to seek the Parquet footer of each delete file, so a
-    /// 0 (or otherwise wrong) value makes metadata loading fail. We do not size delete files on the
-    /// JVM side because the FileIO reconstructed there may not resolve every delete path (e.g.
-    /// Trino-written tables on S3); see CometIcebergNativeScan.scala. Instead we stat each unique
-    /// delete file here, in parallel, with the same FileIO the reader uses.
-    ///
-    /// A stat failure is fatal: applying only some deletes would silently leak deleted rows, so we
-    /// propagate the error rather than read with missing deletes.
+    /// iceberg-rust seeks the Parquet footer from this size, so it must be correct. A stat failure
+    /// is fatal: reading with missing deletes would silently leak deleted rows.
     async fn fill_delete_file_sizes(
         tasks: &mut [FileScanTask],
         file_io: &FileIO,
     ) -> Result<(), DataFusionError> {
         use datafusion::common::{HashMap, HashSet};
 
-        // Unique delete-file paths still missing a size. Deduplicate so a delete file shared by
-        // many tasks is statted once. Owns the paths so no borrow of `tasks` is held into the
-        // mutable write-back below.
+        // Owns the paths so no borrow of `tasks` is held into the mutable write-back below.
         let mut needed: HashSet<String> = HashSet::new();
         for task in tasks.iter() {
             for delete in &task.deletes {
@@ -307,14 +298,8 @@ impl IcebergScanExec {
         let size_map: HashMap<String, u64> = sizes.into_iter().collect();
         for task in tasks.iter_mut() {
             for delete in task.deletes.iter_mut() {
-                if delete.file_size_in_bytes == 0 {
-                    delete.file_size_in_bytes =
-                        *size_map.get(&delete.file_path).ok_or_else(|| {
-                            DataFusionError::Execution(format!(
-                                "Missing computed size for delete file '{}'",
-                                delete.file_path
-                            ))
-                        })?;
+                if let Some(&size) = size_map.get(&delete.file_path) {
+                    delete.file_size_in_bytes = size;
                 }
             }
         }
@@ -678,10 +663,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(
-            tasks[0].deletes[0].file_size_in_bytes,
-            bytes.len() as u64
-        );
+        assert_eq!(tasks[0].deletes[0].file_size_in_bytes, bytes.len() as u64);
     }
 
     // No deletes means no stats and no error.

--- a/native/core/src/execution/operators/iceberg_scan.rs
+++ b/native/core/src/execution/operators/iceberg_scan.rs
@@ -178,9 +178,10 @@ impl IcebergScanExec {
         // iceberg runtime alongside the reads, not on the calling executor thread (see
         // fill_delete_file_sizes).
         let fill_io = file_io.clone();
+        let concurrency_limit = self.data_file_concurrency_limit;
         let task_stream = futures::stream::once(async move {
             let mut tasks = tasks;
-            Self::fill_delete_file_sizes(&mut tasks, &fill_io).await?;
+            Self::fill_delete_file_sizes(&mut tasks, &fill_io, concurrency_limit).await?;
             Ok::<_, Error>(futures::stream::iter(tasks.into_iter().map(Ok::<_, Error>)))
         })
         .try_flatten()
@@ -261,8 +262,10 @@ impl IcebergScanExec {
     async fn fill_delete_file_sizes(
         tasks: &mut [FileScanTask],
         file_io: &FileIO,
+        concurrency_limit: usize,
     ) -> Result<(), Error> {
         use datafusion::common::{HashMap, HashSet};
+        use futures::TryStreamExt;
 
         // Dedup: the JVM pools delete-file lists, not individual files, so the same delete file
         // recurs across the tasks that share it. Owning the paths also avoids holding a borrow of
@@ -281,7 +284,13 @@ impl IcebergScanExec {
             return Ok(());
         }
 
-        let sizes = futures::future::try_join_all(needed.into_iter().map(|path| {
+        // Bound the in-flight stats to match the downstream read concurrency (iceberg-rust uses
+        // try_buffer_unordered at the same limit for delete-file loads). An unbounded fan-out
+        // would burst N HEAD requests at once for no gain, since the reads are throttled anyway.
+        // Guaranteed > 0 by COMET_ICEBERG_DATA_FILE_CONCURRENCY_LIMIT; buffer_unordered(0) would
+        // never poll.
+        debug_assert!(concurrency_limit > 0);
+        let sizes: Vec<(String, u64)> = futures::stream::iter(needed.into_iter().map(|path| {
             let file_io = file_io.clone();
             async move {
                 let size = file_io
@@ -299,6 +308,8 @@ impl IcebergScanExec {
                 Ok::<(String, u64), Error>((path, size))
             }
         }))
+        .buffer_unordered(concurrency_limit)
+        .try_collect()
         .await?;
 
         let size_map: HashMap<String, u64> = sizes.into_iter().collect();
@@ -644,7 +655,7 @@ mod tests {
             missing.to_str().unwrap(),
         )])];
 
-        let result = IcebergScanExec::fill_delete_file_sizes(&mut tasks, &fs_file_io()).await;
+        let result = IcebergScanExec::fill_delete_file_sizes(&mut tasks, &fs_file_io(), 4).await;
 
         assert!(
             result.is_err(),
@@ -664,7 +675,7 @@ mod tests {
         f.flush().unwrap();
 
         let mut tasks = vec![task_with_deletes(vec![delete_file(path.to_str().unwrap())])];
-        IcebergScanExec::fill_delete_file_sizes(&mut tasks, &fs_file_io())
+        IcebergScanExec::fill_delete_file_sizes(&mut tasks, &fs_file_io(), 4)
             .await
             .unwrap();
 
@@ -675,7 +686,7 @@ mod tests {
     #[tokio::test]
     async fn fill_delete_file_sizes_noop_without_deletes() {
         let mut tasks = vec![task_with_deletes(vec![])];
-        IcebergScanExec::fill_delete_file_sizes(&mut tasks, &fs_file_io())
+        IcebergScanExec::fill_delete_file_sizes(&mut tasks, &fs_file_io(), 4)
             .await
             .unwrap();
     }

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -3635,6 +3635,15 @@ fn parse_file_scan_tasks_from_common(
                         }
                     };
 
+                    // The JVM serializer intentionally leaves delete-file sizes unset; the real
+                    // size is filled in natively (see IcebergScanExec::fill_delete_file_sizes).
+                    // Assert the invariant so a future change that starts sending a size is caught.
+                    debug_assert_eq!(
+                        del.file_size_in_bytes, 0,
+                        "expected JVM to leave delete file size as 0, got {} for {}",
+                        del.file_size_in_bytes, del.file_path
+                    );
+
                     Ok(iceberg::scan::FileScanTaskDeleteFile {
                         file_path: del.file_path.clone(),
                         file_type,

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -3635,19 +3635,11 @@ fn parse_file_scan_tasks_from_common(
                         }
                     };
 
-                    // The JVM serializer intentionally leaves delete-file sizes unset; the real
-                    // size is filled in natively (see IcebergScanExec::fill_delete_file_sizes).
-                    // Assert the invariant so a future change that starts sending a size is caught.
-                    debug_assert_eq!(
-                        del.file_size_in_bytes, 0,
-                        "expected JVM to leave delete file size as 0, got {} for {}",
-                        del.file_size_in_bytes, del.file_path
-                    );
-
                     Ok(iceberg::scan::FileScanTaskDeleteFile {
                         file_path: del.file_path.clone(),
                         file_type,
-                        file_size_in_bytes: del.file_size_in_bytes,
+                        // Not serialized; filled in by IcebergScanExec::fill_delete_file_sizes.
+                        file_size_in_bytes: 0,
                         partition_spec_id: del.partition_spec_id,
                         equality_ids: if del.equality_ids.is_empty() {
                             None

--- a/native/proto/src/proto/operator.proto
+++ b/native/proto/src/proto/operator.proto
@@ -277,9 +277,6 @@ message IcebergDeleteFile {
 
   // Equality field IDs (empty for positional deletes)
   repeated int32 equality_ids = 4;
-
-  // // Total file size from the manifest entry, used to skip stat/HEAD calls
-  uint64 file_size_in_bytes = 5;
 }
 
 message Projection {

--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
@@ -222,10 +222,9 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
   /**
    * Extracts delete files from an Iceberg FileScanTask as a list (for deduplication).
    *
-   * The delete file's size is intentionally left as 0 here. We do not size delete files on the
-   * JVM side: the file_size_in_bytes is populated natively by the Iceberg scan, which stats each
-   * delete file through the same FileIO it uses to read it. See `execute_with_tasks` in
-   * native/core/src/execution/operators/iceberg_scan.rs.
+   * Delete-file size is not serialized; the native scan stats each file for it (see
+   * IcebergScanExec::fill_delete_file_sizes). The manifest size cannot be trusted as a substitute
+   * (apache/iceberg#12554).
    */
   private def extractDeleteFilesList(
       task: Any,
@@ -241,8 +240,8 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
         // and silently skipping it would leak deleted rows, so treat a missing path as fatal.
         val deletePath = IcebergReflection
           .extractFileLocation(contentFileClass, deleteFile)
-          .getOrElse(throw new RuntimeException(
-            "Failed to extract delete file path from FileScanTask"))
+          .getOrElse(
+            throw new RuntimeException("Failed to extract delete file path from FileScanTask"))
 
         val deleteBuilder = OperatorOuterClass.IcebergDeleteFile.newBuilder()
         deleteBuilder.setFilePath(deletePath)
@@ -272,11 +271,6 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
             case _: Exception => 0
           }
         deleteBuilder.setPartitionSpecId(specId)
-
-        // Placeholder: the native scan stats the file and fills in the real size before reading.
-        // The manifest value cannot be trusted (see apache/iceberg#12554), and the FileIO we could
-        // reconstruct here may not resolve every delete path (e.g. Trino-written tables on S3).
-        deleteBuilder.setFileSizeInBytes(0L)
 
         try {
           val equalityIdsMethod =

--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
@@ -221,85 +221,75 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
 
   /**
    * Extracts delete files from an Iceberg FileScanTask as a list (for deduplication).
+   *
+   * The delete file's size is intentionally left as 0 here. We do not size delete files on the
+   * JVM side: the file_size_in_bytes is populated natively by the Iceberg scan, which stats each
+   * delete file through the same FileIO it uses to read it. See `execute_with_tasks` in
+   * native/core/src/execution/operators/iceberg_scan.rs.
    */
   private def extractDeleteFilesList(
       task: Any,
       contentFileClass: Class[_],
-      fileScanTaskClass: Class[_],
-      fileIO: Option[Any]): Seq[OperatorOuterClass.IcebergDeleteFile] = {
+      fileScanTaskClass: Class[_]): Seq[OperatorOuterClass.IcebergDeleteFile] = {
     try {
       val deleteFileClass = IcebergReflection.loadClass(IcebergReflection.ClassNames.DELETE_FILE)
 
       val deletes = IcebergReflection.getDeleteFilesFromTask(task, fileScanTaskClass)
 
-      deletes.asScala.flatMap { deleteFile =>
-        try {
-          IcebergReflection
-            .extractFileLocation(contentFileClass, deleteFile)
-            .map { deletePath =>
-              val deleteBuilder =
-                OperatorOuterClass.IcebergDeleteFile.newBuilder()
-              deleteBuilder.setFilePath(deletePath)
+      deletes.asScala.map { deleteFile =>
+        // The path is the one essential field. A delete file we cannot locate cannot be applied,
+        // and silently skipping it would leak deleted rows, so treat a missing path as fatal.
+        val deletePath = IcebergReflection
+          .extractFileLocation(contentFileClass, deleteFile)
+          .getOrElse(throw new RuntimeException(
+            "Failed to extract delete file path from FileScanTask"))
 
-              val contentType =
-                try {
-                  val contentMethod = deleteFileClass.getMethod("content")
-                  val content = contentMethod.invoke(deleteFile)
-                  content.toString match {
-                    case IcebergReflection.ContentTypes.POSITION_DELETES =>
-                      IcebergReflection.ContentTypes.POSITION_DELETES
-                    case IcebergReflection.ContentTypes.EQUALITY_DELETES =>
-                      IcebergReflection.ContentTypes.EQUALITY_DELETES
-                    case other => other
-                  }
-                } catch {
-                  case _: Exception =>
-                    IcebergReflection.ContentTypes.POSITION_DELETES
-                }
-              deleteBuilder.setContentType(contentType)
+        val deleteBuilder = OperatorOuterClass.IcebergDeleteFile.newBuilder()
+        deleteBuilder.setFilePath(deletePath)
 
-              val specId =
-                try {
-                  val specIdMethod = deleteFileClass.getMethod("specId")
-                  specIdMethod.invoke(deleteFile).asInstanceOf[Int]
-                } catch {
-                  case _: Exception => 0
-                }
-              deleteBuilder.setPartitionSpecId(specId)
-
-              // Workaround for https://github.com/apache/iceberg/issues/12554
-              // RewriteTablePath rewrites path references inside position delete files,
-              // making the copied file possibly differ in size, but does not update
-              // file_size_in_bytes in the manifest. The manifest value cannot be trusted;
-              // always use FileIO to get the actual size.
-              val inputFile = fileIO.get.getClass
-                .getMethod("newInputFile", classOf[String])
-                .invoke(fileIO.get, deletePath)
-              val actualDeleteFileSizeInBytes =
-                inputFile.getClass
-                  .getMethod("getLength")
-                  .invoke(inputFile)
-                  .asInstanceOf[Long]
-              deleteBuilder.setFileSizeInBytes(actualDeleteFileSizeInBytes)
-
-              try {
-                val equalityIdsMethod =
-                  deleteFileClass.getMethod("equalityFieldIds")
-                val equalityIds = equalityIdsMethod
-                  .invoke(deleteFile)
-                  .asInstanceOf[java.util.List[Integer]]
-                equalityIds.forEach(id => deleteBuilder.addEqualityIds(id))
-              } catch {
-                case _: Exception =>
-              }
-
-              deleteBuilder.build()
+        val contentType =
+          try {
+            val contentMethod = deleteFileClass.getMethod("content")
+            val content = contentMethod.invoke(deleteFile)
+            content.toString match {
+              case IcebergReflection.ContentTypes.POSITION_DELETES =>
+                IcebergReflection.ContentTypes.POSITION_DELETES
+              case IcebergReflection.ContentTypes.EQUALITY_DELETES =>
+                IcebergReflection.ContentTypes.EQUALITY_DELETES
+              case other => other
             }
+          } catch {
+            case _: Exception =>
+              IcebergReflection.ContentTypes.POSITION_DELETES
+          }
+        deleteBuilder.setContentType(contentType)
+
+        val specId =
+          try {
+            val specIdMethod = deleteFileClass.getMethod("specId")
+            specIdMethod.invoke(deleteFile).asInstanceOf[Int]
+          } catch {
+            case _: Exception => 0
+          }
+        deleteBuilder.setPartitionSpecId(specId)
+
+        // Placeholder: the native scan stats the file and fills in the real size before reading.
+        // The manifest value cannot be trusted (see apache/iceberg#12554), and the FileIO we could
+        // reconstruct here may not resolve every delete path (e.g. Trino-written tables on S3).
+        deleteBuilder.setFileSizeInBytes(0L)
+
+        try {
+          val equalityIdsMethod =
+            deleteFileClass.getMethod("equalityFieldIds")
+          val equalityIds = equalityIdsMethod
+            .invoke(deleteFile)
+            .asInstanceOf[java.util.List[Integer]]
+          equalityIds.forEach(id => deleteBuilder.addEqualityIds(id))
         } catch {
-          case e: Exception =>
-            logWarning(s"Failed to serialize delete file: ${e.getMessage}")
-            None
+          case _: Exception =>
         }
+
+        deleteBuilder.build()
       }.toSeq
     } catch {
       case e: Exception =>
@@ -747,8 +737,6 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
       mutable.HashMap[Seq[OperatorOuterClass.IcebergDeleteFile], Int]()
     val residualToPoolIndex = mutable.HashMap[Option[Expr], Int]()
 
-    val fileIO = IcebergReflection.getFileIO(metadata.table)
-
     val perPartitionBuilders = mutable.ArrayBuffer[OperatorOuterClass.IcebergScan]()
 
     var totalTasks = 0
@@ -906,7 +894,7 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
                 taskBuilder.setProjectFieldIdsIdx(projectFieldIdsIdx)
 
                 val deleteFilesList =
-                  extractDeleteFilesList(task, contentFileClass, fileScanTaskClass, fileIO)
+                  extractDeleteFilesList(task, contentFileClass, fileScanTaskClass)
                 if (deleteFilesList.nonEmpty) {
                   val deleteFilesIdx = deleteFilesToPoolIndex.getOrElseUpdate(
                     deleteFilesList, {

--- a/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
@@ -737,8 +737,8 @@ class CometIcebergNativeSuite
             s"DELETE FROM test_cat.db.compacted_delete_test WHERE id % 7 = 0 AND id >= $lo AND id < $hi")
         }
 
-        // Compaction equivalent to Trino's OPTIMIZE. This rewrites data files and can rewrite or
-        // re-reference position delete files, which is where the reporter's serialization fails.
+        // Compaction equivalent to Trino's OPTIMIZE; rewrites data files and may rewrite or
+        // re-reference position delete files.
         spark.sql("CALL test_cat.system.rewrite_data_files(table => 'db.compacted_delete_test')")
 
         // More deletes after compaction so the live snapshot mixes pre- and post-compaction deletes.
@@ -756,7 +756,6 @@ class CometIcebergNativeSuite
   // When a delete file cannot be statted natively, the scan must fail loudly rather than read the
   // data file with deletes silently dropped (the #4723 corruption). Here we delete the positional
   // delete file from disk after it is committed, so the native fill_delete_file_sizes stat fails.
-  // The printed exception shows how a delete-file stat failure surfaces through JNI to Spark.
   test("delete file stat failure surfaces as an exception") {
     assume(icebergAvailable, "Iceberg not available in classpath")
 
@@ -796,8 +795,7 @@ class CometIcebergNativeSuite
         assert(deletePaths.nonEmpty, "expected at least one positional delete file")
 
         deletePaths.foreach { p =>
-          val local = if (p.contains(":")) new File(new URI(p)) else new File(p)
-          assert(local.delete(), s"failed to remove delete file from disk: $p")
+          assert(new File(new URI(p)).delete(), s"failed to remove delete file from disk: $p")
         }
 
         // If deletes were silently dropped (the #4723 bug), COUNT(*) would return a wrong count
@@ -805,15 +803,9 @@ class CometIcebergNativeSuite
         val e = intercept[Exception] {
           spark.sql("SELECT COUNT(*) FROM test_cat.db.missing_delete_test").collect()
         }
-
-        println(e)
-
-        // Surface the full cause chain so we can see how the native error is wrapped.
-        var cause: Throwable = e
-        while (cause != null) {
-          logInfo(s"delete-stat failure [${cause.getClass.getName}]: ${cause.getMessage}")
-          cause = cause.getCause
-        }
+        assert(
+          e.getMessage != null && e.getMessage.contains("stat delete file"),
+          s"expected a delete-file stat failure, got: ${e.getMessage}")
 
         spark.sql("DROP TABLE test_cat.db.missing_delete_test")
       }

--- a/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
@@ -754,8 +754,8 @@ class CometIcebergNativeSuite
   }
 
   // When a delete file cannot be statted natively, the scan must fail loudly rather than read the
-  // data file with deletes silently dropped (the #4723 corruption). Here we delete the positional
-  // delete file from disk after it is committed, so the native fill_delete_file_sizes stat fails.
+  // data file with deletes silently dropped. Here we delete the positional delete file from disk
+  // after it is committed, so the native fill_delete_file_sizes stat fails.
   test("delete file stat failure surfaces as an exception") {
     assume(icebergAvailable, "Iceberg not available in classpath")
 
@@ -800,8 +800,8 @@ class CometIcebergNativeSuite
           assert(local.delete(), s"failed to remove delete file from disk: $p")
         }
 
-        // If deletes were silently dropped (the #4723 bug), COUNT(*) would return a wrong count
-        // with no error and this intercept would fail. The fill must fail the scan instead.
+        // If deletes were silently dropped, COUNT(*) would return a wrong count with no error and
+        // this intercept would fail. The fill must fail the scan instead.
         val e = intercept[Exception] {
           spark.sql("SELECT COUNT(*) FROM test_cat.db.missing_delete_test").collect()
         }

--- a/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.execution.exchange.{ReusedExchangeExec, ShuffleExcha
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{StringType, TimestampType}
 
-import org.apache.comet.CometSparkSessionExtensions.{isSpark35Plus, isSpark42Plus}
+import org.apache.comet.CometSparkSessionExtensions.{isSpark35Plus, isSpark40Plus, isSpark42Plus}
 import org.apache.comet.iceberg.RESTCatalogHelper
 import org.apache.comet.testing.{FuzzDataGenerator, SchemaGenOptions}
 
@@ -701,6 +701,9 @@ class CometIcebergNativeSuite
   // size fill over a multi-snapshot, post-compaction delete layout.
   test("MOR positional deletes after rewrite_data_files compaction") {
     assume(icebergAvailable, "Iceberg not available in classpath")
+    // CALL <proc> is only in Spark's own SQL grammar on 4.0+; on 3.x it needs Iceberg's
+    // session-extension parser, which the Comet test session does not register.
+    assume(isSpark40Plus, "CALL procedure syntax requires Spark 4.0+")
 
     withTempIcebergDir { warehouseDir =>
       withSQLConf(

--- a/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
@@ -795,7 +795,9 @@ class CometIcebergNativeSuite
         assert(deletePaths.nonEmpty, "expected at least one positional delete file")
 
         deletePaths.foreach { p =>
-          assert(new File(new URI(p)).delete(), s"failed to remove delete file from disk: $p")
+          // Iceberg may report the path with or without a file: scheme.
+          val local = if (p.startsWith("file:")) new File(new URI(p)) else new File(p)
+          assert(local.delete(), s"failed to remove delete file from disk: $p")
         }
 
         // If deletes were silently dropped (the #4723 bug), COUNT(*) would return a wrong count

--- a/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergNativeSuite.scala
@@ -20,6 +20,7 @@
 package org.apache.comet
 
 import java.io.File
+import java.net.URI
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
@@ -691,6 +692,130 @@ class CometIcebergNativeSuite
         checkIcebergNativeScan("SELECT * FROM test_cat.db.multi_delete_test ORDER BY id")
 
         spark.sql("DROP TABLE test_cat.db.multi_delete_test")
+      }
+    }
+  }
+
+  // MOR positional deletes accumulated across multiple snapshots, then compacted with
+  // rewrite_data_files (the equivalent of Trino's OPTIMIZE). Exercises the native delete-file
+  // size fill over a multi-snapshot, post-compaction delete layout.
+  test("MOR positional deletes after rewrite_data_files compaction") {
+    assume(icebergAvailable, "Iceberg not available in classpath")
+
+    withTempIcebergDir { warehouseDir =>
+      withSQLConf(
+        "spark.sql.catalog.test_cat" -> "org.apache.iceberg.spark.SparkCatalog",
+        "spark.sql.catalog.test_cat.type" -> "hadoop",
+        "spark.sql.catalog.test_cat.warehouse" -> warehouseDir.getAbsolutePath,
+        CometConf.COMET_ENABLED.key -> "true",
+        CometConf.COMET_EXEC_ENABLED.key -> "true",
+        CometConf.COMET_ICEBERG_NATIVE_ENABLED.key -> "true") {
+
+        spark.sql("""
+          CREATE TABLE test_cat.db.compacted_delete_test (
+            id INT,
+            value DOUBLE
+          ) USING iceberg
+          TBLPROPERTIES (
+            'write.delete.mode' = 'merge-on-read',
+            'write.merge.mode' = 'merge-on-read',
+            'format-version' = '2'
+          )
+        """)
+
+        // Build a multi-snapshot history: several inserts into separate data files,
+        // interleaved with deletes that produce positional delete files.
+        (0 until 5).foreach { batch =>
+          val lo = batch * 100
+          val hi = lo + 100
+          spark.sql(s"""
+            INSERT INTO test_cat.db.compacted_delete_test
+            SELECT id, CAST(id AS DOUBLE) * 1.5 AS value
+            FROM range($lo, $hi)
+          """)
+          spark.sql(
+            s"DELETE FROM test_cat.db.compacted_delete_test WHERE id % 7 = 0 AND id >= $lo AND id < $hi")
+        }
+
+        // Compaction equivalent to Trino's OPTIMIZE. This rewrites data files and can rewrite or
+        // re-reference position delete files, which is where the reporter's serialization fails.
+        spark.sql("CALL test_cat.system.rewrite_data_files(table => 'db.compacted_delete_test')")
+
+        // More deletes after compaction so the live snapshot mixes pre- and post-compaction deletes.
+        spark.sql("DELETE FROM test_cat.db.compacted_delete_test WHERE id % 13 = 0")
+
+        checkIcebergNativeScan("SELECT * FROM test_cat.db.compacted_delete_test ORDER BY id")
+        checkIcebergNativeScan("SELECT COUNT(*) FROM test_cat.db.compacted_delete_test")
+        checkIcebergNativeScan("SELECT SUM(value) FROM test_cat.db.compacted_delete_test")
+
+        spark.sql("DROP TABLE test_cat.db.compacted_delete_test")
+      }
+    }
+  }
+
+  // When a delete file cannot be statted natively, the scan must fail loudly rather than read the
+  // data file with deletes silently dropped (the #4723 corruption). Here we delete the positional
+  // delete file from disk after it is committed, so the native fill_delete_file_sizes stat fails.
+  // The printed exception shows how a delete-file stat failure surfaces through JNI to Spark.
+  test("delete file stat failure surfaces as an exception") {
+    assume(icebergAvailable, "Iceberg not available in classpath")
+
+    withTempIcebergDir { warehouseDir =>
+      withSQLConf(
+        "spark.sql.catalog.test_cat" -> "org.apache.iceberg.spark.SparkCatalog",
+        "spark.sql.catalog.test_cat.type" -> "hadoop",
+        "spark.sql.catalog.test_cat.warehouse" -> warehouseDir.getAbsolutePath,
+        CometConf.COMET_ENABLED.key -> "true",
+        CometConf.COMET_EXEC_ENABLED.key -> "true",
+        CometConf.COMET_ICEBERG_NATIVE_ENABLED.key -> "true") {
+
+        spark.sql("""
+          CREATE TABLE test_cat.db.missing_delete_test (
+            id INT,
+            value DOUBLE
+          ) USING iceberg
+          TBLPROPERTIES (
+            'write.delete.mode' = 'merge-on-read',
+            'write.merge.mode' = 'merge-on-read',
+            'format-version' = '2'
+          )
+        """)
+
+        spark.sql("""
+          INSERT INTO test_cat.db.missing_delete_test
+          SELECT id, CAST(id AS DOUBLE) FROM range(20)
+        """)
+        spark.sql("DELETE FROM test_cat.db.missing_delete_test WHERE id IN (3, 7, 11)")
+
+        // Authoritative delete file paths from Iceberg's metadata table (Comet falls back to
+        // Spark for metadata tables, so this read does not depend on the native scan).
+        val deletePaths = spark
+          .sql("SELECT file_path FROM test_cat.db.missing_delete_test.delete_files")
+          .collect()
+          .map(_.getString(0))
+        assert(deletePaths.nonEmpty, "expected at least one positional delete file")
+
+        deletePaths.foreach { p =>
+          val local = if (p.contains(":")) new File(new URI(p)) else new File(p)
+          assert(local.delete(), s"failed to remove delete file from disk: $p")
+        }
+
+        // If deletes were silently dropped (the #4723 bug), COUNT(*) would return a wrong count
+        // with no error and this intercept would fail. The fill must fail the scan instead.
+        val e = intercept[Exception] {
+          spark.sql("SELECT COUNT(*) FROM test_cat.db.missing_delete_test").collect()
+        }
+
+        println(e)
+
+        // Surface the full cause chain so we can see how the native error is wrapped.
+        var cause: Throwable = e
+        while (cause != null) {
+          logInfo(s"delete-stat failure [${cause.getClass.getName}]: ${cause.getMessage}")
+          cause = cause.getCause
+        }
+
+        spark.sql("DROP TABLE test_cat.db.missing_delete_test")
       }
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4723.

## Rationale for this change

The native Iceberg scan returned more rows than Spark on MOR tables with positional deletes (the reporter in #4723 saw ~42% extra rows and a `WARN CometIcebergNativeScan: Failed to serialize delete file: null`). Root cause: the JVM serializer sized each delete file with a `FileIO.getLength()` HEAD on a reconstructed FileIO, and on any failure (e.g. a path the reconstructed FileIO could not resolve) it silently dropped the delete file. Dropped deletes mean deleted rows leak back into the scan, producing wrong counts and inflated aggregates.

The size was never needed on the JVM side. iceberg-rust seeks each delete file's Parquet footer from `file_size_in_bytes`, and the native scan already holds a working FileIO (the one that reads the data files). So the native side can stat the delete file itself, with the same FileIO, instead of trusting a fragile JVM-side HEAD or the manifest value (which is itself untrustworthy, see apache/iceberg#12554). A delete file that genuinely cannot be sized now fails the query loudly instead of being dropped.

## What changes are included in this PR?

- Stop sizing delete files on the JVM side and remove `file_size_in_bytes` from the `IcebergDeleteFile` proto message. A delete file whose path cannot be extracted is now fatal rather than silently skipped.
- Native scan fills each unique delete file's size as the first step of the `FileScanTaskStream`, statting via `FileIO::new_input(path).metadata()` on the iceberg runtime (deduped, concurrent). A stat failure is fatal and surfaces as a query error, never a silent row leak.

## How are these changes tested?

- Native unit tests for `fill_delete_file_sizes`: errors on an unreadable delete file, populates the real size, no-op without deletes.
- `CometIcebergNativeSuite`: existing MOR positional/equality delete tests now exercise the native fill; new tests cover deletes after `rewrite_data_files` compaction and assert that an unreadable delete file fails the scan loudly instead of dropping deletes.
- `IcebergReadFromS3Suite`: MOR-with-deletes over MinIO exercises the fill against an S3 object store.
- Reproduced the original corruption against `main`: a MOR table with three deleted rows whose delete file is then removed from disk returns `COUNT(*) = 20` instead of `17` (deletes silently dropped, only a `WARN`). With this change the same scenario fails loudly instead of returning wrong data.

