### PR TITLE
fix: correct user guide URL in compatibility fallback messages

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -46,7 +46,7 @@ import org.apache.comet.shims.ShimCometConf
 object CometConf extends ShimCometConf {
 
   val COMPAT_GUIDE: String = "For more information, refer to the Comet Compatibility " +
-    "Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html)"
+    "Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)"
 
   private val TUNING_GUIDE = "For more information, refer to the Comet Tuning " +
     "Guide (https://datafusion.apache.org/comet/user-guide/tuning.html)"

--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -49,7 +49,7 @@ object CometConf extends ShimCometConf {
     "Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)"
 
   private val TUNING_GUIDE = "For more information, refer to the Comet Tuning " +
-    "Guide (https://datafusion.apache.org/comet/user-guide/tuning.html)"
+    "Guide (https://datafusion.apache.org/comet/user-guide/latest/tuning.html)"
 
   private val TRACING_GUIDE = "For more information, refer to the Comet Tracing " +
     "Guide (https://datafusion.apache.org/comet/contributor-guide/tracing.html)"

--- a/spark/src/main/scala/org/apache/comet/serde/SupportLevel.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/SupportLevel.scala
@@ -30,8 +30,8 @@ sealed trait SupportLevel
  * Comet either supports this feature with full compatibility with Spark, or may have known
  * differences in some specific edge cases that are unlikely to be an issue for most users.
  *
- * Any compatibility differences are noted in the
- * [[https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html Comet Compatibility Guide]].
+ * Any compatibility differences are noted in the Comet Compatibility Guide:
+ * [[https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html]].
  */
 case class Compatible(notes: Option[String] = None, nativeOptIn: Option[NativeOptIn] = None)
     extends SupportLevel
@@ -39,8 +39,8 @@ case class Compatible(notes: Option[String] = None, nativeOptIn: Option[NativeOp
 /**
  * Comet supports this feature but results can be different from Spark.
  *
- * Any compatibility differences are noted in the
- * [[https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html Comet Compatibility Guide]].
+ * Any compatibility differences are noted in the Comet Compatibility Guide:
+ * [[https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html]].
  */
 case class Incompatible(notes: Option[String] = None) extends SupportLevel
 

--- a/spark/src/main/scala/org/apache/comet/serde/SupportLevel.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/SupportLevel.scala
@@ -31,7 +31,7 @@ sealed trait SupportLevel
  * differences in some specific edge cases that are unlikely to be an issue for most users.
  *
  * Any compatibility differences are noted in the
- * [[https://datafusion.apache.org/comet/user-guide/compatibility.html Comet Compatibility Guide]].
+ * [[https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html Comet Compatibility Guide]].
  */
 case class Compatible(notes: Option[String] = None, nativeOptIn: Option[NativeOptIn] = None)
     extends SupportLevel
@@ -40,7 +40,7 @@ case class Compatible(notes: Option[String] = None, nativeOptIn: Option[NativeOp
  * Comet supports this feature but results can be different from Spark.
  *
  * Any compatibility differences are noted in the
- * [[https://datafusion.apache.org/comet/user-guide/compatibility.html Comet Compatibility Guide]].
+ * [[https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html Comet Compatibility Guide]].
  */
 case class Incompatible(notes: Option[String] = None) extends SupportLevel
 

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a/extended.txt
@@ -9,7 +9,7 @@ CometNativeColumnarToRow
    :                    +- CometExchange
    :                       +- CometHashAggregate
    :                          +- CometProject
-   :                             +-  CometBroadcastHashJoin [COMET-INFO: A native implementation of Upper is available. Set spark.comet.caseConversion.enabled=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html)]
+   :                             +-  CometBroadcastHashJoin [COMET-INFO: A native implementation of Upper is available. Set spark.comet.caseConversion.enabled=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
    :                                :- CometProject
    :                                :  +- CometBroadcastHashJoin
    :                                :     :- CometProject
@@ -51,7 +51,7 @@ CometNativeColumnarToRow
                +- CometExchange
                   +- CometHashAggregate
                      +- CometProject
-                        +-  CometBroadcastHashJoin [COMET-INFO: A native implementation of Upper is available. Set spark.comet.caseConversion.enabled=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html)]
+                        +-  CometBroadcastHashJoin [COMET-INFO: A native implementation of Upper is available. Set spark.comet.caseConversion.enabled=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
                            :- CometProject
                            :  +- CometBroadcastHashJoin
                            :     :- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b/extended.txt
@@ -9,7 +9,7 @@ CometNativeColumnarToRow
    :                    +- CometExchange
    :                       +- CometHashAggregate
    :                          +- CometProject
-   :                             +-  CometBroadcastHashJoin [COMET-INFO: A native implementation of Upper is available. Set spark.comet.caseConversion.enabled=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html)]
+   :                             +-  CometBroadcastHashJoin [COMET-INFO: A native implementation of Upper is available. Set spark.comet.caseConversion.enabled=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
    :                                :- CometProject
    :                                :  +- CometBroadcastHashJoin
    :                                :     :- CometProject
@@ -51,7 +51,7 @@ CometNativeColumnarToRow
                +- CometExchange
                   +- CometHashAggregate
                      +- CometProject
-                        +-  CometBroadcastHashJoin [COMET-INFO: A native implementation of Upper is available. Set spark.comet.caseConversion.enabled=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html)]
+                        +-  CometBroadcastHashJoin [COMET-INFO: A native implementation of Upper is available. Set spark.comet.caseConversion.enabled=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
                            :- CometProject
                            :  +- CometBroadcastHashJoin
                            :     :- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24/extended.txt
@@ -11,7 +11,7 @@ CometNativeColumnarToRow
          :                    +- CometExchange
          :                       +- CometHashAggregate
          :                          +- CometProject
-         :                             +-  CometBroadcastHashJoin [COMET-INFO: A native implementation of Upper is available. Set spark.comet.caseConversion.enabled=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html)]
+         :                             +-  CometBroadcastHashJoin [COMET-INFO: A native implementation of Upper is available. Set spark.comet.caseConversion.enabled=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
          :                                :- CometProject
          :                                :  +- CometBroadcastHashJoin
          :                                :     :- CometProject
@@ -53,7 +53,7 @@ CometNativeColumnarToRow
                      +- CometExchange
                         +- CometHashAggregate
                            +- CometProject
-                              +-  CometBroadcastHashJoin [COMET-INFO: A native implementation of Upper is available. Set spark.comet.caseConversion.enabled=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html)]
+                              +-  CometBroadcastHashJoin [COMET-INFO: A native implementation of Upper is available. Set spark.comet.caseConversion.enabled=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
                                  :- CometProject
                                  :  +- CometBroadcastHashJoin
                                  :     :- CometProject


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4851.

## Rationale for this change

Fallback messages emitted in query plans (and the scaladoc on `SupportLevel`) link to `https://datafusion.apache.org/comet/user-guide/compatibility.html`. After the user guide documentation was reorganized under a versioned `latest/` path, the compatibility guide moved from a single page to a directory, so the old link is stale. The configured redirect (`user-guide/compatibility.html` -> `latest/compatibility.html` in `docs/source/conf.py`) also no longer resolves because the target is now a directory rather than an `.html` file.

## What changes are included in this PR?

Update the compatibility guide URL used in fallback messages and scaladoc to the current canonical location:

`https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html`

This matches how the compatibility guide is linked elsewhere in the docs (for example `docs/source/about/gluten_comparison.md`).

Only the compatibility guide link is changed. The tuning guide link still redirects correctly because that page remained a single file.

## How are these changes tested?

The changes are limited to documentation URL string literals. The updated URL was verified to return HTTP 200 on the published documentation site.