### PR TITLE
test: migrate curated temporal expression tests to SQL file tests

### DIFF
--- a/spark/src/test/resources/sql-tests/expressions/cast/cast_timestamp_ntz_dst.sql
+++ b/spark/src/test/resources/sql-tests/expressions/cast/cast_timestamp_ntz_dst.sql
@@ -1,0 +1,32 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Europe/London observes DST, so NTZ values that land on the spring-forward gap and the
+-- fall-back overlap exercise the timezone-sensitive NTZ -> Timestamp cast. The native path
+-- must resolve these the same way Spark does.
+-- Config: spark.sql.session.timeZone=Europe/London
+
+statement
+CREATE TABLE test_ntz_dst(ts_ntz timestamp_ntz) USING parquet
+
+statement
+INSERT INTO test_ntz_dst VALUES
+  (cast('2024-03-31 01:30:00' as timestamp_ntz)),
+  (cast('2024-10-27 01:30:00' as timestamp_ntz))
+
+query
+SELECT ts_ntz, cast(ts_ntz as timestamp) FROM test_ntz_dst ORDER BY ts_ntz

--- a/spark/src/test/resources/sql-tests/expressions/datetime/date_format.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/date_format.sql
@@ -39,3 +39,19 @@ SELECT date_format(ts, 'yyyy-MM-dd HH:mm:ss') FROM test_date_format
 -- literal arguments
 query
 SELECT date_format(timestamp('2024-06-15 10:30:45'), 'yyyy-MM-dd')
+
+query
+SELECT date_format(timestamp('2024-03-15 14:30:45'), 'yyyy-MM-dd HH:mm:ss')
+
+query
+SELECT date_format(timestamp('2024-03-15 14:30:45'), 'HH:mm:ss')
+
+query
+SELECT date_format(timestamp('2024-03-15 14:30:45'), 'EEEE')
+
+query
+SELECT date_format(timestamp('2024-03-15 14:30:45'), 'hh:mm:ss a')
+
+-- null input
+query
+SELECT date_format(cast(NULL as timestamp), 'yyyy-MM-dd')

--- a/spark/src/test/resources/sql-tests/expressions/datetime/unix_timestamp.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/unix_timestamp.sql
@@ -27,3 +27,16 @@ SELECT unix_timestamp(ts) FROM test_unix_ts
 -- literal arguments
 query ignore(https://github.com/apache/datafusion-comet/issues/3336)
 SELECT unix_timestamp(timestamp('1970-01-01 00:00:00')), unix_timestamp(timestamp('2024-06-15 10:30:45'))
+
+-- String input is not supported by the native unix_timestamp, so the expression falls back to Spark.
+statement
+CREATE TABLE test_unix_ts_str(ts_str string) USING parquet
+
+statement
+INSERT INTO test_unix_ts_str VALUES ('2020-01-01 00:00:00'), ('2021-06-15 12:30:45'), ('2022-12-31 23:59:59'), (NULL)
+
+query expect_fallback(unix_timestamp does not support input type: StringType)
+SELECT ts_str, unix_timestamp(ts_str) FROM test_unix_ts_str ORDER BY ts_str
+
+query expect_fallback(unix_timestamp does not support input type: StringType)
+SELECT ts_str, unix_timestamp(ts_str, 'yyyy-MM-dd HH:mm:ss') FROM test_unix_ts_str ORDER BY ts_str

--- a/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
@@ -374,31 +374,6 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
     }
   }
 
-  test("unix_timestamp - string input falls back to Spark") {
-    withTempView("string_tbl") {
-      // Create test data with timestamp strings
-      val schema = StructType(Seq(StructField("ts_str", DataTypes.StringType, true)))
-      val data = Seq(
-        Row("2020-01-01 00:00:00"),
-        Row("2021-06-15 12:30:45"),
-        Row("2022-12-31 23:59:59"),
-        Row(null))
-      spark
-        .createDataFrame(spark.sparkContext.parallelize(data), schema)
-        .createOrReplaceTempView("string_tbl")
-
-      // String input should fall back to Spark
-      checkSparkAnswerAndFallbackReason(
-        "SELECT ts_str, unix_timestamp(ts_str) from string_tbl order by ts_str",
-        "unix_timestamp does not support input type: StringType")
-
-      // String input with custom format should also fall back
-      checkSparkAnswerAndFallbackReason(
-        "SELECT ts_str, unix_timestamp(ts_str, 'yyyy-MM-dd HH:mm:ss') from string_tbl",
-        "unix_timestamp does not support input type: StringType")
-    }
-  }
-
   private def createTimestampTestData(
       baseDate: Long = FuzzDataGenerator.defaultBaseDate): DataFrame = {
     val r = new Random(42)
@@ -533,34 +508,6 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
       // ISO format (use double single-quotes to escape the literal T)
       checkSparkAnswerAndOperator(
         "SELECT c0, date_format(c0, \"yyyy-MM-dd'T'HH:mm:ss\") from tbl order by c0")
-    }
-  }
-
-  test("date_format with literal timestamp") {
-    // Test specific literal timestamp formats
-    // Disable constant folding to ensure Comet actually executes the expression
-    withSQLConf(
-      SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC",
-      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-        "org.apache.spark.sql.catalyst.optimizer.ConstantFolding") {
-      checkSparkAnswerAndOperator(
-        "SELECT date_format(TIMESTAMP '2024-03-15 14:30:45', 'yyyy-MM-dd')")
-      checkSparkAnswerAndOperator(
-        "SELECT date_format(TIMESTAMP '2024-03-15 14:30:45', 'yyyy-MM-dd HH:mm:ss')")
-      checkSparkAnswerAndOperator(
-        "SELECT date_format(TIMESTAMP '2024-03-15 14:30:45', 'HH:mm:ss')")
-      checkSparkAnswerAndOperator("SELECT date_format(TIMESTAMP '2024-03-15 14:30:45', 'EEEE')")
-      checkSparkAnswerAndOperator(
-        "SELECT date_format(TIMESTAMP '2024-03-15 14:30:45', 'hh:mm:ss a')")
-    }
-  }
-
-  test("date_format with null") {
-    withSQLConf(
-      SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC",
-      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-        "org.apache.spark.sql.catalyst.optimizer.ConstantFolding") {
-      checkSparkAnswerAndOperator("SELECT date_format(CAST(NULL AS TIMESTAMP), 'yyyy-MM-dd')")
     }
   }
 
@@ -804,19 +751,4 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
       expectedDF)
   }
 
-  test("cast TimestampNTZ to Timestamp - DST edge cases") {
-    val data = Seq(
-      Row(java.time.LocalDateTime.parse("2024-03-31T01:30:00")), // Spring forward (Europe/London)
-      Row(java.time.LocalDateTime.parse("2024-10-27T01:30:00")) // Fall back (Europe/London)
-    )
-    val schema = StructType(Seq(StructField("ts_ntz", DataTypes.TimestampNTZType, true)))
-    spark
-      .createDataFrame(spark.sparkContext.parallelize(data), schema)
-      .createOrReplaceTempView("dst_tbl")
-
-    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "Europe/London") {
-      checkSparkAnswerAndOperator(
-        "SELECT ts_ntz, CAST(ts_ntz AS TIMESTAMP) FROM dst_tbl ORDER BY ts_ntz")
-    }
-  }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Follows up on review feedback from #4761, where @comphead suggested moving the temporal expression suite to the SQL file test framework.

## Rationale for this change

`CometTemporalExpressionSuite` contains several tests whose value is fully expressible in the SQL file test framework (curated/literal inputs, fallback-reason checks). Those read more clearly as SQL fixtures and live alongside the other datetime/cast fixtures, so this PR migrates that subset and removes the now-redundant Scala versions.

The migration is intentionally focused. Many tests in the suite cannot be faithfully expressed as SQL fixtures and are left in place:

- Fuzz-based correctness tests (`last_day`, `datediff`, `unix_date`, the `date_trunc` / `date_format` column tests) rely on 1000-row random data that SQL fixtures cannot replicate.
- `days` / `hours` tests build `Days` / `Hours`, which are `Unevaluable` partition-transform expressions not reachable through SQL.
- The `allowIncompatible`-enabled tests verify only that execution stays native (they intentionally skip answer comparison because the native result may diverge from Spark). The SQL framework has no operator-only assertion mode.

## What changes are included in this PR?

Migrated to SQL file tests and removed from `CometTemporalExpressionSuite`:

- `unix_timestamp` string-input fallback to `datetime/unix_timestamp.sql` (via `query expect_fallback(...)`)
- `date_format` literal and null inputs to `datetime/date_format.sql`
- `cast TimestampNTZ to Timestamp` DST edge cases to new `cast/cast_timestamp_ntz_dst.sql` (Europe/London spring-forward gap and fall-back overlap)

The suite drops from 34 to 30 tests.

## How are these changes tested?

- `CometSqlFileTestSuite` runs the migrated fixtures (`unix_timestamp.sql`, `date_format.sql`, and the new `cast_timestamp_ntz_dst.sql`); all pass.
- `CometTemporalExpressionSuite` (30/30) continues to pass.
