### PR TITLE
chore: start 1.1.0 development

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -26,7 +26,7 @@ under the License.
   <parent>
     <groupId>org.apache.datafusion</groupId>
     <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dev/diffs/3.4.3.diff
+++ b/dev/diffs/3.4.3.diff
@@ -7,7 +7,7 @@ index d3544881af1..ff963395ec3 100644
      <ivy.version>2.5.1</ivy.version>
      <oro.version>2.0.8</oro.version>
 +    <spark.version.short>3.4</spark.version.short>
-+    <comet.version>1.0.0-SNAPSHOT</comet.version>
++    <comet.version>1.1.0-SNAPSHOT</comet.version>
      <!--
      If you changes codahale.metrics.version, you also need to change
      the link to metrics.dropwizard.io in docs/monitoring.md.

--- a/dev/diffs/3.5.8.diff
+++ b/dev/diffs/3.5.8.diff
@@ -7,7 +7,7 @@ index edd2ad57880..45f8fd01538 100644
      <ivy.version>2.5.1</ivy.version>
      <oro.version>2.0.8</oro.version>
 +    <spark.version.short>3.5</spark.version.short>
-+    <comet.version>1.0.0-SNAPSHOT</comet.version>
++    <comet.version>1.1.0-SNAPSHOT</comet.version>
      <!--
      If you changes codahale.metrics.version, you also need to change
      the link to metrics.dropwizard.io in docs/monitoring.md.

--- a/dev/diffs/4.0.2.diff
+++ b/dev/diffs/4.0.2.diff
@@ -47,7 +47,7 @@ index 252cfdf9073..50ec9d6314e 100644
      <ivy.version>2.5.3</ivy.version>
      <oro.version>2.0.8</oro.version>
 +    <spark.version.short>4.0</spark.version.short>
-+    <comet.version>1.0.0-SNAPSHOT</comet.version>
++    <comet.version>1.1.0-SNAPSHOT</comet.version>
      <!--
      If you change codahale.metrics.version, you also need to change
      the link to metrics.dropwizard.io in docs/monitoring.md.

--- a/dev/diffs/4.1.2.diff
+++ b/dev/diffs/4.1.2.diff
@@ -47,7 +47,7 @@ index dc201151999..20ee0e7482a 100644
      <ivy.version>2.5.3</ivy.version>
      <oro.version>2.0.8</oro.version>
 +    <spark.version.short>4.1</spark.version.short>
-+    <comet.version>1.0.0-SNAPSHOT</comet.version>
++    <comet.version>1.1.0-SNAPSHOT</comet.version>
      <!--
      If you change codahale.metrics.version, you also need to change
      the link to metrics.dropwizard.io in docs/monitoring.md.

--- a/dev/diffs/iceberg/1.10.0.diff
+++ b/dev/diffs/iceberg/1.10.0.diff
@@ -7,7 +7,7 @@ index eeabe54f5f..a76d7bdcbc 100644
  caffeine = "2.9.3"
  calcite = "1.40.0"
 -comet = "0.8.1"
-+comet = "1.0.0-SNAPSHOT"
++comet = "1.1.0-SNAPSHOT"
  datasketches = "6.2.0"
  delta-standalone = "3.3.2"
  delta-spark = "3.3.2"

--- a/dev/diffs/iceberg/1.11.0.diff
+++ b/dev/diffs/iceberg/1.11.0.diff
@@ -6,7 +6,7 @@ index db659dc06b..78f5e3440f 100644
  bson-ver = "4.11.5"
  caffeine = "2.9.3"
  calcite = "1.41.0"
-+comet = "1.0.0-SNAPSHOT"
++comet = "1.1.0-SNAPSHOT"
  datasketches = "6.2.0"
  delta-standalone = "3.3.2"
  delta-spark = "3.3.2"

--- a/dev/diffs/iceberg/1.8.1.diff
+++ b/dev/diffs/iceberg/1.8.1.diff
@@ -6,7 +6,7 @@ index 04ffa8f4ed..5a925fd594 100644
  awssdk-s3accessgrants = "2.3.0"
  caffeine = "2.9.3"
  calcite = "1.10.0"
-+comet = "1.0.0-SNAPSHOT"
++comet = "1.1.0-SNAPSHOT"
  datasketches = "6.2.0"
  delta-standalone = "3.3.0"
  delta-spark = "3.3.0"

--- a/dev/diffs/iceberg/1.9.1.diff
+++ b/dev/diffs/iceberg/1.9.1.diff
@@ -6,7 +6,7 @@ index c50991c5fc..2892f11068 100644
  bson-ver = "4.11.5"
  caffeine = "2.9.3"
  calcite = "1.39.0"
-+comet = "1.0.0-SNAPSHOT"
++comet = "1.1.0-SNAPSHOT"
  datasketches = "6.2.0"
  delta-standalone = "3.3.1"
  delta-spark = "3.3.1"

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1935,7 +1935,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-comet"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "arrow",
  "assertables",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-comet-common"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "arrow",
  "datafusion",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-comet-jni-bridge"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "arrow",
  "assertables",
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-comet-proto"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-comet-shuffle"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-comet-spark-expr"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "arrow",
  "base64 0.23.0",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -21,7 +21,7 @@ members = ["core", "spark-expr", "common", "proto", "jni-bridge", "shuffle"]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.0"
+version = "1.1.0"
 homepage = "https://datafusion.apache.org/comet"
 repository = "https://github.com/apache/datafusion-comet"
 authors = ["Apache DataFusion <dev@datafusion.apache.org>"]

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ under the License.
   </parent>
   <groupId>org.apache.datafusion</groupId>
   <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Comet Project Parent POM</name>
 

--- a/spark-integration/pom.xml
+++ b/spark-integration/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.datafusion</groupId>
         <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -26,7 +26,7 @@ under the License.
   <parent>
     <groupId>org.apache.datafusion</groupId>
     <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A - release process task ("Update Version in main" step in the [release process](https://github.com/apache/datafusion-comet/blob/main/docs/source/contributor-guide/release_process.md#update-version-in-main)).

## Rationale for this change

`branch-1.0` has been cut, so `main` should move on to the next development version.

## What changes are included in this PR?

Per the release process documentation:

- Maven version `1.0.0-SNAPSHOT` -> `1.1.0-SNAPSHOT` in `pom.xml`, `common/pom.xml`, `spark/pom.xml`, and `spark-integration/pom.xml`
- `<comet.version>` in the Spark test diffs (`dev/diffs/3.4.3.diff`, `3.5.8.diff`, `4.0.2.diff`, `4.1.2.diff`)
- `comet` Gradle version catalog entry in the Iceberg test diffs (`dev/diffs/iceberg/1.8.1.diff`, `1.9.1.diff`, `1.10.0.diff`, `1.11.0.diff`)
- Rust crate version `1.0.0` -> `1.1.0` in `native/Cargo.toml` (and `native/Cargo.lock`)

`git grep '1.0.0-SNAPSHOT'` returns no hits outside the change log.

## How are these changes tested?

Existing CI.