### PR TITLE
feat: Support Spark expression hours_of_time

### DIFF
--- a/docs/source/contributor-guide/expression-audits/datetime_funcs.md
+++ b/docs/source/contributor-guide/expression-audits/datetime_funcs.md
@@ -44,6 +44,13 @@
 - Spark 4.0.1 (audited 2026-05-12): `inputTypes` widened to `StringTypeWithCollation`; behaviour unchanged for ASCII timezone strings.
 - Marked `Incompatible`: Comet's native timezone parser only accepts IANA zone IDs (e.g. `America/Los_Angeles`) and fixed `+HH:MM` offsets, while Spark also accepts legacy forms (`GMT+1`, `UTC+1`, three-letter abbreviations like `PST`). By default it runs through the codegen dispatcher (Spark-correct) and uses the native path only when incompatible expressions are explicitly allowed, where legacy zone forms throw a native parse error at execution (https://github.com/apache/datafusion-comet/issues/2013).
 
+## hour
+
+- Spark 3.4.3 (audited 2026-07-08): baseline. `Hour(TIMESTAMP)` only; no TIME-input variant. Handled by `CometHour`.
+- Spark 3.5.8 (audited 2026-07-08): identical to 3.4.3.
+- Spark 4.0.1 (audited 2026-07-08): identical to 3.5.8; still no `TimeType`.
+- Spark 4.1.1 (audited 2026-07-08): non-TIME `Hour` continues to use `CometHour`. `hour()` on a `TimeType` child routes through `HourExpressionBuilder` to `HoursOfTime`, a `RuntimeReplaceable` whose replacement is `StaticInvoke(DateTimeUtils, IntegerType, "getHoursOfTime", Seq(child))`. Comet's Spark 4.1 shim rewrites it to DataFusion's built-in `datepart('hour', time)`, which accepts Arrow `Time64(Nanosecond)` and returns Int32, matching Spark's Int result. `EXTRACT(HOUR FROM time)` rewrites to the same `HoursOfTime`, so it uses the same shim path. No timezone dependence: `TimeType` is a local time-of-day and `DateTimeUtils.getHoursOfTime` just calls `nanosToLocalTime(nanos).getHour`.
+
 ## make_timestamp_ltz
 
 - The 6-argument form rewrites to `MakeTimestamp` and runs via the codegen dispatcher. The 2-argument `(date, time)` form requires the Spark 4.1 TIME type and falls back.

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -389,9 +389,14 @@ impl PhysicalPlanner {
                             DataType::Timestamp(TimeUnit::Microsecond, Some(tz)) => {
                                 ScalarValue::TimestampMicrosecond(Some(*value), Some(tz))
                             }
+                            // Spark 4.1 TimeType literals arrive as i64 nanoseconds-since-midnight,
+                            // matching Arrow's Time64(Nanosecond) storage exactly.
+                            DataType::Time64(TimeUnit::Nanosecond) => {
+                                ScalarValue::Time64Nanosecond(Some(*value))
+                            }
                             dt => {
                                 return Err(GeneralError(format!(
-                                    "Expected either 'Int64' or 'Timestamp' for LongVal, but found {dt:?}"
+                                    "Expected 'Int64', 'Timestamp', or 'Time64(Nanosecond)' for LongVal, but found {dt:?}"
                                 )))
                             }
                         },

--- a/spark/src/main/spark-4.1+/org/apache/comet/shims/CometExprShim.scala
+++ b/spark/src/main/spark-4.1+/org/apache/comet/shims/CometExprShim.scala
@@ -66,6 +66,26 @@ trait CometExprShim extends Spark4xCometExprShim {
           scalarFunctionExprToProtoWithReturnType("make_time", s.dataType, true, childExprs: _*)
         optExprWithFallbackReason(optExpr, expr, s.arguments: _*)
 
+      // Spark 4.1's HoursOfTime is RuntimeReplaceable and resolves to
+      // StaticInvoke(DateTimeUtils, IntegerType, "getHoursOfTime", Seq(timeChild)).
+      // The child is a TimeType, which Comet maps to Arrow's Time64(Nanosecond). Route
+      // to DataFusion's built-in date_part, whose signature accepts Time and returns
+      // Int32 for hour, matching Spark's Int return type.
+      case s: StaticInvoke
+          if s.staticObject == classOf[DateTimeUtils.type] &&
+            s.functionName == "getHoursOfTime" &&
+            s.arguments.size == 1 &&
+            s.arguments.head.dataType.isInstanceOf[TimeType] =>
+        val periodExpr = exprToProtoInternal(Literal("hour"), inputs, binding)
+        val childExpr = exprToProtoInternal(s.arguments.head, inputs, binding)
+        val optExpr = scalarFunctionExprToProtoWithReturnType(
+          "datepart",
+          s.dataType,
+          false,
+          periodExpr,
+          childExpr)
+        optExprWithFallbackReason(optExpr, expr, s.arguments: _*)
+
       case i: Invoke =>
         (i.targetObject, i.functionName, i.arguments) match {
           case (Literal(parser: ToTimeParser, _), "parse", args)

--- a/spark/src/test/resources/sql-tests/expressions/datetime/hour_of_time.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/hour_of_time.sql
@@ -1,0 +1,67 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- MinSparkVersion: 4.1
+-- Config: spark.sql.timeType.enabled=true
+-- ConfigMatrix: spark.sql.session.timeZone=UTC,Asia/Kolkata
+
+-- hour() with TIME input resolves to HoursOfTime, which expands to a
+-- StaticInvoke(DateTimeUtils, "getHoursOfTime", TimeType). TIME cannot be stored in Parquet,
+-- so column-input TIME values are synthesized via to_time() on a string column.
+-- ConfigMatrix pins timezone-independence: TIME is a local time-of-day, so the extractor
+-- must return the same value under any session timezone (Asia/Kolkata has a half-hour
+-- offset that would surface any accidental zone conversion).
+
+statement
+CREATE TABLE test_hour_of_time(s STRING) USING parquet
+
+statement
+INSERT INTO test_hour_of_time VALUES
+  ('00:00:00'),
+  ('00:00:00.000001'),
+  ('12:30:45'),
+  ('12:30:45.123456'),
+  ('23:59:59'),
+  ('23:59:59.999999'),
+  (NULL)
+
+-- column-input TIME derived from to_time(string)
+query
+SELECT s, hour(to_time(s)) FROM test_hour_of_time ORDER BY s
+
+-- literal TIME (constant-folded at analysis; still exercises the parser path)
+query
+SELECT hour(TIME '00:00:00')
+
+query
+SELECT hour(TIME '12:30:45.123456')
+
+query
+SELECT hour(TIME '23:59:59.999999')
+
+-- explicit NULL cast
+query
+SELECT hour(CAST(NULL AS TIME))
+
+-- HoursOfTime on lower-precision TimeType(0)
+query
+SELECT hour(CAST(TIME '13:00:00' AS TIME(0)))
+
+-- EXTRACT(HOUR FROM ...) rewrites to HoursOfTime(source) via TimeExtract.parseExtractField,
+-- so the shim must fire on this grammar too.
+query
+SELECT EXTRACT(HOUR FROM to_time(s)) FROM test_hour_of_time ORDER BY s


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #3126
Supersedes #3615  

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Spark 4.1 introduces `TimeType` and the `hour()` function on a TIME child, which resolves through `HourExpressionBuilder` to `HoursOfTime`, `RuntimeReplaceable` whose replacement is `StaticInvoke(DateTimeUtils, IntegerType, "getHoursOfTime", Seq(child))`. 
Without a shim, Comet falls back to the JVM for `hour(TIME ...)` and for `EXTRACT(HOUR FROM TIME ...)` (which parses to the same `HoursOfTime`).  

Note that `HoursOfTime` / `TimeType` do **not** exist in Spark 3.4, 3.5, or 4.0 (see the datetime expression audit), so this only needs to be wired in the spark-4.1+ shim.  

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- spark-4.1+ `CometExprShim`: match `StaticInvoke(DateTimeUtils,"getHoursOfTime", TimeType)` and rewrite it to DataFusion's built-in `date_part('hour', time)`. DataFusion's `date_part` signature already accepts `Time64(Nanosecond)` and returns `Int32`, matching Spark's `Int` result. No new protobuf variant and no new native code path.        
                   
- native planner**: accept `LongVal` with `DataType::Time64(Nanosecond)` so Spark 4.1 TIME literals (i64 nanoseconds-since-midnight) deserialize into `ScalarValue::Time64Nanosecond`, matching Arrow's storage exactly.       
      
## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
- New SQL file test: `spark/src/test/resources/sql-tests/expressions/datetime/hour_of_time.sql`
- `./mvnw test -Dsuites="org.apache.comet.CometSqlFileTestSuite hour_of_time" -Dtest=none` 