### PR TITLE
test: add schema scenarios and allocation measurement to isolated C2R benchmark

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometC2RIsolatedBench.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometC2RIsolatedBench.scala
@@ -33,35 +33,138 @@ import org.apache.comet.NativeColumnarToRowConverter
  * Isolated columnar-to-row microbenchmark that excludes the parquet scan entirely. Batches are
  * built once in memory; each case converts them to rows and consumes the values so that the
  * conversion itself is what gets measured.
+ *
+ * The schema scenarios exist because the two implementations have very different per-value costs
+ * by data type. The JVM path allocates a Decimal object per non-null decimal value (and a
+ * BigInteger/BigDecimal chain for precision > 18), while the native path writes the unscaled
+ * value directly. The native path also has a column-wise fast path that only engages when every
+ * column in the schema is fixed-width.
  */
 object CometC2RIsolatedBench {
 
   private val totalRows = 1024 * 1024
 
-  private def makeBatches(schema: StructType, batchSize: Int): Array[ColumnarBatch] = {
-    val rows = (0 until totalRows).iterator.map { i =>
-      InternalRow(i.toLong, i, i.toDouble, UTF8String.fromString(s"value_$i"))
-    }
+  private case class Scenario(
+      name: String,
+      schema: StructType,
+      makeRow: Int => InternalRow,
+      consume: InternalRow => Long)
+
+  private val mixedPrimitives = Scenario(
+    "long, int, double, string",
+    new StructType()
+      .add("a", LongType)
+      .add("b", IntegerType)
+      .add("c", DoubleType)
+      .add("d", StringType),
+    i => InternalRow(i.toLong, i, i.toDouble, UTF8String.fromString(s"value_$i")),
+    row => row.getLong(0) + row.getUTF8String(3).numBytes())
+
+  // The columns a TPC-H lineitem aggregation reaches C2R with: four compact decimals, a date,
+  // and two short flag strings. The strings force the native general (row-at-a-time) path.
+  private val tpchDecimalsWithStrings = Scenario(
+    "4 x decimal(12,2), date, 2 x string (tpch-like)",
+    new StructType()
+      .add("l_quantity", DecimalType(12, 2))
+      .add("l_extendedprice", DecimalType(12, 2))
+      .add("l_discount", DecimalType(12, 2))
+      .add("l_tax", DecimalType(12, 2))
+      .add("l_shipdate", DateType)
+      .add("l_returnflag", StringType)
+      .add("l_linestatus", StringType),
+    i =>
+      InternalRow(
+        Decimal.createUnsafe(i % 5000000, 12, 2),
+        Decimal.createUnsafe(i % 9000000, 12, 2),
+        Decimal.createUnsafe(i % 10, 12, 2),
+        Decimal.createUnsafe(i % 8, 12, 2),
+        8000 + i % 2500,
+        UTF8String.fromString(if (i % 2 == 0) "A" else "R"),
+        UTF8String.fromString(if (i % 3 == 0) "F" else "O")),
+    row => row.getDecimal(0, 12, 2).toUnscaledLong + row.getInt(4))
+
+  // Same decimals without any var-length column, so the native column-wise fast path engages.
+  private val decimalsAllFixedWidth = Scenario(
+    "4 x decimal(12,2), date, long (all fixed-width)",
+    new StructType()
+      .add("a", DecimalType(12, 2))
+      .add("b", DecimalType(12, 2))
+      .add("c", DecimalType(12, 2))
+      .add("d", DecimalType(12, 2))
+      .add("e", DateType)
+      .add("f", LongType),
+    i =>
+      InternalRow(
+        Decimal.createUnsafe(i % 5000000, 12, 2),
+        Decimal.createUnsafe(i % 9000000, 12, 2),
+        Decimal.createUnsafe(i % 10, 12, 2),
+        Decimal.createUnsafe(i % 8, 12, 2),
+        8000 + i % 2500,
+        i.toLong),
+    row => row.getDecimal(0, 12, 2).toUnscaledLong + row.getLong(5))
+
+  // Precision > 18: the JVM accessor allocates byte[] -> BigInteger -> java BigDecimal ->
+  // scala BigDecimal -> Decimal per value; the native side writes 16 bytes.
+  private val highPrecisionDecimals = Scenario(
+    "2 x decimal(38,10), long (high precision)",
+    new StructType()
+      .add("a", DecimalType(38, 10))
+      .add("b", DecimalType(38, 10))
+      .add("c", LongType),
+    i =>
+      InternalRow(
+        Decimal(new java.math.BigDecimal(java.math.BigInteger.valueOf(i.toLong * 1000003), 10)),
+        Decimal(new java.math.BigDecimal(java.math.BigInteger.valueOf(i.toLong * 999983), 10)),
+        i.toLong),
+    // Consume only the cheap column: reading a decimal(38,10) back out of the UnsafeRow
+    // allocates on both sides and would mask the conversion cost being measured.
+    row => row.getLong(2))
+
+  private val widePrimitives = Scenario(
+    "16 x long (wide primitives)",
+    (0 until 16).foldLeft(new StructType())((s, i) => s.add(s"c$i", LongType)),
+    i => InternalRow((0 until 16).map(c => i.toLong + c): _*),
+    row => row.getLong(0) + row.getLong(15))
+
+  private def makeBatches(scenario: Scenario, batchSize: Int): Array[ColumnarBatch] = {
+    val rows = (0 until totalRows).iterator.map(scenario.makeRow)
     CometArrowConverters
-      .rowToArrowBatchIter(rows, schema, batchSize, "UTC", org.apache.comet.CometArrowAllocator)
+      .rowToArrowBatchIter(
+        rows,
+        scenario.schema,
+        batchSize,
+        "UTC",
+        org.apache.comet.CometArrowAllocator)
       .toArray
   }
 
-  private def runForBatchSize(schema: StructType, batchSize: Int): Unit = {
-    val batches = makeBatches(schema, batchSize)
+  /** Bytes allocated on the JVM heap by the current thread while running `body`. */
+  private def measureAllocatedBytes(body: => Unit): Long = {
+    val bean = java.lang.management.ManagementFactory.getThreadMXBean
+      .asInstanceOf[com.sun.management.ThreadMXBean]
+    val tid = Thread.currentThread().getId
+    val before = bean.getThreadAllocatedBytes(tid)
+    body
+    bean.getThreadAllocatedBytes(tid) - before
+  }
+
+  private def runForBatchSize(scenario: Scenario, batchSize: Int): Unit = {
+    val batches = makeBatches(scenario, batchSize)
 
     val benchmark =
-      new Benchmark(s"Isolated C2R (no scan), batchSize=$batchSize", totalRows.toLong)
+      new Benchmark(
+        s"Isolated C2R (no scan), ${scenario.name}, batchSize=$batchSize",
+        totalRows.toLong)
 
     benchmark.addCase("JVM rowIterator + UnsafeProjection") { _ =>
-      val proj = UnsafeProjection.create(schema.fields.map(_.dataType))
+      val proj = UnsafeProjection.create(scenario.schema.fields.map(_.dataType))
       var sink = 0L
       var b = 0
       while (b < batches.length) {
         val it = batches(b).rowIterator()
         while (it.hasNext) {
           val u = proj(it.next())
-          sink += u.getLong(0) + u.getUTF8String(3).numBytes()
+          sink += scenario.consume(u)
         }
         b += 1
       }
@@ -69,15 +172,14 @@ object CometC2RIsolatedBench {
     }
 
     benchmark.addCase("Native converter") { _ =>
-      val converter = new NativeColumnarToRowConverter(schema, batchSize)
+      val converter = new NativeColumnarToRowConverter(scenario.schema, batchSize)
       var sink = 0L
       try {
         var b = 0
         while (b < batches.length) {
           val it = converter.convert(batches(b))
           while (it.hasNext) {
-            val u = it.next()
-            sink += u.getLong(0) + u.getUTF8String(3).numBytes()
+            sink += scenario.consume(it.next())
           }
           b += 1
         }
@@ -89,18 +191,53 @@ object CometC2RIsolatedBench {
 
     benchmark.run()
 
+    // GC pressure comparison: the JVM path allocates per object-typed value (Decimal,
+    // UTF8String) but reuses its output row buffer, while the native path allocates a
+    // byte[] + UnsafeRow per row for the defensive copy in NativeRowIterator.
+    val jvmAlloc = measureAllocatedBytes {
+      val proj = UnsafeProjection.create(scenario.schema.fields.map(_.dataType))
+      var sink = 0L
+      for (batch <- batches) {
+        val it = batch.rowIterator()
+        while (it.hasNext) {
+          sink += scenario.consume(proj(it.next()))
+        }
+      }
+      if (sink == Long.MinValue) println(sink)
+    }
+    val nativeAlloc = measureAllocatedBytes {
+      val converter = new NativeColumnarToRowConverter(scenario.schema, batchSize)
+      var sink = 0L
+      try {
+        for (batch <- batches) {
+          val it = converter.convert(batch)
+          while (it.hasNext) {
+            sink += scenario.consume(it.next())
+          }
+        }
+      } finally {
+        converter.close()
+      }
+      if (sink == Long.MinValue) println(sink)
+    }
+    println(
+      f"JVM heap allocation per row: JVM path ${jvmAlloc.toDouble / totalRows}%.1f bytes, " +
+        f"native path ${nativeAlloc.toDouble / totalRows}%.1f bytes%n")
+
     batches.foreach(_.close())
   }
 
   def main(args: Array[String]): Unit = {
-    val schema = new StructType()
-      .add("a", LongType)
-      .add("b", IntegerType)
-      .add("c", DoubleType)
-      .add("d", StringType)
+    val scenarios =
+      Seq(
+        mixedPrimitives,
+        tpchDecimalsWithStrings,
+        decimalsAllFixedWidth,
+        highPrecisionDecimals,
+        widePrimitives)
 
-    runForBatchSize(schema, 8192)
-    runForBatchSize(schema, 512)
-    runForBatchSize(schema, 32)
+    for (scenario <- scenarios; batchSize <- Seq(8192, 512, 32)) {
+      runForBatchSize(scenario, batchSize)
+    }
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Part of #5112.

## Rationale for this change

The isolated columnar-to-row benchmark added in #5113 only measures one schema (long, int, double, string), which is close to the JVM path's best case: every accessor is allocation-free or escape-analyzable, and the schema contains a var-length column so the native converter is forced onto its slower row-at-a-time path. Real workloads such as TPC-H reach C2R with very different schemas, and cluster results there can favor the native converter even though this benchmark says otherwise. The benchmark needs to cover the schema dimensions that decide which implementation wins.

## What changes are included in this PR?

Parameterizes `CometC2RIsolatedBench` over schema scenarios, sweeping each at batch sizes 8192, 512, and 32:

- long, int, double, string (the original baseline)
- 4 x decimal(12,2), date, 2 x string (TPC-H lineitem-like; the JVM accessor allocates a `Decimal` per value)
- 4 x decimal(12,2), date, long (all fixed-width, which engages the native column-wise fast path)
- 2 x decimal(38,10), long (high precision; the JVM accessor allocates a byte[], `BigInteger`, java `BigDecimal`, scala `BigDecimal`, and `Decimal` per value)
- 16 x long (wide primitives)

Also reports JVM heap bytes allocated per row for each path via `ThreadMXBean.getThreadAllocatedBytes`, since the two implementations have very different allocation profiles that an idle-heap microbenchmark's wall-clock numbers do not surface: the JVM path allocates per object-typed value but reuses its output row buffer, while the native path allocates a `byte[]` plus `UnsafeRow` per row for the defensive copy added in #3367.

Results on Apple M3 Ultra, Spark 4.1 (per-row ns, best time; allocation in JVM heap bytes per row at batchSize=8192):

| Scenario | JVM 8192 | Native 8192 | JVM 32 | Native 32 | JVM alloc B/row | Native alloc B/row |
|---|---|---|---|---|---|---|
| long, int, double, string | 8.5 | 32.7 | 16.5 | 309.9 | 24.1 | 100.0 |
| 4 x decimal(12,2), date, 2 x string | 35.5 | 52.6 | 45.9 | 518.6 | 131.2 | 120.8 |
| 4 x decimal(12,2), date, long (all fixed-width) | 20.4 | **16.7** | 30.7 | 451.0 | 152.2 | 146.0 |
| 2 x decimal(38,10), long | 58.7 | 70.5 | 73.6 | 310.5 | 392.1 | 137.0 |
| 16 x long | 23.7 | 31.4 | 36.5 | 966.3 | 24.5 | 228.5 |

The all-fixed-width decimal scenario is the first case where the native converter wins outright, and the decimal scenarios show the JVM path allocating up to 3x more heap per row, a cost that is mostly invisible on an idle benchmark heap but real on a loaded executor.

## How are these changes tested?

Ran `make benchmark-org.apache.spark.sql.benchmark.CometC2RIsolatedBench` twice; results above are from the second run and the baseline scenario reproduces the numbers reported in #5112.
