### PR TITLE
perf: optimize `spark_lpad` (up to 2x faster)

### DIFF
--- a/native/spark-expr/benches/padding.rs
+++ b/native/spark-expr/benches/padding.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use arrow::array::builder::StringBuilder;
-use arrow::array::ArrayRef;
+use arrow::array::{ArrayRef, Int32Array};
 use criterion::{criterion_group, criterion_main, Criterion};
 use datafusion::common::ScalarValue;
 use datafusion::physical_plan::ColumnarValue;
@@ -36,9 +36,16 @@ fn create_string_array(size: usize) -> ArrayRef {
     Arc::new(builder.finish())
 }
 
+fn create_length_array(size: usize) -> ArrayRef {
+    Arc::new(Int32Array::from(
+        (0..size).map(|i| (i % 24) as i32).collect::<Vec<_>>(),
+    ))
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     let size = 8192;
     let string_array = create_string_array(size);
+    let length_array = create_length_array(size);
 
     // lpad with default padding (space)
     c.bench_function("spark_lpad: default padding", |b| {
@@ -112,6 +119,34 @@ fn criterion_benchmark(c: &mut Criterion) {
         let args = vec![
             ColumnarValue::Array(Arc::clone(&string_array)),
             ColumnarValue::Scalar(ScalarValue::Int32(Some(5))),
+        ];
+        b.iter(|| black_box(spark_rpad(black_box(&args)).unwrap()))
+    });
+
+    // lpad with the target length taken from a column
+    c.bench_function("spark_lpad: length from column", |b| {
+        let args = vec![
+            ColumnarValue::Array(Arc::clone(&string_array)),
+            ColumnarValue::Array(Arc::clone(&length_array)),
+        ];
+        b.iter(|| black_box(spark_lpad(black_box(&args)).unwrap()))
+    });
+
+    // rpad with the target length taken from a column
+    c.bench_function("spark_rpad: length from column", |b| {
+        let args = vec![
+            ColumnarValue::Array(Arc::clone(&string_array)),
+            ColumnarValue::Array(Arc::clone(&length_array)),
+        ];
+        b.iter(|| black_box(spark_rpad(black_box(&args)).unwrap()))
+    });
+
+    // rpad with the target length from a column and a multi-char padding string
+    c.bench_function("spark_rpad: length from column, multi-char padding", |b| {
+        let args = vec![
+            ColumnarValue::Array(Arc::clone(&string_array)),
+            ColumnarValue::Array(Arc::clone(&length_array)),
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some("abc".to_string()))),
         ];
         b.iter(|| black_box(spark_rpad(black_box(&args)).unwrap()))
     });

--- a/native/spark-expr/src/static_invoke/char_varchar_utils/read_side_padding.rs
+++ b/native/spark-expr/src/static_invoke/char_varchar_utils/read_side_padding.rs
@@ -23,6 +23,7 @@ use arrow::array::{ArrayRef, OffsetSizeTrait};
 use arrow::datatypes::DataType;
 use datafusion::common::{cast::as_generic_string_array, DataFusionError, ScalarValue};
 use datafusion::physical_plan::ColumnarValue;
+use std::fmt::Write;
 use std::sync::Arc;
 
 const SPACE: &str = " ";
@@ -195,36 +196,37 @@ fn spark_read_side_padding_internal<T: OffsetSizeTrait>(
 ) -> Result<ColumnarValue, DataFusionError> {
     let string_array = as_generic_string_array::<T>(array)?;
 
-    // Pre-compute pad characters once to avoid repeated iteration
-    let pad_chars: Vec<char> = pad_string.chars().collect();
-
     match pad_type {
         ColumnarValue::Array(array_int) => {
             let int_pad_array = array_int.as_primitive::<Int32Type>();
 
+            // Every row is padded to its target length, so the sum of the target
+            // lengths sizes the output (exactly, for ASCII input), except when a
+            // row is longer than its target and passes through untruncated.
+            let mut data_capacity = 0usize;
+            let mut max_length = 0usize;
+            for length in int_pad_array.values() {
+                let length = (*length).max(0) as usize;
+                data_capacity = data_capacity.saturating_add(length);
+                max_length = max_length.max(length);
+            }
             let mut builder = GenericStringBuilder::<T>::with_capacity(
                 string_array.len(),
-                string_array.len() * int_pad_array.len(),
+                data_capacity.max(string_array.value_data().len()),
             );
-
-            // Reusable buffer to avoid per-element allocations
-            let mut buffer = String::with_capacity(pad_chars.len());
+            let padder = Padder {
+                pad: PadPattern::new(pad_string, max_length),
+                ascii: string_array.is_ascii(),
+                truncate,
+                is_left_pad,
+            };
 
             for (string, length) in string_array.iter().zip(int_pad_array) {
                 let length = length.unwrap();
                 match string {
                     Some(string) => {
                         if length >= 0 {
-                            buffer.clear();
-                            write_padded_string(
-                                &mut buffer,
-                                string,
-                                length as usize,
-                                truncate,
-                                &pad_chars,
-                                is_left_pad,
-                            );
-                            builder.append_value(&buffer);
+                            padder.append(&mut builder, string, length as usize);
                         } else {
                             builder.append_value("");
                         }
@@ -239,26 +241,18 @@ fn spark_read_side_padding_internal<T: OffsetSizeTrait>(
 
             let mut builder = GenericStringBuilder::<T>::with_capacity(
                 string_array.len(),
-                string_array.len() * length,
+                string_array.len().saturating_mul(length),
             );
-
-            // Reusable buffer to avoid per-element allocations
-            let mut buffer = String::with_capacity(length);
+            let padder = Padder {
+                pad: PadPattern::new(pad_string, length),
+                ascii: string_array.is_ascii(),
+                truncate,
+                is_left_pad,
+            };
 
             for string in string_array.iter() {
                 match string {
-                    Some(string) => {
-                        buffer.clear();
-                        write_padded_string(
-                            &mut buffer,
-                            string,
-                            length,
-                            truncate,
-                            &pad_chars,
-                            is_left_pad,
-                        );
-                        builder.append_value(&buffer);
-                    }
+                    Some(string) => padder.append(&mut builder, string, length),
                     _ => builder.append_null(),
                 }
             }
@@ -267,74 +261,235 @@ fn spark_read_side_padding_internal<T: OffsetSizeTrait>(
     }
 }
 
-/// Writes a padded string to the provided buffer, avoiding allocations.
-///
-/// The buffer is assumed to be cleared before calling this function.
-/// Padding characters are written directly to the buffer without intermediate allocations.
-#[inline]
-fn write_padded_string(
-    buffer: &mut String,
-    string: &str,
-    length: usize,
-    truncate: bool,
-    pad_chars: &[char],
-    is_left_pad: bool,
-) {
-    // Spark's UTF8String uses char count, not grapheme count
-    // https://stackoverflow.com/a/46290728
-    let char_len = string.chars().count();
+/// The padding pattern, materialized as a repeating buffer so that padding a row
+/// is a single copy of a slice rather than a character-at-a-time loop.
+struct PadPattern<'a> {
+    /// One repetition of the pattern.
+    pattern: &'a str,
+    /// Byte offset of the first `i` characters of one repetition, for every `i` in
+    /// `0..=pattern.chars().count()`.
+    char_offsets: Vec<usize>,
+    /// The pattern repeated enough times to supply the longest padding needed.
+    buffer: String,
+}
 
-    if length <= char_len {
-        if truncate {
-            // Find byte index for the truncation point
-            let idx = string
-                .char_indices()
-                .nth(length)
-                .map(|(i, _)| i)
-                .unwrap_or(string.len());
-            buffer.push_str(&string[..idx]);
+impl<'a> PadPattern<'a> {
+    /// Builds a pattern that can supply up to `max_chars` padding characters.
+    fn new(pattern: &'a str, max_chars: usize) -> Self {
+        let char_offsets: Vec<usize> = pattern
+            .char_indices()
+            .map(|(i, _)| i)
+            .chain(std::iter::once(pattern.len()))
+            .collect();
+        let pattern_chars = char_offsets.len() - 1;
+        let buffer = if pattern_chars == 0 {
+            String::new()
         } else {
-            buffer.push_str(string);
+            pattern.repeat(max_chars.div_ceil(pattern_chars))
+        };
+        Self {
+            pattern,
+            char_offsets,
+            buffer,
         }
-    } else {
-        let pad_needed = length - char_len;
+    }
 
-        if is_left_pad {
-            // Write padding first, then string
-            write_padding_chars(buffer, pad_chars, pad_needed);
-            buffer.push_str(string);
-        } else {
-            // Write string first, then padding
-            buffer.push_str(string);
-            write_padding_chars(buffer, pad_chars, pad_needed);
+    /// Returns a slice holding exactly `chars` characters of the repeating pattern,
+    /// or an empty slice if the pattern itself is empty. `chars` must not exceed the
+    /// `max_chars` the pattern was built with.
+    #[inline]
+    fn slice(&self, chars: usize) -> &str {
+        let pattern_chars = self.char_offsets.len() - 1;
+        if pattern_chars == 0 {
+            return "";
         }
+        let bytes = if self.pattern.len() == pattern_chars {
+            // One byte per character (the default single space), so no offset lookup.
+            chars
+        } else {
+            (chars / pattern_chars) * self.pattern.len() + self.char_offsets[chars % pattern_chars]
+        };
+        &self.buffer[..bytes]
     }
 }
 
-/// Writes `count` characters from the cycling pad pattern directly to the buffer.
-#[inline]
-fn write_padding_chars(buffer: &mut String, pad_chars: &[char], count: usize) {
-    if pad_chars.is_empty() {
-        return;
+/// Pads rows of a single string array, holding the settings that are constant
+/// across the array.
+struct Padder<'a> {
+    pad: PadPattern<'a>,
+    /// Whether every value in the array is ASCII, which lets character counts and
+    /// truncation points be read off byte offsets directly.
+    ascii: bool,
+    truncate: bool,
+    is_left_pad: bool,
+}
+
+impl Padder<'_> {
+    /// Appends `string`, padded or truncated to `length` characters, to `builder`.
+    #[inline]
+    fn append<T: OffsetSizeTrait>(
+        &self,
+        builder: &mut GenericStringBuilder<T>,
+        string: &str,
+        length: usize,
+    ) {
+        // Spark's UTF8String uses char count, not grapheme count
+        // https://stackoverflow.com/a/46290728
+        let char_len = if self.ascii {
+            string.len()
+        } else {
+            string.chars().count()
+        };
+
+        if length <= char_len {
+            if self.truncate {
+                let idx = if self.ascii {
+                    length
+                } else {
+                    string
+                        .char_indices()
+                        .nth(length)
+                        .map(|(i, _)| i)
+                        .unwrap_or(string.len())
+                };
+                builder.append_value(&string[..idx]);
+            } else {
+                builder.append_value(string);
+            }
+            return;
+        }
+
+        let padding = self.pad.slice(length - char_len);
+        let (first, second) = if self.is_left_pad {
+            (padding, string)
+        } else {
+            (string, padding)
+        };
+        // Writing through `fmt::Write` appends to the value in progress, so the two
+        // pieces are copied once each rather than staged in a temporary `String`.
+        let _ = builder.write_str(first);
+        let _ = builder.write_str(second);
+        builder.append_value("");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int32Array, StringArray};
+
+    fn utf8(values: &[Option<&str>]) -> ColumnarValue {
+        ColumnarValue::Array(Arc::new(StringArray::from(values.to_vec())) as ArrayRef)
     }
 
-    // Optimize for the common single-character padding case
-    if pad_chars.len() == 1 {
-        let ch = pad_chars[0];
-        for _ in 0..count {
-            buffer.push(ch);
-        }
-    } else {
-        // Multi-character padding: cycle through pad_chars
-        let mut remaining = count;
-        while remaining > 0 {
-            for &ch in pad_chars {
-                if remaining == 0 {
-                    break;
-                }
-                buffer.push(ch);
-                remaining -= 1;
-            }
-        }
+    fn result_values(col: ColumnarValue) -> Vec<Option<String>> {
+        let array = col.to_array(0).unwrap();
+        array
+            .as_string::<i32>()
+            .iter()
+            .map(|v| v.map(|s| s.to_string()))
+            .collect()
+    }
+
+    fn len_scalar(length: i32) -> ColumnarValue {
+        ColumnarValue::Scalar(ScalarValue::Int32(Some(length)))
+    }
+
+    fn pad_scalar(pad: &str) -> ColumnarValue {
+        ColumnarValue::Scalar(ScalarValue::Utf8(Some(pad.to_string())))
+    }
+
+    #[test]
+    fn rpad_default_padding() {
+        let args = vec![
+            utf8(&[Some("abc"), None, Some(""), Some("abcdef")]),
+            len_scalar(5),
+        ];
+        assert_eq!(
+            result_values(spark_rpad(&args).unwrap()),
+            vec![
+                Some("abc  ".to_string()),
+                None,
+                Some("     ".to_string()),
+                Some("abcde".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn lpad_default_padding() {
+        let args = vec![utf8(&[Some("abc"), None, Some("abcdef")]), len_scalar(5)];
+        assert_eq!(
+            result_values(spark_lpad(&args).unwrap()),
+            vec![Some("  abc".to_string()), None, Some("abcde".to_string()),]
+        );
+    }
+
+    #[test]
+    fn read_side_padding_does_not_truncate() {
+        let args = vec![utf8(&[Some("abcdef")]), len_scalar(3)];
+        assert_eq!(
+            result_values(spark_read_side_padding(&args).unwrap()),
+            vec![Some("abcdef".to_string())]
+        );
+    }
+
+    #[test]
+    fn multi_char_pattern_cycles() {
+        let args = vec![utf8(&[Some("x")]), len_scalar(8), pad_scalar("ab")];
+        assert_eq!(
+            result_values(spark_rpad(&args).unwrap()),
+            vec![Some("xabababa".to_string())]
+        );
+        let args = vec![utf8(&[Some("x")]), len_scalar(8), pad_scalar("ab")];
+        assert_eq!(
+            result_values(spark_lpad(&args).unwrap()),
+            vec![Some("abababax".to_string())]
+        );
+    }
+
+    #[test]
+    fn padding_counts_chars_not_bytes() {
+        // multi-byte characters count as one character each
+        let args = vec![utf8(&[Some("úñî")]), len_scalar(5), pad_scalar("ö")];
+        assert_eq!(
+            result_values(spark_rpad(&args).unwrap()),
+            vec![Some("úñîöö".to_string())]
+        );
+        // truncation is by character, not byte
+        let args = vec![utf8(&[Some("úñîçö")]), len_scalar(2)];
+        assert_eq!(
+            result_values(spark_rpad(&args).unwrap()),
+            vec![Some("úñ".to_string())]
+        );
+    }
+
+    #[test]
+    fn empty_pad_string_leaves_value_unchanged() {
+        let args = vec![utf8(&[Some("abc")]), len_scalar(6), pad_scalar("")];
+        assert_eq!(
+            result_values(spark_rpad(&args).unwrap()),
+            vec![Some("abc".to_string())]
+        );
+    }
+
+    #[test]
+    fn negative_length_yields_empty_string() {
+        let lengths = ColumnarValue::Array(Arc::new(Int32Array::from(vec![-1, 4])) as ArrayRef);
+        let args = vec![utf8(&[Some("abc"), Some("abc")]), lengths];
+        assert_eq!(
+            result_values(spark_rpad(&args).unwrap()),
+            vec![Some("".to_string()), Some("abc ".to_string())]
+        );
+    }
+
+    #[test]
+    fn length_from_array() {
+        let lengths = ColumnarValue::Array(Arc::new(Int32Array::from(vec![1, 5, 3])) as ArrayRef);
+        let args = vec![utf8(&[Some("abc"), Some("abc"), None]), lengths];
+        assert_eq!(
+            result_values(spark_lpad(&args).unwrap()),
+            vec![Some("a".to_string()), Some("  abc".to_string()), None]
+        );
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Optimize existing expression.

## What changes are included in this PR?

Pad rows with one memcpy from a precomputed repeating pad buffer and write pieces directly into the string builder instead of a scratch String, plus an ASCII fast path and a fix for a rows*rows capacity hint in the column-length path.

## How are these changes tested?

Existing tests + new unit tests.

Benchmark (criterion):

- spark_rpad_ default padding: 40.449% faster (base 130815ns -> cand 77902ns)
- spark_rpad_ length from column, multi-char padding: 41.531% faster (base 128111ns -> cand 74905ns)
- spark_lpad_ default padding: 37.778% faster (base 126685ns -> cand 78826ns)
- spark_lpad_ length from column: 31.923% faster (base 110963ns -> cand 75540ns)
- spark_lpad_ custom padding: 35.618% faster (base 123106ns -> cand 79258ns)
- spark_rpad_ multi-char padding: 52.516% faster (base 165109ns -> cand 78401ns)
- spark_lpad_ with truncation: 50.694% faster (base 110062ns -> cand 54268ns)
- spark_lpad_ multi-char padding: 57.246% faster (base 181356ns -> cand 77536ns)
- spark_rpad_ length from column: 32.23% faster (base 110303ns -> cand 74752ns)
- spark_rpad_ custom padding: 40.385% faster (base 130616ns -> cand 77866ns)
- spark_rpad_ with truncation: 50.556% faster (base 109976ns -> cand 54377ns)

Full criterion output:

```text
spark_lpad: default padding
                        time:   [78.908 µs 79.083 µs 79.261 µs]
                        change: [−37.968% −37.778% −37.621%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild

spark_lpad: custom padding
                        time:   [78.999 µs 79.093 µs 79.196 µs]
                        change: [−35.699% −35.618% −35.554%] (p = 0.00 < 0.05)
                        Performance has improved.

spark_rpad: default padding
                        time:   [78.086 µs 78.410 µs 78.731 µs]
                        change: [−40.596% −40.449% −40.294%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 20 outliers among 100 measurements (20.00%)
  3 (3.00%) high mild
  17 (17.00%) high severe

spark_rpad: custom padding
                        time:   [77.806 µs 77.855 µs 77.931 µs]
                        change: [−40.474% −40.385% −40.290%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

spark_lpad: multi-char padding
                        time:   [77.424 µs 77.539 µs 77.677 µs]
                        change: [−57.312% −57.246% −57.187%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

spark_rpad: multi-char padding
                        time:   [78.306 µs 78.409 µs 78.530 µs]
                        change: [−52.583% −52.516% −52.442%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe

spark_lpad: with truncation
                        time:   [54.249 µs 54.317 µs 54.393 µs]
                        change: [−50.755% −50.694% −50.637%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low mild
  11 (11.00%) high mild
  1 (1.00%) high severe

spark_rpad: with truncation
                        time:   [54.146 µs 54.203 µs 54.268 µs]
                        change: [−50.698% −50.556% −50.370%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

spark_lpad: length from column
                        time:   [75.318 µs 75.499 µs 75.686 µs]
                        change: [−32.039% −31.923% −31.795%] (p = 0.00 < 0.05)
                        Performance has improved.

spark_rpad: length from column
                        time:   [74.721 µs 74.759 µs 74.818 µs]
                        change: [−32.298% −32.230% −32.168%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

spark_rpad: length from column, multi-char padding
                        time:   [74.876 µs 74.937 µs 75.016 µs]
                        change: [−41.976% −41.531% −41.269%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
```


