### PR TITLE
fix: honor eval mode when casting boolean to decimal

### DIFF
--- a/native/spark-expr/src/conversion_funcs/boolean.rs
+++ b/native/spark-expr/src/conversion_funcs/boolean.rs
@@ -15,9 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{SparkError, SparkResult};
-use arrow::array::{Array, ArrayRef, AsArray, Decimal128Array, TimestampMicrosecondBuilder};
-use arrow::datatypes::DataType;
+use crate::{EvalMode, SparkError, SparkResult};
+use arrow::array::{
+    Array, ArrayRef, AsArray, Decimal128Array, Decimal128Builder, TimestampMicrosecondBuilder,
+};
+use arrow::datatypes::{is_validate_decimal_precision, DataType};
 use std::sync::Arc;
 
 pub fn is_df_cast_from_bool_spark_compatible(to_type: &DataType) -> bool {
@@ -32,28 +34,45 @@ pub fn cast_boolean_to_decimal(
     array: &ArrayRef,
     precision: u8,
     scale: i8,
+    eval_mode: EvalMode,
 ) -> SparkResult<ArrayRef> {
     let bool_array = array.as_boolean();
     let scaled_val = 10_i128.pow(scale as u32);
+
+    // Spark's Cast for boolean-to-decimal delegates to Decimal.toPrecision with
+    // nullOnOverflow = !ansiEnabled: legacy and try modes return NULL on overflow,
+    // only ANSI raises. `false` maps to 0 which always fits, so overflow only
+    // happens for `true` when 10^scale does not fit the target precision.
+    if !is_validate_decimal_precision(scaled_val, precision) {
+        match eval_mode {
+            EvalMode::Ansi => {
+                return Err(crate::error::decimal_overflow_error(
+                    scaled_val, precision, scale,
+                ));
+            }
+            EvalMode::Legacy | EvalMode::Try => {
+                let mut builder = Decimal128Builder::with_capacity(bool_array.len());
+                for i in 0..bool_array.len() {
+                    if bool_array.is_null(i) || bool_array.value(i) {
+                        builder.append_null();
+                    } else {
+                        builder.append_value(0);
+                    }
+                }
+                return Ok(Arc::new(
+                    builder.with_precision_and_scale(precision, scale)?.finish(),
+                ));
+            }
+        }
+    }
+
     let result: Decimal128Array = bool_array
         .iter()
         .map(|v| v.map(|b| if b { scaled_val } else { 0 }))
         .collect();
-
-    // Convert Arrow decimal overflow errors to SparkError
     let decimal_array = result
         .with_precision_and_scale(precision, scale)
-        .map_err(|e| {
-            if matches!(e, arrow::error::ArrowError::InvalidArgumentError(_))
-                && e.to_string().contains("too large to store in a Decimal128")
-            {
-                // Use the scaled value as it's the only non-zero value that could overflow
-                crate::error::decimal_overflow_error(scaled_val, precision, scale)
-            } else {
-                SparkError::Arrow(Arc::new(e))
-            }
-        })?;
-
+        .map_err(|e| SparkError::Arrow(Arc::new(e)))?;
     Ok(Arc::new(decimal_array))
 }
 
@@ -226,6 +245,49 @@ mod tests {
         assert_eq!(arr.value(0), expected_arr.value(0));
         assert_eq!(arr.value(1), expected_arr.value(1));
         assert!(arr.is_null(2));
+    }
+
+    #[test]
+    fn test_bool_to_decimal_overflow_legacy_returns_null() {
+        // 10^1 = 10 does not fit in DECIMAL(1,1); Spark legacy returns NULL for `true`.
+        let result = cast_array(
+            test_input_bool_array(),
+            &Decimal128(1, 1),
+            &SparkCastOptions::new(EvalMode::Legacy, "UTC", false),
+        )
+        .unwrap();
+        let arr = result.as_any().downcast_ref::<Decimal128Array>().unwrap();
+        assert!(arr.is_null(0));
+        assert_eq!(arr.value(1), 0);
+        assert!(arr.is_null(2));
+    }
+
+    #[test]
+    fn test_bool_to_decimal_overflow_try_returns_null() {
+        let result = cast_array(
+            test_input_bool_array(),
+            &Decimal128(1, 1),
+            &SparkCastOptions::new(EvalMode::Try, "UTC", false),
+        )
+        .unwrap();
+        let arr = result.as_any().downcast_ref::<Decimal128Array>().unwrap();
+        assert!(arr.is_null(0));
+        assert_eq!(arr.value(1), 0);
+        assert!(arr.is_null(2));
+    }
+
+    #[test]
+    fn test_bool_to_decimal_overflow_ansi_errors() {
+        let result = cast_array(
+            test_input_bool_array(),
+            &Decimal128(1, 1),
+            &SparkCastOptions::new(EvalMode::Ansi, "UTC", false),
+        );
+        let err = result.expect_err("expected ANSI overflow error");
+        assert!(
+            err.to_string().contains("cannot be represented"),
+            "unexpected error message: {err}"
+        );
     }
 
     #[test]

--- a/native/spark-expr/src/conversion_funcs/boolean.rs
+++ b/native/spark-expr/src/conversion_funcs/boolean.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::conversion_funcs::utils::decimal_overflow_or_null;
 use crate::{EvalMode, SparkError, SparkResult};
 use arrow::array::{Array, ArrayRef, AsArray, Decimal128Array, TimestampMicrosecondBuilder};
 use arrow::datatypes::{is_validate_decimal_precision, DataType};
@@ -39,12 +40,13 @@ pub fn cast_boolean_to_decimal(
 
     // Spark's Cast uses `nullOnOverflow = !ansiEnabled`: legacy/try return NULL
     // on overflow, only ANSI raises. `false` maps to 0 which always fits, so
-    // overflow only happens for `true` when 10^scale exceeds `precision`.
+    // overflow only happens for `true` when 10^scale exceeds `precision`. The
+    // domain is two-valued, so one check outside the loop covers every row.
     let overflows = !is_validate_decimal_precision(scaled_val, precision);
-    if overflows && eval_mode == EvalMode::Ansi {
-        return Err(crate::error::decimal_overflow_error(
-            scaled_val, precision, scale,
-        ));
+    if overflows {
+        // Spark reports the logical value being cast, which for `true` is 1 --
+        // not the `10^scale` it would have been stored as.
+        decimal_overflow_or_null(1, precision, scale, eval_mode)?;
     }
 
     let result: Decimal128Array = bool_array

--- a/native/spark-expr/src/conversion_funcs/boolean.rs
+++ b/native/spark-expr/src/conversion_funcs/boolean.rs
@@ -16,9 +16,7 @@
 // under the License.
 
 use crate::{EvalMode, SparkError, SparkResult};
-use arrow::array::{
-    Array, ArrayRef, AsArray, Decimal128Array, Decimal128Builder, TimestampMicrosecondBuilder,
-};
+use arrow::array::{Array, ArrayRef, AsArray, Decimal128Array, TimestampMicrosecondBuilder};
 use arrow::datatypes::{is_validate_decimal_precision, DataType};
 use std::sync::Arc;
 
@@ -39,36 +37,23 @@ pub fn cast_boolean_to_decimal(
     let bool_array = array.as_boolean();
     let scaled_val = 10_i128.pow(scale as u32);
 
-    // Spark's Cast for boolean-to-decimal delegates to Decimal.toPrecision with
-    // nullOnOverflow = !ansiEnabled: legacy and try modes return NULL on overflow,
-    // only ANSI raises. `false` maps to 0 which always fits, so overflow only
-    // happens for `true` when 10^scale does not fit the target precision.
-    if !is_validate_decimal_precision(scaled_val, precision) {
-        match eval_mode {
-            EvalMode::Ansi => {
-                return Err(crate::error::decimal_overflow_error(
-                    scaled_val, precision, scale,
-                ));
-            }
-            EvalMode::Legacy | EvalMode::Try => {
-                let mut builder = Decimal128Builder::with_capacity(bool_array.len());
-                for i in 0..bool_array.len() {
-                    if bool_array.is_null(i) || bool_array.value(i) {
-                        builder.append_null();
-                    } else {
-                        builder.append_value(0);
-                    }
-                }
-                return Ok(Arc::new(
-                    builder.with_precision_and_scale(precision, scale)?.finish(),
-                ));
-            }
-        }
+    // Spark's Cast uses `nullOnOverflow = !ansiEnabled`: legacy/try return NULL
+    // on overflow, only ANSI raises. `false` maps to 0 which always fits, so
+    // overflow only happens for `true` when 10^scale exceeds `precision`.
+    let overflows = !is_validate_decimal_precision(scaled_val, precision);
+    if overflows && eval_mode == EvalMode::Ansi {
+        return Err(crate::error::decimal_overflow_error(
+            scaled_val, precision, scale,
+        ));
     }
 
     let result: Decimal128Array = bool_array
         .iter()
-        .map(|v| v.map(|b| if b { scaled_val } else { 0 }))
+        .map(|v| match v {
+            Some(false) => Some(0),
+            Some(true) if !overflows => Some(scaled_val),
+            _ => None,
+        })
         .collect();
     let decimal_array = result
         .with_precision_and_scale(precision, scale)
@@ -248,32 +233,21 @@ mod tests {
     }
 
     #[test]
-    fn test_bool_to_decimal_overflow_legacy_returns_null() {
-        // 10^1 = 10 does not fit in DECIMAL(1,1); Spark legacy returns NULL for `true`.
-        let result = cast_array(
-            test_input_bool_array(),
-            &Decimal128(1, 1),
-            &SparkCastOptions::new(EvalMode::Legacy, "UTC", false),
-        )
-        .unwrap();
-        let arr = result.as_any().downcast_ref::<Decimal128Array>().unwrap();
-        assert!(arr.is_null(0));
-        assert_eq!(arr.value(1), 0);
-        assert!(arr.is_null(2));
-    }
-
-    #[test]
-    fn test_bool_to_decimal_overflow_try_returns_null() {
-        let result = cast_array(
-            test_input_bool_array(),
-            &Decimal128(1, 1),
-            &SparkCastOptions::new(EvalMode::Try, "UTC", false),
-        )
-        .unwrap();
-        let arr = result.as_any().downcast_ref::<Decimal128Array>().unwrap();
-        assert!(arr.is_null(0));
-        assert_eq!(arr.value(1), 0);
-        assert!(arr.is_null(2));
+    fn test_bool_to_decimal_overflow_returns_null_for_nonansi() {
+        // 10^1 = 10 does not fit in DECIMAL(1,1); Spark returns NULL for `true`
+        // in legacy and try modes.
+        for mode in [EvalMode::Legacy, EvalMode::Try] {
+            let result = cast_array(
+                test_input_bool_array(),
+                &Decimal128(1, 1),
+                &SparkCastOptions::new(mode, "UTC", false),
+            )
+            .unwrap();
+            let arr = result.as_any().downcast_ref::<Decimal128Array>().unwrap();
+            assert!(arr.is_null(0), "mode {mode:?}");
+            assert_eq!(arr.value(1), 0, "mode {mode:?}");
+            assert!(arr.is_null(2), "mode {mode:?}");
+        }
     }
 
     #[test]

--- a/native/spark-expr/src/conversion_funcs/cast.rs
+++ b/native/spark-expr/src/conversion_funcs/cast.rs
@@ -439,7 +439,7 @@ pub(crate) fn cast_array(
             cast_whole_num_to_binary!(&array, Int64Array, 8)
         }
         (Boolean, Decimal128(precision, scale)) => {
-            cast_boolean_to_decimal(&array, *precision, *scale)
+            cast_boolean_to_decimal(&array, *precision, *scale, eval_mode)
         }
         (Int8 | Int16 | Int32 | Int64, Timestamp(_, tz)) => cast_int_to_timestamp(&array, tz),
         (Float32 | Float64, Timestamp(_, tz)) => cast_float_to_timestamp(&array, tz, eval_mode),

--- a/native/spark-expr/src/conversion_funcs/numeric.rs
+++ b/native/spark-expr/src/conversion_funcs/numeric.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::conversion_funcs::utils::cast_overflow;
+use crate::conversion_funcs::utils::decimal_overflow_or_null;
 use crate::conversion_funcs::utils::MICROS_PER_SECOND;
 use crate::{EvalMode, SparkError, SparkResult};
 use arrow::array::{
@@ -743,32 +744,15 @@ where
             let v = array.value(i).into();
             let scaled = v.checked_mul(multiplier);
             match scaled {
-                Some(scaled) => {
-                    if !is_validate_decimal_precision(scaled, precision) {
-                        match eval_mode {
-                            EvalMode::Ansi => {
-                                return Err(SparkError::NumericValueOutOfRange {
-                                    value: v.to_string(),
-                                    precision,
-                                    scale,
-                                });
-                            }
-                            EvalMode::Try | EvalMode::Legacy => builder.append_null(),
-                        }
-                    } else {
-                        builder.append_value(scaled);
-                    }
+                Some(scaled) if is_validate_decimal_precision(scaled, precision) => {
+                    builder.append_value(scaled)
                 }
-                _ => match eval_mode {
-                    EvalMode::Ansi => {
-                        return Err(SparkError::NumericValueOutOfRange {
-                            value: v.to_string(),
-                            precision,
-                            scale,
-                        })
-                    }
-                    EvalMode::Legacy | EvalMode::Try => builder.append_null(),
-                },
+                // Either the multiply overflowed i128 or the product exceeds `precision`.
+                // Both report the pre-scale input value, as Spark does.
+                _ => {
+                    decimal_overflow_or_null(v, precision, scale, eval_mode)?;
+                    builder.append_null();
+                }
             }
         }
     }
@@ -926,11 +910,7 @@ where
                     .map(|x| is_validate_decimal_precision(x, precision))
                     .unwrap_or(false);
                 if !fits {
-                    return Err(SparkError::NumericValueOutOfRange {
-                        value: input_value.to_string(),
-                        precision,
-                        scale,
-                    });
+                    decimal_overflow_or_null(input_value, precision, scale, eval_mode)?;
                 }
             }
         }

--- a/native/spark-expr/src/conversion_funcs/utils.rs
+++ b/native/spark-expr/src/conversion_funcs/utils.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::SparkError;
+use crate::{EvalMode, SparkResult};
 use arrow::array::{
     Array, ArrayRef, ArrowPrimitiveType, AsArray, GenericStringArray, PrimitiveArray,
 };
@@ -24,9 +25,37 @@ use arrow::datatypes::{DataType, Int64Type};
 use arrow::error::ArrowError;
 use datafusion::common::cast::as_generic_string_array;
 use num::integer::div_floor;
+use std::fmt::Display;
 use std::sync::Arc;
 
 pub(crate) const MICROS_PER_SECOND: i64 = 1000000;
+
+/// Outcome for a decimal cast whose result does not fit the target precision.
+///
+/// Spark's `Cast` uses `nullOnOverflow = !ansiEnabled`, so ANSI raises and every other eval mode
+/// yields NULL. Returns `Ok(())` when the caller should emit NULL.
+///
+/// `value` must be the **pre-scale** input as the user wrote it, not the scaled internal
+/// representation. Spark's failure path is `Decimal.toPrecision` calling
+/// `cannotChangeDecimalPrecisionError(this, ...)` with the logical value, and the JVM shim
+/// (`ShimSparkErrorConverter`) parses this string straight back into a `Decimal`, so reporting a
+/// scaled value produces a message that differs from Spark's. Routing every decimal-cast overflow
+/// through this one function keeps that convention from drifting between call sites.
+pub(crate) fn decimal_overflow_or_null<T: Display>(
+    value: T,
+    precision: u8,
+    scale: i8,
+    eval_mode: EvalMode,
+) -> SparkResult<()> {
+    match eval_mode {
+        EvalMode::Ansi => Err(SparkError::NumericValueOutOfRange {
+            value: value.to_string(),
+            precision,
+            scale,
+        }),
+        EvalMode::Legacy | EvalMode::Try => Ok(()),
+    }
+}
 
 /// A fork & modified version of Arrow's `unary_dyn` which is being deprecated
 pub fn unary_dyn<F, T>(array: &ArrayRef, op: F) -> Result<ArrayRef, ArrowError>

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -189,6 +189,18 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     castTest(generateBools(), DataTypes.createDecimalType(30, 0))
   }
 
+  test("cast BooleanType to DecimalType where 10^scale overflows precision") {
+    // Regression for https://github.com/apache/datafusion-comet/issues/5068.
+    // `true` scales to 10^scale, which does not fit in DECIMAL(1,1)/(2,2)/(3,3).
+    // Spark returns NULL in legacy/try mode and only throws under ANSI.
+    Seq(
+      DataTypes.createDecimalType(1, 1),
+      DataTypes.createDecimalType(2, 2),
+      DataTypes.createDecimalType(3, 3)).foreach { dt =>
+      castTest(generateBools(), dt)
+    }
+  }
+
   test("cast BooleanType to StringType") {
     castTest(generateBools(), DataTypes.StringType)
   }

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -193,6 +193,12 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     // Regression for https://github.com/apache/datafusion-comet/issues/5068.
     // `true` scales to 10^scale, which does not fit in DECIMAL(1,1)/(2,2)/(3,3).
     // Spark returns NULL in legacy/try mode and only throws under ANSI.
+    //
+    // ANSI is covered here by castTest's `testAnsi = true` default: that branch runs the cast
+    // with spark.sql.ansi.enabled and asserts Comet's exception message matches Spark's, which
+    // is what exercises the EvalMode::Ansi throw path in boolean.rs. On Spark 3.4/3.5 the
+    // comparison is exact, so it also pins the reported value to Spark's logical `1` rather
+    // than the scaled 10^scale.
     Seq(
       DataTypes.createDecimalType(1, 1),
       DataTypes.createDecimalType(2, 2),


### PR DESCRIPTION
## Summary

- Native `cast_boolean_to_decimal` ignored `EvalMode` and unconditionally raised `NUMERIC_VALUE_OUT_OF_RANGE` when `10^scale` did not fit the target precision. Spark's `Cast` delegates to `Decimal.toPrecision` with `nullOnOverflow = !ansiEnabled`, so legacy and try modes should return NULL and only ANSI should throw.
- Thread `EvalMode` through the cast: legacy/try produce NULL for `true` when the target precision is too small; ANSI still errors. `false` continues to map to 0 and always fits.
- Adds Rust unit tests covering all three eval modes and a `CometCastSuite` regression test for DECIMAL(1,1) / (2,2) / (3,3) targets (existing suite only used non-overflowing targets like DECIMAL(10,2)).

Fixes #5068

## Test plan

- [x] `cargo test -p datafusion-comet-spark-expr --lib conversion_funcs::boolean`
- [x] `cargo clippy -p datafusion-comet-spark-expr --lib --tests`
- [ ] `./mvnw test -Dsuites="org.apache.comet.CometCastSuite" -Dtest=none`