### PR TITLE
feat: support shuffle array expression

### DIFF
--- a/docs/source/contributor-guide/expression-audits/array_funcs.md
+++ b/docs/source/contributor-guide/expression-audits/array_funcs.md
@@ -175,6 +175,13 @@
 - Spark 4.0.1 (audited 2026-05-27): semantics unchanged; ANSI default flips to `true`.
 - Spark 4.1.1 (audited 2026-05-27): `inputTypes` tightened to `Seq(ArrayType, IntegralType)` (analysis-time only); runtime unchanged.
 
+## shuffle
+
+- Spark 3.4.3 (audited 2026-07-02): `Shuffle(child, randomSeed: Option[Long])`; `inputTypes = Seq(ArrayType)`, `dataType = child.dataType`, non-deterministic and stateful. Seeds a Commons Math3 `MersenneTwister` with `randomSeed + partitionIndex` and applies the "inside-out" Fisher-Yates from `RandomIndicesGenerator`. Only the one-argument `shuffle(array)` form exists in SQL. NULL input returns NULL without advancing the RNG.
+- Spark 3.5.8 (audited 2026-07-02): identical to 3.4.3.
+- Spark 4.0.1 (audited 2026-07-02): adds the two-argument constructor `Shuffle(child, seed: Expression)`, exposing `shuffle(array, seed)` in SQL (seed must be an integer/long literal). `RandomIndicesGenerator` and the eval logic are unchanged.
+- Spark 4.1.1 (audited 2026-07-02): identical to 4.0.1. Comet routes via `CometShuffle` and a dedicated stateful `ShuffleExpr` that reproduces the same MersenneTwister and inside-out Fisher-Yates, so results match Spark bit for bit. `childTypesSupportLevel` falls back for binary/struct/map element types, consistent with the other array expressions.
+
 ## sort_array
 
 - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -155,7 +155,7 @@ The tables below list every Spark built-in expression with its current status.
 | `flatten` | ✅ | Binary/struct/map elements fall back |
 | `get` | ✅ |  |
 | `sequence` | ✅ |  |
-| `shuffle` | 🔜 | Random array shuffle |
+| `shuffle` | ✅ | Binary/struct/map elements fall back |
 | `slice` | ✅ | Native ([#4149](https://github.com/apache/datafusion-comet/issues/4149)) |
 | `sort_array` | ✅ | Nested struct/null arrays fall back |
 

--- a/native/core/src/execution/expressions/random.rs
+++ b/native/core/src/execution/expressions/random.rs
@@ -22,7 +22,7 @@ use crate::extract_expr;
 use arrow::datatypes::SchemaRef;
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion_comet_proto::spark_expression::Expr;
-use datafusion_comet_spark_expr::{RandExpr, RandnExpr};
+use datafusion_comet_spark_expr::{RandExpr, RandnExpr, ShuffleExpr};
 use std::sync::Arc;
 
 pub struct RandBuilder;
@@ -37,6 +37,23 @@ impl ExpressionBuilder for RandBuilder {
         let expr = extract_expr!(spark_expr, Rand);
         let seed = expr.seed.wrapping_add(planner.partition().into());
         Ok(Arc::new(RandExpr::new(seed)))
+    }
+}
+
+pub struct ShuffleBuilder;
+
+impl ExpressionBuilder for ShuffleBuilder {
+    fn build(
+        &self,
+        spark_expr: &Expr,
+        input_schema: SchemaRef,
+        planner: &PhysicalPlanner,
+    ) -> Result<Arc<dyn PhysicalExpr>, ExecutionError> {
+        let expr = extract_expr!(spark_expr, Shuffle);
+        let child = planner.create_expr(expr.child.as_ref().unwrap(), input_schema)?;
+        // Spark seeds a fresh generator per partition with `randomSeed + partitionIndex`.
+        let seed = expr.seed.wrapping_add(planner.partition().into());
+        Ok(Arc::new(ShuffleExpr::new(child, seed)))
     }
 }
 

--- a/native/core/src/execution/planner/expression_registry.rs
+++ b/native/core/src/execution/planner/expression_registry.rs
@@ -101,6 +101,7 @@ pub enum ExpressionType {
     ArrayInsert,
     Rand,
     Randn,
+    Shuffle,
     SparkPartitionId,
     MonotonicallyIncreasingId,
     ArraysZip,
@@ -378,6 +379,7 @@ impl ExpressionRegistry {
             Some(ExprStruct::ArrayInsert(_)) => Ok(ExpressionType::ArrayInsert),
             Some(ExprStruct::Rand(_)) => Ok(ExpressionType::Rand),
             Some(ExprStruct::Randn(_)) => Ok(ExpressionType::Randn),
+            Some(ExprStruct::Shuffle(_)) => Ok(ExpressionType::Shuffle),
             Some(ExprStruct::SparkPartitionId(_)) => Ok(ExpressionType::SparkPartitionId),
             Some(ExprStruct::MonotonicallyIncreasingId(_)) => {
                 Ok(ExpressionType::MonotonicallyIncreasingId)
@@ -409,6 +411,8 @@ impl ExpressionRegistry {
             .insert(ExpressionType::Rand, Box::new(RandBuilder));
         self.builders
             .insert(ExpressionType::Randn, Box::new(RandnBuilder));
+        self.builders
+            .insert(ExpressionType::Shuffle, Box::new(ShuffleBuilder));
     }
 
     /// Register partition expression builders

--- a/native/proto/src/proto/expr.proto
+++ b/native/proto/src/proto/expr.proto
@@ -92,6 +92,7 @@ message Expr {
     ArraysZip arrays_zip = 69;
     JvmScalarUdf jvm_scalar_udf = 70;
     PreciseTimestampConversion precise_timestamp_conversion = 71;
+    Shuffle shuffle = 72;
   }
 
   // Optional QueryContext for error reporting (contains SQL text and position)
@@ -524,6 +525,15 @@ message ArrayJoin {
 
 message Rand {
   int64 seed = 1;
+}
+
+// Spark's Shuffle returns a random permutation of the given array. It is
+// non-deterministic: the resolved random seed is combined with the partition
+// index and drives a MersenneTwister-based inside-out Fisher-Yates shuffle,
+// matching org.apache.spark.sql.catalyst.util.RandomIndicesGenerator.
+message Shuffle {
+  Expr child = 1;
+  int64 seed = 2;
 }
 
 // Spark's ArraysZip takes children: Seq[Expression] and names: Seq[Expression]

--- a/native/spark-expr/src/nondetermenistic_funcs/mod.rs
+++ b/native/spark-expr/src/nondetermenistic_funcs/mod.rs
@@ -19,6 +19,8 @@ pub mod internal;
 pub mod monotonically_increasing_id;
 pub mod rand;
 pub mod randn;
+pub mod shuffle;
 
 pub use rand::RandExpr;
 pub use randn::RandnExpr;
+pub use shuffle::ShuffleExpr;

--- a/native/spark-expr/src/nondetermenistic_funcs/shuffle.rs
+++ b/native/spark-expr/src/nondetermenistic_funcs/shuffle.rs
@@ -1,0 +1,433 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::{
+    Array, ArrayRef, FixedSizeListArray, GenericListArray, OffsetSizeTrait, RecordBatch,
+    UInt64Array,
+};
+use arrow::buffer::OffsetBuffer;
+use arrow::compute::take;
+use arrow::datatypes::{DataType, FieldRef, Schema};
+use datafusion::common::{exec_err, Result};
+use datafusion::logical_expr::ColumnarValue;
+use datafusion::physical_expr::PhysicalExpr;
+use std::fmt::{Display, Formatter};
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex};
+
+/// A bit-for-bit port of Apache Commons Math3's `MersenneTwister`, the RNG Spark
+/// uses to shuffle arrays. Spark seeds a fresh generator per partition with
+/// `randomSeed + partitionIndex` and drives the "inside-out" Fisher-Yates
+/// algorithm from `org.apache.spark.sql.catalyst.util.RandomIndicesGenerator`.
+///
+/// See:
+/// - `org/apache/commons/math3/random/MersenneTwister.java`
+/// - `org/apache/commons/math3/random/BitsStreamGenerator.java` (`nextInt(int)`)
+#[derive(Debug, Clone)]
+pub(crate) struct SparkMersenneTwister {
+    /// Bytes pool.
+    mt: [i32; Self::N],
+    /// Current index in the bytes pool.
+    mti: usize,
+}
+
+impl SparkMersenneTwister {
+    /// Size of the bytes pool.
+    const N: usize = 624;
+    /// Period second parameter.
+    const M: usize = 397;
+    /// X * MATRIX_A for X = {0, 1}.
+    const MAG01: [i32; 2] = [0x0, 0x9908b0dfu32 as i32];
+
+    pub(crate) fn new(seed: i64) -> Self {
+        // `mti` is set by seeding before it is ever read; 0 is just a placeholder.
+        let mut twister = SparkMersenneTwister {
+            mt: [0i32; Self::N],
+            mti: 0,
+        };
+        twister.set_seed_long(seed);
+        twister
+    }
+
+    fn set_seed_int(&mut self, seed: i32) {
+        // We use a long masked by 0xffffffff as a poor man's unsigned int.
+        let mut long_mt = seed as i64;
+        self.mt[0] = long_mt as i32;
+        let mut mti = 1usize;
+        while mti < Self::N {
+            long_mt = (1812433253i64.wrapping_mul(long_mt ^ (long_mt >> 30)) + mti as i64)
+                & 0xffffffffi64;
+            self.mt[mti] = long_mt as i32;
+            mti += 1;
+        }
+        self.mti = mti;
+    }
+
+    fn set_seed_int_array(&mut self, seed: &[i32]) {
+        self.set_seed_int(19650218);
+        let mut i = 1usize;
+        let mut j = 0usize;
+
+        for _ in 0..Self::N.max(seed.len()) {
+            let mt_i = self.mt[i] as i64 & 0xffffffffi64;
+            let mt_im1 = self.mt[i - 1] as i64 & 0xffffffffi64;
+            let l = (mt_i ^ ((mt_im1 ^ (mt_im1 >> 30)).wrapping_mul(1664525)))
+                .wrapping_add(seed[j] as i64)
+                .wrapping_add(j as i64);
+            self.mt[i] = (l & 0xffffffffi64) as i32;
+            i += 1;
+            j += 1;
+            if i >= Self::N {
+                self.mt[0] = self.mt[Self::N - 1];
+                i = 1;
+            }
+            if j >= seed.len() {
+                j = 0;
+            }
+        }
+
+        for _ in 0..(Self::N - 1) {
+            let mt_i = self.mt[i] as i64 & 0xffffffffi64;
+            let mt_im1 = self.mt[i - 1] as i64 & 0xffffffffi64;
+            let l = (mt_i ^ ((mt_im1 ^ (mt_im1 >> 30)).wrapping_mul(1566083941)))
+                .wrapping_sub(i as i64);
+            self.mt[i] = (l & 0xffffffffi64) as i32;
+            i += 1;
+            if i >= Self::N {
+                self.mt[0] = self.mt[Self::N - 1];
+                i = 1;
+            }
+        }
+
+        // MSB is 1, assuring a non-zero initial array.
+        self.mt[0] = 0x80000000u32 as i32;
+    }
+
+    fn set_seed_long(&mut self, seed: i64) {
+        self.set_seed_int_array(&[(seed >> 32) as i32, seed as i32]);
+    }
+
+    fn next(&mut self, bits: u32) -> i32 {
+        let mut y: i32;
+        if self.mti >= Self::N {
+            // Generate N words at one time.
+            let mut mt_next = self.mt[0];
+            for k in 0..(Self::N - Self::M) {
+                let mt_curr = mt_next;
+                mt_next = self.mt[k + 1];
+                y = (mt_curr & (0x80000000u32 as i32)) | (mt_next & 0x7fffffff);
+                self.mt[k] = self.mt[k + Self::M]
+                    ^ (((y as u32) >> 1) as i32)
+                    ^ Self::MAG01[(y & 0x1) as usize];
+            }
+            for k in (Self::N - Self::M)..(Self::N - 1) {
+                let mt_curr = mt_next;
+                mt_next = self.mt[k + 1];
+                y = (mt_curr & (0x80000000u32 as i32)) | (mt_next & 0x7fffffff);
+                self.mt[k] = self.mt[k + Self::M - Self::N]
+                    ^ (((y as u32) >> 1) as i32)
+                    ^ Self::MAG01[(y & 0x1) as usize];
+            }
+            y = (mt_next & (0x80000000u32 as i32)) | (self.mt[0] & 0x7fffffff);
+            self.mt[Self::N - 1] =
+                self.mt[Self::M - 1] ^ (((y as u32) >> 1) as i32) ^ Self::MAG01[(y & 0x1) as usize];
+            self.mti = 0;
+        }
+
+        y = self.mt[self.mti];
+        self.mti += 1;
+
+        // Tempering.
+        y ^= ((y as u32) >> 11) as i32;
+        y ^= (y << 7) & (0x9d2c5680u32 as i32);
+        y ^= (y << 15) & (0xefc60000u32 as i32);
+        y ^= ((y as u32) >> 18) as i32;
+
+        ((y as u32) >> (32 - bits)) as i32
+    }
+
+    /// Port of `BitsStreamGenerator.nextInt(int n)`. The caller always passes a
+    /// strictly positive `n`, matching Spark's `random.nextInt(i + 1)`.
+    fn next_int(&mut self, n: i32) -> i32 {
+        if (n & n.wrapping_neg()) == n {
+            // n is a power of two.
+            return ((n as i64 * self.next(31) as i64) >> 31) as i32;
+        }
+        loop {
+            let bits = self.next(31);
+            let val = bits % n;
+            if bits.wrapping_sub(val).wrapping_add(n.wrapping_sub(1)) >= 0 {
+                return val;
+            }
+        }
+    }
+
+    /// Port of `RandomIndicesGenerator.getNextIndices`. Fills `out` with, for each
+    /// output position, the source position it should draw from. `out` is reused
+    /// across rows to avoid a per-row allocation. Advances the RNG state, which is
+    /// shared across every row in the partition.
+    fn next_indices_into(&mut self, length: usize, out: &mut Vec<usize>) {
+        out.clear();
+        out.resize(length, 0);
+        let mut i = 0usize;
+        while i < length {
+            let j = self.next_int((i + 1) as i32) as usize;
+            if j != i {
+                out[i] = out[j];
+            }
+            out[j] = i;
+            i += 1;
+        }
+    }
+
+    #[cfg(test)]
+    fn next_indices(&mut self, length: usize) -> Vec<usize> {
+        let mut out = Vec::new();
+        self.next_indices_into(length, &mut out);
+        out
+    }
+}
+
+/// Physical expression for Spark's `shuffle`. Like `RandExpr`, the generator
+/// state is kept in a `Mutex` so that it advances continuously across every
+/// batch in a partition, matching Spark's stateful per-partition evaluation.
+#[derive(Debug)]
+pub struct ShuffleExpr {
+    child: Arc<dyn PhysicalExpr>,
+    /// Random seed already combined with the partition index by the planner.
+    seed: i64,
+    state_holder: Arc<Mutex<Option<SparkMersenneTwister>>>,
+}
+
+impl ShuffleExpr {
+    pub fn new(child: Arc<dyn PhysicalExpr>, seed: i64) -> Self {
+        Self {
+            child,
+            seed,
+            state_holder: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+impl Display for ShuffleExpr {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "Shuffle({}, {})", self.child, self.seed)
+    }
+}
+
+impl PartialEq for ShuffleExpr {
+    fn eq(&self, other: &Self) -> bool {
+        self.child.eq(&other.child) && self.seed.eq(&other.seed)
+    }
+}
+
+impl Eq for ShuffleExpr {}
+
+impl Hash for ShuffleExpr {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.child.hash(state);
+        self.seed.hash(state);
+    }
+}
+
+impl PhysicalExpr for ShuffleExpr {
+    fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
+        self.child.data_type(input_schema)
+    }
+
+    fn nullable(&self, input_schema: &Schema) -> Result<bool> {
+        self.child.nullable(input_schema)
+    }
+
+    fn evaluate(&self, batch: &RecordBatch) -> Result<ColumnarValue> {
+        let input = self.child.evaluate(batch)?.into_array(batch.num_rows())?;
+
+        let mut state = self.state_holder.lock().unwrap();
+        let rng = state.get_or_insert_with(|| SparkMersenneTwister::new(self.seed));
+
+        let result = match input.data_type() {
+            DataType::List(field) => shuffle_generic_list::<i32>(input.as_ref(), field, rng)?,
+            DataType::LargeList(field) => shuffle_generic_list::<i64>(input.as_ref(), field, rng)?,
+            DataType::FixedSizeList(field, value_length) => {
+                shuffle_fixed_size_list(input.as_ref(), field, *value_length, rng)?
+            }
+            DataType::Null => Arc::clone(&input),
+            other => {
+                return exec_err!("shuffle does not support type '{other}'");
+            }
+        };
+
+        Ok(ColumnarValue::Array(result))
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn PhysicalExpr>> {
+        vec![&self.child]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        Ok(Arc::new(ShuffleExpr::new(
+            Arc::clone(&children[0]),
+            self.seed,
+        )))
+    }
+
+    fn fmt_sql(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+/// Gather, for every row in order, the absolute source indices of that row's
+/// elements in shuffled order. `span(row)` returns the row's `(start, length)`
+/// within the values array. Null rows are copied through as-is without drawing
+/// from the RNG, matching Spark. The scratch buffer is reused across rows.
+fn gather_shuffled_indices(
+    rng: &mut SparkMersenneTwister,
+    num_rows: usize,
+    total_values: usize,
+    is_null: impl Fn(usize) -> bool,
+    span: impl Fn(usize) -> (usize, usize),
+) -> Vec<u64> {
+    let mut gathered: Vec<u64> = Vec::with_capacity(total_values);
+    let mut scratch: Vec<usize> = Vec::new();
+    for row in 0..num_rows {
+        let (start, length) = span(row);
+        if is_null(row) {
+            gathered.extend((start..start + length).map(|idx| idx as u64));
+        } else {
+            rng.next_indices_into(length, &mut scratch);
+            gathered.extend(scratch.iter().map(|&local| (start + local) as u64));
+        }
+    }
+    gathered
+}
+
+fn shuffle_generic_list<O: OffsetSizeTrait>(
+    array: &dyn Array,
+    field: &FieldRef,
+    rng: &mut SparkMersenneTwister,
+) -> Result<ArrayRef> {
+    let list = array
+        .as_any()
+        .downcast_ref::<GenericListArray<O>>()
+        .expect("expected a list array");
+    let values = list.values();
+    let offsets = list.offsets();
+
+    let gathered = gather_shuffled_indices(
+        rng,
+        list.len(),
+        values.len(),
+        |row| list.is_null(row),
+        |row| {
+            let start = offsets[row].as_usize();
+            (start, offsets[row + 1].as_usize() - start)
+        },
+    );
+
+    let indices = UInt64Array::from(gathered);
+    let new_values = take(values.as_ref(), &indices, None)?;
+
+    // Shuffling preserves row lengths, so the new offsets are the input offsets
+    // rebased to start at zero. This also normalizes any slice offset on the input.
+    let base = offsets[0].as_usize();
+    let new_offsets: Vec<O> = offsets
+        .iter()
+        .map(|o| O::usize_as(o.as_usize() - base))
+        .collect();
+
+    Ok(Arc::new(GenericListArray::<O>::try_new(
+        Arc::clone(field),
+        OffsetBuffer::new(new_offsets.into()),
+        new_values,
+        list.nulls().cloned(),
+    )?))
+}
+
+fn shuffle_fixed_size_list(
+    array: &dyn Array,
+    field: &FieldRef,
+    value_length: i32,
+    rng: &mut SparkMersenneTwister,
+) -> Result<ArrayRef> {
+    let list = array
+        .as_any()
+        .downcast_ref::<FixedSizeListArray>()
+        .expect("expected a fixed size list array");
+    let values = list.values();
+    let length = value_length as usize;
+
+    let gathered = gather_shuffled_indices(
+        rng,
+        list.len(),
+        values.len(),
+        |row| list.is_null(row),
+        |row| (row * length, length),
+    );
+
+    let indices = UInt64Array::from(gathered);
+    let new_values = take(values.as_ref(), &indices, None)?;
+
+    Ok(Arc::new(FixedSizeListArray::try_new(
+        Arc::clone(field),
+        value_length,
+        new_values,
+        list.nulls().cloned(),
+    )?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Golden vectors generated from Apache Commons Math3 `MersenneTwister`
+    /// driving Spark's `RandomIndicesGenerator.getNextIndices`.
+    fn indices(seed: i64, lengths: &[usize]) -> Vec<Vec<usize>> {
+        let mut rng = SparkMersenneTwister::new(seed);
+        lengths.iter().map(|&len| rng.next_indices(len)).collect()
+    }
+
+    #[test]
+    fn test_single_row_permutations() {
+        assert_eq!(indices(42, &[5]), vec![vec![4, 2, 1, 0, 3]]);
+        assert_eq!(indices(42, &[10]), vec![vec![5, 7, 1, 0, 3, 6, 8, 2, 4, 9]]);
+        assert_eq!(indices(0, &[5]), vec![vec![3, 0, 1, 2, 4]]);
+        assert_eq!(indices(123456789, &[8]), vec![vec![2, 6, 1, 7, 4, 0, 5, 3]]);
+    }
+
+    #[test]
+    fn test_state_advances_across_rows() {
+        // One generator shared by consecutive rows, matching Spark's per-partition state.
+        assert_eq!(
+            indices(42, &[3, 3, 3, 4]),
+            vec![
+                vec![0, 2, 1],
+                vec![2, 1, 0],
+                vec![2, 0, 1],
+                vec![3, 2, 1, 0]
+            ]
+        );
+    }
+
+    #[test]
+    fn test_empty_and_single_element() {
+        // A length-0 row draws nothing; a length-1 row still consumes one draw.
+        assert_eq!(indices(7, &[0, 1, 2]), vec![vec![], vec![0], vec![1, 0]]);
+    }
+}

--- a/native/spark-expr/src/nondetermenistic_funcs/shuffle.rs
+++ b/native/spark-expr/src/nondetermenistic_funcs/shuffle.rs
@@ -29,7 +29,7 @@ use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, Mutex};
 
-/// A bit-for-bit port of Apache Commons Math3's `MersenneTwister`, the RNG Spark
+/// A bit-for-bit port of Apache Commons Math3's `MersenneTwister`, the PRNG Spark
 /// uses to shuffle arrays. Spark seeds a fresh generator per partition with
 /// `randomSeed + partitionIndex` and drives the "inside-out" Fisher-Yates
 /// algorithm from `org.apache.spark.sql.catalyst.util.RandomIndicesGenerator`.
@@ -178,7 +178,7 @@ impl SparkMersenneTwister {
 
     /// Port of `RandomIndicesGenerator.getNextIndices`. Fills `out` with, for each
     /// output position, the source position it should draw from. `out` is reused
-    /// across rows to avoid a per-row allocation. Advances the RNG state, which is
+    /// across rows to avoid a per-row allocation. Advances the PRNG state, which is
     /// shared across every row in the partition.
     fn next_indices_into(&mut self, length: usize, out: &mut Vec<usize>) {
         out.clear();
@@ -265,7 +265,6 @@ impl PhysicalExpr for ShuffleExpr {
             DataType::FixedSizeList(field, value_length) => {
                 shuffle_fixed_size_list(input.as_ref(), field, *value_length, rng)?
             }
-            DataType::Null => Arc::clone(&input),
             other => {
                 return exec_err!("shuffle does not support type '{other}'");
             }
@@ -296,7 +295,7 @@ impl PhysicalExpr for ShuffleExpr {
 /// Gather, for every row in order, the absolute source indices of that row's
 /// elements in shuffled order. `span(row)` returns the row's `(start, length)`
 /// within the values array. Null rows are copied through as-is without drawing
-/// from the RNG, matching Spark. The scratch buffer is reused across rows.
+/// from the PRNG, matching Spark. The scratch buffer is reused across rows.
 fn gather_shuffled_indices(
     rng: &mut SparkMersenneTwister,
     num_rows: usize,

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -86,7 +86,8 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
     classOf[ArrayAggregate] -> CometArrayAggregate,
     classOf[ArraySort] -> CometArraySort,
     classOf[ZipWith] -> CometZipWith,
-    classOf[Sequence] -> CometSequence)
+    classOf[Sequence] -> CometSequence,
+    classOf[Shuffle] -> CometShuffle)
 
   private val conditionalExpressions: Map[Class[_ <: Expression], CometExpressionSerde[_]] =
     Map(classOf[CaseWhen] -> CometCaseWhen, classOf[If] -> CometIf)

--- a/spark/src/main/scala/org/apache/comet/serde/collectionOperations.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/collectionOperations.scala
@@ -19,10 +19,12 @@
 
 package org.apache.comet.serde
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Reverse}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Reverse, Shuffle}
 import org.apache.spark.sql.types.ArrayType
 
+import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
 import org.apache.comet.serde.ExprOuterClass.Expr
+import org.apache.comet.serde.QueryPlanSerde.exprToProtoInternal
 import org.apache.comet.shims.CometTypeShim
 
 object CometReverse
@@ -55,6 +57,34 @@ object CometReverse
       CometArrayReverse.convert(expr, inputs, binding)
     } else {
       super.convert(expr, inputs, binding)
+    }
+  }
+}
+
+object CometShuffle extends CometExpressionSerde[Shuffle] with ArraysBase {
+
+  // Comet reproduces Spark's random permutation exactly: the resolved seed is combined with the
+  // partition index and drives the same MersenneTwister-based inside-out Fisher-Yates shuffle as
+  // org.apache.spark.sql.catalyst.util.RandomIndicesGenerator, so results match Spark bit for bit.
+  override def getSupportLevel(expr: Shuffle): SupportLevel = childTypesSupportLevel(expr)
+
+  override def convert(expr: Shuffle, inputs: Seq[Attribute], binding: Boolean): Option[Expr] = {
+    // In a resolved plan `randomSeed` is always defined (resolution requires it). Guard anyway.
+    expr.randomSeed match {
+      case Some(seed) =>
+        exprToProtoInternal(expr.child, inputs, binding).map { child =>
+          ExprOuterClass.Expr
+            .newBuilder()
+            .setShuffle(
+              ExprOuterClass.Shuffle
+                .newBuilder()
+                .setChild(child)
+                .setSeed(seed))
+            .build()
+        }
+      case None =>
+        withFallbackReason(expr, "shuffle requires a resolved random seed")
+        None
     }
   }
 }

--- a/spark/src/test/resources/sql-tests/expressions/array/shuffle.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/shuffle.sql
@@ -1,0 +1,173 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- shuffle(array) with no seed resolves to a fresh random seed on every analysis, so the Spark and
+-- Comet runs use different seeds and their raw output cannot be compared directly. These queries
+-- therefore either assert only that shuffle runs natively while preserving array size (size is
+-- deterministic), or compare seed independent projections (sort_array over the shuffled result).
+-- Exact permutation equality with a fixed seed lives in shuffle_with_seed.sql (Spark 4.0+, where
+-- the two argument shuffle(array, seed) form exists).
+
+-- ===== INT arrays =====
+
+statement
+CREATE TABLE test_shuffle_int(arr array<int>) USING parquet
+
+statement
+INSERT INTO test_shuffle_int VALUES
+  (array(1, 2, 3, 4, 5)),
+  (array()),
+  (NULL),
+  (array(NULL, 1, NULL, 2)),
+  (array(1)),
+  (array(-2147483648, 2147483647, 0)),
+  (array(10, 20, 30, 40, 50, 60, 70, 80, 90, 100))
+
+-- shuffle preserves size and runs natively (column argument)
+query
+SELECT size(shuffle(arr)) FROM test_shuffle_int
+
+-- shuffle preserves size and runs natively (literal argument)
+query
+SELECT size(shuffle(array(1, 20, 3, 5)))
+
+-- single element
+query
+SELECT size(shuffle(array(42)))
+
+-- empty array
+query
+SELECT size(shuffle(CAST(array() AS array<int>)))
+
+-- NULL input
+query
+SELECT size(shuffle(CAST(NULL AS array<int>)))
+
+-- a shuffle is a permutation, so sorting it matches sorting the input (seed independent)
+query spark_answer_only
+SELECT sort_array(shuffle(arr)) FROM test_shuffle_int
+
+-- ===== LONG arrays =====
+
+statement
+CREATE TABLE test_shuffle_long(arr array<bigint>) USING parquet
+
+statement
+INSERT INTO test_shuffle_long VALUES
+  (array(1, 2, 3, 4, 5)),
+  (NULL),
+  (array(NULL, 1, NULL, 2)),
+  (array(-9223372036854775808, 9223372036854775807, 0))
+
+query
+SELECT size(shuffle(arr)) FROM test_shuffle_long
+
+query spark_answer_only
+SELECT sort_array(shuffle(arr)) FROM test_shuffle_long
+
+-- ===== STRING arrays =====
+
+statement
+CREATE TABLE test_shuffle_string(arr array<string>) USING parquet
+
+statement
+INSERT INTO test_shuffle_string VALUES
+  (array('a', 'b', 'c', 'd', 'e')),
+  (array('')),
+  (NULL),
+  (array(NULL, 'a', NULL, 'b')),
+  (array('hello', 'world', '中文', 'é', '\t'))
+
+query
+SELECT size(shuffle(arr)) FROM test_shuffle_string
+
+query spark_answer_only
+SELECT sort_array(shuffle(arr)) FROM test_shuffle_string
+
+-- ===== BOOLEAN arrays =====
+
+statement
+CREATE TABLE test_shuffle_bool(arr array<boolean>) USING parquet
+
+statement
+INSERT INTO test_shuffle_bool VALUES
+  (array(true, false, true, false, true)),
+  (NULL),
+  (array(NULL, true, NULL, false))
+
+query
+SELECT size(shuffle(arr)) FROM test_shuffle_bool
+
+query spark_answer_only
+SELECT sort_array(shuffle(arr)) FROM test_shuffle_bool
+
+-- ===== DOUBLE arrays (NaN, Infinity, -0.0) =====
+
+statement
+CREATE TABLE test_shuffle_double(arr array<double>) USING parquet
+
+statement
+INSERT INTO test_shuffle_double VALUES
+  (array(1.1, 2.2, 3.3, 4.4, 5.5)),
+  (NULL),
+  (array(CAST('NaN' AS DOUBLE), CAST('Infinity' AS DOUBLE), CAST('-Infinity' AS DOUBLE), 0.0, -0.0))
+
+query
+SELECT size(shuffle(arr)) FROM test_shuffle_double
+
+query spark_answer_only
+SELECT sort_array(shuffle(arr)) FROM test_shuffle_double
+
+-- ===== DECIMAL arrays =====
+
+statement
+CREATE TABLE test_shuffle_decimal(arr array<decimal(10,2)>) USING parquet
+
+statement
+INSERT INTO test_shuffle_decimal VALUES
+  (array(1.10, 2.20, 3.30, 4.40)),
+  (NULL),
+  (array(NULL, 1.10, NULL, 2.20))
+
+query
+SELECT size(shuffle(arr)) FROM test_shuffle_decimal
+
+query spark_answer_only
+SELECT sort_array(shuffle(arr)) FROM test_shuffle_decimal
+
+-- ===== DATE arrays =====
+
+statement
+CREATE TABLE test_shuffle_date(arr array<date>) USING parquet
+
+statement
+INSERT INTO test_shuffle_date VALUES
+  (array(DATE '2020-01-01', DATE '2021-06-15', DATE '1999-12-31', DATE '2000-02-29'))
+
+query
+SELECT size(shuffle(arr)) FROM test_shuffle_date
+
+query spark_answer_only
+SELECT sort_array(shuffle(arr)) FROM test_shuffle_date
+
+-- ===== Nested arrays (array of arrays) =====
+
+query
+SELECT size(shuffle(array(array(1, 2), array(3, 4), array(5, 6), array(7, 8))))
+
+query spark_answer_only
+SELECT sort_array(shuffle(array(array(1, 2), array(3, 4), array(5, 6))))

--- a/spark/src/test/resources/sql-tests/expressions/array/shuffle_with_seed.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/shuffle_with_seed.sql
@@ -1,0 +1,181 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- The two argument shuffle(array, seed) form only exists in Spark 4.0+. With a fixed seed the
+-- permutation is deterministic, so Comet must reproduce Spark's output exactly. Comet drives the
+-- same Commons Math3 MersenneTwister and inside-out Fisher-Yates as
+-- org.apache.spark.sql.catalyst.util.RandomIndicesGenerator, combining the seed with the partition
+-- index, so these queries assert bit-for-bit equality with Spark in the default query mode.
+
+-- MinSparkVersion: 4.0
+
+-- ===== INT arrays =====
+
+statement
+CREATE TABLE test_shuffle_seed_int(arr array<int>) USING parquet
+
+statement
+INSERT INTO test_shuffle_seed_int VALUES
+  (array(1, 2, 3, 4, 5)),
+  (array()),
+  (NULL),
+  (array(NULL, 1, NULL, 2)),
+  (array(1)),
+  (array(-2147483648, 2147483647, 0)),
+  (array(10, 20, 30, 40, 50, 60, 70, 80, 90, 100))
+
+-- column argument, fixed seed
+query
+SELECT shuffle(arr, 42) FROM test_shuffle_seed_int
+
+-- column argument, seed 0
+query
+SELECT shuffle(arr, 0) FROM test_shuffle_seed_int
+
+-- column argument, negative seed
+query
+SELECT shuffle(arr, -12345) FROM test_shuffle_seed_int
+
+-- literal argument, fixed seed
+query
+SELECT shuffle(array(1, 20, 3, 5), 42)
+
+-- larger literal array, fixed seed
+query
+SELECT shuffle(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 123456789)
+
+-- literal array with NULLs, fixed seed
+query
+SELECT shuffle(array(1, 20, NULL, 3), 7)
+
+-- single element
+query
+SELECT shuffle(array(42), 1)
+
+-- empty array
+query
+SELECT shuffle(CAST(array() AS array<int>), 1)
+
+-- NULL input
+query
+SELECT shuffle(CAST(NULL AS array<int>), 1)
+
+-- ===== LONG arrays =====
+
+statement
+CREATE TABLE test_shuffle_seed_long(arr array<bigint>) USING parquet
+
+statement
+INSERT INTO test_shuffle_seed_long VALUES
+  (array(1, 2, 3, 4, 5)),
+  (NULL),
+  (array(NULL, 1, NULL, 2)),
+  (array(-9223372036854775808, 9223372036854775807, 0))
+
+query
+SELECT shuffle(arr, 42) FROM test_shuffle_seed_long
+
+query
+SELECT shuffle(array(CAST(-9223372036854775808 AS BIGINT), CAST(0 AS BIGINT), CAST(9223372036854775807 AS BIGINT)), 99)
+
+-- ===== STRING arrays =====
+
+statement
+CREATE TABLE test_shuffle_seed_string(arr array<string>) USING parquet
+
+statement
+INSERT INTO test_shuffle_seed_string VALUES
+  (array('a', 'b', 'c', 'd', 'e')),
+  (array('')),
+  (NULL),
+  (array(NULL, 'a', NULL, 'b')),
+  (array('hello', 'world', '中文', 'é', '\t'))
+
+query
+SELECT shuffle(arr, 42) FROM test_shuffle_seed_string
+
+query
+SELECT shuffle(array('a', 'b', 'c', 'd', 'e', 'f'), 3)
+
+-- multibyte and special characters
+query
+SELECT shuffle(array('中文', 'é', '\t', 'x'), 5)
+
+-- ===== BOOLEAN arrays =====
+
+statement
+CREATE TABLE test_shuffle_seed_bool(arr array<boolean>) USING parquet
+
+statement
+INSERT INTO test_shuffle_seed_bool VALUES
+  (array(true, false, true, false, true)),
+  (NULL),
+  (array(NULL, true, NULL, false))
+
+query
+SELECT shuffle(arr, 42) FROM test_shuffle_seed_bool
+
+-- ===== DOUBLE arrays (NaN, Infinity, -0.0) =====
+
+statement
+CREATE TABLE test_shuffle_seed_double(arr array<double>) USING parquet
+
+statement
+INSERT INTO test_shuffle_seed_double VALUES
+  (array(1.1, 2.2, 3.3, 4.4, 5.5)),
+  (NULL),
+  (array(CAST('NaN' AS DOUBLE), CAST('Infinity' AS DOUBLE), CAST('-Infinity' AS DOUBLE), 0.0, -0.0))
+
+query
+SELECT shuffle(arr, 42) FROM test_shuffle_seed_double
+
+query
+SELECT shuffle(array(CAST('NaN' AS DOUBLE), CAST('Infinity' AS DOUBLE), CAST('-Infinity' AS DOUBLE), 0.0, -0.0), 8)
+
+-- ===== DECIMAL arrays =====
+
+statement
+CREATE TABLE test_shuffle_seed_decimal(arr array<decimal(10,2)>) USING parquet
+
+statement
+INSERT INTO test_shuffle_seed_decimal VALUES
+  (array(1.10, 2.20, 3.30, 4.40)),
+  (NULL),
+  (array(NULL, 1.10, NULL, 2.20))
+
+query
+SELECT shuffle(arr, 42) FROM test_shuffle_seed_decimal
+
+-- ===== DATE arrays =====
+
+statement
+CREATE TABLE test_shuffle_seed_date(arr array<date>) USING parquet
+
+statement
+INSERT INTO test_shuffle_seed_date VALUES
+  (array(DATE '2020-01-01', DATE '2021-06-15', DATE '1999-12-31', DATE '2000-02-29'))
+
+query
+SELECT shuffle(arr, 42) FROM test_shuffle_seed_date
+
+-- ===== Nested arrays (array of arrays) =====
+
+query
+SELECT shuffle(array(array(1, 2), array(3, 4), array(5, 6), array(7, 8)), 42)
+
+query
+SELECT shuffle(array(array(1, 2), CAST(NULL AS array<int>), array(5, 6)), 4)


### PR DESCRIPTION
## Which issue does this PR close?

Relates to #4150 (expressions available in the `datafusion-spark` crate). There is no dedicated tracking issue for `shuffle`, so this does not close a specific issue.

## Rationale for this change

`shuffle(array)` returns a random permutation of an array and was previously unsupported by Comet, causing fallback to Spark. Adding native support removes that fallback.

The challenge with `shuffle` is that it is non-deterministic: for a given seed it produces one specific permutation, and to be Spark-compatible Comet must reproduce Spark's exact output. The upstream `datafusion-spark::SparkShuffle` uses a different RNG (`StdRng` + `SliceRandom`) and does not fold in the partition index, so it does not match Spark. This PR instead reproduces Spark's algorithm exactly.

## What changes are included in this PR?

- New `Shuffle` protobuf message carrying the child array and the resolved seed.
- `CometShuffle` Scala serde (`collectionOperations.scala`), registered in `QueryPlanSerde`. It extracts Spark's resolved `randomSeed` and reports `Compatible` for supported element types via `childTypesSupportLevel` (binary/struct/map element types fall back, consistent with the other array expressions).
- Native `ShuffleExpr` (`nondetermenistic_funcs/shuffle.rs`), a stateful `PhysicalExpr` mirroring the existing `Rand`/`Randn` design:
  - A bit-for-bit port of Apache Commons Math3's `MersenneTwister` plus the inside-out Fisher-Yates algorithm from Spark's `RandomIndicesGenerator`.
  - The builder folds the partition index into the seed (`seed + partition`), matching Spark's `randomSeed + partitionIndex`.
  - RNG state is held in a `Mutex` so it advances continuously across batches within a partition. NULL rows pass through without advancing the RNG, matching Spark.
  - Element reordering uses the Arrow `take` kernel, so all supported element types are handled generically.
- Updated the expression support table and added an entry to the `array_funcs` expression audit.

Note: the two-argument `shuffle(array, seed)` SQL form only exists in Spark 4.0+, so exact-seed tests are gated to Spark 4.0+ while the all-version tests use the one-argument form.

This implementation was scaffolded using the `implement-comet-expression` project skill, which also ran the `audit-comet-expression` skill across Spark 3.4.3, 3.5.8, 4.0.1, and 4.1.1.

## How are these changes tested?

- Native unit tests validate the `MersenneTwister` port against golden vectors generated from the real Apache Commons Math3 library, and against Spark's own reference test values (`Shuffle(array(1,2,3,4,5), Some(0))` -> `[4,1,2,3,5]`).
- `shuffle.sql` (all Spark versions): asserts native execution and that shuffle preserves array size, plus seed-independent multiset equality via `sort_array`.
- `shuffle_with_seed.sql` (Spark 4.0+): asserts bit-for-bit permutation equality with Spark using fixed seeds, across int, long, string, boolean, double (NaN/Infinity/-0.0), decimal, date, and nested-array inputs, including NULL input, null elements, empty, single-element, and boundary values.
- Verified passing on Spark 4.1 (exact seeded match) and Spark 3.5 (all-version file passes, seeded file correctly skipped).