### PR TITLE
fix: Support scalar inputs for datetime expressions when constant folding is disabled

### DIFF
--- a/native/spark-expr/src/datetime_funcs/extract_date_part.rs
+++ b/native/spark-expr/src/datetime_funcs/extract_date_part.rs
@@ -18,7 +18,7 @@
 use crate::utils::array_with_timezone;
 use arrow::compute::{date_part, DatePart};
 use arrow::datatypes::{DataType, TimeUnit::Microsecond};
-use datafusion::common::{internal_datafusion_err, DataFusionError};
+use datafusion::common::{internal_datafusion_err, ScalarValue};
 use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
@@ -82,9 +82,26 @@ macro_rules! extract_date_part {
                         let result = date_part(&array, DatePart::$date_part_variant)?;
                         Ok(ColumnarValue::Array(result))
                     }
-                    _ => Err(DataFusionError::Execution(
-                        concat!($fn_name, "(scalar) should be fold in Spark JVM side.").to_string(),
-                    )),
+                    [ColumnarValue::Scalar(scalar)] => {
+                        // When Spark's ConstantFolding is disabled, literal-only expressions like
+                        // hour can reach the native engine as scalar inputs.
+                        // Instead of failing and requiring JVM folding, we evaluate the scalar
+                        // natively by broadcasting it to a single-element array and then
+                        // converting the result back to a scalar.
+                        let array = scalar.clone().to_array_of_size(1)?;
+                        let array = array_with_timezone(
+                            array,
+                            self.timezone.clone(),
+                            Some(&DataType::Timestamp(
+                                Microsecond,
+                                Some(self.timezone.clone().into()),
+                            )),
+                        )?;
+                        let result = date_part(&array, DatePart::$date_part_variant)?;
+                        let scalar_result = ScalarValue::try_from_array(&result, 0)?;
+
+                        Ok(ColumnarValue::Scalar(scalar_result))
+                    }
                 }
             }
 

--- a/native/spark-expr/src/datetime_funcs/unix_timestamp.rs
+++ b/native/spark-expr/src/datetime_funcs/unix_timestamp.rs
@@ -19,7 +19,7 @@ use crate::utils::array_with_timezone;
 use arrow::array::{Array, AsArray, PrimitiveArray};
 use arrow::compute::cast;
 use arrow::datatypes::{DataType, Int64Type, TimeUnit::Microsecond};
-use datafusion::common::{internal_datafusion_err, DataFusionError};
+use datafusion::common::{internal_datafusion_err, DataFusionError, ScalarValue};
 use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
@@ -73,105 +73,130 @@ impl ScalarUDFImpl for SparkUnixTimestamp {
             .map_err(|_| internal_datafusion_err!("unix_timestamp expects exactly one argument"))?;
 
         match args {
-            [ColumnarValue::Array(array)] => match array.data_type() {
-                DataType::Timestamp(Microsecond, None) => {
-                    // TimestampNTZ: No timezone conversion needed - simply divide microseconds
-                    // by MICROS_PER_SECOND. TimestampNTZ stores local time without timezone.
-                    let timestamp_array =
-                        array.as_primitive::<arrow::datatypes::TimestampMicrosecondType>();
+            [ColumnarValue::Array(array)] => self.eval_array(&array),
+            [ColumnarValue::Scalar(scalar)] => {
+                // When Spark's ConstantFolding is disabled, literal-only expressions like
+                // unix_timestamp can reach the native engine
+                // as scalar inputs. Evaluate the scalar natively by broadcasting it to a
+                // single-element array and converting the result back to a scalar.
+                let array = scalar.clone().to_array_of_size(1)?;
+                let result = self.eval_array(&array)?;
 
-                    let result: PrimitiveArray<Int64Type> = if timestamp_array.null_count() == 0 {
-                        timestamp_array
-                            .values()
-                            .iter()
-                            .map(|&micros| div_floor(micros, MICROS_PER_SECOND))
-                            .collect()
-                    } else {
-                        timestamp_array
-                            .iter()
-                            .map(|v| v.map(|micros| div_floor(micros, MICROS_PER_SECOND)))
-                            .collect()
-                    };
+                let result_array = match result {
+                    ColumnarValue::Array(array) => array,
+                    ColumnarValue::Scalar(_) => {
+                        return Err(DataFusionError::Internal(
+                            "unix_timestamp: expected array result from eval_array".to_string(),
+                        ))
+                    }
+                };
 
-                    Ok(ColumnarValue::Array(Arc::new(result)))
-                }
-                DataType::Timestamp(_, _) => {
-                    let is_utc = self.timezone == "UTC";
-                    let array = if is_utc
-                        && matches!(array.data_type(), DataType::Timestamp(Microsecond, Some(tz)) if tz.as_ref() == "UTC")
-                    {
-                        array
-                    } else {
-                        array_with_timezone(
-                            array,
-                            self.timezone.clone(),
-                            Some(&DataType::Timestamp(Microsecond, Some("UTC".into()))),
-                        )?
-                    };
+                let scalar_result = ScalarValue::try_from_array(&result_array, 0)?;
 
-                    let timestamp_array =
-                        array.as_primitive::<arrow::datatypes::TimestampMicrosecondType>();
-
-                    let result: PrimitiveArray<Int64Type> = if timestamp_array.null_count() == 0 {
-                        timestamp_array
-                            .values()
-                            .iter()
-                            .map(|&micros| div_floor(micros, MICROS_PER_SECOND))
-                            .collect()
-                    } else {
-                        timestamp_array
-                            .iter()
-                            .map(|v| v.map(|micros| div_floor(micros, MICROS_PER_SECOND)))
-                            .collect()
-                    };
-
-                    Ok(ColumnarValue::Array(Arc::new(result)))
-                }
-                DataType::Date32 => {
-                    let timestamp_array = cast(&array, &DataType::Timestamp(Microsecond, None))?;
-
-                    let is_utc = self.timezone == "UTC";
-                    let array = if is_utc {
-                        timestamp_array
-                    } else {
-                        array_with_timezone(
-                            timestamp_array,
-                            self.timezone.clone(),
-                            Some(&DataType::Timestamp(Microsecond, Some("UTC".into()))),
-                        )?
-                    };
-
-                    let timestamp_array =
-                        array.as_primitive::<arrow::datatypes::TimestampMicrosecondType>();
-
-                    let result: PrimitiveArray<Int64Type> = if timestamp_array.null_count() == 0 {
-                        timestamp_array
-                            .values()
-                            .iter()
-                            .map(|&micros| micros / MICROS_PER_SECOND)
-                            .collect()
-                    } else {
-                        timestamp_array
-                            .iter()
-                            .map(|v| v.map(|micros| div_floor(micros, MICROS_PER_SECOND)))
-                            .collect()
-                    };
-
-                    Ok(ColumnarValue::Array(Arc::new(result)))
-                }
-                _ => Err(DataFusionError::Execution(format!(
-                    "unix_timestamp does not support input type: {:?}",
-                    array.data_type()
-                ))),
-            },
-            _ => Err(DataFusionError::Execution(
-                "unix_timestamp(scalar) should be fold in Spark JVM side.".to_string(),
-            )),
+                Ok(ColumnarValue::Scalar(scalar_result))
+            }
         }
     }
 
     fn aliases(&self) -> &[String] {
         &self.aliases
+    }
+}
+
+impl SparkUnixTimestamp {
+    fn eval_array(&self, array: &Arc<dyn Array>) -> datafusion::common::Result<ColumnarValue> {
+        match array.data_type() {
+            DataType::Timestamp(Microsecond, None) => {
+                // TimestampNTZ: No timezone conversion needed - simply divide microseconds
+                // by MICROS_PER_SECOND. TimestampNTZ stores local time without timezone.
+                let timestamp_array =
+                    array.as_primitive::<arrow::datatypes::TimestampMicrosecondType>();
+
+                let result: PrimitiveArray<Int64Type> = if timestamp_array.null_count() == 0 {
+                    timestamp_array
+                        .values()
+                        .iter()
+                        .map(|&micros| div_floor(micros, MICROS_PER_SECOND))
+                        .collect()
+                } else {
+                    timestamp_array
+                        .iter()
+                        .map(|v| v.map(|micros| div_floor(micros, MICROS_PER_SECOND)))
+                        .collect()
+                };
+
+                Ok(ColumnarValue::Array(Arc::new(result)))
+            }
+            DataType::Timestamp(_, _) => {
+                let is_utc = self.timezone == "UTC";
+                let array = if is_utc
+                    && matches!(array.data_type(), DataType::Timestamp(Microsecond, Some(tz)) if tz.as_ref() == "UTC")
+                {
+                    Arc::clone(array)
+                } else {
+                    array_with_timezone(
+                        Arc::clone(array),
+                        self.timezone.clone(),
+                        Some(&DataType::Timestamp(Microsecond, Some("UTC".into()))),
+                    )?
+                };
+
+                let timestamp_array =
+                    array.as_primitive::<arrow::datatypes::TimestampMicrosecondType>();
+
+                let result: PrimitiveArray<Int64Type> = if timestamp_array.null_count() == 0 {
+                    timestamp_array
+                        .values()
+                        .iter()
+                        .map(|&micros| div_floor(micros, MICROS_PER_SECOND))
+                        .collect()
+                } else {
+                    timestamp_array
+                        .iter()
+                        .map(|v| v.map(|micros| div_floor(micros, MICROS_PER_SECOND)))
+                        .collect()
+                };
+
+                Ok(ColumnarValue::Array(Arc::new(result)))
+            }
+            DataType::Date32 => {
+                let timestamp_array =
+                    cast(array.as_ref(), &DataType::Timestamp(Microsecond, None))?;
+
+                let is_utc = self.timezone == "UTC";
+                let array = if is_utc {
+                    timestamp_array
+                } else {
+                    array_with_timezone(
+                        timestamp_array,
+                        self.timezone.clone(),
+                        Some(&DataType::Timestamp(Microsecond, Some("UTC".into()))),
+                    )?
+                };
+
+                let timestamp_array =
+                    array.as_primitive::<arrow::datatypes::TimestampMicrosecondType>();
+
+                let result: PrimitiveArray<Int64Type> = if timestamp_array.null_count() == 0 {
+                    timestamp_array
+                        .values()
+                        .iter()
+                        .map(|&micros| micros / MICROS_PER_SECOND)
+                        .collect()
+                } else {
+                    timestamp_array
+                        .iter()
+                        .map(|v| v.map(|micros| div_floor(micros, MICROS_PER_SECOND)))
+                        .collect()
+                };
+
+                Ok(ColumnarValue::Array(Arc::new(result)))
+            }
+            _ => Err(DataFusionError::Execution(format!(
+                "unix_timestamp does not support input type: {:?}",
+                array.data_type()
+            ))),
+        }
     }
 }
 

--- a/spark/src/test/resources/sql-tests/expressions/datetime/hour.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/hour.sql
@@ -25,7 +25,7 @@ query
 SELECT hour(ts) FROM test_hour
 
 -- literal arguments
-query ignore(https://github.com/apache/datafusion-comet/issues/3336)
+query
 SELECT hour(timestamp('2024-01-15 00:00:00')), hour(timestamp('2024-01-15 12:30:45')), hour(timestamp('2024-01-15 23:59:59'))
 
 -- TimestampNTZ: the native impl is Incompatible for TimestampNTZType (#3180), so this is routed

--- a/spark/src/test/resources/sql-tests/expressions/datetime/minute.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/minute.sql
@@ -25,7 +25,7 @@ query
 SELECT minute(ts) FROM test_minute
 
 -- literal arguments
-query ignore(https://github.com/apache/datafusion-comet/issues/3336)
+query
 SELECT minute(timestamp('2024-01-15 10:00:00')), minute(timestamp('2024-01-15 10:30:00')), minute(timestamp('2024-01-15 10:59:59'))
 
 -- TimestampNTZ: the native impl is Incompatible for TimestampNTZType (#3180), so this is routed

--- a/spark/src/test/resources/sql-tests/expressions/datetime/second.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/second.sql
@@ -25,7 +25,7 @@ query
 SELECT second(ts) FROM test_second
 
 -- literal arguments
-query ignore(https://github.com/apache/datafusion-comet/issues/3336)
+query
 SELECT second(timestamp('2024-01-15 10:30:00')), second(timestamp('2024-01-15 10:30:30')), second(timestamp('2024-01-15 10:30:59'))
 
 -- TimestampNTZ: the native impl is Incompatible for TimestampNTZType (#3180), so this is routed

--- a/spark/src/test/resources/sql-tests/expressions/datetime/unix_timestamp.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/unix_timestamp.sql
@@ -25,5 +25,5 @@ query
 SELECT unix_timestamp(ts) FROM test_unix_ts
 
 -- literal arguments
-query ignore(https://github.com/apache/datafusion-comet/issues/3336)
+query
 SELECT unix_timestamp(timestamp('1970-01-01 00:00:00')), unix_timestamp(timestamp('2024-06-15 10:30:45'))


### PR DESCRIPTION
## Which issue does this PR close?

Closes #3336

This continues the work in #3448 by @0lai0, rebased onto current `main` with the merge conflicts in `unix_timestamp.rs` resolved (the file gained a `TimestampNTZ` branch and `div_floor` handling on `main` since that PR was opened). The original commit authorship is preserved.

## Rationale for this change

When Spark's `ConstantFolding` rule is disabled, all-literal datetime expressions such as `hour(timestamp('2024-01-15 12:30:45'))` reach Comet's native engine as `ColumnarValue::Scalar` instead of being folded away in the JVM. The native engine had no scalar match arm for these functions and returned `"<expr>(scalar) should be fold in Spark JVM side."`, failing the query.

## What changes are included in this PR?

- `extract_date_part.rs`: add a `ColumnarValue::Scalar` match arm to the `extract_date_part!` macro (covers `hour`, `minute`, `second`). The scalar is broadcast to a single-element array, evaluated, and converted back to a scalar via `ScalarValue::try_from_array`.
- `unix_timestamp.rs`: refactor the array evaluation into `eval_array` and add a scalar arm that reuses it. The merge keeps `main`'s `Timestamp(Microsecond, None)` (TimestampNTZ) branch and `div_floor` behavior.
- Remove the `ignore(https://github.com/apache/datafusion-comet/issues/3336)` annotations from the existing `hour`, `minute`, `second`, and `unix_timestamp` SQL file tests so the literal cases are exercised.

## How are these changes tested?

The existing SQL file tests for `hour`, `minute`, `second`, and `unix_timestamp` run with `ConstantFolding` disabled and compare Comet's output against Spark. Their literal-argument cases were previously ignored for this issue and are now enabled. All 104 tests in the datetime SQL file suite pass locally, along with the native `datetime_funcs` unit tests.
