### PR TITLE
doc: Document scan tuning for `spark.sql.files.maxPartitionBytes`

### DIFF
--- a/docs/source/user-guide/latest/tuning.md
+++ b/docs/source/user-guide/latest/tuning.md
@@ -186,13 +186,38 @@ By default, Spark compresses shuffle files using LZ4 compression. Comet override
 Compression can be disabled by setting `spark.shuffle.compress=false`, which may result in faster shuffle times in
 certain environments, such as single-node setups with fast NVMe drives, at the expense of increased disk space usage.
 
-### Native scans
+### Parquet Native Scans
 
-For native scans it is better to check `spark.sql.files.maxPartitionBytes` which is `128M` by default and
-set it to `spark.sql.files.maxPartitionBytes: 64M`. The difference comes from how Apache DataFusion and Spark determine the Parquet row group boundaries.
-This would help to split more uniformly the work for scan tasks
+Spark and DataFusion's native Parquet scans use different rules to decide which row groups belong to a
+given scan range (split). Spark assigns a row group to a split if the row group's start offset falls
+within `[split.start, split.start + split.length)`, guaranteeing that every task Spark plans reads at
+least one row group when the file layout permits. DataFusion's `prune_by_range` also checks whether a
+row group's start offset falls within the split's byte range, but because row group sizes are not aligned
+with Spark's split boundaries, the two systems can disagree on which split "owns" a given row group.
 
-More details in https://github.com/apache/datafusion-comet/issues/3817#issuecomment-4193279630
+When a file contains row groups whose sizes are close to `spark.sql.files.maxPartitionBytes`, this
+mismatch can leave some Comet scan tasks with no row groups to read. Those tasks still load Parquet
+metadata but return zero rows, while neighboring tasks end up reading more row groups than Spark
+intended. The overall effect is that Comet uses only a fraction of the parallelism that Spark planned
+for the scan stage, and end-to-end scan latency increases even though the total amount of data read
+is unchanged.
+
+Symptoms to look for:
+
+- A subset of scan tasks completes almost immediately and reports 0 input rows, while the remaining
+  tasks read noticeably more rows than the equivalent Spark tasks would.
+- The Comet scan stage has the same number of planned tasks as Spark but a much lower count of tasks
+  that actually do work.
+
+Workaround: lower `spark.sql.files.maxPartitionBytes` so that each split is smaller than a single row
+group. For example, if the file's row groups are around 120 MB and `spark.sql.files.maxPartitionBytes`
+is left at the 128 MB default, most splits will contain at most one row group boundary and the
+mismatch is amplified; setting `spark.sql.files.maxPartitionBytes` below 120 MB (for example, 64 MB)
+distributes row groups across more splits and reduces the number of idle tasks. Smaller values produce
+more splits overall, so some idle tasks may remain — tune the value against your file layout.
+
+See [issue #3817](https://github.com/apache/datafusion-comet/issues/3817#issuecomment-4193279630) for a
+worked example and further discussion.
 
 ## Explain Plan
 

--- a/docs/source/user-guide/latest/tuning.md
+++ b/docs/source/user-guide/latest/tuning.md
@@ -186,6 +186,14 @@ By default, Spark compresses shuffle files using LZ4 compression. Comet override
 Compression can be disabled by setting `spark.shuffle.compress=false`, which may result in faster shuffle times in
 certain environments, such as single-node setups with fast NVMe drives, at the expense of increased disk space usage.
 
+### Native scans
+
+For native scans it is better to check `spark.sql.files.maxPartitionBytes` which is `128MB` by default and
+set it to `spark.sql.files.maxPartitionBytes: 64M`. The difference comes from how Apache DataFusion and Spark determine the Parquet row group boundaries.
+This would help to split more uniformly the work for scan tasks
+
+More details in https://github.com/apache/datafusion-comet/issues/3817#issuecomment-4193279630
+
 ## Explain Plan
 
 For an explanation of Comet plan output, the configs that control it, and how

--- a/docs/source/user-guide/latest/tuning.md
+++ b/docs/source/user-guide/latest/tuning.md
@@ -188,7 +188,7 @@ certain environments, such as single-node setups with fast NVMe drives, at the e
 
 ### Native scans
 
-For native scans it is better to check `spark.sql.files.maxPartitionBytes` which is `128MB` by default and
+For native scans it is better to check `spark.sql.files.maxPartitionBytes` which is `128M` by default and
 set it to `spark.sql.files.maxPartitionBytes: 64M`. The difference comes from how Apache DataFusion and Spark determine the Parquet row group boundaries.
 This would help to split more uniformly the work for scan tasks
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related #3817.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
