### PR TITLE
fix: raise REMAINDER_BY_ZERO for Float/Double under ANSI mode

### DIFF
--- a/native/spark-expr/src/math_funcs/modulo_expr.rs
+++ b/native/spark-expr/src/math_funcs/modulo_expr.rs
@@ -344,11 +344,8 @@ mod tests {
                         if !actual_arr.is_null(i) {
                             let actual_value = actual_arr.value(i);
                             let expected_value = expected_arr.value(i);
-                            // `is_eq` uses arrow's total ordering, under which `NaN` equals
-                            // `NaN`. Plain `==` would fail for the NaN results that a
-                            // non-zero divisor produces from NaN or infinite dividends.
-                            assert!(
-                                actual_value.is_eq(expected_value),
+                            assert_eq!(
+                                actual_value, expected_value,
                                 "Mismatch at index {i}, actual {actual_value:?}, expected {expected_value:?}"
                             );
                         }
@@ -843,12 +840,41 @@ mod tests {
         }
     }
 
+    /// Evaluates `a % b` over two Float64 columns and returns the result array.
+    ///
+    /// Used by tests whose expected result is NaN. `verify_result` compares with `==`, under
+    /// which `NaN != NaN`, and arrow's `is_eq`/`total_cmp` is no better here because the NaN
+    /// produced by an invalid `fmod` has a platform-dependent sign — x86 and aarch64 disagree
+    /// on whether it is `+NaN` or `-NaN`. These tests assert NaN-ness instead.
+    fn eval_float64_modulo(lhs: ArrayRef, rhs: ArrayRef, fail_on_error: bool) -> Float64Array {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Float64, true),
+            Field::new("b", DataType::Float64, true),
+        ]));
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![lhs, rhs]).unwrap();
+
+        let session_ctx = SessionContext::new();
+        let modulo_expr = create_modulo_expr(
+            Arc::new(Column::new("a", 0)),
+            Arc::new(Column::new("b", 1)),
+            DataType::Float64,
+            schema,
+            fail_on_error,
+            &session_ctx.state(),
+        )
+        .unwrap();
+
+        let ColumnarValue::Array(result) = modulo_expr.evaluate(&batch).unwrap() else {
+            panic!("Expected an array result");
+        };
+        result.as_primitive::<Float64Type>().clone()
+    }
+
     #[test]
     fn test_modulo_special_dividends_non_zero_divisor_float64_ansi() {
-        // The same dividends must not raise when the divisor is non-zero. `x % 2.0` is
-        // NaN for NaN and for both infinities, and preserves the sign of a zero dividend.
-        run_float_modulo::<Float64Type>(
-            DataType::Float64,
+        // The same dividends must not raise when the divisor is non-zero: `x % 2.0` is NaN
+        // for NaN and for both infinities, 0.0 for a zero dividend, and 1.0 for 5.0.
+        let result = eval_float64_modulo(
             Arc::new(Float64Array::from(vec![
                 Some(f64::NAN),
                 Some(f64::INFINITY),
@@ -858,15 +884,18 @@ mod tests {
             ])),
             Arc::new(Float64Array::from(vec![Some(2.0); 5])),
             true,
-            false,
-            Some(Arc::new(Float64Array::from(vec![
-                Some(f64::NAN),
-                Some(f64::NAN),
-                Some(f64::NAN),
-                Some(0.0),
-                Some(1.0),
-            ]))),
         );
+
+        assert_eq!(result.null_count(), 0);
+        for i in 0..3 {
+            assert!(
+                result.value(i).is_nan(),
+                "Expected NaN at index {i}, got {}",
+                result.value(i)
+            );
+        }
+        assert_eq!(result.value(3), 0.0);
+        assert_eq!(result.value(4), 1.0);
     }
 
     #[test]
@@ -941,13 +970,16 @@ mod tests {
     #[test]
     fn test_modulo_nan_divisor_float64_ansi() {
         // A NaN divisor is not zero either, so `x % NaN` is NaN rather than an error.
-        run_float_modulo::<Float64Type>(
-            DataType::Float64,
+        let result = eval_float64_modulo(
             Arc::new(Float64Array::from(vec![Some(1.0)])),
             Arc::new(Float64Array::from(vec![Some(f64::NAN)])),
             true,
-            false,
-            Some(Arc::new(Float64Array::from(vec![Some(f64::NAN)]))),
+        );
+        assert_eq!(result.null_count(), 0);
+        assert!(
+            result.value(0).is_nan(),
+            "Expected NaN, got {}",
+            result.value(0)
         );
     }
 }

--- a/native/spark-expr/src/math_funcs/modulo_expr.rs
+++ b/native/spark-expr/src/math_funcs/modulo_expr.rs
@@ -17,9 +17,11 @@
 
 use crate::{create_comet_physical_fun, IfExpr};
 use crate::{remainder_by_zero_error, Cast, EvalMode, SparkCastOptions};
-use arrow::array::{Array, ArrayRef, AsArray};
+use arrow::array::{ArrayRef, ArrowNativeTypeOp, AsArray, PrimitiveArray};
+use arrow::compute::kernels::arity::try_binary;
 use arrow::compute::kernels::numeric::rem;
 use arrow::datatypes::*;
+use arrow::error::ArrowError;
 use datafusion::common::{exec_err, internal_err, DataFusionError, Result, ScalarValue};
 use datafusion::config::ConfigOptions;
 use datafusion::execution::FunctionRegistry;
@@ -54,11 +56,15 @@ pub fn spark_modulo(args: &[ColumnarValue], fail_on_error: bool) -> Result<Colum
         return apply_cmp_for_nested(Operator::Modulo, lhs, rhs);
     }
 
-    // Arrow's `rem` kernel only signals `DivideByZero` for integer and decimal types.
-    // For floating point, `x % 0.0` yields NaN silently, so under ANSI mode we must
-    // detect zero divisors explicitly to raise the Spark-compliant error.
-    if fail_on_error && matches!(right_data_type, DataType::Float32 | DataType::Float64) {
-        check_float_remainder_by_zero(lhs, rhs)?;
+    // Arrow's `rem` kernel only signals `DivideByZero` for integer and decimal types. For
+    // floating point it uses `mod_wrapping`, so `x % 0.0` silently yields NaN. Under ANSI
+    // mode we compute the float remainder with `mod_checked` instead, which reports
+    // `DivideByZero` for a zero divisor.
+    if fail_on_error
+        && left_data_type == right_data_type
+        && matches!(right_data_type, DataType::Float32 | DataType::Float64)
+    {
+        return checked_float_modulo(lhs, rhs, &right_data_type);
     }
 
     match apply(lhs, rhs, rem) {
@@ -71,75 +77,59 @@ pub fn spark_modulo(args: &[ColumnarValue], fail_on_error: bool) -> Result<Colum
     }
 }
 
-/// Returns an error if any row has a non-null dividend paired with a zero divisor. Only
-/// meant to be called with floating point operands — Spark treats `-0.0` as zero here,
-/// which falls out naturally from IEEE 754 equality.
-fn check_float_remainder_by_zero(lhs: &ColumnarValue, rhs: &ColumnarValue) -> Result<()> {
-    let is_zero_float_scalar = |sv: &ScalarValue| match sv {
-        ScalarValue::Float32(Some(v)) => *v == 0.0,
-        ScalarValue::Float64(Some(v)) => *v == 0.0,
-        _ => false,
+/// Computes floating point remainder in ANSI mode using `mod_checked`, which raises
+/// `DivideByZero` when the divisor is zero. `-0.0` triggers the error too, since
+/// `mod_checked` compares the divisor against zero with IEEE 754 equality — matching
+/// Spark, which also treats `-0.0` as a zero divisor.
+fn checked_float_modulo(
+    lhs: &ColumnarValue,
+    rhs: &ColumnarValue,
+    data_type: &DataType,
+) -> Result<ColumnarValue> {
+    let (left, right): (ArrayRef, ArrayRef) = match (lhs, rhs) {
+        (ColumnarValue::Array(l), ColumnarValue::Array(r)) => (Arc::clone(l), Arc::clone(r)),
+        (ColumnarValue::Scalar(l), ColumnarValue::Array(r)) => {
+            (l.to_array_of_size(r.len())?, Arc::clone(r))
+        }
+        (ColumnarValue::Array(l), ColumnarValue::Scalar(r)) => {
+            (Arc::clone(l), r.to_array_of_size(l.len())?)
+        }
+        (ColumnarValue::Scalar(l), ColumnarValue::Scalar(r)) => (l.to_array()?, r.to_array()?),
     };
 
-    match (lhs, rhs) {
-        (ColumnarValue::Scalar(l), ColumnarValue::Scalar(r)) => {
-            if !l.is_null() && is_zero_float_scalar(r) {
-                return Err(remainder_by_zero_error().into());
-            }
-        }
-        (ColumnarValue::Array(l_arr), ColumnarValue::Scalar(r)) => {
-            if is_zero_float_scalar(r) && l_arr.null_count() != l_arr.len() {
-                return Err(remainder_by_zero_error().into());
-            }
-        }
-        (ColumnarValue::Scalar(l), ColumnarValue::Array(r_arr)) => {
-            if !l.is_null() && float_array_has_zero(r_arr, None) {
-                return Err(remainder_by_zero_error().into());
-            }
-        }
-        (ColumnarValue::Array(l_arr), ColumnarValue::Array(r_arr)) => {
-            if float_array_has_zero(r_arr, Some(l_arr.as_ref())) {
-                return Err(remainder_by_zero_error().into());
-            }
-        }
-    }
-    Ok(())
-}
+    let result: ArrayRef = match data_type {
+        DataType::Float32 => Arc::new(checked_modulo_kernel::<Float32Type>(&left, &right)?),
+        DataType::Float64 => Arc::new(checked_modulo_kernel::<Float64Type>(&left, &right)?),
+        _ => return internal_err!("checked_float_modulo called with {data_type}"),
+    };
 
-/// Returns true if `divisor` contains any non-null zero. When `dividend_mask` is provided,
-/// positions where `dividend_mask` is null are skipped (they will produce null results and
-/// must not raise an error).
-fn float_array_has_zero(divisor: &ArrayRef, dividend_mask: Option<&dyn Array>) -> bool {
-    match divisor.data_type() {
-        DataType::Float32 => scan_float_array::<Float32Type>(divisor, dividend_mask),
-        DataType::Float64 => scan_float_array::<Float64Type>(divisor, dividend_mask),
-        _ => false,
+    if matches!(
+        (lhs, rhs),
+        (ColumnarValue::Scalar(_), ColumnarValue::Scalar(_))
+    ) {
+        // Preserve `apply`'s behavior of returning a scalar when both operands are scalars.
+        Ok(ColumnarValue::Scalar(ScalarValue::try_from_array(
+            &result, 0,
+        )?))
+    } else {
+        Ok(ColumnarValue::Array(result))
     }
 }
 
-fn scan_float_array<T: ArrowPrimitiveType>(
-    divisor: &ArrayRef,
-    dividend_mask: Option<&dyn Array>,
-) -> bool
-where
-    T::Native: Default + PartialEq,
-{
-    let arr = divisor.as_primitive::<T>();
-    let zero = T::Native::default();
-    for i in 0..arr.len() {
-        if arr.is_null(i) {
-            continue;
-        }
-        if let Some(mask) = dividend_mask {
-            if mask.is_null(i) {
-                continue;
-            }
-        }
-        if arr.value(i) == zero {
-            return true;
-        }
-    }
-    false
+/// `try_binary` only invokes the closure for rows that are valid in both arrays, so rows
+/// where either operand is null produce a null result without raising — matching Spark's
+/// row-wise semantics.
+fn checked_modulo_kernel<T: ArrowPrimitiveType>(
+    lhs: &ArrayRef,
+    rhs: &ArrayRef,
+) -> Result<PrimitiveArray<T>> {
+    try_binary::<_, _, _, T>(lhs.as_primitive::<T>(), rhs.as_primitive::<T>(), |l, r| {
+        l.mod_checked(r)
+    })
+    .map_err(|e| match e {
+        ArrowError::DivideByZero => remainder_by_zero_error().into(),
+        other => DataFusionError::from(other),
+    })
 }
 
 pub fn create_modulo_expr(
@@ -641,5 +631,185 @@ mod tests {
             false,
             Some(Arc::new(Float64Array::from(vec![None, None]))),
         );
+    }
+
+    /// Evaluates `a % <literal>` where `a` is a Float64 column, so `spark_modulo` receives
+    /// `(Array, Scalar)` rather than the `(Array, Array)` pair that `run_float_modulo`
+    /// produces.
+    fn run_float_modulo_with_literal_divisor(
+        lhs: ArrayRef,
+        divisor: ScalarValue,
+        fail_on_error: bool,
+        should_fail: bool,
+        expected: Option<Arc<Float64Array>>,
+    ) {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Float64, true)]));
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![lhs]).unwrap();
+
+        let session_ctx = SessionContext::new();
+        let modulo_expr = create_modulo_expr(
+            Arc::new(Column::new("a", 0)),
+            Arc::new(Literal::new(divisor)),
+            DataType::Float64,
+            schema,
+            fail_on_error,
+            &session_ctx.state(),
+        )
+        .unwrap();
+
+        verify_result(modulo_expr, batch, should_fail, expected);
+    }
+
+    #[test]
+    fn test_modulo_literal_zero_divisor_float64_ansi() {
+        // `(Array, Scalar)` operands with a zero literal divisor must raise.
+        run_float_modulo_with_literal_divisor(
+            Arc::new(Float64Array::from(vec![Some(1.0), Some(2.0)])),
+            ScalarValue::Float64(Some(0.0)),
+            true,
+            true,
+            None,
+        );
+    }
+
+    #[test]
+    fn test_modulo_literal_negative_zero_divisor_float64_ansi() {
+        run_float_modulo_with_literal_divisor(
+            Arc::new(Float64Array::from(vec![Some(1.0)])),
+            ScalarValue::Float64(Some(-0.0)),
+            true,
+            true,
+            None,
+        );
+    }
+
+    #[test]
+    fn test_modulo_all_null_lhs_literal_zero_divisor_float64_ansi() {
+        // Every dividend is null, so no row pairs a non-null dividend with the zero
+        // literal divisor and no error should be raised.
+        run_float_modulo_with_literal_divisor(
+            Arc::new(Float64Array::from(vec![None, None])),
+            ScalarValue::Float64(Some(0.0)),
+            true,
+            false,
+            Some(Arc::new(Float64Array::from(vec![None, None]))),
+        );
+    }
+
+    #[test]
+    fn test_modulo_literal_non_zero_divisor_float64() {
+        with_fail_on_error(|fail_on_error| {
+            run_float_modulo_with_literal_divisor(
+                Arc::new(Float64Array::from(vec![Some(5.0), None])),
+                ScalarValue::Float64(Some(2.0)),
+                fail_on_error,
+                false,
+                Some(Arc::new(Float64Array::from(vec![Some(1.0), None]))),
+            );
+        })
+    }
+
+    /// Evaluates `<literal> % b` where `b` is a Float64 column, covering the
+    /// `(Scalar, Array)` operand pair.
+    fn run_float_modulo_with_literal_dividend(
+        dividend: ScalarValue,
+        rhs: ArrayRef,
+        fail_on_error: bool,
+        should_fail: bool,
+        expected: Option<Arc<Float64Array>>,
+    ) {
+        let schema = Arc::new(Schema::new(vec![Field::new("b", DataType::Float64, true)]));
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![rhs]).unwrap();
+
+        let session_ctx = SessionContext::new();
+        let modulo_expr = create_modulo_expr(
+            Arc::new(Literal::new(dividend)),
+            Arc::new(Column::new("b", 0)),
+            DataType::Float64,
+            schema,
+            fail_on_error,
+            &session_ctx.state(),
+        )
+        .unwrap();
+
+        verify_result(modulo_expr, batch, should_fail, expected);
+    }
+
+    #[test]
+    fn test_modulo_literal_dividend_zero_divisor_float64_ansi() {
+        // `(Scalar, Array)` operands: row 1 pairs the non-null literal dividend with a
+        // zero divisor and must raise.
+        run_float_modulo_with_literal_dividend(
+            ScalarValue::Float64(Some(1.0)),
+            Arc::new(Float64Array::from(vec![Some(2.0), Some(0.0)])),
+            true,
+            true,
+            None,
+        );
+    }
+
+    #[test]
+    fn test_modulo_null_literal_dividend_zero_divisor_float64_ansi() {
+        // A null literal dividend must not raise even though the divisor is zero.
+        run_float_modulo_with_literal_dividend(
+            ScalarValue::Float64(None),
+            Arc::new(Float64Array::from(vec![Some(0.0)])),
+            true,
+            false,
+            Some(Arc::new(Float64Array::from(vec![None]))),
+        );
+    }
+
+    #[test]
+    fn test_modulo_both_literals_zero_divisor_float64_ansi() {
+        // `(Scalar, Scalar)` operands. Spark folds fully-literal expressions before
+        // execution, so this pair only reaches `spark_modulo` via a plan built directly,
+        // but the branch must still raise rather than return NaN.
+        let session_ctx = SessionContext::new();
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Float64, true)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Float64Array::from(vec![Some(1.0)])) as ArrayRef],
+        )
+        .unwrap();
+
+        let modulo_expr = create_modulo_expr(
+            Arc::new(Literal::new(ScalarValue::Float64(Some(1.0)))),
+            Arc::new(Literal::new(ScalarValue::Float64(Some(0.0)))),
+            DataType::Float64,
+            schema,
+            true,
+            &session_ctx.state(),
+        )
+        .unwrap();
+
+        verify_result::<Float64Type>(modulo_expr, batch, true, None);
+    }
+
+    #[test]
+    fn test_modulo_both_literals_non_zero_divisor_float64_ansi() {
+        // `(Scalar, Scalar)` operands must still evaluate to a scalar, not a one-row array.
+        let session_ctx = SessionContext::new();
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Float64, true)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Float64Array::from(vec![Some(1.0), Some(2.0)])) as ArrayRef],
+        )
+        .unwrap();
+
+        let modulo_expr = create_modulo_expr(
+            Arc::new(Literal::new(ScalarValue::Float64(Some(5.0)))),
+            Arc::new(Literal::new(ScalarValue::Float64(Some(2.0)))),
+            DataType::Float64,
+            schema,
+            true,
+            &session_ctx.state(),
+        )
+        .unwrap();
+
+        match modulo_expr.evaluate(&batch).unwrap() {
+            ColumnarValue::Scalar(ScalarValue::Float64(Some(v))) => assert_eq!(v, 1.0),
+            other => panic!("Expected a Float64 scalar, got {other:?}"),
+        }
     }
 }

--- a/native/spark-expr/src/math_funcs/modulo_expr.rs
+++ b/native/spark-expr/src/math_funcs/modulo_expr.rs
@@ -88,7 +88,7 @@ fn check_float_remainder_by_zero(lhs: &ColumnarValue, rhs: &ColumnarValue) -> Re
             }
         }
         (ColumnarValue::Array(l_arr), ColumnarValue::Scalar(r)) => {
-            if is_zero_float_scalar(r) && !array_all_null(l_arr) {
+            if is_zero_float_scalar(r) && l_arr.null_count() != l_arr.len() {
                 return Err(remainder_by_zero_error().into());
             }
         }
@@ -106,20 +106,13 @@ fn check_float_remainder_by_zero(lhs: &ColumnarValue, rhs: &ColumnarValue) -> Re
     Ok(())
 }
 
-fn array_all_null(arr: &ArrayRef) -> bool {
-    match arr.logical_nulls() {
-        Some(nulls) => nulls.null_count() == arr.len(),
-        None => arr.is_empty(),
-    }
-}
-
 /// Returns true if `divisor` contains any non-null zero. When `dividend_mask` is provided,
 /// positions where `dividend_mask` is null are skipped (they will produce null results and
 /// must not raise an error).
 fn float_array_has_zero(divisor: &ArrayRef, dividend_mask: Option<&dyn Array>) -> bool {
     match divisor.data_type() {
-        DataType::Float32 => scan_float_array::<Float32Type>(divisor, dividend_mask, 0.0),
-        DataType::Float64 => scan_float_array::<Float64Type>(divisor, dividend_mask, 0.0),
+        DataType::Float32 => scan_float_array::<Float32Type>(divisor, dividend_mask),
+        DataType::Float64 => scan_float_array::<Float64Type>(divisor, dividend_mask),
         _ => false,
     }
 }
@@ -127,12 +120,12 @@ fn float_array_has_zero(divisor: &ArrayRef, dividend_mask: Option<&dyn Array>) -
 fn scan_float_array<T: ArrowPrimitiveType>(
     divisor: &ArrayRef,
     dividend_mask: Option<&dyn Array>,
-    zero: T::Native,
 ) -> bool
 where
-    T::Native: PartialEq,
+    T::Native: Default + PartialEq,
 {
     let arr = divisor.as_primitive::<T>();
+    let zero = T::Native::default();
     for i in 0..arr.len() {
         if arr.is_null(i) {
             continue;
@@ -563,8 +556,8 @@ mod tests {
             DataType::Float64,
             Arc::new(Float64Array::from(vec![Some(1.0)])),
             Arc::new(Float64Array::from(vec![Some(0.0)])),
-            /* fail_on_error */ true,
-            /* should_fail */ true,
+            true,
+            true,
             None,
         );
     }
@@ -602,8 +595,8 @@ mod tests {
             DataType::Float64,
             Arc::new(Float64Array::from(vec![Some(1.0)])),
             Arc::new(Float64Array::from(vec![Some(0.0)])),
-            /* fail_on_error */ false,
-            /* should_fail */ false,
+            false,
+            false,
             Some(Arc::new(Float64Array::from(vec![None]))),
         );
     }

--- a/native/spark-expr/src/math_funcs/modulo_expr.rs
+++ b/native/spark-expr/src/math_funcs/modulo_expr.rs
@@ -17,6 +17,7 @@
 
 use crate::{create_comet_physical_fun, IfExpr};
 use crate::{remainder_by_zero_error, Cast, EvalMode, SparkCastOptions};
+use arrow::array::{Array, ArrayRef, AsArray};
 use arrow::compute::kernels::numeric::rem;
 use arrow::datatypes::*;
 use datafusion::common::{exec_err, internal_err, DataFusionError, Result, ScalarValue};
@@ -53,6 +54,13 @@ pub fn spark_modulo(args: &[ColumnarValue], fail_on_error: bool) -> Result<Colum
         return apply_cmp_for_nested(Operator::Modulo, lhs, rhs);
     }
 
+    // Arrow's `rem` kernel only signals `DivideByZero` for integer and decimal types.
+    // For floating point, `x % 0.0` yields NaN silently, so under ANSI mode we must
+    // detect zero divisors explicitly to raise the Spark-compliant error.
+    if fail_on_error && matches!(right_data_type, DataType::Float32 | DataType::Float64) {
+        check_float_remainder_by_zero(lhs, rhs)?;
+    }
+
     match apply(lhs, rhs, rem) {
         Ok(result) => Ok(result),
         Err(e) if e.to_string().contains("Divide by zero") && fail_on_error => {
@@ -61,6 +69,84 @@ pub fn spark_modulo(args: &[ColumnarValue], fail_on_error: bool) -> Result<Colum
         }
         Err(e) => Err(e),
     }
+}
+
+/// Returns an error if any row has a non-null dividend paired with a zero divisor. Only
+/// meant to be called with floating point operands — Spark treats `-0.0` as zero here,
+/// which falls out naturally from IEEE 754 equality.
+fn check_float_remainder_by_zero(lhs: &ColumnarValue, rhs: &ColumnarValue) -> Result<()> {
+    let is_zero_float_scalar = |sv: &ScalarValue| match sv {
+        ScalarValue::Float32(Some(v)) => *v == 0.0,
+        ScalarValue::Float64(Some(v)) => *v == 0.0,
+        _ => false,
+    };
+
+    match (lhs, rhs) {
+        (ColumnarValue::Scalar(l), ColumnarValue::Scalar(r)) => {
+            if !l.is_null() && is_zero_float_scalar(r) {
+                return Err(remainder_by_zero_error().into());
+            }
+        }
+        (ColumnarValue::Array(l_arr), ColumnarValue::Scalar(r)) => {
+            if is_zero_float_scalar(r) && !array_all_null(l_arr) {
+                return Err(remainder_by_zero_error().into());
+            }
+        }
+        (ColumnarValue::Scalar(l), ColumnarValue::Array(r_arr)) => {
+            if !l.is_null() && float_array_has_zero(r_arr, None) {
+                return Err(remainder_by_zero_error().into());
+            }
+        }
+        (ColumnarValue::Array(l_arr), ColumnarValue::Array(r_arr)) => {
+            if float_array_has_zero(r_arr, Some(l_arr.as_ref())) {
+                return Err(remainder_by_zero_error().into());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn array_all_null(arr: &ArrayRef) -> bool {
+    match arr.logical_nulls() {
+        Some(nulls) => nulls.null_count() == arr.len(),
+        None => arr.is_empty(),
+    }
+}
+
+/// Returns true if `divisor` contains any non-null zero. When `dividend_mask` is provided,
+/// positions where `dividend_mask` is null are skipped (they will produce null results and
+/// must not raise an error).
+fn float_array_has_zero(divisor: &ArrayRef, dividend_mask: Option<&dyn Array>) -> bool {
+    match divisor.data_type() {
+        DataType::Float32 => scan_float_array::<Float32Type>(divisor, dividend_mask, 0.0),
+        DataType::Float64 => scan_float_array::<Float64Type>(divisor, dividend_mask, 0.0),
+        _ => false,
+    }
+}
+
+fn scan_float_array<T: ArrowPrimitiveType>(
+    divisor: &ArrayRef,
+    dividend_mask: Option<&dyn Array>,
+    zero: T::Native,
+) -> bool
+where
+    T::Native: PartialEq,
+{
+    let arr = divisor.as_primitive::<T>();
+    for i in 0..arr.len() {
+        if arr.is_null(i) {
+            continue;
+        }
+        if let Some(mask) = dividend_mask {
+            if mask.is_null(i) {
+                continue;
+            }
+        }
+        if arr.value(i) == zero {
+            return true;
+        }
+    }
+    false
 }
 
 pub fn create_modulo_expr(
@@ -216,8 +302,8 @@ fn create_modulo_scalar_function(
 mod tests {
     use super::*;
     use arrow::array::{
-        Array, ArrayRef, Decimal128Array, Decimal128Builder, Int32Array, PrimitiveArray,
-        RecordBatch,
+        Array, ArrayRef, Decimal128Array, Decimal128Builder, Float32Array, Float64Array,
+        Int32Array, PrimitiveArray, RecordBatch,
     };
     use datafusion::logical_expr::ColumnarValue;
     use datafusion::physical_expr::expressions::{Column, Literal};
@@ -440,5 +526,127 @@ mod tests {
             let expected_result = Arc::new(Int32Array::from(vec![None, None]));
             verify_result(modulo_expr, batch, fail_on_error, Some(expected_result));
         })
+    }
+
+    fn run_float_modulo<T: ArrowPrimitiveType>(
+        data_type: DataType,
+        lhs: ArrayRef,
+        rhs: ArrayRef,
+        fail_on_error: bool,
+        should_fail: bool,
+        expected: Option<Arc<PrimitiveArray<T>>>,
+    ) {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", data_type.clone(), true),
+            Field::new("b", data_type.clone(), true),
+        ]));
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![lhs, rhs]).unwrap();
+
+        let session_ctx = SessionContext::new();
+        let modulo_expr = create_modulo_expr(
+            Arc::new(Column::new("a", 0)),
+            Arc::new(Column::new("b", 1)),
+            data_type,
+            schema,
+            fail_on_error,
+            &session_ctx.state(),
+        )
+        .unwrap();
+
+        verify_result(modulo_expr, batch, should_fail, expected);
+    }
+
+    #[test]
+    fn test_modulo_divide_by_zero_float64_ansi() {
+        // ANSI mode with a zero divisor must raise REMAINDER_BY_ZERO for Float64.
+        run_float_modulo::<Float64Type>(
+            DataType::Float64,
+            Arc::new(Float64Array::from(vec![Some(1.0)])),
+            Arc::new(Float64Array::from(vec![Some(0.0)])),
+            /* fail_on_error */ true,
+            /* should_fail */ true,
+            None,
+        );
+    }
+
+    #[test]
+    fn test_modulo_divide_by_negative_zero_float64_ansi() {
+        // `-0.0` is equal to `0.0` under IEEE 754, and Spark treats it as a zero divisor.
+        run_float_modulo::<Float64Type>(
+            DataType::Float64,
+            Arc::new(Float64Array::from(vec![Some(1.0)])),
+            Arc::new(Float64Array::from(vec![Some(-0.0)])),
+            true,
+            true,
+            None,
+        );
+    }
+
+    #[test]
+    fn test_modulo_divide_by_zero_float32_ansi() {
+        run_float_modulo::<Float32Type>(
+            DataType::Float32,
+            Arc::new(Float32Array::from(vec![Some(1.0_f32)])),
+            Arc::new(Float32Array::from(vec![Some(0.0_f32)])),
+            true,
+            true,
+            None,
+        );
+    }
+
+    #[test]
+    fn test_modulo_divide_by_zero_float64_non_ansi() {
+        // Non-ANSI mode preserves the existing behavior: the divisor is nulled out and the
+        // result is null.
+        run_float_modulo::<Float64Type>(
+            DataType::Float64,
+            Arc::new(Float64Array::from(vec![Some(1.0)])),
+            Arc::new(Float64Array::from(vec![Some(0.0)])),
+            /* fail_on_error */ false,
+            /* should_fail */ false,
+            Some(Arc::new(Float64Array::from(vec![None]))),
+        );
+    }
+
+    #[test]
+    fn test_modulo_null_dividend_zero_divisor_float64_ansi() {
+        // A null dividend must not raise even when the divisor is zero — Spark returns null
+        // whenever either operand is null.
+        run_float_modulo::<Float64Type>(
+            DataType::Float64,
+            Arc::new(Float64Array::from(vec![None])),
+            Arc::new(Float64Array::from(vec![Some(0.0)])),
+            true,
+            false,
+            Some(Arc::new(Float64Array::from(vec![None]))),
+        );
+    }
+
+    #[test]
+    fn test_modulo_mixed_null_and_zero_divisor_float64_ansi() {
+        // Row 0: null lhs paired with zero divisor -> null result, no error.
+        // Row 1: non-null lhs paired with zero divisor -> must raise.
+        run_float_modulo::<Float64Type>(
+            DataType::Float64,
+            Arc::new(Float64Array::from(vec![None, Some(1.0)])),
+            Arc::new(Float64Array::from(vec![Some(0.0), Some(0.0)])),
+            true,
+            true,
+            None,
+        );
+    }
+
+    #[test]
+    fn test_modulo_all_null_lhs_zero_scalar_divisor_float64_ansi() {
+        // Every lhs row is null, so the zero scalar divisor cannot pair with a non-null
+        // dividend and no error should be raised.
+        run_float_modulo::<Float64Type>(
+            DataType::Float64,
+            Arc::new(Float64Array::from(vec![None, None])),
+            Arc::new(Float64Array::from(vec![Some(0.0), Some(0.0)])),
+            true,
+            false,
+            Some(Arc::new(Float64Array::from(vec![None, None]))),
+        );
     }
 }

--- a/native/spark-expr/src/math_funcs/modulo_expr.rs
+++ b/native/spark-expr/src/math_funcs/modulo_expr.rs
@@ -22,7 +22,9 @@ use arrow::compute::kernels::arity::try_binary;
 use arrow::compute::kernels::numeric::rem;
 use arrow::datatypes::*;
 use arrow::error::ArrowError;
-use datafusion::common::{exec_err, internal_err, DataFusionError, Result, ScalarValue};
+use datafusion::common::{
+    exec_err, internal_err, not_impl_err, DataFusionError, Result, ScalarValue,
+};
 use datafusion::config::ConfigOptions;
 use datafusion::execution::FunctionRegistry;
 use datafusion::physical_expr::expressions::{lit, BinaryExpr};
@@ -100,7 +102,7 @@ fn checked_float_modulo(
     let result: ArrayRef = match data_type {
         DataType::Float32 => Arc::new(checked_modulo_kernel::<Float32Type>(&left, &right)?),
         DataType::Float64 => Arc::new(checked_modulo_kernel::<Float64Type>(&left, &right)?),
-        _ => return internal_err!("checked_float_modulo called with {data_type}"),
+        _ => return not_impl_err!("checked_float_modulo doesn't support {data_type}"),
     };
 
     if matches!(
@@ -342,8 +344,11 @@ mod tests {
                         if !actual_arr.is_null(i) {
                             let actual_value = actual_arr.value(i);
                             let expected_value = expected_arr.value(i);
-                            assert_eq!(
-                                actual_value, expected_value,
+                            // `is_eq` uses arrow's total ordering, under which `NaN` equals
+                            // `NaN`. Plain `==` would fail for the NaN results that a
+                            // non-zero divisor produces from NaN or infinite dividends.
+                            assert!(
+                                actual_value.is_eq(expected_value),
                                 "Mismatch at index {i}, actual {actual_value:?}, expected {expected_value:?}"
                             );
                         }
@@ -811,5 +816,138 @@ mod tests {
             ColumnarValue::Scalar(ScalarValue::Float64(Some(v))) => assert_eq!(v, 1.0),
             other => panic!("Expected a Float64 scalar, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_modulo_special_dividends_zero_divisor_float64_ansi() {
+        // Spark's `DivModLike.eval` only inspects the divisor when deciding whether to
+        // raise, so NaN, +/-Infinity and 0.0 dividends must all throw rather than
+        // producing NaN.
+        for dividend in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY, 0.0, -0.0] {
+            run_float_modulo::<Float64Type>(
+                DataType::Float64,
+                Arc::new(Float64Array::from(vec![Some(dividend)])),
+                Arc::new(Float64Array::from(vec![Some(0.0)])),
+                true,
+                true,
+                None,
+            );
+            // Same dividends against a literal zero divisor, i.e. the `Array/Scalar` pair.
+            run_float_modulo_with_literal_divisor(
+                Arc::new(Float64Array::from(vec![Some(dividend)])),
+                ScalarValue::Float64(Some(0.0)),
+                true,
+                true,
+                None,
+            );
+        }
+    }
+
+    #[test]
+    fn test_modulo_special_dividends_non_zero_divisor_float64_ansi() {
+        // The same dividends must not raise when the divisor is non-zero. `x % 2.0` is
+        // NaN for NaN and for both infinities, and preserves the sign of a zero dividend.
+        run_float_modulo::<Float64Type>(
+            DataType::Float64,
+            Arc::new(Float64Array::from(vec![
+                Some(f64::NAN),
+                Some(f64::INFINITY),
+                Some(f64::NEG_INFINITY),
+                Some(0.0),
+                Some(5.0),
+            ])),
+            Arc::new(Float64Array::from(vec![Some(2.0); 5])),
+            true,
+            false,
+            Some(Arc::new(Float64Array::from(vec![
+                Some(f64::NAN),
+                Some(f64::NAN),
+                Some(f64::NAN),
+                Some(0.0),
+                Some(1.0),
+            ]))),
+        );
+    }
+
+    #[test]
+    fn test_modulo_mixed_batch_float64_ansi() {
+        // A batch mixing non-zero divisors, a zero divisor with a non-null dividend, and a
+        // zero divisor with a null dividend must raise, because of the middle row.
+        run_float_modulo::<Float64Type>(
+            DataType::Float64,
+            Arc::new(Float64Array::from(vec![
+                Some(1.0),
+                Some(3.0),
+                None,
+                Some(5.0),
+            ])),
+            Arc::new(Float64Array::from(vec![
+                Some(2.0),
+                Some(0.0),
+                Some(0.0),
+                Some(1.5),
+            ])),
+            true,
+            true,
+            None,
+        );
+    }
+
+    #[test]
+    fn test_modulo_mixed_batch_zero_divisors_only_null_dividends_float64_ansi() {
+        // Every zero divisor in this batch pairs with a null dividend, so no row can raise
+        // and the non-zero rows must still compute.
+        run_float_modulo::<Float64Type>(
+            DataType::Float64,
+            Arc::new(Float64Array::from(vec![
+                Some(5.0),
+                None,
+                Some(7.0),
+                None,
+                Some(9.0),
+            ])),
+            Arc::new(Float64Array::from(vec![
+                Some(2.0),
+                Some(0.0),
+                Some(4.0),
+                Some(-0.0),
+                Some(2.0),
+            ])),
+            true,
+            false,
+            Some(Arc::new(Float64Array::from(vec![
+                Some(1.0),
+                None,
+                Some(3.0),
+                None,
+                Some(1.0),
+            ]))),
+        );
+    }
+
+    #[test]
+    fn test_modulo_null_divisor_float64_ansi() {
+        // A null divisor is not a zero divisor: Spark returns null without raising.
+        run_float_modulo::<Float64Type>(
+            DataType::Float64,
+            Arc::new(Float64Array::from(vec![Some(1.0), Some(2.0)])),
+            Arc::new(Float64Array::from(vec![None, Some(2.0)])),
+            true,
+            false,
+            Some(Arc::new(Float64Array::from(vec![None, Some(0.0)]))),
+        );
+    }
+
+    #[test]
+    fn test_modulo_nan_divisor_float64_ansi() {
+        // A NaN divisor is not zero either, so `x % NaN` is NaN rather than an error.
+        run_float_modulo::<Float64Type>(
+            DataType::Float64,
+            Arc::new(Float64Array::from(vec![Some(1.0)])),
+            Arc::new(Float64Array::from(vec![Some(f64::NAN)])),
+            true,
+            false,
+            Some(Arc::new(Float64Array::from(vec![Some(f64::NAN)]))),
+        );
     }
 }

--- a/spark/src/test/resources/sql-tests/expressions/math/arithmetic_ansi.sql
+++ b/spark/src/test/resources/sql-tests/expressions/math/arithmetic_ansi.sql
@@ -204,6 +204,63 @@ SELECT CAST(1.0 AS DOUBLE) % CAST(-0.0 AS DOUBLE)
 query expect_error(BY_ZERO)
 SELECT CAST(1.0 AS FLOAT) % CAST(0.0 AS FLOAT)
 
+-- ----------------------------------------------------------------------------
+-- Zero divisor paired with special dividends.
+-- Spark's DivModLike.eval only inspects the divisor when deciding whether to raise, so
+-- NaN, +/-Infinity and 0.0 dividends must all throw rather than yielding NaN. Keeping the
+-- dividend as a column puts these out of reach of ConstantFolding.
+-- ----------------------------------------------------------------------------
+
+statement
+CREATE TABLE ansi_float_special(a double) USING parquet
+
+statement
+INSERT INTO ansi_float_special VALUES (double('NaN')), (double('Infinity')), (double('-Infinity')), (0.0)
+
+-- NaN % 0 should throw
+query expect_error(BY_ZERO)
+SELECT a % CAST(0.0 AS DOUBLE) FROM ansi_float_special WHERE isnan(a)
+
+-- +Infinity % 0 should throw
+query expect_error(BY_ZERO)
+SELECT a % CAST(0.0 AS DOUBLE) FROM ansi_float_special WHERE a = double('Infinity')
+
+-- -Infinity % 0 should throw
+query expect_error(BY_ZERO)
+SELECT a % CAST(0.0 AS DOUBLE) FROM ansi_float_special WHERE a = double('-Infinity')
+
+-- 0 % 0 should throw
+query expect_error(BY_ZERO)
+SELECT a % CAST(0.0 AS DOUBLE) FROM ansi_float_special WHERE a = 0.0
+
+-- the same special dividends with a non-zero divisor must not throw
+query
+SELECT a % CAST(2.0 AS DOUBLE) FROM ansi_float_special ORDER BY 1
+
+-- ----------------------------------------------------------------------------
+-- Mixed-row batches: some rows have a zero divisor, some do not, and some have a null
+-- dividend. Comet raises once per batch, so only a mixed batch checks that the zero
+-- divisor is correlated with dividend nullness rather than tested batch-wide.
+-- ----------------------------------------------------------------------------
+
+statement
+CREATE TABLE ansi_float_mixed(a double, b double) USING parquet
+
+statement
+INSERT INTO ansi_float_mixed VALUES (1.0, 2.0), (3.0, 0.0), (NULL, 0.0), (5.0, 1.5), (NULL, 4.0)
+
+-- a non-null dividend meets a zero divisor somewhere in the batch, so this must throw
+query expect_error(BY_ZERO)
+SELECT a % b FROM ansi_float_mixed
+
+-- the only zero divisor left pairs with a null dividend, so this must return null, not throw
+query
+SELECT a % b FROM ansi_float_mixed WHERE a IS NULL ORDER BY 1
+
+-- no zero divisors in this batch at all
+query
+SELECT a % b FROM ansi_float_mixed WHERE b <> 0.0 ORDER BY 1
+
 -- ============================================================================
 -- Unary minus overflow
 -- ============================================================================

--- a/spark/src/test/resources/sql-tests/expressions/math/arithmetic_ansi.sql
+++ b/spark/src/test/resources/sql-tests/expressions/math/arithmetic_ansi.sql
@@ -148,6 +148,37 @@ query expect_error(BY_ZERO)
 SELECT c % d FROM ansi_div_zero
 
 -- ============================================================================
+-- Float/Double remainder by zero (issue #5067)
+-- Spark 4.1 throws REMAINDER_BY_ZERO for floating-point x % 0 as well.
+-- ============================================================================
+
+statement
+CREATE TABLE ansi_float_div_zero(a float, b float, c double, d double) USING parquet
+
+statement
+INSERT INTO ansi_float_div_zero VALUES (3.0, 0.0, 3.0, 0.0), (1.0, -0.0, 1.0, -0.0)
+
+-- float column % 0 should throw
+query expect_error(BY_ZERO)
+SELECT a % b FROM ansi_float_div_zero WHERE b = 0.0
+
+-- double column % 0 should throw
+query expect_error(BY_ZERO)
+SELECT c % d FROM ansi_float_div_zero WHERE d = 0.0
+
+-- literal double % 0.0 should throw
+query expect_error(BY_ZERO)
+SELECT CAST(1.0 AS DOUBLE) % CAST(0.0 AS DOUBLE)
+
+-- literal double % -0.0 should also throw (IEEE 754: -0.0 == 0.0)
+query expect_error(BY_ZERO)
+SELECT CAST(1.0 AS DOUBLE) % CAST(-0.0 AS DOUBLE)
+
+-- literal float % 0.0 should throw
+query expect_error(BY_ZERO)
+SELECT CAST(1.0 AS FLOAT) % CAST(0.0 AS FLOAT)
+
+-- ============================================================================
 -- Unary minus overflow
 -- ============================================================================
 

--- a/spark/src/test/resources/sql-tests/expressions/math/arithmetic_ansi.sql
+++ b/spark/src/test/resources/sql-tests/expressions/math/arithmetic_ansi.sql
@@ -166,6 +166,32 @@ SELECT a % b FROM ansi_float_div_zero WHERE b = 0.0
 query expect_error(BY_ZERO)
 SELECT c % d FROM ansi_float_div_zero WHERE d = 0.0
 
+-- The cases below keep a column operand so that ConstantFolding cannot evaluate them
+-- during optimization, which means they reach the native remainder at execution time.
+
+-- float column % literal 0.0 should throw
+query expect_error(BY_ZERO)
+SELECT a % CAST(0.0 AS FLOAT) FROM ansi_float_div_zero
+
+-- double column % literal 0.0 should throw
+query expect_error(BY_ZERO)
+SELECT c % CAST(0.0 AS DOUBLE) FROM ansi_float_div_zero
+
+-- double column % literal -0.0 should also throw (IEEE 754: -0.0 == 0.0)
+query expect_error(BY_ZERO)
+SELECT c % CAST(-0.0 AS DOUBLE) FROM ansi_float_div_zero
+
+-- literal double % double column should throw
+query expect_error(BY_ZERO)
+SELECT CAST(1.0 AS DOUBLE) % d FROM ansi_float_div_zero
+
+-- a non-zero literal divisor must still produce results rather than throw
+query
+SELECT c % CAST(2.0 AS DOUBLE) FROM ansi_float_div_zero ORDER BY 1
+
+-- The fully-literal cases below are folded by Spark's ConstantFolding rule before the
+-- query reaches Comet, so they assert Spark's own behavior rather than the native path.
+
 -- literal double % 0.0 should throw
 query expect_error(BY_ZERO)
 SELECT CAST(1.0 AS DOUBLE) % CAST(0.0 AS DOUBLE)

--- a/spark/src/test/resources/sql-tests/expressions/math/arithmetic_ansi.sql
+++ b/spark/src/test/resources/sql-tests/expressions/math/arithmetic_ansi.sql
@@ -233,9 +233,15 @@ SELECT a % CAST(0.0 AS DOUBLE) FROM ansi_float_special WHERE a = double('-Infini
 query expect_error(BY_ZERO)
 SELECT a % CAST(0.0 AS DOUBLE) FROM ansi_float_special WHERE a = 0.0
 
--- the same special dividends with a non-zero divisor must not throw
+-- the same special dividends with a non-zero divisor must not throw. Compare isnan() rather
+-- than the values themselves: NaN % 2.0 and +/-Infinity % 2.0 are NaN, and the sign of a NaN
+-- produced by an invalid fmod is platform-dependent.
 query
-SELECT a % CAST(2.0 AS DOUBLE) FROM ansi_float_special ORDER BY 1
+SELECT isnan(a % CAST(2.0 AS DOUBLE)) AS r FROM ansi_float_special ORDER BY r
+
+-- a finite dividend with a non-zero divisor still compares by value
+query
+SELECT a % CAST(2.0 AS DOUBLE) FROM ansi_float_special WHERE a = 0.0
 
 -- ----------------------------------------------------------------------------
 -- Mixed-row batches: some rows have a zero divisor, some do not, and some have a null


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5067.

## Rationale for this change

Under ANSI mode, `Remainder` on Float/Double operands returned `NaN` for a zero divisor instead of throwing, because Comet's native modulo implementation relies on Arrow's `rem` kernel to signal the error. `arrow-arith` only produces `DivideByZero` for integer and decimal types; for floats `Op::Rem` uses `mod_wrapping`, which returns `NaN` for `x % 0.0` and never errors, so the existing error branch was unreachable for Float32/Float64.

Spark 4.1 raises `REMAINDER_BY_ZERO` (and earlier Spark versions raise `DIVIDE_BY_ZERO`) for all numeric types including floating point, so this was a native correctness gap.

## What changes are included in this PR?

Under ANSI mode, `spark_modulo` no longer routes Float32/Float64 through the `rem` kernel. It computes the remainder with `arrow::compute::kernels::arity::try_binary` and `ArrowNativeTypeOp::mod_checked` instead, which is the same route `checked_arithmetic.rs` already takes for the equivalent float divide-by-zero problem. This means the Spark-compliant semantics fall out of arrow-rs rather than being reimplemented here:

- `mod_checked` returns `DivideByZero` when the divisor `is_zero()`, so a zero divisor raises instead of yielding `NaN`.
- `-0.0` raises too, since `is_zero()` for floats is `self == 0.0` — matching Spark, which also treats `-0.0` as a zero divisor.
- `try_binary` only invokes the closure on rows valid in both operands, so rows where either operand is null produce a null result without raising, matching Spark's row-wise semantics.

Details worth noting for review:

- Only `ArrowError::DivideByZero` maps to `remainder_by_zero_error()`; other errors pass through, so a length mismatch cannot surface as `REMAINDER_BY_ZERO`.
- Scalar/scalar operands still evaluate to a `ColumnarValue::Scalar`, preserving the shape DataFusion's `apply` produced.
- The branch is guarded on both operand types being equal. Spark casts `Remainder` operands to a common type so this always holds in practice, but it prevents a panic in `as_primitive` if it ever does not.

Non-ANSI mode is unchanged: `create_modulo_expr` still rewrites the divisor so zeros become `NULL`, and `rem`/`mod_wrapping` handles the arithmetic.

## How are these changes tested?

Rust unit tests in `modulo_expr` (19 total, 15 covering floats) exercise Float32/Float64 in ANSI and non-ANSI mode across all four operand shapes — `Array/Array`, `Array/Scalar`, `Scalar/Array`, and `Scalar/Scalar` — including zero and `-0.0` divisors, all-null dividends, mixed null-and-zero-divisor rows, and non-zero divisors where results (not just errors) are checked.

SQL-file coverage in `arithmetic_ansi.sql` adds four float/double `% 0` cases that keep a column operand so Spark's `ConstantFolding` rule cannot evaluate them during optimization, plus a non-zero-divisor case asserting results. I verified these actually reach the native path rather than assuming it: with the new float branch disabled *and* the pre-existing column-vs-column cases removed, the file still fails with `Expected Comet to throw an error matching 'BY_ZERO' but query succeeded`. The three fully-literal cases are retained but now carry a comment noting they are folded before reaching Comet, so they assert Spark's own behavior rather than this PR's code.

Also green locally: `cargo test -p datafusion-comet-spark-expr` (553 tests), `cargo clippy -p datafusion-comet-spark-expr --all-targets -- -D warnings`, `cargo fmt --check`, and the existing `remainder function` test in `CometExpressionSuite`.
