### PR TITLE
docs: remove duplicate String to TimestampNTZ section from cast guide

### DIFF
--- a/docs/source/user-guide/latest/compatibility/expressions/_category_template/cast.md
+++ b/docs/source/user-guide/latest/compatibility/expressions/_category_template/cast.md
@@ -124,14 +124,6 @@ Comet's native `CAST(date AS STRING)` is compatible with Spark. Years below 1000
 zero-padded to four digits (e.g. year 999 renders as `0999-01-01`). Years above 9999 are
 rendered without truncation. The cast is timezone-independent.
 
-## String to TimestampNTZ
-
-Comet's native `CAST(string AS TIMESTAMP_NTZ)` implementation matches Apache Spark's behavior.
-Unlike `CAST(string AS TIMESTAMP)`, this cast is timezone-independent: any timezone offset in
-the input string (e.g. `+08:00`, `Z`, `UTC`) is silently discarded, and the local date-time
-components are preserved as-is. Time-only strings (e.g. `T12:34:56`, `12:34`) produce `NULL`.
-The result is always a wall-clock timestamp with no timezone conversion or DST adjustment.
-
 ## Decimal with Negative Scale to String
 
 Casting a `DecimalType` with a negative scale to `StringType` is marked as incompatible when


### PR DESCRIPTION
## Which issue does this PR close?

N/A — small docs cleanup.

## Rationale for this change

`docs/source/user-guide/latest/compatibility/expressions/_category_template/cast.md` contained the same `## String to TimestampNTZ` paragraph twice — once between `## String to Timestamp` and `## TimestampNTZ Casts`, and again between `## Date to String` and `## Decimal with Negative Scale to String`. The `TimestampNTZ Casts` table's link (`See [String to TimestampNTZ](#string-to-timestampntz) above`) already resolves to the first occurrence, so the second copy is pure duplication.

## What changes are included in this PR?

- Delete the duplicate `## String to TimestampNTZ` section (the one below `## Date to String`).

## How are these changes tested?

Docs-only change; the remaining `## String to TimestampNTZ` section is unchanged and is still linked from the `TimestampNTZ Casts` table.
