### PR TITLE
docs: announce JDK 11 and Spark 3.4 deprecation for 1.1.0 removal

### DIFF
--- a/docs/source/user-guide/latest/compatibility/spark-versions.md
+++ b/docs/source/user-guide/latest/compatibility/spark-versions.md
@@ -28,6 +28,10 @@ compatibility guide.
 
 Spark 3.4.3 is supported with Java 11/17 and Scala 2.12/2.13.
 
+```{warning}
+Spark 3.4 support is deprecated as of the 1.0.0 release and will be removed in the 1.1.0 release.
+```
+
 ### Known Limitations
 
 - **Reading `TimestampLTZ` as `TimestampNTZ`**: Spark 3.4 raises an error for this operation
@@ -42,6 +46,11 @@ Spark 3.4.3 is supported with Java 11/17 and Scala 2.12/2.13.
 ## Spark 3.5
 
 Spark 3.5.8 is supported with Java 11/17 and Scala 2.12/2.13.
+
+```{warning}
+JDK 11 support is deprecated as of the 1.0.0 release and will be removed in the 1.1.0 release.
+We recommend moving to JDK 17 or later.
+```
 
 ### Known Limitations
 

--- a/docs/source/user-guide/latest/installation.md
+++ b/docs/source/user-guide/latest/installation.md
@@ -45,6 +45,11 @@ in the [Compatibility Guide] for more information, such as known limitations per
 We recommend only using Comet with Spark versions where we currently have both Comet and Spark tests enabled in CI.
 Other versions may work well enough for development and evaluation purposes.
 
+```{warning}
+JDK 11 and Spark 3.4 support are deprecated as of the 1.0.0 release and will be removed in the 1.1.0 release.
+We recommend moving to JDK 17 or later and Spark 3.5 or later.
+```
+
 | Spark Version | Java Version | Scala Version | Comet Tests in CI | Spark SQL Tests in CI |
 | ------------- | ------------ | ------------- | ----------------- | --------------------- |
 | 3.4.3         | 11/17        | 2.12/2.13     | Yes               | Yes                   |


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4845.

## Rationale for this change

As part of the 1.0.0 release we want to announce that JDK 11 and Spark 3.4 support are deprecated and will be removed in the 1.1.0 release, so users have time to migrate to JDK 17+ and Spark 3.5+.

## What changes are included in this PR?

- Add a deprecation warning to the "Supported Spark Versions" section of the installation guide covering both JDK 11 and Spark 3.4.
- Add a deprecation warning to the Spark 3.4 section of the Spark version compatibility guide.
- Add a JDK 11 deprecation warning to the Spark 3.5 section of the Spark version compatibility guide, since Spark 3.5 can run on JDK 11.

## How are these changes tested?

Documentation-only change. No tests are required.