### PR TITLE
test: cover invalid unhex inputs in SQL file tests

### DIFF
--- a/spark/src/test/resources/sql-tests/expressions/string/unhex.sql
+++ b/spark/src/test/resources/sql-tests/expressions/string/unhex.sql
@@ -19,7 +19,7 @@ statement
 CREATE TABLE test_unhex(s string) USING parquet
 
 statement
-INSERT INTO test_unhex VALUES ('537061726B2053514C'), ('41'), ('0A1B'), (''), (NULL), ('GG'), ('hello'), ('A1B')
+INSERT INTO test_unhex VALUES ('537061726B2053514C'), ('41'), ('0A1B'), (''), (NULL), ('GG'), ('hello'), ('A1B'), ('-123'), ('\0')
 
 query
 SELECT hex(unhex(s)) FROM test_unhex
@@ -30,3 +30,7 @@ SELECT unhex(s) IS NULL FROM test_unhex
 -- literal arguments
 query
 SELECT unhex('41'), unhex('GG'), unhex(''), unhex(NULL)
+
+-- invalid inputs: non-hex characters and the null character both return NULL
+query
+SELECT unhex('-123'), unhex('\0')


### PR DESCRIPTION
## Which issue does this PR close?

N/A. This is a test-only coverage improvement.

## Rationale for this change

The `unhex` SQL file tests did not exercise a couple of invalid-input cases. `unhex` returns NULL when its argument contains non-hex characters or a null character, and Comet should match Spark for these. Adding explicit cases guards this behavior against regressions.

## What changes are included in this PR?

Adds coverage for `unhex('-123')` (contains a non-hex character) and `unhex('\0')` (the null character) to `spark/src/test/resources/sql-tests/expressions/string/unhex.sql`. The values are added both to the column-path INSERT data and to a dedicated literal query so both evaluation paths are checked.

## How are these changes tested?

`./mvnw test -Dsuites="org.apache.comet.CometSqlFileTestSuite unhex" -Dtest=none` passes; Comet runs both new cases natively and matches Spark (both return NULL).