### PR TITLE
chore: Run tests with default ANSI flag

### DIFF
--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -26,7 +26,6 @@ import scala.jdk.CollectionConverters._
 import scala.util.Random
 
 import org.apache.hadoop.fs.Path
-import org.apache.spark.SparkConf
 import org.apache.spark.sql.{CometTestBase, DataFrame, Row, SaveMode}
 import org.apache.spark.sql.catalyst.expressions.Cast
 import org.apache.spark.sql.catalyst.parser.ParseException
@@ -42,11 +41,6 @@ import org.apache.comet.serde.{Compatible, Incompatible, Unsupported}
 class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
 
   import testImplicits._
-
-  // Casts in this suite predominantly test non-ANSI semantics (silent overflow/null on
-  // invalid input); tests that target ANSI behavior opt in explicitly via withSQLConf.
-  override protected def sparkConf: SparkConf =
-    super.sparkConf.set(SQLConf.ANSI_ENABLED.key, "false")
 
   /** Create a data generator using a fixed seed so that tests are reproducible */
   private val gen = DataGenerator.DEFAULT

--- a/spark/src/test/scala/org/apache/comet/CometFuzzMathSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometFuzzMathSuite.scala
@@ -19,17 +19,9 @@
 
 package org.apache.comet
 
-import org.apache.spark.SparkConf
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DecimalType, IntegerType, LongType}
 
 class CometFuzzMathSuite extends CometFuzzTestBase {
-
-  // The integer-math fuzz tests intentionally cover overflowing inputs; under Spark 4's
-  // default ANSI mode those would throw rather than produce a result for both Spark and
-  // Comet to compare against. Pin ANSI off so the parity comparison can run.
-  override protected def sparkConf: SparkConf =
-    super.sparkConf.set(SQLConf.ANSI_ENABLED.key, "false")
 
   for (op <- Seq("+", "-", "*", "/", "div")) {
     test(s"integer math: $op") {
@@ -63,5 +55,4 @@ class CometFuzzMathSuite extends CometFuzzTestBase {
       checkSparkAnswerAndOperator(sql)
     }
   }
-
 }

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -43,11 +43,6 @@ import org.apache.comet.testing.{DataGenOptions, FuzzDataGenerator, ParquetGener
 class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   import testImplicits._
 
-  // Several aggregate tests exercise overflow behavior expected to wrap around silently;
-  // ANSI-mode variants opt in to ANSI explicitly via withSQLConf.
-  override protected def sparkConf: SparkConf =
-    super.sparkConf.set(SQLConf.ANSI_ENABLED.key, "false")
-
   test("min/max floating point with negative zero") {
     val r = new Random(42)
     val schema = StructType(

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -22,7 +22,6 @@ package org.apache.comet.exec
 import scala.util.Random
 
 import org.apache.hadoop.fs.Path
-import org.apache.spark.SparkConf
 import org.apache.spark.sql.{CometTestBase, DataFrame, Row}
 import org.apache.spark.sql.catalyst.expressions.Cast
 import org.apache.spark.sql.catalyst.optimizer.EliminateSorts


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

Spark 4.0 has ANSI mode is ON, so we need to run tests avoiding hardcoded ANSI off

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
