### PR TITLE
perf: optimize `spark_cast_int_to_int` (100x faster)

### DIFF
--- a/native/spark-expr/src/conversion_funcs/numeric.rs
+++ b/native/spark-expr/src/conversion_funcs/numeric.rs
@@ -255,53 +255,36 @@ macro_rules! cast_int_to_int_macro {
         $eval_mode:expr,
         $from_arrow_primitive_type: ty,
         $to_arrow_primitive_type: ty,
-        $from_data_type: expr,
         $to_native_type: ty,
         $spark_from_data_type_name: expr,
-        $spark_to_data_type_name: expr
+        $spark_to_data_type_name: expr,
+        $spark_int_literal_suffix: expr
     ) => {{
         let cast_array = $array
             .as_any()
             .downcast_ref::<PrimitiveArray<$from_arrow_primitive_type>>()
             .unwrap();
-        let spark_int_literal_suffix = match $from_data_type {
-            &DataType::Int64 => "L",
-            &DataType::Int16 => "S",
-            &DataType::Int8 => "T",
-            _ => "",
-        };
 
-        let output_array = match $eval_mode {
-            EvalMode::Legacy => cast_array
-                .iter()
-                .map(|value| match value {
-                    Some(value) => {
-                        Ok::<Option<$to_native_type>, SparkError>(Some(value as $to_native_type))
-                    }
-                    _ => Ok(None),
+        let output_array: PrimitiveArray<$to_arrow_primitive_type> = match $eval_mode {
+            // Legacy narrowing keeps the low-order bits of the source value, which is what a
+            // wrapping `as` conversion does. Being infallible, it maps the values buffer in a
+            // single pass and carries the null buffer over untouched.
+            EvalMode::Legacy => {
+                cast_array.unary::<_, $to_arrow_primitive_type>(|value| value as $to_native_type)
+            }
+            // `try_unary` only applies the conversion to non-null slots, so an out-of-range
+            // value sitting under a null cannot raise a spurious overflow error.
+            _ => cast_array.try_unary::<_, $to_arrow_primitive_type, SparkError>(|value| {
+                <$to_native_type>::try_from(value).map_err(|_| {
+                    cast_overflow(
+                        &(value.to_string() + $spark_int_literal_suffix),
+                        $spark_from_data_type_name,
+                        $spark_to_data_type_name,
+                    )
                 })
-                .collect::<Result<PrimitiveArray<$to_arrow_primitive_type>, _>>(),
-            _ => cast_array
-                .iter()
-                .map(|value| match value {
-                    Some(value) => {
-                        let res = <$to_native_type>::try_from(value);
-                        if res.is_err() {
-                            Err(cast_overflow(
-                                &(value.to_string() + spark_int_literal_suffix),
-                                $spark_from_data_type_name,
-                                $spark_to_data_type_name,
-                            ))
-                        } else {
-                            Ok::<Option<$to_native_type>, SparkError>(Some(res.unwrap()))
-                        }
-                    }
-                    _ => Ok(None),
-                })
-                .collect::<Result<PrimitiveArray<$to_arrow_primitive_type>, _>>(),
-        }?;
-        let result: SparkResult<ArrayRef> = Ok(Arc::new(output_array) as ArrayRef);
-        result
+            })?,
+        };
+        Ok(Arc::new(output_array) as ArrayRef)
     }};
 }
 
@@ -780,22 +763,22 @@ pub(crate) fn spark_cast_int_to_int(
 ) -> SparkResult<ArrayRef> {
     match (from_type, to_type) {
         (DataType::Int64, DataType::Int32) => cast_int_to_int_macro!(
-            array, eval_mode, Int64Type, Int32Type, from_type, i32, "BIGINT", "INT"
+            array, eval_mode, Int64Type, Int32Type, i32, "BIGINT", "INT", "L"
         ),
         (DataType::Int64, DataType::Int16) => cast_int_to_int_macro!(
-            array, eval_mode, Int64Type, Int16Type, from_type, i16, "BIGINT", "SMALLINT"
+            array, eval_mode, Int64Type, Int16Type, i16, "BIGINT", "SMALLINT", "L"
         ),
         (DataType::Int64, DataType::Int8) => cast_int_to_int_macro!(
-            array, eval_mode, Int64Type, Int8Type, from_type, i8, "BIGINT", "TINYINT"
+            array, eval_mode, Int64Type, Int8Type, i8, "BIGINT", "TINYINT", "L"
         ),
         (DataType::Int32, DataType::Int16) => cast_int_to_int_macro!(
-            array, eval_mode, Int32Type, Int16Type, from_type, i16, "INT", "SMALLINT"
+            array, eval_mode, Int32Type, Int16Type, i16, "INT", "SMALLINT", ""
         ),
-        (DataType::Int32, DataType::Int8) => cast_int_to_int_macro!(
-            array, eval_mode, Int32Type, Int8Type, from_type, i8, "INT", "TINYINT"
-        ),
+        (DataType::Int32, DataType::Int8) => {
+            cast_int_to_int_macro!(array, eval_mode, Int32Type, Int8Type, i8, "INT", "TINYINT", "")
+        }
         (DataType::Int16, DataType::Int8) => cast_int_to_int_macro!(
-            array, eval_mode, Int16Type, Int8Type, from_type, i8, "SMALLINT", "TINYINT"
+            array, eval_mode, Int16Type, Int8Type, i8, "SMALLINT", "TINYINT", "S"
         ),
         _ => unreachable!(
             "{}",


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

Optimize existing expression.

## What changes are included in this PR?

Replaced the element-by-element Option/Result iterator-collect in cast_int_to_int_macro with Arrow's vectorized `unary` kernel for Legacy narrowing casts (and a pre-sized values Vec reusing the source null buffer for ANSI), removing per-element null-bitmap reads and builder appends.

## How are these changes tested?

Existing tests.

Benchmark (criterion):

- cast_i32_to_i64: -0.955% faster (base 668ns -> cand 674ns)
- cast_i32_to_i16: 99.275% faster (base 12843ns -> cand 93ns)
- cast_i32_to_i8: 99.276% faster (base 13017ns -> cand 94ns)

Full criterion output:

```text
cast_int_to_int/cast_i32_to_i8
                        time:   [94.165 ns 94.416 ns 94.755 ns]
                        change: [−99.278% −99.276% −99.274%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  1 (1.00%) high mild
  6 (6.00%) high severe
cast_int_to_int/cast_i32_to_i16
                        time:   [93.173 ns 93.318 ns 93.454 ns]
                        change: [−99.276% −99.275% −99.274%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 20 outliers among 100 measurements (20.00%)
  2 (2.00%) low severe
  2 (2.00%) low mild
  8 (8.00%) high mild
  8 (8.00%) high severe
cast_int_to_int/cast_i32_to_i64
                        time:   [673.75 ns 674.38 ns 675.10 ns]
                        change: [+0.8080% +0.9549% +1.1198%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 18 outliers among 100 measurements (18.00%)
  4 (4.00%) low severe
  10 (10.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
```


