### PR TITLE
fix: register partitioning scalar subqueries for native shuffle to avoid "Subquery N not found"

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -763,6 +763,17 @@ object CometShuffleExchangeExec
       spec: NativeShuffleSpec): ShuffleDependency[Int, ColumnarBatch, ColumnarBatch] = {
     val numParts = thinRDD.getNumPartitions
 
+    // Subqueries in the partitioning expressions (e.g. DISTRIBUTE BY over a subquery) belong to
+    // this exchange, not the native child, so the child's collectSubqueries misses them. The
+    // writer serializes them with their exprId, so they must be registered against the iterator or
+    // the native lookup fails with "Subquery N not found". Both shuffle paths funnel through here.
+    val partitioningSubqueries = outputPartitioning match {
+      case e: Expression => e.collect { case s: ScalarSubquery => s }
+      case _ => Nil
+    }
+    val augmentedSpec = spec.copy(execContext =
+      spec.execContext.copy(subqueries = spec.execContext.subqueries ++ partitioningSubqueries))
+
     // The code block below is mostly brought over from
     // ShuffleExchangeExec::prepareShuffleDependency
     val (partitioner, rangePartitionBounds) = outputPartitioning match {
@@ -831,7 +842,7 @@ object CometShuffleExchangeExec
       shuffleWriteMetrics = metrics,
       numParts = numParts,
       rangePartitionBounds = rangePartitionBounds,
-      nativeShuffleSpec = Some(spec))
+      nativeShuffleSpec = Some(augmentedSpec))
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -768,6 +768,13 @@ object CometShuffleExchangeExec
     // writer serializes them with their exprId, so they must be registered against the iterator or
     // the native lookup fails with "Subquery N not found". Both the native-child and
     // non-native-child native-shuffle paths funnel through here.
+    //
+    // Only ScalarSubquery is matched because it is the sole expression QueryPlanSerde turns into a
+    // native Subquery proto (and the only id the native side looks up); this mirrors the other
+    // registration sites (CometExec.collectSubqueries, CometNativeExec.prepareSubqueries). The
+    // exprId is stable under reuse, so a ReusedSubqueryExec plan still resolves to the same result.
+    // The `case _ => Nil` fallthrough is safe: partitionings that are not Expressions
+    // (SinglePartition, RoundRobinPartitioning) carry no key expressions to hold a subquery.
     val partitioningSubqueries = outputPartitioning match {
       case e: Expression => e.collect { case s: ScalarSubquery => s }
       case _ => Nil

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -766,7 +766,8 @@ object CometShuffleExchangeExec
     // Subqueries in the partitioning expressions (e.g. DISTRIBUTE BY over a subquery) belong to
     // this exchange, not the native child, so the child's collectSubqueries misses them. The
     // writer serializes them with their exprId, so they must be registered against the iterator or
-    // the native lookup fails with "Subquery N not found". Both shuffle paths funnel through here.
+    // the native lookup fails with "Subquery N not found". Both the native-child and
+    // non-native-child native-shuffle paths funnel through here.
     val partitioningSubqueries = outputPartitioning match {
       case e: Expression => e.collect { case s: ScalarSubquery => s }
       case _ => Nil

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -2209,6 +2209,48 @@ class CometExecSuite extends CometTestBase {
     }
   }
 
+  // Regression test for https://github.com/apache/datafusion-comet/issues/4787
+  // A scalar subquery inside a RepartitionByExpression (DISTRIBUTE BY) lives in the shuffle's
+  // partitioning expressions, not the native child subtree, so it must be registered separately
+  // for the native shuffle writer to resolve it.
+  test("scalar subquery in repartition") {
+    withParquetTable((0 until 10).map(i => (i, i)), "t") {
+      val df = sql("SELECT * FROM t DISTRIBUTE BY (_1 + (SELECT max(_2) FROM t))")
+      checkSparkAnswerAndOperator(df)
+    }
+  }
+
+  // Same as above but forces a non-native shuffle child (CometSparkToColumnarExec) by disabling
+  // the native scan and routing the parquet read through Spark-to-Arrow conversion. This exercises
+  // the prepareShuffleDependency convenience-overload path, which builds its own NativeExecContext.
+  test("scalar subquery in repartition over non-native child") {
+    withSQLConf(
+      CometConf.COMET_NATIVE_SCAN_ENABLED.key -> "false",
+      CometConf.COMET_CONVERT_FROM_PARQUET_ENABLED.key -> "true",
+      CometConf.COMET_SPARK_TO_ARROW_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_SHUFFLE_ENABLED.key -> "true",
+      CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+      withParquetTable((0 until 10).map(i => (i, i)), "t") {
+        val df = sql("SELECT * FROM t DISTRIBUTE BY (_1 + (SELECT max(_2) FROM t))")
+        checkSparkAnswer(df)
+      }
+    }
+  }
+
+  // Columnar shuffle computes partition keys on the JVM (UnsafeProjection / partitionIdExpression),
+  // so the partitioning subquery resolves via updateResult with no native Subquery serialization.
+  // This confirms the "Subquery N not found" crash is specific to the native shuffle path.
+  test("scalar subquery in repartition (columnar shuffle)") {
+    withSQLConf(
+      CometConf.COMET_EXEC_SHUFFLE_ENABLED.key -> "true",
+      CometConf.COMET_SHUFFLE_MODE.key -> "jvm") {
+      withParquetTable((0 until 10).map(i => (i, i)), "t") {
+        val df = sql("SELECT * FROM t DISTRIBUTE BY (_1 + (SELECT max(_2) FROM t))")
+        checkSparkAnswer(df)
+      }
+    }
+  }
+
   // Regression test for https://github.com/apache/datafusion-comet/issues/4042
   // SPARK-43402 (Spark 4.0+) pushes scalar subqueries into FileSourceScanExec.dataFilters.
   // CometReuseSubquery re-applies subquery deduplication after Comet node conversions, and


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4787.

## Rationale for this change

A scalar subquery in a `RepartitionByExpression` (e.g. `DISTRIBUTE BY (_1 + (SELECT max(_2) FROM t))`) crashes native execution with `Subquery N not found for plan M`.

The subquery lives in the exchange's partitioning expressions, not in the native child subtree. `CometNativeShuffleWriter.buildUnifiedPlan` serializes those partition expressions to the native plan, producing a `Subquery` proto keyed by `exprId.id`. But the subqueries registered against the native iterator come from `collectSubqueries(nativeChild)`, which only walks the child, so the partitioning subquery is serialized into the plan but never registered. The native lookup then fails.

Columnar shuffle is unaffected: it computes partition keys on the JVM and resolves the subquery via `updateResult`, with no native serialization.

## What changes are included in this PR?

`CometShuffleExchangeExec.prepareNativeShuffleDependency` now collects `ScalarSubquery` expressions from `outputPartitioning` and merges them into the spec's `NativeExecContext.subqueries`, so `CometNativeShuffleWriter` registers them against the iterator. This is the single point both the native-child path and the non-native-child (Spark-to-Arrow) path funnel through.

## How are these changes tested?

Three new tests in `CometExecSuite`, each exercising a distinct path:

- `scalar subquery in repartition`: native shuffle over a native child (the original repro).
- `scalar subquery in repartition over non-native child`: native shuffle over `CometSparkToColumnarExec`, covering the convenience-overload path.
- `scalar subquery in repartition (columnar shuffle)`: confirms the JVM shuffle path was never affected.

The first two were verified to fail before the fix with `Subquery N not found`, and all three pass after.
