### PR TITLE
chore: start 1.0.0 development

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -26,7 +26,7 @@ under the License.
   <parent>
     <groupId>org.apache.datafusion</groupId>
     <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dev/diffs/3.4.3.diff
+++ b/dev/diffs/3.4.3.diff
@@ -7,7 +7,7 @@ index d3544881af1..aae0ae3b27b 100644
      <ivy.version>2.5.1</ivy.version>
      <oro.version>2.0.8</oro.version>
 +    <spark.version.short>3.4</spark.version.short>
-+    <comet.version>0.18.0-SNAPSHOT</comet.version>
++    <comet.version>1.0.0-SNAPSHOT</comet.version>
      <!--
      If you changes codahale.metrics.version, you also need to change
      the link to metrics.dropwizard.io in docs/monitoring.md.

--- a/dev/diffs/3.5.8.diff
+++ b/dev/diffs/3.5.8.diff
@@ -7,7 +7,7 @@ index edd2ad57880..a47b7dec672 100644
      <ivy.version>2.5.1</ivy.version>
      <oro.version>2.0.8</oro.version>
 +    <spark.version.short>3.5</spark.version.short>
-+    <comet.version>0.18.0-SNAPSHOT</comet.version>
++    <comet.version>1.0.0-SNAPSHOT</comet.version>
      <!--
      If you changes codahale.metrics.version, you also need to change
      the link to metrics.dropwizard.io in docs/monitoring.md.

--- a/dev/diffs/4.0.2.diff
+++ b/dev/diffs/4.0.2.diff
@@ -47,7 +47,7 @@ index 252cfdf9073..60cb9dcb7cf 100644
      <ivy.version>2.5.3</ivy.version>
      <oro.version>2.0.8</oro.version>
 +    <spark.version.short>4.0</spark.version.short>
-+    <comet.version>0.18.0-SNAPSHOT</comet.version>
++    <comet.version>1.0.0-SNAPSHOT</comet.version>
      <!--
      If you change codahale.metrics.version, you also need to change
      the link to metrics.dropwizard.io in docs/monitoring.md.

--- a/dev/diffs/4.1.2.diff
+++ b/dev/diffs/4.1.2.diff
@@ -47,7 +47,7 @@ index dc201151999..d5c08f11ded 100644
      <ivy.version>2.5.3</ivy.version>
      <oro.version>2.0.8</oro.version>
 +    <spark.version.short>4.1</spark.version.short>
-+    <comet.version>0.18.0-SNAPSHOT</comet.version>
++    <comet.version>1.0.0-SNAPSHOT</comet.version>
      <!--
      If you change codahale.metrics.version, you also need to change
      the link to metrics.dropwizard.io in docs/monitoring.md.

--- a/dev/diffs/iceberg/1.10.0.diff
+++ b/dev/diffs/iceberg/1.10.0.diff
@@ -7,7 +7,7 @@ index eeabe54f5f..4d3160b9f7 100644
  caffeine = "2.9.3"
  calcite = "1.40.0"
 -comet = "0.8.1"
-+comet = "0.18.0-SNAPSHOT"
++comet = "1.0.0-SNAPSHOT"
  datasketches = "6.2.0"
  delta-standalone = "3.3.2"
  delta-spark = "3.3.2"

--- a/dev/diffs/iceberg/1.8.1.diff
+++ b/dev/diffs/iceberg/1.8.1.diff
@@ -6,7 +6,7 @@ index 04ffa8f4ed..2d2c0d6e76 100644
  awssdk-s3accessgrants = "2.3.0"
  caffeine = "2.9.3"
  calcite = "1.10.0"
-+comet = "0.18.0-SNAPSHOT"
++comet = "1.0.0-SNAPSHOT"
  datasketches = "6.2.0"
  delta-standalone = "3.3.0"
  delta-spark = "3.3.0"

--- a/dev/diffs/iceberg/1.9.1.diff
+++ b/dev/diffs/iceberg/1.9.1.diff
@@ -6,7 +6,7 @@ index c50991c5fc..c3bd841c95 100644
  bson-ver = "4.11.5"
  caffeine = "2.9.3"
  calcite = "1.39.0"
-+comet = "0.18.0-SNAPSHOT"
++comet = "1.0.0-SNAPSHOT"
  datasketches = "6.2.0"
  delta-standalone = "3.3.1"
  delta-spark = "3.3.1"

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1981,7 +1981,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-comet"
-version = "0.18.0"
+version = "1.0.0"
 dependencies = [
  "arrow",
  "assertables",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-comet-common"
-version = "0.18.0"
+version = "1.0.0"
 dependencies = [
  "arrow",
  "datafusion",
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-comet-jni-bridge"
-version = "0.18.0"
+version = "1.0.0"
 dependencies = [
  "arrow",
  "assertables",
@@ -2081,7 +2081,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-comet-objectstore-hdfs"
-version = "0.18.0"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-comet-proto"
-version = "0.18.0"
+version = "1.0.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-comet-shuffle"
-version = "0.18.0"
+version = "1.0.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-comet-spark-expr"
-version = "0.18.0"
+version = "1.0.0"
 dependencies = [
  "arrow",
  "base64",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -21,7 +21,7 @@ members = ["core", "spark-expr", "common", "proto", "jni-bridge", "shuffle", "hd
 resolver = "2"
 
 [workspace.package]
-version = "0.18.0"
+version = "1.0.0"
 homepage = "https://datafusion.apache.org/comet"
 repository = "https://github.com/apache/datafusion-comet"
 authors = ["Apache DataFusion <dev@datafusion.apache.org>"]

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ under the License.
   </parent>
   <groupId>org.apache.datafusion</groupId>
   <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
-  <version>0.18.0-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Comet Project Parent POM</name>
 

--- a/spark-integration/pom.xml
+++ b/spark-integration/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.datafusion</groupId>
         <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -26,7 +26,7 @@ under the License.
   <parent>
     <groupId>org.apache.datafusion</groupId>
     <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

The next Comet release will be 1.0.0. This PR bumps the development version so that work on `main` targets the 1.0.0 release.

## What changes are included in this PR?

Bump the project version from 0.18.0 / 0.18.0-SNAPSHOT to 1.0.0 / 1.0.0-SNAPSHOT:

- Rust workspace version in `native/Cargo.toml` and the regenerated `native/Cargo.lock`
- Maven versions in `pom.xml`, `common/pom.xml`, `spark/pom.xml`, and `spark-integration/pom.xml`
- `comet.version` in the Spark diffs (`dev/diffs/3.4.3.diff`, `3.5.8.diff`, `4.0.2.diff`, `4.1.2.diff`)
- `comet` version in the Iceberg diffs (`dev/diffs/iceberg/1.8.1.diff`, `1.9.1.diff`, `1.10.0.diff`)

## How are these changes tested?

This is a version-only change with no functional impact. Existing CI covers the build across all Spark version profiles.
