### PR TITLE
chore: fallback for `spark.sql.mapKeyDedupPolicy` == `LAST_WIN`

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/maps.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/maps.scala
@@ -78,26 +78,25 @@ object CometMapExtract extends CometExpressionSerde[GetMapValue] {
 /**
  * Shared support for the `spark.sql.mapKeyDedupPolicy` divergence between Spark and Comet.
  *
- * Spark's `ArrayBasedMapBuilder` (used by `MapFromArrays` and `MapFromEntries`) rejects null map
- * keys and applies the policy on duplicate keys (default `EXCEPTION`, or `LAST_WIN`). Comet's
- * native map construction implements neither behaviour, so the two only agree when the config is
- * at its default and the user input contains no null / duplicate keys. This helper narrows the
- * divergence to the config-driven half: when the policy has been switched away from the default
- * we mark the expression as incompatible so it falls back to Spark. The null-key / duplicate-key
- * data cases under the default policy remain user-observable divergences tracked separately.
+ * Spark's `ArrayBasedMapBuilder` (used by `MapFromArrays` and `MapFromEntries`) applies the
+ * policy on duplicate keys (`EXCEPTION` — the default, raising `DUPLICATED_MAP_KEY` — or
+ * `LAST_WIN`, keeping the last occurrence). Comet's native `map` scalar has no LAST_WIN path, so
+ * only the `EXCEPTION` mode agrees with Spark; `LAST_WIN` diverges and must fall back. Duplicate-
+ * key data cases under `EXCEPTION` remain a separately tracked user-observable divergence.
  *
  * Other map-building expressions (`CreateMap`, `MapConcat`, `TransformKeys`) already delegate to
  * Spark's own `doGenCode` via `CometCodegenDispatch`, so they inherit Spark's dedup semantics for
  * free and do not need this gate.
  */
 private object MapKeyDedupPolicySupport {
-  val incompatibleReason: String =
-    s"`${SQLConf.MAP_KEY_DEDUP_POLICY.key}` is set to a non-default value; Comet does not " +
-      "enforce Spark's map-key dedup semantics (LAST_WIN vs EXCEPTION) or reject null map keys."
+  private val LastWin = "LAST_WIN"
 
-  def isDefault: Boolean =
-    SQLConf.get.getConf(SQLConf.MAP_KEY_DEDUP_POLICY) ==
-      SQLConf.MAP_KEY_DEDUP_POLICY.defaultValueString
+  val incompatibleReason: String =
+    s"`${SQLConf.MAP_KEY_DEDUP_POLICY.key}` is set to `$LastWin`; Comet's native map construction " +
+      "does not implement LAST_WIN dedup semantics."
+
+  def isLastWin: Boolean =
+    SQLConf.get.getConf(SQLConf.MAP_KEY_DEDUP_POLICY).equalsIgnoreCase(LastWin)
 }
 
 object CometMapFromArrays extends CometExpressionSerde[MapFromArrays] {
@@ -106,7 +105,7 @@ object CometMapFromArrays extends CometExpressionSerde[MapFromArrays] {
     Seq(MapKeyDedupPolicySupport.incompatibleReason)
 
   override def getSupportLevel(expr: MapFromArrays): SupportLevel = {
-    if (!MapKeyDedupPolicySupport.isDefault) {
+    if (MapKeyDedupPolicySupport.isLastWin) {
       Incompatible(Some(MapKeyDedupPolicySupport.incompatibleReason))
     } else {
       Compatible(None)
@@ -170,7 +169,7 @@ object CometMapFromEntries
       Incompatible(Some(keyUnsupportedReason))
     } else if (SupportLevel.containsType(expr.dataType.valueType, classOf[BinaryType])) {
       Incompatible(Some(valueUnsupportedReason))
-    } else if (!MapKeyDedupPolicySupport.isDefault) {
+    } else if (MapKeyDedupPolicySupport.isLastWin) {
       Incompatible(Some(MapKeyDedupPolicySupport.incompatibleReason))
     } else {
       Compatible(None)

--- a/spark/src/main/scala/org/apache/comet/serde/maps.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/maps.scala
@@ -75,7 +75,43 @@ object CometMapExtract extends CometExpressionSerde[GetMapValue] {
   }
 }
 
+/**
+ * Shared support for the `spark.sql.mapKeyDedupPolicy` divergence between Spark and Comet.
+ *
+ * Spark's `ArrayBasedMapBuilder` (used by `MapFromArrays` and `MapFromEntries`) rejects null map
+ * keys and applies the policy on duplicate keys (default `EXCEPTION`, or `LAST_WIN`). Comet's
+ * native map construction implements neither behaviour, so the two only agree when the config is
+ * at its default and the user input contains no null / duplicate keys. This helper narrows the
+ * divergence to the config-driven half: when the policy has been switched away from the default
+ * we mark the expression as incompatible so it falls back to Spark. The null-key / duplicate-key
+ * data cases under the default policy remain user-observable divergences tracked separately.
+ *
+ * Other map-building expressions (`CreateMap`, `MapConcat`, `TransformKeys`) already delegate to
+ * Spark's own `doGenCode` via `CometCodegenDispatch`, so they inherit Spark's dedup semantics for
+ * free and do not need this gate.
+ */
+private object MapKeyDedupPolicySupport {
+  val incompatibleReason: String =
+    s"`${SQLConf.MAP_KEY_DEDUP_POLICY.key}` is set to a non-default value; Comet does not " +
+      "enforce Spark's map-key dedup semantics (LAST_WIN vs EXCEPTION) or reject null map keys."
+
+  def isDefault: Boolean =
+    SQLConf.get.getConf(SQLConf.MAP_KEY_DEDUP_POLICY) ==
+      SQLConf.MAP_KEY_DEDUP_POLICY.defaultValueString
+}
+
 object CometMapFromArrays extends CometExpressionSerde[MapFromArrays] {
+
+  override def getIncompatibleReasons(): Seq[String] =
+    Seq(MapKeyDedupPolicySupport.incompatibleReason)
+
+  override def getSupportLevel(expr: MapFromArrays): SupportLevel = {
+    if (!MapKeyDedupPolicySupport.isDefault) {
+      Incompatible(Some(MapKeyDedupPolicySupport.incompatibleReason))
+    } else {
+      Compatible(None)
+    }
+  }
 
   override def convert(
       expr: MapFromArrays,
@@ -127,16 +163,18 @@ object CometMapFromEntries
     "`BinaryType` is not supported as a map value in `map_from_entries`"
 
   override def getIncompatibleReasons(): Seq[String] =
-    Seq(keyUnsupportedReason, valueUnsupportedReason)
+    Seq(keyUnsupportedReason, valueUnsupportedReason, MapKeyDedupPolicySupport.incompatibleReason)
 
   override def getSupportLevel(expr: MapFromEntries): SupportLevel = {
     if (SupportLevel.containsType(expr.dataType.keyType, classOf[BinaryType])) {
-      return Incompatible(Some(keyUnsupportedReason))
+      Incompatible(Some(keyUnsupportedReason))
+    } else if (SupportLevel.containsType(expr.dataType.valueType, classOf[BinaryType])) {
+      Incompatible(Some(valueUnsupportedReason))
+    } else if (!MapKeyDedupPolicySupport.isDefault) {
+      Incompatible(Some(MapKeyDedupPolicySupport.incompatibleReason))
+    } else {
+      Compatible(None)
     }
-    if (SupportLevel.containsType(expr.dataType.valueType, classOf[BinaryType])) {
-      return Incompatible(Some(valueUnsupportedReason))
-    }
-    Compatible(None)
   }
 }
 

--- a/spark/src/main/scala/org/apache/comet/serde/maps.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/maps.scala
@@ -77,13 +77,29 @@ object CometMapExtract extends CometExpressionSerde[GetMapValue] {
 
 private object MapKeyDedupPolicySupport {
   val incompatibleReason: String =
-    s"`${SQLConf.MAP_KEY_DEDUP_POLICY.key}` is set to `${SQLConf.MapKeyDedupPolicy.LAST_WIN}`; Comet's native map construction " +
+    s"`${SQLConf.MAP_KEY_DEDUP_POLICY.key}` is set to " +
+      s"`${SQLConf.MapKeyDedupPolicy.LAST_WIN}`; Comet's native map construction " +
       "does not implement LAST_WIN dedup semantics."
 
   def isLastWin: Boolean =
-    SQLConf.get.getConf(SQLConf.MAP_KEY_DEDUP_POLICY).toString.equalsIgnoreCase(
-      SQLConf.MapKeyDedupPolicy.LAST_WIN.toString)
+    SQLConf.get
+      .getConf(SQLConf.MAP_KEY_DEDUP_POLICY)
+      .toString
+      .equalsIgnoreCase(SQLConf.MapKeyDedupPolicy.LAST_WIN.toString)
 }
+
+object CometMapFromArrays extends CometExpressionSerde[MapFromArrays] {
+
+  override def getIncompatibleReasons(): Seq[String] =
+    Seq(MapKeyDedupPolicySupport.incompatibleReason)
+
+  override def getSupportLevel(expr: MapFromArrays): SupportLevel = {
+    if (MapKeyDedupPolicySupport.isLastWin) {
+      Incompatible(Some(MapKeyDedupPolicySupport.incompatibleReason))
+    } else {
+      Compatible(None)
+    }
+  }
 
   override def convert(
       expr: MapFromArrays,

--- a/spark/src/main/scala/org/apache/comet/serde/maps.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/maps.scala
@@ -75,42 +75,15 @@ object CometMapExtract extends CometExpressionSerde[GetMapValue] {
   }
 }
 
-/**
- * Shared support for the `spark.sql.mapKeyDedupPolicy` divergence between Spark and Comet.
- *
- * Spark's `ArrayBasedMapBuilder` (used by `MapFromArrays` and `MapFromEntries`) applies the
- * policy on duplicate keys (`EXCEPTION` — the default, raising `DUPLICATED_MAP_KEY` — or
- * `LAST_WIN`, keeping the last occurrence). Comet's native `map` scalar has no LAST_WIN path, so
- * only the `EXCEPTION` mode agrees with Spark; `LAST_WIN` diverges and must fall back. Duplicate-
- * key data cases under `EXCEPTION` remain a separately tracked user-observable divergence.
- *
- * Other map-building expressions (`CreateMap`, `MapConcat`, `TransformKeys`) already delegate to
- * Spark's own `doGenCode` via `CometCodegenDispatch`, so they inherit Spark's dedup semantics for
- * free and do not need this gate.
- */
 private object MapKeyDedupPolicySupport {
-  private val LastWin = "LAST_WIN"
-
   val incompatibleReason: String =
-    s"`${SQLConf.MAP_KEY_DEDUP_POLICY.key}` is set to `$LastWin`; Comet's native map construction " +
+    s"`${SQLConf.MAP_KEY_DEDUP_POLICY.key}` is set to `${SQLConf.MapKeyDedupPolicy.LAST_WIN}`; Comet's native map construction " +
       "does not implement LAST_WIN dedup semantics."
 
   def isLastWin: Boolean =
-    SQLConf.get.getConf(SQLConf.MAP_KEY_DEDUP_POLICY).equalsIgnoreCase(LastWin)
+    SQLConf.get.getConf(SQLConf.MAP_KEY_DEDUP_POLICY).toString.equalsIgnoreCase(
+      SQLConf.MapKeyDedupPolicy.LAST_WIN.toString)
 }
-
-object CometMapFromArrays extends CometExpressionSerde[MapFromArrays] {
-
-  override def getIncompatibleReasons(): Seq[String] =
-    Seq(MapKeyDedupPolicySupport.incompatibleReason)
-
-  override def getSupportLevel(expr: MapFromArrays): SupportLevel = {
-    if (MapKeyDedupPolicySupport.isLastWin) {
-      Incompatible(Some(MapKeyDedupPolicySupport.incompatibleReason))
-    } else {
-      Compatible(None)
-    }
-  }
 
   override def convert(
       expr: MapFromArrays,

--- a/spark/src/test/resources/sql-tests/expressions/map/map_from_arrays_dedup_policy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/map/map_from_arrays_dedup_policy.sql
@@ -15,11 +15,10 @@
 -- specific language governing permissions and limitations
 -- under the License.
 
--- Verifies that `map_from_arrays` falls back to Spark when the map-key dedup policy is switched
--- away from its default (EXCEPTION) to LAST_WIN. Spark's ArrayBasedMapBuilder honours both null-key
--- rejection and the dedup policy; Comet's native `map` scalar does neither, so the two paths only
--- agree at the default policy. The default-mode compatible case is covered by
--- `map_from_arrays.sql`.
+-- Verifies that `map_from_arrays` falls back to Spark when `spark.sql.mapKeyDedupPolicy` is set
+-- to `LAST_WIN`. Spark's ArrayBasedMapBuilder keeps the last occurrence of each duplicate key;
+-- Comet's native `map` scalar has no LAST_WIN path, so it must fall back. The default `EXCEPTION`
+-- mode agrees with Comet and is covered by `map_from_arrays.sql`.
 
 -- Config: spark.sql.mapKeyDedupPolicy=LAST_WIN
 

--- a/spark/src/test/resources/sql-tests/expressions/map/map_from_arrays_dedup_policy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/map/map_from_arrays_dedup_policy.sql
@@ -1,0 +1,42 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Verifies that `map_from_arrays` falls back to Spark when the map-key dedup policy is switched
+-- away from its default (EXCEPTION) to LAST_WIN. Spark's ArrayBasedMapBuilder honours both null-key
+-- rejection and the dedup policy; Comet's native `map` scalar does neither, so the two paths only
+-- agree at the default policy. The default-mode compatible case is covered by
+-- `map_from_arrays.sql`.
+
+-- Config: spark.sql.mapKeyDedupPolicy=LAST_WIN
+
+statement
+CREATE TABLE test_map_from_arrays_dedup(k array<string>, v array<int>) USING parquet
+
+statement
+INSERT INTO test_map_from_arrays_dedup VALUES
+  (array('a', 'b', 'c'), array(1, 2, 3)),
+  (array('a', 'a', 'b'), array(1, 2, 3)),
+  (array('x', 'x'), array(10, 20))
+
+-- literal duplicate keys under LAST_WIN: Spark keeps the last value; Comet must fall back.
+query expect_fallback(mapKeyDedupPolicy)
+SELECT map_from_arrays(array('a', 'a', 'b'), array(1, 2, 3))
+
+-- column input falls back the same way; the incompat branch is triggered by the SQLConf value,
+-- not per-row content.
+query expect_fallback(mapKeyDedupPolicy)
+SELECT map_from_arrays(k, v) FROM test_map_from_arrays_dedup

--- a/spark/src/test/resources/sql-tests/expressions/map/map_from_entries_dedup_policy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/map/map_from_entries_dedup_policy.sql
@@ -15,11 +15,11 @@
 -- specific language governing permissions and limitations
 -- under the License.
 
--- Verifies that `map_from_entries` falls back to Spark when the map-key dedup policy is switched
--- away from its default (EXCEPTION) to LAST_WIN. `CometMapFromEntries` mixes in
--- `CodegenDispatchFallback`, so its native `Incompatible` normally routes through the JVM codegen
--- dispatcher; we disable the dispatcher here so the incompat branch surfaces as a genuine Spark
--- fallback rather than in-pipeline codegen. The default-mode compatible case is covered by
+-- Verifies that `map_from_entries` falls back to Spark when `spark.sql.mapKeyDedupPolicy` is set
+-- to `LAST_WIN`. `CometMapFromEntries` mixes in `CodegenDispatchFallback`, so its native
+-- `Incompatible` normally routes through the JVM codegen dispatcher; we disable the dispatcher
+-- here so the incompat branch surfaces as a genuine Spark fallback rather than in-pipeline
+-- codegen. The default `EXCEPTION` mode agrees with Comet and is covered by
 -- `map_from_entries.sql`.
 
 -- Config: spark.sql.mapKeyDedupPolicy=LAST_WIN

--- a/spark/src/test/resources/sql-tests/expressions/map/map_from_entries_dedup_policy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/map/map_from_entries_dedup_policy.sql
@@ -1,0 +1,44 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Verifies that `map_from_entries` falls back to Spark when the map-key dedup policy is switched
+-- away from its default (EXCEPTION) to LAST_WIN. `CometMapFromEntries` mixes in
+-- `CodegenDispatchFallback`, so its native `Incompatible` normally routes through the JVM codegen
+-- dispatcher; we disable the dispatcher here so the incompat branch surfaces as a genuine Spark
+-- fallback rather than in-pipeline codegen. The default-mode compatible case is covered by
+-- `map_from_entries.sql`.
+
+-- Config: spark.sql.mapKeyDedupPolicy=LAST_WIN
+-- Config: spark.comet.exec.scalaUDF.codegen.enabled=false
+
+statement
+CREATE TABLE test_map_from_entries_dedup(entries array<struct<key:string, value:int>>) USING parquet
+
+statement
+INSERT INTO test_map_from_entries_dedup VALUES
+  (array(struct('a', 1), struct('b', 2), struct('c', 3))),
+  (array(struct('a', 1), struct('a', 2), struct('b', 3))),
+  (array(struct('x', 10), struct('x', 20)))
+
+-- literal duplicate keys under LAST_WIN: Spark keeps the last value; Comet must fall back.
+query expect_fallback(mapKeyDedupPolicy)
+SELECT map_from_entries(array(struct('a', 1), struct('a', 2), struct('b', 3)))
+
+-- column input falls back the same way; the incompat branch is triggered by the SQLConf value,
+-- not per-row content.
+query expect_fallback(mapKeyDedupPolicy)
+SELECT map_from_entries(entries) FROM test_map_from_entries_dedup


### PR DESCRIPTION
## Which issue does this PR close?
  
  Narrows the `spark.sql.mapKeyDedupPolicy` divergence for `map_from_arrays` and `map_from_entries` reported in #4680 

  ## Rationale for this change

  Spark's `ArrayBasedMapBuilder` (used by both expressions) honors two dedup modes:
  - `EXCEPTION` (default): raise `[DUPLICATED_MAP_KEY]` on duplicate keys.
  - `LAST_WIN`: keep the last occurrence.

  Comet is currently pinned to `datafusion-spark 54.0.0`, whose `map_from_arrays` / `map_from_entries` implement neither mode — duplicates simply pass through. That means:
  - Under `EXCEPTION` (the default) with duplicate keys, Comet silently keeps duplicates instead of erroring — a data divergence tracked separately.
  - Under `LAST_WIN`, Comet's output shape disagrees with Spark's per-key dedup — a config-driven divergence we can detect at plan time.

  Upstream [apache/datafusion#21720](https://github.com/apache/datafusion/pull/21720) wires both modes into `datafusion-spark`, but that fix has not yet landed in a release Comet pins to.

  ## What changes are included in this PR?

  - Add `MapKeyDedupPolicySupport` in `serde/maps.scala` — one helper checks `spark.sql.mapKeyDedupPolicy == LAST_WIN`.
  - `CometMapFromArrays` and `CometMapFromEntries` return `Incompatible` when `LAST_WIN` is active, so planning falls back to Spark for that config only. `EXCEPTION` (default) continues to run natively.
  - Sibling expressions (`CreateMap`, `MapConcat`, `TransformKeys`, ...) already delegate to Spark's `doGenCode` via `CometCodegenDispatch` and inherit dedup semantics for free — no gate needed.

  ## Are these changes tested?

  Yes — new SQL file tests exercise the fallback with `spark.sql.mapKeyDedupPolicy=LAST_WIN` for both expressions, on literal and column inputs:
  - `spark/src/test/resources/sql-tests/expressions/map/map_from_arrays_dedup_policy.sql`
  - `spark/src/test/resources/sql-tests/expressions/map/map_from_entries_dedup_policy.sql`

  The `map_from_entries` test also disables the codegen dispatcher so the incompat branch surfaces as a genuine Spark fallback rather than in-pipeline codegen.

  ## Follow-up

  When Comet bumps to a `datafusion-spark` release containing #21720, this gate can be replaced by propagating `spark.sql.mapKeyDedupPolicy` → `datafusion.spark.map_key_dedup_policy` and removing the
  `Incompatible` branch. `str_to_map` gets the same upgrade for free.
