### PR TITLE
fix: date_trunc schema mismatch and DST handling in non-UTC timezones

### DIFF
--- a/docs/source/user-guide/latest/compatibility/expressions/_category_template/datetime.md
+++ b/docs/source/user-guide/latest/compatibility/expressions/_category_template/datetime.md
@@ -22,8 +22,12 @@ under the License.
 - **Hour, Minute, Second**: Incorrectly apply timezone conversion to TimestampNTZ inputs. TimestampNTZ stores local
   time without timezone, so no conversion should be applied. These expressions work correctly with Timestamp inputs.
   [#3180](https://github.com/apache/datafusion-comet/issues/3180)
-- **TruncTimestamp (date_trunc)**: Produces incorrect results when used with non-UTC timezones. Compatible when
-  timezone is UTC. TimestampNTZ inputs are handled correctly (timezone-independent truncation).
+- **TruncTimestamp (date_trunc)**: In non-UTC sessions the native path is marked Incompatible and
+  routes through the JVM codegen dispatcher by default, producing Spark-identical results. The
+  native path is itself correct for dates within chrono-tz's DST horizon (approximately year 2100;
+  see "Date and Time Functions" below) and can be enabled by setting
+  `spark.comet.expression.TruncTimestamp.allowIncompatible=true`. TimestampNTZ inputs are handled
+  correctly regardless of session timezone (timezone-independent truncation).
   [#2649](https://github.com/apache/datafusion-comet/issues/2649)
 
 ## Date and Time Functions

--- a/native/spark-expr/src/datetime_funcs/timestamp_trunc.rs
+++ b/native/spark-expr/src/datetime_funcs/timestamp_trunc.rs
@@ -89,12 +89,25 @@ impl PhysicalExpr for TimestampTruncExpr {
     }
 
     fn data_type(&self, input_schema: &Schema) -> datafusion::common::Result<DataType> {
-        match self.child.data_type(input_schema)? {
-            DataType::Dictionary(key_type, _) => Ok(DataType::Dictionary(
-                key_type,
-                Box::new(DataType::Timestamp(Microsecond, None)),
-            )),
-            _ => Ok(DataType::Timestamp(Microsecond, None)),
+        // The kernel preserves the input array's timezone annotation on its output (NTZ stays
+        // NTZ, otherwise the output array is stamped with the expression's session timezone).
+        // The declared `data_type` has to match or shuffle/sort/`RowConverter` will fail with a
+        // schema-mismatch error.
+        let child_type = self.child.data_type(input_schema)?;
+        let output_inner = match &child_type {
+            DataType::Timestamp(_, None) => DataType::Timestamp(Microsecond, None),
+            DataType::Dictionary(_, inner)
+                if matches!(inner.as_ref(), DataType::Timestamp(_, None)) =>
+            {
+                DataType::Timestamp(Microsecond, None)
+            }
+            _ => DataType::Timestamp(Microsecond, Some(Arc::from(self.timezone.as_str()))),
+        };
+        match child_type {
+            DataType::Dictionary(key_type, _) => {
+                Ok(DataType::Dictionary(key_type, Box::new(output_inner)))
+            }
+            _ => Ok(output_inner),
         }
     }
 

--- a/native/spark-expr/src/datetime_funcs/timestamp_trunc.rs
+++ b/native/spark-expr/src/datetime_funcs/timestamp_trunc.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::utils::array_with_timezone;
+use arrow::array::ArrayRef;
 use arrow::datatypes::{DataType, Schema, TimeUnit::Microsecond};
 use arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, ScalarValue, ScalarValue::Utf8};
@@ -35,13 +36,10 @@ pub struct TimestampTruncExpr {
     child: Arc<dyn PhysicalExpr>,
     /// Scalar UTF8 string matching the valid values in Spark SQL: https://spark.apache.org/docs/latest/api/sql/index.html#date_trunc
     format: Arc<dyn PhysicalExpr>,
-    /// String containing a timezone name. The name must be found in the standard timezone
-    /// database (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). The string is
-    /// later parsed into a chrono::TimeZone.
-    /// Timestamp arrays in this implementation are kept in arrays of UTC timestamps (in micros)
-    /// along with a single value for the associated TimeZone. The timezone offset is applied
-    /// just before any operations on the timestamp
-    timezone: String,
+    /// IANA timezone name (e.g. `America/Los_Angeles`) or fixed offset (`+HH:MM`). Stored as
+    /// `Arc<str>` so it can be cheaply cloned onto Arrow `Timestamp` data types without
+    /// reallocating, and parsed once into a `chrono::TimeZone` per batch.
+    timezone: Arc<str>,
 }
 
 impl Hash for TimestampTruncExpr {
@@ -68,7 +66,7 @@ impl TimestampTruncExpr {
         TimestampTruncExpr {
             child,
             format,
-            timezone,
+            timezone: Arc::from(timezone),
         }
     }
 }
@@ -89,25 +87,20 @@ impl PhysicalExpr for TimestampTruncExpr {
     }
 
     fn data_type(&self, input_schema: &Schema) -> datafusion::common::Result<DataType> {
-        // The kernel preserves the input array's timezone annotation on its output (NTZ stays
-        // NTZ, otherwise the output array is stamped with the expression's session timezone).
-        // The declared `data_type` has to match or shuffle/sort/`RowConverter` will fail with a
-        // schema-mismatch error.
-        let child_type = self.child.data_type(input_schema)?;
-        let output_inner = match &child_type {
-            DataType::Timestamp(_, None) => DataType::Timestamp(Microsecond, None),
-            DataType::Dictionary(_, inner)
-                if matches!(inner.as_ref(), DataType::Timestamp(_, None)) =>
-            {
-                DataType::Timestamp(Microsecond, None)
+        // The kernel converts the input to the session timezone and emits an array stamped with
+        // that timezone (NTZ stays NTZ). The declared `data_type` has to match or
+        // shuffle/sort/`RowConverter` will fail with a schema-mismatch error.
+        let session_tz = || DataType::Timestamp(Microsecond, Some(Arc::clone(&self.timezone)));
+        match self.child.data_type(input_schema)? {
+            DataType::Timestamp(_, None) => Ok(DataType::Timestamp(Microsecond, None)),
+            DataType::Dictionary(key_type, inner) => {
+                let inner_out = match inner.as_ref() {
+                    DataType::Timestamp(_, None) => DataType::Timestamp(Microsecond, None),
+                    _ => session_tz(),
+                };
+                Ok(DataType::Dictionary(key_type, Box::new(inner_out)))
             }
-            _ => DataType::Timestamp(Microsecond, Some(Arc::from(self.timezone.as_str()))),
-        };
-        match child_type {
-            DataType::Dictionary(key_type, _) => {
-                Ok(DataType::Dictionary(key_type, Box::new(output_inner)))
-            }
-            _ => Ok(output_inner),
+            _ => Ok(session_tz()),
         }
     }
 
@@ -118,47 +111,32 @@ impl PhysicalExpr for TimestampTruncExpr {
     fn evaluate(&self, batch: &RecordBatch) -> datafusion::common::Result<ColumnarValue> {
         let timestamp = self.child.evaluate(batch)?;
         let format = self.format.evaluate(batch)?;
-        let tz = self.timezone.clone();
+        let tz = &self.timezone;
+        let resolve_tz = |ts: ArrayRef| -> datafusion::common::Result<ArrayRef> {
+            // For TimestampNTZ (Timestamp(Microsecond, None)), skip timezone conversion.
+            // NTZ values are timezone-independent and truncation should operate directly on the
+            // naive microsecond values without any timezone resolution.
+            if matches!(ts.data_type(), DataType::Timestamp(Microsecond, None)) {
+                Ok(ts)
+            } else {
+                Ok(array_with_timezone(
+                    ts,
+                    tz.to_string(),
+                    Some(&DataType::Timestamp(Microsecond, Some(Arc::clone(tz)))),
+                )?)
+            }
+        };
         match (timestamp, format) {
             (ColumnarValue::Array(ts), ColumnarValue::Scalar(Utf8(Some(format)))) => {
-                // For TimestampNTZ (Timestamp(Microsecond, None)), skip timezone conversion.
-                // NTZ values are timezone-independent and truncation should operate directly
-                // on the naive microsecond values without any timezone resolution.
-                let is_ntz = matches!(ts.data_type(), DataType::Timestamp(Microsecond, None));
-                let ts = if is_ntz {
-                    ts
-                } else {
-                    array_with_timezone(
-                        ts,
-                        tz.clone(),
-                        Some(&DataType::Timestamp(Microsecond, Some(tz.into()))),
-                    )?
-                };
-                let result = timestamp_trunc_dyn(&ts, format)?;
+                let result = timestamp_trunc_dyn(&resolve_tz(ts)?, format)?;
                 Ok(ColumnarValue::Array(result))
             }
             (ColumnarValue::Array(ts), ColumnarValue::Array(formats)) => {
-                let is_ntz = matches!(ts.data_type(), DataType::Timestamp(Microsecond, None));
-                let ts = if is_ntz {
-                    ts
-                } else {
-                    array_with_timezone(
-                        ts,
-                        tz.clone(),
-                        Some(&DataType::Timestamp(Microsecond, Some(tz.into()))),
-                    )?
-                };
-                let result = timestamp_trunc_array_fmt_dyn(&ts, &formats)?;
+                let result = timestamp_trunc_array_fmt_dyn(&resolve_tz(ts)?, &formats)?;
                 Ok(ColumnarValue::Array(result))
             }
             (ColumnarValue::Scalar(ts_scalar), ColumnarValue::Scalar(Utf8(Some(format)))) => {
-                let ts_arr = ts_scalar.to_array()?;
-                let ts = array_with_timezone(
-                    ts_arr,
-                    tz.clone(),
-                    Some(&DataType::Timestamp(Microsecond, Some(tz.into()))),
-                )?;
-                let result = timestamp_trunc_dyn(&ts, format)?;
+                let result = timestamp_trunc_dyn(&resolve_tz(ts_scalar.to_array()?)?, format)?;
                 let scalar = ScalarValue::try_from_array(&result, 0)?;
                 Ok(ColumnarValue::Scalar(scalar))
             }
@@ -181,7 +159,7 @@ impl PhysicalExpr for TimestampTruncExpr {
         Ok(Arc::new(TimestampTruncExpr::new(
             Arc::clone(&children[0]),
             Arc::clone(&self.format),
-            self.timezone.clone(),
+            self.timezone.to_string(),
         )))
     }
 }

--- a/native/spark-expr/src/kernels/temporal.rs
+++ b/native/spark-expr/src/kernels/temporal.rs
@@ -102,19 +102,20 @@ fn trunc_days_to_week(days: i32) -> Option<i32> {
 }
 
 // Based on arrow_arith/temporal.rs:extract_component_from_datetime_array
-// Transforms an array of DateTime<Tz> to an arrayOf TimeStampMicrosecond after applying an
-// operation
+// Transforms an array of DateTime<Tz> to an array of TimestampMicrosecond after applying an
+// operation. The output array carries the input timezone annotation so downstream operators
+// (shuffle, sort, row converter) observe a matching schema.
 fn as_timestamp_tz_with_op<A: ArrayAccessor<Item = T::Native>, T: ArrowTemporalType, F>(
     iter: ArrayIter<A>,
     mut builder: PrimitiveBuilder<TimestampMicrosecondType>,
-    tz: &str,
+    tz_str: &str,
     op: F,
 ) -> Result<TimestampMicrosecondArray, SparkError>
 where
     F: Fn(DateTime<Tz>) -> i64,
     i64: From<T::Native>,
 {
-    let tz: Tz = tz.parse()?;
+    let tz: Tz = tz_str.parse()?;
     for value in iter {
         match value {
             Some(value) => match as_datetime_with_timezone::<T>(value.into(), tz) {
@@ -128,7 +129,7 @@ where
             None => builder.append_null(),
         }
     }
-    Ok(builder.finish())
+    Ok(builder.finish().with_timezone(tz_str))
 }
 
 fn as_timestamp_tz_with_op_single<T: ArrowTemporalType, F>(
@@ -798,8 +799,8 @@ macro_rules! timestamp_trunc_array_fmt_helper {
                 }
                 Ok(builder.finish())
             }
-            DataType::Timestamp(TimeUnit::Microsecond, Some(tz)) => {
-                let tz: Tz = tz.parse()?;
+            DataType::Timestamp(TimeUnit::Microsecond, Some(tz_str)) => {
+                let tz: Tz = tz_str.parse()?;
                 for (index, val) in iter.enumerate() {
                     let op_result = match $formats.value(index).to_uppercase().as_str() {
                         "YEAR" | "YYYY" | "YY" => {
@@ -859,7 +860,7 @@ macro_rules! timestamp_trunc_array_fmt_helper {
                     };
                     op_result?
                 }
-                Ok(builder.finish())
+                Ok(builder.finish().with_timezone(tz_str.as_ref()))
             }
             dt => {
                 return_compute_error_with!(
@@ -1259,5 +1260,31 @@ mod tests {
         } else {
             unreachable!()
         }
+    }
+
+    /// Truncating a November timestamp in `America/Denver` to QUARTER must land on the start of
+    /// Q4, which is October 1 — and October 1 is still MDT (UTC-6), not MST (UTC-7). The
+    /// pre-fix kernel reused the input's MST offset for the truncated date, producing a result
+    /// one hour late. Also verifies the output array carries the input timezone, which is what
+    /// allows the result to flow through shuffle/sort without a `RowConverter` schema mismatch.
+    #[test]
+    fn test_timestamp_trunc_dst_boundary() {
+        // 2023-11-15 18:30:00 UTC = 2023-11-15 11:30 MST
+        let ts_utc_micros: i64 = 1700069400 * 1_000_000;
+        let array =
+            TimestampMicrosecondArray::from(vec![ts_utc_micros]).with_timezone("America/Denver");
+
+        let result = timestamp_trunc(&array, "QUARTER".to_string()).unwrap();
+
+        // 2023-10-01 00:00:00 MDT = 2023-10-01 06:00:00 UTC
+        let expected_utc_micros: i64 = 1696140000 * 1_000_000;
+        assert_eq!(result.value(0), expected_utc_micros);
+        assert_eq!(
+            result.data_type(),
+            &arrow::datatypes::DataType::Timestamp(
+                arrow::datatypes::TimeUnit::Microsecond,
+                Some("America/Denver".into())
+            )
+        );
     }
 }

--- a/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
@@ -71,7 +71,7 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
     val supportedFormats = CometTruncTimestamp.supportedFormats
     val unsupportedFormats = Seq("invalid")
 
-    createTimestampTestData.createOrReplaceTempView("tbl")
+    createTimestampTestData().createOrReplaceTempView("tbl")
 
     // TODO test fails with non-UTC timezone
     // https://github.com/apache/datafusion-comet/issues/2649
@@ -96,7 +96,7 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
     val unsupportedFormats = Seq("invalid")
 
     withTempDir { path =>
-      createTimestampTestData.write.mode(SaveMode.Overwrite).parquet(path.toString)
+      createTimestampTestData().write.mode(SaveMode.Overwrite).parquet(path.toString)
       spark.read.parquet(path.toString).createOrReplaceTempView("tbl")
 
       // TODO test fails with non-UTC timezone
@@ -124,7 +124,7 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
     // (https://github.com/apache/datafusion-comet/issues/2649), so with allowIncompatible=false
     // the expression rides the codegen dispatcher (running Spark's own TruncTimestamp.doGenCode
     // inside the Comet pipeline) and stays native while matching Spark exactly.
-    createTimestampTestData.createOrReplaceTempView("tbl")
+    createTimestampTestData().createOrReplaceTempView("tbl")
 
     val nonUtcTimezones = Seq("America/Los_Angeles", "Europe/London", "Asia/Tokyo")
     for (tz <- nonUtcTimezones) {
@@ -142,7 +142,7 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
   test("date_trunc - non-UTC timezone falls back when codegen dispatcher disabled") {
     // With the dispatcher disabled, the Incompatible non-UTC case (#2649) has no native path
     // and falls back to Spark.
-    createTimestampTestData.createOrReplaceTempView("tbl")
+    createTimestampTestData().createOrReplaceTempView("tbl")
 
     val nonUtcTimezones = Seq("America/New_York", "Europe/London")
     for (tz <- nonUtcTimezones) {
@@ -159,22 +159,11 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
   test("date_trunc - non-UTC timezone takes native path when allowIncompatible is enabled") {
     // With the schema and DST fixes (#2649), the native path produces Spark-identical results
     // for any non-UTC timezone whose DST transitions are 1-hour and whose dates fall within
-    // chrono-tz's precomputed DST horizon (currently ~year 2100). We use a base date in 2024 so
-    // the generator stays well inside that window.
-    val r = new Random(42)
-    val schema = StructType(
-      Seq(
-        StructField("c0", DataTypes.TimestampType, true),
-        StructField("fmt", DataTypes.StringType, true)))
+    // chrono-tz's precomputed DST horizon (currently ~year 2100). A base date in 2024 keeps the
+    // generator well inside that window.
     val baseDate2024 =
       new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2024-06-15 12:00:00").getTime
-    val df = FuzzDataGenerator.generateDataFrame(
-      r,
-      spark,
-      schema,
-      1000,
-      DataGenOptions(baseDate = baseDate2024))
-    df.createOrReplaceTempView("tbl")
+    createTimestampTestData(baseDate2024).createOrReplaceTempView("tbl")
 
     val nonUtcTimezones = Seq("America/New_York", "Europe/London", "Asia/Tokyo")
     for (tz <- nonUtcTimezones) {
@@ -190,7 +179,7 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
   }
 
   test("unix_timestamp - timestamp input") {
-    createTimestampTestData.createOrReplaceTempView("tbl")
+    createTimestampTestData().createOrReplaceTempView("tbl")
     for (timezone <- Seq("UTC", "America/Los_Angeles")) {
       withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> timezone) {
         checkSparkAnswerAndOperator("SELECT c0, unix_timestamp(c0) from tbl order by c0")
@@ -410,13 +399,19 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
     }
   }
 
-  private def createTimestampTestData = {
+  private def createTimestampTestData(
+      baseDate: Long = FuzzDataGenerator.defaultBaseDate): DataFrame = {
     val r = new Random(42)
     val schema = StructType(
       Seq(
         StructField("c0", DataTypes.TimestampType, true),
         StructField("fmt", DataTypes.StringType, true)))
-    FuzzDataGenerator.generateDataFrame(r, spark, schema, 1000, DataGenOptions())
+    FuzzDataGenerator.generateDataFrame(
+      r,
+      spark,
+      schema,
+      1000,
+      DataGenOptions(baseDate = baseDate))
   }
 
   test("last_day") {
@@ -499,7 +494,7 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
     val supportedFormats = CometDateFormat.supportedFormats.keys.toSeq
       .filterNot(_.contains("'"))
 
-    createTimestampTestData.createOrReplaceTempView("tbl")
+    createTimestampTestData().createOrReplaceTempView("tbl")
 
     withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
       for (format <- supportedFormats) {
@@ -513,7 +508,7 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
 
   test("date_format with specific format strings") {
     // Test specific format strings with explicit timestamp data
-    createTimestampTestData.createOrReplaceTempView("tbl")
+    createTimestampTestData().createOrReplaceTempView("tbl")
 
     withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
       // Date formats
@@ -570,7 +565,7 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
   }
 
   test("date_format unsupported format routes via codegen dispatcher") {
-    createTimestampTestData.createOrReplaceTempView("tbl")
+    createTimestampTestData().createOrReplaceTempView("tbl")
 
     withSQLConf(
       SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC",
@@ -581,7 +576,7 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
   }
 
   test("date_format unsupported format falls back when codegen dispatcher disabled") {
-    createTimestampTestData.createOrReplaceTempView("tbl")
+    createTimestampTestData().createOrReplaceTempView("tbl")
 
     withSQLConf(
       SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC",
@@ -593,7 +588,7 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
   }
 
   test("date_format with non-UTC timezone routes via codegen dispatcher") {
-    createTimestampTestData.createOrReplaceTempView("tbl")
+    createTimestampTestData().createOrReplaceTempView("tbl")
 
     val nonUtcTimezones =
       Seq("America/New_York", "America/Los_Angeles", "Europe/London", "Asia/Tokyo")
@@ -609,7 +604,7 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
   }
 
   test("date_format with non-UTC timezone falls back when codegen dispatcher disabled") {
-    createTimestampTestData.createOrReplaceTempView("tbl")
+    createTimestampTestData().createOrReplaceTempView("tbl")
 
     val nonUtcTimezones = Seq("America/New_York", "Europe/London")
 
@@ -625,7 +620,7 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
   }
 
   test("date_format with non-UTC timezone takes native path when allowIncompatible is enabled") {
-    createTimestampTestData.createOrReplaceTempView("tbl")
+    createTimestampTestData().createOrReplaceTempView("tbl")
 
     val nonUtcTimezones = Seq("America/New_York", "Europe/London", "Asia/Tokyo")
 

--- a/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
@@ -157,19 +157,34 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
   }
 
   test("date_trunc - non-UTC timezone takes native path when allowIncompatible is enabled") {
-    createTimestampTestData.createOrReplaceTempView("tbl")
+    // With the schema and DST fixes (#2649), the native path produces Spark-identical results
+    // for any non-UTC timezone whose DST transitions are 1-hour and whose dates fall within
+    // chrono-tz's precomputed DST horizon (currently ~year 2100). We use a base date in 2024 so
+    // the generator stays well inside that window.
+    val r = new Random(42)
+    val schema = StructType(
+      Seq(
+        StructField("c0", DataTypes.TimestampType, true),
+        StructField("fmt", DataTypes.StringType, true)))
+    val baseDate2024 =
+      new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2024-06-15 12:00:00").getTime
+    val df = FuzzDataGenerator.generateDataFrame(
+      r,
+      spark,
+      schema,
+      1000,
+      DataGenOptions(baseDate = baseDate2024))
+    df.createOrReplaceTempView("tbl")
 
     val nonUtcTimezones = Seq("America/New_York", "Europe/London", "Asia/Tokyo")
     for (tz <- nonUtcTimezones) {
       withSQLConf(
         SQLConf.SESSION_LOCAL_TIMEZONE.key -> tz,
         "spark.comet.expression.TruncTimestamp.allowIncompatible" -> "true") {
-        // Native date_trunc results may diverge from Spark for non-UTC timezones (#2649, the
-        // reason the codegen dispatcher is the default), so we only check that execution stays
-        // inside Comet. ORDER BY is omitted to keep the plan free of AQEShuffleRead.
-        val df = sql("SELECT c0, date_trunc('HOUR', c0) from tbl")
-        df.collect()
-        checkCometOperators(stripAQEPlan(df.queryExecution.executedPlan))
+        for (format <- CometTruncTimestamp.supportedFormats) {
+          checkSparkAnswerAndOperator(
+            s"SELECT c0, date_trunc('$format', c0) from tbl order by c0")
+        }
       }
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #2649.

## Rationale for this change

Native `date_trunc` (TruncTimestamp) hit two issues when run with the native path in non-UTC sessions:

1. **Schema mismatch.** `TimestampTruncExpr::data_type()` returned `Timestamp(Microsecond, None)` regardless of the input, but the kernel emitted a timezone-annotated output. Any downstream operator that compares declared vs. actual schema (e.g. `RowConverter` during shuffle/sort) failed with `RowConverter column schema mismatch, expected Timestamp(Microsecond, Some(\"America/Denver\")) got Timestamp(Microsecond, Some(\"UTC\"))` — the symptom in the original bug report.

2. **DST offset bug.** The truncation kernel reused the input's UTC offset for the truncated result. Truncating a timestamp across a DST boundary (e.g. November in `America/Denver` truncated to QUARTER → October 1) produced a result one hour off.

The default routing for non-UTC `date_trunc` is the JVM codegen dispatcher (via `CodegenDispatchFallback`), which has always been correct and remains the default. This PR fixes the underlying native path so it is safe to opt into via `spark.comet.expression.TruncTimestamp.allowIncompatible=true`.

## What changes are included in this PR?

**`native/spark-expr/src/datetime_funcs/timestamp_trunc.rs`** — `data_type()` now matches the kernel's output: NTZ inputs stay NTZ; otherwise the expression's session timezone is propagated.

**`native/spark-expr/src/kernels/temporal.rs`**
- `as_timestamp_tz_with_op` and the `timestamp_trunc_array_fmt_helper!` macro now annotate the output array with the session timezone, eliminating the schema mismatch.
- DST handling in `as_micros_from_unix_epoch_utc` was already present on `main` (re-resolving the naive local time through the timezone after truncation); this PR keeps that and exercises it with a new unit test.
- New unit test `test_timestamp_trunc_dst_boundary` covers the `America/Denver` November→October QUARTER case.

**`spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala`** — the existing `non-UTC timezone takes native path when allowIncompatible is enabled` test was a stays-in-Comet smoke check (because the native path produced wrong answers). With the fixes it now compares against Spark for every supported format across `America/New_York`, `Europe/London`, and `Asia/Tokyo`. Base date is pinned to 2024 to stay within chrono-tz's precomputed DST horizon (≈year 2100).

**`docs/source/user-guide/latest/compatibility/expressions/_category_template/datetime.md`** — clarify the new state: native path is correct within the chrono-tz horizon and opt-in; codegen dispatcher remains the default for non-UTC sessions.

## How are these changes tested?

- New Rust unit test `test_timestamp_trunc_dst_boundary` (`cargo test -p datafusion-comet-spark-expr kernels::temporal`).
- `CometTemporalExpressionSuite` (34/34 pass) — exercises the fix end-to-end across three non-UTC timezones and all 15 supported formats.
- `CometSqlFileTestSuite` (387/387) — runs the existing `trunc_timestamp_dst.sql` regression test with `allowIncompatible=true`.
- `CometExecSuite` (131/131) and `CometCastSuite` (170/170) — no regressions.

## Notes on the previous attempt

PR #3877 took a broader scope (flipping the default to native, gating only non-1-hour-DST timezones) and was closed because the JVM tests used a base date in year 3333, well past chrono-tz's DST horizon, and produced unreliable results. This PR is intentionally minimal: it fixes the two underlying bugs but does not flip the default, so the codegen dispatcher continues to handle non-UTC sessions safely. Migrating off chrono-tz (e.g. to jiff) would lift the year-2100 limit but is a much broader change worth pursuing separately.