### PR TITLE
docs: mark make_dt_interval and make_ym_interval as supported

### DIFF
--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -262,13 +262,13 @@ The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `deci
 | `last_day` | ✅ |  |
 | `localtimestamp` | ✅ |  |
 | `make_date` | ✅ |  |
-| `make_dt_interval` | 🔜 | [#4541](https://github.com/apache/datafusion-comet/issues/4541) |
+| `make_dt_interval` | ✅ |  |
 | `make_interval` | 🔜 | Produces legacy CalendarInterval; tracked by [#4540](https://github.com/apache/datafusion-comet/issues/4540) |
 | `make_time` | 🔜 | Spark 4.1 TIME type; tracked by [#4288](https://github.com/apache/datafusion-comet/issues/4288) |
 | `make_timestamp` | ✅ |  |
 | `make_timestamp_ltz` | ✅ | 2-arg TIME form falls back |
 | `make_timestamp_ntz` | ✅ | 2-arg TIME form falls back |
-| `make_ym_interval` | 🔜 | [#4541](https://github.com/apache/datafusion-comet/issues/4541) |
+| `make_ym_interval` | ✅ |  |
 | `minute` | ✅ |  |
 | `month` | ✅ |  |
 | `monthname` | ✅ | Abbreviated month name (Spark 4.0+) |


### PR DESCRIPTION
## Which issue does this PR close?

Follow-up to #4541 (part of #4540).

## Rationale for this change

#4541 added support for Spark's `YearMonthIntervalType` and `DayTimeIntervalType` and enabled the `make_ym_interval` and `make_dt_interval` constructors via codegen dispatch. The expression support list in `expressions.md` still marked both as planned (🔜), so it no longer reflects reality.

## What changes are included in this PR?

Update `docs/source/user-guide/latest/expressions.md` to mark `make_dt_interval` and `make_ym_interval` as supported (✅) and drop the now-obsolete tracking-issue notes.

## How are these changes tested?

Documentation-only change. The behavior is covered by the SQL file tests added in #4541 (`make_ym_interval.sql` and `make_dt_interval.sql`).