### PR TITLE
fix: normalize nested field nullability in ShuffleScanExec and ExpandExec

### DIFF
--- a/native/common/src/lib.rs
+++ b/native/common/src/lib.rs
@@ -17,9 +17,11 @@
 
 mod error;
 mod query_context;
+mod schema;
 pub mod tracing;
 mod utils;
 
 pub use error::{decimal_overflow_error, SparkError, SparkErrorWithContext, SparkResult};
 pub use query_context::{create_query_context_map, QueryContext, QueryContextMap};
+pub use schema::{cast_and_stamp_schema, describe_type_mismatch, widen_nested_nullability};
 pub use utils::{bytes_to_i128, decode_utf8_spark_lossy};

--- a/native/common/src/lib.rs
+++ b/native/common/src/lib.rs
@@ -23,5 +23,5 @@ mod utils;
 
 pub use error::{decimal_overflow_error, SparkError, SparkErrorWithContext, SparkResult};
 pub use query_context::{create_query_context_map, QueryContext, QueryContextMap};
-pub use schema::{cast_and_stamp_schema, describe_type_mismatch, widen_nested_nullability};
+pub use schema::{cast_and_stamp_schema, widen_nested_nullability};
 pub use utils::{bytes_to_i128, decode_utf8_spark_lossy};

--- a/native/common/src/schema.rs
+++ b/native/common/src/schema.rs
@@ -39,10 +39,17 @@ use std::sync::Arc;
 /// This is the normalizing counterpart to stamping `schema` on directly: it absorbs the
 /// return-type drift — most commonly a nested `nullable` flag — that native kernels and non-Parquet
 /// sources introduce, the same way `ScanExec` absorbs it at the FFI boundary.
+///
+/// Reconciliation follows `schema` in both directions, so it will also narrow a nullable nested
+/// child to non-null when that is what `schema` declares. That is not silently lossy: arrow's
+/// `StructArray::try_new` rejects unmasked nulls under a non-nullable field, so data that cannot
+/// survive the narrowing errors here rather than producing an array that misreports itself.
+/// Callers that must not narrow should widen `schema` first — see [`widen_nested_nullability`],
+/// which is what `SchemaAlignExec` and `ExpandExec` do.
 pub fn cast_and_stamp_schema(
     operator: &str,
     schema: &SchemaRef,
-    columns: &[ArrayRef],
+    mut columns: Vec<ArrayRef>,
     num_rows: usize,
 ) -> Result<RecordBatch, DataFusionError> {
     if columns.len() != schema.fields().len() {
@@ -53,44 +60,28 @@ pub fn cast_and_stamp_schema(
         )));
     }
 
-    let mut aligned: Vec<ArrayRef> = Vec::with_capacity(columns.len());
-    // A cast yields exactly the target type, so after this loop every column's type matches the
-    // declared field. `residual_mismatch` records the one case that would not: a cast that returned
-    // something other than what it was asked for. Tracked here so the error below can name the
-    // column without having to keep `aligned` alive past the stamp.
-    let mut residual_mismatch: Option<(usize, DataType)> = None;
-    for (idx, (column, field)) in columns.iter().zip(schema.fields()).enumerate() {
-        if column.data_type() == field.data_type() {
-            aligned.push(Arc::clone(column));
-            continue;
+    for (idx, (column, field)) in columns.iter_mut().zip(schema.fields()).enumerate() {
+        if column.data_type() != field.data_type() {
+            *column = cast_with_options(column, field.data_type(), &CastOptions::default())
+                .map_err(|e| cast_error(operator, schema, idx, column.data_type(), e))?;
         }
-        let cast = cast_with_options(column, field.data_type(), &CastOptions::default())
-            .map_err(|e| stamp_error(operator, schema, idx, column.data_type(), e))?;
-        if residual_mismatch.is_none() && cast.data_type() != field.data_type() {
-            residual_mismatch = Some((idx, cast.data_type().clone()));
-        }
-        aligned.push(cast);
     }
 
+    // Every column's type now matches its declared field — `cast_with_options` returns either an
+    // error or an array of exactly the requested type — so the stamp can only fail on row counts.
     let options = RecordBatchOptions::new().with_row_count(Some(num_rows));
-    RecordBatch::try_new_with_options(Arc::clone(schema), aligned, &options).map_err(|e| {
-        match residual_mismatch {
-            Some((idx, actual)) => stamp_error(operator, schema, idx, &actual, e),
-            // Types all match, so the stamp can only have failed on row counts.
-            None => DataFusionError::Context(
-                format!(
-                    "{operator} cannot build a batch of {num_rows} rows with its declared schema"
-                ),
-                Box::new(DataFusionError::from(e)),
-            ),
-        }
+    RecordBatch::try_new_with_options(Arc::clone(schema), columns, &options).map_err(|e| {
+        DataFusionError::Context(
+            format!("{operator} cannot build a batch of {num_rows} rows with its declared schema"),
+            Box::new(DataFusionError::from(e)),
+        )
     })
 }
 
 /// Names the operator and the dotted path of the column that could not be reconciled, since
 /// arrow's own message reports only `at column index N` and the two printed types may differ by a
 /// single flag hundreds of characters in.
-fn stamp_error(
+fn cast_error(
     operator: &str,
     schema: &SchemaRef,
     idx: usize,
@@ -108,19 +99,16 @@ fn stamp_error(
 
 /// Describes where `expected` and `actual` first diverge, as a dotted path rooted at `path`.
 /// Returns `None` when the two types are equal.
-pub fn describe_type_mismatch(
-    path: &str,
-    expected: &DataType,
-    actual: &DataType,
-) -> Option<String> {
+///
+/// The nested arms cover the shapes Comet actually builds — see `make_all_fields_nullable` in the
+/// planner and `to_arrow_datatype` in the serde layer, which walk the same set.
+fn describe_type_mismatch(path: &str, expected: &DataType, actual: &DataType) -> Option<String> {
     if expected == actual {
         return None;
     }
     match (expected, actual) {
         (DataType::List(e), DataType::List(a))
-        | (DataType::LargeList(e), DataType::LargeList(a))
-        | (DataType::ListView(e), DataType::ListView(a))
-        | (DataType::LargeListView(e), DataType::LargeListView(a)) => {
+        | (DataType::LargeList(e), DataType::LargeList(a)) => {
             describe_field_mismatch(&format!("{path}.element"), e, a)
         }
         (DataType::FixedSizeList(e, e_len), DataType::FixedSizeList(a, a_len))
@@ -135,11 +123,6 @@ pub fn describe_type_mismatch(
             .iter()
             .zip(a.iter())
             .find_map(|(e, a)| describe_field_mismatch(&format!("{path}.{}", e.name()), e, a)),
-        (DataType::Dictionary(e_key, e_value), DataType::Dictionary(a_key, a_value))
-            if e_key == a_key =>
-        {
-            describe_type_mismatch(path, e_value, a_value)
-        }
         _ => Some(format!("{path}: expected {expected}, found {actual}")),
     }
 }
@@ -159,13 +142,6 @@ fn describe_field_mismatch(path: &str, expected: &FieldRef, actual: &FieldRef) -
             nullability(actual)
         ));
     }
-    if expected.metadata() != actual.metadata() {
-        return Some(format!(
-            "{path}: expected metadata {:?}, found {:?}",
-            expected.metadata(),
-            actual.metadata()
-        ));
-    }
     describe_type_mismatch(path, expected.data_type(), actual.data_type())
 }
 
@@ -182,14 +158,14 @@ fn nullability(field: &FieldRef) -> String {
 /// either type can be stamped with the result. Shapes that do not line up (different struct field
 /// counts, different list flavours, ...) are left as `base`; those are real type differences and
 /// are handled by the cast in [`cast_and_stamp_schema`].
+///
+/// Related but not interchangeable: `make_all_fields_nullable` in the planner widens one type
+/// unconditionally, and arrow's `Field::try_merge` unions two but errors on a leaf type difference
+/// instead of tolerating it and does not recurse into maps or fixed-size lists.
 pub fn widen_nested_nullability(base: &DataType, other: &DataType) -> DataType {
     match (base, other) {
         (DataType::List(b), DataType::List(o)) => DataType::List(widen_field(b, o)),
         (DataType::LargeList(b), DataType::LargeList(o)) => DataType::LargeList(widen_field(b, o)),
-        (DataType::ListView(b), DataType::ListView(o)) => DataType::ListView(widen_field(b, o)),
-        (DataType::LargeListView(b), DataType::LargeListView(o)) => {
-            DataType::LargeListView(widen_field(b, o))
-        }
         (DataType::FixedSizeList(b, b_len), DataType::FixedSizeList(o, o_len))
             if b_len == o_len =>
         {
@@ -204,14 +180,6 @@ pub fn widen_nested_nullability(base: &DataType, other: &DataType) -> DataType {
                 .map(|(b, o)| widen_field(b, o))
                 .collect(),
         ),
-        (DataType::Dictionary(b_key, b_value), DataType::Dictionary(o_key, o_value))
-            if b_key == o_key =>
-        {
-            DataType::Dictionary(
-                b_key.clone(),
-                Box::new(widen_nested_nullability(b_value, o_value)),
-            )
-        }
         _ => base.clone(),
     }
 }
@@ -328,7 +296,7 @@ mod tests {
             "arrow no longer treats nested field nullability as part of DataType identity"
         );
 
-        let batch = cast_and_stamp_schema("TestExec", &schema, &[actual], 2).unwrap();
+        let batch = cast_and_stamp_schema("TestExec", &schema, vec![actual], 2).unwrap();
         assert_eq!(batch.num_rows(), 2);
         assert_eq!(batch.schema(), schema);
         let list = batch
@@ -376,7 +344,8 @@ mod tests {
     fn stamps_equal_types_without_copying() {
         let schema = Arc::new(Schema::new(vec![Field::new("c0", DataType::Int32, true)]));
         let column: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
-        let batch = cast_and_stamp_schema("TestExec", &schema, &[Arc::clone(&column)], 3).unwrap();
+        let batch =
+            cast_and_stamp_schema("TestExec", &schema, vec![Arc::clone(&column)], 3).unwrap();
         assert!(Arc::ptr_eq(batch.column(0), &column));
     }
 
@@ -389,7 +358,7 @@ mod tests {
             true,
         )]));
         let column: ArrayRef = Arc::new(StringArray::from(vec!["a", "b"]));
-        let err = cast_and_stamp_schema("TestExec", &schema, &[column], 2).unwrap_err();
+        let err = cast_and_stamp_schema("TestExec", &schema, vec![column], 2).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("TestExec"), "{msg}");
         assert!(msg.contains("col[0]"), "{msg}");
@@ -399,7 +368,7 @@ mod tests {
     #[test]
     fn error_on_column_count_mismatch() {
         let schema = Arc::new(Schema::new(vec![Field::new("c0", DataType::Int32, true)]));
-        let err = cast_and_stamp_schema("TestExec", &schema, &[], 0).unwrap_err();
+        let err = cast_and_stamp_schema("TestExec", &schema, vec![], 0).unwrap_err();
         assert!(
             err.to_string()
                 .contains("produced 0 columns but its schema declares 1"),

--- a/native/common/src/schema.rs
+++ b/native/common/src/schema.rs
@@ -1,0 +1,409 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Helpers for reconciling the Arrow type an operator actually produced with the type Spark
+//! catalyst declared.
+//!
+//! Arrow treats nested field nullability as part of `DataType` identity, so a column whose nested
+//! `nullable` flags are narrower than the declared type is rejected by
+//! `RecordBatch::try_new_with_options` even though the data is fine — a non-null child is a strict
+//! subset of a nullable one. Every Comet boundary that stamps a declared schema onto a runtime
+//! array therefore normalizes first instead of asserting. See
+//! <https://github.com/apache/datafusion-comet/issues/5137> for the boundaries and
+//! <https://github.com/apache/datafusion-comet/issues/4515> for the upstream drift itself.
+
+use arrow::array::{ArrayRef, RecordBatch, RecordBatchOptions};
+use arrow::compute::{cast_with_options, CastOptions};
+use arrow::datatypes::{DataType, FieldRef, SchemaRef};
+use datafusion::common::DataFusionError;
+use std::sync::Arc;
+
+/// Builds a `RecordBatch` with `schema` from `columns`, casting any column whose Arrow type
+/// differs from the declared field type. `operator` names the caller and is used only in error
+/// messages.
+///
+/// This is the normalizing counterpart to stamping `schema` on directly: it absorbs the
+/// return-type drift — most commonly a nested `nullable` flag — that native kernels and non-Parquet
+/// sources introduce, the same way `ScanExec` absorbs it at the FFI boundary.
+pub fn cast_and_stamp_schema(
+    operator: &str,
+    schema: &SchemaRef,
+    columns: &[ArrayRef],
+    num_rows: usize,
+) -> Result<RecordBatch, DataFusionError> {
+    if columns.len() != schema.fields().len() {
+        return Err(DataFusionError::Internal(format!(
+            "{operator} produced {} columns but its schema declares {}",
+            columns.len(),
+            schema.fields().len()
+        )));
+    }
+
+    let mut aligned: Vec<ArrayRef> = Vec::with_capacity(columns.len());
+    // A cast yields exactly the target type, so after this loop every column's type matches the
+    // declared field. `residual_mismatch` records the one case that would not: a cast that returned
+    // something other than what it was asked for. Tracked here so the error below can name the
+    // column without having to keep `aligned` alive past the stamp.
+    let mut residual_mismatch: Option<(usize, DataType)> = None;
+    for (idx, (column, field)) in columns.iter().zip(schema.fields()).enumerate() {
+        if column.data_type() == field.data_type() {
+            aligned.push(Arc::clone(column));
+            continue;
+        }
+        let cast = cast_with_options(column, field.data_type(), &CastOptions::default())
+            .map_err(|e| stamp_error(operator, schema, idx, column.data_type(), e))?;
+        if residual_mismatch.is_none() && cast.data_type() != field.data_type() {
+            residual_mismatch = Some((idx, cast.data_type().clone()));
+        }
+        aligned.push(cast);
+    }
+
+    let options = RecordBatchOptions::new().with_row_count(Some(num_rows));
+    RecordBatch::try_new_with_options(Arc::clone(schema), aligned, &options).map_err(|e| {
+        match residual_mismatch {
+            Some((idx, actual)) => stamp_error(operator, schema, idx, &actual, e),
+            // Types all match, so the stamp can only have failed on row counts.
+            None => DataFusionError::Context(
+                format!(
+                    "{operator} cannot build a batch of {num_rows} rows with its declared schema"
+                ),
+                Box::new(DataFusionError::from(e)),
+            ),
+        }
+    })
+}
+
+/// Names the operator and the dotted path of the column that could not be reconciled, since
+/// arrow's own message reports only `at column index N` and the two printed types may differ by a
+/// single flag hundreds of characters in.
+fn stamp_error(
+    operator: &str,
+    schema: &SchemaRef,
+    idx: usize,
+    actual: &DataType,
+    source: arrow::error::ArrowError,
+) -> DataFusionError {
+    let field = schema.field(idx);
+    let detail = describe_type_mismatch(field.name(), field.data_type(), actual)
+        .unwrap_or_else(|| format!("{}: expected {}", field.name(), field.data_type()));
+    DataFusionError::Context(
+        format!("{operator} cannot reconcile col[{idx}] with its declared schema at {detail}"),
+        Box::new(DataFusionError::from(source)),
+    )
+}
+
+/// Describes where `expected` and `actual` first diverge, as a dotted path rooted at `path`.
+/// Returns `None` when the two types are equal.
+pub fn describe_type_mismatch(
+    path: &str,
+    expected: &DataType,
+    actual: &DataType,
+) -> Option<String> {
+    if expected == actual {
+        return None;
+    }
+    match (expected, actual) {
+        (DataType::List(e), DataType::List(a))
+        | (DataType::LargeList(e), DataType::LargeList(a))
+        | (DataType::ListView(e), DataType::ListView(a))
+        | (DataType::LargeListView(e), DataType::LargeListView(a)) => {
+            describe_field_mismatch(&format!("{path}.element"), e, a)
+        }
+        (DataType::FixedSizeList(e, e_len), DataType::FixedSizeList(a, a_len))
+            if e_len == a_len =>
+        {
+            describe_field_mismatch(&format!("{path}.element"), e, a)
+        }
+        (DataType::Map(e, e_sorted), DataType::Map(a, a_sorted)) if e_sorted == a_sorted => {
+            describe_field_mismatch(&format!("{path}.entries"), e, a)
+        }
+        (DataType::Struct(e), DataType::Struct(a)) if e.len() == a.len() => e
+            .iter()
+            .zip(a.iter())
+            .find_map(|(e, a)| describe_field_mismatch(&format!("{path}.{}", e.name()), e, a)),
+        (DataType::Dictionary(e_key, e_value), DataType::Dictionary(a_key, a_value))
+            if e_key == a_key =>
+        {
+            describe_type_mismatch(path, e_value, a_value)
+        }
+        _ => Some(format!("{path}: expected {expected}, found {actual}")),
+    }
+}
+
+fn describe_field_mismatch(path: &str, expected: &FieldRef, actual: &FieldRef) -> Option<String> {
+    if expected.name() != actual.name() {
+        return Some(format!(
+            "{path}: expected field name '{}', found '{}'",
+            expected.name(),
+            actual.name()
+        ));
+    }
+    if expected.is_nullable() != actual.is_nullable() {
+        return Some(format!(
+            "{path}: expected {}, found {}",
+            nullability(expected),
+            nullability(actual)
+        ));
+    }
+    if expected.metadata() != actual.metadata() {
+        return Some(format!(
+            "{path}: expected metadata {:?}, found {:?}",
+            expected.metadata(),
+            actual.metadata()
+        ));
+    }
+    describe_type_mismatch(path, expected.data_type(), actual.data_type())
+}
+
+fn nullability(field: &FieldRef) -> String {
+    let qualifier = if field.is_nullable() {
+        "nullable"
+    } else {
+        "non-null"
+    };
+    format!("{qualifier} {}", field.data_type())
+}
+
+/// Returns `base` with nested field nullability widened to also cover `other`, so that arrays of
+/// either type can be stamped with the result. Shapes that do not line up (different struct field
+/// counts, different list flavours, ...) are left as `base`; those are real type differences and
+/// are handled by the cast in [`cast_and_stamp_schema`].
+pub fn widen_nested_nullability(base: &DataType, other: &DataType) -> DataType {
+    match (base, other) {
+        (DataType::List(b), DataType::List(o)) => DataType::List(widen_field(b, o)),
+        (DataType::LargeList(b), DataType::LargeList(o)) => DataType::LargeList(widen_field(b, o)),
+        (DataType::ListView(b), DataType::ListView(o)) => DataType::ListView(widen_field(b, o)),
+        (DataType::LargeListView(b), DataType::LargeListView(o)) => {
+            DataType::LargeListView(widen_field(b, o))
+        }
+        (DataType::FixedSizeList(b, b_len), DataType::FixedSizeList(o, o_len))
+            if b_len == o_len =>
+        {
+            DataType::FixedSizeList(widen_field(b, o), *b_len)
+        }
+        (DataType::Map(b, b_sorted), DataType::Map(o, o_sorted)) if b_sorted == o_sorted => {
+            DataType::Map(widen_field(b, o), *b_sorted)
+        }
+        (DataType::Struct(b), DataType::Struct(o)) if b.len() == o.len() => DataType::Struct(
+            b.iter()
+                .zip(o.iter())
+                .map(|(b, o)| widen_field(b, o))
+                .collect(),
+        ),
+        (DataType::Dictionary(b_key, b_value), DataType::Dictionary(o_key, o_value))
+            if b_key == o_key =>
+        {
+            DataType::Dictionary(
+                b_key.clone(),
+                Box::new(widen_nested_nullability(b_value, o_value)),
+            )
+        }
+        _ => base.clone(),
+    }
+}
+
+/// Widens a single field, keeping `base`'s name and metadata. A map's `entries` field must stay
+/// non-nullable in Arrow, so only the nullability of fields that are already nullable on either
+/// side is propagated — which is exactly `base.nullable || other.nullable`.
+fn widen_field(base: &FieldRef, other: &FieldRef) -> FieldRef {
+    let data_type = widen_nested_nullability(base.data_type(), other.data_type());
+    let nullable = base.is_nullable() || other.is_nullable();
+    if nullable == base.is_nullable() && &data_type == base.data_type() {
+        return Arc::clone(base);
+    }
+    Arc::new(
+        base.as_ref()
+            .clone()
+            .with_data_type(data_type)
+            .with_nullable(nullable),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, Int32Array, Int64Array, ListArray, StringArray, StructArray};
+    use arrow::buffer::OffsetBuffer;
+    use arrow::datatypes::{Field, Fields, Schema};
+
+    fn struct_field(nullable_child: bool) -> FieldRef {
+        Arc::new(Field::new_list_field(
+            DataType::Struct(Fields::from(vec![
+                Field::new("id", DataType::Int64, true),
+                Field::new("flag", DataType::Boolean, nullable_child),
+            ])),
+            true,
+        ))
+    }
+
+    /// The drift from the issue: `List(Struct(..non-null Boolean))` where catalyst declared the
+    /// child nullable. Only the child's `nullable` flag differs, so the path must pin it down.
+    #[test]
+    fn describes_nested_nullability_path() {
+        let expected = DataType::List(struct_field(true));
+        let actual = DataType::List(struct_field(false));
+        assert_eq!(
+            describe_type_mismatch("c0", &expected, &actual).unwrap(),
+            "c0.element.flag: expected nullable Boolean, found non-null Boolean"
+        );
+    }
+
+    #[test]
+    fn describes_leaf_type_difference() {
+        let expected = DataType::List(Arc::new(Field::new_list_field(DataType::Int64, true)));
+        let actual = DataType::List(Arc::new(Field::new_list_field(DataType::Int32, true)));
+        assert_eq!(
+            describe_type_mismatch("c0", &expected, &actual).unwrap(),
+            "c0.element: expected Int64, found Int32"
+        );
+    }
+
+    #[test]
+    fn describes_nothing_for_equal_types() {
+        let dt = DataType::List(struct_field(true));
+        assert_eq!(describe_type_mismatch("c0", &dt, &dt), None);
+    }
+
+    #[test]
+    fn widens_nested_nullability_in_both_directions() {
+        let nullable_child = DataType::List(struct_field(true));
+        let non_null_child = DataType::List(struct_field(false));
+        assert_eq!(
+            widen_nested_nullability(&non_null_child, &nullable_child),
+            nullable_child
+        );
+        assert_eq!(
+            widen_nested_nullability(&nullable_child, &non_null_child),
+            nullable_child
+        );
+    }
+
+    #[test]
+    fn widening_leaves_real_type_differences_alone() {
+        let int64 = DataType::List(Arc::new(Field::new_list_field(DataType::Int64, false)));
+        let int32 = DataType::List(Arc::new(Field::new_list_field(DataType::Int32, true)));
+        // The element nullability still widens; the leaf type stays `base`'s for the cast to fix.
+        assert_eq!(
+            widen_nested_nullability(&int64, &int32),
+            DataType::List(Arc::new(Field::new_list_field(DataType::Int64, true)))
+        );
+    }
+
+    /// A `List(Struct(non-null Boolean))` array stamped with a schema declaring the child nullable
+    /// must be absorbed rather than rejected, and the values must survive unchanged.
+    #[test]
+    fn stamps_nested_nullability_drift() {
+        let actual = drifting_list_of_struct();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "c0",
+            DataType::List(struct_field(true)),
+            true,
+        )]));
+
+        // Pin the reason this helper exists: stamping the declared schema on directly rejects the
+        // batch on the child's `nullable` flag alone. If arrow ever relaxes that, this assertion
+        // flips and every `cast_and_stamp_schema` call site can go back to a plain stamp.
+        let options = RecordBatchOptions::new().with_row_count(Some(2));
+        assert!(
+            RecordBatch::try_new_with_options(
+                Arc::clone(&schema),
+                vec![Arc::clone(&actual)],
+                &options
+            )
+            .is_err(),
+            "arrow no longer treats nested field nullability as part of DataType identity"
+        );
+
+        let batch = cast_and_stamp_schema("TestExec", &schema, &[actual], 2).unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(batch.schema(), schema);
+        let list = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap();
+        assert_eq!(list.value(0).len(), 2);
+        assert_eq!(list.value(1).len(), 1);
+        let entries = list
+            .values()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        let ids = entries
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(ids.values(), &[1, 2, 3]);
+    }
+
+    /// `[[{1,true},{2,false}], [{3,true}]]` with a non-null `flag` child.
+    fn drifting_list_of_struct() -> ArrayRef {
+        let entries = StructArray::new(
+            Fields::from(vec![
+                Field::new("id", DataType::Int64, true),
+                Field::new("flag", DataType::Boolean, false),
+            ]),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])) as ArrayRef,
+                Arc::new(arrow::array::BooleanArray::from(vec![true, false, true])),
+            ],
+            None,
+        );
+        Arc::new(ListArray::new(
+            struct_field(false),
+            OffsetBuffer::new(vec![0, 2, 3].into()),
+            Arc::new(entries),
+            None,
+        ))
+    }
+
+    #[test]
+    fn stamps_equal_types_without_copying() {
+        let schema = Arc::new(Schema::new(vec![Field::new("c0", DataType::Int32, true)]));
+        let column: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let batch = cast_and_stamp_schema("TestExec", &schema, &[Arc::clone(&column)], 3).unwrap();
+        assert!(Arc::ptr_eq(batch.column(0), &column));
+    }
+
+    /// An unreconcilable difference must still name the operator and the column, not just an index.
+    #[test]
+    fn error_names_operator_and_column() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "payload",
+            DataType::Struct(Fields::from(vec![Field::new("id", DataType::Int64, true)])),
+            true,
+        )]));
+        let column: ArrayRef = Arc::new(StringArray::from(vec!["a", "b"]));
+        let err = cast_and_stamp_schema("TestExec", &schema, &[column], 2).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("TestExec"), "{msg}");
+        assert!(msg.contains("col[0]"), "{msg}");
+        assert!(msg.contains("payload: expected Struct"), "{msg}");
+    }
+
+    #[test]
+    fn error_on_column_count_mismatch() {
+        let schema = Arc::new(Schema::new(vec![Field::new("c0", DataType::Int32, true)]));
+        let err = cast_and_stamp_schema("TestExec", &schema, &[], 0).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("produced 0 columns but its schema declares 1"),
+            "{err}"
+        );
+    }
+}

--- a/native/core/src/execution/operators/expand.rs
+++ b/native/core/src/execution/operators/expand.rs
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::{RecordBatch, RecordBatchOptions};
-use arrow::datatypes::SchemaRef;
+use arrow::array::RecordBatch;
+use arrow::datatypes::{Field, Schema, SchemaRef};
 use datafusion::common::DataFusionError;
 use datafusion::physical_expr::{EquivalenceProperties, PhysicalExpr};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
@@ -27,6 +27,7 @@ use datafusion::{
         RecordBatchStream, SendableRecordBatchStream,
     },
 };
+use datafusion_comet_common::{cast_and_stamp_schema, widen_nested_nullability};
 use futures::{Stream, StreamExt};
 use std::{
     pin::Pin,
@@ -64,6 +65,47 @@ impl ExpandExec {
             schema,
             cache,
         }
+    }
+
+    /// Derives the operator's output schema from *every* projection, not just the first.
+    ///
+    /// Each projection produces the same output columns, so their types agree except where a
+    /// native kernel drifts on nested field nullability. Widening each column's nested `nullable`
+    /// flags across all projections gives a schema that is valid for all of them; deriving it from
+    /// `projections[0]` alone yields a schema that the remaining projections cannot be stamped
+    /// with. See <https://github.com/apache/datafusion-comet/issues/5137>.
+    pub fn build_schema(
+        projections: &[Vec<Arc<dyn PhysicalExpr>>],
+        input_schema: &SchemaRef,
+    ) -> Result<SchemaRef, DataFusionError> {
+        let mut data_types = projections
+            .first()
+            .ok_or_else(|| {
+                DataFusionError::Internal("Expand should have at least one projection".to_string())
+            })?
+            .iter()
+            .map(|expr| expr.data_type(input_schema))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        for projection in &projections[1..] {
+            if projection.len() != data_types.len() {
+                return Err(DataFusionError::Internal(format!(
+                    "Expand projections produce differing column counts: {} and {}",
+                    data_types.len(),
+                    projection.len()
+                )));
+            }
+            for (data_type, expr) in data_types.iter_mut().zip(projection) {
+                *data_type = widen_nested_nullability(data_type, &expr.data_type(input_schema)?);
+            }
+        }
+
+        let fields: Vec<Field> = data_types
+            .into_iter()
+            .enumerate()
+            .map(|(idx, dt)| Field::new(format!("col_{idx}"), dt, true))
+            .collect();
+        Ok(Arc::new(Schema::new(fields)))
     }
 }
 
@@ -174,9 +216,9 @@ impl ExpandStream {
             Ok::<(), DataFusionError>(())
         })?;
 
-        let options = RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
-        RecordBatch::try_new_with_options(Arc::clone(&self.schema), columns, &options)
-            .map_err(|e| e.into())
+        // A projection whose nested nullability is narrower than the operator's declared schema is
+        // reconciled here rather than rejected by the stamp.
+        cast_and_stamp_schema("CometExpandExec", &self.schema, &columns, batch.num_rows())
     }
 }
 
@@ -212,5 +254,188 @@ impl Stream for ExpandStream {
 impl RecordBatchStream for ExpandStream {
     fn schema(&self) -> SchemaRef {
         Arc::clone(&self.schema)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! `ExpandExec` stamps its declared schema onto the output of every projection. Nested field
+    //! nullability is part of arrow's `DataType` identity, so a projection whose nested `nullable`
+    //! flags differ from the declared schema used to abort the task. These tests pin both halves of
+    //! the fix independently: `build_schema` widens the declared schema across all projections, and
+    //! the stamp reconciles anything still narrower. See
+    //! <https://github.com/apache/datafusion-comet/issues/5137>.
+
+    use super::*;
+    use arrow::array::{Array, ArrayRef, BooleanArray, Int64Array, ListArray, StructArray};
+    use arrow::buffer::OffsetBuffer;
+    use arrow::datatypes::{DataType, FieldRef, Fields};
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::datasource::source::DataSourceExec;
+    use datafusion::physical_expr::expressions::Column;
+    use datafusion::prelude::SessionContext;
+
+    fn struct_fields(flag_nullable: bool) -> Fields {
+        Fields::from(vec![
+            Field::new("id", DataType::Int64, true),
+            Field::new("flag", DataType::Boolean, flag_nullable),
+        ])
+    }
+
+    fn element_field(flag_nullable: bool) -> FieldRef {
+        Arc::new(Field::new_list_field(
+            DataType::Struct(struct_fields(flag_nullable)),
+            true,
+        ))
+    }
+
+    /// `[[{1,true},{2,false}], [{3,true}]]`. The two variants hold identical values; only the
+    /// `flag` field's `nullable` flag differs, which is the whole of the drift being absorbed.
+    fn list_of_struct(flag_nullable: bool) -> ArrayRef {
+        let entries = StructArray::new(
+            struct_fields(flag_nullable),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])) as ArrayRef,
+                Arc::new(BooleanArray::from(vec![true, false, true])),
+            ],
+            None,
+        );
+        Arc::new(ListArray::new(
+            element_field(flag_nullable),
+            OffsetBuffer::new(vec![0, 2, 3].into()),
+            Arc::new(entries),
+            None,
+        ))
+    }
+
+    /// Child with two columns of the same logical `array<struct<id,flag>>` type that disagree on
+    /// the `flag` field's nullability, so that projecting one per Expand projection reproduces the
+    /// drift.
+    fn drifting_child() -> Arc<dyn ExecutionPlan> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::List(element_field(true)), true),
+            Field::new("b", DataType::List(element_field(false)), true),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![list_of_struct(true), list_of_struct(false)],
+        )
+        .unwrap();
+        let config = MemorySourceConfig::try_new(&[vec![batch]], schema, None).unwrap();
+        Arc::new(DataSourceExec::new(Arc::new(config)))
+    }
+
+    fn drifting_projections() -> Vec<Vec<Arc<dyn PhysicalExpr>>> {
+        vec![
+            vec![Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>],
+            vec![Arc::new(Column::new("b", 1)) as Arc<dyn PhysicalExpr>],
+        ]
+    }
+
+    async fn collect(plan: Arc<dyn ExecutionPlan>) -> Vec<RecordBatch> {
+        let ctx = SessionContext::new().task_ctx();
+        let mut stream = plan.execute(0, ctx).unwrap();
+        let mut batches = vec![];
+        while let Some(batch) = stream.next().await {
+            batches.push(batch.unwrap());
+        }
+        batches
+    }
+
+    /// Each output batch must carry the operator's declared schema and the values the projection
+    /// produced, unchanged.
+    fn assert_expanded(batches: &[RecordBatch], schema: &SchemaRef) {
+        assert_eq!(batches.len(), 2, "one batch per projection");
+        for batch in batches {
+            assert_eq!(&batch.schema(), schema);
+            assert_eq!(batch.num_rows(), 2);
+            let list = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<ListArray>()
+                .unwrap();
+            assert_eq!(list.value(0).len(), 2);
+            assert_eq!(list.value(1).len(), 1);
+        }
+    }
+
+    /// `build_schema` must widen the nested `nullable` flags across all projections, not read them
+    /// off `projections[0]`.
+    #[test]
+    fn build_schema_widens_nested_nullability_across_projections() {
+        let child = drifting_child();
+        // `projections[0]` alone would declare the widened type here, so drive the widening from
+        // the narrow side to prove it is not just projections[0] being echoed back.
+        let projections = vec![
+            vec![Arc::new(Column::new("b", 1)) as Arc<dyn PhysicalExpr>],
+            vec![Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>],
+        ];
+        let schema = ExpandExec::build_schema(&projections, &child.schema()).unwrap();
+        assert_eq!(
+            schema.field(0).data_type(),
+            &DataType::List(element_field(true)),
+            "the flag field must be nullable because projection[1] produces it nullable"
+        );
+    }
+
+    #[test]
+    fn build_schema_rejects_projections_of_differing_width() {
+        let child = drifting_child();
+        let projections = vec![
+            vec![Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>],
+            vec![
+                Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>,
+                Arc::new(Column::new("b", 1)) as Arc<dyn PhysicalExpr>,
+            ],
+        ];
+        let err = ExpandExec::build_schema(&projections, &child.schema()).unwrap_err();
+        assert!(err.to_string().contains("differing column counts"), "{err}");
+    }
+
+    /// End-to-end: projections that disagree on nested nullability both expand successfully under
+    /// the widened schema.
+    #[tokio::test]
+    async fn expands_projections_with_divergent_nested_nullability() {
+        let child = drifting_child();
+        let projections = drifting_projections();
+        let schema = ExpandExec::build_schema(&projections, &child.schema()).unwrap();
+        let expand = Arc::new(ExpandExec::new(projections, child, Arc::clone(&schema)));
+        assert_expanded(&collect(expand).await, &schema);
+    }
+
+    /// The stamp reconciles on its own: even given the narrow `projections[0]`-derived schema that
+    /// the planner used to build, the projection producing a non-null child no longer aborts.
+    #[tokio::test]
+    async fn stamp_reconciles_a_schema_narrower_than_a_projection() {
+        let child = drifting_child();
+        let narrow = Arc::new(Schema::new(vec![Field::new(
+            "col_0",
+            DataType::List(element_field(false)),
+            true,
+        )]));
+        let expand = Arc::new(ExpandExec::new(
+            drifting_projections(),
+            child,
+            Arc::clone(&narrow),
+        ));
+        assert_expanded(&collect(expand).await, &narrow);
+    }
+
+    /// When no projection drifts, the schema is exactly what `projections[0]` yields, and the stamp
+    /// is a no-op passthrough.
+    #[tokio::test]
+    async fn no_drift_is_unchanged() {
+        let child = drifting_child();
+        let projections = vec![
+            vec![Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>],
+            vec![Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>],
+        ];
+        let schema = ExpandExec::build_schema(&projections, &child.schema()).unwrap();
+        assert_eq!(
+            schema.field(0).data_type(),
+            &DataType::List(element_field(true))
+        );
+        let expand = Arc::new(ExpandExec::new(projections, child, Arc::clone(&schema)));
+        assert_expanded(&collect(expand).await, &schema);
     }
 }

--- a/native/core/src/execution/operators/expand.rs
+++ b/native/core/src/execution/operators/expand.rs
@@ -100,6 +100,10 @@ impl ExpandExec {
             }
         }
 
+        // `col_{idx}` is the name the planner used before this logic moved here, kept so that only
+        // the nullability derivation changes. A projection is an arbitrary expression with no
+        // natural output name, and parent operators bind to these columns by index (a bound
+        // reference takes its name from the child schema), so the name is positional either way.
         let fields: Vec<Field> = data_types
             .into_iter()
             .enumerate()

--- a/native/core/src/execution/operators/expand.rs
+++ b/native/core/src/execution/operators/expand.rs
@@ -218,7 +218,7 @@ impl ExpandStream {
 
         // A projection whose nested nullability is narrower than the operator's declared schema is
         // reconciled here rather than rejected by the stamp.
-        cast_and_stamp_schema("CometExpandExec", &self.schema, &columns, batch.num_rows())
+        cast_and_stamp_schema("CometExpandExec", &self.schema, columns, batch.num_rows())
     }
 }
 
@@ -267,62 +267,29 @@ mod tests {
     //! <https://github.com/apache/datafusion-comet/issues/5137>.
 
     use super::*;
-    use arrow::array::{Array, ArrayRef, BooleanArray, Int64Array, ListArray, StructArray};
-    use arrow::buffer::OffsetBuffer;
-    use arrow::datatypes::{DataType, FieldRef, Fields};
+    use crate::execution::operators::nested_nullability_fixture::{
+        list_of_struct, list_of_struct_type,
+    };
+    use arrow::array::{Array, ListArray};
     use datafusion::datasource::memory::MemorySourceConfig;
-    use datafusion::datasource::source::DataSourceExec;
     use datafusion::physical_expr::expressions::Column;
+    use datafusion::physical_plan::collect;
     use datafusion::prelude::SessionContext;
-
-    fn struct_fields(flag_nullable: bool) -> Fields {
-        Fields::from(vec![
-            Field::new("id", DataType::Int64, true),
-            Field::new("flag", DataType::Boolean, flag_nullable),
-        ])
-    }
-
-    fn element_field(flag_nullable: bool) -> FieldRef {
-        Arc::new(Field::new_list_field(
-            DataType::Struct(struct_fields(flag_nullable)),
-            true,
-        ))
-    }
-
-    /// `[[{1,true},{2,false}], [{3,true}]]`. The two variants hold identical values; only the
-    /// `flag` field's `nullable` flag differs, which is the whole of the drift being absorbed.
-    fn list_of_struct(flag_nullable: bool) -> ArrayRef {
-        let entries = StructArray::new(
-            struct_fields(flag_nullable),
-            vec![
-                Arc::new(Int64Array::from(vec![1, 2, 3])) as ArrayRef,
-                Arc::new(BooleanArray::from(vec![true, false, true])),
-            ],
-            None,
-        );
-        Arc::new(ListArray::new(
-            element_field(flag_nullable),
-            OffsetBuffer::new(vec![0, 2, 3].into()),
-            Arc::new(entries),
-            None,
-        ))
-    }
 
     /// Child with two columns of the same logical `array<struct<id,flag>>` type that disagree on
     /// the `flag` field's nullability, so that projecting one per Expand projection reproduces the
     /// drift.
     fn drifting_child() -> Arc<dyn ExecutionPlan> {
         let schema = Arc::new(Schema::new(vec![
-            Field::new("a", DataType::List(element_field(true)), true),
-            Field::new("b", DataType::List(element_field(false)), true),
+            Field::new("a", list_of_struct_type(true), true),
+            Field::new("b", list_of_struct_type(false), true),
         ]));
         let batch = RecordBatch::try_new(
             Arc::clone(&schema),
             vec![list_of_struct(true), list_of_struct(false)],
         )
         .unwrap();
-        let config = MemorySourceConfig::try_new(&[vec![batch]], schema, None).unwrap();
-        Arc::new(DataSourceExec::new(Arc::new(config)))
+        MemorySourceConfig::try_new_exec(&[vec![batch]], schema, None).unwrap()
     }
 
     fn drifting_projections() -> Vec<Vec<Arc<dyn PhysicalExpr>>> {
@@ -332,14 +299,10 @@ mod tests {
         ]
     }
 
-    async fn collect(plan: Arc<dyn ExecutionPlan>) -> Vec<RecordBatch> {
-        let ctx = SessionContext::new().task_ctx();
-        let mut stream = plan.execute(0, ctx).unwrap();
-        let mut batches = vec![];
-        while let Some(batch) = stream.next().await {
-            batches.push(batch.unwrap());
-        }
-        batches
+    async fn expand_all(plan: Arc<dyn ExecutionPlan>) -> Vec<RecordBatch> {
+        collect(plan, SessionContext::new().task_ctx())
+            .await
+            .unwrap()
     }
 
     /// Each output batch must carry the operator's declared schema and the values the projection
@@ -373,7 +336,7 @@ mod tests {
         let schema = ExpandExec::build_schema(&projections, &child.schema()).unwrap();
         assert_eq!(
             schema.field(0).data_type(),
-            &DataType::List(element_field(true)),
+            &list_of_struct_type(true),
             "the flag field must be nullable because projection[1] produces it nullable"
         );
     }
@@ -400,7 +363,7 @@ mod tests {
         let projections = drifting_projections();
         let schema = ExpandExec::build_schema(&projections, &child.schema()).unwrap();
         let expand = Arc::new(ExpandExec::new(projections, child, Arc::clone(&schema)));
-        assert_expanded(&collect(expand).await, &schema);
+        assert_expanded(&expand_all(expand).await, &schema);
     }
 
     /// The stamp reconciles on its own: even given the narrow `projections[0]`-derived schema that
@@ -410,7 +373,7 @@ mod tests {
         let child = drifting_child();
         let narrow = Arc::new(Schema::new(vec![Field::new(
             "col_0",
-            DataType::List(element_field(false)),
+            list_of_struct_type(false),
             true,
         )]));
         let expand = Arc::new(ExpandExec::new(
@@ -418,7 +381,7 @@ mod tests {
             child,
             Arc::clone(&narrow),
         ));
-        assert_expanded(&collect(expand).await, &narrow);
+        assert_expanded(&expand_all(expand).await, &narrow);
     }
 
     /// When no projection drifts, the schema is exactly what `projections[0]` yields, and the stamp
@@ -431,11 +394,8 @@ mod tests {
             vec![Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>],
         ];
         let schema = ExpandExec::build_schema(&projections, &child.schema()).unwrap();
-        assert_eq!(
-            schema.field(0).data_type(),
-            &DataType::List(element_field(true))
-        );
+        assert_eq!(schema.field(0).data_type(), &list_of_struct_type(true));
         let expand = Arc::new(ExpandExec::new(projections, child, Arc::clone(&schema)));
-        assert_expanded(&collect(expand).await, &schema);
+        assert_expanded(&expand_all(expand).await, &schema);
     }
 }

--- a/native/core/src/execution/operators/mod.rs
+++ b/native/core/src/execution/operators/mod.rs
@@ -37,3 +37,52 @@ mod scan;
 mod shuffle_scan;
 pub use csv_scan::init_csv_datasource_exec;
 pub use shuffle_scan::ShuffleScanExec;
+
+/// Fixtures for the nested-nullability drift from
+/// <https://github.com/apache/datafusion-comet/issues/5137>, shared by the `expand` and
+/// `shuffle_scan` tests so the two boundaries are pinned against the same array.
+#[cfg(test)]
+pub(crate) mod nested_nullability_fixture {
+    use arrow::array::{ArrayRef, BooleanArray, Int64Array, ListArray, StructArray};
+    use arrow::buffer::OffsetBuffer;
+    use arrow::datatypes::{DataType, Field, FieldRef, Fields};
+    use std::sync::Arc;
+
+    pub fn struct_fields(flag_nullable: bool) -> Fields {
+        Fields::from(vec![
+            Field::new("id", DataType::Int64, true),
+            Field::new("flag", DataType::Boolean, flag_nullable),
+        ])
+    }
+
+    /// The element field of an `array<struct<id,flag>>`, with `flag`'s nullability as given.
+    pub fn element_field(flag_nullable: bool) -> FieldRef {
+        Arc::new(Field::new_list_field(
+            DataType::Struct(struct_fields(flag_nullable)),
+            true,
+        ))
+    }
+
+    pub fn list_of_struct_type(flag_nullable: bool) -> DataType {
+        DataType::List(element_field(flag_nullable))
+    }
+
+    /// `[[{1,true},{2,false}], [{3,true}]]`. Both variants hold identical values; only the `flag`
+    /// field's `nullable` flag differs, which is the whole of the drift being absorbed.
+    pub fn list_of_struct(flag_nullable: bool) -> ArrayRef {
+        let entries = StructArray::new(
+            struct_fields(flag_nullable),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])) as ArrayRef,
+                Arc::new(BooleanArray::from(vec![true, false, true])),
+            ],
+            None,
+        );
+        Arc::new(ListArray::new(
+            element_field(flag_nullable),
+            OffsetBuffer::new(vec![0, 2, 3].into()),
+            Arc::new(entries),
+            None,
+        ))
+    }
+}

--- a/native/core/src/execution/operators/shuffle_scan.rs
+++ b/native/core/src/execution/operators/shuffle_scan.rs
@@ -326,7 +326,7 @@ impl Stream for ShuffleScanStream {
                 let maybe_batch = cast_and_stamp_schema(
                     self.shuffle_scan.name(),
                     &self.shuffle_scan.schema,
-                    columns,
+                    columns.clone(),
                     *num_rows,
                 );
                 Poll::Ready(Some(maybe_batch))
@@ -512,44 +512,17 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn test_nested_nullability_drift_is_reconciled() {
         use super::*;
-        use arrow::array::{Array, BooleanArray, Int64Array, ListArray, StructArray};
-        use arrow::buffer::OffsetBuffer;
-        use arrow::datatypes::{FieldRef, Fields};
+        use crate::execution::operators::nested_nullability_fixture::{
+            list_of_struct, list_of_struct_type,
+        };
+        use arrow::array::Array;
         use datafusion::physical_plan::ExecutionPlan;
         use futures::StreamExt;
 
-        fn struct_fields(flag_nullable: bool) -> Fields {
-            Fields::from(vec![
-                Field::new("id", DataType::Int64, true),
-                Field::new("flag", DataType::Boolean, flag_nullable),
-            ])
-        }
-
-        fn element_field(flag_nullable: bool) -> FieldRef {
-            Arc::new(Field::new_list_field(
-                DataType::Struct(struct_fields(flag_nullable)),
-                true,
-            ))
-        }
-
-        // The block carries `List(Struct("id": Int64, "flag": non-null Boolean))` ...
-        let entries = StructArray::new(
-            struct_fields(false),
-            vec![
-                Arc::new(Int64Array::from(vec![1, 2, 3])) as ArrayRef,
-                Arc::new(BooleanArray::from(vec![true, false, true])),
-            ],
-            None,
-        );
-        let block_column: ArrayRef = Arc::new(ListArray::new(
-            element_field(false),
-            OffsetBuffer::new(vec![0, 2, 3].into()),
-            Arc::new(entries),
-            None,
-        ));
-
-        // ... while catalyst declared the `flag` child nullable.
-        let declared = DataType::List(element_field(true));
+        // The block carries `List(Struct("id": Int64, "flag": non-null Boolean))` while catalyst
+        // declared the `flag` child nullable.
+        let block_column = list_of_struct(false);
+        let declared = list_of_struct_type(true);
         let mut scan = ShuffleScanExec::new(
             super::super::super::planner::TEST_EXEC_CONTEXT_ID,
             None,
@@ -566,28 +539,10 @@ mod tests {
 
             assert_eq!(batch.schema().field(0).data_type(), &declared);
             assert_eq!(batch.num_rows(), 2);
-
-            // The values must survive the reconciliation untouched.
-            let list = batch
-                .column(0)
-                .as_any()
-                .downcast_ref::<ListArray>()
-                .unwrap();
-            assert_eq!(list.value(0).len(), 2);
-            assert_eq!(list.value(1).len(), 1);
-            let flags = list
-                .values()
-                .as_any()
-                .downcast_ref::<StructArray>()
-                .unwrap()
-                .column(1)
-                .as_any()
-                .downcast_ref::<BooleanArray>()
-                .unwrap();
-            assert_eq!(
-                flags.values().iter().collect::<Vec<_>>()[..3],
-                [true, false, true]
-            );
+            // The values must survive the reconciliation untouched. `ArrayData` equality is
+            // logical, so this holds regardless of whether the cast materialized an all-valid
+            // null buffer for the widened child.
+            assert_eq!(batch.column(0).to_data(), list_of_struct(true).to_data());
         });
     }
 

--- a/native/core/src/execution/operators/shuffle_scan.rs
+++ b/native/core/src/execution/operators/shuffle_scan.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use arrow::array::ArrayRef;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use datafusion::common::{arrow_datafusion_err, Result as DataFusionResult};
+use datafusion::common::Result as DataFusionResult;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::metrics::{
     BaselineMetrics, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet, Time,
@@ -34,6 +34,7 @@ use datafusion::{
     physical_expr::*,
     physical_plan::{ExecutionPlan, *},
 };
+use datafusion_comet_common::cast_and_stamp_schema;
 use futures::Stream;
 use jni::objects::{Global, JByteBuffer, JObject};
 use std::{
@@ -318,14 +319,16 @@ impl Stream for ShuffleScanStream {
             InputBatch::EOF => Poll::Ready(None),
             InputBatch::Batch(columns, num_rows) => {
                 self.baseline_metrics.record_output(*num_rows);
-                let options =
-                    arrow::array::RecordBatchOptions::new().with_row_count(Some(*num_rows));
-                let maybe_batch = arrow::array::RecordBatch::try_new_with_options(
-                    self.shuffle_scan.schema(),
-                    columns.clone(),
-                    &options,
-                )
-                .map_err(|e| arrow_datafusion_err!(e));
+                // Reconcile the decoded block with the catalyst-declared schema rather than
+                // stamping it on, so that nested field nullability drift is absorbed here the way
+                // `ScanExec` absorbs it at the FFI boundary.
+                // See https://github.com/apache/datafusion-comet/issues/5137.
+                let maybe_batch = cast_and_stamp_schema(
+                    self.shuffle_scan.name(),
+                    &self.shuffle_scan.schema,
+                    columns,
+                    *num_rows,
+                );
                 Poll::Ready(Some(maybe_batch))
             }
         };
@@ -497,6 +500,126 @@ mod tests {
             assert_eq!(col1.value(0), "hello");
             assert_eq!(col1.value(1), "world");
             assert_eq!(col1.value(2), "hello");
+        });
+    }
+
+    /// A decoded shuffle block whose nested field nullability is narrower than the catalyst-declared
+    /// type must be reconciled, not rejected. `ShuffleScanExec` used to stamp the declared schema
+    /// straight onto the block, which aborted the task on a single nested `nullable` flag even
+    /// though a non-null child is a strict subset of a nullable one.
+    /// See <https://github.com/apache/datafusion-comet/issues/5137>.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_nested_nullability_drift_is_reconciled() {
+        use super::*;
+        use arrow::array::{Array, BooleanArray, Int64Array, ListArray, StructArray};
+        use arrow::buffer::OffsetBuffer;
+        use arrow::datatypes::{FieldRef, Fields};
+        use datafusion::physical_plan::ExecutionPlan;
+        use futures::StreamExt;
+
+        fn struct_fields(flag_nullable: bool) -> Fields {
+            Fields::from(vec![
+                Field::new("id", DataType::Int64, true),
+                Field::new("flag", DataType::Boolean, flag_nullable),
+            ])
+        }
+
+        fn element_field(flag_nullable: bool) -> FieldRef {
+            Arc::new(Field::new_list_field(
+                DataType::Struct(struct_fields(flag_nullable)),
+                true,
+            ))
+        }
+
+        // The block carries `List(Struct("id": Int64, "flag": non-null Boolean))` ...
+        let entries = StructArray::new(
+            struct_fields(false),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])) as ArrayRef,
+                Arc::new(BooleanArray::from(vec![true, false, true])),
+            ],
+            None,
+        );
+        let block_column: ArrayRef = Arc::new(ListArray::new(
+            element_field(false),
+            OffsetBuffer::new(vec![0, 2, 3].into()),
+            Arc::new(entries),
+            None,
+        ));
+
+        // ... while catalyst declared the `flag` child nullable.
+        let declared = DataType::List(element_field(true));
+        let mut scan = ShuffleScanExec::new(
+            super::super::super::planner::TEST_EXEC_CONTEXT_ID,
+            None,
+            vec![declared.clone()],
+        )
+        .unwrap();
+        scan.set_input_batch(InputBatch::new(vec![block_column], Some(2)));
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let ctx = Arc::new(TaskContext::default());
+            let mut stream = scan.execute(0, ctx).unwrap();
+            let batch = stream.next().await.unwrap().unwrap();
+
+            assert_eq!(batch.schema().field(0).data_type(), &declared);
+            assert_eq!(batch.num_rows(), 2);
+
+            // The values must survive the reconciliation untouched.
+            let list = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<ListArray>()
+                .unwrap();
+            assert_eq!(list.value(0).len(), 2);
+            assert_eq!(list.value(1).len(), 1);
+            let flags = list
+                .values()
+                .as_any()
+                .downcast_ref::<StructArray>()
+                .unwrap()
+                .column(1)
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .unwrap();
+            assert_eq!(
+                flags.values().iter().collect::<Vec<_>>()[..3],
+                [true, false, true]
+            );
+        });
+    }
+
+    /// An unreconcilable column must name the operator and the column, since arrow's own message
+    /// reports only `at column index N`.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_unreconcilable_column_error_names_operator() {
+        use super::*;
+        use arrow::datatypes::Fields;
+        use datafusion::physical_plan::ExecutionPlan;
+        use futures::StreamExt;
+
+        let declared =
+            DataType::Struct(Fields::from(vec![Field::new("id", DataType::Int64, true)]));
+        let mut scan = ShuffleScanExec::new(
+            super::super::super::planner::TEST_EXEC_CONTEXT_ID,
+            None,
+            vec![declared],
+        )
+        .unwrap();
+        let column: ArrayRef = Arc::new(StringArray::from(vec!["a", "b"]));
+        scan.set_input_batch(InputBatch::new(vec![column], Some(2)));
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let ctx = Arc::new(TaskContext::default());
+            let mut stream = scan.execute(0, ctx).unwrap();
+            let err = stream.next().await.unwrap().unwrap_err().to_string();
+            assert!(err.contains("ShuffleScanExec"), "{err}");
+            assert!(err.contains("col[0]"), "{err}");
+            assert!(err.contains("col_0: expected Struct"), "{err}");
         });
     }
 }

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -1785,16 +1785,7 @@ impl PhysicalPlanner {
                     "Expand should have at least one projection"
                 );
 
-                let datatypes = projections[0]
-                    .iter()
-                    .map(|expr| expr.data_type(&child.schema()))
-                    .collect::<Result<Vec<DataType>, _>>()?;
-                let fields: Vec<Field> = datatypes
-                    .iter()
-                    .enumerate()
-                    .map(|(idx, dt)| Field::new(format!("col_{idx}"), dt.clone(), true))
-                    .collect();
-                let schema = Arc::new(Schema::new(fields));
+                let schema = ExpandExec::build_schema(&projections, &child.schema())?;
 
                 // `Expand` operator keeps the input batch and expands it to multiple output
                 // batches. However, `ScanExec` will reuse input arrays for the next

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -1780,11 +1780,6 @@ impl PhysicalPlanner {
                     Ok::<(), ExecutionError>(())
                 })?;
 
-                assert!(
-                    !projections.is_empty(),
-                    "Expand should have at least one projection"
-                );
-
                 let schema = ExpandExec::build_schema(&projections, &child.schema())?;
 
                 // `Expand` operator keeps the input batch and expands it to multiple output

--- a/native/shuffle/src/schema_align.rs
+++ b/native/shuffle/src/schema_align.rs
@@ -22,17 +22,16 @@
 //! return-type drift from DataFusion / `datafusion-spark` is self-healing. When a native plan's
 //! output crosses back to the JVM and feeds another native plan, the consuming `ScanExec` casts
 //! every imported column to the catalyst-declared type, so a wrong Arrow type never survives the
-//! boundary. Shuffle is the lone exception, on two counts:
+//! boundary. Shuffle is the lone exception because the writer hash-partitions on these columns, and
+//! Spark's hash differs by type (e.g. `Int32` vs `Int64`), so a drifted type would route rows to
+//! the wrong partition. A read-side cast cannot undo a wrong partition assignment, so the type must
+//! be corrected before partitioning — which forces the alignment onto the writer input.
 //!
-//!   1. The writer hash-partitions on these columns, and Spark's hash differs by type (e.g. `Int32`
-//!      vs `Int64`), so a drifted type would route rows to the wrong partition. A read-side cast
-//!      cannot undo a wrong partition assignment, so the type must be corrected before partitioning.
-//!   2. The shuffle read path (`ShuffleScanExec`) does not cast; it stamps the catalyst schema onto
-//!      the decoded block and errors on any mismatch. The schema is serialized into the block on
-//!      write and trusted on read.
+//! The read path (`ShuffleScanExec`) casts too, so a drift that only affects the batch's Arrow type
+//! and not its partition assignment is absorbed there as well. See
+//! <https://github.com/apache/datafusion-comet/issues/5137>.
 //!
-//! Both force the alignment to happen on the writer input. See
-//! <https://github.com/apache/datafusion-comet/issues/4515> for the running list of mismatched
+//! See <https://github.com/apache/datafusion-comet/issues/4515> for the running list of mismatched
 //! functions.
 
 use arrow::array::{ArrayRef, RecordBatch, RecordBatchOptions};

--- a/native/shuffle/src/schema_align.rs
+++ b/native/shuffle/src/schema_align.rs
@@ -34,8 +34,7 @@
 //! See <https://github.com/apache/datafusion-comet/issues/4515> for the running list of mismatched
 //! functions.
 
-use arrow::array::{ArrayRef, RecordBatch, RecordBatchOptions};
-use arrow::compute::{cast_with_options, CastOptions};
+use arrow::array::RecordBatch;
 use arrow::datatypes::{Field, Schema, SchemaRef};
 use datafusion::common::DataFusionError;
 use datafusion::physical_expr::EquivalenceProperties;
@@ -47,6 +46,7 @@ use datafusion::{
         RecordBatchStream, SendableRecordBatchStream,
     },
 };
+use datafusion_comet_common::cast_and_stamp_schema;
 use futures::{Stream, StreamExt};
 use std::{
     collections::HashSet,
@@ -71,17 +71,7 @@ fn warn_dedup() -> &'static Mutex<HashSet<String>> {
 pub struct SchemaAlignExec {
     child: Arc<dyn ExecutionPlan>,
     target_schema: SchemaRef,
-    column_actions: Arc<Vec<ColumnAction>>,
     cache: Arc<PlanProperties>,
-}
-
-#[derive(Debug, Clone)]
-enum ColumnAction {
-    /// Pass the input column through unchanged. Any nullability/metadata difference is
-    /// absorbed when the batch is re-stamped via `RecordBatch::try_new_with_options`.
-    Passthrough,
-    /// Cast the input column to the target data_type.
-    Cast,
 }
 
 impl SchemaAlignExec {
@@ -102,7 +92,6 @@ impl SchemaAlignExec {
             )));
         }
         let mut needs_alignment = false;
-        let mut actions = Vec::with_capacity(actual.fields().len());
         let mut target_fields = Vec::with_capacity(actual.fields().len());
         for (idx, (actual_field, expected_field)) in actual
             .fields()
@@ -110,8 +99,8 @@ impl SchemaAlignExec {
             .zip(expected.fields().iter())
             .enumerate()
         {
-            let action = if actual_field.data_type() == expected_field.data_type() {
-                ColumnAction::Passthrough
+            let needs_cast = if actual_field.data_type() == expected_field.data_type() {
+                false
             } else {
                 let signature = format!(
                     "{}|{:?}|{:?}",
@@ -129,10 +118,10 @@ impl SchemaAlignExec {
                         expected_field.data_type()
                     );
                 }
-                ColumnAction::Cast
+                true
             };
             let target_nullable = actual_field.is_nullable() || expected_field.is_nullable();
-            let field_changed = !matches!(action, ColumnAction::Passthrough)
+            let field_changed = needs_cast
                 || target_nullable != actual_field.is_nullable()
                 || expected_field.metadata() != actual_field.metadata()
                 || expected_field.name() != actual_field.name();
@@ -147,7 +136,6 @@ impl SchemaAlignExec {
                 )
                 .with_metadata(expected_field.metadata().clone()),
             );
-            actions.push(action);
         }
         if !needs_alignment {
             return Ok(child);
@@ -162,7 +150,6 @@ impl SchemaAlignExec {
         Ok(Arc::new(Self {
             child,
             target_schema,
-            column_actions: Arc::new(actions),
             cache,
         }))
     }
@@ -203,7 +190,6 @@ impl ExecutionPlan for SchemaAlignExec {
         Ok(Arc::new(Self {
             child: new_child,
             target_schema: Arc::clone(&self.target_schema),
-            column_actions: Arc::clone(&self.column_actions),
             cache,
         }))
     }
@@ -217,7 +203,6 @@ impl ExecutionPlan for SchemaAlignExec {
         Ok(Box::pin(SchemaAlignStream {
             child_stream,
             target_schema: Arc::clone(&self.target_schema),
-            column_actions: Arc::clone(&self.column_actions),
         }))
     }
 
@@ -233,27 +218,17 @@ impl ExecutionPlan for SchemaAlignExec {
 struct SchemaAlignStream {
     child_stream: SendableRecordBatchStream,
     target_schema: SchemaRef,
-    column_actions: Arc<Vec<ColumnAction>>,
 }
 
 impl SchemaAlignStream {
     fn align(&self, batch: RecordBatch) -> Result<RecordBatch, DataFusionError> {
-        let mut columns: Vec<ArrayRef> = Vec::with_capacity(batch.num_columns());
-        for (idx, action) in self.column_actions.iter().enumerate() {
-            let column = batch.column(idx);
-            let aligned = match action {
-                ColumnAction::Passthrough => Arc::clone(column),
-                ColumnAction::Cast => cast_with_options(
-                    column,
-                    self.target_schema.field(idx).data_type(),
-                    &CastOptions::default(),
-                )?,
-            };
-            columns.push(aligned);
-        }
-        let options = RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
-        RecordBatch::try_new_with_options(Arc::clone(&self.target_schema), columns, &options)
-            .map_err(DataFusionError::from)
+        let num_rows = batch.num_rows();
+        cast_and_stamp_schema(
+            "CometSchemaAlignExec",
+            &self.target_schema,
+            batch.columns().to_vec(),
+            num_rows,
+        )
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5137.

## Rationale for this change

Arrow treats nested field nullability as part of `DataType` identity, so `RecordBatch::try_new_with_options` rejects a column whose nested `nullable` flags are narrower than the declared type — even though the data is fine, since a non-null child is a strict subset of a nullable one. It is a metadata assertion failure, not corruption.

Most Comet boundaries already normalize instead of asserting, which is why this drift is usually invisible:

- `ScanExec::build_record_batch` casts every imported column to the declared type, so the FFI boundary absorbs it.
- `SchemaAlignExec` casts the shuffle writer's input (added for #4515).
- `CometLocalTableScanExec` widens its output with `.asNullable` (added for #4789).

Two stamp points still asserted, and because both sit inside native plans (past `ScanExec`'s cast) nothing corrected the drift before them. The task aborted deterministically for the partition's data shape, so retries did not help:

```
Invalid argument error: column types must match schema types,
expected List(Struct("id": Int64, "flag": Boolean))
but found List(Struct("id": Int64, "flag": non-null Boolean))
at column index 0
```

- `ShuffleScanExec::poll_next` stamped the catalyst schema onto the decoded shuffle block with no cast. This is the direct-read shuffle path, enabled by default (`spark.comet.shuffle.directRead.enabled`).
- `ExpandStream::expand` derived its schema from `projections[0]` only and stamped it onto the output of *every* projection, so it failed if any two projections disagreed on a nested nullable flag for the same output column.

## What changes are included in this PR?

A new `cast_and_stamp_schema` helper in `datafusion-comet-common`, used at both stamp points, which casts any column whose Arrow type differs from the declared field type before stamping. Arrow's cast rewrites nested fields from the target (`cast_struct_to_struct` builds with `to_fields`, `cast_list_values` with `to.clone()`), which is exactly how `ScanExec` already absorbs this.

`ExpandExec::build_schema` now derives the output schema by widening nested nullability across **all** projections instead of reading it off `projections[0]`, so the declared schema is valid for every projection. The runtime cast is a second, independent line of defence: each is tested on its own, so neither silently carries the other.

Error messages now name the operator and the dotted path of the offending column:

```
CometExpandExec cannot reconcile col[0] with its declared schema at
col_0.element.flag: expected nullable Boolean, found non-null Boolean
```

instead of only `at column index N`, which for a wide schema of deeply nested structs was very hard to act on — the two printed types could differ by one flag hundreds of characters in.

A narrowing cast (declared non-null child, actual data contains nulls) is not silently accepted: `StructArray::try_new` rejects unmasked nulls for a non-nullable field, so that case still errors loudly, now with the column path named.

This PR is about the boundaries. The upstream nested-nullability drift itself remains tracked by #4515, with concrete kernel instances in #4789 and #4528.

## How are these changes tested?

New Rust unit tests, modelled on the existing `SchemaAlignExec` tests as the issue suggested:

- `native/common/src/schema.rs` — 9 tests over `cast_and_stamp_schema`, `describe_type_mismatch`, and `widen_nested_nullability`. `stamps_nested_nullability_drift` first asserts that the plain stamp *does* reject the drift, then that the helper absorbs it with values intact. That assertion pins why the helper exists: if arrow ever relaxes nested nullability comparison, it flips and the call sites can go back to a plain stamp.
- `native/core/src/execution/operators/expand.rs` — 5 tests: `build_schema` widens across projections (driven from the narrow side, so it cannot pass by echoing `projections[0]`), rejects projections of differing width, expands divergent projections end-to-end, and reconciles even when handed the narrow `projections[0]`-derived schema the planner used to build.
- `native/core/src/execution/operators/shuffle_scan.rs` — 2 tests: a decoded block with a non-null nested child against a nullable declared type is reconciled with values preserved, and an unreconcilable column names the operator and column.

I confirmed these are genuine regression tests rather than tests that pass either way: without the fix, `RecordBatch::try_new_with_options` rejects the drift, which the first assertion in `stamps_nested_nullability_drift` now pins permanently.

Also run and passing: full `cargo test --workspace` (135 + 33 native tests; the 3 pre-existing `datafusion-comet-jni-bridge` `errors::tests` panic-handling failures reproduce on a clean checkout of this branch point and are unrelated), `cargo clippy --all-targets --workspace` clean, `cargo fmt`, and on Spark 3.5: `CometExecSuite "expand operator"`, `CometNativeShuffleSuite` (27), `CometShuffleSuite` (44), `CometAggregateSuite` (85, 2 canceled).

I did not reduce this to a Spark-level SQL test. Both sites need a native plan where a kernel actually produces a nested type narrower than catalyst declared, and those kernels are the subject of #4515/#4789/#4528 — so a SQL repro would be pinned to whichever kernel currently drifts and would evaporate when that kernel is fixed, which is the wrong thing to encode. The tests above pin the boundaries directly, independent of which kernel drifts.

## Are these changes tested?

Yes.

## Are there any user-facing changes?

No API changes. Queries that previously aborted with `column types must match schema types` in the direct-read shuffle path or in Expand (grouping sets / rollup / multiple distinct aggregates over nested columns) now complete. Errors that remain genuinely unreconcilable are reported with the operator and column path named.

## Follow-up

`ScanExec::build_record_batch` does the same cast-then-stamp but keeps its own copy of the logic and its own `cast_time` metric, so its errors still report only `at column index N`. Switching it to the shared helper would need the helper to accept a timer; I left it out to keep this diff focused on the two boundaries the issue names.