### PR TITLE
perf: optimize `spark_cast_utf8_to_boolean` (>2x faster)

### DIFF
--- a/native/spark-expr/Cargo.toml
+++ b/native/spark-expr/Cargo.toml
@@ -139,3 +139,7 @@ harness = false
 [[bench]]
 name = "to_json"
 harness = false
+
+[[bench]]
+name = "cast_string_to_boolean"
+harness = false

--- a/native/spark-expr/benches/cast_string_to_boolean.rs
+++ b/native/spark-expr/benches/cast_string_to_boolean.rs
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::{builder::StringBuilder, ArrayRef};
+use arrow::datatypes::DataType;
+use criterion::{criterion_group, criterion_main, Criterion};
+use datafusion::physical_plan::ColumnarValue;
+use datafusion_comet_spark_expr::{spark_cast, EvalMode, SparkCastOptions};
+use std::sync::Arc;
+
+const NUM_ROWS: usize = 8192;
+
+/// Strings that Spark accepts as booleans, in the mixed casing and padding that shows
+/// up in real data.
+const VALID: [&str; 12] = [
+    "true", "TRUE", "True", "false", "FALSE", " t ", "y", "YES", "no", "N", "1", "0",
+];
+
+/// A mix of valid boolean spellings and values that cast to NULL.
+fn mixed_batch() -> ArrayRef {
+    let mut b = StringBuilder::new();
+    for i in 0..NUM_ROWS {
+        match i % 10 {
+            0 => b.append_null(),
+            1 => b.append_value("maybe"),
+            2 => b.append_value("2"),
+            _ => b.append_value(VALID[i % VALID.len()]),
+        }
+    }
+    Arc::new(b.finish())
+}
+
+/// Only valid boolean spellings, so every row takes the parsing path.
+fn valid_batch() -> ArrayRef {
+    let mut b = StringBuilder::new();
+    for i in 0..NUM_ROWS {
+        b.append_value(VALID[i % VALID.len()]);
+    }
+    Arc::new(b.finish())
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mixed = mixed_batch();
+    let valid = valid_batch();
+
+    let mut group = c.benchmark_group("cast_string_to_boolean");
+    for (mode, mode_name) in [
+        (EvalMode::Legacy, "legacy"),
+        (EvalMode::Try, "try"),
+        (EvalMode::Ansi, "ansi"),
+    ] {
+        let options = SparkCastOptions::new(mode, "", false);
+        // ANSI mode errors on any unparseable value, so it only gets the valid batch.
+        if mode != EvalMode::Ansi {
+            group.bench_function(format!("{mode_name}/mixed"), |b| {
+                b.iter(|| {
+                    spark_cast(
+                        ColumnarValue::Array(Arc::clone(&mixed)),
+                        &DataType::Boolean,
+                        &options,
+                    )
+                    .unwrap()
+                });
+            });
+        }
+        group.bench_function(format!("{mode_name}/valid"), |b| {
+            b.iter(|| {
+                spark_cast(
+                    ColumnarValue::Array(Arc::clone(&valid)),
+                    &DataType::Boolean,
+                    &options,
+                )
+                .unwrap()
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/native/spark-expr/src/conversion_funcs/string.rs
+++ b/native/spark-expr/src/conversion_funcs/string.rs
@@ -17,8 +17,8 @@
 
 use crate::{timezone, EvalMode, SparkError, SparkResult};
 use arrow::array::{
-    Array, ArrayRef, ArrowPrimitiveType, BooleanArray, Decimal128Builder, GenericStringArray,
-    OffsetSizeTrait, PrimitiveArray, PrimitiveBuilder, StringArray,
+    Array, ArrayRef, ArrowPrimitiveType, BooleanArray, BooleanBuilder, Decimal128Builder,
+    GenericStringArray, OffsetSizeTrait, PrimitiveArray, PrimitiveBuilder, StringArray,
 };
 use arrow::compute::DecimalCast;
 use arrow::datatypes::{
@@ -254,6 +254,28 @@ where
     pruned_float_str.parse::<F>().ok()
 }
 
+/// Parse the boolean literals Spark accepts in a string-to-boolean cast, returning
+/// `None` for anything else.
+///
+/// Trimming before comparing is equivalent to trimming afterwards: ASCII case folding
+/// never turns a whitespace character into a non-whitespace one, or vice versa.
+#[inline]
+fn parse_utf8_to_boolean(value: &str) -> Option<bool> {
+    let trimmed = value.trim();
+    match trimmed.len() {
+        1 => match trimmed.as_bytes()[0] {
+            b't' | b'T' | b'y' | b'Y' | b'1' => Some(true),
+            b'f' | b'F' | b'n' | b'N' | b'0' => Some(false),
+            _ => None,
+        },
+        2 if trimmed.eq_ignore_ascii_case("no") => Some(false),
+        3 if trimmed.eq_ignore_ascii_case("yes") => Some(true),
+        4 if trimmed.eq_ignore_ascii_case("true") => Some(true),
+        5 if trimmed.eq_ignore_ascii_case("false") => Some(false),
+        _ => None,
+    }
+}
+
 pub(crate) fn spark_cast_utf8_to_boolean<OffsetSize>(
     from: &dyn Array,
     eval_mode: EvalMode,
@@ -266,22 +288,26 @@ where
         .downcast_ref::<GenericStringArray<OffsetSize>>()
         .unwrap();
 
-    let output_array = array
+    // Only ANSI mode can fail, so the other modes avoid the per-row `Result` entirely.
+    if eval_mode == EvalMode::Ansi {
+        let mut builder = BooleanBuilder::with_capacity(array.len());
+        for value in array.iter() {
+            match value {
+                Some(value) => match parse_utf8_to_boolean(value) {
+                    Some(parsed) => builder.append_value(parsed),
+                    None => return Err(invalid_value(value, "STRING", "BOOLEAN")),
+                },
+                None => builder.append_null(),
+            }
+        }
+
+        return Ok(Arc::new(builder.finish()));
+    }
+
+    let output_array: BooleanArray = array
         .iter()
-        .map(|value| match value {
-            Some(value) => match value.to_ascii_lowercase().trim() {
-                "t" | "true" | "y" | "yes" | "1" => Ok(Some(true)),
-                "f" | "false" | "n" | "no" | "0" => Ok(Some(false)),
-                _ if eval_mode == EvalMode::Ansi => Err(SparkError::CastInvalidValue {
-                    value: value.to_string(),
-                    from_type: "STRING".to_string(),
-                    to_type: "BOOLEAN".to_string(),
-                }),
-                _ => Ok(None),
-            },
-            _ => Ok(None),
-        })
-        .collect::<Result<BooleanArray, _>>()?;
+        .map(|value| value.and_then(parse_utf8_to_boolean))
+        .collect();
 
     Ok(Arc::new(output_array))
 }
@@ -1986,6 +2012,38 @@ mod tests {
             EvalMode::Legacy => parse_string_to_i8_legacy(str),
             EvalMode::Ansi => parse_string_to_i8_ansi(str),
             EvalMode::Try => parse_string_to_i8_try(str),
+        }
+    }
+
+    #[test]
+    fn test_parse_utf8_to_boolean() {
+        for truthy in [
+            "t", "T", "true", "TRUE", "tRuE", "y", "Y", "yes", "YES", "1",
+        ] {
+            assert_eq!(parse_utf8_to_boolean(truthy), Some(true), "{truthy}");
+        }
+        for falsy in [
+            "f", "F", "false", "FALSE", "fAlSe", "n", "N", "no", "NO", "0",
+        ] {
+            assert_eq!(parse_utf8_to_boolean(falsy), Some(false), "{falsy}");
+        }
+        // Surrounding whitespace is ignored, as in Spark.
+        assert_eq!(parse_utf8_to_boolean(" \ttrue\n "), Some(true));
+        assert_eq!(parse_utf8_to_boolean("  no  "), Some(false));
+        // Anything else casts to NULL.
+        for invalid in [
+            "",
+            " ",
+            "tru",
+            "truely",
+            "2",
+            "-1",
+            "on",
+            "off",
+            "úñî",
+            "ｔｒｕｅ",
+        ] {
+            assert_eq!(parse_utf8_to_boolean(invalid), None, "{invalid}");
         }
     }
 

--- a/native/spark-expr/src/conversion_funcs/string.rs
+++ b/native/spark-expr/src/conversion_funcs/string.rs
@@ -261,6 +261,8 @@ where
 /// never turns a whitespace character into a non-whitespace one, or vice versa.
 #[inline]
 fn parse_utf8_to_boolean(value: &str) -> Option<bool> {
+    // TODO(#4959): Spark's UTF8String.trimAll also strips ISO control bytes
+    // (0x00-0x08, 0x0E-0x1F, 0x7F); str::trim only strips Unicode whitespace.
     let trimmed = value.trim();
     match trimmed.len() {
         1 => match trimmed.as_bytes()[0] {
@@ -2042,6 +2044,10 @@ mod tests {
             "off",
             "úñî",
             "ｔｒｕｅ",
+            // Non-ASCII inputs at exactly the target byte length must not match
+            // via `eq_ignore_ascii_case` (2 bytes: "no" arm; 4 bytes: "true" arm).
+            "ñ",
+            "trñ",
         ] {
             assert_eq!(parse_utf8_to_boolean(invalid), None, "{invalid}");
         }


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Optimize existing expressions.

## What changes are included in this PR?

Replaced the per-row `to_ascii_lowercase()` String allocation in the string-to-boolean cast with an allocation-free length-dispatched `eq_ignore_ascii_case` match, and dropped the per-row `Result` for the non-ANSI eval modes.

## How are these changes tested?

Existing tests + new unit tests.

Benchmark (criterion):

- legacy_mixed: 68.325% faster (base 156779ns -> cand 49659ns)
- try_mixed: 68.699% faster (base 158363ns -> cand 49570ns)
- legacy_valid: 67.019% faster (base 169509ns -> cand 55905ns)
- ansi_valid: 68.293% faster (base 171297ns -> cand 54313ns)
- try_valid: 67.195% faster (base 169282ns -> cand 55533ns)

Full criterion output:

```text
cast_string_to_boolean/legacy/mixed
                        time:   [49.828 µs 50.046 µs 50.365 µs]
                        change: [−68.437% −68.325% −68.202%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
cast_string_to_boolean/legacy/valid
                        time:   [55.765 µs 55.855 µs 55.965 µs]
                        change: [−67.067% −67.019% −66.955%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  6 (6.00%) low severe
  1 (1.00%) low mild
  9 (9.00%) high severe
cast_string_to_boolean/try/mixed
                        time:   [49.542 µs 49.571 µs 49.615 µs]
                        change: [−68.723% −68.699% −68.676%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
cast_string_to_boolean/try/valid
                        time:   [55.479 µs 55.502 µs 55.533 µs]
                        change: [−67.236% −67.195% −67.142%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
cast_string_to_boolean/ansi/valid
                        time:   [54.193 µs 54.227 µs 54.275 µs]
                        change: [−68.532% −68.293% −68.070%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
```


