### PR TITLE
test: add isolated and small-batch benchmarks for columnar-to-row conversion

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometC2RIsolatedBench.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometC2RIsolatedBench.scala
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.benchmark
+
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.UnsafeProjection
+import org.apache.spark.sql.comet.execution.arrow.CometArrowConverters
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.unsafe.types.UTF8String
+
+import org.apache.comet.NativeColumnarToRowConverter
+
+/**
+ * Isolated columnar-to-row microbenchmark that excludes the parquet scan entirely. Batches are
+ * built once in memory; each case converts them to rows and consumes the values so that the
+ * conversion itself is what gets measured.
+ */
+object CometC2RIsolatedBench {
+
+  private val totalRows = 1024 * 1024
+
+  private def makeBatches(schema: StructType, batchSize: Int): Array[ColumnarBatch] = {
+    val rows = (0 until totalRows).iterator.map { i =>
+      InternalRow(i.toLong, i, i.toDouble, UTF8String.fromString(s"value_$i"))
+    }
+    CometArrowConverters
+      .rowToArrowBatchIter(rows, schema, batchSize, "UTC", org.apache.comet.CometArrowAllocator)
+      .toArray
+  }
+
+  private def runForBatchSize(schema: StructType, batchSize: Int): Unit = {
+    val batches = makeBatches(schema, batchSize)
+
+    val benchmark =
+      new Benchmark(s"Isolated C2R (no scan), batchSize=$batchSize", totalRows.toLong)
+
+    benchmark.addCase("JVM rowIterator + UnsafeProjection") { _ =>
+      val proj = UnsafeProjection.create(schema.fields.map(_.dataType))
+      var sink = 0L
+      var b = 0
+      while (b < batches.length) {
+        val it = batches(b).rowIterator()
+        while (it.hasNext) {
+          val u = proj(it.next())
+          sink += u.getLong(0) + u.getUTF8String(3).numBytes()
+        }
+        b += 1
+      }
+      if (sink == Long.MinValue) println(sink)
+    }
+
+    benchmark.addCase("Native converter") { _ =>
+      val converter = new NativeColumnarToRowConverter(schema, batchSize)
+      var sink = 0L
+      try {
+        var b = 0
+        while (b < batches.length) {
+          val it = converter.convert(batches(b))
+          while (it.hasNext) {
+            val u = it.next()
+            sink += u.getLong(0) + u.getUTF8String(3).numBytes()
+          }
+          b += 1
+        }
+      } finally {
+        converter.close()
+      }
+      if (sink == Long.MinValue) println(sink)
+    }
+
+    benchmark.run()
+
+    batches.foreach(_.close())
+  }
+
+  def main(args: Array[String]): Unit = {
+    val schema = new StructType()
+      .add("a", LongType)
+      .add("b", IntegerType)
+      .add("c", DoubleType)
+      .add("d", StringType)
+
+    runForBatchSize(schema, 8192)
+    runForBatchSize(schema, 512)
+    runForBatchSize(schema, 32)
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometColumnarToRowBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometColumnarToRowBenchmark.scala
@@ -55,6 +55,7 @@ object CometColumnarToRowBenchmark extends CometBenchmarkBase {
       .getOrCreate()
 
     // Set default configs
+    sparkSession.conf.set(SQLConf.ANSI_ENABLED.key, "false")
     sparkSession.conf.set(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key, "true")
     sparkSession.conf.set(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key, "true")
     sparkSession.conf.set(CometConf.COMET_ENABLED.key, "false")
@@ -355,6 +356,70 @@ object CometColumnarToRowBenchmark extends CometBenchmarkBase {
     }
   }
 
+  /**
+   * Benchmark with dictionary-encoded parquet data (the session default disables dictionary
+   * encoding, but real-world parquet data is usually dictionary-encoded).
+   */
+  def dictionaryEncodedBenchmark(values: Int): Unit = {
+    val benchmark =
+      new Benchmark("Columnar to Row - Dictionary-encoded strings", values, output = output)
+
+    withTempPath { dir =>
+      withTempTable("parquetV1Table") {
+        val df = spark
+          .range(values)
+          .selectExpr(
+            "id",
+            "concat('val_', cast(id % 1000 as string)) as low_card_str",
+            "concat('city_', cast(id % 100 as string)) as city",
+            "concat('cat_', cast(id % 10 as string)) as category")
+
+        // Force dictionary encoding ON for this table only
+        df.write
+          .option("parquet.enable.dictionary", "true")
+          .option("compression", "snappy")
+          .parquet(dir.getCanonicalPath + "/parquetV1")
+        spark.read
+          .parquet(dir.getCanonicalPath + "/parquetV1")
+          .createOrReplaceTempView("parquetV1Table")
+
+        val query = "SELECT * FROM parquetV1Table"
+        addC2RBenchmarkCases(benchmark, query)
+        benchmark.run()
+      }
+    }
+  }
+
+  /**
+   * Benchmark where a JVM operator (Scala UDF projection + aggregate) consumes the rows. Unlike
+   * the noop() sink, this defeats escape analysis and exercises the WholeStageCodegen fusion
+   * asymmetry between the CodegenSupport JVM C2R and the iterator-based native C2R.
+   */
+  def jvmConsumerBenchmark(values: Int): Unit = {
+    val benchmark =
+      new Benchmark("Columnar to Row - JVM UDF consumer", values, output = output)
+
+    spark.udf.register("plus_one", (x: Long) => x + 1)
+
+    withTempPath { dir =>
+      withTempTable("parquetV1Table") {
+        val df = spark
+          .range(values)
+          .selectExpr(
+            "id as long_col",
+            "cast(id as int) as int_col",
+            "cast(id as double) as double_col",
+            "cast(id as string) as string_col")
+
+        prepareTable(dir, df)
+        val query =
+          "SELECT sum(plus_one(long_col)), min(string_col), sum(double_col) FROM parquetV1Table"
+        addC2RBenchmarkCases(benchmark, query)
+        benchmark.run()
+      }
+    }
+  }
+
   override def runCometBenchmark(mainArgs: Array[String]): Unit = {
     val numRows = 1024 * 1024 // 1M rows
 
@@ -388,6 +453,14 @@ object CometColumnarToRowBenchmark extends CometBenchmarkBase {
 
     runBenchmark("Columnar to Row Conversion - Wide Rows") {
       wideRowsBenchmark(numRows)
+    }
+
+    runBenchmark("Columnar to Row Conversion - Dictionary Encoded") {
+      dictionaryEncodedBenchmark(numRows)
+    }
+
+    runBenchmark("Columnar to Row Conversion - JVM UDF Consumer") {
+      jvmConsumerBenchmark(numRows)
     }
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Part of #5112.

## Rationale for this change

#5112 shows that `CometNativeColumnarToRowExec` is 3.7x slower per row than the JVM implementation at the default batch size and up to 15.7x slower on small batches, yet `CometColumnarToRowBenchmark` reports parity in every group. The existing benchmark measures end-to-end parquet queries with a `noop()` sink, so the scan cost (70 to 530 ns/row) swamps the conversion cost and every batch arrives at the full 8192 rows, which amortizes the native path's roughly 10us of fixed per-batch overhead. This PR adds benchmarks that can actually observe conversion cost so that regressions in this class are visible and future improvements can be measured.

## What changes are included in this PR?

- New `CometC2RIsolatedBench`: measures columnar-to-row conversion in isolation on in-memory Arrow batches, comparing the JVM `rowIterator` plus `UnsafeProjection` path against `NativeColumnarToRowConverter` at batch sizes 8192, 512, and 32. Numbers from an Apple M3 Ultra are in #5112.
- Two new groups in `CometColumnarToRowBenchmark`:
  - dictionary-encoded parquet strings (the session default disables dictionary encoding, but real-world parquet data is usually dictionary-encoded)
  - a Scala UDF consumer, which defeats escape analysis and exercises the whole-stage codegen fusion asymmetry between the `CodegenSupport` JVM operator and the iterator-based native operator
- Disable ANSI mode in the benchmark session: on Spark 4.x defaults the data generation queries fail with `CAST_OVERFLOW` on `cast(id as byte)` at id=128, so the benchmark could not run at all against Spark 4.x before this change.

## How are these changes tested?

These are benchmark additions, exercised by running them:

```
make benchmark-org.apache.spark.sql.benchmark.CometColumnarToRowBenchmark
```

and `CometC2RIsolatedBench` via `exec:java` on the test classpath. Result tables from both are posted in #5112.
