### PR TITLE
ci: republish docs site when generated-doc sources change

### DIFF
--- a/dev/ci/compute-changes.py
+++ b/dev/ci/compute-changes.py
@@ -80,6 +80,14 @@ FILTERS = {
         ".asf.yaml",
         ".github/workflows/docs.yaml",
         "docs/**",
+        # Generated docs (configs.md, per-version expression compatibility pages) are
+        # built from these Scala sources by GenerateDocs, so changes to them must
+        # republish the site even when no docs/ file is touched.
+        "spark/src/main/scala/org/apache/comet/CometConf.scala",
+        "spark/src/main/scala/org/apache/comet/GenerateDocs.scala",
+        "spark/src/main/scala/org/apache/comet/serde/**",
+        "spark/src/main/scala/org/apache/comet/expressions/**",
+        "spark/src/main/spark-*/**",
     ],
     "spark_3_4": [
         "native/**/src/**",


### PR DESCRIPTION
## Which issue does this PR close?

<!-- no dedicated issue -->
N/A

## Rationale for this change

The docs deploy job (`docs.yaml`, invoked from `ci.yml`) only runs when `dev/ci/compute-changes.py` reports `docs=true`. That filter previously matched only `.asf.yaml`, the docs workflow itself, and `docs/**`.

However, the published site also contains content generated at build time by `GenerateDocs` (the `configs.md` table and the per-version expression compatibility pages). That content is derived from Scala sources, not from files under `docs/`. As a result, a push to `main` that changed an expression's support level, a config, or a serde, but did not touch any `docs/` file, would not republish the site, so the generated pages could drift from `main`.

(This is not a regression from the recent CI refactor: the standalone docs workflow used the same path filter. The refactor to a reusable `workflow_call` is only why those runs no longer appear under the `docs.yaml` workflow page; the deploy still runs as a job inside CI.)

## What changes are included in this PR?

Add the `GenerateDocs` input paths to the `docs` filter in `compute-changes.py`:

- `spark/src/main/scala/org/apache/comet/CometConf.scala` (feeds `configs.md`)
- `spark/src/main/scala/org/apache/comet/GenerateDocs.scala` (the generator)
- `spark/src/main/scala/org/apache/comet/serde/**` (expression serde maps and compatibility notes)
- `spark/src/main/scala/org/apache/comet/expressions/**` (e.g. `CometCast` cast compatibility)
- `spark/src/main/spark-*/**` (per-version shims that register some expressions)

Native, test-only, and CI-only changes still do not republish the site, since none of them affect the generated content.

## How are these changes tested?

Validated the new globs against the script's own matcher: each added source path classifies as `docs=true`, while native (`native/**`), test (`spark/src/test/**`), common Java, and unrelated `spark/src/main` paths (e.g. `org/apache/spark/sql/comet/CometScanExec.scala`) still classify as `docs=false`.