### PR TITLE
feat: disable native columnar-to-row conversion by default

### DIFF
--- a/dev/diffs/3.4.3.diff
+++ b/dev/diffs/3.4.3.diff
@@ -1124,14 +1124,14 @@ index 18123a4d6ec..0fe185baa33 100644
  
    test("non-matching optional group") {
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
-index 75eabcb96f2..f8141c28f60 100644
+index 75eabcb96f2..c68f4827bf1 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
 @@ -21,10 +21,11 @@ import scala.collection.mutable.ArrayBuffer
  
  import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
  import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Join, LogicalPlan, Project, Sort, Union}
-+import org.apache.spark.sql.comet.{CometNativeColumnarToRowExec, CometNativeScanExec, CometScanExec}
++import org.apache.spark.sql.comet.{CometColumnarToRowExec, CometNativeColumnarToRowExec, CometNativeScanExec, CometScanExec}
  import org.apache.spark.sql.execution._
  import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecution}
  import org.apache.spark.sql.execution.datasources.FileScanRDD
@@ -1140,13 +1140,25 @@ index 75eabcb96f2..f8141c28f60 100644
  import org.apache.spark.sql.execution.joins.{BaseJoinExec, BroadcastHashJoinExec, BroadcastNestedLoopJoinExec}
  import org.apache.spark.sql.internal.SQLConf
  import org.apache.spark.sql.test.SharedSparkSession
-@@ -1543,6 +1544,17 @@ class SubquerySuite extends QueryTest
+@@ -1543,6 +1544,29 @@ class SubquerySuite extends QueryTest
              fs.inputRDDs().forall(
                _.asInstanceOf[FileScanRDD].filePartitions.forall(
                  _.files.forall(_.urlEncodedPath.contains("p=0"))))
 +        case WholeStageCodegenExec(ColumnarToRowExec(InputAdapter(
 +        fs @ CometScanExec(_, _, _, partitionFilters, _, _, _, _, _, _)))) =>
 +          partitionFilters.exists(ExecSubqueryExpression.hasSubquery) &&
++            fs.inputRDDs().forall(
++              _.asInstanceOf[FileScanRDD].filePartitions.forall(
++                _.files.forall(_.urlEncodedPath.contains("p=0"))))
++        case WholeStageCodegenExec(CometColumnarToRowExec(InputAdapter(
++        fs @ CometScanExec(_, _, _, partitionFilters, _, _, _, _, _, _)))) =>
++          partitionFilters.exists(ExecSubqueryExpression.hasSubquery) &&
++            fs.inputRDDs().forall(
++              _.asInstanceOf[FileScanRDD].filePartitions.forall(
++                _.files.forall(_.urlEncodedPath.contains("p=0"))))
++        case WholeStageCodegenExec(CometColumnarToRowExec(InputAdapter(
++        fs: CometNativeScanExec))) =>
++          fs.partitionFilters.exists(ExecSubqueryExpression.hasSubquery) &&
 +            fs.inputRDDs().forall(
 +              _.asInstanceOf[FileScanRDD].filePartitions.forall(
 +                _.files.forall(_.urlEncodedPath.contains("p=0"))))
@@ -1158,7 +1170,7 @@ index 75eabcb96f2..f8141c28f60 100644
          case _ => false
        })
      }
-@@ -2108,7 +2120,7 @@ class SubquerySuite extends QueryTest
+@@ -2108,7 +2132,7 @@ class SubquerySuite extends QueryTest
  
        df.collect()
        val exchanges = collect(df.queryExecution.executedPlan) {

--- a/dev/diffs/3.5.8.diff
+++ b/dev/diffs/3.5.8.diff
@@ -1065,14 +1065,14 @@ index 71af1fd69c3..81a04c93c9c 100644
      }
    }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
-index 04702201f82..c5ab5443ff7 100644
+index 04702201f82..4d38d8d6e51 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
 @@ -22,10 +22,11 @@ import scala.collection.mutable.ArrayBuffer
  import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
  import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftSemi}
  import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Join, LogicalPlan, Project, Sort, Union}
-+import org.apache.spark.sql.comet.{CometNativeColumnarToRowExec, CometNativeScanExec, CometScanExec}
++import org.apache.spark.sql.comet.{CometColumnarToRowExec, CometNativeColumnarToRowExec, CometNativeScanExec, CometScanExec}
  import org.apache.spark.sql.execution._
  import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecution}
  import org.apache.spark.sql.execution.datasources.FileScanRDD
@@ -1081,13 +1081,25 @@ index 04702201f82..c5ab5443ff7 100644
  import org.apache.spark.sql.execution.joins.{BaseJoinExec, BroadcastHashJoinExec, BroadcastNestedLoopJoinExec}
  import org.apache.spark.sql.internal.SQLConf
  import org.apache.spark.sql.test.SharedSparkSession
-@@ -1599,6 +1600,17 @@ class SubquerySuite extends QueryTest
+@@ -1599,6 +1600,29 @@ class SubquerySuite extends QueryTest
              fs.inputRDDs().forall(
                _.asInstanceOf[FileScanRDD].filePartitions.forall(
                  _.files.forall(_.urlEncodedPath.contains("p=0"))))
 +        case WholeStageCodegenExec(ColumnarToRowExec(InputAdapter(
 +        fs @ CometScanExec(_, _, _, partitionFilters, _, _, _, _, _, _)))) =>
 +          partitionFilters.exists(ExecSubqueryExpression.hasSubquery) &&
++            fs.inputRDDs().forall(
++              _.asInstanceOf[FileScanRDD].filePartitions.forall(
++                _.files.forall(_.urlEncodedPath.contains("p=0"))))
++        case WholeStageCodegenExec(CometColumnarToRowExec(InputAdapter(
++        fs @ CometScanExec(_, _, _, partitionFilters, _, _, _, _, _, _)))) =>
++          partitionFilters.exists(ExecSubqueryExpression.hasSubquery) &&
++            fs.inputRDDs().forall(
++              _.asInstanceOf[FileScanRDD].filePartitions.forall(
++                _.files.forall(_.urlEncodedPath.contains("p=0"))))
++        case WholeStageCodegenExec(CometColumnarToRowExec(InputAdapter(
++        fs: CometNativeScanExec))) =>
++          fs.partitionFilters.exists(ExecSubqueryExpression.hasSubquery) &&
 +            fs.inputRDDs().forall(
 +              _.asInstanceOf[FileScanRDD].filePartitions.forall(
 +                _.files.forall(_.urlEncodedPath.contains("p=0"))))
@@ -1099,7 +1111,7 @@ index 04702201f82..c5ab5443ff7 100644
          case _ => false
        })
      }
-@@ -2164,7 +2176,7 @@ class SubquerySuite extends QueryTest
+@@ -2164,7 +2188,7 @@ class SubquerySuite extends QueryTest
  
        df.collect()
        val exchanges = collect(df.queryExecution.executedPlan) {

--- a/dev/diffs/4.0.2.diff
+++ b/dev/diffs/4.0.2.diff
@@ -1298,14 +1298,14 @@ index 0df7f806272..9cdfe8b8f46 100644
              df.collect()
            }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
-index 2e33f6505ab..be967565303 100644
+index 2e33f6505ab..f0e64fd58ca 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
 @@ -23,10 +23,11 @@ import org.apache.spark.SparkRuntimeException
  import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
  import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftSemi}
  import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Join, LogicalPlan, Project, Sort, Union}
-+import org.apache.spark.sql.comet.{CometNativeColumnarToRowExec, CometNativeScanExec, CometScanExec}
++import org.apache.spark.sql.comet.{CometColumnarToRowExec, CometNativeColumnarToRowExec, CometNativeScanExec, CometScanExec}
  import org.apache.spark.sql.execution._
  import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecution}
  import org.apache.spark.sql.execution.datasources.FileScanRDD
@@ -1314,13 +1314,25 @@ index 2e33f6505ab..be967565303 100644
  import org.apache.spark.sql.execution.joins.{BaseJoinExec, BroadcastHashJoinExec, BroadcastNestedLoopJoinExec}
  import org.apache.spark.sql.internal.SQLConf
  import org.apache.spark.sql.test.SharedSparkSession
-@@ -1529,6 +1530,18 @@ class SubquerySuite extends QueryTest
+@@ -1529,6 +1530,30 @@ class SubquerySuite extends QueryTest
              fs.inputRDDs().forall(
                _.asInstanceOf[FileScanRDD].filePartitions.forall(
                  _.files.forall(_.urlEncodedPath.contains("p=0"))))
 +        case WholeStageCodegenExec(ColumnarToRowExec(InputAdapter(
 +        fs @ CometScanExec(_, _, _, partitionFilters, _, _, _, _, _, _)))) =>
 +          partitionFilters.exists(ExecSubqueryExpression.hasSubquery) &&
++            fs.inputRDDs().forall(
++              _.asInstanceOf[FileScanRDD].filePartitions.forall(
++                _.files.forall(_.urlEncodedPath.contains("p=0"))))
++        case WholeStageCodegenExec(CometColumnarToRowExec(InputAdapter(
++        fs @ CometScanExec(_, _, _, partitionFilters, _, _, _, _, _, _)))) =>
++          partitionFilters.exists(ExecSubqueryExpression.hasSubquery) &&
++            fs.inputRDDs().forall(
++              _.asInstanceOf[FileScanRDD].filePartitions.forall(
++                _.files.forall(_.urlEncodedPath.contains("p=0"))))
++        case WholeStageCodegenExec(CometColumnarToRowExec(InputAdapter(
++        fs: CometNativeScanExec))) =>
++          fs.partitionFilters.exists(ExecSubqueryExpression.hasSubquery) &&
 +            fs.inputRDDs().forall(
 +              _.asInstanceOf[FileScanRDD].filePartitions.forall(
 +                _.files.forall(_.urlEncodedPath.contains("p=0"))))
@@ -1333,7 +1345,7 @@ index 2e33f6505ab..be967565303 100644
          case _ => false
        })
      }
-@@ -2094,7 +2107,7 @@ class SubquerySuite extends QueryTest
+@@ -2094,7 +2119,7 @@ class SubquerySuite extends QueryTest
  
        df.collect()
        val exchanges = collect(df.queryExecution.executedPlan) {
@@ -1342,7 +1354,7 @@ index 2e33f6505ab..be967565303 100644
        }
        assert(exchanges.size === 1)
      }
-@@ -2678,18 +2691,29 @@ class SubquerySuite extends QueryTest
+@@ -2678,18 +2703,29 @@ class SubquerySuite extends QueryTest
      def checkFileSourceScan(query: String, answer: Seq[Row]): Unit = {
        val df = sql(query)
        checkAnswer(df, answer)

--- a/dev/diffs/4.1.2.diff
+++ b/dev/diffs/4.1.2.diff
@@ -1397,14 +1397,14 @@ index 7bfc8cf4fa6..4bd387801db 100644
              df.collect()
            }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
-index 3ba48da0e32..0313aaa9ec6 100644
+index 3ba48da0e32..a7f9513b9c8 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
 @@ -23,10 +23,11 @@ import org.apache.spark.SparkRuntimeException
  import org.apache.spark.sql.catalyst.expressions.{EqualTo, NamedExpression, OuterReference, SubqueryExpression}
  import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftSemi}
  import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Join, LogicalPlan, Project, Sort, Union}
-+import org.apache.spark.sql.comet.{CometNativeColumnarToRowExec, CometNativeScanExec, CometScanExec}
++import org.apache.spark.sql.comet.{CometColumnarToRowExec, CometNativeColumnarToRowExec, CometNativeScanExec, CometScanExec}
  import org.apache.spark.sql.execution._
  import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecution}
  import org.apache.spark.sql.execution.datasources.FileScanRDD
@@ -1413,13 +1413,25 @@ index 3ba48da0e32..0313aaa9ec6 100644
  import org.apache.spark.sql.execution.joins.{BaseJoinExec, BroadcastHashJoinExec, BroadcastNestedLoopJoinExec}
  import org.apache.spark.sql.internal.SQLConf
  import org.apache.spark.sql.test.SharedSparkSession
-@@ -1529,6 +1530,18 @@ class SubquerySuite extends QueryTest
+@@ -1529,6 +1530,30 @@ class SubquerySuite extends QueryTest
              fs.inputRDDs().forall(
                _.asInstanceOf[FileScanRDD].filePartitions.forall(
                  _.files.forall(_.urlEncodedPath.contains("p=0"))))
 +        case WholeStageCodegenExec(ColumnarToRowExec(InputAdapter(
 +        fs @ CometScanExec(_, _, _, partitionFilters, _, _, _, _, _, _)))) =>
 +          partitionFilters.exists(ExecSubqueryExpression.hasSubquery) &&
++            fs.inputRDDs().forall(
++              _.asInstanceOf[FileScanRDD].filePartitions.forall(
++                _.files.forall(_.urlEncodedPath.contains("p=0"))))
++        case WholeStageCodegenExec(CometColumnarToRowExec(InputAdapter(
++        fs @ CometScanExec(_, _, _, partitionFilters, _, _, _, _, _, _)))) =>
++          partitionFilters.exists(ExecSubqueryExpression.hasSubquery) &&
++            fs.inputRDDs().forall(
++              _.asInstanceOf[FileScanRDD].filePartitions.forall(
++                _.files.forall(_.urlEncodedPath.contains("p=0"))))
++        case WholeStageCodegenExec(CometColumnarToRowExec(InputAdapter(
++        fs: CometNativeScanExec))) =>
++          fs.partitionFilters.exists(ExecSubqueryExpression.hasSubquery) &&
 +            fs.inputRDDs().forall(
 +              _.asInstanceOf[FileScanRDD].filePartitions.forall(
 +                _.files.forall(_.urlEncodedPath.contains("p=0"))))
@@ -1432,7 +1444,7 @@ index 3ba48da0e32..0313aaa9ec6 100644
          case _ => false
        })
      }
-@@ -2094,7 +2107,7 @@ class SubquerySuite extends QueryTest
+@@ -2094,7 +2119,7 @@ class SubquerySuite extends QueryTest
  
        df.collect()
        val exchanges = collect(df.queryExecution.executedPlan) {
@@ -1441,7 +1453,7 @@ index 3ba48da0e32..0313aaa9ec6 100644
        }
        assert(exchanges.size === 1)
      }
-@@ -2678,18 +2691,29 @@ class SubquerySuite extends QueryTest
+@@ -2678,18 +2703,29 @@ class SubquerySuite extends QueryTest
      def checkFileSourceScan(query: String, answer: Seq[Row]): Unit = {
        val df = sql(query)
        checkAnswer(df, answer)

--- a/dev/diffs/4.1.2.diff
+++ b/dev/diffs/4.1.2.diff
@@ -2736,10 +2736,10 @@ index 3e7d26f74bd..79232dc3664 100644
          assert(o1.semanticEquals(o2), "Different output column order after AQE optimization")
        }
 diff --git a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/CachedBatchSerializerSuite.scala b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/CachedBatchSerializerSuite.scala
-index 47b935a2880..3e9b87f5c32 100644
+index 47b935a2880..3fdeab3113c 100644
 --- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/CachedBatchSerializerSuite.scala
 +++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/CachedBatchSerializerSuite.scala
-@@ -230,9 +230,16 @@ class CachedBatchSerializerNoUnwrapSuite extends QueryTest
+@@ -230,9 +230,21 @@ class CachedBatchSerializerNoUnwrapSuite extends QueryTest
        assert(cachedPlans.length == 2)
        cachedPlans.foreach {
          cachedPlan =>
@@ -2750,11 +2750,16 @@ index 47b935a2880..3e9b87f5c32 100644
 +          // (CometNativeColumnarToRow / CometColumnarToRow). Accept either the
 +          // Spark shape or the equivalent Comet shape, since the important property
 +          // under this serializer is that the row conversion is not unwrapped.
-+          val isSparkShape =
-+            cachedPlan.isInstanceOf[WholeStageCodegenExec] &&
-+              cachedPlan.asInstanceOf[WholeStageCodegenExec]
-+                .child.isInstanceOf[ColumnarToRowExec]
-+          val isCometShape = cachedPlan.getClass.getName.startsWith("org.apache.spark.sql.comet.")
++          // CometColumnarToRowExec supports codegen, so it appears as the child of a
++          // WholeStageCodegenExec, while CometNativeColumnarToRowExec does not and is
++          // the cached plan itself.
++          val transition = cachedPlan match {
++            case w: WholeStageCodegenExec => w.child
++            case other => other
++          }
++          val isSparkShape = cachedPlan.isInstanceOf[WholeStageCodegenExec] &&
++            transition.isInstanceOf[ColumnarToRowExec]
++          val isCometShape = transition.getClass.getName.startsWith("org.apache.spark.sql.comet.")
 +          assert(isSparkShape || isCometShape, s"unexpected cached plan:\n$cachedPlan")
        }
      }

--- a/docs/source/user-guide/latest/installation.md
+++ b/docs/source/user-guide/latest/installation.md
@@ -161,7 +161,7 @@ Comet will log output similar to:
 
 ```shell
 == Physical Plan ==
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometFilter [a#6], (isnotnull(a#6) AND (a#6 > 5))
    +- CometNativeScan parquet [a#6] Batched: true, DataFilters: [isnotnull(a#6), (a#6 > 5)], Format: CometParquet, Location: InMemoryFileIndex(1 paths)[file:/tmp/test], PartitionFilters: [], PushedFilters: [IsNotNull(a), GreaterThan(a,5)], ReadSchema: struct<a:int>
 ```

--- a/docs/source/user-guide/latest/understanding-comet-plans.md
+++ b/docs/source/user-guide/latest/understanding-comet-plans.md
@@ -140,7 +140,7 @@ println(new org.apache.comet.ExtendedExplainInfo()
 Output:
 
 ```
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometProject [COMET-INFO: JVM codegen dispatcher: hypot, levenshtein]
    +- CometNativeScan parquet spark_catalog.default.t
 
@@ -221,7 +221,7 @@ Output
 
 ```
 Project [COMET: from_unixtime(eventTime#5L, yyyy-MM-dd HH:mm:ss, Some(GMT)) is not fully compatible with Spark. To enable it anyway, set spark.comet.expression.FromUnixTime.allowIncompatible=true. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/compatibility.html).]
-+- CometNativeColumnarToRow
++- CometColumnarToRow
    +- CometNativeScan parquet
 
 Comet accelerated 1 out of 2 eligible operators (50%). Final plan contains 1 transitions between Spark and Comet.
@@ -309,12 +309,12 @@ Comet inserts these nodes wherever data has to cross the columnar/row boundary.
 Multiple implementations exist because the optimal strategy depends on what
 produced the columnar data.
 
-| Node                           | Direction           | Notes                                                                                                                                                                                                                             |
-| ------------------------------ | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `CometColumnarToRow`           | columnar → row      | JVM-based row conversion. A fork of Spark's `ColumnarToRowExec` that includes the SPARK-50235 fix.                                                                                                                                |
-| `CometNativeColumnarToRow`     | columnar → row      | Rust-based row conversion that decodes broadcast Arrow batches via `NativeColumnarToRowConverter`. Used downstream of `CometBroadcastExchange`. Zero-copy for variable-length types and avoids an extra JVM materialization step. |
-| `CometSparkColumnarToColumnar` | columnar → columnar | Converts a Spark columnar input (a non-Comet `ColumnarBatch`) into Comet's Arrow batches.                                                                                                                                         |
-| `CometSparkRowToColumnar`      | row → columnar      | Converts a Spark row input into Comet's Arrow batches.                                                                                                                                                                            |
+| Node                           | Direction           | Notes                                                                                                                                                                                                                                               |
+| ------------------------------ | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CometColumnarToRow`           | columnar → row      | JVM-based row conversion. A fork of Spark's `ColumnarToRowExec` that includes the SPARK-50235 fix. This is the default.                                                                                                                             |
+| `CometNativeColumnarToRow`     | columnar → row      | Rust-based row conversion via `NativeColumnarToRowConverter`. Disabled by default; enable with `spark.comet.exec.columnarToRow.native.enabled=true`. It carries a fixed JNI cost per batch and is slower than the JVM conversion for small batches. |
+| `CometSparkColumnarToColumnar` | columnar → columnar | Converts a Spark columnar input (a non-Comet `ColumnarBatch`) into Comet's Arrow batches.                                                                                                                                                           |
+| `CometSparkRowToColumnar`      | row → columnar      | Converts a Spark row input into Comet's Arrow batches.                                                                                                                                                                                              |
 
 The two `CometSpark*` names come from a single `CometSparkToColumnarExec`
 operator that picks the node name based on whether its child supports

--- a/native/spark-expr/src/agg_funcs/avg_decimal.rs
+++ b/native/spark-expr/src/agg_funcs/avg_decimal.rs
@@ -361,7 +361,14 @@ impl Accumulator for AvgDecimalAccumulator {
     fn evaluate(&mut self) -> Result<ScalarValue> {
         // Check for overflow during sum accumulation in ANSI mode.
         // This matches Spark's DecimalDivideWithOverflowCheck behavior.
-        if self.sum.is_none() && !self.is_empty && self.eval_mode == EvalMode::Ansi {
+        // `count` guards against reporting an overflow when there was nothing to sum: an
+        // empty or all-null input also leaves `sum` as None, and `is_empty` cannot
+        // distinguish those cases because the counts merged in `merge_batch` are never null.
+        if self.sum.is_none()
+            && !self.is_empty
+            && self.count > 0
+            && self.eval_mode == EvalMode::Ansi
+        {
             let error = decimal_sum_overflow_error("avg");
             return Err(self.wrap_error_with_context(error));
         }

--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -240,10 +240,10 @@ object CometConf extends ShimCometConf {
       .doc(
         "Whether to enable native columnar to row conversion. When enabled, Comet will use " +
           "native Rust code to convert Arrow columnar data to Spark UnsafeRow format instead " +
-          "of the JVM implementation. This can improve performance for queries that need to " +
-          "convert between columnar and row formats.")
+          "of the JVM implementation. The native conversion carries a fixed JNI cost per batch " +
+          "and is slower than the JVM implementation for small batches.")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val COMET_EXEC_SORT_MERGE_JOIN_WITH_JOIN_FILTER_ENABLED: ConfigEntry[Boolean] =
     conf("spark.comet.exec.sortMergeJoinWithJoinFilter.enabled")

--- a/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
@@ -440,10 +440,20 @@ case class CometExecRule(session: SparkSession)
       case sub: SubqueryBroadcastExec =>
         sub.child match {
           case b: BroadcastExchangeExec =>
-            // The BroadcastExchangeExec child is CometNativeColumnarToRowExec wrapping
+            // The BroadcastExchangeExec child is a Comet columnar-to-row transition wrapping
             // a Comet plan. Strip the row transition to get the columnar Comet plan.
+            // CometColumnarToRowExec is CodegenSupport, so by the time this rule sees the
+            // subquery plan it is compiled into WholeStageCodegenExec(CometColumnarToRowExec(
+            // InputAdapter(cometPlan))); CometNativeColumnarToRowExec is not CodegenSupport and
+            // sits directly under the exchange.
             val cometChild = b.child match {
               case c2r: CometNativeColumnarToRowExec => c2r.child
+              case c2r: CometColumnarToRowExec => c2r.child
+              case WholeStageCodegenExec(c2r: CometColumnarToRowExec) =>
+                c2r.child match {
+                  case InputAdapter(child) => child
+                  case other => other
+                }
               case other => other
             }
             if (cometChild.isInstanceOf[CometNativeExec]) {

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeColumnarToRowExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeColumnarToRowExec.scala
@@ -45,13 +45,10 @@ import org.apache.comet.{CometConf, NativeColumnarToRowConverter}
  * Native implementation of ColumnarToRowExec that converts Arrow columnar data to Spark UnsafeRow
  * format using Rust.
  *
- * This feature is enabled by default and can be disabled by setting
- * `spark.comet.exec.columnarToRow.native.enabled=false`.
- *
- * Benefits over the JVM implementation:
- *   - Zero-copy for variable-length types (strings, binary)
- *   - Better CPU cache utilization through vectorized processing
- *   - Reduced GC pressure
+ * This feature is disabled by default and can be enabled by setting
+ * `spark.comet.exec.columnarToRow.native.enabled=true`. The native conversion carries a fixed JNI
+ * cost per batch and is slower than the JVM implementation for small batches (see issue #5112 for
+ * measurements).
  *
  * @param child
  *   The child plan that produces columnar batches

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q44/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q44/extended.txt
@@ -10,15 +10,15 @@ TakeOrderedAndProject
       :     :     :     +- Filter
       :     :     :        +- Window
       :     :     :           +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-      :     :     :              +- CometNativeColumnarToRow
+      :     :     :              +- CometColumnarToRow
       :     :     :                 +- CometSort
       :     :     :                    +- CometColumnarExchange
       :     :     :                       +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-      :     :     :                          +- CometNativeColumnarToRow
+      :     :     :                          +- CometColumnarToRow
       :     :     :                             +- CometSort
       :     :     :                                +- CometFilter
       :     :     :                                   :  +- Subquery
-      :     :     :                                   :     +- CometNativeColumnarToRow
+      :     :     :                                   :     +- CometColumnarToRow
       :     :     :                                   :        +- CometHashAggregate
       :     :     :                                   :           +- CometExchange
       :     :     :                                   :              +- CometHashAggregate
@@ -36,11 +36,11 @@ TakeOrderedAndProject
       :     :           +- Filter
       :     :              +- Window
       :     :                 +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-      :     :                    +- CometNativeColumnarToRow
+      :     :                    +- CometColumnarToRow
       :     :                       +- CometSort
       :     :                          +- CometColumnarExchange
       :     :                             +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-      :     :                                +- CometNativeColumnarToRow
+      :     :                                +- CometColumnarToRow
       :     :                                   +- CometSort
       :     :                                      +- CometFilter
       :     :                                         :  +- ReusedSubquery
@@ -51,12 +51,12 @@ TakeOrderedAndProject
       :     :                                                     +- CometFilter
       :     :                                                        +- CometNativeScan parquet spark_catalog.default.store_sales
       :     +- BroadcastExchange
-      :        +- CometNativeColumnarToRow
+      :        +- CometColumnarToRow
       :           +- CometProject
       :              +- CometFilter
       :                 +- CometNativeScan parquet spark_catalog.default.item
       +- BroadcastExchange
-         +- CometNativeColumnarToRow
+         +- CometColumnarToRow
             +- CometProject
                +- CometFilter
                   +- CometNativeScan parquet spark_catalog.default.item

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q44/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q44/extended.txt
@@ -10,15 +10,15 @@ TakeOrderedAndProject
       :     :     :     +- Filter
       :     :     :        +- Window
       :     :     :           +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-      :     :     :              +- CometNativeColumnarToRow
+      :     :     :              +- CometColumnarToRow
       :     :     :                 +- CometSort
       :     :     :                    +- CometColumnarExchange
       :     :     :                       +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-      :     :     :                          +- CometNativeColumnarToRow
+      :     :     :                          +- CometColumnarToRow
       :     :     :                             +- CometSort
       :     :     :                                +- CometFilter
       :     :     :                                   :  +- Subquery
-      :     :     :                                   :     +- CometNativeColumnarToRow
+      :     :     :                                   :     +- CometColumnarToRow
       :     :     :                                   :        +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
       :     :     :                                   :           +- CometExchange
       :     :     :                                   :              +- CometHashAggregate
@@ -36,11 +36,11 @@ TakeOrderedAndProject
       :     :           +- Filter
       :     :              +- Window
       :     :                 +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-      :     :                    +- CometNativeColumnarToRow
+      :     :                    +- CometColumnarToRow
       :     :                       +- CometSort
       :     :                          +- CometColumnarExchange
       :     :                             +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-      :     :                                +- CometNativeColumnarToRow
+      :     :                                +- CometColumnarToRow
       :     :                                   +- CometSort
       :     :                                      +- CometFilter
       :     :                                         :  +- ReusedSubquery
@@ -51,12 +51,12 @@ TakeOrderedAndProject
       :     :                                                     +- CometFilter
       :     :                                                        +- CometNativeScan parquet spark_catalog.default.store_sales
       :     +- BroadcastExchange
-      :        +- CometNativeColumnarToRow
+      :        +- CometColumnarToRow
       :           +- CometProject
       :              +- CometFilter
       :                 +- CometNativeScan parquet spark_catalog.default.item
       +- BroadcastExchange
-         +- CometNativeColumnarToRow
+         +- CometColumnarToRow
             +- CometProject
                +- CometFilter
                   +- CometNativeScan parquet spark_catalog.default.item

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q58/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q58/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin
@@ -24,7 +24,7 @@ CometNativeColumnarToRow
          :     :                 :     :                       +- CometProject
          :     :                 :     :                          +- CometFilter
          :     :                 :     :                             :  +- Subquery
-         :     :                 :     :                             :     +- CometNativeColumnarToRow
+         :     :                 :     :                             :     +- CometColumnarToRow
          :     :                 :     :                             :        +- CometProject
          :     :                 :     :                             :           +- CometFilter
          :     :                 :     :                             :              +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -42,7 +42,7 @@ CometNativeColumnarToRow
          :     :                             +- CometProject
          :     :                                +- CometFilter
          :     :                                   :  +- Subquery
-         :     :                                   :     +- CometNativeColumnarToRow
+         :     :                                   :     +- CometColumnarToRow
          :     :                                   :        +- CometProject
          :     :                                   :           +- CometFilter
          :     :                                   :              +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -72,7 +72,7 @@ CometNativeColumnarToRow
          :                                      +- CometProject
          :                                         +- CometFilter
          :                                            :  +- Subquery
-         :                                            :     +- CometNativeColumnarToRow
+         :                                            :     +- CometColumnarToRow
          :                                            :        +- CometProject
          :                                            :           +- CometFilter
          :                                            :              +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -102,7 +102,7 @@ CometNativeColumnarToRow
                                           +- CometProject
                                              +- CometFilter
                                                 :  +- Subquery
-                                                :     +- CometNativeColumnarToRow
+                                                :     +- CometColumnarToRow
                                                 :        +- CometProject
                                                 :           +- CometFilter
                                                 :              +- CometNativeScan parquet spark_catalog.default.date_dim

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q67/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q67/extended.txt
@@ -2,11 +2,11 @@ TakeOrderedAndProject
 +- Filter
    +- Window
       +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-         +- CometNativeColumnarToRow
+         +- CometColumnarToRow
             +- CometSort
                +- CometColumnarExchange
                   +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-                     +- CometNativeColumnarToRow
+                     +- CometColumnarToRow
                         +- CometSort
                            +- CometHashAggregate
                               +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q70/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q70/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometWindowExec
@@ -10,7 +10,7 @@ CometNativeColumnarToRow
                         +- Expand
                            +- Project
                               +- BroadcastHashJoin
-                                 :- CometNativeColumnarToRow
+                                 :- CometColumnarToRow
                                  :  +- CometProject
                                  :     +- CometBroadcastHashJoin
                                  :        :- CometFilter
@@ -27,7 +27,7 @@ CometNativeColumnarToRow
                                  +- BroadcastExchange
                                     +- Project
                                        +- BroadcastHashJoin
-                                          :- CometNativeColumnarToRow
+                                          :- CometColumnarToRow
                                           :  +- CometFilter
                                           :     +- CometNativeScan parquet spark_catalog.default.store
                                           +- BroadcastExchange
@@ -35,7 +35,7 @@ CometNativeColumnarToRow
                                                 +- Filter
                                                    +- Window
                                                       +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-                                                         +- CometNativeColumnarToRow
+                                                         +- CometColumnarToRow
                                                             +- CometSort
                                                                +- CometHashAggregate
                                                                   +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q83/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q83/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q14b/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q14b/extended.txt
@@ -1,9 +1,9 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometBroadcastHashJoin
       :- CometFilter
       :  :  +- Subquery
-      :  :     +- CometNativeColumnarToRow
+      :  :     +- CometColumnarToRow
       :  :        +- CometHashAggregate
       :  :           +- CometExchange
       :  :              +- CometHashAggregate
@@ -49,7 +49,7 @@ CometNativeColumnarToRow
       :                 :     :  :                    :  +- ReusedSubquery
       :                 :     :  :                    +- CometNativeScan parquet spark_catalog.default.date_dim
       :                 :     :  :                          +- Subquery
-      :                 :     :  :                             +- CometNativeColumnarToRow
+      :                 :     :  :                             +- CometColumnarToRow
       :                 :     :  :                                +- CometProject
       :                 :     :  :                                   +- CometFilter
       :                 :     :  :                                      +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -181,7 +181,7 @@ CometNativeColumnarToRow
       :                          :  +- ReusedSubquery
       :                          +- CometNativeScan parquet spark_catalog.default.date_dim
       :                                +- Subquery
-      :                                   +- CometNativeColumnarToRow
+      :                                   +- CometColumnarToRow
       :                                      +- CometProject
       :                                         +- CometFilter
       :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -205,7 +205,7 @@ CometNativeColumnarToRow
                            :     :  :                    :  +- ReusedSubquery
                            :     :  :                    +- CometNativeScan parquet spark_catalog.default.date_dim
                            :     :  :                          +- Subquery
-                           :     :  :                             +- CometNativeColumnarToRow
+                           :     :  :                             +- CometColumnarToRow
                            :     :  :                                +- CometProject
                            :     :  :                                   +- CometFilter
                            :     :  :                                      +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -337,7 +337,7 @@ CometNativeColumnarToRow
                                     :  +- ReusedSubquery
                                     +- CometNativeScan parquet spark_catalog.default.date_dim
                                           +- Subquery
-                                             +- CometNativeColumnarToRow
+                                             +- CometColumnarToRow
                                                 +- CometProject
                                                    +- CometFilter
                                                       +- CometNativeScan parquet spark_catalog.default.date_dim

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q44/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q44/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin
@@ -12,15 +12,15 @@ CometNativeColumnarToRow
          :     :     :        +- Filter
          :     :     :           +- Window
          :     :     :              +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-         :     :     :                 +- CometNativeColumnarToRow
+         :     :     :                 +- CometColumnarToRow
          :     :     :                    +- CometSort
          :     :     :                       +- CometColumnarExchange
          :     :     :                          +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-         :     :     :                             +- CometNativeColumnarToRow
+         :     :     :                             +- CometColumnarToRow
          :     :     :                                +- CometSort
          :     :     :                                   +- CometFilter
          :     :     :                                      :  +- Subquery
-         :     :     :                                      :     +- CometNativeColumnarToRow
+         :     :     :                                      :     +- CometColumnarToRow
          :     :     :                                      :        +- CometHashAggregate
          :     :     :                                      :           +- CometExchange
          :     :     :                                      :              +- CometHashAggregate
@@ -39,11 +39,11 @@ CometNativeColumnarToRow
          :     :              +- Filter
          :     :                 +- Window
          :     :                    +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-         :     :                       +- CometNativeColumnarToRow
+         :     :                       +- CometColumnarToRow
          :     :                          +- CometSort
          :     :                             +- CometColumnarExchange
          :     :                                +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-         :     :                                   +- CometNativeColumnarToRow
+         :     :                                   +- CometColumnarToRow
          :     :                                      +- CometSort
          :     :                                         +- CometFilter
          :     :                                            :  +- ReusedSubquery

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q44/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q44/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin
@@ -12,15 +12,15 @@ CometNativeColumnarToRow
          :     :     :        +- Filter
          :     :     :           +- Window
          :     :     :              +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-         :     :     :                 +- CometNativeColumnarToRow
+         :     :     :                 +- CometColumnarToRow
          :     :     :                    +- CometSort
          :     :     :                       +- CometColumnarExchange
          :     :     :                          +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-         :     :     :                             +- CometNativeColumnarToRow
+         :     :     :                             +- CometColumnarToRow
          :     :     :                                +- CometSort
          :     :     :                                   +- CometFilter
          :     :     :                                      :  +- Subquery
-         :     :     :                                      :     +- CometNativeColumnarToRow
+         :     :     :                                      :     +- CometColumnarToRow
          :     :     :                                      :        +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
          :     :     :                                      :           +- CometExchange
          :     :     :                                      :              +- CometHashAggregate
@@ -39,11 +39,11 @@ CometNativeColumnarToRow
          :     :              +- Filter
          :     :                 +- Window
          :     :                    +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-         :     :                       +- CometNativeColumnarToRow
+         :     :                       +- CometColumnarToRow
          :     :                          +- CometSort
          :     :                             +- CometColumnarExchange
          :     :                                +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-         :     :                                   +- CometNativeColumnarToRow
+         :     :                                   +- CometColumnarToRow
          :     :                                      +- CometSort
          :     :                                         +- CometFilter
          :     :                                            :  +- ReusedSubquery

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q54/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q54/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange
@@ -58,7 +58,7 @@ CometNativeColumnarToRow
                            :     :     :                             :  +- ReusedSubquery
                            :     :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
                            :     :     :                                   :- Subquery
-                           :     :     :                                   :  +- CometNativeColumnarToRow
+                           :     :     :                                   :  +- CometColumnarToRow
                            :     :     :                                   :     +- CometHashAggregate
                            :     :     :                                   :        +- CometExchange
                            :     :     :                                   :           +- CometHashAggregate
@@ -66,7 +66,7 @@ CometNativeColumnarToRow
                            :     :     :                                   :                 +- CometFilter
                            :     :     :                                   :                    +- CometNativeScan parquet spark_catalog.default.date_dim
                            :     :     :                                   +- Subquery
-                           :     :     :                                      +- CometNativeColumnarToRow
+                           :     :     :                                      +- CometColumnarToRow
                            :     :     :                                         +- CometHashAggregate
                            :     :     :                                            +- CometExchange
                            :     :     :                                               +- CometHashAggregate
@@ -88,7 +88,7 @@ CometNativeColumnarToRow
                                     :  +- ReusedSubquery
                                     +- CometNativeScan parquet spark_catalog.default.date_dim
                                           :- Subquery
-                                          :  +- CometNativeColumnarToRow
+                                          :  +- CometColumnarToRow
                                           :     +- CometHashAggregate
                                           :        +- CometExchange
                                           :           +- CometHashAggregate
@@ -96,7 +96,7 @@ CometNativeColumnarToRow
                                           :                 +- CometFilter
                                           :                    +- CometNativeScan parquet spark_catalog.default.date_dim
                                           +- Subquery
-                                             +- CometNativeColumnarToRow
+                                             +- CometColumnarToRow
                                                 +- CometHashAggregate
                                                    +- CometExchange
                                                       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q58/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q58/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin
@@ -26,7 +26,7 @@ CometNativeColumnarToRow
          :     :                 :     :                             :  +- ReusedSubquery
          :     :                 :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
          :     :                 :     :                                   +- Subquery
-         :     :                 :     :                                      +- CometNativeColumnarToRow
+         :     :                 :     :                                      +- CometColumnarToRow
          :     :                 :     :                                         +- CometProject
          :     :                 :     :                                            +- CometFilter
          :     :                 :     :                                               +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -45,7 +45,7 @@ CometNativeColumnarToRow
          :     :                                   :  +- ReusedSubquery
          :     :                                   +- CometNativeScan parquet spark_catalog.default.date_dim
          :     :                                         +- Subquery
-         :     :                                            +- CometNativeColumnarToRow
+         :     :                                            +- CometColumnarToRow
          :     :                                               +- CometProject
          :     :                                                  +- CometFilter
          :     :                                                     +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -76,7 +76,7 @@ CometNativeColumnarToRow
          :                                            :  +- ReusedSubquery
          :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
          :                                                  +- Subquery
-         :                                                     +- CometNativeColumnarToRow
+         :                                                     +- CometColumnarToRow
          :                                                        +- CometProject
          :                                                           +- CometFilter
          :                                                              +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -107,7 +107,7 @@ CometNativeColumnarToRow
                                                 :  +- ReusedSubquery
                                                 +- CometNativeScan parquet spark_catalog.default.date_dim
                                                       +- Subquery
-                                                         +- CometNativeColumnarToRow
+                                                         +- CometColumnarToRow
                                                             +- CometProject
                                                                +- CometFilter
                                                                   +- CometNativeScan parquet spark_catalog.default.date_dim

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q6/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q6/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometFilter
       +- CometHashAggregate
@@ -28,7 +28,7 @@ CometNativeColumnarToRow
                      :     :                             :  +- ReusedSubquery
                      :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
                      :     :                                   +- Subquery
-                     :     :                                      +- CometNativeColumnarToRow
+                     :     :                                      +- CometColumnarToRow
                      :     :                                         +- CometHashAggregate
                      :     :                                            +- CometExchange
                      :     :                                               +- CometHashAggregate
@@ -41,7 +41,7 @@ CometNativeColumnarToRow
                      :              :  +- ReusedSubquery
                      :              +- CometNativeScan parquet spark_catalog.default.date_dim
                      :                    +- Subquery
-                     :                       +- CometNativeColumnarToRow
+                     :                       +- CometColumnarToRow
                      :                          +- CometHashAggregate
                      :                             +- CometExchange
                      :                                +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q83.ansi/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q83.ansi/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_1/q33/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_1/q33/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_1/q49/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_1/q49/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_1/q56/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_1/q56/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_1/q60/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_1/q60/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_1/q66/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_1/q66/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q1/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q1/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10/extended.txt
@@ -10,7 +10,7 @@ TakeOrderedAndProject
                :     :  +- Filter
                :     :     +- BroadcastHashJoin
                :     :        :-  BroadcastHashJoin [COMET: Unsupported join type ExistenceJoin(exists#1)]
-               :     :        :  :- CometNativeColumnarToRow
+               :     :        :  :- CometColumnarToRow
                :     :        :  :  +- CometBroadcastHashJoin
                :     :        :  :     :- CometFilter
                :     :        :  :     :  +- CometNativeScan parquet spark_catalog.default.customer
@@ -28,7 +28,7 @@ TakeOrderedAndProject
                :     :        :  :                    +- CometFilter
                :     :        :  :                       +- CometNativeScan parquet spark_catalog.default.date_dim
                :     :        :  +- BroadcastExchange
-               :     :        :     +- CometNativeColumnarToRow
+               :     :        :     +- CometColumnarToRow
                :     :        :        +- CometProject
                :     :        :           +- CometBroadcastHashJoin
                :     :        :              :- CometNativeScan parquet spark_catalog.default.web_sales
@@ -38,7 +38,7 @@ TakeOrderedAndProject
                :     :        :                    +- CometFilter
                :     :        :                       +- CometNativeScan parquet spark_catalog.default.date_dim
                :     :        +- BroadcastExchange
-               :     :           +- CometNativeColumnarToRow
+               :     :           +- CometColumnarToRow
                :     :              +- CometProject
                :     :                 +- CometBroadcastHashJoin
                :     :                    :- CometNativeScan parquet spark_catalog.default.catalog_sales
@@ -48,12 +48,12 @@ TakeOrderedAndProject
                :     :                          +- CometFilter
                :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
                :     +- BroadcastExchange
-               :        +- CometNativeColumnarToRow
+               :        +- CometColumnarToRow
                :           +- CometProject
                :              +- CometFilter
                :                 +- CometNativeScan parquet spark_catalog.default.customer_address
                +- BroadcastExchange
-                  +- CometNativeColumnarToRow
+                  +- CometColumnarToRow
                      +- CometProject
                         +- CometFilter
                            +- CometNativeScan parquet spark_catalog.default.customer_demographics

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q11/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q11/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q12/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q12/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometWindowExec

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q13/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q13/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometHashAggregate
    +- CometExchange
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q13/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q13/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
    +- CometExchange
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange
@@ -8,7 +8,7 @@ CometNativeColumnarToRow
                   :- CometProject
                   :  +- CometFilter
                   :     :  +- Subquery
-                  :     :     +- CometNativeColumnarToRow
+                  :     :     +- CometColumnarToRow
                   :     :        +- CometHashAggregate
                   :     :           +- CometExchange
                   :     :              +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b/extended.txt
@@ -1,9 +1,9 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometBroadcastHashJoin
       :- CometFilter
       :  :  +- Subquery
-      :  :     +- CometNativeColumnarToRow
+      :  :     +- CometColumnarToRow
       :  :        +- CometHashAggregate
       :  :           +- CometExchange
       :  :              +- CometHashAggregate
@@ -47,7 +47,7 @@ CometNativeColumnarToRow
       :                 :     :  :              +- CometProject
       :                 :     :  :                 +- CometFilter
       :                 :     :  :                    :  +- Subquery
-      :                 :     :  :                    :     +- CometNativeColumnarToRow
+      :                 :     :  :                    :     +- CometColumnarToRow
       :                 :     :  :                    :        +- CometProject
       :                 :     :  :                    :           +- CometFilter
       :                 :     :  :                    :              +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -178,7 +178,7 @@ CometNativeColumnarToRow
       :                    +- CometProject
       :                       +- CometFilter
       :                          :  +- Subquery
-      :                          :     +- CometNativeColumnarToRow
+      :                          :     +- CometColumnarToRow
       :                          :        +- CometProject
       :                          :           +- CometFilter
       :                          :              +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -201,7 +201,7 @@ CometNativeColumnarToRow
                            :     :  :              +- CometProject
                            :     :  :                 +- CometFilter
                            :     :  :                    :  +- Subquery
-                           :     :  :                    :     +- CometNativeColumnarToRow
+                           :     :  :                    :     +- CometColumnarToRow
                            :     :  :                    :        +- CometProject
                            :     :  :                    :           +- CometFilter
                            :     :  :                    :              +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -332,7 +332,7 @@ CometNativeColumnarToRow
                               +- CometProject
                                  +- CometFilter
                                     :  +- Subquery
-                                    :     +- CometNativeColumnarToRow
+                                    :     +- CometColumnarToRow
                                     :        +- CometProject
                                     :           +- CometFilter
                                     :              +- CometNativeScan parquet spark_catalog.default.date_dim

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q15/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q15/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometHashAggregate
    +- CometExchange
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometSort
    +- CometExchange
       +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q20/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q20/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometWindowExec

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q21/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q21/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometFilter
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q22/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q22/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometHashAggregate
    +- CometExchange
       +- CometHashAggregate
@@ -45,7 +45,7 @@ CometNativeColumnarToRow
             :     :        +- CometProject
             :     :           +- CometFilter
             :     :              :  +- Subquery
-            :     :              :     +- CometNativeColumnarToRow
+            :     :              :     +- CometColumnarToRow
             :     :              :        +- CometHashAggregate
             :     :              :           +- CometExchange
             :     :              :              +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometUnion
       :- CometHashAggregate
@@ -48,7 +48,7 @@ CometNativeColumnarToRow
       :              :     :     +- CometProject
       :              :     :        +- CometFilter
       :              :     :           :  +- Subquery
-      :              :     :           :     +- CometNativeColumnarToRow
+      :              :     :           :     +- CometColumnarToRow
       :              :     :           :        +- CometHashAggregate
       :              :     :           :           +- CometExchange
       :              :     :           :              +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a/extended.txt
@@ -1,7 +1,7 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometFilter
    :  +- Subquery
-   :     +- CometNativeColumnarToRow
+   :     +- CometColumnarToRow
    :        +- CometHashAggregate
    :           +- CometExchange
    :              +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b/extended.txt
@@ -1,7 +1,7 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometFilter
    :  +- Subquery
-   :     +- CometNativeColumnarToRow
+   :     +- CometColumnarToRow
    :        +- CometHashAggregate
    :           +- CometExchange
    :              +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q26/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q26/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q27/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q27/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q28/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q28/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometBroadcastNestedLoopJoin
    :- CometBroadcastNestedLoopJoin
    :  :- CometBroadcastNestedLoopJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q3/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q3/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q30/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q30/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q31/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q31/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometSort
    +- CometExchange
       +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometHashAggregate
    +- CometExchange
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q33/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q33/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q34/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q34/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometSort
    +- CometExchange
       +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q35/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q35/extended.txt
@@ -10,7 +10,7 @@ TakeOrderedAndProject
                :     :  +- Filter
                :     :     +- BroadcastHashJoin
                :     :        :-  BroadcastHashJoin [COMET: Unsupported join type ExistenceJoin(exists#1)]
-               :     :        :  :- CometNativeColumnarToRow
+               :     :        :  :- CometColumnarToRow
                :     :        :  :  +- CometBroadcastHashJoin
                :     :        :  :     :- CometFilter
                :     :        :  :     :  +- CometNativeScan parquet spark_catalog.default.customer
@@ -28,7 +28,7 @@ TakeOrderedAndProject
                :     :        :  :                    +- CometFilter
                :     :        :  :                       +- CometNativeScan parquet spark_catalog.default.date_dim
                :     :        :  +- BroadcastExchange
-               :     :        :     +- CometNativeColumnarToRow
+               :     :        :     +- CometColumnarToRow
                :     :        :        +- CometProject
                :     :        :           +- CometBroadcastHashJoin
                :     :        :              :- CometNativeScan parquet spark_catalog.default.web_sales
@@ -38,7 +38,7 @@ TakeOrderedAndProject
                :     :        :                    +- CometFilter
                :     :        :                       +- CometNativeScan parquet spark_catalog.default.date_dim
                :     :        +- BroadcastExchange
-               :     :           +- CometNativeColumnarToRow
+               :     :           +- CometColumnarToRow
                :     :              +- CometProject
                :     :                 +- CometBroadcastHashJoin
                :     :                    :- CometNativeScan parquet spark_catalog.default.catalog_sales
@@ -48,12 +48,12 @@ TakeOrderedAndProject
                :     :                          +- CometFilter
                :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
                :     +- BroadcastExchange
-               :        +- CometNativeColumnarToRow
+               :        +- CometColumnarToRow
                :           +- CometProject
                :              +- CometFilter
                :                 +- CometNativeScan parquet spark_catalog.default.customer_address
                +- BroadcastExchange
-                  +- CometNativeColumnarToRow
+                  +- CometColumnarToRow
                      +- CometProject
                         +- CometFilter
                            +- CometNativeScan parquet spark_catalog.default.customer_demographics

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometWindowExec

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometHashAggregate
    +- CometExchange
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometSort
    +- CometExchange
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39b/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39b/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometSort
    +- CometExchange
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q4/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q4/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q41/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q41/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q42/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q42/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q43/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q43/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin
@@ -14,7 +14,7 @@ CometNativeColumnarToRow
          :     :     :              +- CometExchange
          :     :     :                 +- CometFilter
          :     :     :                    :  +- Subquery
-         :     :     :                    :     +- CometNativeColumnarToRow
+         :     :     :                    :     +- CometColumnarToRow
          :     :     :                    :        +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
          :     :     :                    :           +- CometExchange
          :     :     :                    :              +- CometHashAggregate
@@ -35,7 +35,7 @@ CometNativeColumnarToRow
          :     :                    +- CometExchange
          :     :                       +- CometFilter
          :     :                          :  +- Subquery
-         :     :                          :     +- CometNativeColumnarToRow
+         :     :                          :     +- CometColumnarToRow
          :     :                          :        +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
          :     :                          :           +- CometExchange
          :     :                          :              +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin
@@ -14,7 +14,7 @@ CometNativeColumnarToRow
          :     :     :              +- CometExchange
          :     :     :                 +- CometFilter
          :     :     :                    :  +- Subquery
-         :     :     :                    :     +- CometNativeColumnarToRow
+         :     :     :                    :     +- CometColumnarToRow
          :     :     :                    :        +- CometHashAggregate
          :     :     :                    :           +- CometExchange
          :     :     :                    :              +- CometHashAggregate
@@ -35,7 +35,7 @@ CometNativeColumnarToRow
          :     :                    +- CometExchange
          :     :                       +- CometFilter
          :     :                          :  +- Subquery
-         :     :                          :     +- CometNativeColumnarToRow
+         :     :                          :     +- CometColumnarToRow
          :     :                          :        +- CometHashAggregate
          :     :                          :           +- CometExchange
          :     :                          :              +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q45/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q45/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometColumnarExchange
@@ -6,7 +6,7 @@ CometNativeColumnarToRow
             +- Project
                +- Filter
                   +-  BroadcastHashJoin [COMET: Unsupported join type ExistenceJoin(exists#1)]
-                     :- CometNativeColumnarToRow
+                     :- CometColumnarToRow
                      :  +- CometProject
                      :     +- CometBroadcastHashJoin
                      :        :- CometProject
@@ -38,7 +38,7 @@ CometNativeColumnarToRow
                      :              +- CometFilter
                      :                 +- CometNativeScan parquet spark_catalog.default.item
                      +- BroadcastExchange
-                        +- CometNativeColumnarToRow
+                        +- CometColumnarToRow
                            +- CometProject
                               +- CometFilter
                                  +- CometNativeScan parquet spark_catalog.default.item

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q46/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q46/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q48/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q48/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometHashAggregate
    +- CometExchange
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q49/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q49/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q50/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q50/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q51/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q51/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometFilter
       +- CometWindowExec

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q52/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q52/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q53/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q53/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometFilter

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange
@@ -55,7 +55,7 @@ CometNativeColumnarToRow
                            :     :     :                       +- CometProject
                            :     :     :                          +- CometFilter
                            :     :     :                             :  :- Subquery
-                           :     :     :                             :  :  +- CometNativeColumnarToRow
+                           :     :     :                             :  :  +- CometColumnarToRow
                            :     :     :                             :  :     +- CometHashAggregate
                            :     :     :                             :  :        +- CometExchange
                            :     :     :                             :  :           +- CometHashAggregate
@@ -63,7 +63,7 @@ CometNativeColumnarToRow
                            :     :     :                             :  :                 +- CometFilter
                            :     :     :                             :  :                    +- CometNativeScan parquet spark_catalog.default.date_dim
                            :     :     :                             :  +- Subquery
-                           :     :     :                             :     +- CometNativeColumnarToRow
+                           :     :     :                             :     +- CometColumnarToRow
                            :     :     :                             :        +- CometHashAggregate
                            :     :     :                             :           +- CometExchange
                            :     :     :                             :              +- CometHashAggregate
@@ -83,7 +83,7 @@ CometNativeColumnarToRow
                               +- CometProject
                                  +- CometFilter
                                     :  :- Subquery
-                                    :  :  +- CometNativeColumnarToRow
+                                    :  :  +- CometColumnarToRow
                                     :  :     +- CometHashAggregate
                                     :  :        +- CometExchange
                                     :  :           +- CometHashAggregate
@@ -91,7 +91,7 @@ CometNativeColumnarToRow
                                     :  :                 +- CometFilter
                                     :  :                    +- CometNativeScan parquet spark_catalog.default.date_dim
                                     :  +- Subquery
-                                    :     +- CometNativeColumnarToRow
+                                    :     +- CometColumnarToRow
                                     :        +- CometHashAggregate
                                     :           +- CometExchange
                                     :              +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q55/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q55/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q56/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q56/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q58/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q58/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin
@@ -24,7 +24,7 @@ CometNativeColumnarToRow
          :     :                 :     :                       +- CometProject
          :     :                 :     :                          +- CometFilter
          :     :                 :     :                             :  +- Subquery
-         :     :                 :     :                             :     +- CometNativeColumnarToRow
+         :     :                 :     :                             :     +- CometColumnarToRow
          :     :                 :     :                             :        +- CometProject
          :     :                 :     :                             :           +- CometFilter
          :     :                 :     :                             :              +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -42,7 +42,7 @@ CometNativeColumnarToRow
          :     :                             +- CometProject
          :     :                                +- CometFilter
          :     :                                   :  +- Subquery
-         :     :                                   :     +- CometNativeColumnarToRow
+         :     :                                   :     +- CometColumnarToRow
          :     :                                   :        +- CometProject
          :     :                                   :           +- CometFilter
          :     :                                   :              +- CometNativeScan parquet spark_catalog.default.date_dim

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q6/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q6/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometFilter
       +- CometHashAggregate
@@ -26,7 +26,7 @@ CometNativeColumnarToRow
                      :     :                       +- CometProject
                      :     :                          +- CometFilter
                      :     :                             :  +- Subquery
-                     :     :                             :     +- CometNativeColumnarToRow
+                     :     :                             :     +- CometColumnarToRow
                      :     :                             :        +- CometHashAggregate
                      :     :                             :           +- CometExchange
                      :     :                             :              +- CometHashAggregate
@@ -38,7 +38,7 @@ CometNativeColumnarToRow
                      :        +- CometProject
                      :           +- CometFilter
                      :              :  +- Subquery
-                     :              :     +- CometNativeColumnarToRow
+                     :              :     +- CometColumnarToRow
                      :              :        +- CometHashAggregate
                      :              :           +- CometExchange
                      :              :              +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q60/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q60/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q61/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q61/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometProject
    +- CometBroadcastNestedLoopJoin
       :- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q62/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q62/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q63/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q63/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometFilter

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q64/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q64/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometSort
    +- CometExchange
       +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q65/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q65/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q66/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q66/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q67/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q67/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometFilter
       +- CometWindowExec

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q68/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q68/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q7/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q7/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q70/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q70/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometWindowExec

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q71/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q71/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometSort
    +- CometExchange
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometSort
    +- CometExchange
       +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q74/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q74/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q75/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q75/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometSortMergeJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q77/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q77/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q78/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q78/extended.txt
@@ -1,6 +1,6 @@
 TakeOrderedAndProject
 +-  Project [COMET: Comet does not support Spark's BigDecimal rounding]
-   +- CometNativeColumnarToRow
+   +- CometColumnarToRow
       +- CometSortMergeJoin
          :- CometProject
          :  +- CometSortMergeJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q8/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q8/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q81/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q81/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q83/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q83/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q84/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q84/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q86/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q86/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometWindowExec

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometHashAggregate
    +- CometExchange
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q88/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q88/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometBroadcastNestedLoopJoin
    :- CometBroadcastNestedLoopJoin
    :  :- CometBroadcastNestedLoopJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometFilter

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q9/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q9/extended.txt
@@ -1,6 +1,6 @@
  Project [COMET: ]
 :  :- Subquery
-:  :  +- CometNativeColumnarToRow
+:  :  +- CometColumnarToRow
 :  :     +- CometProject
 :  :        +- CometHashAggregate
 :  :           +- CometExchange
@@ -11,7 +11,7 @@
 :  :- ReusedSubquery
 :  :- ReusedSubquery
 :  :- Subquery
-:  :  +- CometNativeColumnarToRow
+:  :  +- CometColumnarToRow
 :  :     +- CometProject
 :  :        +- CometHashAggregate
 :  :           +- CometExchange
@@ -22,7 +22,7 @@
 :  :- ReusedSubquery
 :  :- ReusedSubquery
 :  :- Subquery
-:  :  +- CometNativeColumnarToRow
+:  :  +- CometColumnarToRow
 :  :     +- CometProject
 :  :        +- CometHashAggregate
 :  :           +- CometExchange
@@ -33,7 +33,7 @@
 :  :- ReusedSubquery
 :  :- ReusedSubquery
 :  :- Subquery
-:  :  +- CometNativeColumnarToRow
+:  :  +- CometColumnarToRow
 :  :     +- CometProject
 :  :        +- CometHashAggregate
 :  :           +- CometExchange
@@ -44,7 +44,7 @@
 :  :- ReusedSubquery
 :  :- ReusedSubquery
 :  :- Subquery
-:  :  +- CometNativeColumnarToRow
+:  :  +- CometColumnarToRow
 :  :     +- CometProject
 :  :        +- CometHashAggregate
 :  :           +- CometExchange
@@ -54,7 +54,7 @@
 :  :                       +- CometNativeScan parquet spark_catalog.default.store_sales
 :  :- ReusedSubquery
 :  +- ReusedSubquery
-+- CometNativeColumnarToRow
++- CometColumnarToRow
    +- CometFilter
       +- CometNativeScan parquet spark_catalog.default.reason
 

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q90/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q90/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometProject
    +- CometBroadcastNestedLoopJoin
       :- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q91/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q91/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometSort
    +- CometExchange
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometHashAggregate
    +- CometExchange
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q93/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q93/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometHashAggregate
    +- CometExchange
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometHashAggregate
    +- CometExchange
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q96/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q96/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometHashAggregate
    +- CometExchange
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q97/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q97/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometHashAggregate
    +- CometExchange
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q98/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q98/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometProject
    +- CometSort
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q99/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q99/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark3_5/q67a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark3_5/q67a/extended.txt
@@ -2,11 +2,11 @@ TakeOrderedAndProject
 +- Filter
    +- Window
       +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-         +- CometNativeColumnarToRow
+         +- CometColumnarToRow
             +- CometSort
                +- CometColumnarExchange
                   +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-                     +- CometNativeColumnarToRow
+                     +- CometColumnarToRow
                         +- CometSort
                            +- CometUnion
                               :- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark3_5/q70a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark3_5/q70a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometWindowExec
@@ -13,7 +13,7 @@ CometNativeColumnarToRow
                            :     +- HashAggregate
                            :        +- Project
                            :           +- BroadcastHashJoin
-                           :              :- CometNativeColumnarToRow
+                           :              :- CometColumnarToRow
                            :              :  +- CometProject
                            :              :     +- CometBroadcastHashJoin
                            :              :        :- CometFilter
@@ -30,7 +30,7 @@ CometNativeColumnarToRow
                            :              +- BroadcastExchange
                            :                 +- Project
                            :                    +- BroadcastHashJoin
-                           :                       :- CometNativeColumnarToRow
+                           :                       :- CometColumnarToRow
                            :                       :  +- CometFilter
                            :                       :     +- CometNativeScan parquet spark_catalog.default.store
                            :                       +- BroadcastExchange
@@ -38,7 +38,7 @@ CometNativeColumnarToRow
                            :                             +- Filter
                            :                                +- Window
                            :                                   +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-                           :                                      +- CometNativeColumnarToRow
+                           :                                      +- CometColumnarToRow
                            :                                         +- CometSort
                            :                                            +- CometHashAggregate
                            :                                               +- CometExchange
@@ -66,7 +66,7 @@ CometNativeColumnarToRow
                            :              +- HashAggregate
                            :                 +- Project
                            :                    +- BroadcastHashJoin
-                           :                       :- CometNativeColumnarToRow
+                           :                       :- CometColumnarToRow
                            :                       :  +- CometProject
                            :                       :     +- CometBroadcastHashJoin
                            :                       :        :- CometFilter
@@ -83,7 +83,7 @@ CometNativeColumnarToRow
                            :                       +- BroadcastExchange
                            :                          +- Project
                            :                             +- BroadcastHashJoin
-                           :                                :- CometNativeColumnarToRow
+                           :                                :- CometColumnarToRow
                            :                                :  +- CometFilter
                            :                                :     +- CometNativeScan parquet spark_catalog.default.store
                            :                                +- BroadcastExchange
@@ -91,7 +91,7 @@ CometNativeColumnarToRow
                            :                                      +- Filter
                            :                                         +- Window
                            :                                            +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-                           :                                               +- CometNativeColumnarToRow
+                           :                                               +- CometColumnarToRow
                            :                                                  +- CometSort
                            :                                                     +- CometHashAggregate
                            :                                                        +- CometExchange
@@ -119,7 +119,7 @@ CometNativeColumnarToRow
                                           +- HashAggregate
                                              +- Project
                                                 +- BroadcastHashJoin
-                                                   :- CometNativeColumnarToRow
+                                                   :- CometColumnarToRow
                                                    :  +- CometProject
                                                    :     +- CometBroadcastHashJoin
                                                    :        :- CometFilter
@@ -136,7 +136,7 @@ CometNativeColumnarToRow
                                                    +- BroadcastExchange
                                                       +- Project
                                                          +- BroadcastHashJoin
-                                                            :- CometNativeColumnarToRow
+                                                            :- CometColumnarToRow
                                                             :  +- CometFilter
                                                             :     +- CometNativeScan parquet spark_catalog.default.store
                                                             +- BroadcastExchange
@@ -144,7 +144,7 @@ CometNativeColumnarToRow
                                                                   +- Filter
                                                                      +- Window
                                                                         +-  WindowGroupLimit [COMET: WindowGroupLimit is not supported]
-                                                                           +- CometNativeColumnarToRow
+                                                                           +- CometColumnarToRow
                                                                               +- CometSort
                                                                                  +- CometHashAggregate
                                                                                     +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_0/q14/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_0/q14/extended.txt
@@ -1,9 +1,9 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometBroadcastHashJoin
       :- CometFilter
       :  :  +- Subquery
-      :  :     +- CometNativeColumnarToRow
+      :  :     +- CometColumnarToRow
       :  :        +- CometHashAggregate
       :  :           +- CometExchange
       :  :              +- CometHashAggregate
@@ -49,7 +49,7 @@ CometNativeColumnarToRow
       :                 :     :  :                    :  +- ReusedSubquery
       :                 :     :  :                    +- CometNativeScan parquet spark_catalog.default.date_dim
       :                 :     :  :                          +- Subquery
-      :                 :     :  :                             +- CometNativeColumnarToRow
+      :                 :     :  :                             +- CometColumnarToRow
       :                 :     :  :                                +- CometProject
       :                 :     :  :                                   +- CometFilter
       :                 :     :  :                                      +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -181,7 +181,7 @@ CometNativeColumnarToRow
       :                          :  +- ReusedSubquery
       :                          +- CometNativeScan parquet spark_catalog.default.date_dim
       :                                +- Subquery
-      :                                   +- CometNativeColumnarToRow
+      :                                   +- CometColumnarToRow
       :                                      +- CometProject
       :                                         +- CometFilter
       :                                            +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -205,7 +205,7 @@ CometNativeColumnarToRow
                            :     :  :                    :  +- ReusedSubquery
                            :     :  :                    +- CometNativeScan parquet spark_catalog.default.date_dim
                            :     :  :                          +- Subquery
-                           :     :  :                             +- CometNativeColumnarToRow
+                           :     :  :                             +- CometColumnarToRow
                            :     :  :                                +- CometProject
                            :     :  :                                   +- CometFilter
                            :     :  :                                      +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -337,7 +337,7 @@ CometNativeColumnarToRow
                                     :  +- ReusedSubquery
                                     +- CometNativeScan parquet spark_catalog.default.date_dim
                                           +- Subquery
-                                             +- CometNativeColumnarToRow
+                                             +- CometColumnarToRow
                                                 +- CometProject
                                                    +- CometFilter
                                                       +- CometNativeScan parquet spark_catalog.default.date_dim

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_0/q6/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_0/q6/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometFilter
       +- CometHashAggregate
@@ -28,7 +28,7 @@ CometNativeColumnarToRow
                      :     :                             :  +- ReusedSubquery
                      :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
                      :     :                                   +- Subquery
-                     :     :                                      +- CometNativeColumnarToRow
+                     :     :                                      +- CometColumnarToRow
                      :     :                                         +- CometHashAggregate
                      :     :                                            +- CometExchange
                      :     :                                               +- CometHashAggregate
@@ -41,7 +41,7 @@ CometNativeColumnarToRow
                      :              :  +- ReusedSubquery
                      :              +- CometNativeScan parquet spark_catalog.default.date_dim
                      :                    +- Subquery
-                     :                       +- CometNativeColumnarToRow
+                     :                       +- CometColumnarToRow
                      :                          +- CometHashAggregate
                      :                             +- CometExchange
                      :                                +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_1/q14a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_1/q14a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange
@@ -9,7 +9,7 @@ CometNativeColumnarToRow
                :     +- CometUnion
                :        :- CometFilter
                :        :  :  +- Subquery
-               :        :  :     +- CometNativeColumnarToRow
+               :        :  :     +- CometColumnarToRow
                :        :  :        +- CometHashAggregate
                :        :  :           +- CometExchange
                :        :  :              +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_1/q49/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_1/q49/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q77a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_2/q77a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometColumnarExchange
@@ -8,7 +8,7 @@ CometNativeColumnarToRow
                :  +- Exchange
                :     +- HashAggregate
                :        +- Union
-               :           :- CometNativeColumnarToRow
+               :           :- CometColumnarToRow
                :           :  +- CometProject
                :           :     +- CometBroadcastHashJoin
                :           :        :- CometHashAggregate
@@ -53,7 +53,7 @@ CometNativeColumnarToRow
                :           :- Project
                :           :  +- BroadcastNestedLoopJoin
                :           :     :- BroadcastExchange
-               :           :     :  +- CometNativeColumnarToRow
+               :           :     :  +- CometColumnarToRow
                :           :     :     +- CometHashAggregate
                :           :     :        +- CometExchange
                :           :     :           +- CometHashAggregate
@@ -67,7 +67,7 @@ CometNativeColumnarToRow
                :           :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
                :           :     +- Project
                :           :        :  :- Subquery
-               :           :        :  :  +- CometNativeColumnarToRow
+               :           :        :  :  +- CometColumnarToRow
                :           :        :  :     +- CometProject
                :           :        :  :        +- CometHashAggregate
                :           :        :  :           +- CometExchange
@@ -82,7 +82,7 @@ CometNativeColumnarToRow
                :           :        :  :                                +- CometNativeScan parquet spark_catalog.default.date_dim
                :           :        :  +- ReusedSubquery
                :           :        +-  Scan OneRowRelation [COMET: Scan OneRowRelation is not supported]
-               :           +- CometNativeColumnarToRow
+               :           +- CometColumnarToRow
                :              +- CometProject
                :                 +- CometBroadcastHashJoin
                :                    :- CometHashAggregate
@@ -127,7 +127,7 @@ CometNativeColumnarToRow
                :           +- Exchange
                :              +- HashAggregate
                :                 +- Union
-               :                    :- CometNativeColumnarToRow
+               :                    :- CometColumnarToRow
                :                    :  +- CometProject
                :                    :     +- CometBroadcastHashJoin
                :                    :        :- CometHashAggregate
@@ -172,7 +172,7 @@ CometNativeColumnarToRow
                :                    :- Project
                :                    :  +- BroadcastNestedLoopJoin
                :                    :     :- BroadcastExchange
-               :                    :     :  +- CometNativeColumnarToRow
+               :                    :     :  +- CometColumnarToRow
                :                    :     :     +- CometHashAggregate
                :                    :     :        +- CometExchange
                :                    :     :           +- CometHashAggregate
@@ -186,7 +186,7 @@ CometNativeColumnarToRow
                :                    :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
                :                    :     +- Project
                :                    :        :  :- Subquery
-               :                    :        :  :  +- CometNativeColumnarToRow
+               :                    :        :  :  +- CometColumnarToRow
                :                    :        :  :     +- CometProject
                :                    :        :  :        +- CometHashAggregate
                :                    :        :  :           +- CometExchange
@@ -201,7 +201,7 @@ CometNativeColumnarToRow
                :                    :        :  :                                +- CometNativeScan parquet spark_catalog.default.date_dim
                :                    :        :  +- ReusedSubquery
                :                    :        +-  Scan OneRowRelation [COMET: Scan OneRowRelation is not supported]
-               :                    +- CometNativeColumnarToRow
+               :                    +- CometColumnarToRow
                :                       +- CometProject
                :                          +- CometBroadcastHashJoin
                :                             :- CometHashAggregate
@@ -246,7 +246,7 @@ CometNativeColumnarToRow
                            +- Exchange
                               +- HashAggregate
                                  +- Union
-                                    :- CometNativeColumnarToRow
+                                    :- CometColumnarToRow
                                     :  +- CometProject
                                     :     +- CometBroadcastHashJoin
                                     :        :- CometHashAggregate
@@ -291,7 +291,7 @@ CometNativeColumnarToRow
                                     :- Project
                                     :  +- BroadcastNestedLoopJoin
                                     :     :- BroadcastExchange
-                                    :     :  +- CometNativeColumnarToRow
+                                    :     :  +- CometColumnarToRow
                                     :     :     +- CometHashAggregate
                                     :     :        +- CometExchange
                                     :     :           +- CometHashAggregate
@@ -305,7 +305,7 @@ CometNativeColumnarToRow
                                     :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
                                     :     +- Project
                                     :        :  :- Subquery
-                                    :        :  :  +- CometNativeColumnarToRow
+                                    :        :  :  +- CometColumnarToRow
                                     :        :  :     +- CometProject
                                     :        :  :        +- CometHashAggregate
                                     :        :  :           +- CometExchange
@@ -320,7 +320,7 @@ CometNativeColumnarToRow
                                     :        :  :                                +- CometNativeScan parquet spark_catalog.default.date_dim
                                     :        :  +- ReusedSubquery
                                     :        +-  Scan OneRowRelation [COMET: Scan OneRowRelation is not supported]
-                                    +- CometNativeColumnarToRow
+                                    +- CometColumnarToRow
                                        +- CometProject
                                           +- CometBroadcastHashJoin
                                              :- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q11/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q11/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q12/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q12/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometWindowExec

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14/extended.txt
@@ -1,9 +1,9 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometBroadcastHashJoin
       :- CometFilter
       :  :  +- Subquery
-      :  :     +- CometNativeColumnarToRow
+      :  :     +- CometColumnarToRow
       :  :        +- CometHashAggregate
       :  :           +- CometExchange
       :  :              +- CometHashAggregate
@@ -47,7 +47,7 @@ CometNativeColumnarToRow
       :                 :     :  :              +- CometProject
       :                 :     :  :                 +- CometFilter
       :                 :     :  :                    :  +- Subquery
-      :                 :     :  :                    :     +- CometNativeColumnarToRow
+      :                 :     :  :                    :     +- CometColumnarToRow
       :                 :     :  :                    :        +- CometProject
       :                 :     :  :                    :           +- CometFilter
       :                 :     :  :                    :              +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -178,7 +178,7 @@ CometNativeColumnarToRow
       :                    +- CometProject
       :                       +- CometFilter
       :                          :  +- Subquery
-      :                          :     +- CometNativeColumnarToRow
+      :                          :     +- CometColumnarToRow
       :                          :        +- CometProject
       :                          :           +- CometFilter
       :                          :              +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -201,7 +201,7 @@ CometNativeColumnarToRow
                            :     :  :              +- CometProject
                            :     :  :                 +- CometFilter
                            :     :  :                    :  +- Subquery
-                           :     :  :                    :     +- CometNativeColumnarToRow
+                           :     :  :                    :     +- CometColumnarToRow
                            :     :  :                    :        +- CometProject
                            :     :  :                    :           +- CometFilter
                            :     :  :                    :              +- CometNativeScan parquet spark_catalog.default.date_dim
@@ -332,7 +332,7 @@ CometNativeColumnarToRow
                               +- CometProject
                                  +- CometFilter
                                     :  +- Subquery
-                                    :     +- CometNativeColumnarToRow
+                                    :     +- CometColumnarToRow
                                     :        +- CometProject
                                     :           +- CometFilter
                                     :              +- CometNativeScan parquet spark_catalog.default.date_dim

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange
@@ -10,7 +10,7 @@ CometNativeColumnarToRow
                :        +- CometUnion
                :           :- CometFilter
                :           :  :  +- Subquery
-               :           :  :     +- CometNativeColumnarToRow
+               :           :  :     +- CometColumnarToRow
                :           :  :        +- CometHashAggregate
                :           :  :           +- CometExchange
                :           :  :              +- CometHashAggregate
@@ -471,7 +471,7 @@ CometNativeColumnarToRow
                :                 +- CometUnion
                :                    :- CometFilter
                :                    :  :  +- Subquery
-               :                    :  :     +- CometNativeColumnarToRow
+               :                    :  :     +- CometColumnarToRow
                :                    :  :        +- CometHashAggregate
                :                    :  :           +- CometExchange
                :                    :  :              +- CometHashAggregate
@@ -932,7 +932,7 @@ CometNativeColumnarToRow
                :                 +- CometUnion
                :                    :- CometFilter
                :                    :  :  +- Subquery
-               :                    :  :     +- CometNativeColumnarToRow
+               :                    :  :     +- CometColumnarToRow
                :                    :  :        +- CometHashAggregate
                :                    :  :           +- CometExchange
                :                    :  :              +- CometHashAggregate
@@ -1393,7 +1393,7 @@ CometNativeColumnarToRow
                :                 +- CometUnion
                :                    :- CometFilter
                :                    :  :  +- Subquery
-               :                    :  :     +- CometNativeColumnarToRow
+               :                    :  :     +- CometColumnarToRow
                :                    :  :        +- CometHashAggregate
                :                    :  :           +- CometExchange
                :                    :  :              +- CometHashAggregate
@@ -1854,7 +1854,7 @@ CometNativeColumnarToRow
                                  +- CometUnion
                                     :- CometFilter
                                     :  :  +- Subquery
-                                    :  :     +- CometNativeColumnarToRow
+                                    :  :     +- CometColumnarToRow
                                     :  :        +- CometHashAggregate
                                     :  :           +- CometExchange
                                     :  :              +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometUnion
       :- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q20/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q20/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometWindowExec

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometUnion
       :- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24/extended.txt
@@ -1,9 +1,9 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometSort
    +- CometExchange
       +- CometFilter
          :  +- Subquery
-         :     +- CometNativeColumnarToRow
+         :     +- CometColumnarToRow
          :        +- CometHashAggregate
          :           +- CometExchange
          :              +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometUnion
       :- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometSort
    +- CometExchange
       +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35/extended.txt
@@ -10,7 +10,7 @@ TakeOrderedAndProject
                :     :  +- Filter
                :     :     +- BroadcastHashJoin
                :     :        :-  BroadcastHashJoin [COMET: Unsupported join type ExistenceJoin(exists#1)]
-               :     :        :  :- CometNativeColumnarToRow
+               :     :        :  :- CometColumnarToRow
                :     :        :  :  +- CometBroadcastHashJoin
                :     :        :  :     :- CometFilter
                :     :        :  :     :  +- CometNativeScan parquet spark_catalog.default.customer
@@ -28,7 +28,7 @@ TakeOrderedAndProject
                :     :        :  :                    +- CometFilter
                :     :        :  :                       +- CometNativeScan parquet spark_catalog.default.date_dim
                :     :        :  +- BroadcastExchange
-               :     :        :     +- CometNativeColumnarToRow
+               :     :        :     +- CometColumnarToRow
                :     :        :        +- CometProject
                :     :        :           +- CometBroadcastHashJoin
                :     :        :              :- CometNativeScan parquet spark_catalog.default.web_sales
@@ -38,7 +38,7 @@ TakeOrderedAndProject
                :     :        :                    +- CometFilter
                :     :        :                       +- CometNativeScan parquet spark_catalog.default.date_dim
                :     :        +- BroadcastExchange
-               :     :           +- CometNativeColumnarToRow
+               :     :           +- CometColumnarToRow
                :     :              +- CometProject
                :     :                 +- CometBroadcastHashJoin
                :     :                    :- CometNativeScan parquet spark_catalog.default.catalog_sales
@@ -48,12 +48,12 @@ TakeOrderedAndProject
                :     :                          +- CometFilter
                :     :                             +- CometNativeScan parquet spark_catalog.default.date_dim
                :     +- BroadcastExchange
-               :        +- CometNativeColumnarToRow
+               :        +- CometColumnarToRow
                :           +- CometProject
                :              +- CometFilter
                :                 +- CometNativeScan parquet spark_catalog.default.customer_address
                +- BroadcastExchange
-                  +- CometNativeColumnarToRow
+                  +- CometColumnarToRow
                      +- CometProject
                         +- CometFilter
                            +- CometNativeScan parquet spark_catalog.default.customer_demographics

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometWindowExec

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q49/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q49/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q51a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q51a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometFilter
       +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometFilter
       +- CometHashAggregate
@@ -26,7 +26,7 @@ CometNativeColumnarToRow
                      :     :                       +- CometProject
                      :     :                          +- CometFilter
                      :     :                             :  +- Subquery
-                     :     :                             :     +- CometNativeColumnarToRow
+                     :     :                             :     +- CometColumnarToRow
                      :     :                             :        +- CometHashAggregate
                      :     :                             :           +- CometExchange
                      :     :                             :              +- CometHashAggregate
@@ -38,7 +38,7 @@ CometNativeColumnarToRow
                      :        +- CometProject
                      :           +- CometFilter
                      :              :  +- Subquery
-                     :              :     +- CometNativeColumnarToRow
+                     :              :     +- CometColumnarToRow
                      :              :        +- CometHashAggregate
                      :              :           +- CometExchange
                      :              :              +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q64/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q64/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometSort
    +- CometExchange
       +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometFilter
       +- CometWindowExec

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometWindowExec

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q74/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q74/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometBroadcastHashJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometSortMergeJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78/extended.txt
@@ -1,6 +1,6 @@
 TakeOrderedAndProject
 +-  Project [COMET: Comet does not support Spark's BigDecimal rounding]
-   +- CometNativeColumnarToRow
+   +- CometColumnarToRow
       +- CometSortMergeJoin
          :- CometProject
          :  +- CometSortMergeJoin

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometHashAggregate
       +- CometExchange

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometProject
       +- CometWindowExec

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q98/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q98/extended.txt
@@ -1,4 +1,4 @@
-CometNativeColumnarToRow
+CometColumnarToRow
 +- CometSort
    +- CometExchange
       +- CometProject

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -1203,6 +1203,30 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("avg decimal with nothing to average") {
+    // There is no sum to overflow when the input is empty or entirely null, so avg must
+    // return null rather than raising ARITHMETIC_OVERFLOW in ANSI mode.
+    // https://github.com/apache/datafusion-comet/issues/5148
+    Seq(true, false).foreach { ansiEnabled =>
+      withSQLConf(
+        SQLConf.ANSI_ENABLED.key -> ansiEnabled.toString,
+        CometConf.COMET_SHUFFLE_ENABLED.key -> "true",
+        CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+        val table = s"avg_decimal_empty_ansi_$ansiEnabled"
+        withTable(table) {
+          sql(s"create table $table(a decimal(38, 2), b INT) using parquet")
+          // no rows at all
+          checkSparkAnswer(s"select avg(a) from $table")
+          checkSparkAnswer(s"select b, avg(a) from $table group by b")
+          // rows, but every value to average is null
+          sql(s"insert into $table values(null, 1), (null, 2)")
+          checkSparkAnswer(s"select avg(a) from $table")
+          checkSparkAnswer(s"select b, avg(a) from $table group by b")
+        }
+      }
+    }
+  }
+
   test("test final avg") {
     withSQLConf(
       CometConf.COMET_SHUFFLE_ENABLED.key -> "true",


### PR DESCRIPTION
## Which issue does this PR close?

Part of #5112. Related to #4440. Also fixes #5148.

## Rationale for this change

Isolated benchmarking in #5112 shows the native columnar-to-row converter is 3.7x slower per row than the JVM `CometColumnarToRowExec` at the default 8192-row batch size, and up to 15.7x slower for small batches, because the native path carries roughly 10us of fixed JNI and FFI cost per batch. End-to-end microbenchmarks and the TPC-DS SF1000 comparison in #4440 show no measurable benefit from the native operator, and the original GC-pressure rationale no longer holds since #3367 made the converter deep-copy every row to the JVM heap. Real workloads that reach C2R with small batches (selective filters, small shuffle partitions, broadcast dimension tables) regress, so the safer default is the JVM implementation until the native path is competitive.

## What changes are included in this PR?

- Change the default of `spark.comet.exec.columnarToRow.native.enabled` from `true` to `false`, and update the config doc to mention the per-batch JNI cost.
- Update the `CometNativeColumnarToRowExec` scaladoc: it claimed zero-copy variable-length data and reduced GC pressure, neither of which holds since the #3308 fix.
- Fix the DPP subquery-broadcast rewrite in `CometExecRule` to also strip the JVM `CometColumnarToRowExec`. Unlike `CometNativeColumnarToRowExec`, it is `CodegenSupport`, so by the time the rule sees the subquery plan it has been collapsed into `WholeStageCodegenExec(CometColumnarToRowExec(InputAdapter(cometPlan)))`. Without this the rule failed to recognize the Comet child and the columnar plan was not unwrapped.
- Regenerate the TPC-DS plan-stability golden files: the transition node in every affected plan changes from `CometNativeColumnarToRow` to `CometColumnarToRow`.
- Update `dev/diffs/*.diff` so the Spark `SubquerySuite` partition-pruning assertion accepts the whole-stage-codegen-wrapped `CometColumnarToRowExec` shape in addition to `CometNativeColumnarToRowExec`, and so `CachedBatchSerializerNoUnwrapSuite` looks through the `WholeStageCodegenExec` before classifying the cached plan's transition node. The latter previously matched only on the top node being a Comet operator, which held for the non-codegen `CometNativeColumnarToRowExec` but not for the codegen-wrapped `CometColumnarToRow`.
- Fix a pre-existing decimal `avg` bug (#5148) that this change exposes: in ANSI mode, an ungrouped `avg` over an empty or all-null decimal input raised `[ARITHMETIC_OVERFLOW] Overflow in sum of decimals` instead of returning NULL, because `AvgDecimalAccumulator::merge_batch` derives `is_empty` from the nullness of the merged counts and a global partial aggregate over zero rows emits `sum = NULL, count = 0` with a non-null count. `evaluate` now guards that check with `count > 0`, matching the neighbouring `is_not_null` check and the `GroupsAccumulator` path. This surfaces here because `CometColumnarToRowExec` supports codegen, so `BenchmarkQueryTest.checkGeneratedCode` reaches `WholeStageCodegenExec.doCodeGen`, which prepares the plan and eagerly executes scalar subqueries: `LogicalPlanTagInSparkPlanSuite` q24a/q24b/q24-v2.7 then ran q24's `SELECT 0.05 * avg(netpaid) FROM ssales` against the row-less TPC-DS tables that suite creates. It is only visible in the Spark 4.1 lane because ANSI is off by default in Spark 3.5.
- Update the plan documentation (`understanding-comet-plans.md`, `installation.md`): example plans now show `CometColumnarToRow`, and the operator reference entry for `CometNativeColumnarToRow` no longer claims zero-copy variable-length handling and records that it is now opt-in.

Users can still opt in with `spark.comet.exec.columnarToRow.native.enabled=true`.

## How are these changes tested?

Existing tests cover both code paths explicitly: `CometNativeColumnarToRowSuite` enables the config in its own `withSQLConf` blocks, `CometFuzzTestBase` parameterizes it, and plan assertions in `CometExecSuite` and `CometPlanChecker` match both operator variants, so no test depends on the default. The rest of the suite now exercises `CometColumnarToRowExec` by default, which was the default behavior before #3299. The Spark SQL test lanes (`dev/diffs`) and the TPC-DS plan-stability suites cover the plan-shape changes.

The decimal `avg` fix adds `CometAggregateSuite."avg decimal with nothing to average"`, covering the ungrouped and grouped cases over both an empty table and a table whose values are all null, with ANSI enabled and disabled. It fails with `ARITHMETIC_OVERFLOW` without the native fix.
