### PR TITLE
docs: teach audit/review skills the recurring findings from recent reviews [WIP]

### DIFF
--- a/.claude/skills/audit-comet-expression/SKILL.md
+++ b/.claude/skills/audit-comet-expression/SKILL.md
@@ -374,62 +374,74 @@ Also review the Comet implementation (Step 3) against the Spark behavior (Step 1
 The Spark-behaviour matrix above catches missing SQL-level coverage.
 This checklist catches missing unit coverage in the Rust
 implementation: cases where the tests pass but a targeted regression
-in the new code path would still pass. Every item that is not covered
-must either be added as a Rust unit test in the same file or explicitly
-justified as N/A.
+in the new code path would still pass.
+
+Split into general items that apply to any Rust expression change and
+performance items that apply only when the audit was triggered by a
+native fast path, overflow-sensitive cast, arithmetic kernel, or
+buffer-sizing change. Skip the performance subsection if the audited
+expression has no fast/slow path split and no numeric overflow
+behaviour. Do not manufacture a finding just because the checklist
+lists the item.
+
+**General**
 
 1. **All eval modes exercised.** `EvalMode::Legacy`, `EvalMode::Try`,
    and `EvalMode::Ansi` are separate code paths for cast, arithmetic,
    and overflow-sensitive expressions. A test that only covers Legacy
-   does not cover ANSI. Do not accept "the code path is shared" without
-   reading the branch and confirming it.
-2. **Fast path AND fallback each hit at least once.** Any `if` that
-   selects between an i64 fast path and an i128 fallback (or a
-   dictionary fast path and a general fallback, or an ASCII fast path
-   and a Unicode fallback) needs at least one input that lands on each
-   arm. A test whose inputs all fit in the fast path would silently
-   pass if the fallback regressed.
-3. **Boundary values.** Exact bounds (`10^p - 1` fits, `10^p`
-   overflows), `i64::MAX ± 1` for i64→i128 fast paths, the 38→39 digit
-   boundary for decimal, leap-day / month-end boundaries for date. If
-   the code names a threshold, one test hits it and one straddles it.
-4. **Positive AND negative overflow.** Do not accept a test that only
-   overflows on the positive side when an underflow path exists. This
-   is a recurring failure mode when overflow error text uses a
-   substring like "too large" that only matches one direction.
-5. **NaN, +Infinity, -Infinity** for every float→X cast, in every
-   eval mode. These are distinct code paths from finite overflow.
-6. **All-null, all-valid, all-invalid batches, plus a mixed batch.**
+   does not cover ANSI. Do not accept "the code path is shared"
+   without reading the branch and confirming it.
+2. **All-null, all-valid, all-invalid batches, plus a mixed batch.**
    The all-empty case is where `iter().all(...)` returns `true` on an
    empty iterator and a "nothing overflows" fast path claims success
-   trivially. The all-invalid case is where the slow path must run for
-   every row.
-7. **First-offender ordering.** If the error message reports the
-   "first offending value" in row order, include a batch with two
-   different-looking offenders and assert the first is reported. A
-   test with a single offender cannot distinguish "reports first" from
-   "reports any".
-8. **Error assertion depth.** On ANSI and try-cast paths, match on the
-   exact `SparkError` variant and assert every field (`value`,
+   trivially. The all-invalid case is where the slow path must run
+   for every row.
+3. **Error assertion depth.** On ANSI and try-cast paths, match on
+   the exact `SparkError` variant and assert every field (`value`,
    `precision`, `scale`, `from_type`, `to_type`). Never accept a bare
    `assert!(result.is_err())`. A regression that returned the wrong
-   variant, the wrong value, or a stringified default would still pass.
-9. **Multi-limb / wide-value coverage for i128 code.** Include values
-   that straddle both 64-bit halves and at least one where the low
-   half has leading zeros the formatter must emit. Small-value tests
-   never exercise the wide formatting path.
-10. **Fuzz-suite reach check.** If the coverage argument is "the Scala
-    fuzz suite exercises this", open the generator (e.g.
+   variant, the wrong value, or a stringified default would still
+   pass.
+4. **Load-bearing invariants documented.** Any code that relies on an
+   unchecked cast (`x as i32`), a specific IPC/format version, or a
+   caller-side precondition must have either a `debug_assert!` at
+   the enforcement point or a one-line comment naming the invariant.
+
+**Performance-specific (native fast paths, overflow, buffers)**
+
+5. **Fast path AND fallback each hit at least once.** Any `if` that
+   selects between an i64 fast path and an i128 fallback (or a
+   dictionary fast path and a general fallback, or an ASCII fast
+   path and a Unicode fallback) needs at least one input that lands
+   on each arm. A test whose inputs all fit in the fast path would
+   silently pass if the fallback regressed.
+6. **Boundary values.** Exact bounds (`10^p - 1` fits, `10^p`
+   overflows), `i64::MAX ± 1` for i64→i128 fast paths, the 38→39
+   digit boundary for decimal, leap-day / month-end boundaries for
+   date. If the code names a threshold, one test hits it and one
+   straddles it.
+7. **Positive AND negative overflow.** Do not accept a test that
+   only overflows on the positive side when an underflow path
+   exists. This is a recurring failure mode when overflow error text
+   uses a substring like "too large" that only matches one
+   direction.
+8. **NaN, +Infinity, -Infinity** for every float→X cast, in every
+   eval mode. These are distinct code paths from finite overflow.
+9. **First-offender ordering.** If the error message reports the
+   "first offending value" in row order, include a batch with two
+   different-looking offenders and assert the first is reported. A
+   test with a single offender cannot distinguish "reports first"
+   from "reports any".
+10. **Multi-limb / wide-value coverage for i128 code.** Include
+    values that straddle both 64-bit halves and at least one where
+    the low half has leading zeros the formatter must emit.
+    Small-value tests never exercise the wide formatting path.
+11. **Fuzz-suite reach check.** If the coverage argument is "the
+    Scala fuzz suite exercises this", open the generator (e.g.
     `CometCastSuite.scala`) and confirm it actually generates values
     that reach the new branch. Fuzz generators frequently cap at
     exactly the boundary you care about (e.g. digit count ≤ 38), so
     they never hit the code path they appear to cover.
-11. **Load-bearing invariants documented.** Any fast path that relies
-    on an unchecked cast (`x as i32`), a specific IPC/format version,
-    or "previous row finalized" state must have either a
-    `debug_assert!` at the enforcement point or a one-line comment
-    naming the invariant. A future edit that violates the invariant
-    should not be able to slip past review.
 
 ### Support-level consistency audit
 

--- a/.claude/skills/audit-comet-expression/SKILL.md
+++ b/.claude/skills/audit-comet-expression/SKILL.md
@@ -369,6 +369,68 @@ Also review the Comet implementation (Step 3) against the Spark behavior (Step 1
 - Are there behavioral differences between Spark versions that the Comet implementation does not account for (missing shim)?
 - Does the Rust implementation match the Spark behavior for all edge cases?
 
+### Rust-side test-hygiene checklist
+
+The Spark-behaviour matrix above catches missing SQL-level coverage.
+This checklist catches missing unit coverage in the Rust
+implementation: cases where the tests pass but a targeted regression
+in the new code path would still pass. Every item that is not covered
+must either be added as a Rust unit test in the same file or explicitly
+justified as N/A.
+
+1. **All eval modes exercised.** `EvalMode::Legacy`, `EvalMode::Try`,
+   and `EvalMode::Ansi` are separate code paths for cast, arithmetic,
+   and overflow-sensitive expressions. A test that only covers Legacy
+   does not cover ANSI. Do not accept "the code path is shared" without
+   reading the branch and confirming it.
+2. **Fast path AND fallback each hit at least once.** Any `if` that
+   selects between an i64 fast path and an i128 fallback (or a
+   dictionary fast path and a general fallback, or an ASCII fast path
+   and a Unicode fallback) needs at least one input that lands on each
+   arm. A test whose inputs all fit in the fast path would silently
+   pass if the fallback regressed.
+3. **Boundary values.** Exact bounds (`10^p - 1` fits, `10^p`
+   overflows), `i64::MAX ± 1` for i64→i128 fast paths, the 38→39 digit
+   boundary for decimal, leap-day / month-end boundaries for date. If
+   the code names a threshold, one test hits it and one straddles it.
+4. **Positive AND negative overflow.** Do not accept a test that only
+   overflows on the positive side when an underflow path exists. This
+   is a recurring failure mode when overflow error text uses a
+   substring like "too large" that only matches one direction.
+5. **NaN, +Infinity, -Infinity** for every float→X cast, in every
+   eval mode. These are distinct code paths from finite overflow.
+6. **All-null, all-valid, all-invalid batches, plus a mixed batch.**
+   The all-empty case is where `iter().all(...)` returns `true` on an
+   empty iterator and a "nothing overflows" fast path claims success
+   trivially. The all-invalid case is where the slow path must run for
+   every row.
+7. **First-offender ordering.** If the error message reports the
+   "first offending value" in row order, include a batch with two
+   different-looking offenders and assert the first is reported. A
+   test with a single offender cannot distinguish "reports first" from
+   "reports any".
+8. **Error assertion depth.** On ANSI and try-cast paths, match on the
+   exact `SparkError` variant and assert every field (`value`,
+   `precision`, `scale`, `from_type`, `to_type`). Never accept a bare
+   `assert!(result.is_err())`. A regression that returned the wrong
+   variant, the wrong value, or a stringified default would still pass.
+9. **Multi-limb / wide-value coverage for i128 code.** Include values
+   that straddle both 64-bit halves and at least one where the low
+   half has leading zeros the formatter must emit. Small-value tests
+   never exercise the wide formatting path.
+10. **Fuzz-suite reach check.** If the coverage argument is "the Scala
+    fuzz suite exercises this", open the generator (e.g.
+    `CometCastSuite.scala`) and confirm it actually generates values
+    that reach the new branch. Fuzz generators frequently cap at
+    exactly the boundary you care about (e.g. digit count ≤ 38), so
+    they never hit the code path they appear to cover.
+11. **Load-bearing invariants documented.** Any fast path that relies
+    on an unchecked cast (`x as i32`), a specific IPC/format version,
+    or "previous row finalized" state must have either a
+    `debug_assert!` at the enforcement point or a one-line comment
+    naming the invariant. A future edit that violates the invariant
+    should not be able to slip past review.
+
 ### Support-level consistency audit
 
 Walk through this checklist against the serde. Each failed item is a

--- a/.claude/skills/review-comet-pr/SKILL.md
+++ b/.claude/skills/review-comet-pr/SKILL.md
@@ -288,27 +288,25 @@ If the PR adds a new expression but does not update `expressions.md`, flag that.
 
 ### 8. Recurring Review Checks
 
-These ten checks encode the most frequent findings by senior Comet
-reviewers on recent perf/correctness PRs. Run through them explicitly
-on every non-trivial diff. Anything that fires here goes into the
-review; anything that doesn't, drop.
+These checks encode the most frequent findings senior Comet reviewers
+make on real PRs. They are split into checks that apply to almost any
+non-trivial diff and checks that only apply when the PR touches native
+performance code (Rust perf, cast, arithmetic, overflow, buffer
+sizing, criterion benchmarks). Skip a section that does not match the
+diff. A checklist item that does not match the diff is not a finding.
+Do not manufacture one to fill the list.
+
+#### 8a. General checks (any non-trivial PR)
 
 1. **Diff-branch test coverage.** For every added branch (new `if`,
-   new `match` arm, new fast path, new eval-mode arm), locate the test
-   that would fail if _that specific branch_ regressed. If the
-   pre-existing tests still pass without touching the new branch, that
-   branch is untested. This is the single most common missing item.
-   The ANSI/Try/Legacy arms are independent code paths — a Legacy test
-   does not cover ANSI.
+   new `match` arm, new eval-mode arm), locate the test that would
+   fail if _that specific branch_ regressed. If the pre-existing
+   tests still pass without touching the new branch, that branch is
+   untested. This is the single most common missing item. ANSI, Try,
+   and Legacy arms are independent code paths — a Legacy test does
+   not cover ANSI.
 
-2. **Fast path AND fallback each hit.** When a PR adds an i64 fast
-   path with an i128 fallback (or ASCII fast path with Unicode
-   fallback, dictionary fast path with general fallback, etc.),
-   confirm at least one test input lands on each arm. A test suite
-   whose inputs all fit in the fast path would still pass if the
-   fallback returned wrong answers.
-
-3. **Error assertion depth.** For ANSI / try-cast / overflow paths, do
+2. **Error assertion depth.** For ANSI / try-cast / overflow paths, do
    not accept `assert!(result.is_err())`. Require matching on the
    exact `SparkError` variant and asserting every field (`value`,
    `precision`, `scale`, `from_type`, `to_type`). Also check
@@ -316,7 +314,7 @@ review; anything that doesn't, drop.
    `"too large"` in `find(...)`, negative overflow may fall through to
    an `.unwrap_or(0)` and report the wrong value.
 
-4. **Comment / code alignment.** Read every added or modified comment
+3. **Comment / code alignment.** Read every added or modified comment
    and confirm it names the correct method (`.any(...)` vs
    `.contains(...)`), states the correct Spark behavior (e.g. does
    Spark actually return NULL for `2020-02-30` or throw?), references
@@ -325,15 +323,41 @@ review; anything that doesn't, drop.
    single-partition output shape actually changed). A comment that
    drifts from the code is a review finding.
 
-5. **Sibling call sites.** For any fix or optimization applied to one
-   helper, grep for structurally identical siblings. Common families:
-   `date_trunc` / `timestamp_trunc` / `timestamp_trunc_ntz`, the
-   scalar and array variants of the same helper, `to_uppercase` /
-   `eq_ignore_ascii_case` in temporal code. Either fold the sibling
-   into the PR or require a follow-up issue linked from the PR body.
-   Do not accept "we can do the others later" without an issue number.
+4. **Sibling call sites.** For a fix applied to one helper, grep for
+   structurally identical siblings before approving. Common families:
+   `date_trunc` / `timestamp_trunc` / `timestamp_trunc_ntz`, scalar
+   and array variants of the same helper, `to_uppercase` /
+   `eq_ignore_ascii_case` in temporal code. Do this only when the fix
+   is a pattern likely to recur, not on every one-line change. If
+   siblings exist, fold them in or require a follow-up issue linked
+   from the PR body. Do not accept "we can do the others later"
+   without an issue number.
 
-6. **Upstream API first.** Before accepting a hand-rolled helper
+5. **Load-bearing invariants have a `debug_assert!` or a comment.**
+   When correctness depends on an unchecked cast (`x as i32`), a
+   specific IPC/format version (`MetadataVersion::V5`), a
+   finalization step earlier in the loop (`append_value("")` on the
+   null branch), or a caller-side precondition, either
+   `debug_assert!` the invariant at the enforcement point or leave a
+   one-line comment naming it. A future edit that silently violates
+   the invariant should not slip past review.
+
+#### 8b. Native performance PR checks
+
+Only apply this subsection when the PR adds a fast path, tunes a
+buffer size, adds or edits a criterion benchmark, or claims a
+speed-up. On non-perf PRs (serde changes, planner rules, docs,
+Scala-only changes), skip it. A finding here should tie to something
+the diff actually introduced.
+
+1. **Fast path AND fallback each hit.** When a PR adds an i64 fast
+   path with an i128 fallback (or ASCII fast path with Unicode
+   fallback, dictionary fast path with general fallback), confirm at
+   least one test input lands on each arm. A test suite whose inputs
+   all fit in the fast path would still pass if the fallback returned
+   wrong answers.
+
+2. **Upstream API first.** Before accepting a hand-rolled helper
    (dictionary detection, integer-to-string formatting, ASCII case
    folding, schema flattening), grep arrow-rs and std for an existing
    equivalent. Recent hits: `Schema::flattened_fields()`, `write!` on
@@ -343,7 +367,7 @@ review; anything that doesn't, drop.
    `&dyn Fn` and one `impl Fn`, and callers should not pass `&f` to
    an `impl Fn` parameter.
 
-7. **Capacity hints and worst-case reasoning.** Any
+3. **Capacity hints and worst-case reasoning.** Any
    `with_capacity(rows * K)` or arithmetic like `4 * n.div_ceil(3) + n`
    needs three checks: (a) `K` matches arrow-rs's own defaults where
    they exist (e.g. `AVERAGE_STRING_LENGTH = 16` for string buffers),
@@ -352,7 +376,7 @@ review; anything that doesn't, drop.
    arithmetic (`+ num_rows` is not needed on top of `div_ceil`).
    Over-provisioning by 3x on the common path is a real cost.
 
-8. **Benchmark integrity.** For any new Criterion benchmark, confirm:
+4. **Benchmark integrity.** For any new Criterion benchmark, confirm:
    (a) the `group/function` name is unique across `benches/` — two
    benches with the same name silently clobber each other's
    `target/criterion/...` baseline directory; (b) RNGs are seeded
@@ -361,31 +385,15 @@ review; anything that doesn't, drop.
    description actually exists as committed code — hallucinated bench
    names in perf PR descriptions are a recurring pattern; (d) the
    default (non-fast-path) case is measured before and after so the
-   claim is evidence-based.
+   claim is evidence-based, not just the case the fast path targets.
 
-9. **Panic-safety of new helpers.** Table lookups with arithmetic
+5. **Panic-safety of new helpers.** Table lookups with arithmetic
    fallbacks (e.g. `POW10_I128.get(exp).copied().unwrap_or_else(||
    10_i128.pow(exp))`) must be total across all inputs the caller can
    actually reach. Trace every call site and confirm the argument is
    bounded before the call. `10_i128.pow(40)` panics in debug and
    wraps in release. `n.checked_mul(k).unwrap()` at the top of a hot
    loop is not exception-safe.
-
-10. **Load-bearing invariants have a `debug_assert!` or a comment.**
-    When correctness depends on an unchecked cast (`x as i32`), a
-    specific IPC/format version (`MetadataVersion::V5`), a
-    finalization step earlier in the loop (`append_value("")` on the
-    null branch), or a caller-side precondition, either
-    `debug_assert!` the invariant at the enforcement point or leave a
-    one-line comment naming it. A future edit that silently violates
-    the invariant should not slip past review.
-
-Style tells to strip from Claude-authored diffs before requesting
-merge: `**bold**` and ALL-CAPS emphasis inside code comments;
-fully-qualified names in place of `use` imports; multi-sentence
-docstrings on trivial helpers. These are cosmetic but they are
-consistent enough to be recognizable as machine-authored, and
-reviewers flag them.
 
 ### 9. Common Comet Review Issues
 

--- a/.claude/skills/review-comet-pr/SKILL.md
+++ b/.claude/skills/review-comet-pr/SKILL.md
@@ -286,7 +286,108 @@ See `docs/source/contributor-guide/adding_a_new_expression.md` (sections "Docume
 
 If the PR adds a new expression but does not update `expressions.md`, flag that. If it touches incompatibility behavior, flag that the serde reasons should reflect the change.
 
-### 8. Common Comet Review Issues
+### 8. Recurring Review Checks
+
+These ten checks encode the most frequent findings by senior Comet
+reviewers on recent perf/correctness PRs. Run through them explicitly
+on every non-trivial diff. Anything that fires here goes into the
+review; anything that doesn't, drop.
+
+1. **Diff-branch test coverage.** For every added branch (new `if`,
+   new `match` arm, new fast path, new eval-mode arm), locate the test
+   that would fail if _that specific branch_ regressed. If the
+   pre-existing tests still pass without touching the new branch, that
+   branch is untested. This is the single most common missing item.
+   The ANSI/Try/Legacy arms are independent code paths — a Legacy test
+   does not cover ANSI.
+
+2. **Fast path AND fallback each hit.** When a PR adds an i64 fast
+   path with an i128 fallback (or ASCII fast path with Unicode
+   fallback, dictionary fast path with general fallback, etc.),
+   confirm at least one test input lands on each arm. A test suite
+   whose inputs all fit in the fast path would still pass if the
+   fallback returned wrong answers.
+
+3. **Error assertion depth.** For ANSI / try-cast / overflow paths, do
+   not accept `assert!(result.is_err())`. Require matching on the
+   exact `SparkError` variant and asserting every field (`value`,
+   `precision`, `scale`, `from_type`, `to_type`). Also check
+   sign-symmetry: if the overflow-error path uses a substring like
+   `"too large"` in `find(...)`, negative overflow may fall through to
+   an `.unwrap_or(0)` and report the wrong value.
+
+4. **Comment / code alignment.** Read every added or modified comment
+   and confirm it names the correct method (`.any(...)` vs
+   `.contains(...)`), states the correct Spark behavior (e.g. does
+   Spark actually return NULL for `2020-02-30` or throw?), references
+   config keys that still exist after any rename in the same PR, and
+   does not overclaim invariants ("output identical to before" when
+   single-partition output shape actually changed). A comment that
+   drifts from the code is a review finding.
+
+5. **Sibling call sites.** For any fix or optimization applied to one
+   helper, grep for structurally identical siblings. Common families:
+   `date_trunc` / `timestamp_trunc` / `timestamp_trunc_ntz`, the
+   scalar and array variants of the same helper, `to_uppercase` /
+   `eq_ignore_ascii_case` in temporal code. Either fold the sibling
+   into the PR or require a follow-up issue linked from the PR body.
+   Do not accept "we can do the others later" without an issue number.
+
+6. **Upstream API first.** Before accepting a hand-rolled helper
+   (dictionary detection, integer-to-string formatting, ASCII case
+   folding, schema flattening), grep arrow-rs and std for an existing
+   equivalent. Recent hits: `Schema::flattened_fields()`, `write!` on
+   a `String` for integer formatting, arrow-rs
+   `AVERAGE_STRING_LENGTH`. Also flag Rust monomorphization
+   asymmetries: paired helpers should both take `impl Fn`, not one
+   `&dyn Fn` and one `impl Fn`, and callers should not pass `&f` to
+   an `impl Fn` parameter.
+
+7. **Capacity hints and worst-case reasoning.** Any
+   `with_capacity(rows * K)` or arithmetic like `4 * n.div_ceil(3) + n`
+   needs three checks: (a) `K` matches arrow-rs's own defaults where
+   they exist (e.g. `AVERAGE_STRING_LENGTH = 16` for string buffers),
+   (b) the value is the true worst case for the encoding used, and
+   (c) any comment justifying the formula matches the actual
+   arithmetic (`+ num_rows` is not needed on top of `div_ceil`).
+   Over-provisioning by 3x on the common path is a real cost.
+
+8. **Benchmark integrity.** For any new Criterion benchmark, confirm:
+   (a) the `group/function` name is unique across `benches/` — two
+   benches with the same name silently clobber each other's
+   `target/criterion/...` baseline directory; (b) RNGs are seeded
+   (`StdRng::seed_from_u64(...)`), never `rand::random`, so numbers
+   are reproducible; (c) every benchmark mentioned in the PR
+   description actually exists as committed code — hallucinated bench
+   names in perf PR descriptions are a recurring pattern; (d) the
+   default (non-fast-path) case is measured before and after so the
+   claim is evidence-based.
+
+9. **Panic-safety of new helpers.** Table lookups with arithmetic
+   fallbacks (e.g. `POW10_I128.get(exp).copied().unwrap_or_else(||
+   10_i128.pow(exp))`) must be total across all inputs the caller can
+   actually reach. Trace every call site and confirm the argument is
+   bounded before the call. `10_i128.pow(40)` panics in debug and
+   wraps in release. `n.checked_mul(k).unwrap()` at the top of a hot
+   loop is not exception-safe.
+
+10. **Load-bearing invariants have a `debug_assert!` or a comment.**
+    When correctness depends on an unchecked cast (`x as i32`), a
+    specific IPC/format version (`MetadataVersion::V5`), a
+    finalization step earlier in the loop (`append_value("")` on the
+    null branch), or a caller-side precondition, either
+    `debug_assert!` the invariant at the enforcement point or leave a
+    one-line comment naming it. A future edit that silently violates
+    the invariant should not slip past review.
+
+Style tells to strip from Claude-authored diffs before requesting
+merge: `**bold**` and ALL-CAPS emphasis inside code comments;
+fully-qualified names in place of `use` imports; multi-sentence
+docstrings on trivial helpers. These are cosmetic but they are
+consistent enough to be recognizable as machine-authored, and
+reviewers flag them.
+
+### 9. Common Comet Review Issues
 
 1. **Incomplete type support**: Spark expression supports types not handled in PR
 2. **Missing edge cases**: Null, overflow, empty string, negative values


### PR DESCRIPTION
## Summary

Encode the ~10 recurring patterns that senior reviewers catch on Comet perf/correctness PRs into the `audit-comet-expression` and `review-comet-pr` skills, so contributors and reviewers can catch these locally before human review.

Findings were derived by sweeping mbutrovich's review comments across ~50 andygrove PRs merged in the past 4 weeks and clustering the substantive feedback by theme.

## What changed

**`audit-comet-expression`** — new "Rust-side test-hygiene checklist" (11 items) after the implementation-gaps section:

- All eval modes (`Legacy`, `Try`, `Ansi`) exercised independently
- Fast path AND fallback each hit by at least one input
- Boundary values (`10^p - 1` vs `10^p`, `i64::MAX ± 1`, 38→39 digits, leap-day)
- Positive AND negative overflow (guards against sign-asymmetric error text like `"too large"`)
- NaN, +Inf, -Inf per eval mode
- All-null / all-valid / all-invalid batches (`iter().all()` on empty)
- First-offender ordering (batches with two different-looking offenders)
- Error assertion depth: match on exact `SparkError` variant and all fields, never bare `is_err()`
- Multi-limb / wide-value coverage for `i128` code
- Fuzz-suite reach check (confirm the Scala generator actually reaches the new branch, e.g. digit-count cap)
- Load-bearing invariants documented with `debug_assert!` or a comment

**`review-comet-pr`** — new section 8 "Recurring Review Checks" with 10 numbered items, each tied to a real recent finding:

1. Diff-branch test coverage
2. Fast path AND fallback each hit
3. Error-assertion depth + sign symmetry
4. Comment / code alignment
5. Sibling call sites (fold in or file a linked follow-up)
6. Upstream arrow-rs / std API first; watch for `&dyn Fn` vs `impl Fn` asymmetry
7. Capacity hints vs `AVERAGE_STRING_LENGTH`, watch redundant headroom
8. Benchmark integrity (unique names, seeded RNG, no hallucinated benches, default-case measurement)
9. Panic-safety of table-lookup helpers (`10_i128.pow(40)` panics/wraps)
10. `debug_assert!` or comment for load-bearing invariants

Plus a short "style tells to strip from Claude-authored diffs" note (`**bold**`, ALL-CAPS emphasis in comments, FQNs instead of `use`).

## Test plan

- [ ] Docs-only change to skills under `.claude/skills/`; no runtime impact
- [ ] Skill files still parse (frontmatter unchanged)