### PR TITLE
fix: emit JDK libjvm search path from core build script to fix -ljvm CI link failures

### DIFF
--- a/native/core/build.rs
+++ b/native/core/build.rs
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::env;
+use std::path::Path;
+
+fn main() {
+    // The `hdfs-sys` dependency (pulled in by the default `hdfs-opendal` feature)
+    // links against `libjvm` and bakes an absolute `-L` path to the JDK's libjvm
+    // directory into its build-script output. That output is cached and replayed
+    // when only downstream crates change. On CI runners where `setup-java` floats
+    // the Zulu patch version, the cached path can disappear, and linking the final
+    // `libcomet.so` fails with `cannot find -ljvm`.
+    //
+    // `core` is that final `cdylib`, so emit a search path for the currently
+    // resolved JDK here: the linker then finds `libjvm` regardless of any stale
+    // path replayed from a dependency's cached build script. Re-run when JAVA_HOME
+    // or the resolved directory changes so it self-heals across JDK swaps.
+    println!("cargo:rerun-if-env-changed=JAVA_HOME");
+    if let Ok(java_home) = env::var("JAVA_HOME") {
+        // libjvm lives at $JAVA_HOME/lib/server for every JDK Comet supports (11+).
+        let server = Path::new(&java_home).join("lib").join("server");
+        if server.is_dir() {
+            let server = server.display();
+            println!("cargo:rerun-if-changed={server}");
+            println!("cargo:rustc-link-search=native={server}");
+        }
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

No dedicated issue. This addresses a repo-wide CI failure where native builds fail at link time with:

```
error: linking with `cc` failed: exit status: 1
  = note: /usr/bin/ld.bfd: cannot find -ljvm: No such file or directory
error: could not compile `datafusion-comet` (lib)
```

It has been hitting `PR Build (Linux)`, `Iceberg Spark SQL Tests`, and `Spark SQL Tests` jobs across open PRs.

## Rationale for this change

The `hdfs-sys` dependency (pulled in by the default `hdfs-opendal` feature) links `libjvm` and, from its build script, bakes an absolute `-L` search path to the JDK's `libjvm` directory. Cargo caches that build-script output and replays it when only downstream crates change, without re-running the build script.

CI caches `native/target` keyed on `hashFiles('native/**/*.rs', ...Cargo.toml/lock)`. When a change does not touch native sources, the same cache is restored. If the runner's JDK has moved in the meantime (`setup-java` floats the Zulu patch version, so `JAVA_HOME`'s value can stay the same while the underlying install is swapped), the replayed `-L` path points at a directory that no longer exists, and the final link of `libcomet.so` fails with `cannot find -ljvm`.

`core` is the crate that produces the final `cdylib`, so the fix belongs there: emit a `-L` search path for the currently resolved JDK at build time. The linker then finds `libjvm` regardless of any stale path replayed from a dependency's cached build script.

## What changes are included in this PR?

- Add `native/core/build.rs` that:
  - emits `cargo:rustc-link-search=native=$JAVA_HOME/lib/server` (the `libjvm` location for every supported JDK, 11+), and
  - emits `cargo:rerun-if-env-changed=JAVA_HOME` and `cargo:rerun-if-changed=<that dir>` so the search path is refreshed automatically whenever the JDK is swapped, rather than relying on a cache invalidation.

No workflow or dependency changes are needed; the fix is self-contained in the crate that performs the final link, so it applies to every native-build job.

## How are these changes tested?

Verbose local build (`cargo build -p datafusion-comet -vv`) confirms the core build script now contributes the search path alongside the dependency's:

```
[hdfs-sys 0.3.0]     cargo:rustc-link-search=native=<JDK>/lib/server
[datafusion-comet 1.0.0] cargo:rerun-if-changed=<JDK>/lib/server
[datafusion-comet 1.0.0] cargo:rustc-link-search=native=<JDK>/lib/server
```

so `-ljvm` resolves against the current JDK even when a dependency replays a stale path. The existing native-build and Spark SQL CI jobs exercise the link path that was failing.
