### PR TITLE
docs: triage bug vs enhancement and apply type labels consistently

### DIFF
--- a/.claude/skills/bug-triage/SKILL.md
+++ b/.claude/skills/bug-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bug-triage
-description: Triage open Comet issues marked `requires-triage` per the project bug triage guide. Applies the recommended priority and area labels, removes `requires-triage`, and files a dated summary issue listing what was done. A human reviews the summary issue and closes it when satisfied.
+description: Triage open Comet issues marked `requires-triage` per the project bug triage guide. Classifies each issue as a bug or an enhancement, applies the recommended type (`bug`/`enhancement`), priority, and area labels, removes `requires-triage`, and files a dated summary issue listing what was done. A human reviews the summary issue and closes it when satisfied.
 ---
 
 <!--
@@ -29,10 +29,16 @@ Run a bug triage pass for the `apache/datafusion-comet` repository.
 This skill triages every open issue carrying the `requires-triage` label. For
 each one it:
 
-1. Decides a priority and area labels using the project's triage guide.
-2. Applies those labels via `gh`.
-3. Removes the `requires-triage` label.
-4. Records the decision (with rationale) in a single dated summary issue.
+1. Decides whether the issue is a bug or an enhancement (feature request).
+2. Decides a priority (bugs only) and area labels using the project's triage
+   guide.
+3. Applies those labels via `gh` (`bug` or `enhancement`, plus priority/area),
+   ensuring `bug` and `enhancement` are never both present.
+4. Removes the `requires-triage` label.
+5. Records the decision (with rationale) in a single dated summary issue.
+
+`requires-triage` is auto-applied to **every** new issue, not just bug reports,
+so the first decision for each issue is always bug vs. enhancement.
 
 A human reviewer reads the summary issue, sanity-checks the calls, and closes
 it when satisfied. Any label correction is done by the reviewer directly on the
@@ -74,26 +80,42 @@ file an empty summary issue and do not modify any labels.
 
 For each issue, review the title and body and determine:
 
-1. **Priority label** (exactly one): apply the decision tree from the guide.
+1. **Type label** (exactly one of `bug` / `enhancement`):
+   - `bug`: something is broken. Wrong results, crashes, panics, regressions,
+     test/CI failures, or any behavior that differs from what Comet should do.
+   - `enhancement`: a request for new functionality or improvement that is not
+     yet expected to work. New expression/operator support, a new config, a
+     performance optimization request, a refactor, or a docs addition.
+   - Do not rely on the title wording alone. An issue titled "bug: ..." may
+     actually be a feature request, and an issue with no "bug" in the title may
+     be a genuine defect. Classify from the actual content.
+   - A bug and an enhancement are mutually exclusive: an issue must never carry
+     both `bug` and `enhancement`. If the issue already has the wrong type label,
+     remove it (see Step 5).
+2. **Priority label** (exactly one, **bugs only**): apply the decision tree from
+   the guide.
    - `priority:critical` for correctness issues (silent wrong results, data
      corruption) and security vulnerabilities
    - `priority:high` for crashes, panics, segfaults, NPEs on supported paths
    - `priority:medium` for functional bugs / performance regressions with
      workarounds
    - `priority:low` for test-only, CI flakes, tooling, cosmetic
-2. **Area labels** (zero or more): from the area table in the guide
+3. **Area labels** (zero or more): from the area table in the guide
    (`area:writer`, `area:shuffle`, `area:aggregation`, `area:scan`,
    `area:expressions`, `area:ffi`, `area:ci`) plus the pre-existing area
-   indicators (`spark 4`, `spark sql tests`).
-3. **Escalation note**: if the issue matches an escalation trigger from the
+   indicators (`spark 4`, `spark sql tests`). Area labels apply to both bugs
+   and enhancements.
+4. **Escalation note**: if the issue matches an escalation trigger from the
    guide (e.g., a `priority:high` crash that may also produce wrong results),
    note it in the summary.
 
 ## Step 4: Skip Issues You Cannot Confidently Classify
 
-If an issue lacks reproduction steps or is otherwise too ambiguous to classify
-with confidence:
+If an issue is too ambiguous to classify with confidence (you cannot tell
+whether it is a bug or an enhancement, or a bug lacks reproduction steps and the
+priority is unclear):
 
+- **Do not** apply a type label (`bug`/`enhancement`).
 - **Do not** apply a priority label.
 - **Do not** remove `requires-triage`.
 - **Do not** comment on the issue or ask the reporter for more info from this
@@ -106,17 +128,35 @@ Guessing is worse than skipping.
 ## Step 5: Apply Labels
 
 For each issue you classified in Step 3, apply the labels and remove
-`requires-triage` in a single `gh` call:
+`requires-triage` in a single `gh` call.
+
+For a bug, add the `bug` type label and a priority label:
 
 ```bash
 gh issue edit <NUMBER> \
   --repo apache/datafusion-comet \
-  --add-label "priority:high,area:expressions" \
-  --remove-label "requires-triage"
+  --add-label "bug,priority:high,area:expressions" \
+  --remove-label "requires-triage,enhancement"
+```
+
+For an enhancement, add the `enhancement` type label and no priority label:
+
+```bash
+gh issue edit <NUMBER> \
+  --repo apache/datafusion-comet \
+  --add-label "enhancement,area:expressions" \
+  --remove-label "requires-triage,bug"
 ```
 
 Notes:
 
+- Always set exactly one type label. Add `bug` for bugs, `enhancement` for
+  enhancements.
+- Always remove the opposite type label so an issue never carries both `bug`
+  and `enhancement`. `--remove-label` is a no-op if the label is not present,
+  so it is safe to remove the opposite type unconditionally.
+- Apply a priority label only to bugs. Do not add a priority label to
+  enhancements.
 - Pass the labels as a single comma-separated string (no spaces around commas).
 - Quote labels that contain spaces (e.g., `"spark 4"`).
 - Only add labels that already exist in the repo. If a label from the guide is
@@ -141,11 +181,12 @@ Title: `Bug triage results: ${TRIAGE_DATE}`
 Body: a markdown report with these sections, in this order:
 
 1. **Header**
-   - Date, total issues processed, and counts per priority
+   - Date, total issues processed, count of bugs vs. enhancements, and counts
+     per priority
    - Link to `docs/source/contributor-guide/bug_triage.md`
    - Note that labels have already been applied; the reviewer should spot-check
      and close this issue when satisfied
-2. **Triaged** — one subsection per priority, ordered highest priority first
+2. **Bugs** — one subsection per priority, ordered highest priority first
    (`priority:critical`, then `priority:high`, then `priority:medium`, then
    `priority:low`). Omit any subsection whose count is zero. Do **not** use a
    markdown table anywhere in this section; use nested bullet lists only.
@@ -162,14 +203,17 @@ Body: a markdown report with these sections, in this order:
 
    The issue number (not the title) is the link target. The title is plain
    text. If there are no area labels, write `Area labels: none`.
-
-3. **Escalations to consider** (omit section if empty) — bullet per issue with
+3. **Enhancements** (omit section if empty) — one top-level bullet per issue in
+   the same `<title> ([#N](url))` form, with an `Area labels:` sub-bullet and a
+   one-sentence rationale for classifying it as an enhancement. Enhancements
+   have no priority subsections.
+4. **Escalations to consider** (omit section if empty) — bullet per issue with
    the same `<title> ([#N](url))` form, plus a sub-bullet explaining the
    trigger from the guide.
-4. **Skipped — needs more info** (omit if empty) — bullet per issue with the
+5. **Skipped — needs more info** (omit if empty) — bullet per issue with the
    same `<title> ([#N](url))` form, plus a sub-bullet explaining what is
    missing.
-5. **Failed to label** (omit if empty) — bullet per issue with the same
+6. **Failed to label** (omit if empty) — bullet per issue with the same
    `<title> ([#N](url))` form, plus a sub-bullet quoting the `gh` error.
 
 File the issue with `gh`. Use a temp file for the body to keep quoting sane:

--- a/.claude/skills/bug-triage/SKILL.md
+++ b/.claude/skills/bug-triage/SKILL.md
@@ -203,6 +203,7 @@ Body: a markdown report with these sections, in this order:
 
    The issue number (not the title) is the link target. The title is plain
    text. If there are no area labels, write `Area labels: none`.
+
 3. **Enhancements** (omit section if empty) — one top-level bullet per issue in
    the same `<title> ([#N](url))` form, with an `Area labels:` sub-bullet and a
    one-sentence rationale for classifying it as an enhancement. Enhancements

--- a/docs/source/contributor-guide/bug_triage.md
+++ b/docs/source/contributor-guide/bug_triage.md
@@ -23,6 +23,25 @@ This guide describes how we prioritize and triage bugs in the Comet project. The
 that the most impactful bugs — especially correctness issues that produce wrong results — are
 identified and addressed before less critical issues.
 
+## Type Labels
+
+Every new issue is auto-labeled with `requires-triage`, and this applies to **all** issues, not
+just bug reports. The first triage decision for any issue is therefore whether it is a bug or an
+enhancement.
+
+| Label         | Description                                                                                        |
+| ------------- | -------------------------------------------------------------------------------------------------- |
+| `bug`         | Something is broken: wrong results, crashes, panics, regressions, test/CI failures                 |
+| `enhancement` | A request for new functionality or improvement: new expression/operator support, a new config, performance optimization, refactoring, or documentation |
+
+Apply exactly one of these to every triaged issue. An issue must never carry both `bug` and
+`enhancement`. Classify from the actual content of the issue, not from the title wording: an issue
+titled "bug: ..." may really be a feature request, and a genuine defect may not mention "bug" in
+its title at all.
+
+Only bugs receive a priority label (see below). Enhancements are not assigned a priority label
+through this process. Both bugs and enhancements may receive area labels.
+
 ## Priority Labels
 
 Every bug should have exactly one priority label. When filing or triaging a bug, apply the
@@ -83,16 +102,18 @@ been triaged, remove the `requires-triage` label and apply the appropriate prior
 
 ### For New Issues
 
-When a new bug is filed:
+When a new issue is filed:
 
-1. **Reproduce or verify** the issue if possible. If the report lacks reproduction steps, ask
+1. **Decide bug or enhancement.** Apply `bug` or `enhancement` based on the content of the issue.
+   The remaining steps about priority apply only to bugs.
+2. **Reproduce or verify** the issue if possible. If the report lacks reproduction steps, ask
    the reporter for more details.
-2. **Assess correctness impact first.** Ask: "Could this produce wrong results silently?" This
+3. **Assess correctness impact first.** Ask: "Could this produce wrong results silently?" This
    is more important than whether it crashes.
-3. **Apply a priority label** using the decision tree above.
-4. **Apply area labels** to indicate the affected subsystem(s).
-5. **Apply `good first issue`** if the fix is likely straightforward and well-scoped.
-6. **Remove the `requires-triage` label** to indicate triage is complete.
+4. **Apply a priority label** using the decision tree above (bugs only).
+5. **Apply area labels** to indicate the affected subsystem(s).
+6. **Apply `good first issue`** if the fix is likely straightforward and well-scoped.
+7. **Remove the `requires-triage` label** to indicate triage is complete.
 
 ### For Existing Bugs
 

--- a/docs/source/contributor-guide/bug_triage.md
+++ b/docs/source/contributor-guide/bug_triage.md
@@ -29,9 +29,9 @@ Every new issue is auto-labeled with `requires-triage`, and this applies to **al
 just bug reports. The first triage decision for any issue is therefore whether it is a bug or an
 enhancement.
 
-| Label         | Description                                                                                        |
-| ------------- | -------------------------------------------------------------------------------------------------- |
-| `bug`         | Something is broken: wrong results, crashes, panics, regressions, test/CI failures                 |
+| Label         | Description                                                                                                                                            |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `bug`         | Something is broken: wrong results, crashes, panics, regressions, test/CI failures                                                                     |
 | `enhancement` | A request for new functionality or improvement: new expression/operator support, a new config, performance optimization, refactoring, or documentation |
 
 Apply exactly one of these to every triaged issue. An issue must never carry both `bug` and


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A. This is a small documentation and tooling change to the triage process.

## Rationale for this change

The `requires-triage` label is auto-applied to every new issue, not just bug reports. The bug triage guide and the `bug-triage` skill, however, only described assigning priority and area labels, implicitly treating every triaged issue as a bug. As a result the `bug` label was applied inconsistently and was sometimes present on issues that are really feature requests. This makes the first triage decision explicit: classify each issue as a bug or an enhancement, and apply the matching type label.

## What changes are included in this PR?

- `docs/source/contributor-guide/bug_triage.md`: add a "Type Labels" section describing the `bug` and `enhancement` labels and the rule that an issue must never carry both, that the type is decided from issue content rather than title wording, and that only bugs receive a priority label. The "For New Issues" steps now start with the bug-vs-enhancement decision.
- `.claude/skills/bug-triage/SKILL.md`: the triage pass now classifies each issue as a bug or an enhancement first, applies `bug` (plus a priority) or `enhancement` (no priority), always removes the opposite type label so the two are mutually exclusive, and reports bugs and enhancements separately in the summary issue.

## How are these changes tested?

Documentation and skill-instruction changes only; there is no code to test. The `gh` label commands in the skill use labels that already exist in the repository (`bug`, `enhancement`, the `priority:*` and `area:*` labels).
