### PR TITLE
fix: resolve Comet jar without hardcoding the SNAPSHOT qualifier

### DIFF
--- a/benchmarks/pyspark/run_all_benchmarks.sh
+++ b/benchmarks/pyspark/run_all_benchmarks.sh
@@ -25,10 +25,17 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DATA_PATH="${1:-/tmp/shuffle-benchmark-data}"
-COMET_JAR="${COMET_JAR:-$SCRIPT_DIR/../../spark/target/comet-spark-spark3.5_2.12-0.14.0-SNAPSHOT.jar}"
+# Resolve the built jar without hardcoding the version, which changes every
+# development cycle and drops the `-SNAPSHOT` qualifier on release branches.
+COMET_JAR="${COMET_JAR:-$(ls "$SCRIPT_DIR"/../../spark/target/comet-spark-spark3.5_2.12-*.jar 2>/dev/null | grep -v -e sources -e tests | tail -1)}"
 SPARK_MASTER="${SPARK_MASTER:-local[*]}"
 EXECUTOR_MEMORY="${EXECUTOR_MEMORY:-16g}"
 EVENT_LOG_DIR="${EVENT_LOG_DIR:-/tmp/spark-events}"
+
+if [ ! -f "$COMET_JAR" ]; then
+  echo "Comet jar not found. Set COMET_JAR or run 'make release'." >&2
+  exit 1
+fi
 
 # Create event log directory
 mkdir -p "$EVENT_LOG_DIR"

--- a/benchmarks/tpc/infra/docker/Dockerfile.build-comet
+++ b/benchmarks/tpc/infra/docker/Dockerfile.build-comet
@@ -73,4 +73,4 @@ RUN make release-nogit
 
 # The entrypoint copies the built JAR to /output (bind-mounted from host).
 RUN mkdir -p /output
-CMD ["sh", "-c", "cp spark/target/comet-spark-spark3.5_2.12-*-SNAPSHOT.jar /output/ && echo 'Comet JAR copied to /output/' && ls -lh /output/*.jar"]
+CMD ["sh", "-c", "cp spark/target/comet-spark-spark3.5_2.12-*.jar /output/ && echo 'Comet JAR copied to /output/' && ls -lh /output/*.jar"]

--- a/docs/source/contributor-guide/release_process.md
+++ b/docs/source/contributor-guide/release_process.md
@@ -142,18 +142,35 @@ targeting the release branch.
 
 ### Update Maven Version
 
-Open a PR targeting the release branch that changes the Maven version from `0.13.0-SNAPSHOT` to `0.13.0` in
-the `pom.xml` files and in the diff files under `dev/diffs`.
+Open a PR targeting the release branch that changes the Maven version from `0.13.0-SNAPSHOT` to `0.13.0` in:
+
+- the `pom.xml` files: `pom.xml`, `common/pom.xml`, `spark/pom.xml`, and `spark-integration/pom.xml`
+- the `<comet.version>` property in the Spark test diffs under `dev/diffs`
+- the `comet` version in the Iceberg test diffs under `dev/diffs/iceberg`, which use a Gradle version
+  catalog entry (`comet = "0.13.0"`) rather than a Maven property
 
 There is no need to update the Rust crate versions because they will already be `0.13.0`.
+
+Once the version is bumped, verify that no references to the old version remain:
+
+```shell
+git grep -n '0.13.0-SNAPSHOT' -- . ':!docs/source/changelog'
+```
+
+Any hit outside the change log is a place that will break on the release branch. Note that dropping the
+`-SNAPSHOT` qualifier changes the built artifact file names, so anything that locates the jar by glob must
+match a bare version too. Prefer patterns such as `comet-spark-spark3.5_2.12-*.jar` over
+`comet-spark-spark3.5_2.12-*-SNAPSHOT.jar`, and prefer resolving the jar by glob over hardcoding a version.
+The release branch runs the same CI workflows as `main`, including the PyArrow UDF tests, so a
+`-SNAPSHOT`-only glob in a test harness or script fails only after the release branch is cut.
 
 ### Update Version in main
 
 Create a PR against the main branch to prepare for developing the next release:
 
 - Update the Rust crate version to `0.14.0`.
-- Update the Maven version to `0.14.0-SNAPSHOT` (both in the `pom.xml` files and also in the diff files
-  under `dev/diffs`).
+- Update the Maven version to `0.14.0-SNAPSHOT` in the same set of files listed above (the `pom.xml` files,
+  the Spark test diffs under `dev/diffs`, and the Iceberg test diffs under `dev/diffs/iceberg`).
 
 ### Generate the Change Log
 

--- a/spark/src/test/resources/pyspark/conftest.py
+++ b/spark/src/test/resources/pyspark/conftest.py
@@ -56,14 +56,20 @@ def resolve_comet_jar() -> str:
     major_minor = ".".join(pyspark.__version__.split(".")[:2])
     spark_tag = f"spark{major_minor}"
     scala_tag = "_2.12" if major_minor.startswith("3.") else "_2.13"
+    # Match any version suffix, not just `-SNAPSHOT`: on a release branch the
+    # Maven version is the final release version (e.g. `1.0.0`) with no
+    # `-SNAPSHOT` qualifier.
     pattern = os.path.join(
         REPO_ROOT,
-        f"spark/target/comet-spark-{spark_tag}{scala_tag}-*-SNAPSHOT.jar",
+        f"spark/target/comet-spark-{spark_tag}{scala_tag}-*.jar",
     )
     candidates = [
         m
         for m in sorted(glob.glob(pattern))
-        if "sources" not in os.path.basename(m) and "tests" not in os.path.basename(m)
+        if not any(
+            tag in os.path.basename(m)
+            for tag in ("sources", "tests", "javadoc", "shaded")
+        )
     ]
     if not candidates:
         raise FileNotFoundError(


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

The PyArrow UDF test harness locates the built Comet jar with a glob that hardcodes the `-SNAPSHOT` qualifier:

```
spark/target/comet-spark-{spark_tag}{scala_tag}-*-SNAPSHOT.jar
```

On a release branch the Maven version is the final release version with no `-SNAPSHOT` qualifier, so the glob matches nothing and every PyArrow UDF test errors out with `FileNotFoundError: Comet jar not found`. This is what happened on the 1.0.0 release branch in #5105, where the PyArrow UDF jobs were the only failing checks. The release branch runs the same workflows as `main`, so this class of breakage only surfaces after the release branch is cut and the version is bumped.

Two benchmark helpers have the same problem: the TPC docker build copies `comet-spark-spark3.5_2.12-*-SNAPSHOT.jar` out of the container, and `run_all_benchmarks.sh` defaults `COMET_JAR` to a hardcoded `0.14.0-SNAPSHOT` path that is already stale.

## What changes are included in this PR?

- `spark/src/test/resources/pyspark/conftest.py`: match any version suffix rather than only `-SNAPSHOT`, and widen the artifact filter so sources/tests/javadoc/shaded jars are still excluded.
- `benchmarks/tpc/infra/docker/Dockerfile.build-comet`: drop `-SNAPSHOT` from the jar copy glob.
- `benchmarks/pyspark/run_all_benchmarks.sh`: resolve the default `COMET_JAR` by glob instead of a hardcoded version, and fail with a clear message when no jar is found.
- `docs/source/contributor-guide/release_process.md`: enumerate the files that carry the Maven version (including the Gradle version catalog entry in the Iceberg diffs, which uses a different syntax than the Maven property in the Spark diffs), add a `git grep` verification step after the bump, and note that jar globs must not assume a `-SNAPSHOT` suffix.

## How are these changes tested?

Existing CI. The PyArrow UDF workflow triggers on `conftest.py`, so it exercises the new resolution logic on `main`, where the version still carries `-SNAPSHOT`. The non-SNAPSHOT path is verified on the 1.0.0 release branch, where the same `conftest.py` change turns the previously failing PyArrow UDF jobs green in #5105.
