### PR TITLE
docs: fix sidebar drawer mis-tap, missing aria-expanded, homepage permalink, and ASF links page

### DIFF
--- a/docs/source/_static/comet-ux.js
+++ b/docs/source/_static/comet-ux.js
@@ -221,6 +221,14 @@
     titles.forEach(function (link) {
       var details = link.nextElementSibling;
       if (!details || details.tagName !== 'DETAILS') return;
+      link.setAttribute('role', 'button');
+      link.setAttribute('aria-expanded', details.open ? 'true' : 'false');
+      // Listen on <details>'s own toggle event, not just this link's click,
+      // so aria-expanded stays correct whether the chevron/summary or the
+      // title triggered the change.
+      details.addEventListener('toggle', function () {
+        link.setAttribute('aria-expanded', details.open ? 'true' : 'false');
+      });
       link.addEventListener('click', function (e) {
         e.preventDefault();
         details.open = !details.open;

--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -684,10 +684,19 @@ html[data-theme="light"] .bd-links li.current:not(:has(li.current)) > a.current.
   font-weight: 400 !important;
 }
 
-/* Mobile sidebar nav header */
+/* Mobile sidebar nav header. Extra top padding: the mobile off-canvas
+   sidebar is a native <dialog> opened via showModal(), which the browser
+   promotes to the "top layer" above everything else and makes the rest of
+   the page inert — so the hamburger button behind it is never reachable
+   while the drawer is open, by design (Escape and tapping the backdrop
+   both already close it correctly). But this drawer's own first item —
+   the "Home" link comet-ux.js prepends into its nav copy — sat close
+   enough to the header's hamburger position that a user instinctively
+   tapping there to close the menu was likely to hit "Home" and navigate
+   away instead. Push it down so it doesn't overlap that corner. */
 .sidebar-header-items {
   border-bottom: 1px solid var(--pst-color-border) !important;
-  padding: 8px 0 !important;
+  padding: 56px 0 8px !important;
 }
 
 /* ─── LAYOUT GRID ──────────────────────────────────────────────────── */
@@ -1347,10 +1356,14 @@ body:has(.comet-hero) article.bd-article {
 
 /* Landing page: hide chrome that doesn't belong on a marketing page.
    The H1 stays (now lives inside the hero as the project's brand statement)
-   so we no longer hide it. */
+   so we no longer hide it. myst_heading_anchors auto-adds a "#" permalink
+   next to every heading so readers can deep-link to a doc subsection —
+   useful on regular content pages, but meaningless on the hero title of a
+   landing page, so it's hidden here specifically. */
 body:has(.comet-hero) .bd-breadcrumbs,
 body:has(.comet-hero) footer.prev-next-footer,
-body:has(.comet-hero) .prev-next-area {
+body:has(.comet-hero) .prev-next-area,
+body:has(.comet-hero) a.headerlink {
   display: none !important;
 }
 

--- a/docs/source/asf/index.md
+++ b/docs/source/asf/index.md
@@ -21,17 +21,10 @@ under the License.
 
 Apache DataFusion Comet is part of the Apache Software Foundation. The links below point to ASF
 resources covering licensing, donations, security reporting, and the Foundation's code of conduct.
-Select a link from the navigation menu.
 
-```{toctree}
-:maxdepth: 1
-:caption: ASF Links
-:hidden:
-
-Apache Software Foundation <https://apache.org>
-License <https://www.apache.org/licenses/>
-Donate <https://www.apache.org/foundation/sponsorship.html>
-Thanks <https://www.apache.org/foundation/thanks.html>
-Security <https://www.apache.org/security/>
-Code of conduct <https://www.apache.org/foundation/policies/conduct.html>
-```
+- [Apache Software Foundation](https://apache.org)
+- [License](https://www.apache.org/licenses/)
+- [Donate](https://www.apache.org/foundation/sponsorship.html)
+- [Thanks](https://www.apache.org/foundation/thanks.html)
+- [Security](https://www.apache.org/security/)
+- [Code of conduct](https://www.apache.org/foundation/policies/conduct.html)


### PR DESCRIPTION

- Mobile sidebar drawer: tapping the hamburger's screen position while the drawer was open hit an injected "Home" link underneath it instead of closing the menu. Push the drawer's own nav content down so it doesn't overlap that corner.
- Sidebar section-title toggle wasn't exposing its open/closed state to screen readers. Sync aria-expanded with the details element.
- The homepage hero title showed a heading permalink ("#") that doesn't make sense on a marketing landing page. Hide it there, keep it working on regular docs pages.
- The ASF Links page said "select a link from the navigation menu" but the links only existed in a hidden sidebar toctree, never in the page itself. Show them as a plain list in the page body instead.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.



## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

3. before-
<img width="1710" height="1107" alt="Screenshot 2026-07-07 at 11 30 38 PM" src="https://github.com/user-attachments/assets/cd66f467-3732-4d0b-8212-16761eb609b1" />

after-
<img width="1710" height="1107" alt="Screenshot 2026-07-07 at 11 30 09 PM" src="https://github.com/user-attachments/assets/a0b56500-df6e-4e48-89d1-20c787135d97" />


4. ASF Links-
before-
<img width="1710" height="1107" alt="Screenshot 2026-07-07 at 11 26 26 PM" src="https://github.com/user-attachments/assets/3ed2a255-f40b-44f5-9d10-153953487013" />

after-
<img width="1710" height="1107" alt="Screenshot 2026-07-07 at 11 25 43 PM" src="https://github.com/user-attachments/assets/2503c907-2ab7-4f27-bb06-d69c6995a7dd" />

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
