### PR TITLE
feat: reserve GROUPS in the native window-frame protocol

### DIFF
--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -3206,6 +3206,8 @@ fn spark_window_frame_to_datafusion(
     let units = match spark_window_frame.frame_type() {
         WindowFrameType::Rows => WindowFrameUnits::Rows,
         WindowFrameType::Range => WindowFrameUnits::Range,
+        // The protocol reserves GROUPS for a future Spark version that can
+        // construct the corresponding Catalyst window frame.
         WindowFrameType::Groups => WindowFrameUnits::Groups,
     };
 
@@ -3219,8 +3221,9 @@ fn spark_window_frame_to_datafusion(
                 physical_window_frame_unbounded_preceding(units)
             }
             LowerFrameBoundStruct::Preceding(offset) => {
-                // Spark encodes ROWS/GROUPS bound direction via the sign of
-                // the offset: negative => PRECEDING, positive => FOLLOWING.
+                // The Comet protocol encodes physical ROWS/GROUPS bound
+                // direction via the sign of the offset: negative =>
+                // PRECEDING, positive => FOLLOWING.
                 // The proto `LowerWindowFrameBound` only carries a `Preceding`
                 // variant, so Comet overloads it for both cases. Route to the
                 // matching DataFusion `WindowFrameBound` based on the sign.
@@ -3254,9 +3257,8 @@ fn spark_window_frame_to_datafusion(
             UpperFrameBoundStruct::Following(offset) => match units {
                 WindowFrameUnits::Rows | WindowFrameUnits::Groups => {
                     // Mirror the lower-bound sign handling: the upper proto
-                    // variant is `Following`, but Spark encodes the bound
-                    // direction via sign. Negative => PRECEDING, positive =>
-                    // FOLLOWING.
+                    // variant is `Following`, while the signed offset carries
+                    // the direction. Negative => PRECEDING, positive => FOLLOWING.
                     signed_physical_offset_window_frame_bound(offset.offset)
                 }
                 WindowFrameUnits::Range => {
@@ -4319,7 +4321,7 @@ mod tests {
     use datafusion_comet_spark_expr::EvalMode;
 
     #[test]
-    fn test_groups_window_frame_with_offsets() {
+    fn test_groups_window_frame_proto_conversion_with_offsets() {
         let frame = spark_operator::WindowFrame {
             frame_type: spark_operator::WindowFrameType::Groups as i32,
             lower_bound: Some(spark_operator::LowerWindowFrameBound {
@@ -4358,7 +4360,7 @@ mod tests {
     }
 
     #[test]
-    fn test_groups_window_frame_defaults_to_unbounded() {
+    fn test_groups_window_frame_proto_conversion_defaults_to_unbounded() {
         let frame = spark_operator::WindowFrame {
             frame_type: spark_operator::WindowFrameType::Groups as i32,
             lower_bound: None,

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -2720,131 +2720,7 @@ impl PhysicalPlanner {
             }
         };
 
-        let units = match spark_window_frame.frame_type() {
-            WindowFrameType::Rows => WindowFrameUnits::Rows,
-            WindowFrameType::Range => WindowFrameUnits::Range,
-        };
-
-        let lower_bound: WindowFrameBound = match spark_window_frame
-            .lower_bound
-            .as_ref()
-            .and_then(|inner| inner.lower_frame_bound_struct.as_ref())
-        {
-            Some(l) => match l {
-                LowerFrameBoundStruct::UnboundedPreceding(_) => match units {
-                    WindowFrameUnits::Rows => {
-                        WindowFrameBound::Preceding(ScalarValue::UInt64(None))
-                    }
-                    WindowFrameUnits::Range => {
-                        WindowFrameBound::Preceding(ScalarValue::Int64(None))
-                    }
-                    WindowFrameUnits::Groups => {
-                        return Err(GeneralError(
-                            "WindowFrameUnits::Groups is not supported.".to_string(),
-                        ));
-                    }
-                },
-                LowerFrameBoundStruct::Preceding(offset) => {
-                    // Spark encodes ROWS bound direction via the sign of the offset:
-                    // negative => PRECEDING, positive => FOLLOWING. The proto
-                    // `LowerWindowFrameBound` only carries a `Preceding` variant, so
-                    // Comet overloads it for both cases. Route to the matching
-                    // DataFusion `WindowFrameBound` based on the sign.
-                    match units {
-                        WindowFrameUnits::Rows => {
-                            let abs = offset.offset.unsigned_abs();
-                            if offset.offset < 0 {
-                                WindowFrameBound::Preceding(ScalarValue::UInt64(Some(abs)))
-                            } else {
-                                WindowFrameBound::Following(ScalarValue::UInt64(Some(abs)))
-                            }
-                        }
-                        WindowFrameUnits::Range => {
-                            let scalar = match offset.range_offset.as_ref() {
-                                Some(lit) => numeric_literal_to_scalar(lit)?,
-                                None => ScalarValue::Int64(Some(offset.offset.abs())),
-                            };
-                            WindowFrameBound::Preceding(scalar)
-                        }
-                        WindowFrameUnits::Groups => {
-                            return Err(GeneralError(
-                                "WindowFrameUnits::Groups is not supported.".to_string(),
-                            ));
-                        }
-                    }
-                }
-                LowerFrameBoundStruct::CurrentRow(_) => WindowFrameBound::CurrentRow,
-            },
-            None => match units {
-                WindowFrameUnits::Rows => WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
-                WindowFrameUnits::Range => WindowFrameBound::Preceding(ScalarValue::Int64(None)),
-                WindowFrameUnits::Groups => {
-                    return Err(GeneralError(
-                        "WindowFrameUnits::Groups is not supported.".to_string(),
-                    ));
-                }
-            },
-        };
-
-        let upper_bound: WindowFrameBound = match spark_window_frame
-            .upper_bound
-            .as_ref()
-            .and_then(|inner| inner.upper_frame_bound_struct.as_ref())
-        {
-            Some(u) => match u {
-                UpperFrameBoundStruct::UnboundedFollowing(_) => match units {
-                    WindowFrameUnits::Rows => {
-                        WindowFrameBound::Following(ScalarValue::UInt64(None))
-                    }
-                    WindowFrameUnits::Range => {
-                        WindowFrameBound::Following(ScalarValue::Int64(None))
-                    }
-                    WindowFrameUnits::Groups => {
-                        return Err(GeneralError(
-                            "WindowFrameUnits::Groups is not supported.".to_string(),
-                        ));
-                    }
-                },
-                UpperFrameBoundStruct::Following(offset) => match units {
-                    WindowFrameUnits::Rows => {
-                        // Mirror the lower-bound sign handling: the upper proto
-                        // variant is `Following`, but Spark encodes the bound
-                        // direction via sign. Negative => PRECEDING, positive =>
-                        // FOLLOWING.
-                        let abs = offset.offset.unsigned_abs();
-                        if offset.offset < 0 {
-                            WindowFrameBound::Preceding(ScalarValue::UInt64(Some(abs)))
-                        } else {
-                            WindowFrameBound::Following(ScalarValue::UInt64(Some(abs)))
-                        }
-                    }
-                    WindowFrameUnits::Range => {
-                        let scalar = match offset.range_offset.as_ref() {
-                            Some(lit) => numeric_literal_to_scalar(lit)?,
-                            None => ScalarValue::Int64(Some(offset.offset)),
-                        };
-                        WindowFrameBound::Following(scalar)
-                    }
-                    WindowFrameUnits::Groups => {
-                        return Err(GeneralError(
-                            "WindowFrameUnits::Groups is not supported.".to_string(),
-                        ));
-                    }
-                },
-                UpperFrameBoundStruct::CurrentRow(_) => WindowFrameBound::CurrentRow,
-            },
-            None => match units {
-                WindowFrameUnits::Rows => WindowFrameBound::Following(ScalarValue::UInt64(None)),
-                WindowFrameUnits::Range => WindowFrameBound::Following(ScalarValue::Int64(None)),
-                WindowFrameUnits::Groups => {
-                    return Err(GeneralError(
-                        "WindowFrameUnits::Groups is not supported.".to_string(),
-                    ));
-                }
-            },
-        };
-
-        let window_frame = WindowFrame::new_bounds(units, lower_bound, upper_bound);
+        let window_frame = spark_window_frame_to_datafusion(spark_window_frame)?;
         let lex_orderings = LexOrdering::new(sort_exprs.to_vec());
         let sort_phy_exprs = lex_orderings.as_deref().unwrap_or(&[]);
 
@@ -3295,6 +3171,108 @@ fn expr_to_columns(
     right_field_indices.sort();
 
     Ok((left_field_indices, right_field_indices))
+}
+
+fn physical_window_frame_unbounded_preceding(units: WindowFrameUnits) -> WindowFrameBound {
+    match units {
+        WindowFrameUnits::Rows | WindowFrameUnits::Groups => {
+            WindowFrameBound::Preceding(ScalarValue::UInt64(None))
+        }
+        WindowFrameUnits::Range => WindowFrameBound::Preceding(ScalarValue::Int64(None)),
+    }
+}
+
+fn physical_window_frame_unbounded_following(units: WindowFrameUnits) -> WindowFrameBound {
+    match units {
+        WindowFrameUnits::Rows | WindowFrameUnits::Groups => {
+            WindowFrameBound::Following(ScalarValue::UInt64(None))
+        }
+        WindowFrameUnits::Range => WindowFrameBound::Following(ScalarValue::Int64(None)),
+    }
+}
+
+fn signed_physical_offset_window_frame_bound(offset: i64) -> WindowFrameBound {
+    let abs = offset.unsigned_abs();
+    if offset < 0 {
+        WindowFrameBound::Preceding(ScalarValue::UInt64(Some(abs)))
+    } else {
+        WindowFrameBound::Following(ScalarValue::UInt64(Some(abs)))
+    }
+}
+
+fn spark_window_frame_to_datafusion(
+    spark_window_frame: &spark_operator::WindowFrame,
+) -> Result<WindowFrame, ExecutionError> {
+    let units = match spark_window_frame.frame_type() {
+        WindowFrameType::Rows => WindowFrameUnits::Rows,
+        WindowFrameType::Range => WindowFrameUnits::Range,
+        WindowFrameType::Groups => WindowFrameUnits::Groups,
+    };
+
+    let lower_bound: WindowFrameBound = match spark_window_frame
+        .lower_bound
+        .as_ref()
+        .and_then(|inner| inner.lower_frame_bound_struct.as_ref())
+    {
+        Some(l) => match l {
+            LowerFrameBoundStruct::UnboundedPreceding(_) => {
+                physical_window_frame_unbounded_preceding(units)
+            }
+            LowerFrameBoundStruct::Preceding(offset) => {
+                // Spark encodes ROWS/GROUPS bound direction via the sign of
+                // the offset: negative => PRECEDING, positive => FOLLOWING.
+                // The proto `LowerWindowFrameBound` only carries a `Preceding`
+                // variant, so Comet overloads it for both cases. Route to the
+                // matching DataFusion `WindowFrameBound` based on the sign.
+                match units {
+                    WindowFrameUnits::Rows | WindowFrameUnits::Groups => {
+                        signed_physical_offset_window_frame_bound(offset.offset)
+                    }
+                    WindowFrameUnits::Range => {
+                        let scalar = match offset.range_offset.as_ref() {
+                            Some(lit) => numeric_literal_to_scalar(lit)?,
+                            None => ScalarValue::Int64(Some(offset.offset.abs())),
+                        };
+                        WindowFrameBound::Preceding(scalar)
+                    }
+                }
+            }
+            LowerFrameBoundStruct::CurrentRow(_) => WindowFrameBound::CurrentRow,
+        },
+        None => physical_window_frame_unbounded_preceding(units),
+    };
+
+    let upper_bound: WindowFrameBound = match spark_window_frame
+        .upper_bound
+        .as_ref()
+        .and_then(|inner| inner.upper_frame_bound_struct.as_ref())
+    {
+        Some(u) => match u {
+            UpperFrameBoundStruct::UnboundedFollowing(_) => {
+                physical_window_frame_unbounded_following(units)
+            }
+            UpperFrameBoundStruct::Following(offset) => match units {
+                WindowFrameUnits::Rows | WindowFrameUnits::Groups => {
+                    // Mirror the lower-bound sign handling: the upper proto
+                    // variant is `Following`, but Spark encodes the bound
+                    // direction via sign. Negative => PRECEDING, positive =>
+                    // FOLLOWING.
+                    signed_physical_offset_window_frame_bound(offset.offset)
+                }
+                WindowFrameUnits::Range => {
+                    let scalar = match offset.range_offset.as_ref() {
+                        Some(lit) => numeric_literal_to_scalar(lit)?,
+                        None => ScalarValue::Int64(Some(offset.offset)),
+                    };
+                    WindowFrameBound::Following(scalar)
+                }
+            },
+            UpperFrameBoundStruct::CurrentRow(_) => WindowFrameBound::CurrentRow,
+        },
+        None => physical_window_frame_unbounded_following(units),
+    };
+
+    Ok(WindowFrame::new_bounds(units, lower_bound, upper_bound))
 }
 
 /// Convert a Spark numeric Literal proto into a `ScalarValue` whose data type
@@ -4308,6 +4286,7 @@ mod tests {
     };
     use arrow::datatypes::{DataType, Field, FieldRef, Fields, Schema};
     use datafusion::catalog::memory::DataSourceExec;
+    use datafusion::common::ScalarValue;
     use datafusion::config::TableParquetOptions;
     use datafusion::datasource::listing::PartitionedFile;
     use datafusion::datasource::object_store::ObjectStoreUrl;
@@ -4315,7 +4294,7 @@ mod tests {
         FileGroup, FileScanConfigBuilder, FileSource, ParquetSource,
     };
     use datafusion::error::DataFusionError;
-    use datafusion::logical_expr::ScalarUDF;
+    use datafusion::logical_expr::{ScalarUDF, WindowFrameBound, WindowFrameUnits};
     use datafusion::physical_plan::ExecutionPlan;
     use datafusion::{assert_batches_eq, physical_plan::common::collect, prelude::SessionContext};
     use datafusion_physical_expr_adapter::PhysicalExprAdapterFactory;
@@ -4325,7 +4304,7 @@ mod tests {
     use crate::execution::{operators::InputBatch, planner::PhysicalPlanner};
 
     use crate::execution::operators::ExecutionError;
-    use crate::execution::planner::literal_to_array_ref;
+    use crate::execution::planner::{literal_to_array_ref, spark_window_frame_to_datafusion};
     use crate::parquet::parquet_support::SparkParquetOptions;
     use crate::parquet::schema_adapter::SparkPhysicalExprAdapterFactory;
     use datafusion_comet_proto::spark_expression::expr::ExprStruct;
@@ -4338,6 +4317,66 @@ mod tests {
         spark_operator::{operator::OpStruct, Operator},
     };
     use datafusion_comet_spark_expr::EvalMode;
+
+    #[test]
+    fn test_groups_window_frame_with_offsets() {
+        let frame = spark_operator::WindowFrame {
+            frame_type: spark_operator::WindowFrameType::Groups as i32,
+            lower_bound: Some(spark_operator::LowerWindowFrameBound {
+                lower_frame_bound_struct: Some(
+                    spark_operator::lower_window_frame_bound::LowerFrameBoundStruct::Preceding(
+                        spark_operator::Preceding {
+                            offset: -1,
+                            range_offset: None,
+                        },
+                    ),
+                ),
+            }),
+            upper_bound: Some(spark_operator::UpperWindowFrameBound {
+                upper_frame_bound_struct: Some(
+                    spark_operator::upper_window_frame_bound::UpperFrameBoundStruct::Following(
+                        spark_operator::Following {
+                            offset: 2,
+                            range_offset: None,
+                        },
+                    ),
+                ),
+            }),
+        };
+
+        let frame = spark_window_frame_to_datafusion(&frame).unwrap();
+
+        assert_eq!(frame.units, WindowFrameUnits::Groups);
+        assert_eq!(
+            frame.start_bound,
+            WindowFrameBound::Preceding(ScalarValue::UInt64(Some(1)))
+        );
+        assert_eq!(
+            frame.end_bound,
+            WindowFrameBound::Following(ScalarValue::UInt64(Some(2)))
+        );
+    }
+
+    #[test]
+    fn test_groups_window_frame_defaults_to_unbounded() {
+        let frame = spark_operator::WindowFrame {
+            frame_type: spark_operator::WindowFrameType::Groups as i32,
+            lower_bound: None,
+            upper_bound: None,
+        };
+
+        let frame = spark_window_frame_to_datafusion(&frame).unwrap();
+
+        assert_eq!(frame.units, WindowFrameUnits::Groups);
+        assert_eq!(
+            frame.start_bound,
+            WindowFrameBound::Preceding(ScalarValue::UInt64(None))
+        );
+        assert_eq!(
+            frame.end_bound,
+            WindowFrameBound::Following(ScalarValue::UInt64(None))
+        );
+    }
 
     #[test]
     fn test_unpack_dictionary_primitive() {

--- a/native/proto/src/proto/operator.proto
+++ b/native/proto/src/proto/operator.proto
@@ -435,6 +435,8 @@ message WindowExpr {
 enum WindowFrameType {
   Rows = 0;
   Range = 1;
+  // Reserved for forward compatibility. Supported Spark versions cannot
+  // currently construct GROUPS window frames.
   Groups = 2;
 }
 

--- a/native/proto/src/proto/operator.proto
+++ b/native/proto/src/proto/operator.proto
@@ -435,6 +435,7 @@ message WindowExpr {
 enum WindowFrameType {
   Rows = 0;
   Range = 1;
+  Groups = 2;
 }
 
 message WindowFrame {
@@ -460,7 +461,7 @@ message UpperWindowFrameBound {
 }
 
 message Preceding {
-  // Used for ROWS frames. Integer row count.
+  // Used for ROWS and GROUPS frames. Integer row/group count.
   int64 offset = 1;
   // Used for RANGE frames. Carries the typed offset value so the native
   // side can build a ScalarValue whose type matches the ORDER BY column.
@@ -468,7 +469,7 @@ message Preceding {
 }
 
 message Following {
-  // Used for ROWS frames. Integer row count.
+  // Used for ROWS and GROUPS frames. Integer row/group count.
   int64 offset = 1;
   // Used for RANGE frames. Carries the typed offset value so the native
   // side can build a ScalarValue whose type matches the ORDER BY column.

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometWindowExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometWindowExec.scala
@@ -21,7 +21,7 @@ package org.apache.spark.sql.comet
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeSet, Cast, CumeDist, CurrentRow, DenseRank, Divide, Expression, FrameType, Lag, Lead, Literal, MakeDecimal, NamedExpression, NthValue, NTile, PercentRank, RangeFrame, Rank, RowFrame, RowNumber, SortOrder, SpecialFrameBoundary, SpecifiedWindowFrame, UnboundedFollowing, UnboundedPreceding, UnscaledValue, WindowExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeSet, Cast, CumeDist, CurrentRow, DenseRank, Divide, Expression, Lag, Lead, Literal, MakeDecimal, NamedExpression, NthValue, NTile, PercentRank, RangeFrame, Rank, RowFrame, RowNumber, SortOrder, SpecialFrameBoundary, SpecifiedWindowFrame, UnboundedFollowing, UnboundedPreceding, UnscaledValue, WindowExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Average, Complete, Count, First, Last, Max, Min, Sum}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.SparkPlan
@@ -42,22 +42,6 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
 
   override def enabledConfig: Option[ConfigEntry[Boolean]] = Some(
     CometConf.COMET_EXEC_WINDOW_ENABLED)
-
-  private def isGroupsFrame(frameType: FrameType): Boolean =
-    frameType.sql.equalsIgnoreCase("GROUPS")
-
-  private def isPhysicalOffsetFrame(frameType: FrameType): Boolean =
-    frameType == RowFrame || isGroupsFrame(frameType)
-
-  private def frameTypeToProto(frameType: FrameType): Option[OperatorOuterClass.WindowFrameType] =
-    frameType match {
-      case RowFrame => Some(OperatorOuterClass.WindowFrameType.Rows)
-      case RangeFrame => Some(OperatorOuterClass.WindowFrameType.Range)
-      // Spark versions supported today do not expose a GroupsFrame class, but
-      // keep serde ready for Spark versions that do by matching the SQL spelling.
-      case other if isGroupsFrame(other) => Some(OperatorOuterClass.WindowFrameType.Groups)
-      case _ => None
-    }
 
   override def convert(
       op: WindowExec,
@@ -439,9 +423,9 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
 
     val (frameType, lowerBound, upperBound) = f match {
       case SpecifiedWindowFrame(frameType, lBound, uBound) =>
-        val frameProto = frameTypeToProto(frameType).getOrElse {
-          withFallbackReason(windowExpr, s"Unsupported window frame type: ${frameType.sql}")
-          return None
+        val frameProto = frameType match {
+          case RowFrame => OperatorOuterClass.WindowFrameType.Rows
+          case RangeFrame => OperatorOuterClass.WindowFrameType.Range
         }
 
         val lBoundProto = lBound match {
@@ -455,14 +439,14 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
               .newBuilder()
               .setCurrentRow(OperatorOuterClass.CurrentRow.newBuilder().build())
               .build()
-          case e if isPhysicalOffsetFrame(frameType) =>
+          case e if frameType == RowFrame =>
             val offset = e.eval() match {
               case i: Integer => i.toLong
               case l: Long => l
               case _ =>
                 withFallbackReason(
                   windowExpr,
-                  s"Unsupported ${frameType.sql} frame lower offset: $e (${e.dataType})")
+                  s"Unsupported ROWS frame lower offset: $e (${e.dataType})")
                 return None
             }
             OperatorOuterClass.LowerWindowFrameBound
@@ -491,7 +475,7 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
           case e =>
             withFallbackReason(
               windowExpr,
-              s"${frameType.sql} frame with non-numeric offset is not supported: ${e.dataType}")
+              s"RANGE frame with non-numeric offset is not supported: ${e.dataType}")
             return None
         }
 
@@ -506,14 +490,14 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
               .newBuilder()
               .setCurrentRow(OperatorOuterClass.CurrentRow.newBuilder().build())
               .build()
-          case e if isPhysicalOffsetFrame(frameType) =>
+          case e if frameType == RowFrame =>
             val offset = e.eval() match {
               case i: Integer => i.toLong
               case l: Long => l
               case _ =>
                 withFallbackReason(
                   windowExpr,
-                  s"Unsupported ${frameType.sql} frame upper offset: $e (${e.dataType})")
+                  s"Unsupported ROWS frame upper offset: $e (${e.dataType})")
                 return None
             }
             OperatorOuterClass.UpperWindowFrameBound
@@ -542,7 +526,7 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
           case e =>
             withFallbackReason(
               windowExpr,
-              s"${frameType.sql} frame with non-numeric offset is not supported: ${e.dataType}")
+              s"RANGE frame with non-numeric offset is not supported: ${e.dataType}")
             return None
         }
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometWindowExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometWindowExec.scala
@@ -21,7 +21,7 @@ package org.apache.spark.sql.comet
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeSet, Cast, CumeDist, CurrentRow, DenseRank, Divide, Expression, Lag, Lead, Literal, MakeDecimal, NamedExpression, NthValue, NTile, PercentRank, RangeFrame, Rank, RowFrame, RowNumber, SortOrder, SpecialFrameBoundary, SpecifiedWindowFrame, UnboundedFollowing, UnboundedPreceding, UnscaledValue, WindowExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeSet, Cast, CumeDist, CurrentRow, DenseRank, Divide, Expression, FrameType, Lag, Lead, Literal, MakeDecimal, NamedExpression, NthValue, NTile, PercentRank, RangeFrame, Rank, RowFrame, RowNumber, SortOrder, SpecialFrameBoundary, SpecifiedWindowFrame, UnboundedFollowing, UnboundedPreceding, UnscaledValue, WindowExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Average, Complete, Count, First, Last, Max, Min, Sum}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.SparkPlan
@@ -42,6 +42,22 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
 
   override def enabledConfig: Option[ConfigEntry[Boolean]] = Some(
     CometConf.COMET_EXEC_WINDOW_ENABLED)
+
+  private def isGroupsFrame(frameType: FrameType): Boolean =
+    frameType.sql.equalsIgnoreCase("GROUPS")
+
+  private def isPhysicalOffsetFrame(frameType: FrameType): Boolean =
+    frameType == RowFrame || isGroupsFrame(frameType)
+
+  private def frameTypeToProto(frameType: FrameType): Option[OperatorOuterClass.WindowFrameType] =
+    frameType match {
+      case RowFrame => Some(OperatorOuterClass.WindowFrameType.Rows)
+      case RangeFrame => Some(OperatorOuterClass.WindowFrameType.Range)
+      // Spark versions supported today do not expose a GroupsFrame class, but
+      // keep serde ready for Spark versions that do by matching the SQL spelling.
+      case other if isGroupsFrame(other) => Some(OperatorOuterClass.WindowFrameType.Groups)
+      case _ => None
+    }
 
   override def convert(
       op: WindowExec,
@@ -423,9 +439,9 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
 
     val (frameType, lowerBound, upperBound) = f match {
       case SpecifiedWindowFrame(frameType, lBound, uBound) =>
-        val frameProto = frameType match {
-          case RowFrame => OperatorOuterClass.WindowFrameType.Rows
-          case RangeFrame => OperatorOuterClass.WindowFrameType.Range
+        val frameProto = frameTypeToProto(frameType).getOrElse {
+          withFallbackReason(windowExpr, s"Unsupported window frame type: ${frameType.sql}")
+          return None
         }
 
         val lBoundProto = lBound match {
@@ -439,14 +455,14 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
               .newBuilder()
               .setCurrentRow(OperatorOuterClass.CurrentRow.newBuilder().build())
               .build()
-          case e if frameType == RowFrame =>
+          case e if isPhysicalOffsetFrame(frameType) =>
             val offset = e.eval() match {
               case i: Integer => i.toLong
               case l: Long => l
               case _ =>
                 withFallbackReason(
                   windowExpr,
-                  s"Unsupported ROWS frame lower offset: $e (${e.dataType})")
+                  s"Unsupported ${frameType.sql} frame lower offset: $e (${e.dataType})")
                 return None
             }
             OperatorOuterClass.LowerWindowFrameBound
@@ -475,7 +491,7 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
           case e =>
             withFallbackReason(
               windowExpr,
-              s"RANGE frame with non-numeric offset is not supported: ${e.dataType}")
+              s"${frameType.sql} frame with non-numeric offset is not supported: ${e.dataType}")
             return None
         }
 
@@ -490,14 +506,14 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
               .newBuilder()
               .setCurrentRow(OperatorOuterClass.CurrentRow.newBuilder().build())
               .build()
-          case e if frameType == RowFrame =>
+          case e if isPhysicalOffsetFrame(frameType) =>
             val offset = e.eval() match {
               case i: Integer => i.toLong
               case l: Long => l
               case _ =>
                 withFallbackReason(
                   windowExpr,
-                  s"Unsupported ROWS frame upper offset: $e (${e.dataType})")
+                  s"Unsupported ${frameType.sql} frame upper offset: $e (${e.dataType})")
                 return None
             }
             OperatorOuterClass.UpperWindowFrameBound
@@ -526,7 +542,7 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
           case e =>
             withFallbackReason(
               windowExpr,
-              s"RANGE frame with non-numeric offset is not supported: ${e.dataType}")
+              s"${frameType.sql} frame with non-numeric offset is not supported: ${e.dataType}")
             return None
         }
 


### PR DESCRIPTION
## Which issue does this PR close?

Related to #4836. This PR does not close it because supported Spark versions cannot yet construct GROUPS window frames.

## Rationale for this change

DataFusion supports GROUPS frames, but Apache Spark versions supported by Comet expose only ROWS and RANGE in both the SQL parser and the sealed Catalyst FrameType. This PR adds forward-compatible protocol and native-planner groundwork without claiming that Spark SQL can originate GROUPS frames today.

## What changes are included in this PR?

- Add a reserved Groups value to the window-frame proto enum.
- Convert incoming GROUPS protocol frames to DataFusion WindowFrameUnits::Groups.
- Use unsigned physical offsets for GROUPS, matching the protocol convention used by ROWS.
- Keep Spark window-frame serialization unchanged until Spark exposes a reachable GROUPS representation.
- Add focused native tests for protocol conversion of GROUPS offsets and default unbounded bounds.

## How are these changes tested?

- cargo test -p datafusion-comet test_groups_window_frame --lib
- ./mvnw -Pjdk17 -DskipTests compile
- The follow-up scope correction was independently reviewed; no additional tests were run.