### PR TITLE
fix: throw ARITHMETIC_OVERFLOW for Long.MinValue div -1 under ANSI mode

### DIFF
--- a/native/common/src/error.rs
+++ b/native/common/src/error.rs
@@ -69,7 +69,7 @@ pub enum SparkError {
     #[error("[ARITHMETIC_OVERFLOW] {from_type} overflow. If necessary set \"spark.sql.ansi.enabled\" to \"false\" to bypass this error.")]
     ArithmeticOverflow { from_type: String },
 
-    #[error("[ARITHMETIC_OVERFLOW] Overflow in integral divide. Use `try_divide` to tolerate overflow and return NULL instead. If necessary set \"spark.sql.ansi.enabled\" to \"false\" to bypass this error.")]
+    #[error("[ARITHMETIC_OVERFLOW] Overflow in integral divide. Use 'try_divide' to tolerate overflow and return NULL instead. If necessary set \"spark.sql.ansi.enabled\" to \"false\" to bypass this error.")]
     IntegralDivideOverflow,
 
     #[error("[ARITHMETIC_OVERFLOW] Overflow in sum of decimals. Use `try_{function_name}` to tolerate overflow and return NULL instead. If necessary set \"spark.sql.ansi.enabled\" to \"false\" to bypass this error.")]

--- a/native/core/src/execution/expressions/arithmetic.rs
+++ b/native/core/src/execution/expressions/arithmetic.rs
@@ -215,6 +215,7 @@ impl ExpressionBuilder for IntegralDivideBuilder {
             input_schema,
             BinaryExprOptions {
                 is_integral_div: true,
+                check_divide_overflow: expr.check_divide_overflow,
             },
             eval_mode,
         )

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -227,9 +227,7 @@ fn strip_timestamp_tz(
 #[derive(Default)]
 pub struct BinaryExprOptions {
     pub is_integral_div: bool,
-    /// True when Spark would check integral divide overflow (ANSI mode with LONG
-    /// operands), in which case Long.MinValue div -1 throws ARITHMETIC_OVERFLOW
-    /// instead of wrapping around.
+    /// See `MathExpr.check_divide_overflow` in expr.proto
     pub check_divide_overflow: bool,
 }
 
@@ -953,6 +951,8 @@ impl PhysicalPlanner {
                 } else {
                     "decimal_div"
                 };
+                // check_divide_overflow rides in the generic fail_on_error slot; only
+                // decimal_integral_div consumes it
                 let fun_expr = create_comet_physical_fun_with_eval_mode(
                     func_name,
                     data_type.clone(),
@@ -5349,6 +5349,7 @@ mod tests {
                     type_info: None,
                 }),
                 eval_mode: 0, // Legacy mode
+                check_divide_overflow: false,
             }))),
             expr_id: None,
             query_context: None,

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -227,6 +227,10 @@ fn strip_timestamp_tz(
 #[derive(Default)]
 pub struct BinaryExprOptions {
     pub is_integral_div: bool,
+    /// True when Spark would check integral divide overflow (ANSI mode with LONG
+    /// operands), in which case Long.MinValue div -1 throws ARITHMETIC_OVERFLOW
+    /// instead of wrapping around.
+    pub check_divide_overflow: bool,
 }
 
 pub const TEST_EXEC_CONTEXT_ID: i64 = -1;
@@ -953,7 +957,7 @@ impl PhysicalPlanner {
                     func_name,
                     data_type.clone(),
                     &self.session_ctx.state(),
-                    None,
+                    Some(options.check_divide_overflow),
                     eval_mode,
                 )?;
                 Ok(Arc::new(ScalarFunctionExpr::new(

--- a/native/proto/src/proto/expr.proto
+++ b/native/proto/src/proto/expr.proto
@@ -322,6 +322,10 @@ message MathExpr {
   Expr right = 2;
   DataType return_type = 4;
   EvalMode eval_mode = 5;
+  // Only set for integral_divide: true when Spark would check for overflow
+  // (ANSI mode with LONG operands), in which case Long.MinValue div -1 throws
+  // ARITHMETIC_OVERFLOW instead of wrapping around.
+  bool check_divide_overflow = 6;
 }
 
 message Cast {

--- a/native/proto/src/proto/expr.proto
+++ b/native/proto/src/proto/expr.proto
@@ -322,9 +322,11 @@ message MathExpr {
   Expr right = 2;
   DataType return_type = 4;
   EvalMode eval_mode = 5;
-  // Only set for integral_divide: true when Spark would check for overflow
-  // (ANSI mode with LONG operands), in which case Long.MinValue div -1 throws
-  // ARITHMETIC_OVERFLOW instead of wrapping around.
+  // Only set for integral_divide: mirrors Spark's IntegralDivide.checkDivideOverflow
+  // (LONG operands with failOnError). When this is set and eval_mode is ANSI, a quotient
+  // that does not fit in a LONG (Long.MinValue div -1) throws ARITHMETIC_OVERFLOW
+  // instead of wrapping around. Never set for DECIMAL operands, which wrap around on
+  // the cast to LONG even in ANSI mode, matching Spark.
   bool check_divide_overflow = 6;
 }
 

--- a/native/spark-expr/benches/decimal_div.rs
+++ b/native/spark-expr/benches/decimal_div.rs
@@ -59,6 +59,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 black_box(&args),
                 black_box(&DataType::Decimal128(10, 4)),
                 EvalMode::Legacy,
+                false,
             ))
         })
     });

--- a/native/spark-expr/src/comet_scalar_funcs.rs
+++ b/native/spark-expr/src/comet_scalar_funcs.rs
@@ -79,6 +79,15 @@ macro_rules! make_comet_scalar_udf {
         );
         Ok(Arc::new(ScalarUDF::new_from_impl(scalar_func)))
     }};
+    ($name:expr, $func:ident, $data_type:ident, $eval_mode:ident, $fail_on_error:ident) => {{
+        let scalar_func = CometScalarFunction::new(
+            $name.to_string(),
+            Signature::variadic_any(Volatility::Immutable),
+            $data_type.clone(),
+            Arc::new(move |args| $func(args, &$data_type, $eval_mode, $fail_on_error)),
+        );
+        Ok(Arc::new(ScalarUDF::new_from_impl(scalar_func)))
+    }};
 }
 
 /// Create a physical scalar function.
@@ -155,7 +164,8 @@ pub fn create_comet_physical_fun_with_eval_mode(
                 "decimal_integral_div",
                 spark_decimal_integral_div,
                 data_type,
-                eval_mode
+                eval_mode,
+                fail_on_error
             )
         }
         "checked_add" => {

--- a/native/spark-expr/src/comet_scalar_funcs.rs
+++ b/native/spark-expr/src/comet_scalar_funcs.rs
@@ -160,12 +160,15 @@ pub fn create_comet_physical_fun_with_eval_mode(
             make_comet_scalar_udf!("decimal_div", spark_decimal_div, data_type, eval_mode)
         }
         "decimal_integral_div" => {
+            // the planner repurposes the fail_on_error slot to carry check_divide_overflow
+            // (see MathExpr.check_divide_overflow in expr.proto)
+            let check_divide_overflow = fail_on_error;
             make_comet_scalar_udf!(
                 "decimal_integral_div",
                 spark_decimal_integral_div,
                 data_type,
                 eval_mode,
-                fail_on_error
+                check_divide_overflow
             )
         }
         "checked_add" => {

--- a/native/spark-expr/src/lib.rs
+++ b/native/spark-expr/src/lib.rs
@@ -137,6 +137,10 @@ pub(crate) fn divide_by_zero_error() -> SparkError {
     SparkError::DivideByZero
 }
 
+pub(crate) fn integral_divide_overflow_error() -> SparkError {
+    SparkError::IntegralDivideOverflow
+}
+
 pub(crate) fn remainder_by_zero_error() -> SparkError {
     SparkError::RemainderByZero
 }

--- a/native/spark-expr/src/math_funcs/div.rs
+++ b/native/spark-expr/src/math_funcs/div.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::math_funcs::utils::get_precision_scale;
-use crate::{divide_by_zero_error, EvalMode};
+use crate::{divide_by_zero_error, integral_divide_overflow_error, EvalMode};
 use arrow::array::{Array, Decimal128Array};
 use arrow::datatypes::{DataType, DECIMAL128_MAX_PRECISION};
 use arrow::error::ArrowError;
@@ -34,15 +34,16 @@ pub fn spark_decimal_div(
     data_type: &DataType,
     eval_mode: EvalMode,
 ) -> Result<ColumnarValue, DataFusionError> {
-    spark_decimal_div_internal(args, data_type, false, eval_mode)
+    spark_decimal_div_internal(args, data_type, false, eval_mode, false)
 }
 
 pub fn spark_decimal_integral_div(
     args: &[ColumnarValue],
     data_type: &DataType,
     eval_mode: EvalMode,
+    check_divide_overflow: bool,
 ) -> Result<ColumnarValue, DataFusionError> {
-    spark_decimal_div_internal(args, data_type, true, eval_mode)
+    spark_decimal_div_internal(args, data_type, true, eval_mode, check_divide_overflow)
 }
 
 // Let Decimal(p3, s3) as return type i.e. Decimal(p1, s1) / Decimal(p2, s2) = Decimal(p3, s3).
@@ -55,6 +56,10 @@ fn spark_decimal_div_internal(
     data_type: &DataType,
     is_integral_div: bool,
     eval_mode: EvalMode,
+    // Only set for integral divide when Spark would check for overflow (ANSI mode with
+    // LONG operands): Long.MinValue div -1 is the only LONG quotient that cannot be
+    // represented as a LONG, so any out-of-range quotient throws ARITHMETIC_OVERFLOW.
+    check_divide_overflow: bool,
 ) -> Result<ColumnarValue, DataFusionError> {
     let left = &args[0];
     let right = &args[1];
@@ -107,6 +112,11 @@ fn spark_decimal_div_internal(
             } else {
                 div + &five
             } / &ten;
+            if check_divide_overflow && res.to_i64().is_none() {
+                return Err(ArrowError::ComputeError(
+                    integral_divide_overflow_error().to_string(),
+                ));
+            }
             Ok(res.to_i128().unwrap_or(i128::MAX))
         })?
     } else {
@@ -134,6 +144,11 @@ fn spark_decimal_div_internal(
             } else {
                 div + 5
             } / 10;
+            if check_divide_overflow && res.to_i64().is_none() {
+                return Err(ArrowError::ComputeError(
+                    integral_divide_overflow_error().to_string(),
+                ));
+            }
             Ok(res.to_i128().unwrap_or(i128::MAX))
         })?
     };

--- a/native/spark-expr/src/math_funcs/div.rs
+++ b/native/spark-expr/src/math_funcs/div.rs
@@ -51,16 +51,34 @@ pub fn spark_decimal_integral_div(
 // get enough scale that matches with Spark behavior, it requires to widen s1 to s2 + s3 + 1. Since
 // both s2 and s3 are 38 at max., s1 is 77 at max. DataFusion division cannot handle such scale >
 // Decimal256Type::MAX_SCALE. Therefore, we need to implement this decimal division using BigInt.
+/// Convert a computed quotient to the `i128` stored in the result array, throwing
+/// ARITHMETIC_OVERFLOW when the integral divide overflow check applies and the quotient
+/// does not fit in a LONG (see `MathExpr.check_divide_overflow` in expr.proto).
+#[inline]
+fn quotient_to_i128<T: ToPrimitive>(
+    res: &T,
+    check_divide_overflow: bool,
+) -> Result<i128, ArrowError> {
+    let res = res.to_i128().unwrap_or(i128::MAX);
+    if check_divide_overflow && i64::try_from(res).is_err() {
+        return Err(ArrowError::ComputeError(
+            integral_divide_overflow_error().to_string(),
+        ));
+    }
+    Ok(res)
+}
+
 fn spark_decimal_div_internal(
     args: &[ColumnarValue],
     data_type: &DataType,
     is_integral_div: bool,
     eval_mode: EvalMode,
-    // Only set for integral divide when Spark would check for overflow (ANSI mode with
-    // LONG operands): Long.MinValue div -1 is the only LONG quotient that cannot be
-    // represented as a LONG, so any out-of-range quotient throws ARITHMETIC_OVERFLOW.
+    // See `MathExpr.check_divide_overflow` in expr.proto
     check_divide_overflow: bool,
 ) -> Result<ColumnarValue, DataFusionError> {
+    // Spark captures rather than throws overflow errors in TRY mode, and never checks
+    // in legacy mode, so the overflow check only ever throws under ANSI
+    let check_divide_overflow = check_divide_overflow && eval_mode == EvalMode::Ansi;
     let left = &args[0];
     let right = &args[1];
     let (p3, s3) = get_precision_scale(data_type);
@@ -112,12 +130,7 @@ fn spark_decimal_div_internal(
             } else {
                 div + &five
             } / &ten;
-            if check_divide_overflow && res.to_i64().is_none() {
-                return Err(ArrowError::ComputeError(
-                    integral_divide_overflow_error().to_string(),
-                ));
-            }
-            Ok(res.to_i128().unwrap_or(i128::MAX))
+            quotient_to_i128(&res, check_divide_overflow)
         })?
     } else {
         let l_mul = 10_i128.pow(l_exp);
@@ -144,12 +157,7 @@ fn spark_decimal_div_internal(
             } else {
                 div + 5
             } / 10;
-            if check_divide_overflow && res.to_i64().is_none() {
-                return Err(ArrowError::ComputeError(
-                    integral_divide_overflow_error().to_string(),
-                ));
-            }
-            Ok(res.to_i128().unwrap_or(i128::MAX))
+            quotient_to_i128(&res, check_divide_overflow)
         })?
     };
     let result = result.with_data_type(DataType::Decimal128(p3, s3));

--- a/spark/src/main/scala/org/apache/comet/serde/arithmetic.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arithmetic.scala
@@ -38,8 +38,8 @@ trait MathBase {
       binding: Boolean,
       dataType: DataType,
       evalMode: EvalMode.Value,
-      f: (ExprOuterClass.Expr.Builder, ExprOuterClass.MathExpr) => ExprOuterClass.Expr.Builder)
-      : Option[ExprOuterClass.Expr] = {
+      f: (ExprOuterClass.Expr.Builder, ExprOuterClass.MathExpr) => ExprOuterClass.Expr.Builder,
+      checkDivideOverflow: Boolean = false): Option[ExprOuterClass.Expr] = {
     val leftExpr = exprToProtoInternal(left, inputs, binding)
     val rightExpr = exprToProtoInternal(right, inputs, binding)
 
@@ -49,6 +49,7 @@ trait MathBase {
       builder.setLeft(leftExpr.get)
       builder.setRight(rightExpr.get)
       builder.setEvalMode(evalModeToProto(CometEvalModeUtil.fromSparkEvalMode(evalMode)))
+      builder.setCheckDivideOverflow(checkDivideOverflow)
       serializeDataType(dataType).foreach { t =>
         builder.setReturnType(t)
       }
@@ -318,6 +319,11 @@ object CometIntegralDivide extends CometExpressionSerde[IntegralDivide] with Mat
       case _ => left.dataType
     }
 
+    // Spark only checks integral divide overflow (Long.MinValue div -1) when the operands
+    // are LONG and ANSI mode is enabled; DECIMAL operands wrap around on the cast to LONG
+    val checkDivideOverflow =
+      expr.left.dataType == LongType && expr.evalMode == EvalMode.ANSI
+
     val divideExpr = createMathExpression(
       expr,
       left,
@@ -326,7 +332,8 @@ object CometIntegralDivide extends CometExpressionSerde[IntegralDivide] with Mat
       binding,
       dataType,
       expr.evalMode,
-      (builder, mathExpr) => builder.setIntegralDivide(mathExpr))
+      (builder, mathExpr) => builder.setIntegralDivide(mathExpr),
+      checkDivideOverflow = checkDivideOverflow)
 
     if (divideExpr.isDefined) {
       val childExpr = if (dataType.isInstanceOf[DecimalType]) {

--- a/spark/src/main/scala/org/apache/comet/serde/arithmetic.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arithmetic.scala
@@ -319,11 +319,6 @@ object CometIntegralDivide extends CometExpressionSerde[IntegralDivide] with Mat
       case _ => left.dataType
     }
 
-    // Spark only checks integral divide overflow (Long.MinValue div -1) when the operands
-    // are LONG and ANSI mode is enabled; DECIMAL operands wrap around on the cast to LONG
-    val checkDivideOverflow =
-      expr.left.dataType == LongType && expr.evalMode == EvalMode.ANSI
-
     val divideExpr = createMathExpression(
       expr,
       left,
@@ -333,7 +328,9 @@ object CometIntegralDivide extends CometExpressionSerde[IntegralDivide] with Mat
       dataType,
       expr.evalMode,
       (builder, mathExpr) => builder.setIntegralDivide(mathExpr),
-      checkDivideOverflow = checkDivideOverflow)
+      // Spark only checks integral divide overflow (Long.MinValue div -1) for LONG
+      // operands; DECIMAL operands wrap around on the cast to LONG even in ANSI mode
+      checkDivideOverflow = expr.checkDivideOverflow)
 
     if (divideExpr.isDefined) {
       val childExpr = if (dataType.isInstanceOf[DecimalType]) {

--- a/spark/src/test/resources/sql-tests/expressions/math/arithmetic_ansi.sql
+++ b/spark/src/test/resources/sql-tests/expressions/math/arithmetic_ansi.sql
@@ -107,13 +107,11 @@ SELECT a * 2 FROM ansi_long_overflow WHERE a = 9223372036854775807
 -- ============================================================================
 
 -- LONG_MIN div -1 should overflow
--- (match on the message body rather than the ARITHMETIC_OVERFLOW condition name,
--- which is not rendered on all Spark versions)
-query expect_error(Overflow in integral divide)
+query expect_error(ARITHMETIC_OVERFLOW)
 SELECT a div b FROM ansi_long_overflow WHERE a = -9223372036854775808 AND b = -1
 
 -- literal LONG_MIN div -1 should overflow
-query expect_error(Overflow in integral divide)
+query expect_error(ARITHMETIC_OVERFLOW)
 SELECT -9223372036854775808L div -1L
 
 -- INT_MIN div -1 does not overflow because the result type is LONG

--- a/spark/src/test/resources/sql-tests/expressions/math/arithmetic_ansi.sql
+++ b/spark/src/test/resources/sql-tests/expressions/math/arithmetic_ansi.sql
@@ -103,6 +103,33 @@ query expect_error(ARITHMETIC_OVERFLOW)
 SELECT a * 2 FROM ansi_long_overflow WHERE a = 9223372036854775807
 
 -- ============================================================================
+-- Integral divide overflow
+-- ============================================================================
+
+-- LONG_MIN div -1 should overflow
+-- (match on the message body rather than the ARITHMETIC_OVERFLOW condition name,
+-- which is not rendered on all Spark versions)
+query expect_error(Overflow in integral divide)
+SELECT a div b FROM ansi_long_overflow WHERE a = -9223372036854775808 AND b = -1
+
+-- literal LONG_MIN div -1 should overflow
+query expect_error(Overflow in integral divide)
+SELECT -9223372036854775808L div -1L
+
+-- INT_MIN div -1 does not overflow because the result type is LONG
+query
+SELECT a div b FROM ansi_int_overflow WHERE a = -2147483648 AND b = -1
+
+-- LONG_MIN div 1 does not overflow
+query
+SELECT a div b FROM ansi_long_overflow WHERE b = 1
+
+-- Spark only checks integral divide overflow for LONG operands; DECIMAL operands
+-- wrap around on the implicit cast to LONG even in ANSI mode
+query
+SELECT CAST(a AS DECIMAL(19,0)) div CAST(b AS DECIMAL(19,0)) FROM ansi_long_overflow WHERE a = -9223372036854775808 AND b = -1
+
+-- ============================================================================
 -- Integer division by zero
 -- ============================================================================
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5065.

## Rationale for this change

Under ANSI mode, Spark throws `ARITHMETIC_OVERFLOW` ("Overflow in integral divide") for `Long.MinValue div -1`, since the quotient `9223372036854775808` cannot be represented as a `LONG`. Comet performs integral division by casting both operands to `DECIMAL(19,0)`, dividing, and casting the result back to `LONG` with legacy (wrapping) semantics, so it silently returned `-9223372036854775808` instead of throwing.

Spark only performs this check when the operands are `LONG` (`checkDivideOverflow` in `arithmetic.scala`): `DECIMAL` operands wrap around on the implicit cast to `LONG` even in ANSI mode, and smaller integer types cannot overflow because the result type is `LONG`. The fix therefore has to know the original operand type, which is no longer visible on the native side after the serde casts both operands to decimal.

## What changes are included in this PR?

- Add a `check_divide_overflow` field to the `MathExpr` protobuf message, set by `CometIntegralDivide` only when the left operand is `LONG` and eval mode is ANSI (mirroring Spark's `checkDivideOverflow`)
- Plumb the flag through `IntegralDivideBuilder` / `BinaryExprOptions` into the existing `fail_on_error` parameter of `create_comet_physical_fun_with_eval_mode`, with a new `make_comet_scalar_udf!` arm that passes both `eval_mode` and `fail_on_error`
- In `spark_decimal_div_internal`, when the flag is set and the quotient does not fit in an `i64`, return the previously never-constructed `SparkError::IntegralDivideOverflow`, which already maps to `SparkArithmeticException` with error class `ARITHMETIC_OVERFLOW`
- Align the `IntegralDivideOverflow` message with Spark's wording (`Use 'try_divide' ...` with single quotes rather than backticks, matching Spark 3.4 through 4.1)

## How are these changes tested?

New cases in `expressions/math/arithmetic_ansi.sql` (verified to fail before the fix):

- `a div b` and literal `div` for `Long.MinValue div -1` expect an error matching `Overflow in integral divide` from both Spark and Comet
- Pinning queries for the cases that must NOT throw: `INT_MIN div -1`, `LONG_MIN div 1`, and `DECIMAL(19,0)` operands (which wrap around even in ANSI mode, matching Spark)

Also ran the full `CometSqlFileTestSuite` (427 tests) and the `div`-related tests in `CometExpressionSuite`, plus `cargo clippy --all-targets --workspace -- -D warnings`.
