### PR TITLE
chore: [branch-1.0] change version from 1.0.0-SNAPSHOT to 1.0.0

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -26,7 +26,7 @@ under the License.
   <parent>
     <groupId>org.apache.datafusion</groupId>
     <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dev/diffs/3.4.3.diff
+++ b/dev/diffs/3.4.3.diff
@@ -7,7 +7,7 @@ index d3544881af1..ff963395ec3 100644
      <ivy.version>2.5.1</ivy.version>
      <oro.version>2.0.8</oro.version>
 +    <spark.version.short>3.4</spark.version.short>
-+    <comet.version>1.0.0-SNAPSHOT</comet.version>
++    <comet.version>1.0.0</comet.version>
      <!--
      If you changes codahale.metrics.version, you also need to change
      the link to metrics.dropwizard.io in docs/monitoring.md.

--- a/dev/diffs/3.5.8.diff
+++ b/dev/diffs/3.5.8.diff
@@ -7,7 +7,7 @@ index edd2ad57880..45f8fd01538 100644
      <ivy.version>2.5.1</ivy.version>
      <oro.version>2.0.8</oro.version>
 +    <spark.version.short>3.5</spark.version.short>
-+    <comet.version>1.0.0-SNAPSHOT</comet.version>
++    <comet.version>1.0.0</comet.version>
      <!--
      If you changes codahale.metrics.version, you also need to change
      the link to metrics.dropwizard.io in docs/monitoring.md.

--- a/dev/diffs/4.0.2.diff
+++ b/dev/diffs/4.0.2.diff
@@ -47,7 +47,7 @@ index 252cfdf9073..50ec9d6314e 100644
      <ivy.version>2.5.3</ivy.version>
      <oro.version>2.0.8</oro.version>
 +    <spark.version.short>4.0</spark.version.short>
-+    <comet.version>1.0.0-SNAPSHOT</comet.version>
++    <comet.version>1.0.0</comet.version>
      <!--
      If you change codahale.metrics.version, you also need to change
      the link to metrics.dropwizard.io in docs/monitoring.md.

--- a/dev/diffs/4.1.2.diff
+++ b/dev/diffs/4.1.2.diff
@@ -47,7 +47,7 @@ index dc201151999..20ee0e7482a 100644
      <ivy.version>2.5.3</ivy.version>
      <oro.version>2.0.8</oro.version>
 +    <spark.version.short>4.1</spark.version.short>
-+    <comet.version>1.0.0-SNAPSHOT</comet.version>
++    <comet.version>1.0.0</comet.version>
      <!--
      If you change codahale.metrics.version, you also need to change
      the link to metrics.dropwizard.io in docs/monitoring.md.

--- a/dev/diffs/iceberg/1.10.0.diff
+++ b/dev/diffs/iceberg/1.10.0.diff
@@ -7,7 +7,7 @@ index eeabe54f5f..a76d7bdcbc 100644
  caffeine = "2.9.3"
  calcite = "1.40.0"
 -comet = "0.8.1"
-+comet = "1.0.0-SNAPSHOT"
++comet = "1.0.0"
  datasketches = "6.2.0"
  delta-standalone = "3.3.2"
  delta-spark = "3.3.2"

--- a/dev/diffs/iceberg/1.11.0.diff
+++ b/dev/diffs/iceberg/1.11.0.diff
@@ -6,7 +6,7 @@ index db659dc06b..78f5e3440f 100644
  bson-ver = "4.11.5"
  caffeine = "2.9.3"
  calcite = "1.41.0"
-+comet = "1.0.0-SNAPSHOT"
++comet = "1.0.0"
  datasketches = "6.2.0"
  delta-standalone = "3.3.2"
  delta-spark = "3.3.2"

--- a/dev/diffs/iceberg/1.8.1.diff
+++ b/dev/diffs/iceberg/1.8.1.diff
@@ -6,7 +6,7 @@ index 04ffa8f4ed..5a925fd594 100644
  awssdk-s3accessgrants = "2.3.0"
  caffeine = "2.9.3"
  calcite = "1.10.0"
-+comet = "1.0.0-SNAPSHOT"
++comet = "1.0.0"
  datasketches = "6.2.0"
  delta-standalone = "3.3.0"
  delta-spark = "3.3.0"

--- a/dev/diffs/iceberg/1.9.1.diff
+++ b/dev/diffs/iceberg/1.9.1.diff
@@ -6,7 +6,7 @@ index c50991c5fc..2892f11068 100644
  bson-ver = "4.11.5"
  caffeine = "2.9.3"
  calcite = "1.39.0"
-+comet = "1.0.0-SNAPSHOT"
++comet = "1.0.0"
  datasketches = "6.2.0"
  delta-standalone = "3.3.1"
  delta-spark = "3.3.1"

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ under the License.
   </parent>
   <groupId>org.apache.datafusion</groupId>
   <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>pom</packaging>
   <name>Comet Project Parent POM</name>
 

--- a/spark-integration/pom.xml
+++ b/spark-integration/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.datafusion</groupId>
         <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -26,7 +26,7 @@ under the License.
   <parent>
     <groupId>org.apache.datafusion</groupId>
     <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/spark/src/test/resources/pyspark/conftest.py
+++ b/spark/src/test/resources/pyspark/conftest.py
@@ -56,14 +56,20 @@ def resolve_comet_jar() -> str:
     major_minor = ".".join(pyspark.__version__.split(".")[:2])
     spark_tag = f"spark{major_minor}"
     scala_tag = "_2.12" if major_minor.startswith("3.") else "_2.13"
+    # Match any version suffix, not just `-SNAPSHOT`: on a release branch the
+    # Maven version is the final release version (e.g. `1.0.0`) with no
+    # `-SNAPSHOT` qualifier.
     pattern = os.path.join(
         REPO_ROOT,
-        f"spark/target/comet-spark-{spark_tag}{scala_tag}-*-SNAPSHOT.jar",
+        f"spark/target/comet-spark-{spark_tag}{scala_tag}-*.jar",
     )
     candidates = [
         m
         for m in sorted(glob.glob(pattern))
-        if "sources" not in os.path.basename(m) and "tests" not in os.path.basename(m)
+        if not any(
+            tag in os.path.basename(m)
+            for tag in ("sources", "tests", "javadoc", "shaded")
+        )
     ]
     if not candidates:
         raise FileNotFoundError(


### PR DESCRIPTION
## Which issue does this PR close?

N/A - this is a release process step for the 1.0.0 release.

## Rationale for this change

The [release process](https://github.com/apache/datafusion-comet/blob/main/docs/source/contributor-guide/release_process.md#update-maven-version) requires that the Maven version on the release branch is changed from `1.0.0-SNAPSHOT` to `1.0.0` before the release candidate is tagged, so that the staged Maven artifacts and the source tarball carry the final release version.

## What changes are included in this PR?

- Change the Maven version from `1.0.0-SNAPSHOT` to `1.0.0` in `pom.xml`, `common/pom.xml`, `spark/pom.xml`, and `spark-integration/pom.xml`.
- Update `comet.version` in the Spark test diffs (`dev/diffs/3.4.3.diff`, `3.5.8.diff`, `4.0.2.diff`, `4.1.2.diff`).
- Update the `comet` version in the Iceberg diffs (`dev/diffs/iceberg/1.8.1.diff`, `1.9.1.diff`, `1.10.0.diff`, `1.11.0.diff`).

The Rust crate versions are already `1.0.0` and do not need to change.

## How are these changes tested?

Existing CI. The Spark SQL and Iceberg test workflows apply the updated diffs and build against the new version, so they cover the version references in both the poms and the diff files.
