### PR TITLE
fix: honor fail_on_error in native make_decimal

### DIFF
--- a/native/spark-expr/src/comet_scalar_funcs.rs
+++ b/native/spark-expr/src/comet_scalar_funcs.rs
@@ -141,7 +141,9 @@ pub fn create_comet_physical_fun_with_eval_mode(
             make_comet_scalar_udf!("unscaled_value", func, without data_type)
         }
         "make_decimal" => {
-            make_comet_scalar_udf!("make_decimal", spark_make_decimal, data_type)
+            // fail_on_error corresponds to Spark's nullOnOverflow = false (ANSI mode): the
+            // unscaled long must fit the target precision or the query fails.
+            make_comet_scalar_udf!("make_decimal", spark_make_decimal, data_type, fail_on_error)
         }
         "unhex" => {
             let func = Arc::new(spark_unhex);

--- a/native/spark-expr/src/math_funcs/internal/make_decimal.rs
+++ b/native/spark-expr/src/math_funcs/internal/make_decimal.rs
@@ -15,13 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::error::decimal_overflow_error;
 use crate::math_funcs::utils::get_precision_scale;
 use arrow::datatypes::DataType;
 use arrow::{
     array::{AsArray, Decimal128Builder},
     datatypes::{validate_decimal_precision, Int64Type},
 };
-use datafusion::common::{internal_err, Result as DataFusionResult, ScalarValue};
+use datafusion::common::{internal_err, DataFusionError, Result as DataFusionResult, ScalarValue};
 use datafusion::physical_plan::ColumnarValue;
 use std::sync::Arc;
 
@@ -29,12 +30,13 @@ use std::sync::Arc;
 pub fn spark_make_decimal(
     args: &[ColumnarValue],
     data_type: &DataType,
+    fail_on_error: bool,
 ) -> DataFusionResult<ColumnarValue> {
     let (precision, scale) = get_precision_scale(data_type);
     match &args[0] {
         ColumnarValue::Scalar(v) => match v {
             ScalarValue::Int64(n) => Ok(ColumnarValue::Scalar(ScalarValue::Decimal128(
-                long_to_decimal(n, precision, scale),
+                long_to_decimal(n, precision, scale, fail_on_error)?,
                 precision,
                 scale,
             ))),
@@ -45,7 +47,7 @@ pub fn spark_make_decimal(
                 let arr = a.as_primitive::<Int64Type>();
                 let mut result = Decimal128Builder::new();
                 for v in arr.into_iter() {
-                    result.append_option(long_to_decimal(&v, precision, scale))
+                    result.append_option(long_to_decimal(&v, precision, scale, fail_on_error)?)
                 }
                 let result_type = DataType::Decimal128(precision, scale);
 
@@ -58,14 +60,83 @@ pub fn spark_make_decimal(
     }
 }
 
-/// Convert the input long to decimal with the given maximum precision. If overflows, returns null
-/// instead.
+/// Convert the input long to decimal with the given maximum precision. On overflow, errors when
+/// `fail_on_error` is set (Spark's `nullOnOverflow = false`, i.e. ANSI mode) and returns null
+/// otherwise.
 #[inline]
-fn long_to_decimal(v: &Option<i64>, precision: u8, scale: i8) -> Option<i128> {
+fn long_to_decimal(
+    v: &Option<i64>,
+    precision: u8,
+    scale: i8,
+    fail_on_error: bool,
+) -> DataFusionResult<Option<i128>> {
     match v {
-        Some(v) if validate_decimal_precision(*v as i128, precision, scale).is_ok() => {
-            Some(*v as i128)
-        }
-        _ => None,
+        Some(v) => match validate_decimal_precision(*v as i128, precision, scale) {
+            Ok(()) => Ok(Some(*v as i128)),
+            Err(_) if fail_on_error => Err(DataFusionError::External(Box::new(
+                decimal_overflow_error(*v as i128, precision, scale),
+            ))),
+            Err(_) => Ok(None),
+        },
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, Int64Array};
+
+    fn overflow_args() -> [ColumnarValue; 1] {
+        // 123456 does not fit Decimal128(3, 0)
+        [ColumnarValue::Array(Arc::new(Int64Array::from(vec![
+            Some(123456),
+            None,
+            Some(99),
+        ])))]
+    }
+
+    #[test]
+    fn test_array_overflow_errors_when_fail_on_error() {
+        let err = spark_make_decimal(&overflow_args(), &DataType::Decimal128(3, 0), true)
+            .expect_err("overflow should error when fail_on_error is set");
+        assert!(
+            err.to_string().contains("NUMERIC_VALUE_OUT_OF_RANGE"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_array_overflow_nulls_when_not_fail_on_error() {
+        let result = spark_make_decimal(&overflow_args(), &DataType::Decimal128(3, 0), false)
+            .expect("overflow should become null without fail_on_error");
+        let ColumnarValue::Array(array) = result else {
+            panic!("expected array result")
+        };
+        assert!(array.is_null(0));
+        assert!(array.is_null(1));
+        assert!(array.is_valid(2));
+    }
+
+    #[test]
+    fn test_scalar_overflow_errors_when_fail_on_error() {
+        let args = [ColumnarValue::Scalar(ScalarValue::Int64(Some(123456)))];
+        let err = spark_make_decimal(&args, &DataType::Decimal128(3, 0), true)
+            .expect_err("overflow should error when fail_on_error is set");
+        assert!(
+            err.to_string().contains("NUMERIC_VALUE_OUT_OF_RANGE"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_scalar_null_is_not_an_error() {
+        let args = [ColumnarValue::Scalar(ScalarValue::Int64(None))];
+        let result = spark_make_decimal(&args, &DataType::Decimal128(3, 0), true)
+            .expect("null input should not error");
+        let ColumnarValue::Scalar(ScalarValue::Decimal128(v, 3, 0)) = result else {
+            panic!("expected decimal scalar result")
+        };
+        assert!(v.is_none());
     }
 }

--- a/native/spark-expr/src/math_funcs/internal/make_decimal.rs
+++ b/native/spark-expr/src/math_funcs/internal/make_decimal.rs
@@ -36,7 +36,7 @@ pub fn spark_make_decimal(
     match &args[0] {
         ColumnarValue::Scalar(v) => match v {
             ScalarValue::Int64(n) => Ok(ColumnarValue::Scalar(ScalarValue::Decimal128(
-                long_to_decimal(n, precision, scale, fail_on_error)?,
+                long_to_decimal(*n, precision, scale, fail_on_error)?,
                 precision,
                 scale,
             ))),
@@ -47,7 +47,7 @@ pub fn spark_make_decimal(
                 let arr = a.as_primitive::<Int64Type>();
                 let mut result = Decimal128Builder::new();
                 for v in arr.into_iter() {
-                    result.append_option(long_to_decimal(&v, precision, scale, fail_on_error)?)
+                    result.append_option(long_to_decimal(v, precision, scale, fail_on_error)?)
                 }
                 let result_type = DataType::Decimal128(precision, scale);
 
@@ -65,21 +65,21 @@ pub fn spark_make_decimal(
 /// otherwise.
 #[inline]
 fn long_to_decimal(
-    v: &Option<i64>,
+    v: Option<i64>,
     precision: u8,
     scale: i8,
     fail_on_error: bool,
 ) -> DataFusionResult<Option<i128>> {
-    match v {
-        Some(v) => match validate_decimal_precision(*v as i128, precision, scale) {
-            Ok(()) => Ok(Some(*v as i128)),
+    v.map_or(Ok(None), |v| {
+        let v = v as i128;
+        match validate_decimal_precision(v, precision, scale) {
+            Ok(()) => Ok(Some(v)),
             Err(_) if fail_on_error => Err(DataFusionError::External(Box::new(
-                decimal_overflow_error(*v as i128, precision, scale),
+                decimal_overflow_error(v, precision, scale),
             ))),
             Err(_) => Ok(None),
-        },
-        None => Ok(None),
-    }
+        }
+    })
 }
 
 #[cfg(test)]

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -3246,6 +3246,30 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("make decimal using DataFrame API - overflow throws when nullOnOverflow=false") {
+    // https://github.com/apache/datafusion-comet/issues/5066
+    withTable("t1") {
+      sql("create table t1 using parquet as select cast(123456 as long) as c1 from range(1)")
+
+      withSQLConf(
+        SQLConf.USE_V1_SOURCE_LIST.key -> "parquet",
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+        SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key -> "org.apache.spark.sql.catalyst.optimizer.ConstantFolding") {
+
+        val df = sql("select * from t1")
+        val makeDecimalColumn =
+          createMakeDecimalColumn(df.col("c1").expr, 3, 0, nullOnOverflow = false)
+        val df1 = df.withColumn("result", makeDecimalColumn)
+
+        val (sparkErr, cometErr) = checkSparkAnswerMaybeThrows(df1)
+        assert(sparkErr.isDefined, "Spark should throw on overflow when nullOnOverflow=false")
+        assert(cometErr.isDefined, "Comet should throw on overflow when nullOnOverflow=false")
+        assert(sparkErr.get.getMessage.contains("cannot be represented as Decimal(3, 0)"))
+        assert(cometErr.get.getMessage.contains("cannot be represented as Decimal(3, 0)"))
+      }
+    }
+  }
+
   test("deep AND/OR predicate chains do not overflow the protobuf recursion limit") {
     // A left-deep chain of N associative boolean operands serializes to a proto nested N
     // levels deep. With N > protobuf's default recursion limit (100), the message overflows

--- a/spark/src/test/spark-3.4/org/apache/spark/sql/ShimCometTestBase.scala
+++ b/spark/src/test/spark-3.4/org/apache/spark/sql/ShimCometTestBase.scala
@@ -50,4 +50,12 @@ trait ShimCometTestBase {
   def createMakeDecimalColumn(child: Expression, precision: Int, scale: Int): Column = {
     new Column(MakeDecimal(child, precision, scale))
   }
+
+  def createMakeDecimalColumn(
+      child: Expression,
+      precision: Int,
+      scale: Int,
+      nullOnOverflow: Boolean): Column = {
+    new Column(MakeDecimal(child, precision, scale, nullOnOverflow))
+  }
 }

--- a/spark/src/test/spark-3.5/org/apache/spark/sql/ShimCometTestBase.scala
+++ b/spark/src/test/spark-3.5/org/apache/spark/sql/ShimCometTestBase.scala
@@ -51,4 +51,12 @@ trait ShimCometTestBase {
     new Column(MakeDecimal(child, precision, scale))
   }
 
+  def createMakeDecimalColumn(
+      child: Expression,
+      precision: Int,
+      scale: Int,
+      nullOnOverflow: Boolean): Column = {
+    new Column(MakeDecimal(child, precision, scale, nullOnOverflow))
+  }
+
 }

--- a/spark/src/test/spark-4.x/org/apache/spark/sql/ShimCometTestBase.scala
+++ b/spark/src/test/spark-4.x/org/apache/spark/sql/ShimCometTestBase.scala
@@ -49,6 +49,14 @@ trait ShimCometTestBase {
   }
 
   def createMakeDecimalColumn(child: Expression, precision: Int, scale: Int): Column = {
-    new Column(ExpressionColumnNode.apply(MakeDecimal(child, precision, scale, true)))
+    createMakeDecimalColumn(child, precision, scale, nullOnOverflow = true)
+  }
+
+  def createMakeDecimalColumn(
+      child: Expression,
+      precision: Int,
+      scale: Int,
+      nullOnOverflow: Boolean): Column = {
+    new Column(ExpressionColumnNode.apply(MakeDecimal(child, precision, scale, nullOnOverflow)))
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5066.

## Rationale for this change

`MakeDecimal` with `nullOnOverflow = false` (ANSI mode) must fail on overflow, matching Spark's `Decimal.set(unscaled, precision, scale)`, which throws `NUMERIC_VALUE_OUT_OF_RANGE`. The Scala serde already serializes `failOnError = !nullOnOverflow`, but the native registration of `make_decimal` discarded the flag, so Comet returned NULL where Spark throws. Since `MakeDecimal` is generated by the `DecimalAggregates` optimizer rule, the divergence surfaces on decimal aggregations rather than user-written SQL.

## What changes are included in this PR?

- `spark_make_decimal` now takes `fail_on_error` and raises `SparkError::NumericValueOutOfRange` (via the existing `decimal_overflow_error` helper, as `CheckOverflow` already does) when the unscaled long does not fit the target precision. Non-ANSI behavior is unchanged: overflow becomes NULL.
- The `make_decimal` registration in `comet_scalar_funcs.rs` threads `fail_on_error` through instead of dropping it.
- Test-only: `createMakeDecimalColumn` in `ShimCometTestBase` (all Spark version variants) gained an overload that accepts `nullOnOverflow`, since the existing helper hardcoded the null-on-overflow behavior.

## How are these changes tested?

- New Rust unit tests in `make_decimal.rs` covering array and scalar overflow with `fail_on_error` set (error) and unset (NULL), plus NULL input under `fail_on_error`.
- New JVM test `make decimal using DataFrame API - overflow throws when nullOnOverflow=false` in `CometExpressionSuite`, asserting Spark and Comet both fail with the `cannot be represented as Decimal(3, 0)` message. The test was verified to fail before the native fix and pass after it.

This issue was found by an audit run with the `audit-comet-expression` project skill (tracked under epic #5078).
