### PR TITLE
fix: remove redundant references in format macro arguments to satisfy clippy

### DIFF
--- a/native/fs-hdfs/src/hdfs.rs
+++ b/native/fs-hdfs/src/hdfs.rs
@@ -100,7 +100,7 @@ impl HdfsManager {
                 let hdfs_builder = hdfsNewBuilder();
                 let cstr_uri = CString::new(namenode_uri.as_bytes()).unwrap();
                 hdfsBuilderSetNameNode(hdfs_builder, cstr_uri.as_ptr());
-                info!("Connecting to Namenode ({})", &namenode_uri);
+                info!("Connecting to Namenode ({})", namenode_uri);
                 hdfsBuilderConnect(hdfs_builder)
             };
 

--- a/native/spark-expr/src/conversion_funcs/cast.rs
+++ b/native/spark-expr/src/conversion_funcs/cast.rs
@@ -732,7 +732,7 @@ impl Display for Cast {
         write!(
             f,
             "Cast [data_type: {}, timezone: {}, child: {}, eval_mode: {:?}]",
-            self.data_type, self.cast_options.timezone, self.child, &self.cast_options.eval_mode
+            self.data_type, self.cast_options.timezone, self.child, self.cast_options.eval_mode
         )
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

N/A. This is a small lint fix to unblock CI.

## Rationale for this change

A newer Rust/clippy version now flags the `useless_borrows_in_formatting` lint (`redundant reference in ... argument`) in two workspace crates. CI runs `cargo clippy --all-targets --workspace -- -D warnings`, and clippy aborts each crate at its first denied lint, so the two occurrences surface one at a time: fixing only the first lets clippy proceed to the next crate and fail there.

```
error: redundant reference in `info!` argument
   --> fs-hdfs/src/hdfs.rs:103:54

error: redundant reference in `write!` argument
   --> spark-expr/src/conversion_funcs/cast.rs:735:69
```

The `fs-hdfs` crate is a workspace member listed in `members` but not `default-members`, so local default-member builds do not lint it, which is why this only shows up in CI.

## What changes are included in this PR?

Remove the redundant `&` in two format macro arguments:

- `native/fs-hdfs/src/hdfs.rs:103`: the `namenode_uri` argument in the `info!` call.
- `native/spark-expr/src/conversion_funcs/cast.rs:735`: the `eval_mode` argument in the `Cast` `Display` `write!` call.

## How are these changes tested?

`cargo clippy --all-targets --workspace -- -D warnings` passes end-to-end with these changes and fails without them. Covered by the existing `rust-test` CI job.