### PR TITLE
docs: mark try_avg and try_sum as natively supported

### DIFF
--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -121,8 +121,8 @@ The tables below list every Spark built-in expression with its current status.
 | `stddev_samp` | ✅ |  |
 | `string_agg` | 🔜 | String aggregation (alias of `listagg`) |
 | `sum` | ✅ |  |
-| `try_avg` | 🔜 | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098) |
-| `try_sum` | 🔜 | tracking [#4098](https://github.com/apache/datafusion-comet/issues/4098) |
+| `try_avg` | ✅ | Interval types fall back |
+| `try_sum` | ✅ |  |
 | `var_pop` | ✅ |  |
 | `var_samp` | ✅ |  |
 | `variance` | ✅ |  |


### PR DESCRIPTION
## Which issue does this PR close?

Part of #4098.

## Rationale for this change

`try_avg` and `try_sum` were already fully implemented and tested natively: both parse to Spark's `Average`/`Sum` aggregates with `EvalMode.TRY`, which Comet's serde already plumbs through to the native accumulators (`SumInteger`, `SumDecimal`, `AvgDecimal` all handle `Try` mode, including overflow-to-`NULL` semantics). `CometAggregateSuite` already covers integer overflow, partial-overflow with `GROUP BY`, decimal overflow, null handling, and ANSI/non-ANSI combinations, and these tests pass with `checkSparkAnswerAndOperator` (confirming native execution and a match against Spark).

The only stale artifact was the expression support guide, which still listed both as not-yet-supported.

## What changes are included in this PR?

Update `docs/source/user-guide/latest/expressions.md` to mark `try_avg` and `try_sum` as supported (✅), matching their non-`try` counterparts (`avg` notes that interval types fall back; `sum` has no caveat).

This change was scoped using the `implement-comet-expression` skill, which surfaced that the native implementation and test coverage already existed and that only the documentation needed updating.

## How are these changes tested?

Existing `try_avg`/`try_sum` tests in `CometAggregateSuite` pass (10 tests, 0 failures), verifying native execution and Spark-matching results across overflow, group-by, decimal, and null cases.
