### PR TITLE
fix: round on Int64 with scale <= -19 now overflows correctly

### DIFF
--- a/native/spark-expr/Cargo.toml
+++ b/native/spark-expr/Cargo.toml
@@ -196,5 +196,9 @@ name = "check_overflow"
 harness = false
 
 [[bench]]
+name = "round"
+harness = false
+
+[[bench]]
 name = "unscaled_value"
 harness = false

--- a/native/spark-expr/benches/round.rs
+++ b/native/spark-expr/benches/round.rs
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::{ArrayRef, Int32Array, Int64Array};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use datafusion::common::ScalarValue;
+use datafusion::physical_plan::ColumnarValue;
+use datafusion_comet_spark_expr::spark_round;
+use std::hint::black_box;
+use std::sync::Arc;
+
+const ROWS: usize = 8192;
+
+/// Long values spread over the whole i64 range, with every 10th row null.
+fn int64_array() -> ArrayRef {
+    let values: Vec<Option<i64>> = (0..ROWS)
+        .map(|i| {
+            if i % 10 == 0 {
+                None
+            } else {
+                let v = (i as i64).wrapping_mul(1_125_899_906_842_624);
+                Some(if i % 2 == 0 { v } else { -v })
+            }
+        })
+        .collect();
+    Arc::new(Int64Array::from(values))
+}
+
+fn int32_array() -> ArrayRef {
+    let values: Vec<Option<i32>> = (0..ROWS)
+        .map(|i| {
+            if i % 10 == 0 {
+                None
+            } else {
+                let v = (i as i32).wrapping_mul(262_144);
+                Some(if i % 2 == 0 { v } else { -v })
+            }
+        })
+        .collect();
+    Arc::new(Int32Array::from(values))
+}
+
+fn bench_array(c: &mut Criterion, name: &str, array: &ArrayRef, point: i64, fail_on_error: bool) {
+    let data_type = array.data_type().clone();
+    c.bench_function(name, |b| {
+        let args = vec![
+            ColumnarValue::Array(Arc::clone(array)),
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(point))),
+        ];
+        b.iter(|| black_box(spark_round(black_box(&args), &data_type, fail_on_error).unwrap()))
+    });
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let longs = int64_array();
+    // Small negative scale: 10^(-point) fits in i64, the common case.
+    bench_array(c, "spark_round: int64 scale=-1 legacy", &longs, -1, false);
+    bench_array(c, "spark_round: int64 scale=-1 ansi", &longs, -1, true);
+    bench_array(c, "spark_round: int64 scale=-9 legacy", &longs, -9, false);
+    // 10^(-point) overflows i64 but fits i128, the band fixed by #5070. Values
+    // here are below the rounding threshold, so no overflow is raised.
+    bench_array(c, "spark_round: int64 scale=-19 legacy", &longs, -19, false);
+    // 10^(-point) overflows i128 too: every long rounds to 0.
+    bench_array(c, "spark_round: int64 scale=-40 legacy", &longs, -40, false);
+
+    let ints = int32_array();
+    bench_array(c, "spark_round: int32 scale=-1 legacy", &ints, -1, false);
+    bench_array(c, "spark_round: int32 scale=-1 ansi", &ints, -1, true);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/native/spark-expr/src/math_funcs/round.rs
+++ b/native/spark-expr/src/math_funcs/round.rs
@@ -60,29 +60,24 @@ macro_rules! integer_round {
 }
 
 // Round a single native integer when `10^(-point)` does not fit in the native
-// integer type but still fits in i128. `|x|` is strictly less than `div` here
-// (otherwise the caller would have taken the in-native fast path), so the
-// only possible results are `0`, `+div`, or `-div`. The latter two overflow
-// the native type: under ANSI we throw, under legacy we wrap by truncation
-// (equivalent to `BigDecimal.longValue`'s low-64-bit semantics).
+// integer type but still fits in i128. The caller has already excluded the
+// case where `div` fits the native type, so `|x| < div` and the result is
+// either `0` (when `|x| < half`) or `sign(x) * div` — the latter always
+// overflows the native type. Under ANSI we throw, under legacy we wrap by
+// truncation (matches `BigDecimal.longValue`'s low-64-bit semantics).
 macro_rules! integer_round_widened {
     ($X:expr, $DIV:expr, $HALF:expr, $NATIVE:ty, $FAIL_ON_ERROR:expr) => {{
         let x128 = $X as i128;
-        let rounded: i128 = if x128 <= -$HALF {
-            -$DIV
-        } else if x128 >= $HALF {
-            $DIV
-        } else {
-            0
-        };
-        if rounded >= <$NATIVE>::MIN as i128 && rounded <= <$NATIVE>::MAX as i128 {
-            Ok(rounded as $NATIVE)
+        if x128 > -$HALF && x128 < $HALF {
+            Ok(0 as $NATIVE)
         } else if $FAIL_ON_ERROR {
             Err(ArrowError::ComputeError(
                 arithmetic_overflow_error("integer").to_string(),
             ))
+        } else if x128 >= $HALF {
+            Ok($DIV as $NATIVE)
         } else {
-            Ok(rounded as $NATIVE)
+            Ok((-$DIV) as $NATIVE)
         }
     }};
 }
@@ -336,15 +331,12 @@ mod test {
     // values with |x| >= 5e18 round to sign(x)*1e19, which does not fit in a long:
     // Spark throws under ANSI and wraps (low-order 64 bits) under legacy.
 
-    #[test]
-    fn test_round_int64_negative_scale_overflow_ansi() {
-        // 5e18 rounds up to 1e19, which overflows i64.
-        let args = vec![
-            ColumnarValue::Array(Arc::new(Int64Array::from(vec![
-                5_000_000_000_000_000_000i64,
-            ]))),
-            ColumnarValue::Scalar(ScalarValue::Int64(Some(-19))),
-        ];
+    // 1e19 truncated to the low 64 bits, matching `BigDecimal.longValue`.
+    const WRAPPED_POS_1E19: i64 = 10_000_000_000_000_000_000u64 as i64;
+    const WRAPPED_NEG_1E19: i64 = -WRAPPED_POS_1E19;
+
+    fn assert_round_int64_ansi_overflows(value: ColumnarValue) {
+        let args = vec![value, ColumnarValue::Scalar(ScalarValue::Int64(Some(-19)))];
         let err = spark_round(&args, &DataType::Int64, true).unwrap_err();
         assert!(
             err.to_string().to_ascii_lowercase().contains("overflow"),
@@ -353,8 +345,23 @@ mod test {
     }
 
     #[test]
+    fn test_round_int64_negative_scale_overflow_ansi() {
+        // 5e18 rounds up to 1e19, which overflows i64.
+        assert_round_int64_ansi_overflows(ColumnarValue::Array(Arc::new(Int64Array::from(vec![
+            5_000_000_000_000_000_000i64,
+        ]))));
+    }
+
+    #[test]
+    fn test_round_int64_negative_scale_overflow_ansi_scalar() {
+        assert_round_int64_ansi_overflows(ColumnarValue::Scalar(ScalarValue::Int64(Some(
+            5_000_000_000_000_000_000i64,
+        ))));
+    }
+
+    #[test]
     fn test_round_int64_negative_scale_overflow_legacy() -> Result<()> {
-        // Under legacy mode, 1e19 wraps to its low-order 64 bits.
+        // Under legacy mode, ±1e19 wraps to its low-order 64 bits.
         let args = vec![
             ColumnarValue::Array(Arc::new(Int64Array::from(vec![
                 5_000_000_000_000_000_000i64,
@@ -370,14 +377,13 @@ mod test {
             unreachable!()
         };
         let longs = as_int64_array(&result)?;
-        // 1e19 as i64 wraps to -8446744073709551616; -1e19 wraps to +8446744073709551616.
         let expected = Int64Array::from(vec![
-            10_000_000_000_000_000_000u64 as i64,
-            -10_000_000_000_000_000_000i128 as i64,
+            WRAPPED_POS_1E19,
+            WRAPPED_NEG_1E19,
             0i64,
             0i64,
-            10_000_000_000_000_000_000u64 as i64,
-            -10_000_000_000_000_000_000i128 as i64,
+            WRAPPED_POS_1E19,
+            WRAPPED_NEG_1E19,
         ]);
         assert_eq!(longs, &expected);
         Ok(())
@@ -404,19 +410,6 @@ mod test {
     }
 
     #[test]
-    fn test_round_int64_negative_scale_overflow_ansi_scalar() {
-        let args = vec![
-            ColumnarValue::Scalar(ScalarValue::Int64(Some(5_000_000_000_000_000_000i64))),
-            ColumnarValue::Scalar(ScalarValue::Int64(Some(-19))),
-        ];
-        let err = spark_round(&args, &DataType::Int64, true).unwrap_err();
-        assert!(
-            err.to_string().to_ascii_lowercase().contains("overflow"),
-            "expected arithmetic overflow error, got: {err}"
-        );
-    }
-
-    #[test]
     fn test_round_int64_negative_scale_legacy_scalar() -> Result<()> {
         let args = vec![
             ColumnarValue::Scalar(ScalarValue::Int64(Some(5_000_000_000_000_000_000i64))),
@@ -427,7 +420,7 @@ mod test {
         else {
             unreachable!()
         };
-        assert_eq!(result, 10_000_000_000_000_000_000u64 as i64);
+        assert_eq!(result, WRAPPED_POS_1E19);
         Ok(())
     }
 }

--- a/native/spark-expr/src/math_funcs/round.rs
+++ b/native/spark-expr/src/math_funcs/round.rs
@@ -59,6 +59,34 @@ macro_rules! integer_round {
     }};
 }
 
+// Round a single native integer when `10^(-point)` does not fit in the native
+// integer type but still fits in i128. `|x|` is strictly less than `div` here
+// (otherwise the caller would have taken the in-native fast path), so the
+// only possible results are `0`, `+div`, or `-div`. The latter two overflow
+// the native type: under ANSI we throw, under legacy we wrap by truncation
+// (equivalent to `BigDecimal.longValue`'s low-64-bit semantics).
+macro_rules! integer_round_widened {
+    ($X:expr, $DIV:expr, $HALF:expr, $NATIVE:ty, $FAIL_ON_ERROR:expr) => {{
+        let x128 = $X as i128;
+        let rounded: i128 = if x128 <= -$HALF {
+            -$DIV
+        } else if x128 >= $HALF {
+            $DIV
+        } else {
+            0
+        };
+        if rounded >= <$NATIVE>::MIN as i128 && rounded <= <$NATIVE>::MAX as i128 {
+            Ok(rounded as $NATIVE)
+        } else if $FAIL_ON_ERROR {
+            Err(ArrowError::ComputeError(
+                arithmetic_overflow_error("integer").to_string(),
+            ))
+        } else {
+            Ok(rounded as $NATIVE)
+        }
+    }};
+}
+
 macro_rules! round_integer_array {
     ($ARRAY:expr, $POINT:expr, $TYPE:ty, $NATIVE:ty, $FAIL_ON_ERROR:expr) => {{
         let array = $ARRAY.as_any().downcast_ref::<$TYPE>().unwrap();
@@ -68,7 +96,14 @@ macro_rules! round_integer_array {
             arrow::compute::kernels::arity::try_unary(array, |x| {
                 integer_round!(x, div, half, $FAIL_ON_ERROR)
             })?
+        } else if let Some(div) = 10_i128.checked_pow((-(*$POINT)) as u32) {
+            let half = div / 2;
+            arrow::compute::kernels::arity::try_unary(array, |x| {
+                integer_round_widened!(x, div, half, $NATIVE, $FAIL_ON_ERROR)
+            })?
         } else {
+            // Even i128 cannot hold 10^(-point); every bounded native
+            // integer rounds to 0.
             arrow::compute::kernels::arity::try_unary(array, |_| Ok(0))?
         };
         Ok(ColumnarValue::Array(Arc::new(result)))
@@ -82,6 +117,21 @@ macro_rules! round_integer_scalar {
             let half = div / 2;
             let scalar_opt = match $SCALAR {
                 Some(x) => match integer_round!(x, div, half, $FAIL_ON_ERROR) {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        return Err(DataFusionError::ArrowError(
+                            Box::from(e),
+                            Some(DataFusionError::get_back_trace()),
+                        ))
+                    }
+                },
+                None => None,
+            };
+            Ok(ColumnarValue::Scalar($TYPE(scalar_opt)))
+        } else if let Some(div) = 10_i128.checked_pow((-(*$POINT)) as u32) {
+            let half = div / 2;
+            let scalar_opt = match $SCALAR {
+                Some(x) => match integer_round_widened!(*x, div, half, $NATIVE, $FAIL_ON_ERROR) {
                     Ok(v) => Some(v),
                     Err(e) => {
                         return Err(DataFusionError::ArrowError(
@@ -207,9 +257,9 @@ mod test {
 
     use crate::spark_round;
 
-    use arrow::array::{Float32Array, Float64Array};
+    use arrow::array::{Float32Array, Float64Array, Int64Array};
     use arrow::datatypes::DataType;
-    use datafusion::common::cast::{as_float32_array, as_float64_array};
+    use datafusion::common::cast::{as_float32_array, as_float64_array, as_int64_array};
     use datafusion::common::{Result, ScalarValue};
     use datafusion::physical_plan::ColumnarValue;
 
@@ -278,6 +328,106 @@ mod test {
             unreachable!()
         };
         assert_eq!(result, 125.23);
+        Ok(())
+    }
+
+    // Regression tests for https://github.com/apache/datafusion-comet/issues/5070:
+    // round(Int64, scale) where `10^(-scale)` does not fit in i64. For scale=-19,
+    // values with |x| >= 5e18 round to sign(x)*1e19, which does not fit in a long:
+    // Spark throws under ANSI and wraps (low-order 64 bits) under legacy.
+
+    #[test]
+    fn test_round_int64_negative_scale_overflow_ansi() {
+        // 5e18 rounds up to 1e19, which overflows i64.
+        let args = vec![
+            ColumnarValue::Array(Arc::new(Int64Array::from(vec![
+                5_000_000_000_000_000_000i64,
+            ]))),
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(-19))),
+        ];
+        let err = spark_round(&args, &DataType::Int64, true).unwrap_err();
+        assert!(
+            err.to_string().to_ascii_lowercase().contains("overflow"),
+            "expected arithmetic overflow error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_round_int64_negative_scale_overflow_legacy() -> Result<()> {
+        // Under legacy mode, 1e19 wraps to its low-order 64 bits.
+        let args = vec![
+            ColumnarValue::Array(Arc::new(Int64Array::from(vec![
+                5_000_000_000_000_000_000i64,
+                -5_000_000_000_000_000_000i64,
+                4_999_999_999_999_999_999i64,
+                0i64,
+                i64::MAX,
+                i64::MIN,
+            ]))),
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(-19))),
+        ];
+        let ColumnarValue::Array(result) = spark_round(&args, &DataType::Int64, false)? else {
+            unreachable!()
+        };
+        let longs = as_int64_array(&result)?;
+        // 1e19 as i64 wraps to -8446744073709551616; -1e19 wraps to +8446744073709551616.
+        let expected = Int64Array::from(vec![
+            10_000_000_000_000_000_000u64 as i64,
+            -10_000_000_000_000_000_000i128 as i64,
+            0i64,
+            0i64,
+            10_000_000_000_000_000_000u64 as i64,
+            -10_000_000_000_000_000_000i128 as i64,
+        ]);
+        assert_eq!(longs, &expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_round_int64_negative_scale_below_threshold() -> Result<()> {
+        // scale=-20: threshold is 5e19, which exceeds i64::MAX, so every long
+        // rounds to 0 under both ANSI and legacy.
+        let arr = Int64Array::from(vec![i64::MAX, i64::MIN, 0, 1_000_000_000_000_000_000]);
+        for fail_on_error in [false, true] {
+            let args = vec![
+                ColumnarValue::Array(Arc::new(arr.clone())),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(-20))),
+            ];
+            let ColumnarValue::Array(result) = spark_round(&args, &DataType::Int64, fail_on_error)?
+            else {
+                unreachable!()
+            };
+            let longs = as_int64_array(&result)?;
+            assert_eq!(longs, &Int64Array::from(vec![0i64; arr.len()]));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_round_int64_negative_scale_overflow_ansi_scalar() {
+        let args = vec![
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(5_000_000_000_000_000_000i64))),
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(-19))),
+        ];
+        let err = spark_round(&args, &DataType::Int64, true).unwrap_err();
+        assert!(
+            err.to_string().to_ascii_lowercase().contains("overflow"),
+            "expected arithmetic overflow error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_round_int64_negative_scale_legacy_scalar() -> Result<()> {
+        let args = vec![
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(5_000_000_000_000_000_000i64))),
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(-19))),
+        ];
+        let ColumnarValue::Scalar(ScalarValue::Int64(Some(result))) =
+            spark_round(&args, &DataType::Int64, false)?
+        else {
+            unreachable!()
+        };
+        assert_eq!(result, 10_000_000_000_000_000_000u64 as i64);
         Ok(())
     }
 }

--- a/native/spark-expr/src/math_funcs/round.rs
+++ b/native/spark-expr/src/math_funcs/round.rs
@@ -61,37 +61,57 @@ macro_rules! integer_round {
 
 // Round a single native integer when `10^(-point)` does not fit in the native
 // integer type but still fits in i128. The caller has already excluded the
-// case where `div` fits the native type, so `|x| < div` and the result is
-// either `0` (when `|x| < half`) or `sign(x) * div` — the latter always
-// overflows the native type. Under ANSI we throw, under legacy we wrap by
-// truncation (matches `BigDecimal.longValue`'s low-64-bit semantics).
+// case where `div` fits the native type, so `|x| <= NATIVE::MAX < div`, which
+// makes `x % div == x`: no division is needed here, and the result is either
+// `0` (when `|x| < half`) or `sign(x) * div` — the latter always overflows the
+// native type. Under ANSI we throw, under legacy we wrap by truncation
+// (matches `BigDecimal.longValue`'s low-64-bit semantics).
 macro_rules! integer_round_widened {
     ($X:expr, $DIV:expr, $HALF:expr, $NATIVE:ty, $FAIL_ON_ERROR:expr) => {{
         let x128 = $X as i128;
+        debug_assert!(
+            x128 > -$DIV && x128 < $DIV,
+            "integer_round_widened! requires div to overflow the native type"
+        );
         if x128 > -$HALF && x128 < $HALF {
             Ok(0 as $NATIVE)
         } else if $FAIL_ON_ERROR {
             Err(ArrowError::ComputeError(
                 arithmetic_overflow_error("integer").to_string(),
             ))
-        } else if x128 >= $HALF {
-            Ok($DIV as $NATIVE)
         } else {
-            Ok((-$DIV) as $NATIVE)
+            Ok((if x128 >= $HALF { $DIV } else { -$DIV }) as $NATIVE)
         }
     }};
+}
+
+// Lift an `ArrowError` from the rounding macros into a `DataFusionError`,
+// returning early from the enclosing function. Used by `round_integer_scalar!`.
+macro_rules! round_scalar_result {
+    ($RESULT:expr) => {
+        match $RESULT {
+            Ok(v) => Some(v),
+            Err(e) => {
+                return Err(DataFusionError::ArrowError(
+                    Box::from(e),
+                    Some(DataFusionError::get_back_trace()),
+                ))
+            }
+        }
+    };
 }
 
 macro_rules! round_integer_array {
     ($ARRAY:expr, $POINT:expr, $TYPE:ty, $NATIVE:ty, $FAIL_ON_ERROR:expr) => {{
         let array = $ARRAY.as_any().downcast_ref::<$TYPE>().unwrap();
         let ten: $NATIVE = 10;
-        let result: $TYPE = if let Some(div) = ten.checked_pow((-(*$POINT)) as u32) {
+        let point_abs = (-(*$POINT)) as u32;
+        let result: $TYPE = if let Some(div) = ten.checked_pow(point_abs) {
             let half = div / 2;
             arrow::compute::kernels::arity::try_unary(array, |x| {
                 integer_round!(x, div, half, $FAIL_ON_ERROR)
             })?
-        } else if let Some(div) = 10_i128.checked_pow((-(*$POINT)) as u32) {
+        } else if let Some(div) = 10_i128.checked_pow(point_abs) {
             let half = div / 2;
             arrow::compute::kernels::arity::try_unary(array, |x| {
                 integer_round_widened!(x, div, half, $NATIVE, $FAIL_ON_ERROR)
@@ -108,39 +128,30 @@ macro_rules! round_integer_array {
 macro_rules! round_integer_scalar {
     ($SCALAR:expr, $POINT:expr, $TYPE:expr, $NATIVE:ty, $FAIL_ON_ERROR:expr) => {{
         let ten: $NATIVE = 10;
-        if let Some(div) = ten.checked_pow((-(*$POINT)) as u32) {
-            let half = div / 2;
-            let scalar_opt = match $SCALAR {
-                Some(x) => match integer_round!(x, div, half, $FAIL_ON_ERROR) {
-                    Ok(v) => Some(v),
-                    Err(e) => {
-                        return Err(DataFusionError::ArrowError(
-                            Box::from(e),
-                            Some(DataFusionError::get_back_trace()),
-                        ))
-                    }
-                },
-                None => None,
-            };
-            Ok(ColumnarValue::Scalar($TYPE(scalar_opt)))
-        } else if let Some(div) = 10_i128.checked_pow((-(*$POINT)) as u32) {
-            let half = div / 2;
-            let scalar_opt = match $SCALAR {
-                Some(x) => match integer_round_widened!(*x, div, half, $NATIVE, $FAIL_ON_ERROR) {
-                    Ok(v) => Some(v),
-                    Err(e) => {
-                        return Err(DataFusionError::ArrowError(
-                            Box::from(e),
-                            Some(DataFusionError::get_back_trace()),
-                        ))
-                    }
-                },
-                None => None,
-            };
-            Ok(ColumnarValue::Scalar($TYPE(scalar_opt)))
-        } else {
-            Ok(ColumnarValue::Scalar($TYPE(Some(0))))
-        }
+        let point_abs = (-(*$POINT)) as u32;
+        let scalar_opt = match $SCALAR {
+            None => None,
+            Some(x) => {
+                if let Some(div) = ten.checked_pow(point_abs) {
+                    let half = div / 2;
+                    round_scalar_result!(integer_round!(*x, div, half, $FAIL_ON_ERROR))
+                } else if let Some(div) = 10_i128.checked_pow(point_abs) {
+                    let half = div / 2;
+                    round_scalar_result!(integer_round_widened!(
+                        *x,
+                        div,
+                        half,
+                        $NATIVE,
+                        $FAIL_ON_ERROR
+                    ))
+                } else {
+                    // Even i128 cannot hold 10^(-point); every bounded native
+                    // integer rounds to 0.
+                    Some(0)
+                }
+            }
+        };
+        Ok(ColumnarValue::Scalar($TYPE(scalar_opt)))
     }};
 }
 
@@ -331,9 +342,12 @@ mod test {
     // values with |x| >= 5e18 round to sign(x)*1e19, which does not fit in a long:
     // Spark throws under ANSI and wraps (low-order 64 bits) under legacy.
 
-    // 1e19 truncated to the low 64 bits, matching `BigDecimal.longValue`.
-    const WRAPPED_POS_1E19: i64 = 10_000_000_000_000_000_000u64 as i64;
-    const WRAPPED_NEG_1E19: i64 = -WRAPPED_POS_1E19;
+    // 1e19 truncated to the low 64 bits, matching `BigDecimal.longValue`. Note
+    // this value is *negative* (-8446744073709551616): 1e19 exceeds i64::MAX, so
+    // reinterpreting its low 64 bits as a signed long flips the sign. Rounding
+    // -5e18 down to -1e19 therefore wraps to a positive value.
+    const WRAPPED_1E19: i64 = 10_000_000_000_000_000_000u64 as i64;
+    const WRAPPED_MINUS_1E19: i64 = -WRAPPED_1E19;
 
     fn assert_round_int64_ansi_overflows(value: ColumnarValue) {
         let args = vec![value, ColumnarValue::Scalar(ScalarValue::Int64(Some(-19)))];
@@ -346,17 +360,21 @@ mod test {
 
     #[test]
     fn test_round_int64_negative_scale_overflow_ansi() {
-        // 5e18 rounds up to 1e19, which overflows i64.
-        assert_round_int64_ansi_overflows(ColumnarValue::Array(Arc::new(Int64Array::from(vec![
-            5_000_000_000_000_000_000i64,
-        ]))));
+        // ±5e18 rounds away from zero to ±1e19, which overflows i64.
+        for value in [5_000_000_000_000_000_000i64, -5_000_000_000_000_000_000i64] {
+            assert_round_int64_ansi_overflows(ColumnarValue::Array(Arc::new(Int64Array::from(
+                vec![value],
+            ))));
+        }
     }
 
     #[test]
     fn test_round_int64_negative_scale_overflow_ansi_scalar() {
-        assert_round_int64_ansi_overflows(ColumnarValue::Scalar(ScalarValue::Int64(Some(
-            5_000_000_000_000_000_000i64,
-        ))));
+        for value in [5_000_000_000_000_000_000i64, -5_000_000_000_000_000_000i64] {
+            assert_round_int64_ansi_overflows(ColumnarValue::Scalar(ScalarValue::Int64(Some(
+                value,
+            ))));
+        }
     }
 
     #[test]
@@ -378,12 +396,12 @@ mod test {
         };
         let longs = as_int64_array(&result)?;
         let expected = Int64Array::from(vec![
-            WRAPPED_POS_1E19,
-            WRAPPED_NEG_1E19,
+            WRAPPED_1E19,
+            WRAPPED_MINUS_1E19,
             0i64,
             0i64,
-            WRAPPED_POS_1E19,
-            WRAPPED_NEG_1E19,
+            WRAPPED_1E19,
+            WRAPPED_MINUS_1E19,
         ]);
         assert_eq!(longs, &expected);
         Ok(())
@@ -410,6 +428,58 @@ mod test {
     }
 
     #[test]
+    fn test_round_int64_scale_below_i128_range() -> Result<()> {
+        // scale=-40: 10^40 does not fit in i128 either, so `checked_pow` returns
+        // None and the fallback returns 0 for every long, under both modes.
+        let arr = Int64Array::from(vec![i64::MAX, i64::MIN, 0, 5_000_000_000_000_000_000]);
+        for fail_on_error in [false, true] {
+            let args = vec![
+                ColumnarValue::Array(Arc::new(arr.clone())),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(-40))),
+            ];
+            let ColumnarValue::Array(result) = spark_round(&args, &DataType::Int64, fail_on_error)?
+            else {
+                unreachable!()
+            };
+            let longs = as_int64_array(&result)?;
+            assert_eq!(longs, &Int64Array::from(vec![0i64; arr.len()]));
+
+            let scalar_args = vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(5_000_000_000_000_000_000i64))),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(-40))),
+            ];
+            let ColumnarValue::Scalar(ScalarValue::Int64(result)) =
+                spark_round(&scalar_args, &DataType::Int64, fail_on_error)?
+            else {
+                unreachable!()
+            };
+            assert_eq!(result, Some(0));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_round_int64_negative_scale_null_scalar() -> Result<()> {
+        // A null long stays null in every scale band: 10^(-scale) fits in i64
+        // (-9), only in i128 (-19), or in neither (-40).
+        for point in [-9i64, -19, -40] {
+            for fail_on_error in [false, true] {
+                let args = vec![
+                    ColumnarValue::Scalar(ScalarValue::Int64(None)),
+                    ColumnarValue::Scalar(ScalarValue::Int64(Some(point))),
+                ];
+                let ColumnarValue::Scalar(ScalarValue::Int64(result)) =
+                    spark_round(&args, &DataType::Int64, fail_on_error)?
+                else {
+                    unreachable!()
+                };
+                assert_eq!(result, None, "scale={point}, ansi={fail_on_error}");
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
     fn test_round_int64_negative_scale_legacy_scalar() -> Result<()> {
         let args = vec![
             ColumnarValue::Scalar(ScalarValue::Int64(Some(5_000_000_000_000_000_000i64))),
@@ -420,7 +490,7 @@ mod test {
         else {
             unreachable!()
         };
-        assert_eq!(result, WRAPPED_POS_1E19);
+        assert_eq!(result, WRAPPED_1E19);
         Ok(())
     }
 }

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -3054,7 +3054,7 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
         Short.MaxValue)).foreach { value =>
       val data = Seq(value)
       withParquetTable(data, "tbl") {
-        Seq(-1000, -100, -10, -1, 0, 1, 10, 100, 1000).foreach { scale =>
+        Seq(-1000, -100, -20, -19, -10, -1, 0, 1, 10, 100, 1000).foreach { scale =>
           Seq(true, false).foreach { ansi =>
             withSQLConf(SQLConf.ANSI_ENABLED.key -> ansi.toString) {
               val res = spark.sql(s"SELECT round(_1, $scale) from tbl")
@@ -3069,6 +3069,46 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
                   fail("Spark threw an exception but Comet did not. Spark exception: " +
                     sparkException.getMessage)
               }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  test("ANSI support for round function with negative scale overflow on long") {
+    // The test above only ever rounds `_1`, an int, so it never reaches the band
+    // where rounding a *long* overflows: 10^19 does not fit in a long, so scales
+    // in [-19, -18] can round a long to a value outside the long range. Spark
+    // throws ARITHMETIC_OVERFLOW under ANSI and wraps to the low-order 64 bits
+    // under legacy. Scales <= -20 round every long to 0 instead, and -39 is past
+    // the point where 10^(-scale) fits in an i128, so include those to pin the
+    // band boundaries. See https://github.com/apache/datafusion-comet/issues/5070.
+    val data = Seq(
+      Long.MaxValue,
+      Long.MinValue,
+      5000000000000000000L,
+      -5000000000000000000L,
+      4999999999999999999L,
+      0L).map(Tuple1.apply)
+    withParquetTable(data, "tbl") {
+      Seq(-39, -38, -20, -19, -18).foreach { scale =>
+        Seq(true, false).foreach { ansi =>
+          withSQLConf(SQLConf.ANSI_ENABLED.key -> ansi.toString) {
+            val res = spark.sql(s"SELECT round(_1, $scale) from tbl")
+            checkSparkAnswerMaybeThrows(res) match {
+              case (Some(sparkException), Some(cometException)) =>
+                assert(sparkException.getMessage.contains("ARITHMETIC_OVERFLOW"))
+                assert(cometException.getMessage.contains("ARITHMETIC_OVERFLOW"))
+              case (None, None) => checkSparkAnswerAndOperator(res)
+              case (None, Some(ex)) =>
+                fail(
+                  s"Comet threw an exception but Spark did not (scale=$scale, ansi=$ansi). " +
+                    "Comet exception: " + ex.getMessage)
+              case (Some(sparkException), None) =>
+                fail(
+                  s"Spark threw an exception but Comet did not (scale=$scale, ansi=$ansi). " +
+                    "Spark exception: " + sparkException.getMessage)
             }
           }
         }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5070.

## Rationale for this change

`spark_round`'s integer path returned `Ok(0)` for every row whenever `10^(-scale)` did not fit in the native integer type (`native/spark-expr/src/math_funcs/round.rs` lines 66-72 and 79-96 in the pre-fix code). For `Int64` with `scale == -19` this masked a real overflow: values with `|x| >= 5e18` round to `sign(x) * 10^19`, which does not fit in a `long`. Spark throws `ARITHMETIC_OVERFLOW` under ANSI mode and wraps (low-order 64 bits) under legacy mode; Comet silently returned `0` in both modes.

`Int8`/`Int16`/`Int32` were not affected because their maxima are strictly less than half the overflowing divisor, so `0` is the correct answer at every overflowing scale.

## What changes are included in this PR?

- In `round_integer_array!` and `round_integer_scalar!`, when `10^(-scale)` overflows the native integer type but still fits in `i128`, widen the intermediate rounding computation to `i128` and check the result against the native type's range: fail under ANSI, truncate under legacy (matches `BigDecimal.longValue`'s low-order-64-bit semantics).
- When `10^(-scale)` also overflows `i128` (`-scale > 38`), retain the fast path that returns `0` — every bounded native integer rounds to `0`.
- Add Rust unit tests covering:
  - `Int64` array + scale `-19`, ANSI mode → throws `ARITHMETIC_OVERFLOW`.
  - `Int64` array + scale `-19`, legacy mode → wraps to the two's-complement low 64 bits (`±10^19 as i64`), including `i64::MAX`, `i64::MIN`, `±5e18`, and values below the rounding threshold.
  - `Int64` array + scale `-20`, both modes → always `0`.
  - `Int64` scalar equivalents for ANSI throw and legacy wrap.

## Are these changes tested?

Yes: six new tests in `native/spark-expr/src/math_funcs/round.rs`, run via `cargo test -p datafusion-comet-spark-expr --lib math_funcs::round::`.

## Are there any user-facing changes?

Yes. `round(cast(x as long), s)` where `s <= -19` and `|x| >= 5 * 10^(-s-1)`:
- ANSI mode: now throws `ARITHMETIC_OVERFLOW` (previously returned `0` silently).
- Legacy mode: now returns the wrapped low-64-bit value (previously returned `0`).
Both match Apache Spark 3.4–4.1.