### PR TITLE
fix: widen local table scan child nullability to match native kernels

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometSink.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometSink.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.adaptive.ShuffleQueryStageExec
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
+import org.apache.spark.sql.types.DataType
 
 import org.apache.comet.CometConf
 import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
@@ -41,6 +42,13 @@ import org.apache.comet.serde.QueryPlanSerde.{serializeDataType, supportedDataTy
 abstract class CometSink[T <: SparkPlan] extends CometOperatorSerde[T] {
 
   override def enabledConfig: Option[ConfigEntry[Boolean]] = None
+
+  /**
+   * The data type to declare for a scan output field. Overridden by sinks whose source carries
+   * non-null nested child fields that must be widened to match the planned kernel output types
+   * (see [[org.apache.spark.sql.comet.CometLocalTableScanExec]] and issue #4789).
+   */
+  protected def scanFieldType(dt: DataType): DataType = dt
 
   override def convert(
       op: T,
@@ -64,7 +72,7 @@ abstract class CometSink[T <: SparkPlan] extends CometOperatorSerde[T] {
     }
 
     val scanTypes = op.output.flatten { attr =>
-      serializeDataType(attr.dataType)
+      serializeDataType(scanFieldType(attr.dataType))
     }
 
     if (scanTypes.length == op.output.length) {

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometLocalTableScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometLocalTableScanExec.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.comet.execution.arrow.{CometArrowStream, CometNative
 import org.apache.spark.sql.comet.util.Utils
 import org.apache.spark.sql.execution.{LeafExecNode, LocalTableScanExec}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
-import org.apache.spark.sql.types.{DataType, NullType}
+import org.apache.spark.sql.types.{DataType, NullType, StructType}
 
 import com.google.common.base.Objects
 
@@ -76,7 +76,15 @@ case class CometLocalTableScanExec(
       consume: (String, BufferAllocator => ArrowReader) => Iterator[T]): RDD[T] = {
     val numOutputRows = longMetric("numOutputRows")
     val maxRecordsPerBatch = CometConf.COMET_BATCH_SIZE.get(conf)
-    val sparkSchema = originalPlan.schema
+    // Normalize nested child-field nullability. An in-memory Seq/Map encodes array elements and
+    // map values as non-null (containsNull=false / valueContainsNull=false), but Comet expression
+    // serdes promise nullable children, so feeding a non-null child from the local scan into a
+    // native kernel fails the planned-vs-actual type assertion (issue #4789). Widening children to
+    // nullable is always safe: the row data contains no nulls, and Arrow map keys stay non-null via
+    // Utils.toArrowField. This must agree with the widened scan schema declared in
+    // CometLocalTableScanExec.scanFieldType so the native ScanExec does not cast the batch back.
+    val sparkSchema =
+      StructType(originalPlan.schema.map(f => f.copy(dataType = f.dataType.asNullable)))
     rdd.mapPartitionsInternal { rowIter =>
       val arrowSchema = Utils.toArrowSchema(sparkSchema, CometArrowStream.NATIVE_TIMEZONE)
       consume(
@@ -117,6 +125,11 @@ object CometLocalTableScanExec extends CometSink[LocalTableScanExec] with DataTy
 
   override def enabledConfig: Option[ConfigEntry[Boolean]] = Some(
     CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED)
+
+  // Widen nested child-field nullability in the declared scan schema so it matches both the widened
+  // Arrow batch produced by CometLocalTableScanExec and the nullable children promised by
+  // downstream expression serdes (issue #4789).
+  override protected def scanFieldType(dt: DataType): DataType = dt.asNullable
 
   // ArrowWriter (used by RowArrowReader) handles NullType via Utils.toArrowType + NullWriter;
   // other types off DataTypeSupport's allow list (TimeType, intervals, ...) have no ArrowWriter

--- a/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
@@ -1146,6 +1146,37 @@ class CometArrayExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelp
     }
   }
 
+  // Local table scan carries non-null array child fields (an in-memory Seq encodes
+  // containsNull=false) into native kernels that promise nullable elements. ConvertToLocalRelation
+  // must be disabled or the optimizer folds the expression at plan time and nothing runs natively.
+  // https://github.com/apache/datafusion-comet/issues/4789
+  private def withLocalTableScanNoFold(f: => Unit): Unit = {
+    withSQLConf(
+      CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true",
+      "spark.sql.optimizer.excludedRules" ->
+        "org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation") {
+      f
+    }
+  }
+
+  test("slice on non-null element array from local table scan (#4789)") {
+    withLocalTableScanNoFold {
+      import testImplicits._
+      val df = Seq(Seq(1, 2, 3), Seq(4, 5)).toDF("x")
+      checkSparkAnswerAndOperator(df.selectExpr("slice(x, 2, 2)"))
+    }
+  }
+
+  test("array_insert on non-null element array from local table scan (#4789)") {
+    assume(isSpark35Plus)
+    withLocalTableScanNoFold {
+      import testImplicits._
+      val df = Seq(Seq(1, 2, 3), Seq(4, 5)).toDF("x")
+      // SPARK-41233 array prepend lowers to array_insert at position 1
+      checkSparkAnswerAndOperator(df.selectExpr("array_insert(x, 1, 0)"))
+    }
+  }
+
   // https://issues.apache.org/jira/browse/SPARK-55747
   test("(ansi) GetArrayItem on null array from split()") {
     withSQLConf(

--- a/spark/src/test/scala/org/apache/comet/CometMapExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometMapExpressionSuite.scala
@@ -247,4 +247,18 @@ class CometMapExpressionSuite extends CometTestBase {
     }
   }
 
+  test("map_entries on non-null value map from local table scan (#4789)") {
+    // An in-memory Map encodes valueContainsNull=false; the local scan must widen the map value
+    // to nullable so map_entries' native ListArray/Struct build does not fail on the child type.
+    // ConvertToLocalRelation must be disabled or the expression folds at plan time.
+    withSQLConf(
+      CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true",
+      "spark.sql.optimizer.excludedRules" ->
+        "org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation") {
+      import testImplicits._
+      val df = Seq(Map(1 -> 100, 2 -> 200)).toDF("m")
+      checkSparkAnswerAndOperator(df.selectExpr("map_entries(m)"))
+    }
+  }
+
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4789.

## Rationale for this change

Several Comet array/map expressions crash natively when the input comes through `CometLocalTableScanExec` with a non-nullable child field. An in-memory `Seq[Int]` / `Map[Int, Int]` column encodes its array element / map value as non-null (`containsNull=false` / `valueContainsNull=false`), but Comet expression serdes promise nullable children. Feeding a non-null child into a native kernel disagrees with the planned output type:

- `slice`: `Assertion failed: result_data_type == *expected_type: Function 'spark_array_slice' returned value of type 'List(non-null Int32)' while ... expected: 'List(Int32)'`
- `map_entries`: `ListArray expected data type Struct("key": non-null Int32, "value": Int32) got Struct("key": non-null Int32, "value": non-null Int32)`
- `array_insert` / SPARK-41233 array prepend: analogous item-vs-array type mismatch

It does not reproduce over a native Parquet scan (which normalizes children to nullable) or with a SQL `array(...)` / `map(...)` literal (literal children are nullable), so it is specific to the local scan path.

## What changes are included in this PR?

The non-null child is carried in two places, so both must be reconciled:

1. The Arrow batch produced by `CometLocalTableScanExec.mapToReaders` (built from `originalPlan.schema`).
2. The native `ScanExec`'s declared schema, serialized from `op.output` in `CometSink.convert`. `scan.rs:build_record_batch` casts the imported batch back to this declared schema, so widening only the Arrow data is reverted by the cast.

Changes:

- Add `QueryPlanSerde.widenChildNullability`, which recursively widens array elements, map values, and struct fields to nullable while leaving top-level types and map keys unchanged (map keys stay non-null, matching Arrow, and their nullability is never serialized).
- Add an overridable `scanFieldType` hook in `CometSink` (default identity) so the widening is scoped to the local table scan and does not affect Union/Coalesce/shuffle sinks, whose children come from already-normalized native execution.
- `CometLocalTableScanExec` overrides the hook and applies the same widening to its Arrow schema, so the declared schema and the batch agree exactly and no per-batch cast is needed.

This mirrors how the Parquet scan path already normalizes children to nullable. No native/Rust changes are required.

## How are these changes tested?

Added regression tests that run through the local table scan with `ConvertToLocalRelation` disabled (so the expression executes natively rather than being folded at plan time):

- `CometArrayExpressionSuite`: `slice` and `array_insert` on non-null-element arrays.
- `CometMapExpressionSuite`: `map_entries` on a non-null-value map.

All new tests pass, along with the existing `CometArrayExpressionSuite`, `CometMapExpressionSuite`, and the `LocalTableScan` tests in `CometExecSuite` (including nested `NullType` in struct/array/map).
