### PR TITLE
chore: stop enabling incompatible casts in plan stability suite

### DIFF
--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q44/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark3_5/q44/extended.txt
@@ -19,13 +19,13 @@ TakeOrderedAndProject
       :     :     :                                +- CometFilter
       :     :     :                                   :  +- Subquery
       :     :     :                                   :     +- CometNativeColumnarToRow
-      :     :     :                                   :        +- CometHashAggregate
+      :     :     :                                   :        +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
       :     :     :                                   :           +- CometExchange
       :     :     :                                   :              +- CometHashAggregate
       :     :     :                                   :                 +- CometProject
       :     :     :                                   :                    +- CometFilter
       :     :     :                                   :                       +- CometNativeScan parquet spark_catalog.default.store_sales
-      :     :     :                                   +- CometHashAggregate
+      :     :     :                                   +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
       :     :     :                                      +- CometExchange
       :     :     :                                         +- CometHashAggregate
       :     :     :                                            +- CometProject
@@ -44,7 +44,7 @@ TakeOrderedAndProject
       :     :                                   +- CometSort
       :     :                                      +- CometFilter
       :     :                                         :  +- ReusedSubquery
-      :     :                                         +- CometHashAggregate
+      :     :                                         +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
       :     :                                            +- CometExchange
       :     :                                               +- CometHashAggregate
       :     :                                                  +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q44/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q44/extended.txt
@@ -21,13 +21,13 @@ CometNativeColumnarToRow
          :     :     :                                   +- CometFilter
          :     :     :                                      :  +- Subquery
          :     :     :                                      :     +- CometNativeColumnarToRow
-         :     :     :                                      :        +- CometHashAggregate
+         :     :     :                                      :        +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
          :     :     :                                      :           +- CometExchange
          :     :     :                                      :              +- CometHashAggregate
          :     :     :                                      :                 +- CometProject
          :     :     :                                      :                    +- CometFilter
          :     :     :                                      :                       +- CometNativeScan parquet spark_catalog.default.store_sales
-         :     :     :                                      +- CometHashAggregate
+         :     :     :                                      +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
          :     :     :                                         +- CometExchange
          :     :     :                                            +- CometHashAggregate
          :     :     :                                               +- CometProject
@@ -47,7 +47,7 @@ CometNativeColumnarToRow
          :     :                                      +- CometSort
          :     :                                         +- CometFilter
          :     :                                            :  +- ReusedSubquery
-         :     :                                            +- CometHashAggregate
+         :     :                                            +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
          :     :                                               +- CometExchange
          :     :                                                  +- CometHashAggregate
          :     :                                                     +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q6/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4-spark4_0/q6/extended.txt
@@ -55,7 +55,7 @@ CometNativeColumnarToRow
                               :  +- CometNativeScan parquet spark_catalog.default.item
                               +- CometBroadcastExchange
                                  +- CometFilter
-                                    +- CometHashAggregate
+                                    +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
                                        +- CometExchange
                                           +- CometHashAggregate
                                              +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q13/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q13/extended.txt
@@ -1,5 +1,5 @@
 CometNativeColumnarToRow
-+- CometHashAggregate
++-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
    +- CometExchange
       +- CometHashAggregate
          +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q26/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q26/extended.txt
@@ -1,6 +1,6 @@
 CometNativeColumnarToRow
 +- CometTakeOrderedAndProject
-   +- CometHashAggregate
+   +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
       +- CometExchange
          +- CometHashAggregate
             +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q27/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q27/extended.txt
@@ -1,6 +1,6 @@
 CometNativeColumnarToRow
 +- CometTakeOrderedAndProject
-   +- CometHashAggregate
+   +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
       +- CometExchange
          +- CometHashAggregate
             +- CometExpand

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q28/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q28/extended.txt
@@ -4,7 +4,7 @@ CometNativeColumnarToRow
    :  :- CometBroadcastNestedLoopJoin
    :  :  :- CometBroadcastNestedLoopJoin
    :  :  :  :- CometBroadcastNestedLoopJoin
-   :  :  :  :  :- CometHashAggregate
+   :  :  :  :  :-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
    :  :  :  :  :  +- CometExchange
    :  :  :  :  :     +- CometHashAggregate
    :  :  :  :  :        +- CometHashAggregate
@@ -14,7 +14,7 @@ CometNativeColumnarToRow
    :  :  :  :  :                    +- CometFilter
    :  :  :  :  :                       +- CometNativeScan parquet spark_catalog.default.store_sales
    :  :  :  :  +- CometBroadcastExchange
-   :  :  :  :     +- CometHashAggregate
+   :  :  :  :     +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
    :  :  :  :        +- CometExchange
    :  :  :  :           +- CometHashAggregate
    :  :  :  :              +- CometHashAggregate
@@ -24,7 +24,7 @@ CometNativeColumnarToRow
    :  :  :  :                          +- CometFilter
    :  :  :  :                             +- CometNativeScan parquet spark_catalog.default.store_sales
    :  :  :  +- CometBroadcastExchange
-   :  :  :     +- CometHashAggregate
+   :  :  :     +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
    :  :  :        +- CometExchange
    :  :  :           +- CometHashAggregate
    :  :  :              +- CometHashAggregate
@@ -34,7 +34,7 @@ CometNativeColumnarToRow
    :  :  :                          +- CometFilter
    :  :  :                             +- CometNativeScan parquet spark_catalog.default.store_sales
    :  :  +- CometBroadcastExchange
-   :  :     +- CometHashAggregate
+   :  :     +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
    :  :        +- CometExchange
    :  :           +- CometHashAggregate
    :  :              +- CometHashAggregate
@@ -44,7 +44,7 @@ CometNativeColumnarToRow
    :  :                          +- CometFilter
    :  :                             +- CometNativeScan parquet spark_catalog.default.store_sales
    :  +- CometBroadcastExchange
-   :     +- CometHashAggregate
+   :     +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
    :        +- CometExchange
    :           +- CometHashAggregate
    :              +- CometHashAggregate
@@ -54,7 +54,7 @@ CometNativeColumnarToRow
    :                          +- CometFilter
    :                             +- CometNativeScan parquet spark_catalog.default.store_sales
    +- CometBroadcastExchange
-      +- CometHashAggregate
+      +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
          +- CometExchange
             +- CometHashAggregate
                +- CometHashAggregate

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32/extended.txt
@@ -21,7 +21,7 @@ CometNativeColumnarToRow
                :     :              +- CometNativeScan parquet spark_catalog.default.item
                :     +- CometBroadcastExchange
                :        +- CometFilter
-               :           +- CometHashAggregate
+               :           +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
                :              +- CometExchange
                :                 +- CometHashAggregate
                :                    +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/extended.txt
@@ -15,13 +15,13 @@ CometNativeColumnarToRow
          :     :     :                 +- CometFilter
          :     :     :                    :  +- Subquery
          :     :     :                    :     +- CometNativeColumnarToRow
-         :     :     :                    :        +- CometHashAggregate
+         :     :     :                    :        +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
          :     :     :                    :           +- CometExchange
          :     :     :                    :              +- CometHashAggregate
          :     :     :                    :                 +- CometProject
          :     :     :                    :                    +- CometFilter
          :     :     :                    :                       +- CometNativeScan parquet spark_catalog.default.store_sales
-         :     :     :                    +- CometHashAggregate
+         :     :     :                    +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
          :     :     :                       +- CometExchange
          :     :     :                          +- CometHashAggregate
          :     :     :                             +- CometProject
@@ -36,13 +36,13 @@ CometNativeColumnarToRow
          :     :                       +- CometFilter
          :     :                          :  +- Subquery
          :     :                          :     +- CometNativeColumnarToRow
-         :     :                          :        +- CometHashAggregate
+         :     :                          :        +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
          :     :                          :           +- CometExchange
          :     :                          :              +- CometHashAggregate
          :     :                          :                 +- CometProject
          :     :                          :                    +- CometFilter
          :     :                          :                       +- CometNativeScan parquet spark_catalog.default.store_sales
-         :     :                          +- CometHashAggregate
+         :     :                          +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
          :     :                             +- CometExchange
          :     :                                +- CometHashAggregate
          :     :                                   +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q6/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q6/extended.txt
@@ -53,7 +53,7 @@ CometNativeColumnarToRow
                               :  +- CometNativeScan parquet spark_catalog.default.item
                               +- CometBroadcastExchange
                                  +- CometFilter
-                                    +- CometHashAggregate
+                                    +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
                                        +- CometExchange
                                           +- CometHashAggregate
                                              +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q7/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q7/extended.txt
@@ -1,6 +1,6 @@
 CometNativeColumnarToRow
 +- CometTakeOrderedAndProject
-   +- CometHashAggregate
+   +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
       +- CometExchange
          +- CometHashAggregate
             +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85/extended.txt
@@ -1,6 +1,6 @@
 CometNativeColumnarToRow
 +- CometTakeOrderedAndProject
-   +- CometHashAggregate
+   +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
       +- CometExchange
          +- CometHashAggregate
             +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q9/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q9/extended.txt
@@ -2,7 +2,7 @@
 :  :- Subquery
 :  :  +- CometNativeColumnarToRow
 :  :     +- CometProject
-:  :        +- CometHashAggregate
+:  :        +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
 :  :           +- CometExchange
 :  :              +- CometHashAggregate
 :  :                 +- CometProject
@@ -13,7 +13,7 @@
 :  :- Subquery
 :  :  +- CometNativeColumnarToRow
 :  :     +- CometProject
-:  :        +- CometHashAggregate
+:  :        +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
 :  :           +- CometExchange
 :  :              +- CometHashAggregate
 :  :                 +- CometProject
@@ -24,7 +24,7 @@
 :  :- Subquery
 :  :  +- CometNativeColumnarToRow
 :  :     +- CometProject
-:  :        +- CometHashAggregate
+:  :        +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
 :  :           +- CometExchange
 :  :              +- CometHashAggregate
 :  :                 +- CometProject
@@ -35,7 +35,7 @@
 :  :- Subquery
 :  :  +- CometNativeColumnarToRow
 :  :     +- CometProject
-:  :        +- CometHashAggregate
+:  :        +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
 :  :           +- CometExchange
 :  :              +- CometHashAggregate
 :  :                 +- CometProject
@@ -46,7 +46,7 @@
 :  :- Subquery
 :  :  +- CometNativeColumnarToRow
 :  :     +- CometProject
-:  :        +- CometHashAggregate
+:  :        +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
 :  :           +- CometExchange
 :  :              +- CometHashAggregate
 :  :                 +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92/extended.txt
@@ -21,7 +21,7 @@ CometNativeColumnarToRow
                :     :              +- CometNativeScan parquet spark_catalog.default.item
                :     +- CometBroadcastExchange
                :        +- CometFilter
-               :           +- CometHashAggregate
+               :           +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
                :              +- CometExchange
                :                 +- CometHashAggregate
                :                    +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_0/q6/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7-spark4_0/q6/extended.txt
@@ -55,7 +55,7 @@ CometNativeColumnarToRow
                               :  +- CometNativeScan parquet spark_catalog.default.item
                               +- CometBroadcastExchange
                                  +- CometFilter
-                                    +- CometHashAggregate
+                                    +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
                                        +- CometExchange
                                           +- CometHashAggregate
                                              +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a/extended.txt
@@ -1,7 +1,7 @@
 CometNativeColumnarToRow
 +- CometTakeOrderedAndProject
    +- CometUnion
-      :- CometHashAggregate
+      :-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
       :  +- CometExchange
       :     +- CometHashAggregate
       :        +- CometProject
@@ -35,7 +35,7 @@ CometNativeColumnarToRow
       :                 +- CometProject
       :                    +- CometFilter
       :                       +- CometNativeScan parquet spark_catalog.default.item
-      :- CometHashAggregate
+      :-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
       :  +- CometExchange
       :     +- CometHashAggregate
       :        +- CometProject
@@ -65,7 +65,7 @@ CometNativeColumnarToRow
       :                 +- CometProject
       :                    +- CometFilter
       :                       +- CometNativeScan parquet spark_catalog.default.item
-      +- CometHashAggregate
+      +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
          +- CometExchange
             +- CometHashAggregate
                +- CometProject

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6/extended.txt
@@ -53,7 +53,7 @@ CometNativeColumnarToRow
                               :  +- CometNativeScan parquet spark_catalog.default.item
                               +- CometBroadcastExchange
                                  +- CometFilter
-                                    +- CometHashAggregate
+                                    +-  CometHashAggregate [COMET-INFO: A native implementation of Cast is available. Set spark.comet.expression.Cast.allowIncompatible=true to enable it. For more information, refer to the Comet Compatibility Guide (https://datafusion.apache.org/comet/user-guide/latest/compatibility/index.html)]
                                        +- CometExchange
                                           +- CometHashAggregate
                                              +- CometProject

--- a/spark/src/test/scala/org/apache/spark/sql/comet/CometPlanStabilitySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/CometPlanStabilitySuite.scala
@@ -28,7 +28,7 @@ import org.apache.commons.io.FileUtils
 import org.apache.spark.SparkContext
 import org.apache.spark.internal.config.{MEMORY_OFFHEAP_ENABLED, MEMORY_OFFHEAP_SIZE}
 import org.apache.spark.sql.TPCDSBase
-import org.apache.spark.sql.catalyst.expressions.{AttributeSet, Cast}
+import org.apache.spark.sql.catalyst.expressions.AttributeSet
 import org.apache.spark.sql.catalyst.util.resourceToString
 import org.apache.spark.sql.execution.{ReusedSubqueryExec, SparkPlan, SubqueryBroadcastExec, SubqueryExec}
 import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecutionSuite

--- a/spark/src/test/scala/org/apache/spark/sql/comet/CometPlanStabilitySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/CometPlanStabilitySuite.scala
@@ -282,8 +282,6 @@ trait CometPlanStabilitySuite extends DisableAdaptiveExecutionSuite with TPCDSBa
       CometConf.COMET_EXEC_ENABLED.key -> "true",
       CometConf.COMET_SHUFFLE_ENABLED.key -> "true",
       CometConf.COMET_EXEC_SORT_MERGE_JOIN_WITH_JOIN_FILTER_ENABLED.key -> "true",
-      // as well as for v1.4/q9, v1.4/q44, v2.7.0/q6, v2.7.0/q64
-      CometConf.getExprAllowIncompatConfigKey(classOf[Cast]) -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
       val qe = sql(queryString).queryExecution
       val plan = qe.executedPlan


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

TPC-DS had many fallbacks due to incompatible casts from floating-point to decimal. These fallbacks did not show up in the stability suite because we enabled these  incompatible casts in the test. Now that cast supports codegen dispatch fallback, we no longer need to set this config.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Stop setting config
- Updated golden files

## How are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

CI