### PR TITLE
feat: hint at native pyarrow UDF path when the feature is disabled

### DIFF
--- a/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
@@ -30,6 +30,8 @@ import org.apache.spark.sql.execution.adaptive.QueryStageExec
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 
 import org.apache.comet.CometConf
+import org.apache.comet.CometSparkSessionExtensions.withInfo
+import org.apache.comet.serde.NativeOptIn
 import org.apache.comet.shims.ShimSQLConf
 
 // This rule is responsible for eliminating redundant transitions between row-based and
@@ -114,13 +116,26 @@ case class EliminateRedundantTransitions(session: SparkSession)
       // source string/binary vectors always use 4-byte offsets while the destination root is
       // allocated with 8-byte offsets when this conf is on. The buffer counts match but the
       // offset width does not, so a direct memcpy would corrupt the offsets.
-      case EligibleMapInBatch(info, columnarChild) =>
-        CometMapInBatchExec(
-          info.func,
-          info.output,
-          columnarChild,
-          info.isBarrier,
-          info.pythonEvalType)
+      //
+      // `EligibleMapInBatch` matches whenever the operator *would* run natively if the feature
+      // were enabled. When it is disabled (the default) we leave the vanilla Spark operator in
+      // place but annotate it with a non-fallback `[COMET-INFO]` hint so the user knows the native
+      // path exists behind a config flag.
+      case p @ EligibleMapInBatch(info, columnarChild) =>
+        if (CometConf.COMET_PYARROW_UDF_ENABLED.get()) {
+          CometMapInBatchExec(
+            info.func,
+            info.output,
+            columnarChild,
+            info.isBarrier,
+            info.pythonEvalType)
+        } else {
+          withInfo(
+            p,
+            NativeOptIn.message(
+              "PyArrow UDFs (mapInArrow/mapInPandas)",
+              CometConf.COMET_PYARROW_UDF_ENABLED.key))
+        }
 
       // Spark adds `RowToColumnar` under Comet columnar shuffle. But it's redundant as the
       // shuffle takes row-based input.
@@ -174,19 +189,19 @@ case class EliminateRedundantTransitions(session: SparkSession)
   }
 
   /**
-   * Matches the plans this rule should rewrite to `CometMapInBatchExec`. Single extractor used in
-   * the `transformUp` arm above so the matchers and conf reads run once per visited plan. Returns
-   * `(info, columnarChild)` where `columnarChild` is the Comet columnar producer that
-   * `CometMapInBatchExec` will consume directly. Returns `None` (and the arm misses) when the
-   * conf is off, when `useLargeVarTypes` forces the fallback, when the plan is not one of the
-   * version-shimmed MapInArrow / MapInPandas operators, or when the child is not a Comet
-   * columnar-to-row transition we can strip.
+   * Matches the plans that could run natively as `CometMapInBatchExec`, independent of whether
+   * the `spark.comet.exec.pyarrowUdf.enabled` feature flag is set. The `transformUp` arm reads
+   * that flag to decide between rewriting the operator and merely annotating it with an opt-in
+   * hint. Single extractor so the matchers run once per visited plan. Returns `(info,
+   * columnarChild)` where `columnarChild` is the Comet columnar producer that
+   * `CometMapInBatchExec` will consume directly. Returns `None` (and the arm misses) when
+   * `useLargeVarTypes` forces the fallback, when the plan is not one of the version-shimmed
+   * MapInArrow / MapInPandas operators, or when the child is not a Comet columnar-to-row
+   * transition we can strip.
    */
   private object EligibleMapInBatch {
     def unapply(plan: SparkPlan): Option[(MapInBatchInfo, SparkPlan)] = {
-      if (!CometConf.COMET_PYARROW_UDF_ENABLED.get()) {
-        None
-      } else if (arrowUseLargeVarTypes(plan.conf)) {
+      if (arrowUseLargeVarTypes(plan.conf)) {
         None
       } else {
         matchMapInArrow(plan)

--- a/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
@@ -117,10 +117,10 @@ case class EliminateRedundantTransitions(session: SparkSession)
       // allocated with 8-byte offsets when this conf is on. The buffer counts match but the
       // offset width does not, so a direct memcpy would corrupt the offsets.
       //
-      // `EligibleMapInBatch` matches whenever the operator *would* run natively if the feature
-      // were enabled. When it is disabled (the default) we leave the vanilla Spark operator in
-      // place but annotate it with a non-fallback `[COMET-INFO]` hint so the user knows the native
-      // path exists behind a config flag.
+      // `EligibleMapInBatch` matches whenever the operator would run natively if the feature were
+      // enabled. When it is disabled (the default) we leave the vanilla Spark operator in place
+      // but annotate it with a non-fallback `[COMET-INFO]` hint so the user knows the native path
+      // exists behind a config flag.
       case p @ EligibleMapInBatch(info, columnarChild) =>
         if (CometConf.COMET_PYARROW_UDF_ENABLED.get()) {
           CometMapInBatchExec(

--- a/spark/src/test/spark-4.x/org/apache/spark/sql/comet/CometMapInBatchSuite.scala
+++ b/spark/src/test/spark-4.x/org/apache/spark/sql/comet/CometMapInBatchSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.execution.python.MapInArrowExec
 import org.apache.spark.sql.types.{LongType, StructField, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-import org.apache.comet.CometConf
+import org.apache.comet.{CometConf, ExtendedExplainInfo}
 import org.apache.comet.rules.EliminateRedundantTransitions
 
 /** Minimal CometPlan leaf used to anchor the rule's transform without triggering execution. */
@@ -102,6 +102,27 @@ class CometMapInBatchSuite extends CometTestBase {
       assert(
         !rewritten.exists(_.isInstanceOf[CometMapInBatchExec]),
         s"unexpected CometMapInBatchExec when disabled:\n$rewritten")
+    }
+  }
+
+  test("rule annotates operator with opt-in hint when feature is disabled") {
+    withSQLConf(CometConf.COMET_PYARROW_UDF_ENABLED.key -> "false") {
+      val rewritten = EliminateRedundantTransitions(spark).apply(buildPlan())
+      val info = new ExtendedExplainInfo().generateExtendedInfo(rewritten)
+      assert(info.contains("[COMET-INFO:"), s"expected a [COMET-INFO: hint in:\n$info")
+      assert(
+        info.contains(CometConf.COMET_PYARROW_UDF_ENABLED.key),
+        s"expected the opt-in config key in the hint:\n$info")
+    }
+  }
+
+  test("rule emits no opt-in hint when feature is enabled") {
+    withSQLConf(CometConf.COMET_PYARROW_UDF_ENABLED.key -> "true") {
+      val rewritten = EliminateRedundantTransitions(spark).apply(buildPlan())
+      val info = new ExtendedExplainInfo().generateExtendedInfo(rewritten)
+      assert(
+        !info.contains(CometConf.COMET_PYARROW_UDF_ENABLED.key),
+        s"unexpected opt-in hint when feature is enabled:\n$info")
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

There is no dedicated tracking issue for this change.

## Rationale for this change

`spark.comet.exec.pyarrowUdf.enabled` is `false` by default. When it is off, `mapInArrow` / `mapInPandas` operators silently fall back to vanilla Spark execution, and nothing in the plan tells the user that a faster native path (`CometMapInBatchExec`, which passes Arrow columnar data directly to Python UDFs) is available behind a config flag.

Comet already surfaces this kind of guidance for expressions via `NativeOptIn` + `withInfo`, which writes a non-fallback `[COMET-INFO: ...]` message into extended-explain output pointing the user at the config that would opt into a native path. This PR applies the same idiom at the operator level for the PyArrow UDF feature.

## What changes are included in this PR?

- In `EliminateRedundantTransitions`, the `EligibleMapInBatch` extractor no longer gates on `spark.comet.exec.pyarrowUdf.enabled`. It now matches whenever an operator *would* run natively (version-shimmed `mapInArrow` / `mapInPandas` matcher, strippable Comet columnar child, `useLargeVarTypes` off).
- The conf check moves into the rewrite arm: when the feature is enabled the operator is rewritten to `CometMapInBatchExec` as before; when it is disabled the vanilla Spark operator is left in place but annotated with a `[COMET-INFO]` opt-in hint (reusing `NativeOptIn.message` so the wording stays consistent with the expression-level hints).

Because the hint reuses the full eligibility check with only the conf inverted, it fires only on operators that would actually go native if the flag were flipped, and stays silent when `useLargeVarTypes` or a non-Comet child would prevent the rewrite anyway. This is Spark 4.x-only, matching where the feature exists (the 3.x matchers return `None`).

## How are these changes tested?

Added two JVM-only cases to the existing `CometMapInBatchSuite` (which exercises the rule against a stubbed `MapInArrowExec` over a Comet leaf without spinning up Python): one asserts the `[COMET-INFO]` hint and config key appear in extended-explain output when the feature is disabled, and one asserts no hint is emitted when it is enabled. No plan-stability golden files are affected, as no TPCDS query uses these operators.