### PR TITLE
feat: support SampleExec natively for sampling without replacement

### DIFF
--- a/docs/source/contributor-guide/adding_a_new_operator.md
+++ b/docs/source/contributor-guide/adding_a_new_operator.md
@@ -138,7 +138,7 @@ For reference, see existing operators like `Filter` (simple), `HashAggregate` (c
 
 ### Step 2: Create a CometOperatorSerde Implementation
 
-Create a new Scala file in `spark/src/main/scala/org/apache/comet/serde/operator/` (e.g., `CometYourOperator.scala`) that extends `CometOperatorSerde[T]` where `T` is the Spark operator type.
+Create a new Scala file in `spark/src/main/scala/org/apache/spark/sql/comet/` (e.g., `CometYourOperatorExec.scala`) holding both the `CometOperatorSerde[T]` object, where `T` is the Spark operator type, and the `CometNativeExec` case class it creates. Scan and sink serdes live in `spark/src/main/scala/org/apache/comet/serde/operator/` instead.
 
 The `CometOperatorSerde` trait provides several key methods:
 

--- a/docs/source/user-guide/latest/compatibility/operators.md
+++ b/docs/source/user-guide/latest/compatibility/operators.md
@@ -26,11 +26,10 @@ Comet runs `SampleExec` natively when sampling is performed without replacement,
 reproduces Spark's per-row `XORShiftRandom` draw sequence, so for a given seed it selects the same
 rows as Spark.
 
-Because the sampler consumes one random value per row within a partition, it selects the same rows
-as Spark only when the rows reach it in the same order. Sampling directly above a scan, filter, or
-projection meets that condition. Sampling above an operator where Comet may emit rows in a
-different order than Spark, such as a join or an aggregate, still returns a valid sample of the
-same expected size, but not necessarily the same rows Spark would have selected.
+Because the sampler consumes one random value per row, sampling directly above a scan, filter, or
+projection reproduces Spark's selection. Above an operator where Comet may emit rows in a different
+order than Spark, such as a join or an aggregate, the result is still a valid sample of the same
+expected size, but not necessarily the same rows.
 
 Sampling with replacement (`df.sample(withReplacement = true, ...)`) falls back to Spark, because
 it draws from a Poisson distribution that Comet does not implement natively

--- a/docs/source/user-guide/latest/compatibility/operators.md
+++ b/docs/source/user-guide/latest/compatibility/operators.md
@@ -19,6 +19,23 @@ under the License.
 
 # Operator Compatibility
 
+## Sampling
+
+Comet runs `SampleExec` natively when sampling is performed without replacement, which covers
+`DataFrame.sample`, SQL `TABLESAMPLE`, and `DataFrame.randomSplit`. The native implementation
+reproduces Spark's per-row `XORShiftRandom` draw sequence, so for a given seed it selects the same
+rows as Spark.
+
+Because the sampler consumes one random value per row within a partition, it selects the same rows
+as Spark only when the rows reach it in the same order. Sampling directly above a scan, filter, or
+projection meets that condition. Sampling above an operator where Comet may emit rows in a
+different order than Spark, such as a join or an aggregate, still returns a valid sample of the
+same expected size, but not necessarily the same rows Spark would have selected.
+
+Sampling with replacement (`df.sample(withReplacement = true, ...)`) falls back to Spark, because
+it draws from a Poisson distribution that Comet does not implement natively
+([#5109](https://github.com/apache/datafusion-comet/issues/5109)).
+
 ## Window Functions
 
 Comet runs `WindowExec` natively and it is enabled by default (`spark.comet.exec.window.enabled`). A broad set of

--- a/docs/source/user-guide/latest/operators.md
+++ b/docs/source/user-guide/latest/operators.md
@@ -44,7 +44,7 @@ omitted from the tables below and may be reconsidered based on demand:
 
 - **Structured Streaming operators** (`StateStoreSaveExec`, `StateStoreRestoreExec`, `StreamingSymmetricHashJoinExec`, and similar): Comet targets batch execution.
 - **Cartesian / cross joins** (`CartesianProductExec`): rare and expensive, with little acceleration benefit.
-- **Sampling and range generation** (`SampleExec`, `RangeExec`): niche leaf operators.
+- **Range generation** (`RangeExec`): niche leaf operator.
 - **Pickled (non-Arrow) Python UDFs** (`BatchEvalPythonExec`): Comet accelerates Arrow-based Python UDFs only ([#4234](https://github.com/apache/datafusion-comet/pull/4234)).
 
 ## Scans
@@ -58,10 +58,11 @@ omitted from the tables below and may be reconsidered based on demand:
 
 ## Projection and filtering
 
-| Operator      | Status | Notes |
-| ------------- | ------ | ----- |
-| `ProjectExec` | ✅     |       |
-| `FilterExec`  | ✅     |       |
+| Operator      | Status | Notes                                                                                        |
+| ------------- | ------ | -------------------------------------------------------------------------------------------- |
+| `ProjectExec` | ✅     |                                                                                              |
+| `FilterExec`  | ✅     |                                                                                              |
+| `SampleExec`  | ⚠️     | Sampling without replacement only. See [Operator Compatibility](compatibility/operators.md). |
 
 ## Sorting and limiting
 

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -270,6 +270,7 @@ fn op_name(op: &OpStruct) -> &'static str {
         OpStruct::CsvScan(_) => "CsvScan",
         OpStruct::ShuffleScan(_) => "ShuffleScan",
         OpStruct::BroadcastNestedLoopJoin(_) => "BroadcastNestedLoopJoin",
+        OpStruct::Sample(_) => "Sample",
     }
 }
 

--- a/native/core/src/execution/operators/mod.rs
+++ b/native/core/src/execution/operators/mod.rs
@@ -33,6 +33,8 @@ mod parquet_writer;
 pub use parquet_writer::{ParquetCompression, ParquetWriterExec};
 mod csv_scan;
 pub mod projection;
+mod sample;
+pub use sample::SampleExec;
 mod scan;
 mod shuffle_scan;
 pub use csv_scan::init_csv_datasource_exec;

--- a/native/core/src/execution/operators/sample.rs
+++ b/native/core/src/execution/operators/sample.rs
@@ -183,6 +183,34 @@ mod tests {
         assert!(!single.is_empty() && single.len() < 300);
     }
 
+    /// Empty batches consume no draws from the generator, so interleaving them with non-empty
+    /// batches cannot change which rows are selected.
+    #[tokio::test]
+    async fn test_empty_batches_do_not_affect_selection() {
+        let without_empty = collect_sample(
+            vec![batch((0..100).collect()), batch((100..200).collect())],
+            0.0,
+            0.4,
+            42,
+        )
+        .await;
+        let with_empty = collect_sample(
+            vec![
+                batch(vec![]),
+                batch((0..100).collect()),
+                batch(vec![]),
+                batch((100..200).collect()),
+                batch(vec![]),
+            ],
+            0.0,
+            0.4,
+            42,
+        )
+        .await;
+        assert_eq!(without_empty, with_empty);
+        assert!(!without_empty.is_empty());
+    }
+
     /// Complementary ranges must partition the input, which is the property `randomSplit` needs.
     #[tokio::test]
     async fn test_complementary_ranges_partition_input() {

--- a/native/core/src/execution/operators/sample.rs
+++ b/native/core/src/execution/operators/sample.rs
@@ -1,0 +1,208 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::{BooleanArray, RecordBatch};
+use arrow::compute::filter_record_batch;
+use arrow::datatypes::SchemaRef;
+use datafusion::common::Result;
+use datafusion::execution::TaskContext;
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+    SendableRecordBatchStream,
+};
+use datafusion_comet_spark_expr::BernoulliCellSampler;
+use futures::StreamExt;
+use std::fmt::Formatter;
+use std::sync::Arc;
+
+/// A Comet native operator matching Spark's `SampleExec` for the case where sampling is performed
+/// without replacement.
+///
+/// Spark applies a `BernoulliCellSampler` to each partition, drawing one
+/// `XORShiftRandom.nextDouble()` per input row and keeping the row when the value falls in
+/// `[lower_bound, upper_bound)`. Reproducing that draw sequence exactly is what makes this
+/// operator select the same rows as Spark for a given seed.
+#[derive(Debug)]
+pub struct SampleExec {
+    input: Arc<dyn ExecutionPlan>,
+    lower_bound: f64,
+    upper_bound: f64,
+    /// Seed with the partition index already applied.
+    seed: i64,
+    cache: Arc<PlanProperties>,
+}
+
+impl SampleExec {
+    pub fn new(
+        input: Arc<dyn ExecutionPlan>,
+        lower_bound: f64,
+        upper_bound: f64,
+        seed: i64,
+    ) -> Self {
+        // Sampling only removes rows, so any ordering and partitioning of the input is preserved.
+        let cache = Arc::new(PlanProperties::new(
+            input.equivalence_properties().clone(),
+            input.output_partitioning().clone(),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        ));
+        Self {
+            input,
+            lower_bound,
+            upper_bound,
+            seed,
+            cache,
+        }
+    }
+
+    fn sample_batch(
+        sampler: &mut BernoulliCellSampler,
+        batch: &RecordBatch,
+    ) -> Result<RecordBatch> {
+        let mask: BooleanArray = (0..batch.num_rows())
+            .map(|_| Some(sampler.sample()))
+            .collect();
+        Ok(filter_record_batch(batch, &mask)?)
+    }
+}
+
+impl DisplayAs for SampleExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(
+                    f,
+                    "CometSampleExec: range=[{}, {}), seed={}",
+                    self.lower_bound, self.upper_bound, self.seed
+                )
+            }
+            DisplayFormatType::TreeRender => unimplemented!(),
+        }
+    }
+}
+
+impl ExecutionPlan for SampleExec {
+    fn name(&self) -> &str {
+        "CometSampleExec"
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.input.schema()
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.cache
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(SampleExec::new(
+            Arc::clone(&children[0]),
+            self.lower_bound,
+            self.upper_bound,
+            self.seed,
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let input = self.input.execute(partition, context)?;
+        let schema = self.schema();
+        // The generator advances across batch boundaries, so a single sampler is used for the
+        // whole stream rather than one per batch.
+        let mut sampler = BernoulliCellSampler::new(self.lower_bound, self.upper_bound, self.seed);
+        let stream = input.map(move |batch| Self::sample_batch(&mut sampler, &batch?));
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Int32Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::datasource::source::DataSourceExec;
+    use datafusion::prelude::SessionContext;
+
+    fn batch(values: Vec<i32>) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(values))]).unwrap()
+    }
+
+    async fn collect_sample(batches: Vec<RecordBatch>, lb: f64, ub: f64, seed: i64) -> Vec<i32> {
+        let schema = batches[0].schema();
+        let config = MemorySourceConfig::try_new(&[batches], schema, None).unwrap();
+        let input = Arc::new(DataSourceExec::new(Arc::new(config)));
+        let sample = Arc::new(SampleExec::new(input, lb, ub, seed));
+        let ctx = SessionContext::new();
+        let mut stream = sample.execute(0, ctx.task_ctx()).unwrap();
+        let mut values = Vec::new();
+        while let Some(batch) = stream.next().await {
+            let batch = batch.unwrap();
+            let column = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            values.extend(column.values().iter().copied());
+        }
+        values
+    }
+
+    /// The generator must not restart at each batch, so splitting the input into batches cannot
+    /// change which rows are selected.
+    #[tokio::test]
+    async fn test_batching_does_not_affect_selection() {
+        let single = collect_sample(vec![batch((0..300).collect())], 0.0, 0.4, 1234).await;
+        let split = collect_sample(
+            vec![
+                batch((0..100).collect()),
+                batch((100..200).collect()),
+                batch((200..300).collect()),
+            ],
+            0.0,
+            0.4,
+            1234,
+        )
+        .await;
+        assert_eq!(single, split);
+        assert!(!single.is_empty() && single.len() < 300);
+    }
+
+    /// Complementary ranges must partition the input, which is the property `randomSplit` needs.
+    #[tokio::test]
+    async fn test_complementary_ranges_partition_input() {
+        let input = vec![batch((0..500).collect())];
+        let lower = collect_sample(input.clone(), 0.0, 0.25, 99).await;
+        let upper = collect_sample(input, 0.25, 1.0, 99).await;
+        let mut all = [lower, upper].concat();
+        all.sort();
+        assert_eq!(all, (0..500).collect::<Vec<i32>>());
+    }
+}

--- a/native/core/src/execution/operators/sample.rs
+++ b/native/core/src/execution/operators/sample.rs
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::{BooleanArray, RecordBatch};
+use arrow::array::BooleanArray;
+use arrow::buffer::BooleanBuffer;
 use arrow::compute::filter_record_batch;
-use arrow::datatypes::SchemaRef;
 use datafusion::common::Result;
 use datafusion::execution::TaskContext;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
@@ -32,12 +32,8 @@ use std::fmt::Formatter;
 use std::sync::Arc;
 
 /// A Comet native operator matching Spark's `SampleExec` for the case where sampling is performed
-/// without replacement.
-///
-/// Spark applies a `BernoulliCellSampler` to each partition, drawing one
-/// `XORShiftRandom.nextDouble()` per input row and keeping the row when the value falls in
-/// `[lower_bound, upper_bound)`. Reproducing that draw sequence exactly is what makes this
-/// operator select the same rows as Spark for a given seed.
+/// without replacement. Rows are selected by `BernoulliCellSampler`, which reproduces Spark's
+/// per-row draw sequence.
 #[derive(Debug)]
 pub struct SampleExec {
     input: Arc<dyn ExecutionPlan>,
@@ -70,16 +66,6 @@ impl SampleExec {
             cache,
         }
     }
-
-    fn sample_batch(
-        sampler: &mut BernoulliCellSampler,
-        batch: &RecordBatch,
-    ) -> Result<RecordBatch> {
-        let mask: BooleanArray = (0..batch.num_rows())
-            .map(|_| Some(sampler.sample()))
-            .collect();
-        Ok(filter_record_batch(batch, &mask)?)
-    }
 }
 
 impl DisplayAs for SampleExec {
@@ -100,10 +86,6 @@ impl DisplayAs for SampleExec {
 impl ExecutionPlan for SampleExec {
     fn name(&self) -> &str {
         "CometSampleExec"
-    }
-
-    fn schema(&self) -> SchemaRef {
-        self.input.schema()
     }
 
     fn properties(&self) -> &Arc<PlanProperties> {
@@ -136,7 +118,13 @@ impl ExecutionPlan for SampleExec {
         // The generator advances across batch boundaries, so a single sampler is used for the
         // whole stream rather than one per batch.
         let mut sampler = BernoulliCellSampler::new(self.lower_bound, self.upper_bound, self.seed);
-        let stream = input.map(move |batch| Self::sample_batch(&mut sampler, &batch?));
+        let stream = input.map(move |batch| {
+            let batch = batch?;
+            // `collect_bool` invokes the closure once per row, in order, which is what keeps the
+            // draw sequence identical to Spark's.
+            let mask = BooleanBuffer::collect_bool(batch.num_rows(), |_| sampler.sample());
+            Ok(filter_record_batch(&batch, &BooleanArray::new(mask, None))?)
+        });
         Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
     }
 }
@@ -144,7 +132,7 @@ impl ExecutionPlan for SampleExec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::Int32Array;
+    use arrow::array::{Int32Array, RecordBatch};
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion::datasource::memory::MemorySourceConfig;
     use datafusion::datasource::source::DataSourceExec;

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -28,7 +28,7 @@ use crate::execution::{
     expressions::list_positions::ListPositionsExpr,
     expressions::subquery::Subquery,
     operators::{
-        ExecutionError, ExpandExec, ParquetCompression, ParquetWriterExec, ScanExec,
+        ExecutionError, ExpandExec, ParquetCompression, ParquetWriterExec, SampleExec, ScanExec,
         ShuffleScanExec,
     },
     planner::expression_registry::ExpressionRegistry,
@@ -1373,6 +1373,24 @@ impl PhysicalPlanner {
                     scans,
                     shuffle_scans,
                     Arc::new(SparkPlan::new(spark_plan.plan_id, limit, vec![child])),
+                ))
+            }
+            OpStruct::Sample(sample) => {
+                assert_eq!(children.len(), 1);
+                let (scans, shuffle_scans, child) =
+                    self.create_plan(&children[0], inputs, partition_count)?;
+                // Spark seeds a fresh sampler per partition with `seed + partitionIndex`.
+                let seed = sample.seed.wrapping_add(self.partition().into());
+                let sample_exec: Arc<dyn ExecutionPlan> = Arc::new(SampleExec::new(
+                    Arc::clone(&child.native_plan),
+                    sample.lower_bound,
+                    sample.upper_bound,
+                    seed,
+                ));
+                Ok((
+                    scans,
+                    shuffle_scans,
+                    Arc::new(SparkPlan::new(spark_plan.plan_id, sample_exec, vec![child])),
                 ))
             }
             OpStruct::Sort(sort) => {

--- a/native/core/src/execution/planner/operator_registry.rs
+++ b/native/core/src/execution/planner/operator_registry.rs
@@ -152,5 +152,6 @@ fn get_operator_type(spark_operator: &Operator) -> Option<OperatorType> {
         OpStruct::CsvScan(_) => Some(OperatorType::CsvScan),
         OpStruct::ShuffleScan(_) => None, // Not yet in OperatorType enum
         OpStruct::BroadcastNestedLoopJoin(_) => None,
+        OpStruct::Sample(_) => None, // Not yet in OperatorType enum
     }
 }

--- a/native/proto/src/proto/operator.proto
+++ b/native/proto/src/proto/operator.proto
@@ -55,6 +55,7 @@ message Operator {
     CsvScan csv_scan = 115;
     ShuffleScan shuffle_scan = 116;
     BroadcastNestedLoopJoin broadcast_nested_loop_join = 117;
+    Sample sample = 118;
   }
 }
 
@@ -394,6 +395,16 @@ message HashAggregate {
 message Limit {
   int32 limit = 1;
   int32 offset = 2;
+}
+
+// Sampling without replacement. Spark's SampleExec also supports sampling with
+// replacement, but that path is not serialized to native yet, so there is no
+// `with_replacement` field.
+message Sample {
+  double lower_bound = 1;
+  double upper_bound = 2;
+  // Seed before the partition index is added, which happens on the native side.
+  int64 seed = 3;
 }
 
 enum CompressionCodec {

--- a/native/spark-expr/src/nondetermenistic_funcs/bernoulli_cell_sampler.rs
+++ b/native/spark-expr/src/nondetermenistic_funcs/bernoulli_cell_sampler.rs
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::nondetermenistic_funcs::internal::StatefulSeedValueGenerator;
+use crate::nondetermenistic_funcs::rand::XorShiftRandom;
+
+/// Port of Spark's `BernoulliCellSampler`, used by `SampleExec` when sampling without
+/// replacement. One `XORShiftRandom.nextDouble()` is drawn per row, and the row is kept when the
+/// value falls in `[lower_bound, upper_bound)`.
+///
+/// See: <https://github.com/apache/spark/blob/v4.1.1/core/src/main/scala/org/apache/spark/util/random/RandomSampler.scala>
+#[derive(Debug)]
+pub struct BernoulliCellSampler {
+    lower_bound: f64,
+    upper_bound: f64,
+    rng: XorShiftRandom,
+}
+
+impl BernoulliCellSampler {
+    /// `seed` must already include the partition index, matching Spark, which seeds a fresh
+    /// sampler per partition with `seed + partitionIndex`.
+    pub fn new(lower_bound: f64, upper_bound: f64, seed: i64) -> Self {
+        Self {
+            lower_bound,
+            upper_bound,
+            rng: XorShiftRandom::from_init_seed(seed),
+        }
+    }
+
+    /// Whether the next row should be included in the sample.
+    pub fn sample(&mut self) -> bool {
+        if self.upper_bound - self.lower_bound <= 0.0 {
+            // Spark returns early here without consuming a value from the generator.
+            return false;
+        }
+        let x = self.rng.next_f64();
+        x >= self.lower_bound && x < self.upper_bound
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Exactly one value is drawn per row, in order, so that the sampler stays in lockstep with
+    /// the generator Spark uses. `XorShiftRandom` itself is verified against Spark separately.
+    #[test]
+    fn test_consumes_one_draw_per_row() {
+        let mut sampler = BernoulliCellSampler::new(0.0, 0.3, 42);
+        let mut rng = XorShiftRandom::from_init_seed(42);
+        for _ in 0..100 {
+            let x = rng.next_f64();
+            assert_eq!(sampler.sample(), x < 0.3);
+        }
+    }
+
+    /// The complement range of the test above must select exactly the rows that it rejected,
+    /// which is the property `randomSplit` relies on.
+    #[test]
+    fn test_ranges_partition_the_rows() {
+        let mut lower = BernoulliCellSampler::new(0.0, 0.3, 7);
+        let mut upper = BernoulliCellSampler::new(0.3, 1.0, 7);
+        for _ in 0..1000 {
+            assert_ne!(lower.sample(), upper.sample());
+        }
+    }
+
+    #[test]
+    fn test_empty_range_selects_nothing() {
+        let mut sampler = BernoulliCellSampler::new(0.5, 0.5, 42);
+        for _ in 0..100 {
+            assert!(!sampler.sample());
+        }
+    }
+}

--- a/native/spark-expr/src/nondetermenistic_funcs/bernoulli_cell_sampler.rs
+++ b/native/spark-expr/src/nondetermenistic_funcs/bernoulli_cell_sampler.rs
@@ -27,6 +27,9 @@ use crate::nondetermenistic_funcs::rand::XorShiftRandom;
 pub struct BernoulliCellSampler {
     lower_bound: f64,
     upper_bound: f64,
+    /// Spark selects nothing, without consuming a value from the generator, when the range is
+    /// empty. The range is fixed at construction, so the check is not repeated per row.
+    selects_nothing: bool,
     rng: XorShiftRandom,
 }
 
@@ -37,14 +40,15 @@ impl BernoulliCellSampler {
         Self {
             lower_bound,
             upper_bound,
+            selects_nothing: upper_bound - lower_bound <= 0.0,
             rng: XorShiftRandom::from_init_seed(seed),
         }
     }
 
     /// Whether the next row should be included in the sample.
+    #[inline]
     pub fn sample(&mut self) -> bool {
-        if self.upper_bound - self.lower_bound <= 0.0 {
-            // Spark returns early here without consuming a value from the generator.
+        if self.selects_nothing {
             return false;
         }
         let x = self.rng.next_f64();

--- a/native/spark-expr/src/nondetermenistic_funcs/mod.rs
+++ b/native/spark-expr/src/nondetermenistic_funcs/mod.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+pub mod bernoulli_cell_sampler;
 pub mod internal;
 pub mod monotonically_increasing_id;
 pub mod rand;
@@ -22,6 +23,7 @@ pub mod randn;
 pub mod randstr;
 pub mod shuffle;
 
+pub use bernoulli_cell_sampler::BernoulliCellSampler;
 pub use rand::RandExpr;
 pub use randn::RandnExpr;
 pub use randstr::RandStrExpr;

--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -233,6 +233,8 @@ object CometConf extends ShimCometConf {
     createExecEnabledConfig("takeOrderedAndProject", defaultValue = true)
   val COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED: ConfigEntry[Boolean] =
     createExecEnabledConfig("localTableScan", defaultValue = false)
+  val COMET_EXEC_SAMPLE_ENABLED: ConfigEntry[Boolean] =
+    createExecEnabledConfig("sample", defaultValue = true)
 
   val COMET_NATIVE_COLUMNAR_TO_ROW_ENABLED: ConfigEntry[Boolean] =
     conf(s"$COMET_EXEC_CONFIG_PREFIX.columnarToRow.native.enabled")

--- a/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
@@ -86,6 +86,7 @@ object CometExecRule {
       classOf[SortMergeJoinExec] -> CometSortMergeJoinExec,
       classOf[SortExec] -> CometSortExec,
       classOf[LocalTableScanExec] -> CometLocalTableScanExec,
+      classOf[SampleExec] -> CometSampleExec,
       classOf[WindowExec] -> CometWindowExec)
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometSampleExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometSampleExec.scala
@@ -50,16 +50,18 @@ object CometSampleExec extends CometOperatorSerde[SampleExec] {
       op: SampleExec,
       builder: Operator.Builder,
       childOp: OperatorOuterClass.Operator*): Option[OperatorOuterClass.Operator] = {
-    if (childOp.isEmpty) {
+    if (childOp.nonEmpty) {
+      val sampleBuilder = OperatorOuterClass.Sample
+        .newBuilder()
+        .setLowerBound(op.lowerBound)
+        .setUpperBound(op.upperBound)
+        // The partition index is added to the seed on the native side.
+        .setSeed(op.seed)
+      Some(builder.setSample(sampleBuilder).build())
+    } else {
       withFallbackReason(op, "No child operator")
-      return None
+      None
     }
-    val sampleBuilder = OperatorOuterClass.Sample
-      .newBuilder()
-      .setLowerBound(op.lowerBound)
-      .setUpperBound(op.upperBound)
-      .setSeed(op.seed)
-    Some(builder.setSample(sampleBuilder).build())
   }
 
   override def createExec(nativeOp: Operator, op: SampleExec): CometNativeExec = {
@@ -76,11 +78,7 @@ object CometSampleExec extends CometOperatorSerde[SampleExec] {
 
 /**
  * Comet physical plan node for Spark `SampleExec`, for the case where sampling is performed
- * without replacement.
- *
- * Spark applies `BernoulliCellSampler` to each partition, seeded with `seed + partitionIndex`,
- * and draws one `XORShiftRandom.nextDouble()` per input row, keeping the row when the value falls
- * in `[lowerBound, upperBound)`. The native operator reproduces that draw sequence exactly, so it
+ * without replacement. The native operator reproduces Spark's per-row draw sequence, so it
  * selects the same rows as Spark for a given seed as long as the input rows arrive in the same
  * order.
  */

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometSampleExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometSampleExec.scala
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
+import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.execution.{SampleExec, SparkPlan}
+
+import com.google.common.base.Objects
+
+import org.apache.comet.{CometConf, ConfigEntry}
+import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
+import org.apache.comet.serde.{CometOperatorSerde, OperatorOuterClass, SupportLevel, Unsupported}
+import org.apache.comet.serde.OperatorOuterClass.Operator
+
+object CometSampleExec extends CometOperatorSerde[SampleExec] {
+
+  override def enabledConfig: Option[ConfigEntry[Boolean]] = Some(
+    CometConf.COMET_EXEC_SAMPLE_ENABLED)
+
+  override def getSupportLevel(operator: SampleExec): SupportLevel = {
+    if (operator.withReplacement) {
+      // Sampling with replacement draws from a Poisson distribution seeded by
+      // commons-math3 Well19937c, which the native side does not implement yet.
+      // https://github.com/apache/datafusion-comet/issues/5109
+      Unsupported(Some("Sampling with replacement is not supported"))
+    } else {
+      super.getSupportLevel(operator)
+    }
+  }
+
+  override def convert(
+      op: SampleExec,
+      builder: Operator.Builder,
+      childOp: OperatorOuterClass.Operator*): Option[OperatorOuterClass.Operator] = {
+    if (childOp.isEmpty) {
+      withFallbackReason(op, "No child operator")
+      return None
+    }
+    val sampleBuilder = OperatorOuterClass.Sample
+      .newBuilder()
+      .setLowerBound(op.lowerBound)
+      .setUpperBound(op.upperBound)
+      .setSeed(op.seed)
+    Some(builder.setSample(sampleBuilder).build())
+  }
+
+  override def createExec(nativeOp: Operator, op: SampleExec): CometNativeExec = {
+    CometSampleExec(
+      nativeOp,
+      op,
+      op.lowerBound,
+      op.upperBound,
+      op.seed,
+      op.child,
+      SerializedPlan(None))
+  }
+}
+
+/**
+ * Comet physical plan node for Spark `SampleExec`, for the case where sampling is performed
+ * without replacement.
+ *
+ * Spark applies `BernoulliCellSampler` to each partition, seeded with `seed + partitionIndex`,
+ * and draws one `XORShiftRandom.nextDouble()` per input row, keeping the row when the value falls
+ * in `[lowerBound, upperBound)`. The native operator reproduces that draw sequence exactly, so it
+ * selects the same rows as Spark for a given seed as long as the input rows arrive in the same
+ * order.
+ */
+case class CometSampleExec(
+    override val nativeOp: Operator,
+    override val originalPlan: SparkPlan,
+    lowerBound: Double,
+    upperBound: Double,
+    seed: Long,
+    child: SparkPlan,
+    override val serializedPlanOpt: SerializedPlan)
+    extends CometUnaryExec {
+
+  override def output: Seq[Attribute] = child.output
+
+  override def outputPartitioning: Partitioning = child.outputPartitioning
+
+  override def outputOrdering: Seq[SortOrder] = child.outputOrdering
+
+  override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
+    this.copy(child = newChild)
+
+  override def stringArgs: Iterator[Any] = Iterator(lowerBound, upperBound, seed, child)
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case other: CometSampleExec =>
+        this.output == other.output &&
+        this.lowerBound == other.lowerBound &&
+        this.upperBound == other.upperBound &&
+        this.seed == other.seed &&
+        this.child == other.child &&
+        this.serializedPlanOpt == other.serializedPlanOpt
+      case _ =>
+        false
+    }
+  }
+
+  override def hashCode(): Int =
+    Objects.hashCode(
+      output,
+      lowerBound: java.lang.Double,
+      upperBound: java.lang.Double,
+      seed: java.lang.Long,
+      child)
+}

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometSampleExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometSampleExec.scala
@@ -29,6 +29,7 @@ import org.apache.comet.{CometConf, ConfigEntry}
 import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
 import org.apache.comet.serde.{CometOperatorSerde, OperatorOuterClass, SupportLevel, Unsupported}
 import org.apache.comet.serde.OperatorOuterClass.Operator
+import org.apache.comet.shims.CometSampleShim
 
 object CometSampleExec extends CometOperatorSerde[SampleExec] {
 
@@ -56,7 +57,7 @@ object CometSampleExec extends CometOperatorSerde[SampleExec] {
         .setLowerBound(op.lowerBound)
         .setUpperBound(op.upperBound)
         // The partition index is added to the seed on the native side.
-        .setSeed(op.seed)
+        .setSeed(CometSampleShim.seed(op))
       Some(builder.setSample(sampleBuilder).build())
     } else {
       withFallbackReason(op, "No child operator")
@@ -70,7 +71,7 @@ object CometSampleExec extends CometOperatorSerde[SampleExec] {
       op,
       op.lowerBound,
       op.upperBound,
-      op.seed,
+      CometSampleShim.seed(op),
       op.child,
       SerializedPlan(None))
   }

--- a/spark/src/main/spark-3.x/org/apache/comet/shims/CometSampleShim.scala
+++ b/spark/src/main/spark-3.x/org/apache/comet/shims/CometSampleShim.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.shims
+
+import org.apache.spark.sql.execution.SampleExec
+
+/**
+ * Shim for the seed that `SampleExec` samples with. Spark 3.4 through 4.1 carry it as a plain
+ * `Long`. Spark 4.2 made it an `Option[Long]` resolved into a `resolvedSeed` field, handled by
+ * the spark-4.2 shim.
+ */
+object CometSampleShim {
+  def seed(op: SampleExec): Long = op.seed
+}

--- a/spark/src/main/spark-4.0/org/apache/comet/shims/CometSampleShim.scala
+++ b/spark/src/main/spark-4.0/org/apache/comet/shims/CometSampleShim.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.shims
+
+import org.apache.spark.sql.execution.SampleExec
+
+/**
+ * Shim for the seed that `SampleExec` samples with. Spark 3.4 through 4.1 carry it as a plain
+ * `Long`. Spark 4.2 made it an `Option[Long]` resolved into a `resolvedSeed` field, handled by
+ * the spark-4.2 shim.
+ */
+object CometSampleShim {
+  def seed(op: SampleExec): Long = op.seed
+}

--- a/spark/src/main/spark-4.1/org/apache/comet/shims/CometSampleShim.scala
+++ b/spark/src/main/spark-4.1/org/apache/comet/shims/CometSampleShim.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.shims
+
+import org.apache.spark.sql.execution.SampleExec
+
+/**
+ * Shim for the seed that `SampleExec` samples with. Spark 3.4 through 4.1 carry it as a plain
+ * `Long`. Spark 4.2 made it an `Option[Long]` resolved into a `resolvedSeed` field, handled by
+ * the spark-4.2 shim.
+ */
+object CometSampleShim {
+  def seed(op: SampleExec): Long = op.seed
+}

--- a/spark/src/main/spark-4.2/org/apache/comet/shims/CometSampleShim.scala
+++ b/spark/src/main/spark-4.2/org/apache/comet/shims/CometSampleShim.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.shims
+
+import org.apache.spark.sql.execution.SampleExec
+
+/**
+ * Shim for the seed that `SampleExec` samples with. Spark 4.2 made the seed an `Option[Long]` and
+ * resolves an absent one into `resolvedSeed`, which is what the operator itself samples with, so
+ * this shim reads that field rather than the option.
+ */
+object CometSampleShim {
+  def seed(op: SampleExec): Long = op.resolvedSeed
+}

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -97,14 +97,9 @@ class CometExecSuite extends CometTestBase {
   // The sampler is seeded per partition with `seed + partitionIndex`, so a multi-partition input
   // is what catches a native side that ignores the partition index.
   test("sample without replacement over multiple partitions") {
-    withTempDir { dir =>
-      val path = new Path(dir.toURI.toString, "sample.parquet")
-      spark
-        .range(0, 4000)
-        .repartition(4)
-        .write
-        .parquet(path.toString)
-      withParquetTable(path.toString, "tbl") {
+    withTempPath { dir =>
+      spark.range(0, 4000).repartition(4).write.parquet(dir.getCanonicalPath)
+      withParquetTable(dir.getCanonicalPath, "tbl") {
         val df =
           sql("SELECT * FROM tbl").sample(withReplacement = false, fraction = 0.2, seed = 7)
         assert(df.rdd.getNumPartitions > 1)
@@ -117,16 +112,13 @@ class CometExecSuite extends CometTestBase {
     withParquetTable((0 until 1000).map(i => (i, i + 1)), "tbl") {
       val splits = sql("SELECT * FROM tbl").randomSplit(Array(0.3, 0.7), seed = 42)
       splits.foreach(checkSparkAnswerAndOperator(_, Seq(classOf[CometSampleExec])))
-      assert(splits.map(_.count()).sum == 1000)
     }
   }
 
   test("sample with replacement falls back to Spark") {
     withParquetTable((0 until 1000).map(i => (i, i + 1)), "tbl") {
       val df = sql("SELECT * FROM tbl").sample(withReplacement = true, fraction = 0.3, seed = 42)
-      checkSparkAnswer(df)
-      assert(collect(df.queryExecution.executedPlan) { case s: CometSampleExec => s }.isEmpty)
-      assert(collect(df.queryExecution.executedPlan) { case s: SampleExec => s }.size == 1)
+      checkSparkAnswerAndFallbackReason(df, "Sampling with replacement is not supported")
     }
   }
 
@@ -135,8 +127,7 @@ class CometExecSuite extends CometTestBase {
       withParquetTable((0 until 1000).map(i => (i, i + 1)), "tbl") {
         val df =
           sql("SELECT * FROM tbl").sample(withReplacement = false, fraction = 0.3, seed = 42)
-        checkSparkAnswer(df)
-        assert(collect(df.queryExecution.executedPlan) { case s: CometSampleExec => s }.isEmpty)
+        checkSparkAnswerAndFallbackReason(df, "spark.comet.exec.sample.enabled=true")
       }
     }
   }

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -115,6 +115,47 @@ class CometExecSuite extends CometTestBase {
     }
   }
 
+  test("sample via SQL TABLESAMPLE") {
+    withParquetTable((0 until 1000).map(i => (i, i + 1)), "tbl") {
+      val df = sql("SELECT * FROM tbl TABLESAMPLE (30 PERCENT) REPEATABLE (42)")
+      checkSparkAnswerAndOperator(df, Seq(classOf[CometSampleExec]))
+    }
+  }
+
+  // Sampling only drops rows, so above an order-preserving input the output must stay sorted and
+  // match Spark row-for-row. The logical plan contains a Sort, so checkSparkAnswerAndOperator
+  // compares results in order rather than sorting both sides first.
+  test("sample preserves ordering of sorted input") {
+    withParquetTable((0 until 1000).reverse.map(i => (i, i + 1)), "tbl") {
+      val df = sql("SELECT * FROM tbl")
+        .orderBy("_1")
+        .sample(withReplacement = false, fraction = 0.3, seed = 42)
+      checkSparkAnswerAndOperator(df, Seq(classOf[CometSampleExec]))
+      val ids = df.collect().map(_.getInt(0))
+      assert(ids.nonEmpty && ids.sameElements(ids.sorted))
+    }
+  }
+
+  // Above an operator where Comet may emit rows in a different order than Spark, such as an
+  // aggregate, the sampler sees a different row sequence and can select different rows, but the
+  // result must still be a valid sample of the same expected size.
+  test("sample above aggregate produces a valid sample of the expected size") {
+    withParquetTable((0 until 10000).map(i => (i % 1000, i)), "tbl") {
+      val agg = sql("SELECT _1, SUM(_2) FROM tbl GROUP BY _1")
+      val df = agg.sample(withReplacement = false, fraction = 0.5, seed = 42)
+      val sampled = df.collect()
+      val plan = stripAQEPlan(df.queryExecution.executedPlan)
+      assert(plan.collect { case s: CometSampleExec => s }.nonEmpty)
+      // Every sampled row must be a distinct row of the aggregate output.
+      val full = agg.collect().toSet
+      assert(sampled.length == sampled.distinct.length)
+      assert(sampled.forall(full.contains))
+      // 1000 Bernoulli(0.5) draws have a standard deviation of ~15.8, so a tolerance of 100
+      // is a ~6-sigma bound.
+      assert(math.abs(sampled.length - 500) < 100)
+    }
+  }
+
   test("sample with replacement falls back to Spark") {
     withParquetTable((0 until 1000).map(i => (i, i + 1)), "tbl") {
       val df = sql("SELECT * FROM tbl").sample(withReplacement = true, fraction = 0.3, seed = 42)

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -87,6 +87,60 @@ class CometExecSuite extends CometTestBase {
     }
   }
 
+  test("sample without replacement") {
+    withParquetTable((0 until 1000).map(i => (i, i + 1)), "tbl") {
+      val df = sql("SELECT * FROM tbl").sample(withReplacement = false, fraction = 0.3, seed = 42)
+      checkSparkAnswerAndOperator(df, Seq(classOf[CometSampleExec]))
+    }
+  }
+
+  // The sampler is seeded per partition with `seed + partitionIndex`, so a multi-partition input
+  // is what catches a native side that ignores the partition index.
+  test("sample without replacement over multiple partitions") {
+    withTempDir { dir =>
+      val path = new Path(dir.toURI.toString, "sample.parquet")
+      spark
+        .range(0, 4000)
+        .repartition(4)
+        .write
+        .parquet(path.toString)
+      withParquetTable(path.toString, "tbl") {
+        val df =
+          sql("SELECT * FROM tbl").sample(withReplacement = false, fraction = 0.2, seed = 7)
+        assert(df.rdd.getNumPartitions > 1)
+        checkSparkAnswerAndOperator(df, Seq(classOf[CometSampleExec]))
+      }
+    }
+  }
+
+  test("sample without replacement with non-zero lower bound (randomSplit)") {
+    withParquetTable((0 until 1000).map(i => (i, i + 1)), "tbl") {
+      val splits = sql("SELECT * FROM tbl").randomSplit(Array(0.3, 0.7), seed = 42)
+      splits.foreach(checkSparkAnswerAndOperator(_, Seq(classOf[CometSampleExec])))
+      assert(splits.map(_.count()).sum == 1000)
+    }
+  }
+
+  test("sample with replacement falls back to Spark") {
+    withParquetTable((0 until 1000).map(i => (i, i + 1)), "tbl") {
+      val df = sql("SELECT * FROM tbl").sample(withReplacement = true, fraction = 0.3, seed = 42)
+      checkSparkAnswer(df)
+      assert(collect(df.queryExecution.executedPlan) { case s: CometSampleExec => s }.isEmpty)
+      assert(collect(df.queryExecution.executedPlan) { case s: SampleExec => s }.size == 1)
+    }
+  }
+
+  test("sample falls back to Spark when disabled") {
+    withSQLConf(CometConf.COMET_EXEC_SAMPLE_ENABLED.key -> "false") {
+      withParquetTable((0 until 1000).map(i => (i, i + 1)), "tbl") {
+        val df =
+          sql("SELECT * FROM tbl").sample(withReplacement = false, fraction = 0.3, seed = 42)
+        checkSparkAnswer(df)
+        assert(collect(df.queryExecution.executedPlan) { case s: CometSampleExec => s }.isEmpty)
+      }
+    }
+  }
+
   test("TopK operator should return correct results on dictionary column with nulls") {
     withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "") {
       withTable("test_data") {

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometExecBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometExecBenchmark.scala
@@ -162,6 +162,36 @@ object CometExecBenchmark extends CometBenchmarkBase {
     }
   }
 
+  def sampleExecBenchmark(values: Int, fraction: Double): Unit = {
+    val benchmark = new Benchmark(s"Sample Exec (fraction $fraction)", values, output = output)
+
+    withTempPath { dir =>
+      withTempTable("parquetV1Table") {
+        prepareTable(dir, spark.sql(s"SELECT * FROM $tbl"))
+
+        benchmark.addCase("SQL Parquet - Spark") { _ =>
+          spark
+            .sql("select * from parquetV1Table")
+            .sample(withReplacement = false, fraction = fraction, seed = 42)
+            .noop()
+        }
+
+        benchmark.addCase("SQL Parquet - Comet") { _ =>
+          withSQLConf(
+            CometConf.COMET_ENABLED.key -> "true",
+            CometConf.COMET_EXEC_ENABLED.key -> "true") {
+            spark
+              .sql("select * from parquetV1Table")
+              .sample(withReplacement = false, fraction = fraction, seed = 42)
+              .noop()
+          }
+        }
+
+        benchmark.run()
+      }
+    }
+  }
+
   def expandExecBenchmark(values: Int): Unit = {
     val benchmark = new Benchmark("Expand Exec", values, output = output)
 
@@ -253,6 +283,12 @@ object CometExecBenchmark extends CometBenchmarkBase {
 
     runBenchmarkWithTable("Sort", 1024 * 1024 * 10) { v =>
       sortExecBenchmark(v)
+    }
+
+    runBenchmarkWithTable("Sample", 1024 * 1024 * 10) { v =>
+      for (fraction <- List(0.05, 0.5, 0.95)) {
+        sampleExecBenchmark(v, fraction)
+      }
     }
 
     runBenchmarkWithTable("BloomFilterAggregate", 1024 * 1024 * 10) { v =>


### PR DESCRIPTION
## Which issue does this PR close?

Part of #5109.

## Rationale for this change

`SampleExec` is not supported today, so any query using `DataFrame.sample`, SQL `TABLESAMPLE`, or `DataFrame.randomSplit` falls back to Spark and breaks up the surrounding native execution block.

Spark has two sampling paths. Without replacement, it applies `BernoulliCellSampler` to each partition, seeded with `seed + partitionIndex`, drawing one `XORShiftRandom.nextDouble()` per input row and keeping the row when the value falls in `[lowerBound, upperBound)`. With replacement, it draws from a commons-math3 `PoissonDistribution` seeded by `Well19937c`.

This PR covers the first path, which is the common case. Comet already has a bit-exact port of `XORShiftRandom` (used by `rand` / `randn` / `shuffle`), including the murmur3 `hashSeed` that `setSeed` applies, so reproducing Spark's exact draw sequence is a small addition rather than a new RNG port. The with-replacement path needs ports of `Well19937c` and `PoissonDistribution.sample()` and is left as follow-up work, tracked by #5109.

## What changes are included in this PR?

- New `Sample` protobuf message and `SampleExec` native operator (`native/core/src/execution/operators/sample.rs`), which filters each batch by the sampler's decisions and carries generator state across batch boundaries.
- New `BernoulliCellSampler` in the `spark-expr` crate, a port of Spark's sampler built on the existing `XorShiftRandom`.
- `CometSampleExec` operator serde, registered in `CometExecRule.nativeExecs`, gated by the new `spark.comet.exec.sample.enabled` config (default true). `getSupportLevel` returns `Unsupported` when `withReplacement` is set, so that case falls back to Spark.
- The planner applies the partition index to the seed the same way the `rand` / `shuffle` expression builders do.
- Documentation: a Sampling section in the operator compatibility guide covering the row-order caveat below, and a `SampleExec` row in the operator support reference.

Because the sampler consumes one random value per row within a partition, it matches Spark's selection only when rows reach it in the same order. That holds when sampling above a scan, filter, or projection. Above an operator where Comet may emit rows in a different order than Spark, such as a join or an aggregate, the result is still a valid sample of the same expected size but not necessarily the same rows. This is inherent to per-row RNG consumption and already applies to `rand()`; it is documented in the compatibility guide.

## How are these changes tested?

New Rust unit tests cover that exactly one value is drawn per row, that complementary ranges partition the input, that an empty range selects nothing, and that splitting the input into multiple batches does not change which rows are selected.

New tests in `CometExecSuite` compare results against Spark for `sample` with a fixed seed, for a multi-partition input (which is what catches a native side that ignores the partition index), and for `randomSplit` (non-zero lower bound), and assert that sampling with replacement and the disabled config both fall back to Spark.

The result-comparison tests were verified to be non-vacuous by temporarily perturbing the native seed by one, which fails all three comparison tests. The suite passes on both the default profile and `-Pspark-3.4`.
