### PR TITLE
fix: honour Spark's legacy `null IN ()` behavior

### DIFF
--- a/docs/source/user-guide/latest/compatibility/index.md
+++ b/docs/source/user-guide/latest/compatibility/index.md
@@ -145,9 +145,6 @@ so users hunting an unexpected value have a single place to check:
 - Native `RANGE` window frames with an explicit `PRECEDING` / `FOLLOWING` offset diverge from
   Spark when the boundary arithmetic overflows for `DATE` or `DECIMAL` `ORDER BY` columns
   ([#5022](https://github.com/apache/datafusion-comet/issues/5022)).
-- For an empty `IN` list, Comet always returns `false` for a `NULL` operand. Spark returns `NULL`
-  when `spark.sql.legacy.nullInEmptyListBehavior=true` (Spark 4.0+)
-  ([#4786](https://github.com/apache/datafusion-comet/issues/4786)).
 
 ## Object store cache
 

--- a/spark/src/main/scala/org/apache/comet/serde/predicates.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/predicates.scala
@@ -22,9 +22,10 @@ package org.apache.comet.serde
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.sql.catalyst.expressions.{And, Attribute, BinaryExpression, EqualNullSafe, EqualTo, Expression, GreaterThan, GreaterThanOrEqual, In, InSet, IsNaN, IsNotNull, IsNull, LessThan, LessThanOrEqual, Literal, Not, Or}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.BooleanType
 
-import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
+import org.apache.comet.CometSparkSessionExtensions.{isSpark35Plus, isSpark40Plus, withFallbackReason}
 import org.apache.comet.serde.ExprOuterClass.Expr
 import org.apache.comet.serde.QueryPlanSerde._
 
@@ -53,15 +54,19 @@ object CometNot extends CometExpressionSerde[Not] {
           inputs,
           binding,
           (builder, binaryExpr) => builder.setNeqNullSafe(binaryExpr))
-      case inner: In if !hasCollatedOperand((inner.value +: inner.list): _*) =>
+      case inner: In
+          if !hasCollatedOperand((inner.value +: inner.list): _*) &&
+            !ComparisonUtils.legacyNullInEmptyList(inner.list) =>
         ComparisonUtils.in(inner, inner.value, inner.list, inputs, binding, negate = true)
       case _ =>
-        // Includes the collated variants of EqualTo / EqualNullSafe / In above: fall through so
-        // the child expression's own serde is consulted, which now returns `Unsupported` for
-        // non-UTF8_BINARY operands (see `CometEqualTo.getSupportLevel` and siblings). That makes
-        // `exprToProtoInternal` return None for the child, which cascades this Not to None and
-        // falls the enclosing operator back to Spark — the only way to honour collation-aware
-        // (in)equality without a native path.
+        // Includes the collated variants of EqualTo / EqualNullSafe / In above, and the legacy
+        // `null IN ()` case: fall through so the child expression's own serde is consulted, which
+        // now returns `Unsupported` for non-UTF8_BINARY operands (see
+        // `CometEqualTo.getSupportLevel` and siblings). That makes `exprToProtoInternal` return
+        // None for the child, which cascades this Not to None and falls the enclosing operator
+        // back to Spark — the only way to honour collation-aware (in)equality without a native
+        // path. For serdes that mix in `CodegenDispatchFallback`, such as `CometIn`, the child is
+        // instead routed through the JVM codegen dispatcher and this Not stays native.
         createUnaryExpr(
           expr,
           expr.child,
@@ -244,15 +249,14 @@ object CometIsNaN extends CometExpressionSerde[IsNaN] {
 object CometIn extends CometExpressionSerde[In] with CodegenDispatchFallback {
 
   override def getSupportLevel(expr: In): SupportLevel =
-    ComparisonUtils.collationSupportLevel("In", (expr.value +: expr.list): _*)
+    if (ComparisonUtils.legacyNullInEmptyList(expr.list)) {
+      Unsupported(Some(ComparisonUtils.legacyNullInEmptyListReason))
+    } else {
+      ComparisonUtils.collationSupportLevel("In", (expr.value +: expr.list): _*)
+    }
 
   override def getUnsupportedReasons(): Seq[String] =
-    Seq(ComparisonUtils.nonDefaultCollationDocReason)
-
-  override def getCompatibleNotes(): Seq[String] = Seq(
-    "For an empty `IN` list, Comet always returns `false` for a `NULL` operand. Spark returns" +
-      " `NULL` when `spark.sql.legacy.nullInEmptyListBehavior=true` (Spark 4.0+)" +
-      " ([#4786](https://github.com/apache/datafusion-comet/issues/4786)).")
+    Seq(ComparisonUtils.nonDefaultCollationDocReason, ComparisonUtils.legacyNullInEmptyListReason)
 
   override def convert(
       expr: In,
@@ -265,10 +269,14 @@ object CometIn extends CometExpressionSerde[In] with CodegenDispatchFallback {
 object CometInSet extends CometExpressionSerde[InSet] with CodegenDispatchFallback {
 
   override def getSupportLevel(expr: InSet): SupportLevel =
-    ComparisonUtils.collationSupportLevel("InSet", expr.child)
+    if (ComparisonUtils.legacyNullInEmptyList(expr.hset)) {
+      Unsupported(Some(ComparisonUtils.legacyNullInEmptyListReason))
+    } else {
+      ComparisonUtils.collationSupportLevel("InSet", expr.child)
+    }
 
   override def getUnsupportedReasons(): Seq[String] =
-    Seq(ComparisonUtils.nonDefaultCollationDocReason)
+    Seq(ComparisonUtils.nonDefaultCollationDocReason, ComparisonUtils.legacyNullInEmptyListReason)
 
   override def convert(
       expr: InSet,
@@ -329,6 +337,37 @@ object ComparisonUtils {
     } else {
       Compatible()
     }
+
+  // Spark's `In` / `InSet` return `false` for any operand against an empty list, except under the
+  // legacy `null IN ()` behavior, where a `NULL` operand returns `NULL` (SPARK-44550). Comet's
+  // native `in` kernel only implements the non-legacy behavior, so the legacy case is marked
+  // `Unsupported` and, because both serdes mix in `CodegenDispatchFallback`, routed through the
+  // JVM codegen dispatcher (Spark's own `doGenCode` inside the Comet pipeline).
+  private val legacyNullInEmptyListConfig = "spark.sql.legacy.nullInEmptyListBehavior"
+
+  val legacyNullInEmptyListReason: String =
+    "An empty `IN` list has no native path when Spark's legacy `null IN ()` behavior is in " +
+      s"effect (`$legacyNullInEmptyListConfig`), because a `NULL` operand then evaluates to " +
+      "`NULL` rather than `false`."
+
+  /**
+   * Whether Spark's legacy `null IN ()` behavior is in effect for the current session. Spark 3.4
+   * has no config and always uses the legacy behavior, Spark 3.5 defaults the config to true, and
+   * Spark 4.0+ makes it optional with a default of `!spark.sql.ansi.enabled`. Read by string key
+   * so this compiles against every supported Spark version.
+   */
+  def legacyNullInEmptyListBehavior: Boolean = {
+    if (!isSpark35Plus) {
+      true
+    } else {
+      val default = if (isSpark40Plus) !SQLConf.get.ansiEnabled else true
+      SQLConf.get.getConfString(legacyNullInEmptyListConfig, default.toString).toBoolean
+    }
+  }
+
+  /** True when `list` is an empty `IN` list that must honour the legacy `null IN ()` behavior. */
+  def legacyNullInEmptyList(list: Iterable[_]): Boolean =
+    list.isEmpty && legacyNullInEmptyListBehavior
 
   def in(
       expr: Expression,

--- a/spark/src/main/scala/org/apache/comet/serde/predicates.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/predicates.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.{And, Attribute, BinaryExpressi
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.BooleanType
 
+import org.apache.comet.CometConf
 import org.apache.comet.CometSparkSessionExtensions.{isSpark35Plus, isSpark40Plus, withFallbackReason}
 import org.apache.comet.serde.ExprOuterClass.Expr
 import org.apache.comet.serde.QueryPlanSerde._
@@ -35,10 +36,15 @@ object CometNot extends CometExpressionSerde[Not] {
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
 
-    import ComparisonUtils.hasCollatedOperand
+    // The fused fast paths below build a single native node from `Not` and its child, bypassing
+    // `exprToProtoInternal`, and with it the child serde's `getSupportLevel` gate. Consult that
+    // gate here so the fast path is only taken when the child has a native path, rather than
+    // re-checking the child's conditions by hand.
+    def hasNativePath[T <: Expression](serde: CometExpressionSerde[T], child: T): Boolean =
+      serde.getSupportLevel(child).isInstanceOf[Compatible]
 
     expr.child match {
-      case inner: EqualTo if !hasCollatedOperand(inner.left, inner.right) =>
+      case inner: EqualTo if hasNativePath(CometEqualTo, inner) =>
         createBinaryExpr(
           inner,
           inner.left,
@@ -46,7 +52,7 @@ object CometNot extends CometExpressionSerde[Not] {
           inputs,
           binding,
           (builder, binaryExpr) => builder.setNeq(binaryExpr))
-      case inner: EqualNullSafe if !hasCollatedOperand(inner.left, inner.right) =>
+      case inner: EqualNullSafe if hasNativePath(CometEqualNullSafe, inner) =>
         createBinaryExpr(
           inner,
           inner.left,
@@ -54,19 +60,15 @@ object CometNot extends CometExpressionSerde[Not] {
           inputs,
           binding,
           (builder, binaryExpr) => builder.setNeqNullSafe(binaryExpr))
-      case inner: In
-          if !hasCollatedOperand((inner.value +: inner.list): _*) &&
-            !ComparisonUtils.legacyNullInEmptyList(inner.list) =>
+      case inner: In if hasNativePath(CometIn, inner) =>
         ComparisonUtils.in(inner, inner.value, inner.list, inputs, binding, negate = true)
       case _ =>
-        // Includes the collated variants of EqualTo / EqualNullSafe / In above, and the legacy
-        // `null IN ()` case: fall through so the child expression's own serde is consulted, which
-        // now returns `Unsupported` for non-UTF8_BINARY operands (see
-        // `CometEqualTo.getSupportLevel` and siblings). That makes `exprToProtoInternal` return
-        // None for the child, which cascades this Not to None and falls the enclosing operator
-        // back to Spark — the only way to honour collation-aware (in)equality without a native
-        // path. For serdes that mix in `CodegenDispatchFallback`, such as `CometIn`, the child is
-        // instead routed through the JVM codegen dispatcher and this Not stays native.
+        // Includes the cases the child serdes above declare as having no native path, such as
+        // non-UTF8_BINARY collated operands and the legacy `null IN ()` behavior: fall through so
+        // the child expression's own serde is consulted. `exprToProtoInternal` then either routes
+        // the child through the JVM codegen dispatcher (Spark's own `doGenCode`), keeping this Not
+        // native, or returns None, which cascades this Not to None and falls the enclosing
+        // operator back to Spark.
         createUnaryExpr(
           expr,
           expr.child,
@@ -249,14 +251,9 @@ object CometIsNaN extends CometExpressionSerde[IsNaN] {
 object CometIn extends CometExpressionSerde[In] with CodegenDispatchFallback {
 
   override def getSupportLevel(expr: In): SupportLevel =
-    if (ComparisonUtils.legacyNullInEmptyList(expr.list)) {
-      Unsupported(Some(ComparisonUtils.legacyNullInEmptyListReason))
-    } else {
-      ComparisonUtils.collationSupportLevel("In", (expr.value +: expr.list): _*)
-    }
+    ComparisonUtils.inSupportLevel("In", expr.list, (expr.value +: expr.list): _*)
 
-  override def getUnsupportedReasons(): Seq[String] =
-    Seq(ComparisonUtils.nonDefaultCollationDocReason, ComparisonUtils.legacyNullInEmptyListReason)
+  override def getUnsupportedReasons(): Seq[String] = ComparisonUtils.inUnsupportedReasons
 
   override def convert(
       expr: In,
@@ -269,14 +266,9 @@ object CometIn extends CometExpressionSerde[In] with CodegenDispatchFallback {
 object CometInSet extends CometExpressionSerde[InSet] with CodegenDispatchFallback {
 
   override def getSupportLevel(expr: InSet): SupportLevel =
-    if (ComparisonUtils.legacyNullInEmptyList(expr.hset)) {
-      Unsupported(Some(ComparisonUtils.legacyNullInEmptyListReason))
-    } else {
-      ComparisonUtils.collationSupportLevel("InSet", expr.child)
-    }
+    ComparisonUtils.inSupportLevel("InSet", expr.hset, expr.child)
 
-  override def getUnsupportedReasons(): Seq[String] =
-    Seq(ComparisonUtils.nonDefaultCollationDocReason, ComparisonUtils.legacyNullInEmptyListReason)
+  override def getUnsupportedReasons(): Seq[String] = ComparisonUtils.inUnsupportedReasons
 
   override def convert(
       expr: InSet,
@@ -345,29 +337,33 @@ object ComparisonUtils {
   // JVM codegen dispatcher (Spark's own `doGenCode` inside the Comet pipeline).
   private val legacyNullInEmptyListConfig = "spark.sql.legacy.nullInEmptyListBehavior"
 
-  val legacyNullInEmptyListReason: String =
+  private val legacyNullInEmptyListReason: String =
     "An empty `IN` list has no native path when Spark's legacy `null IN ()` behavior is in " +
       s"effect (`$legacyNullInEmptyListConfig`), because a `NULL` operand then evaluates to " +
       "`NULL` rather than `false`."
 
-  /**
-   * Whether Spark's legacy `null IN ()` behavior is in effect for the current session. Spark 3.4
-   * has no config and always uses the legacy behavior, Spark 3.5 defaults the config to true, and
-   * Spark 4.0+ makes it optional with a default of `!spark.sql.ansi.enabled`. Read by string key
-   * so this compiles against every supported Spark version.
-   */
-  def legacyNullInEmptyListBehavior: Boolean = {
-    if (!isSpark35Plus) {
-      true
-    } else {
-      val default = if (isSpark40Plus) !SQLConf.get.ansiEnabled else true
-      SQLConf.get.getConfString(legacyNullInEmptyListConfig, default.toString).toBoolean
+  // Spark 3.4 has no config and always uses the legacy behavior, Spark 3.5 defaults the config to
+  // true, and Spark 4.0+ makes it optional with a default of `!spark.sql.ansi.enabled`. Read by
+  // string key so this compiles against every supported Spark version.
+  private def legacyNullInEmptyListBehavior: Boolean =
+    !isSpark35Plus || {
+      val default = !isSpark40Plus || !SQLConf.get.ansiEnabled
+      CometConf.getBooleanConf(legacyNullInEmptyListConfig, default, SQLConf.get)
     }
-  }
 
-  /** True when `list` is an empty `IN` list that must honour the legacy `null IN ()` behavior. */
-  def legacyNullInEmptyList(list: Iterable[_]): Boolean =
-    list.isEmpty && legacyNullInEmptyListBehavior
+  /**
+   * Support level shared by the `In` and `InSet` serdes: `list` is the set of values being tested
+   * against, and `operands` are the expressions whose collation must be checked.
+   */
+  def inSupportLevel(exprName: String, list: Iterable[_], operands: Expression*): SupportLevel =
+    if (list.isEmpty && legacyNullInEmptyListBehavior) {
+      Unsupported(Some(legacyNullInEmptyListReason))
+    } else {
+      collationSupportLevel(exprName, operands: _*)
+    }
+
+  val inUnsupportedReasons: Seq[String] =
+    Seq(nonDefaultCollationDocReason, legacyNullInEmptyListReason)
 
   def in(
       expr: Expression,

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -26,7 +26,7 @@ import scala.util.Random
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{Column, CometTestBase, DataFrame, Row}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Cast, FromUnixTime, Literal, StructsToJson, TruncDate, TruncTimestamp}
-import org.apache.spark.sql.catalyst.optimizer.SimplifyExtractValueOps
+import org.apache.spark.sql.catalyst.optimizer.{ConvertToLocalRelation, OptimizeIn, SimplifyExtractValueOps}
 import org.apache.spark.sql.comet.CometProjectExec
 import org.apache.spark.sql.execution.{ProjectExec, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
@@ -1724,11 +1724,8 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     // (and `ConvertToLocalRelation`) excluded.
     withSQLConf(
       SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-        Seq(
-          "org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation",
-          "org.apache.spark.sql.catalyst.optimizer.OptimizeIn").mkString(",")) {
-      val data: Seq[(Integer, Integer)] =
-        Seq((Integer.valueOf(1), Integer.valueOf(1)), (null, Integer.valueOf(2)))
+        Seq(ConvertToLocalRelation.ruleName, OptimizeIn.ruleName).mkString(",")) {
+      val data: Seq[(Integer, Int)] = Seq((1, 1), (null, 2))
       withParquetTable(data, "tbl") {
         // An unset config exercises the version-dependent default, which follows ANSI mode on
         // Spark 4.0+ and is always the legacy behavior on Spark 3.x.

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1715,6 +1715,35 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("null IN empty list honours legacy null-in-empty behavior") {
+    // Spark returns NULL for a NULL operand against an empty IN list when the legacy behavior is
+    // in effect (SPARK-44550): always on Spark 3.4, on by default on Spark 3.5, and whenever ANSI
+    // mode is disabled on Spark 4.0+. Comet's native `in` kernel always returns false, so the
+    // legacy case must leave the native path. Empty IN lists are not expressible in SQL and
+    // `OptimizeIn` folds them away, so build the expression via the DataFrame API with that rule
+    // (and `ConvertToLocalRelation`) excluded.
+    withSQLConf(
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        Seq(
+          "org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation",
+          "org.apache.spark.sql.catalyst.optimizer.OptimizeIn").mkString(",")) {
+      val data: Seq[(Integer, Integer)] =
+        Seq((Integer.valueOf(1), Integer.valueOf(1)), (null, Integer.valueOf(2)))
+      withParquetTable(data, "tbl") {
+        // An unset config exercises the version-dependent default, which follows ANSI mode on
+        // Spark 4.0+ and is always the legacy behavior on Spark 3.x.
+        for (legacy <- Seq(Some("true"), Some("false"), None); ansi <- Seq("true", "false")) {
+          val legacyConf = legacy.map("spark.sql.legacy.nullInEmptyListBehavior" -> _).toSeq
+          withSQLConf(Seq(SQLConf.ANSI_ENABLED.key -> ansi) ++ legacyConf: _*) {
+            val df = sql("SELECT _1 AS a FROM tbl")
+              .select(col("a"), col("a").isin(), !col("a").isin())
+            checkSparkAnswer(df)
+          }
+        }
+      }
+    }
+  }
+
   test("not") {
     Seq(false, true).foreach { dictionary =>
       withSQLConf("parquet.enable.dictionary" -> dictionary.toString) {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #4786.

## Rationale for this change

Comet's native `in` kernel always returns `false` for any operand against an empty `IN` list. Spark only behaves that way under the non-legacy behavior; under the legacy behavior a `NULL` operand evaluates to `NULL` (SPARK-44550), so Comet returns `false` where Spark returns `NULL`.

That legacy behavior applies more often than the config name suggests:

- Spark 3.4: no config exists and `In`/`InSet` always use the legacy behavior
- Spark 3.5: `spark.sql.legacy.nullInEmptyListBehavior` defaults to `true`
- Spark 4.0+: the config is optional and defaults to `!spark.sql.ansi.enabled`, so the legacy behavior is in effect whenever ANSI mode is disabled

## What changes are included in this PR?

- `CometIn` / `CometInSet` return `Unsupported` for an empty list when the legacy behavior is in effect. Both serdes already mix in `CodegenDispatchFallback`, so these cases run Spark's own `doGenCode` inside the Comet pipeline instead of falling the whole operator back to Spark.
- `CometNot`'s `Not(In(...))` fast path skips the same case so it defers to `CometIn` (otherwise `NOT (null IN ())` returned `true` instead of `NULL`).
- Removed the now-fixed divergence from the compatibility guide, and replaced `CometIn`'s compatible note with an unsupported-case reason.

`OptimizeIn` rewrites empty `IN` lists away, so this only affects plans where that rule is excluded; non-empty `IN` lists are unaffected.

## How are these changes tested?

New test in `CometExpressionSuite` covering `a IN ()` and `NOT (a IN ())` over a Parquet scan with a `NULL` operand, across `spark.sql.legacy.nullInEmptyListBehavior` set to `true`, `false`, and unset (which exercises the version- and ANSI-derived default) with ANSI mode both on and off. The test fails on `main` with:

```
!== Spark Answer - 2 ==     == Comet Answer - 2 ==
 [1,false,true]             [1,false,true]
![null,null,null]           [null,false,true]
```