### PR TITLE
docs: expand list of operators in user guide "supported operators" section 

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -342,6 +342,7 @@ jobs:
               org.apache.spark.sql.comet.CometMapInBatchSuite
               org.apache.comet.CometNativeSuite
               org.apache.comet.CometConfSuite
+              org.apache.comet.CometOperatorDocSuite
               org.apache.comet.CometPublicApiSuite
               org.apache.comet.CometSetOpWithGroupBySuite
               org.apache.comet.CometSparkSessionExtensionsSuite

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -158,6 +158,7 @@ jobs:
               org.apache.spark.sql.comet.CometMapInBatchSuite
               org.apache.comet.CometNativeSuite
               org.apache.comet.CometConfSuite
+              org.apache.comet.CometOperatorDocSuite
               org.apache.comet.CometPublicApiSuite
               org.apache.comet.CometSetOpWithGroupBySuite
               org.apache.comet.CometSparkSessionExtensionsSuite

--- a/docs/source/user-guide/latest/operators.md
+++ b/docs/source/user-guide/latest/operators.md
@@ -24,6 +24,11 @@ Comet replaces supported operators with native equivalents. Comet runs whole sub
 operators together, so if a query stage contains an operator Comet does not support, that stage
 falls back to regular Spark execution. Results are unaffected.
 
+Every concrete operator in `org.apache.spark.sql.execution` has a row in one of the tables below,
+across all Spark versions Comet builds against (3.4 through 4.2). Operators that exist only in
+some versions are annotated. `CometOperatorDocSuite` fails the build if Spark adds an operator
+that is not listed here.
+
 Operators marked ✅ Supported are enabled by default. Each can be turned off individually with
 `spark.comet.exec.OPERATOR.enabled=false` (for example `spark.comet.exec.sort.enabled=false`), and
 all native execution can be turned off with `spark.comet.exec.enabled=false`. See the
@@ -31,55 +36,73 @@ all native execution can be turned off with `spark.comet.exec.enabled=false`. Se
 
 ## Status legend
 
-| Status                 | Meaning                                                                                                                           |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| ✅ Supported           | Native implementation, enabled by default; works in the common case. Some inputs or forms may fall back to Spark.                 |
-| ⚠️ Supported (caveats) | Experimental or disabled by default, or accelerates only a limited subset. See the [Compatibility Guide](compatibility/index.md). |
-| 🔜 Planned             | Intended; tracked by an open issue or pull request.                                                                               |
+| Status                 | Meaning                                                                                                                                                                                                                            |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ✅ Supported           | Native implementation, enabled by default; works in the common case. Some inputs or forms may fall back to Spark.                                                                                                                  |
+| ⚠️ Supported (caveats) | Experimental or disabled by default, or accelerates only a limited subset. See the [Compatibility Guide](compatibility/index.md).                                                                                                  |
+| 🔜 Planned             | Intended; tracked by an open issue or pull request.                                                                                                                                                                                |
+| ❌ Not supported       | Falls back to Spark today. Native execution would be worthwhile, so these are genuine gaps.                                                                                                                                        |
+| ➖ Not applicable      | Falls back to Spark by design. Either there is no meaningful native work to do — catalog commands, streaming, arbitrary JVM closures, driver-side operations — or the operator is plan plumbing that Comet handles while planning. |
 
-## Not currently planned
-
-The following operator families fall back to Spark and are not on the current roadmap. They are
-omitted from the tables below and may be reconsidered based on demand:
-
-- **Structured Streaming operators** (`StateStoreSaveExec`, `StateStoreRestoreExec`, `StreamingSymmetricHashJoinExec`, and similar): Comet targets batch execution.
-- **Cartesian / cross joins** (`CartesianProductExec`): rare and expensive, with little acceleration benefit.
-- **Sampling and range generation** (`SampleExec`, `RangeExec`): niche leaf operators.
-- **Pickled (non-Arrow) Python UDFs** (`BatchEvalPythonExec`): Comet accelerates Arrow-based Python UDFs only ([#4234](https://github.com/apache/datafusion-comet/pull/4234)).
+Neither ❌ nor ➖ is a correctness concern: Comet falls back rather than producing a different
+answer. Set [`spark.comet.explainFallback.enabled=true`](tuning.md) to see which operator in your
+plan caused a fallback.
 
 ## Scans
 
-| Operator                | Status | Notes                                                                                                                                                                                                        |
-| ----------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `FileSourceScanExec`    | ✅     | Parquet only. Some types and configurations fall back. See [Parquet Scan Compatibility](compatibility/scans.md).                                                                                             |
-| `BatchScanExec`         | ✅     | Parquet, Apache Iceberg Parquet, and CSV (native) scans. See [Parquet Scan Compatibility](compatibility/scans.md) and the [Iceberg Guide](iceberg.md).                                                       |
-| `LocalTableScanExec`    | ⚠️     | Disabled by default; there is no acceleration advantage and this operator is typically only used in test code. Can be opted into via config ([#4393](https://github.com/apache/datafusion-comet/pull/4393)). |
-| `InMemoryTableScanExec` | 🔜     | Cached / in-memory table scans fall back today.                                                                                                                                                              |
+| Operator                | Status | Notes                                                                                                                                                                                                            |
+| ----------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FileSourceScanExec`    | ✅     | Parquet only. Some types and configurations fall back. See [Parquet Scan Compatibility](compatibility/scans.md).                                                                                                 |
+| `BatchScanExec`         | ✅     | Parquet, Apache Iceberg Parquet, and CSV (native) scans. See [Parquet Scan Compatibility](compatibility/scans.md) and the [Iceberg Guide](iceberg.md).                                                           |
+| `LocalTableScanExec`    | ⚠️     | Disabled by default; there is no acceleration advantage and this operator is typically only used in test code. Can be opted into via config ([#4393](https://github.com/apache/datafusion-comet/pull/4393)).     |
+| `InMemoryTableScanExec` | 🔜     | Cached / in-memory table scans fall back today. The output can still be fed into a native stage with `spark.comet.sparkToColumnar.enabled=true` (see [Bridging non-native leaves](#bridging-non-native-leaves)). |
+| `UnionLoopExec`         | ❌     | Spark 4.1+. The recursion driver for `WITH RECURSIVE` common table expressions.                                                                                                                                  |
+| `RowDataSourceScanExec` | ➖     | V1 sources that are not file-based, most commonly JDBC. Rows arrive from the external system already materialized, so there is no columnar read to accelerate.                                                   |
+| `RDDScanExec`           | ➖     | `createDataFrame` over an RDD or local collection. Can be bridged into a native stage (see below); it is in the default bridge list.                                                                             |
+| `ExternalRDDScanExec`   | ➖     | `Dataset` built from an RDD of JVM objects. Rows arrive as deserialized objects, so there is nothing columnar to read.                                                                                           |
+| `OneRowRelationExec`    | ➖     | Spark 4.1+. A single-row source, for example `SELECT 1`. Can be bridged into a native stage; it is in the default bridge list.                                                                                   |
+| `RangeExec`             | ➖     | `spark.range(...)`. Generating a sequence is not a bottleneck, but it is in the default bridge list, so a native stage above it does not have to fall back.                                                      |
+| `EmptyRelationExec`     | ➖     | Spark 4.0+. An empty relation folded out by AQE. There are no rows to process.                                                                                                                                   |
+
+### Bridging non-native leaves
+
+Some non-native leaf operators can still feed a native stage: Comet inserts a
+`CometSparkToColumnarExec` that converts their row output to Arrow, so the operators above them do
+not have to fall back. This is disabled by default. Enable it with
+`spark.comet.sparkToColumnar.enabled=true`; the set of eligible operators is
+`spark.comet.sparkToColumnar.supportedOperatorList`, which defaults to
+`Range,InMemoryTableScan,RDDScan,OneRowRelation`. The conversion itself costs CPU, so it only pays
+off when enough native work sits above the leaf.
 
 ## Projection and filtering
 
-| Operator      | Status | Notes |
-| ------------- | ------ | ----- |
-| `ProjectExec` | ✅     |       |
-| `FilterExec`  | ✅     |       |
+| Operator             | Status | Notes                                                                                                                                                                    |
+| -------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ProjectExec`        | ✅     |                                                                                                                                                                          |
+| `FilterExec`         | ✅     |                                                                                                                                                                          |
+| `SampleExec`         | ❌     | `df.sample(...)` and `TABLESAMPLE`. Matching Spark's output row-for-row requires reproducing its per-partition RNG stream, which is why this has not been attempted yet. |
+| `CollectMetricsExec` | ❌     | `df.observe(...)`. Falls back, and because it sits in the middle of a plan it also splits the surrounding native stage in two.                                           |
 
 ## Sorting and limiting
 
-| Operator                    | Status | Notes |
-| --------------------------- | ------ | ----- |
-| `SortExec`                  | ✅     |       |
-| `GlobalLimitExec`           | ✅     |       |
-| `LocalLimitExec`            | ✅     |       |
-| `CollectLimitExec`          | ✅     |       |
-| `TakeOrderedAndProjectExec` | ✅     |       |
+| Operator                    | Status | Notes                                                                                                       |
+| --------------------------- | ------ | ----------------------------------------------------------------------------------------------------------- |
+| `SortExec`                  | ✅     |                                                                                                             |
+| `GlobalLimitExec`           | ✅     |                                                                                                             |
+| `LocalLimitExec`            | ✅     |                                                                                                             |
+| `CollectLimitExec`          | ✅     |                                                                                                             |
+| `TakeOrderedAndProjectExec` | ✅     |                                                                                                             |
+| `CollectTailExec`           | ➖     | `df.tail(n)`. Reads from the end of the last partition; a driver-side operation with nothing to accelerate. |
 
 ## Aggregation
 
-| Operator                  | Status | Notes                                                             |
-| ------------------------- | ------ | ----------------------------------------------------------------- |
-| `HashAggregateExec`       | ✅     |                                                                   |
-| `ObjectHashAggregateExec` | ✅     | Supports a limited set of aggregates, such as `bloom_filter_agg`. |
-| `SortAggregateExec`       | 🔜     | Falls back today; Comet currently accelerates hash aggregates.    |
+| Operator                  | Status | Notes                                                                                      |
+| ------------------------- | ------ | ------------------------------------------------------------------------------------------ |
+| `HashAggregateExec`       | ✅     |                                                                                            |
+| `ObjectHashAggregateExec` | ✅     | Supports a limited set of aggregates, such as `bloom_filter_agg`.                          |
+| `SortAggregateExec`       | 🔜     | Falls back today; Comet currently accelerates hash aggregates.                             |
+| `MergingSessionsExec`     | ❌     | Session-window aggregation (`session_window`). Used in batch as well as streaming queries. |
+| `UpdatingSessionsExec`    | ❌     | Assigns rows to session windows ahead of a session-window aggregate.                       |
 
 ## Joins
 
@@ -89,6 +112,7 @@ omitted from the tables below and may be reconsidered based on demand:
 | `ShuffledHashJoinExec`        | ✅     |                                                                                                                                                                               |
 | `SortMergeJoinExec`           | ✅     |                                                                                                                                                                               |
 | `BroadcastNestedLoopJoinExec` | ✅     | Falls back to Spark when the preserved side is broadcast (for example LEFT OUTER with BROADCAST on the left) ([#4429](https://github.com/apache/datafusion-comet/pull/4429)). |
+| `CartesianProductExec`        | ➖     | Cross joins. Runtime is dominated by output size rather than per-row cost, so there is little for a native implementation to win.                                             |
 
 ## Exchanges
 
@@ -102,7 +126,7 @@ omitted from the tables below and may be reconsidered based on demand:
 | Operator               | Status | Notes                                                                                                                                                                                            |
 | ---------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `WindowExec`           | ⚠️     | Runs natively and is enabled by default. A broad set of window functions is accelerated; unsupported shapes fall back to Spark. See [window function compatibility](compatibility/operators.md). |
-| `WindowGroupLimitExec` | 🔜     | Window-based limit pushdown falls back today ([#4837](https://github.com/apache/datafusion-comet/issues/4837)).                                                                                  |
+| `WindowGroupLimitExec` | 🔜     | Spark 3.5+. Window-based limit pushdown falls back today ([#4837](https://github.com/apache/datafusion-comet/issues/4837)).                                                                      |
 
 ## Generators and set operations
 
@@ -113,19 +137,124 @@ omitted from the tables below and may be reconsidered based on demand:
 | `UnionExec`    | ✅     |                                                                                                                            |
 | `CoalesceExec` | ✅     |                                                                                                                            |
 
+## Typed Dataset operators
+
+Operators from the typed `Dataset[T]` API all fall back. They evaluate arbitrary JVM closures over
+deserialized objects, so there is no expression tree for Comet to translate and no columnar
+representation to work on. This is worth knowing about even though there is nothing for Comet to
+do: a single `ds.map(...)` takes its whole query stage back to Spark. Prefer the DataFrame / SQL
+API on hot paths.
+
+| Operator                        | Status | Notes                                                                          |
+| ------------------------------- | ------ | ------------------------------------------------------------------------------ |
+| `DeserializeToObjectExec`       | ➖     | Converts rows to JVM objects at the start of a typed section of a plan.        |
+| `SerializeFromObjectExec`       | ➖     | Converts JVM objects back to rows at the end of a typed section.               |
+| `MapPartitionsExec`             | ➖     | `ds.mapPartitions(...)`.                                                       |
+| `MapElementsExec`               | ➖     | `ds.map(...)` / `ds.flatMap(...)` / `ds.filter(func)`.                         |
+| `MapGroupsExec`                 | ➖     | `ds.groupByKey(...).mapGroups(...)` / `flatMapGroups(...)`.                    |
+| `CoGroupExec`                   | ➖     | `KeyValueGroupedDataset.cogroup(...)`.                                         |
+| `AppendColumnsExec`             | ➖     | Computes the grouping key added by `groupByKey`.                               |
+| `AppendColumnsWithObjectExec`   | ➖     | Object-input variant of the same.                                              |
+| `SparkScriptTransformationExec` | ➖     | `TRANSFORM ... USING 'script'`. Rows are piped to an external process as text. |
+
+## Python, pandas, and R UDFs
+
+Comet can keep data in Arrow format across `mapInArrow` and `mapInPandas`, avoiding the
+Arrow→row→Arrow round trip Spark performs. This is experimental and disabled by default; enable it
+with `spark.comet.exec.pyarrowUdf.enabled=true` and see the
+[PyArrow UDF guide](pyarrow-udfs.md) for limitations, including that it requires Spark 4.0+ and
+Comet's native shuffle.
+
+The remaining Arrow-based UDF operators are marked ❌ rather than ➖ because the same optimization
+applies to them in principle — they already exchange Arrow batches with the Python worker. Pickled
+UDFs and SparkR are marked ➖ because they serialize row at a time, with no columnar boundary to
+preserve.
+
+| Operator                                                                                 | Status | Notes                                                                                                                                                         |
+| ---------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PythonMapInArrowExec`, `MapInArrowExec`                                                 | ⚠️     | `df.mapInArrow(...)`. Native path is opt-in via `spark.comet.exec.pyarrowUdf.enabled` and requires Spark 4.0+. Named `PythonMapInArrowExec` before Spark 4.0. |
+| `MapInPandasExec`                                                                        | ⚠️     | `df.mapInPandas(...)`. Same opt-in and version requirement.                                                                                                   |
+| `ArrowEvalPythonExec`                                                                    | 🔜     | Scalar `@pandas_udf` ([#4234](https://github.com/apache/datafusion-comet/pull/4234)).                                                                         |
+| `FlatMapGroupsInPandasExec`                                                              | 🔜     | `df.groupBy(...).applyInPandas(...)` ([#4234](https://github.com/apache/datafusion-comet/pull/4234)).                                                         |
+| `AggregateInPandasExec`, `ArrowAggregatePythonExec`                                      | ❌     | Grouped-aggregate pandas UDFs. Renamed to `ArrowAggregatePythonExec` in Spark 4.1.                                                                            |
+| `WindowInPandasExec`, `ArrowWindowPythonExec`                                            | ❌     | Window pandas UDFs. Renamed to `ArrowWindowPythonExec` in Spark 4.1.                                                                                          |
+| `ArrowEvalPythonUDTFExec`                                                                | ❌     | Spark 3.5+. Arrow-based Python UDTFs (`udtf`).                                                                                                                |
+| `FlatMapGroupsInArrowExec`                                                               | ❌     | Spark 4.0+. `applyInArrow` on a grouped DataFrame.                                                                                                            |
+| `FlatMapCoGroupsInPandasExec`                                                            | ❌     | `cogroup(...).applyInPandas(...)`.                                                                                                                            |
+| `FlatMapCoGroupsInArrowExec`                                                             | ❌     | Spark 4.0+. `cogroup(...).applyInArrow(...)`.                                                                                                                 |
+| `AttachDistributedSequenceExec`                                                          | ❌     | Assigns the distributed sequence index used by the pandas API on Spark (`pyspark.pandas`).                                                                    |
+| `BatchEvalPythonExec`                                                                    | ➖     | Pickled (non-Arrow) Python UDFs. Rows are pickled one at a time, so there is no columnar boundary to exploit.                                                 |
+| `BatchEvalPythonUDTFExec`                                                                | ➖     | Spark 3.5+. Pickled Python UDTFs.                                                                                                                             |
+| `PythonWorkerLogsExec`                                                                   | ➖     | Spark 4.1+. Surfaces Python worker logs as a relation. Metadata, not user data.                                                                               |
+| `FlatMapGroupsInRExec`, `FlatMapGroupsInRWithArrowExec`, `MapPartitionsInRWithArrowExec` | ➖     | SparkR UDFs (`gapply`, `dapply`). Comet has no R integration.                                                                                                 |
+
 ## Writes
 
-| Operator                 | Status | Notes                                                             |
-| ------------------------ | ------ | ----------------------------------------------------------------- |
-| `DataWritingCommandExec` | ⚠️     | Experimental native Parquet writes, disabled by default (opt-in). |
+| Operator                                                                                                   | Status | Notes                                                                                                                            |
+| ---------------------------------------------------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `DataWritingCommandExec`                                                                                   | ⚠️     | Experimental native Parquet writes, disabled by default (opt-in).                                                                |
+| `WriteFilesExec`                                                                                           | ⚠️     | The V1 write operator that `DataWritingCommandExec` wraps. Comet converts the pair together; it is never accelerated on its own. |
+| `AppendDataExec`, `OverwriteByExpressionExec`, `OverwritePartitionsDynamicExec`, `WriteToDataSourceV2Exec` | ❌     | DataSource V2 writes, including Iceberg writes. Comet accelerates Iceberg reads only.                                            |
+| `ReplaceDataExec`, `WriteDeltaExec`, `MergeRowsExec`, `InsertOnlyMergeExec`, `DeleteFromTableExec`         | ❌     | Row-level `MERGE` / `UPDATE` / `DELETE` plans. `MergeRowsExec` is Spark 3.5+, `InsertOnlyMergeExec` is Spark 4.2+.               |
 
-## Python and UDF
+## Plan infrastructure
 
-| Operator                                                                                | Status | Notes                                                                                                                        |
-| --------------------------------------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| `ArrowEvalPythonExec`, `MapInArrowExec`, `MapInPandasExec`, `FlatMapGroupsInPandasExec` | 🔜     | Experimental accelerated PyArrow UDF support is in progress ([#4234](https://github.com/apache/datafusion-comet/pull/4234)). |
+These operators are how Spark stitches a plan together rather than places where work happens. Comet
+rewrites, wraps, or plans around each of them; none is an acceleration target in its own right.
+They are listed so that seeing one in a plan does not read as an undocumented gap.
+
+| Operator                                                                   | Status | Notes                                                                                                                                  |
+| -------------------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `WholeStageCodegenExec`                                                    | ➖     | Comet replaces the operators inside a stage before codegen, so a fully native stage has no codegen wrapper.                            |
+| `ColumnarToRowExec`, `RowToColumnarExec`                                   | ➖     | Comet substitutes `CometColumnarToRowExec` and `CometSparkToColumnarExec`, and removes transition pairs that cancel out.               |
+| `AdaptiveSparkPlanExec`                                                    | ➖     | Comet's rules run on each AQE stage as it is planned, so conversion happens inside AQE rather than around it.                          |
+| `AQEShuffleReadExec`                                                       | ➖     | Reads the output of a `CometShuffleExchangeExec` and is preserved across conversion, so AQE coalescing and skew splitting still apply. |
+| `ShuffleQueryStageExec`, `BroadcastQueryStageExec`, `ResultQueryStageExec` | ➖     | AQE stage wrappers. Comet unwraps them to find the underlying exchange. `ResultQueryStageExec` is Spark 4.0+.                          |
+| `TableCacheQueryStageExec`                                                 | ➖     | AQE wrapper around a cached-table scan; see `InMemoryTableScanExec` above.                                                             |
+| `ReusedExchangeExec`                                                       | ➖     | Reuse of an already-materialized exchange, including reuse of a Comet exchange.                                                        |
+| `SubqueryExec`, `ReusedSubqueryExec`                                       | ➖     | Scalar subqueries. The subquery plan is converted independently on its own merits.                                                     |
+| `InSubqueryExec`, `SubqueryBroadcastExec`, `SubqueryAdaptiveBroadcastExec` | ➖     | Dynamic partition pruning. Comet rewrites these so a DPP filter still resolves when the broadcast side became a Comet exchange.        |
+| `CommandResultExec`, `ExecutedCommandExec`, `MultiResultExec`              | ➖     | Hold already-computed command results. `MultiResultExec` is Spark 4.1+ (SQL scripting).                                                |
+| `GroupPartitionsExec`                                                      | ➖     | Spark 4.2+. Regroups DataSource V2 input partitions for storage-partitioned joins.                                                     |
+
+## Commands
+
+DDL, catalog, and metadata commands operate on catalog state rather than row data and execute once
+on the driver, so there is nothing for a columnar engine to accelerate. This is not expected to
+change.
+
+| Operator group   | Status | Operators                                                                                                                                                                                                                                                                                                                                                           |
+| ---------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Table DDL        | ➖     | `CreateTableExec`, `CreateTableAsSelectExec`, `AtomicCreateTableAsSelectExec`, `ReplaceTableExec`, `AtomicReplaceTableExec`, `ReplaceTableAsSelectExec`, `AtomicReplaceTableAsSelectExec`, `DropTableExec`, `RenameTableExec`, `AlterTableExec`, `TruncateTableExec`, `RefreshTableExec`, `CreateTableLikeExec` (Spark 4.2+), `AddCheckConstraintExec` (Spark 4.1+) |
+| Partition DDL    | ➖     | `AddPartitionExec`, `DropPartitionExec`, `RenamePartitionExec`, `TruncatePartitionExec`                                                                                                                                                                                                                                                                             |
+| Namespace DDL    | ➖     | `CreateNamespaceExec`, `DropNamespaceExec`, `AlterNamespaceSetPropertiesExec`, `SetCatalogAndNamespaceExec`                                                                                                                                                                                                                                                         |
+| View DDL         | ➖     | `DropViewExec`, and Spark 4.2+ V2 views: `CreateV2ViewExec`, `CreateV2MetricViewExec`, `AlterV2ViewExec`, `AlterV2ViewSetPropertiesExec`, `AlterV2ViewUnsetPropertiesExec`, `AlterV2ViewSchemaBindingExec`, `RenameV2ViewExec`                                                                                                                                      |
+| Index DDL        | ➖     | `CreateIndexExec`, `DropIndexExec`                                                                                                                                                                                                                                                                                                                                  |
+| Metadata queries | ➖     | `DescribeTableExec`, `DescribeColumnExec`, `DescribeNamespaceExec`, `DescribeTablePartitionExec` (Spark 4.2+), `ShowTablesExec`, `ShowTablesExtendedExec` (Spark 4.0+), `ShowTablePropertiesExec`, `ShowTablePartitionExec`, `ShowPartitionsExec`, `ShowColumnsExec`, `ShowNamespacesExec`, `ShowFunctionsExec`, `ShowCreateTableExec`                              |
+| View metadata    | ➖     | `ShowViewsExec`, `DescribeV2ViewExec`, `DescribeV2ViewColumnExec`, `ShowCreateV2ViewExec`, `ShowV2ViewColumnsExec`, `ShowV2ViewPropertiesExec` (Spark 4.2+)                                                                                                                                                                                                         |
+| Caching          | ➖     | `CacheTableExec`, `CacheTableAsSelectExec`, `UncacheTableExec`                                                                                                                                                                                                                                                                                                      |
+| SQL variables    | ➖     | `CreateVariableExec`, `SetVariableExec`, `DropVariableExec` (Spark 4.0+)                                                                                                                                                                                                                                                                                            |
+| Cursors          | ➖     | `DeclareCursorExec`, `OpenCursorExec`, `FetchCursorExec`, `CloseCursorExec` (Spark 4.2+)                                                                                                                                                                                                                                                                            |
+
+## Structured Streaming
+
+Comet targets batch execution. Streaming-specific operators, and the stateful operators that back
+them, fall back to Spark. This is not on the roadmap. A streaming query can still benefit from
+Comet where it uses batch operators, for example a `FilterExec` over a Parquet source.
+
+| Operator group     | Status | Operators                                                                                                                                                                                                |
+| ------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Streaming sources  | ➖     | `StreamingRelationExec`, `MicroBatchScanExec`, `ContinuousScanExec`, `RealTimeStreamScanExec` (Spark 4.1+)                                                                                               |
+| Streaming sinks    | ➖     | `WriteToContinuousDataSourceExec`                                                                                                                                                                        |
+| State store        | ➖     | `StateStoreSaveExec`, `StateStoreRestoreExec`, `SessionWindowStateStoreSaveExec`, `SessionWindowStateStoreRestoreExec`                                                                                   |
+| Stateful transform | ➖     | `FlatMapGroupsWithStateExec`, `FlatMapGroupsInPandasWithStateExec`, `TransformWithStateExec` (Spark 4.0+), `TransformWithStateInPandasExec` (Spark 4.0+), `TransformWithStateInPySparkExec` (Spark 4.1+) |
+| Streaming joins    | ➖     | `StreamingSymmetricHashJoinExec`                                                                                                                                                                         |
+| Deduplication      | ➖     | `StreamingDeduplicateExec`, `StreamingDeduplicateWithinWatermarkExec` (Spark 3.5+)                                                                                                                       |
+| Streaming limits   | ➖     | `StreamingGlobalLimitExec`, `StreamingLocalLimitExec`                                                                                                                                                    |
+| Watermarks         | ➖     | `EventTimeWatermarkExec`, `UpdateEventTimeColumnExec` (Spark 4.0+)                                                                                                                                       |
 
 ## See also
 
 - [Comet Compatibility Guide](compatibility/index.md) - known incompatibilities and edge cases.
 - [Supported Spark Expressions](expressions.md) - the equivalent reference for expressions.
+- [PyArrow UDF Acceleration](pyarrow-udfs.md) - the opt-in native path for `mapInArrow` / `mapInPandas`.

--- a/docs/source/user-guide/latest/operators.md
+++ b/docs/source/user-guide/latest/operators.md
@@ -40,8 +40,8 @@ all native execution can be turned off with `spark.comet.exec.enabled=false`. Se
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | ✅ Supported           | Native implementation, enabled by default; works in the common case. Some inputs or forms may fall back to Spark.                                                                                                                  |
 | ⚠️ Supported (caveats) | Experimental or disabled by default, or accelerates only a limited subset. See the [Compatibility Guide](compatibility/index.md).                                                                                                  |
-| 🔜 Planned             | Intended; tracked by an open issue or pull request.                                                                                                                                                                                |
-| ❌ Not supported       | Falls back to Spark today. Native execution would be worthwhile, so these are genuine gaps.                                                                                                                                        |
+| 🔜 Planned             | Actively planned or in progress; tracked by an open issue or pull request.                                                                                                                                                         |
+| ❌ Not supported       | Falls back to Spark today. Native execution would be worthwhile, so these are genuine gaps. Tracking issues for proposed work are linked in the notes.                                                                             |
 | ➖ Not applicable      | Falls back to Spark by design. Either there is no meaningful native work to do — catalog commands, streaming, arbitrary JVM closures, driver-side operations — or the operator is plan plumbing that Comet handles while planning. |
 
 Neither ❌ nor ➖ is a correctness concern: Comet falls back rather than producing a different
@@ -50,19 +50,19 @@ plan caused a fallback.
 
 ## Scans
 
-| Operator                | Status | Notes                                                                                                                                                                                                            |
-| ----------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `FileSourceScanExec`    | ✅     | Parquet only. Some types and configurations fall back. See [Parquet Scan Compatibility](compatibility/scans.md).                                                                                                 |
-| `BatchScanExec`         | ✅     | Parquet, Apache Iceberg Parquet, and CSV (native) scans. See [Parquet Scan Compatibility](compatibility/scans.md) and the [Iceberg Guide](iceberg.md).                                                           |
-| `LocalTableScanExec`    | ⚠️     | Disabled by default; there is no acceleration advantage and this operator is typically only used in test code. Can be opted into via config ([#4393](https://github.com/apache/datafusion-comet/pull/4393)).     |
-| `InMemoryTableScanExec` | 🔜     | Cached / in-memory table scans fall back today. The output can still be fed into a native stage with `spark.comet.sparkToColumnar.enabled=true` (see [Bridging non-native leaves](#bridging-non-native-leaves)). |
-| `UnionLoopExec`         | ❌     | Spark 4.1+. The recursion driver for `WITH RECURSIVE` common table expressions.                                                                                                                                  |
-| `RowDataSourceScanExec` | ➖     | V1 sources that are not file-based, most commonly JDBC. Rows arrive from the external system already materialized, so there is no columnar read to accelerate.                                                   |
-| `RDDScanExec`           | ➖     | `createDataFrame` over an RDD or local collection. Can be bridged into a native stage (see below); it is in the default bridge list.                                                                             |
-| `ExternalRDDScanExec`   | ➖     | `Dataset` built from an RDD of JVM objects. Rows arrive as deserialized objects, so there is nothing columnar to read.                                                                                           |
-| `OneRowRelationExec`    | ➖     | Spark 4.1+. A single-row source, for example `SELECT 1`. Can be bridged into a native stage; it is in the default bridge list.                                                                                   |
-| `RangeExec`             | ➖     | `spark.range(...)`. Generating a sequence is not a bottleneck, but it is in the default bridge list, so a native stage above it does not have to fall back.                                                      |
-| `EmptyRelationExec`     | ➖     | Spark 4.0+. An empty relation folded out by AQE. There are no rows to process.                                                                                                                                   |
+| Operator                | Status | Notes                                                                                                                                                                                                                                                                              |
+| ----------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FileSourceScanExec`    | ✅     | Parquet only. Some types and configurations fall back. See [Parquet Scan Compatibility](compatibility/scans.md).                                                                                                                                                                   |
+| `BatchScanExec`         | ✅     | Parquet, Apache Iceberg Parquet, and CSV (native) scans. See [Parquet Scan Compatibility](compatibility/scans.md) and the [Iceberg Guide](iceberg.md).                                                                                                                             |
+| `LocalTableScanExec`    | ⚠️     | Disabled by default; there is no acceleration advantage and this operator is typically only used in test code. Can be opted into via config ([#4393](https://github.com/apache/datafusion-comet/pull/4393)).                                                                       |
+| `InMemoryTableScanExec` | 🔜     | Cached / in-memory table scans fall back today ([#2391](https://github.com/apache/datafusion-comet/issues/2391)). The output can still be fed into a native stage with `spark.comet.sparkToColumnar.enabled=true` (see [Bridging non-native leaves](#bridging-non-native-leaves)). |
+| `UnionLoopExec`         | ❌     | Spark 4.1+. The recursion driver for `WITH RECURSIVE` common table expressions.                                                                                                                                                                                                    |
+| `RowDataSourceScanExec` | ➖     | V1 sources that are not file-based, most commonly JDBC. Rows arrive from the external system already materialized, so there is no columnar read to accelerate.                                                                                                                     |
+| `RDDScanExec`           | ➖     | `createDataFrame` over an RDD or local collection. Can be bridged into a native stage (see below); it is in the default bridge list.                                                                                                                                               |
+| `ExternalRDDScanExec`   | ➖     | `Dataset` built from an RDD of JVM objects. Rows arrive as deserialized objects, so there is nothing columnar to read.                                                                                                                                                             |
+| `OneRowRelationExec`    | ➖     | Spark 4.1+. A single-row source, for example `SELECT 1`. Can be bridged into a native stage; it is in the default bridge list.                                                                                                                                                     |
+| `RangeExec`             | ➖     | `spark.range(...)`. Generating a sequence is not a bottleneck, but it is in the default bridge list, so a native stage above it does not have to fall back.                                                                                                                        |
+| `EmptyRelationExec`     | ➖     | Spark 4.0+. An empty relation folded out by AQE. There are no rows to process.                                                                                                                                                                                                     |
 
 ### Bridging non-native leaves
 
@@ -76,12 +76,12 @@ off when enough native work sits above the leaf.
 
 ## Projection and filtering
 
-| Operator             | Status | Notes                                                                                                                                                                    |
-| -------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ProjectExec`        | ✅     |                                                                                                                                                                          |
-| `FilterExec`         | ✅     |                                                                                                                                                                          |
-| `SampleExec`         | ❌     | `df.sample(...)` and `TABLESAMPLE`. Matching Spark's output row-for-row requires reproducing its per-partition RNG stream, which is why this has not been attempted yet. |
-| `CollectMetricsExec` | ❌     | `df.observe(...)`. Falls back, and because it sits in the middle of a plan it also splits the surrounding native stage in two.                                           |
+| Operator             | Status | Notes                                                                                                                                                                                                                                      |
+| -------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ProjectExec`        | ✅     |                                                                                                                                                                                                                                            |
+| `FilterExec`         | ✅     |                                                                                                                                                                                                                                            |
+| `SampleExec`         | ❌     | `df.sample(...)` and `TABLESAMPLE`. Matching Spark's output row-for-row requires reproducing its per-partition RNG stream, which is why this has not been attempted yet ([#5109](https://github.com/apache/datafusion-comet/issues/5109)). |
+| `CollectMetricsExec` | ❌     | `df.observe(...)`. Falls back, and because it sits in the middle of a plan it also splits the surrounding native stage in two ([#5124](https://github.com/apache/datafusion-comet/issues/5124)).                                           |
 
 ## Sorting and limiting
 
@@ -96,23 +96,23 @@ off when enough native work sits above the leaf.
 
 ## Aggregation
 
-| Operator                  | Status | Notes                                                                                      |
-| ------------------------- | ------ | ------------------------------------------------------------------------------------------ |
-| `HashAggregateExec`       | ✅     |                                                                                            |
-| `ObjectHashAggregateExec` | ✅     | Supports a limited set of aggregates, such as `bloom_filter_agg`.                          |
-| `SortAggregateExec`       | 🔜     | Falls back today; Comet currently accelerates hash aggregates.                             |
-| `MergingSessionsExec`     | ❌     | Session-window aggregation (`session_window`). Used in batch as well as streaming queries. |
-| `UpdatingSessionsExec`    | ❌     | Assigns rows to session windows ahead of a session-window aggregate.                       |
+| Operator                  | Status | Notes                                                                                                                                                        |
+| ------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `HashAggregateExec`       | ✅     |                                                                                                                                                              |
+| `ObjectHashAggregateExec` | ✅     | Supports a limited set of aggregates, such as `bloom_filter_agg`.                                                                                            |
+| `SortAggregateExec`       | 🔜     | Falls back today; Comet currently accelerates hash aggregates ([#1994](https://github.com/apache/datafusion-comet/issues/1994)).                             |
+| `MergingSessionsExec`     | ❌     | Session-window aggregation (`session_window`). Used in batch as well as streaming queries ([#4785](https://github.com/apache/datafusion-comet/issues/4785)). |
+| `UpdatingSessionsExec`    | ❌     | Assigns rows to session windows ahead of a session-window aggregate ([#4785](https://github.com/apache/datafusion-comet/issues/4785)).                       |
 
 ## Joins
 
-| Operator                      | Status | Notes                                                                                                                                                                         |
-| ----------------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `BroadcastHashJoinExec`       | ✅     |                                                                                                                                                                               |
-| `ShuffledHashJoinExec`        | ✅     |                                                                                                                                                                               |
-| `SortMergeJoinExec`           | ✅     |                                                                                                                                                                               |
-| `BroadcastNestedLoopJoinExec` | ✅     | Falls back to Spark when the preserved side is broadcast (for example LEFT OUTER with BROADCAST on the left) ([#4429](https://github.com/apache/datafusion-comet/pull/4429)). |
-| `CartesianProductExec`        | ➖     | Cross joins. Runtime is dominated by output size rather than per-row cost, so there is little for a native implementation to win.                                             |
+| Operator                      | Status | Notes                                                                                                                                                                                      |
+| ----------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `BroadcastHashJoinExec`       | ✅     |                                                                                                                                                                                            |
+| `ShuffledHashJoinExec`        | ✅     |                                                                                                                                                                                            |
+| `SortMergeJoinExec`           | ✅     |                                                                                                                                                                                            |
+| `BroadcastNestedLoopJoinExec` | ✅     | Falls back to Spark when the preserved side is broadcast (for example LEFT OUTER with BROADCAST on the left) ([#4429](https://github.com/apache/datafusion-comet/pull/4429)).              |
+| `CartesianProductExec`        | ➖     | Cross joins. Runtime is dominated by output size rather than per-row cost, so there is little for the operator itself to win, though a fallback here does split an otherwise native stage. |
 
 ## Exchanges
 
@@ -130,12 +130,12 @@ off when enough native work sits above the leaf.
 
 ## Generators and set operations
 
-| Operator       | Status | Notes                                                                                                                      |
-| -------------- | ------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `GenerateExec` | ✅     | Supports `explode` and `posexplode` over arrays. The `_outer` variants are incompatible, and `inline` / `stack` fall back. |
-| `ExpandExec`   | ✅     |                                                                                                                            |
-| `UnionExec`    | ✅     |                                                                                                                            |
-| `CoalesceExec` | ✅     |                                                                                                                            |
+| Operator       | Status | Notes                                                                                                                                                                                                                                                          |
+| -------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GenerateExec` | ✅     | Supports `explode` and `posexplode` over arrays. The `_outer` variants are incompatible ([#2838](https://github.com/apache/datafusion-comet/issues/2838)), and `inline` / `stack` fall back ([#5125](https://github.com/apache/datafusion-comet/issues/5125)). |
+| `ExpandExec`   | ✅     |                                                                                                                                                                                                                                                                |
+| `UnionExec`    | ✅     |                                                                                                                                                                                                                                                                |
+| `CoalesceExec` | ✅     |                                                                                                                                                                                                                                                                |
 
 ## Typed Dataset operators
 
@@ -166,9 +166,10 @@ with `spark.comet.exec.pyarrowUdf.enabled=true` and see the
 Comet's native shuffle.
 
 The remaining Arrow-based UDF operators are marked ❌ rather than ➖ because the same optimization
-applies to them in principle — they already exchange Arrow batches with the Python worker. Pickled
-UDFs and SparkR are marked ➖ because they serialize row at a time, with no columnar boundary to
-preserve.
+applies to them in principle — they already exchange Arrow batches with the Python worker.
+Extending the native path to them is tracked by
+[#5123](https://github.com/apache/datafusion-comet/issues/5123). Pickled UDFs and SparkR are
+marked ➖ because they serialize row at a time, with no columnar boundary to preserve.
 
 | Operator                                                                                 | Status | Notes                                                                                                                                                         |
 | ---------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -190,12 +191,12 @@ preserve.
 
 ## Writes
 
-| Operator                                                                                                   | Status | Notes                                                                                                                            |
-| ---------------------------------------------------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| `DataWritingCommandExec`                                                                                   | ⚠️     | Experimental native Parquet writes, disabled by default (opt-in).                                                                |
-| `WriteFilesExec`                                                                                           | ⚠️     | The V1 write operator that `DataWritingCommandExec` wraps. Comet converts the pair together; it is never accelerated on its own. |
-| `AppendDataExec`, `OverwriteByExpressionExec`, `OverwritePartitionsDynamicExec`, `WriteToDataSourceV2Exec` | ❌     | DataSource V2 writes, including Iceberg writes. Comet accelerates Iceberg reads only.                                            |
-| `ReplaceDataExec`, `WriteDeltaExec`, `MergeRowsExec`, `InsertOnlyMergeExec`, `DeleteFromTableExec`         | ❌     | Row-level `MERGE` / `UPDATE` / `DELETE` plans. `MergeRowsExec` is Spark 3.5+, `InsertOnlyMergeExec` is Spark 4.2+.               |
+| Operator                                                                                                   | Status | Notes                                                                                                                                                                                |
+| ---------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `DataWritingCommandExec`                                                                                   | ⚠️     | Experimental native Parquet writes, disabled by default (opt-in). See [#1625](https://github.com/apache/datafusion-comet/issues/1625).                                               |
+| `WriteFilesExec`                                                                                           | ⚠️     | The V1 write operator that `DataWritingCommandExec` wraps. Comet converts the pair together; it is never accelerated on its own.                                                     |
+| `AppendDataExec`, `OverwriteByExpressionExec`, `OverwritePartitionsDynamicExec`, `WriteToDataSourceV2Exec` | ❌     | DataSource V2 writes, including Iceberg writes. Comet accelerates Iceberg reads only ([#5121](https://github.com/apache/datafusion-comet/issues/5121)).                              |
+| `ReplaceDataExec`, `WriteDeltaExec`, `MergeRowsExec`, `InsertOnlyMergeExec`, `DeleteFromTableExec`         | ❌     | Row-level `MERGE` / `UPDATE` / `DELETE` plans ([#5122](https://github.com/apache/datafusion-comet/issues/5122)). `MergeRowsExec` is Spark 3.5+, `InsertOnlyMergeExec` is Spark 4.2+. |
 
 ## Plan infrastructure
 

--- a/spark/src/test/scala/org/apache/comet/CometOperatorDocSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometOperatorDocSuite.scala
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet
+
+import java.io.File
+import java.lang.reflect.Modifier
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.jar.JarFile
+
+import scala.jdk.CollectionConverters._
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.execution.SparkPlan
+
+/**
+ * Guards the operator reference in `docs/source/user-guide/latest/operators.md`.
+ *
+ * That page claims to describe every Spark physical operator, which is only useful if it is
+ * actually complete: an operator that is silently absent reads as "supported" to anyone scanning
+ * the tables. This suite enumerates the concrete `SparkPlan` implementations in the spark-sql jar
+ * on the test classpath and fails if any of them has no entry.
+ *
+ * Because the suite runs under every Spark profile, the doc must cover the union of operators
+ * across all supported Spark versions. When a new Spark version introduces an operator, add a row
+ * for it — including a ❌ or ➖ row saying why it is not accelerated.
+ */
+class CometOperatorDocSuite extends AnyFunSuite {
+
+  test("every Spark physical operator is listed in operators.md") {
+    val doc = new String(Files.readAllBytes(operatorDoc().toPath), StandardCharsets.UTF_8)
+    val operators = sparkOperators()
+
+    // Without this the suite would pass vacuously if the classpath scan ever stopped finding
+    // anything. Spark 3.4 has ~125 concrete operators, so this floor has plenty of headroom.
+    assert(
+      operators.size > 100,
+      s"only found ${operators.size} Spark operators; the classpath scan is broken")
+
+    val undocumented = operators.filterNot(name => doc.contains(s"`$name`")).sorted
+
+    assert(
+      undocumented.isEmpty,
+      s"""${undocumented.size} Spark operator(s) are missing from
+         |docs/source/user-guide/latest/operators.md:
+         |
+         |  ${undocumented.mkString("\n  ")}
+         |
+         |Add a row for each one. If Comet does not accelerate it, use the ❌ status and say why
+         |in the notes; if it is plan plumbing rather than an acceleration target, use ➖.""".stripMargin)
+  }
+
+  /**
+   * Simple names of every concrete operator in `org.apache.spark.sql.execution`, read from the
+   * spark-sql jar on the test classpath.
+   */
+  private def sparkOperators(): Seq[String] = {
+    val jar = new JarFile(sparkSqlJar())
+    try {
+      jar
+        .entries()
+        .asScala
+        .map(_.getName)
+        .filter(n => n.startsWith("org/apache/spark/sql/execution/") && n.endsWith("Exec.class"))
+        .map(_.stripSuffix(".class").replace('/', '.'))
+        // Scala companion objects and anonymous classes are not operators.
+        .filterNot(n => n.contains("$"))
+        .flatMap(loadClass)
+        .filter(c =>
+          classOf[SparkPlan].isAssignableFrom(c) && !Modifier.isAbstract(c.getModifiers))
+        .map(_.getSimpleName)
+        .toList
+        .distinct
+    } finally {
+      jar.close()
+    }
+  }
+
+  private def sparkSqlJar(): File = {
+    val location = classOf[SparkPlan].getProtectionDomain.getCodeSource.getLocation
+    val file = new File(location.toURI)
+    assert(
+      file.isFile && file.getName.endsWith(".jar"),
+      s"expected spark-sql to resolve to a jar, got $file")
+    file
+  }
+
+  /**
+   * Walk up from the working directory to find the doc, which is at a fixed repo-relative path.
+   */
+  private def operatorDoc(): File = {
+    val relative = "docs/source/user-guide/latest/operators.md"
+    var dir = new File(".").getCanonicalFile
+    while (dir != null) {
+      val candidate = new File(dir, relative)
+      if (candidate.isFile) return candidate
+      dir = dir.getParentFile
+    }
+    fail(s"could not locate $relative above ${new File(".").getCanonicalPath}")
+  }
+
+  private def loadClass(name: String): Option[Class[_]] =
+    try {
+      // Do not initialize: some operators touch optional integrations at class-init time.
+      Some(Class.forName(name, false, getClass.getClassLoader))
+    } catch {
+      // Skip anything unresolvable from the test classpath rather than reporting it as
+      // undocumented; a class we cannot even load is not something we can describe.
+      case _: Throwable => None
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

N/A — found while investigating why `SampleExec` appeared to be undocumented.

## Rationale for this change

`operators.md` opens with "This page is the complete reference for how Apache Comet handles each Spark physical operator." It named 38 of the 180 concrete operators in `org.apache.spark.sql.execution` (union across the spark-3.4 through spark-4.2 profiles).

That is worse than an incomplete page: an operator with no row reads as supported to anyone scanning the tables. `SampleExec` is the case that prompted this — it *was* mentioned, but only inside a prose bullet under "Not currently planned", so it did not show up when scanning for a table entry.

## What changes are included in this PR?

### Operators added

- **Typed `Dataset[T]` API** — `MapPartitionsExec`, `MapElementsExec`, `MapGroupsExec`, `CoGroupExec`, `AppendColumnsExec`, and the object serde operators. Common in user code and previously absent, so there was no hint that `ds.map(...)` takes its whole stage back to Spark.
- **Non-Parquet scans** — `RowDataSourceScanExec` (JDBC), `RDDScanExec`, `ExternalRDDScanExec`, `EmptyRelationExec`, `OneRowRelationExec`, `UnionLoopExec`. The scan table had 4 of 11 rows.
- **Individually notable** — `CollectMetricsExec` (`df.observe`, which also splits a native stage in two), `CollectTailExec`, `MergingSessionsExec` / `UpdatingSessionsExec` (session windows, batch as well as streaming), `SparkScriptTransformationExec`.
- **Writes** — DataSource V2 writes (`AppendDataExec`, `OverwriteByExpressionExec`, …) and row-level MERGE/UPDATE/DELETE plans. Worth stating explicitly given that Iceberg *reads* are documented.
- **Python / pandas / R** — the remaining UDF operators, including pandas aggregate and window UDFs, Python UDTFs, `applyInArrow`, `AttachDistributedSequenceExec`, and the SparkR operators.
- **Plan infrastructure** — a new section for AQE stage wrappers, transitions, and DPP subqueries. Comet has dedicated rules for these, so a reader who finds one in a plan now has somewhere to look.
- **Commands and streaming** — grouped rows so the long tail is covered without 60 individual entries.

### Corrections

- The PyArrow UDF row was stale in both directions: `mapInArrow` / `mapInPandas` landed as opt-in behind `spark.comet.exec.pyarrowUdf.enabled` (Spark 4.0+), while `ArrowEvalPythonExec` and `FlatMapGroupsInPandasExec` shared the same 🔜 row and do still fall back.
- `WriteFilesExec` is converted together with `DataWritingCommandExec`; only the latter was documented.
- Documented that `spark.comet.sparkToColumnar.enabled` can bridge `RangeExec`, `RDDScanExec`, `InMemoryTableScanExec`, and `OneRowRelationExec` into a native stage. The default operator list is not mentioned anywhere in the user guide today.

### Status vocabulary

Two statuses replace the old catch-all so the tables do not read as a wall of failures:

- ❌ **Not supported** — falls back today, and native execution would be worthwhile. A genuine gap.
- ➖ **Not applicable** — falls back by design: catalog commands, streaming, arbitrary JVM closures, driver-side operations, or plan plumbing Comet handles while planning.

### Drift guard

`CometOperatorDocSuite` enumerates concrete `SparkPlan` subclasses from the spark-sql jar on the test classpath and fails if any lacks an entry, with a message naming the missing operators. It also asserts the scan found >100 operators so it cannot pass vacuously if the scan breaks.

The suite runs under every profile, so the doc covers the union across Spark versions; version-specific operators are annotated in the notes. When a new Spark version adds an operator, this fails with a list of what to document.

## How are these changes tested?

`CometOperatorDocSuite` passes under `spark-3.4`, `spark-3.5`, `spark-4.0`, `spark-4.1`, and `spark-4.2`, and under `scala-2.12`. Verified that it fails with a useful message by running it against `spark-4.2` before the V2 view operators were added.

Statuses were checked against `CometExecRule.nativeExecs` / `sinks`, `CometScanRule`, `EliminateRedundantTransitions`, and `CometConf` rather than assumed.

Draft because the ❌ / ➖ split is a judgement call per operator and worth a second opinion — in particular `SampleExec`, `RowDataSourceScanExec` (JDBC), `CartesianProductExec`, and the SparkR operators, which could reasonably go either way.