### PR TITLE
docs: avoid "not a blocker" comments in reviews for review skill

### DIFF
--- a/.claude/skills/review-comet-pr/SKILL.md
+++ b/.claude/skills/review-comet-pr/SKILL.md
@@ -298,6 +298,19 @@ If the PR adds a new expression but does not update `expressions.md`, flag that.
 
 ---
 
+## Review Bar
+
+Hold a high bar. Several rounds of review and revision before merge are normal and expected. Prefer iterating on the PR over merging it and trusting a follow-up, because follow-ups that are not filed as issues do not get done. Treat "we can fix that later" as "that will not get fixed."
+
+Every finding must be actionable. Before writing a comment, decide whether it is worth addressing before merge. If it is, raise it and expect a response. If it is not, cut it. There is no third tier.
+
+- Never label feedback as "not a blocker", "nit", "minor", "optional", "low priority", or "feel free to ignore". Either raise it as something to address or drop it. That label tells the author to skip it and leaves nobody accountable for it.
+- If a finding is real but genuinely belongs in separate work, say that plainly and ask for a tracking issue, then reference the issue link in the review. Do not leave it as a floating remark.
+- Bikeshedding is worse than silence. A preference with no correctness, performance, compatibility, or maintainability argument behind it does not go in the review.
+- This bar is about what gets raised, not about how it is worded. Keep the tone below. A question you expect an answer to still counts as something the author needs to address.
+
+---
+
 ## Output Format
 
 Present your review as guidance for the reviewer. Structure your output as:
@@ -305,7 +318,7 @@ Present your review as guidance for the reviewer. Structure your output as:
 1. **PR Summary** - Brief description of what the PR does
 2. **CI Status** - Summary of CI check results
 3. **Findings** - Your analysis organized by area (Spark compatibility, implementation, tests, etc.)
-4. **Suggested Review Comments** - Specific comments the reviewer could leave on the PR, with file and line references where applicable
+4. **Suggested Review Comments** - Specific comments the reviewer could leave on the PR, with file and line references where applicable. Everything here is something you expect the author to address. Anything that did not clear that bar should not appear.
 
 ## Review Tone and Style
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

I saw this comment and it reminded of something the Claude tends to do with review comments that bothers me. https://github.com/apache/datafusion-comet/pull/5053#issuecomment-5095074456

These "not a blocker" comments aren't really useful. We should hold ourselves to high quality code: if it's worth raising, it's worth addressing or at least filing a followup issue.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Update skill.

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
