### PR TITLE
docs: add blog posts and talks page

### DIFF
--- a/docs/source/about/blogs-and-talks.md
+++ b/docs/source/about/blogs-and-talks.md
@@ -33,8 +33,8 @@ Release announcements for each Comet version are published on the
 
 ## 🎤 Talks and Videos
 
-- **2025**: [Accelerating Spark with Iceberg and DataFusion Comet: Challenges, Performance Insights, and Roadmap](https://www.youtube.com/watch?v=kd4iqN0dmog) — Huaxin Gao and Parth Chandra (Apple), Iceberg Summit 2025.
-- **2025**: [Apache DataFusion: Putting Theory Into Practice](https://www.youtube.com/watch?v=P_GLl14d9A4) — Matt Butrovich, DC Systems 004.
+- **2026-07-25**: [Learn How to Accelerate Apache Iceberg Reads on EMR with Apache DataFusion Comet](https://www.youtube.com/watch?v=mGMtrk2RXVY) — step-by-step guide.
+- **2026-07-23**: [DataFusion Community Showcase Vol. 2: DataFusion Comet & DataFusion Ballista](https://www.youtube.com/watch?v=G8In--2RUwI).
+- **2025-06-13**: [Apache DataFusion: Putting Theory Into Practice](https://www.youtube.com/watch?v=P_GLl14d9A4) — Matt Butrovich, DC Systems 004.
+- **2025-04-30**: [Accelerating Spark with Iceberg and DataFusion Comet: Challenges, Performance Insights, and Roadmap](https://www.youtube.com/watch?v=kd4iqN0dmog) — Huaxin Gao and Parth Chandra (Apple), Iceberg Summit 2025.
 - **2024-09-30**: [Accelerating Apache Spark Workloads with Apache DataFusion Comet](https://www.youtube.com/watch?v=o59s0d3HE1k) — Andy Grove, CMU Database Group "Database Building Blocks" seminar series.
-- [DataFusion Community Showcase Vol. 2: DataFusion Comet & DataFusion Ballista](https://www.youtube.com/watch?v=G8In--2RUwI).
-- [Learn How to Accelerate Apache Iceberg Reads on EMR with Apache DataFusion Comet](https://www.youtube.com/watch?v=mGMtrk2RXVY) — step-by-step guide.

--- a/docs/source/about/blogs-and-talks.md
+++ b/docs/source/about/blogs-and-talks.md
@@ -35,6 +35,7 @@ Release announcements for each Comet version are published on the
 
 - **2026-07-25**: [Learn How to Accelerate Apache Iceberg Reads on EMR with Apache DataFusion Comet](https://www.youtube.com/watch?v=mGMtrk2RXVY) — step-by-step guide.
 - **2026-07-23**: [DataFusion Community Showcase Vol. 2: DataFusion Comet & DataFusion Ballista](https://www.youtube.com/watch?v=G8In--2RUwI).
+- **2025-11-24**: [Fusing Academic Research and Open Source Systems for Petabyte-Scale Analytics](https://uci.yuja.com/V/Video?v=14629808&node=63064690&a=99786452) — Matt Butrovich, UC Irvine CS 224P.
 - **2025-06-13**: [Apache DataFusion: Putting Theory Into Practice](https://www.youtube.com/watch?v=P_GLl14d9A4) — Matt Butrovich, DC Systems 004.
 - **2025-04-30**: [Accelerating Spark with Iceberg and DataFusion Comet: Challenges, Performance Insights, and Roadmap](https://www.youtube.com/watch?v=kd4iqN0dmog) — Huaxin Gao and Parth Chandra, Iceberg Summit 2025.
 - **2024-09-30**: [Accelerating Apache Spark Workloads with Apache DataFusion Comet](https://www.youtube.com/watch?v=o59s0d3HE1k) — Andy Grove, CMU Database Group "Database Building Blocks" seminar series.

--- a/docs/source/about/blogs-and-talks.md
+++ b/docs/source/about/blogs-and-talks.md
@@ -36,5 +36,5 @@ Release announcements for each Comet version are published on the
 - **2026-07-25**: [Learn How to Accelerate Apache Iceberg Reads on EMR with Apache DataFusion Comet](https://www.youtube.com/watch?v=mGMtrk2RXVY) — step-by-step guide.
 - **2026-07-23**: [DataFusion Community Showcase Vol. 2: DataFusion Comet & DataFusion Ballista](https://www.youtube.com/watch?v=G8In--2RUwI).
 - **2025-06-13**: [Apache DataFusion: Putting Theory Into Practice](https://www.youtube.com/watch?v=P_GLl14d9A4) — Matt Butrovich, DC Systems 004.
-- **2025-04-30**: [Accelerating Spark with Iceberg and DataFusion Comet: Challenges, Performance Insights, and Roadmap](https://www.youtube.com/watch?v=kd4iqN0dmog) — Huaxin Gao and Parth Chandra (Apple), Iceberg Summit 2025.
+- **2025-04-30**: [Accelerating Spark with Iceberg and DataFusion Comet: Challenges, Performance Insights, and Roadmap](https://www.youtube.com/watch?v=kd4iqN0dmog) — Huaxin Gao and Parth Chandra, Iceberg Summit 2025.
 - **2024-09-30**: [Accelerating Apache Spark Workloads with Apache DataFusion Comet](https://www.youtube.com/watch?v=o59s0d3HE1k) — Andy Grove, CMU Database Group "Database Building Blocks" seminar series.

--- a/docs/source/about/blogs-and-talks.md
+++ b/docs/source/about/blogs-and-talks.md
@@ -1,0 +1,40 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Blog Posts and Talks
+
+A collection of blog posts, conference talks, and videos about Apache DataFusion Comet.
+If you have written or presented something about Comet that is not listed here, please
+open a pull request to add it.
+
+## 📝 Blog Posts
+
+- **2024-03-06**: [Announcing Apache Arrow DataFusion Comet](https://arrow.apache.org/blog/2024/03/06/comet-donation/) — the Apache Arrow PMC announces the donation of Comet, a native Spark SQL accelerator built on Apache DataFusion.
+- [Accelerating Apache Spark Queries (and Iceberg Rust Development) with Apache DataFusion Comet](https://iceberg.apache.org/blog/accelerating-iceberg-rust-development-with-datafusion-comet/) — on the Apache Iceberg blog, covering Comet's native Iceberg Parquet scan support.
+
+Release announcements for each Comet version are published on the
+[Apache DataFusion blog](https://datafusion.apache.org/blog/).
+
+## 🎤 Talks and Videos
+
+- **2025**: [Accelerating Spark with Iceberg and DataFusion Comet: Challenges, Performance Insights, and Roadmap](https://www.youtube.com/watch?v=kd4iqN0dmog) — Huaxin Gao and Parth Chandra (Apple), Iceberg Summit 2025.
+- **2025**: [Apache DataFusion: Putting Theory Into Practice](https://www.youtube.com/watch?v=P_GLl14d9A4) — Matt Butrovich, DC Systems 004.
+- **2024-09-30**: [Accelerating Apache Spark Workloads with Apache DataFusion Comet](https://www.youtube.com/watch?v=o59s0d3HE1k) — Andy Grove, CMU Database Group "Database Building Blocks" seminar series.
+- [DataFusion Community Showcase Vol. 2: DataFusion Comet & DataFusion Ballista](https://www.youtube.com/watch?v=G8In--2RUwI).
+- [Learn How to Accelerate Apache Iceberg Reads on EMR with Apache DataFusion Comet](https://www.youtube.com/watch?v=mGMtrk2RXVY) — step-by-step guide.

--- a/docs/source/about/blogs-and-talks.md
+++ b/docs/source/about/blogs-and-talks.md
@@ -25,8 +25,8 @@ open a pull request to add it.
 
 ## 📝 Blog Posts
 
+- **2026-07-15**: [Accelerating Apache Spark Queries (and Iceberg Rust Development) with Apache DataFusion Comet](https://iceberg.apache.org/blog/accelerating-iceberg-rust-development-with-datafusion-comet/) — on the Apache Iceberg blog, covering Comet's native Iceberg Parquet scan support.
 - **2024-03-06**: [Announcing Apache Arrow DataFusion Comet](https://arrow.apache.org/blog/2024/03/06/comet-donation/) — the Apache Arrow PMC announces the donation of Comet, a native Spark SQL accelerator built on Apache DataFusion.
-- [Accelerating Apache Spark Queries (and Iceberg Rust Development) with Apache DataFusion Comet](https://iceberg.apache.org/blog/accelerating-iceberg-rust-development-with-datafusion-comet/) — on the Apache Iceberg blog, covering Comet's native Iceberg Parquet scan support.
 
 Release announcements for each Comet version are published on the
 [Apache DataFusion blog](https://datafusion.apache.org/blog/).

--- a/docs/source/about/index.md
+++ b/docs/source/about/index.md
@@ -24,6 +24,7 @@ are versioned, and links to the Apache Software Foundation resources behind it.
 
 - [Comparison with Gluten](gluten_comparison.md) — how Comet differs from other Spark accelerators
 - [Versioning Policy](versioning_policy.md) — what our version numbers mean and our release cadence
+- [Blog Posts and Talks](blogs-and-talks.md) — external writing and conference talks about Comet
 - [ASF Links](../asf/index.md) — licensing, donations, security reporting, and the code of conduct
 
 ```{toctree}
@@ -33,5 +34,6 @@ are versioned, and links to the Apache Software Foundation resources behind it.
 
 Comparison with Gluten <gluten_comparison>
 Versioning Policy <versioning_policy>
+Blog Posts and Talks <blogs-and-talks>
 ASF Links <../asf/index>
 ```


### PR DESCRIPTION
## Which issue does this PR close?

<!-- No dedicated issue; this is a docs-only addition. -->

N/A

## Rationale for this change

The DataFusion documentation has a "Concepts, Readings, Events" page that collects external blog posts and conference talks. Comet had no equivalent, so there was no single place in the docs pointing users to the growing body of talks and articles about the project. This adds that page.

## What changes are included in this PR?

- Add a new `Blog Posts and Talks` page under the About section (`docs/source/about/blogs-and-talks.md`), modeled after the DataFusion "Concepts, Readings, Events" page, with sections for blog posts and for talks/videos.
- Wire the new page into the About index list and toctree.

<img width="793" height="673" alt="Screenshot 2026-07-26 at 10 57 15 AM" src="https://github.com/user-attachments/assets/2502d6c9-5ebc-4d0a-8baf-bcfa82e1e699" />

## How are these changes tested?

Documentation-only change. Rendered locally with Sphinx to confirm the page builds and links resolve.
