### PR TITLE
perf: bypass shuffle BatchCoalescer for already-sized batches

### DIFF
--- a/native/shuffle/src/shuffle_writer.rs
+++ b/native/shuffle/src/shuffle_writer.rs
@@ -924,6 +924,80 @@ mod test {
             .sum()
     }
 
+    /// Batches that are already at least `batch_size` rows should bypass the
+    /// coalescer, being written one-block-per-batch, while smaller batches are
+    /// still coalesced. In both cases the data must roundtrip exactly, in order.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_full_batches_bypass_coalescer() {
+        use crate::writers::BufBatchWriter;
+        use arrow::array::Int32Array;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
+        let batch_size = 100;
+
+        let make_batch = |start: i32, len: i32| {
+            let values: Vec<i32> = (start..start + len).collect();
+            RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![Arc::new(Int32Array::from(values)) as Arc<dyn Array>],
+            )
+            .unwrap()
+        };
+
+        // Sequence: two full batches (bypass), a partial batch (buffered), then a
+        // full batch (must not bypass because the coalescer still holds buffered rows).
+        let inputs = vec![
+            make_batch(0, batch_size),          // rows 0..100   -> bypass
+            make_batch(batch_size, batch_size), // rows 100..200 -> bypass
+            make_batch(200, 30),                // rows 200..230 -> buffered
+            make_batch(230, batch_size),        // rows 230..330 -> coalesced with buffered 30
+        ];
+
+        let codec = CompressionCodec::Lz4Frame;
+        let encode_time = Time::default();
+        let write_time = Time::default();
+
+        let mut output = Vec::new();
+        {
+            let mut writer = ShuffleBlockWriter::try_new(schema.as_ref(), codec.clone()).unwrap();
+            let mut buf_writer = BufBatchWriter::new(
+                &mut writer,
+                Cursor::new(&mut output),
+                1024 * 1024,
+                batch_size as usize,
+            );
+            for batch in &inputs {
+                buf_writer.write(batch, &encode_time, &write_time).unwrap();
+            }
+            buf_writer.flush(&encode_time, &write_time).unwrap();
+        }
+
+        let blocks = read_all_ipc_batches(&output);
+
+        // The two full batches are emitted verbatim as their own blocks, then the
+        // partial+full pair coalesces into a full block plus a 30-row tail block.
+        let block_rows: Vec<usize> = blocks.iter().map(|b| b.num_rows()).collect();
+        assert_eq!(
+            block_rows,
+            vec![100, 100, 100, 30],
+            "unexpected block boundaries"
+        );
+
+        // All 330 rows must roundtrip in order (0..330).
+        let mut roundtripped = Vec::new();
+        for block in &blocks {
+            let col = block
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            roundtripped.extend(col.values().iter().copied());
+        }
+        let expected: Vec<i32> = (0..330).collect();
+        assert_eq!(roundtripped, expected, "rows not preserved in order");
+    }
+
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_empty_schema_shuffle_writer() {

--- a/native/shuffle/src/shuffle_writer.rs
+++ b/native/shuffle/src/shuffle_writer.rs
@@ -945,13 +945,18 @@ mod test {
             .unwrap()
         };
 
-        // Sequence: two full batches (bypass), a partial batch (buffered), then a
-        // full batch (must not bypass because the coalescer still holds buffered rows).
+        // Sequence: a full batch (bypass), an oversized batch (bypass, emitted whole),
+        // a partial batch (buffered), then a full batch (must not bypass because the
+        // coalescer still holds buffered rows).
+        //
+        // The 150-row batch is the case that distinguishes the fast path: the
+        // coalescer alone would split it into a 100-row block plus 50 buffered rows,
+        // so it can only appear as a single 150-row block when the passthrough fires.
         let inputs = vec![
-            make_batch(0, batch_size),          // rows 0..100   -> bypass
-            make_batch(batch_size, batch_size), // rows 100..200 -> bypass
-            make_batch(200, 30),                // rows 200..230 -> buffered
-            make_batch(230, batch_size),        // rows 230..330 -> coalesced with buffered 30
+            make_batch(0, batch_size),   // rows 0..100   -> bypass (100-row block)
+            make_batch(batch_size, 150), // rows 100..250 -> oversized bypass (150-row block)
+            make_batch(250, 30),         // rows 250..280 -> buffered
+            make_batch(280, batch_size), // rows 280..380 -> coalesced with buffered 30
         ];
 
         let codec = CompressionCodec::Lz4Frame;
@@ -975,16 +980,16 @@ mod test {
 
         let blocks = read_all_ipc_batches(&output);
 
-        // The two full batches are emitted verbatim as their own blocks, then the
-        // partial+full pair coalesces into a full block plus a 30-row tail block.
+        // The full and oversized batches are emitted verbatim as their own blocks,
+        // then the partial+full pair coalesces into a full block plus a 30-row tail.
         let block_rows: Vec<usize> = blocks.iter().map(|b| b.num_rows()).collect();
         assert_eq!(
             block_rows,
-            vec![100, 100, 100, 30],
+            vec![100, 150, 100, 30],
             "unexpected block boundaries"
         );
 
-        // All 330 rows must roundtrip in order (0..330).
+        // All 380 rows must roundtrip in order (0..380).
         let mut roundtripped = Vec::new();
         for block in &blocks {
             let col = block
@@ -994,7 +999,7 @@ mod test {
                 .unwrap();
             roundtripped.extend(col.values().iter().copied());
         }
-        let expected: Vec<i32> = (0..330).collect();
+        let expected: Vec<i32> = (0..380).collect();
         assert_eq!(roundtripped, expected, "rows not preserved in order");
     }
 

--- a/native/shuffle/src/writers/buf_batch_writer.rs
+++ b/native/shuffle/src/writers/buf_batch_writer.rs
@@ -28,7 +28,9 @@ use std::io::{Cursor, Seek, SeekFrom, Write};
 ///
 /// Small batches are coalesced using Arrow's [`BatchCoalescer`] before serialization,
 /// producing exactly `batch_size`-row output batches to reduce per-block IPC schema overhead.
-/// The coalescer is lazily initialized on the first write.
+/// The coalescer is lazily initialized on the first write and configured (via
+/// `biggest_coalesce_batch_size`) to pass batches that are already at least `batch_size` rows
+/// straight through without copying them.
 pub(crate) struct BufBatchWriter<S: Borrow<ShuffleBlockWriter>, W: Write> {
     shuffle_block_writer: S,
     writer: W,
@@ -64,9 +66,17 @@ impl<S: Borrow<ShuffleBlockWriter>, W: Write> BufBatchWriter<S, W> {
         encode_time: &Time,
         write_time: &Time,
     ) -> datafusion::common::Result<usize> {
-        let coalescer = self
-            .coalescer
-            .get_or_insert_with(|| BatchCoalescer::new(batch.schema(), self.batch_size));
+        let batch_size = self.batch_size;
+        let coalescer = self.coalescer.get_or_insert_with(|| {
+            // Enable BatchCoalescer's zero-copy passthrough for batches that are already big
+            // enough, so we don't `copy_rows` the whole batch into the in-progress builders just
+            // to re-emit a same-sized batch. The passthrough fires for batches strictly larger
+            // than the limit, so set it to `batch_size - 1` to include batches of exactly
+            // `batch_size`, which is what `PartitionedBatchIterator` emits (except the tail). This
+            // removes a full copy of the shuffle payload with bit-identical output.
+            BatchCoalescer::new(batch.schema(), batch_size)
+                .with_biggest_coalesce_batch_size(Some(batch_size.saturating_sub(1)))
+        });
         coalescer.push_batch(batch.clone())?;
 
         // Drain completed batches into a local vec so the coalescer borrow ends

--- a/native/shuffle/src/writers/buf_batch_writer.rs
+++ b/native/shuffle/src/writers/buf_batch_writer.rs
@@ -26,11 +26,12 @@ use std::io::{Cursor, Seek, SeekFrom, Write};
 /// The record batches were first written by ShuffleBlockWriter into an internal buffer.
 /// Once the buffer exceeds the max size, the buffer will be flushed to the writer.
 ///
-/// Small batches are coalesced using Arrow's [`BatchCoalescer`] before serialization,
-/// producing exactly `batch_size`-row output batches to reduce per-block IPC schema overhead.
-/// The coalescer is lazily initialized on the first write and configured (via
-/// `biggest_coalesce_batch_size`) to pass batches that are already at least `batch_size` rows
-/// straight through without copying them.
+/// Small batches are coalesced using Arrow's [`BatchCoalescer`] before serialization, reducing
+/// per-block IPC schema overhead. Output batches hold at least `batch_size` rows, apart from the
+/// remainder emitted on flush. The coalescer is lazily initialized on the first write and
+/// configured (via `biggest_coalesce_batch_size`) to pass batches that are already at least
+/// `batch_size` rows straight through, verbatim and without copying them, so an oversized input
+/// batch is written as a single oversized block.
 pub(crate) struct BufBatchWriter<S: Borrow<ShuffleBlockWriter>, W: Write> {
     shuffle_block_writer: S,
     writer: W,
@@ -72,8 +73,12 @@ impl<S: Borrow<ShuffleBlockWriter>, W: Write> BufBatchWriter<S, W> {
             // enough, so we don't `copy_rows` the whole batch into the in-progress builders just
             // to re-emit a same-sized batch. The passthrough fires for batches strictly larger
             // than the limit, so set it to `batch_size - 1` to include batches of exactly
-            // `batch_size`, which is what `PartitionedBatchIterator` emits (except the tail). This
-            // removes a full copy of the shuffle payload with bit-identical output.
+            // `batch_size`, which is what `PartitionedBatchIterator` emits (except the tail),
+            // removing a full copy of the shuffle payload. Block boundaries are unchanged for
+            // that iterator since it never emits more than `batch_size` rows. The
+            // single-partition path routes `>= batch_size` batches here directly, so those now
+            // form one oversized block rather than being split at `batch_size`. Rows are written
+            // in the same order either way.
             BatchCoalescer::new(batch.schema(), batch_size)
                 .with_biggest_coalesce_batch_size(Some(batch_size.saturating_sub(1)))
         });


### PR DESCRIPTION
## Which issue does this PR close?

Addresses the "Every batch is copied an extra time through `BatchCoalescer`, even when already full" item in #5002. That issue is an umbrella tracking several shuffle-writer optimizations, so this PR does not close it.

## Rationale for this change

`BufBatchWriter::write` pushes every batch through a `BatchCoalescer`. In arrow 58.3 the normal push path always does `copy_rows` into the in-progress builders, even when the pushed batch is exactly `target_batch_size` and the buffer is empty. The zero-copy bypass in `BatchCoalescer` only activates when `biggest_coalesce_batch_size` is explicitly set, which Comet never does.

`PartitionedBatchIterator` already emits exactly `batch_size`-row batches from `interleave_record_batch` (except the tail), so in the multi-partition spill and finish paths, and the single-partition path, essentially all shuffle data was copied twice: once by interleave, once by the coalescer.

## What changes are included in this PR?

`BufBatchWriter` now configures its `BatchCoalescer` with `biggest_coalesce_batch_size = batch_size - 1`, enabling Arrow's zero-copy passthrough for batches that are already at least `batch_size` rows. Those batches are serialized verbatim instead of being copied into the in-progress builders. Smaller (tail) batches still flow through the coalescer as before, and the passthrough does not fire while the coalescer holds buffered rows, so output ordering is preserved.

For the multi-partition spill and finish paths, `PartitionedBatchIterator` never emits batches larger than `batch_size`, so the passthrough fires only for exactly-`batch_size` batches and block boundaries are unchanged. The single-partition path routes `>= batch_size` batches to the writer directly, so an oversized batch there is now written as one oversized block instead of being split at `batch_size`. Rows are written in the same order either way. This removes one full copy of the shuffle payload.

An end-to-end microbenchmark (`shuffle_writer` bench, 8192-row batches, 16 partitions, Lz4) shows roughly a 3% improvement, with a larger relative win expected for the uncompressed path where the copy is a bigger fraction of total work.

## How are these changes tested?

Existing `datafusion-comet-shuffle` unit tests continue to pass. A new `test_full_batches_bypass_coalescer` test feeds a sequence of full, oversized, and partial batches and asserts the resulting block boundaries. The oversized (150-row) batch is what distinguishes the passthrough: the coalescer alone would split it into a 100-row block plus 50 buffered rows, so it can only appear as a single 150-row block when the passthrough fires. The test also asserts that a partial batch is still coalesced with the following full batch, and that all rows roundtrip in order.

