### PR TITLE
test: enable literal sha2 now that native engine handles scalar args

### DIFF
--- a/spark/src/test/resources/sql-tests/expressions/hash/hash.sql
+++ b/spark/src/test/resources/sql-tests/expressions/hash/hash.sql
@@ -26,5 +26,7 @@ query
 SELECT md5(col), md5(cast(a as string)), md5(cast(b as string)), hash(col), hash(col, 1), hash(col, 0), hash(col, a, b), hash(b, a, col), xxhash64(col), xxhash64(col, 1), xxhash64(col, 0), xxhash64(col, a, b), xxhash64(b, a, col), sha2(col, 0), sha2(col, 256), sha2(col, 224), sha2(col, 384), sha2(col, 512), sha2(col, 128), sha2(col, -1), sha1(col), sha1(cast(a as string)), sha1(cast(b as string)) FROM test
 
 -- literal arguments
-query ignore(https://github.com/apache/datafusion-comet/issues/3340)
-SELECT md5('Spark SQL'), sha1('test'), sha2('test', 256), hash('test'), xxhash64('test')
+-- The SQL file test suite disables ConstantFolding, so these literal arguments reach Comet's
+-- native engine as scalar values rather than being folded away by Spark's optimizer.
+query
+SELECT md5('Spark SQL'), sha1('test'), sha2('test', 0), sha2('test', 256), sha2('test', 224), sha2('test', 384), sha2('test', 512), sha2('test', 128), sha2('test', -1), sha2(cast(null as string), 256), hash('test'), xxhash64('test')

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -2111,6 +2111,22 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("sha2 with all-literal arguments and ConstantFolding disabled") {
+    // https://github.com/apache/datafusion-comet/issues/3340
+    // When ConstantFolding is disabled, an all-literal sha2() call reaches the native
+    // engine as scalar arguments. Verify it computes the correct result rather than crashing.
+    withSQLConf(
+      "spark.sql.optimizer.excludedRules" ->
+        "org.apache.spark.sql.catalyst.optimizer.ConstantFolding") {
+      checkSparkAnswerAndOperator("""
+          |select
+          |sha2('test', 0), sha2('test', 256), sha2('test', 224),
+          |sha2('test', 384), sha2('test', 512), sha2('test', 128), sha2('test', -1),
+          |sha2(cast(null as string), 256)
+          |""".stripMargin)
+    }
+  }
+
   test("remainder function") {
     def withAnsiMode(enabled: Boolean)(f: => Unit): Unit = {
       withSQLConf(


### PR DESCRIPTION
## Which issue does this PR close?

Closes #3340.

## Rationale for this change

Issue #3340 reported that an all-literal `sha2()` call (reached when Spark's `ConstantFolding` optimizer rule is disabled) crashed the native engine with `Unsupported argument types for sha2 function`. That crash came from Comet's own `sha2` implementation, which has since been removed in favor of `datafusion-spark`'s `SparkSha2` (PR #2063). The upstream implementation explicitly handles the all-scalar `(Scalar, Scalar)` case, so the crash no longer occurs. This PR removes the now-stale workaround and adds regression coverage so the scenario stays fixed.

## What changes are included in this PR?

- Remove the `ignore(#3340)` directive on the literal-arguments query in `expressions/hash/hash.sql`, enabling it again. The SQL file test suite already disables `ConstantFolding` globally, so this query exercises the exact reported scenario. The query is also extended to cover all `sha2` bit lengths (0, 224, 256, 384, 512), an unsupported bit length (128), a negative bit length (-1), and a null input.
- Add a focused Scala regression test in `CometExpressionSuite` that disables `ConstantFolding` and runs all-literal `sha2()` calls across the same bit lengths.

## How are these changes tested?

Both tests run all-literal `sha2()` through the native engine with `ConstantFolding` disabled and assert the result matches Spark via `checkSparkAnswerAndOperator`:

- `CometSqlFileTestSuite` -> `sql-file: expressions/hash/hash.sql`
- `CometExpressionSuite` -> `sha2 with all-literal arguments and ConstantFolding disabled`
