### PR TITLE
fix: count returning zero when scan is disabled and going through CometSparkColumnarToColumnar

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/arrow/SparkColumnarArrowReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/arrow/SparkColumnarArrowReader.scala
@@ -91,6 +91,11 @@ private[comet] class SparkColumnarArrowReader(
     rowsConsumedInCurrent += rowsToProduce
 
     writer.finish()
+    // ArrowWriter derives the root row count from its per-column writes, so a zero-column
+    // input batch (Spark's count-from-metadata scan: numRows > 0, numCols == 0) would otherwise
+    // produce a root with rowCount == 0 and silently drop the rows. Set rowCount explicitly so
+    // downstream aggregations (e.g. df.count()) see the correct value.
+    getVectorSchemaRoot.setRowCount(rowsToProduce)
     onConversionNs(System.nanoTime() - startNs)
     true
   }

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -3733,6 +3733,13 @@ class CometExecSuite extends CometTestBase {
 
         val df = spark.read.parquet(dir.toString)
         assert(df.count() == expected, "df.count() should match number of written rows")
+
+        // Ensuring that this test actually follows the SparkColumnarArrowReader code path
+        // guarded by the fix, so we can catch future regressions.
+        val sparkToColumnar = collect(df.queryExecution.executedPlan) {
+          case s: CometSparkToColumnarExec => s
+        }
+        assert(sparkToColumnar.nonEmpty, "Expected CometSparkToColumnarExec in the executed plan")
       }
     }
   }

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -3732,11 +3732,17 @@ class CometExecSuite extends CometTestBase {
           .parquet(dir.toString)
 
         val df = spark.read.parquet(dir.toString)
-        assert(df.count() == expected, "df.count() should match number of written rows")
+        // Materialize the count query explicitly so we can inspect the plan
+        // that runs — Dataset.count() executes groupBy().count() internally
+        // but doesn't expose that plan
+        val countDf = df.groupBy().count()
+        assert(
+          countDf.collect().head.getLong(0) == expected,
+          "df.count() should match number of written rows")
 
-        // Ensuring that this test actually follows the SparkColumnarArrowReader code path
-        // guarded by the fix, so we can catch future regressions.
-        val sparkToColumnar = collect(df.queryExecution.executedPlan) {
+        // Ensure this test actually exercises the SparkColumnarArrowReader code path
+        // guarded by the fix, so future regressions are caught.
+        val sparkToColumnar = collect(countDf.queryExecution.executedPlan) {
           case s: CometSparkToColumnarExec => s
         }
         assert(sparkToColumnar.nonEmpty, "Expected CometSparkToColumnarExec in the executed plan")

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -3711,6 +3711,32 @@ class CometExecSuite extends CometTestBase {
     }
   }
 
+  test("SparkToColumnar preserves row count for zero-column input batches (df.count())") {
+    // Regression test: when spark.comet.scan is disabled but convert.parquet is enabled,
+    // Spark's count-from-metadata optimization emits ColumnarBatches with numRows > 0 and
+    // numCols == 0. SparkColumnarArrowReader used to derive the Arrow row count from
+    // per-column writes only, silently producing zero-row Arrow batches in this case and
+    // making df.count() return 0.
+    withSQLConf(
+      SQLConf.USE_V1_SOURCE_LIST.key -> "parquet",
+      CometConf.COMET_NATIVE_SCAN_ENABLED.key -> "false",
+      CometConf.COMET_SPARK_TO_ARROW_ENABLED.key -> "true",
+      CometConf.COMET_CONVERT_FROM_PARQUET_ENABLED.key -> "true") {
+      withTempPath { dir =>
+        val expected = 10000L
+        spark
+          .range(expected)
+          .selectExpr("id as key", "id % 8 as value")
+          .toDF("key", "value")
+          .write
+          .parquet(dir.toString)
+
+        val df = spark.read.parquet(dir.toString)
+        assert(df.count() == expected, "df.count() should match number of written rows")
+      }
+    }
+  }
+
   test("read CSV file") {
     Seq("", "csv").foreach { v1List =>
       withSQLConf(


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/datafusion-comet/issues/4793.

## Rationale for this change

This change fixes the bug where `df.count()` returns **zero**, when `spark.comet.scan.enabled` is disabled and `spark.comet.convert.parquet.enabled`  is enabled.

 Spark has a well-known "count-from-metadata" optimization: `df.count()` rewrites the
 Parquet scan to require **zero data columns**. `FileSourceScanExec` therefore emits
 `ColumnarBatch` with `numRows == <row-group row count>` and `numCols == 0`.
 
 With `spark.comet.scan.enabled=false` and `spark.comet.convert.parquet.enabled=true`,
 Comet inserts a `CometSparkColumnarToColumnar` node that funnels every Spark batch
 through `SparkColumnarArrowReader.loadNextBatch()`. That method only sets the Arrow
 row count as a side-effect of copying columns:
 
 ```scala
 val writer = ArrowWriter.create(getVectorSchemaRoot)
 var col = 0
 while (col < current.numCols()) { // never executes when numCols == 0
   val column = current.column(col)
   val columnArray = new ColumnarArray(column, rowsConsumedInCurrent, rowsToProduce)
   if (column.hasNull) writer.writeCol(columnArray, col)
   else writer.writeColNoNull(columnArray, col)
   col += 1
 }
 writer.finish()  // ArrowWriter.count is still 0
 ```
 
 `ArrowWriter.finish()` calls `root.setRowCount(count)`, where `count` was set to
 `input.numElements()` inside `writeCol` / `writeColNoNull`. With zero columns those
 methods are never called, `count` remains `0`, and the emitted Arrow batch has
 `numRows == 0` even though the input Spark batch had thousands of rows. Downstream
 aggregations then see zero rows per partition and `df.count()` returns `0`.
 
 `df.show()` was unaffected because it requires actual columns; the loop runs and
 `count` is set correctly.

## What changes are included in this PR?

 Set the row count on the Arrow `VectorSchemaRoot` explicitly from the pre-computed
 `rowsToProduce`, so the value is correct regardless of column count. For batches with
 columns this is a no-op (the same value `ArrowWriter.finish()` would have written);
 for zero-column batches it restores correctness.

## How are these changes tested?

### Query plan for df.count() with comet 0.16.0 jar file
<img width="1660" height="1164" alt="Screenshot 2026-07-02 at 9 46 24 PM" src="https://github.com/user-attachments/assets/1911ea40-86c1-4d37-9e80-9da54f57a13b" />

### Query plan for df.count() with the jar file built from source using these changes
<img width="1458" height="1168" alt="Screenshot 2026-07-02 at 9 46 34 PM" src="https://github.com/user-attachments/assets/3591a147-6857-4207-a207-fa01d7688c3c" />
