### PR TITLE
fix: suppress spurious WriteFilesExec fallback reason on native writes

### DIFF
--- a/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
@@ -371,9 +371,14 @@ case class CometExecRule(session: SparkSession)
         op match {
           case _: CometPlan | _: AQEShuffleReadExec | _: BroadcastExchangeExec |
               _: BroadcastQueryStageExec | _: AdaptiveSparkPlanExec | _: ExecutedCommandExec |
-              _: V2CommandExec =>
+              _: V2CommandExec | _: WriteFilesExec =>
             // Some execs should never be replaced. We include
-            // these cases specially here so we do not add a misleading 'info' message
+            // these cases specially here so we do not add a misleading 'info' message.
+            // WriteFilesExec is always wrapped by DataWritingCommandExec (via Spark's V1Writes
+            // rule); the parent case converts the whole write to CometNativeWriteExec and
+            // unwraps WriteFilesExec inside convertToComet. Tagging WriteFilesExec here would
+            // produce a spurious "WriteFilesExec is not supported" fallback reason (and a
+            // warning when COMET_LOG_FALLBACK_REASONS=true) even when the write is fully native.
             op
           case _ =>
             // The operator was not converted to a Comet plan. Possible reasons for this happening:


### PR DESCRIPTION
## Summary

Suppress a spurious `WriteFilesExec is not supported` fallback reason emitted during native Parquet writes.

Spark's `V1Writes` rule wraps native writes as `DataWritingCommandExec(cmd, WriteFilesExec(child))`. `CometExecRule` converts the outer `DataWritingCommandExec` to `CometNativeWriteExec` and unwraps the inner `WriteFilesExec` inside `convertToComet`, so the write runs natively end-to-end.

However, `transformUp` visits `WriteFilesExec` before its parent. No case in the outer `match` handles it, so it falls through to the generic `${op.nodeName} is not supported` tag at the bottom of `convertNode`. The `WriteFilesExec` instance is then discarded when the parent converts, so the executed plan looks correct — but with `spark.comet.logFallbackReasons.enabled=true` the log emits a misleading warning:

```
Comet cannot accelerate WriteFilesExec because: WriteFilesExec is not supported
```

Add `WriteFilesExec` to the list of operators that should never be tagged with a generic fallback reason (alongside `CometPlan`, `AQEShuffleReadExec`, `BroadcastExchangeExec`, `BroadcastQueryStageExec`, `AdaptiveSparkPlanExec`, `ExecutedCommandExec`, `V2CommandExec`).

## Test plan

- [ ] Enable `spark.comet.logFallbackReasons.enabled=true` and a native Parquet write via `df.write.parquet(...)`; confirm the `WriteFilesExec is not supported` warning no longer appears.
- [ ] Confirm existing `CometParquetWriterSuite` tests still pass.
