### PR TITLE
fix: match Spark's whitespace trim semantics for casts from string to boolean, integral, float/double and decimal

### DIFF
--- a/docs/source/user-guide/latest/compatibility/expressions/_category_template/cast.md
+++ b/docs/source/user-guide/latest/compatibility/expressions/_category_template/cast.md
@@ -34,14 +34,33 @@ Cast operations in Comet fall into three levels of support:
 
 Cast will fall back to Spark in some cases when ANSI mode is enabled. This can be enabled by setting `spark.comet.expression.Cast.allowIncompatible=true`. See the [Comet Supported Expressions Guide](../../../expressions.md) for more information on this configuration setting.
 
+## Whitespace Trimming in Casts from String
+
+Spark uses two different notions of whitespace when casting from string. Comet reproduces both,
+with one known exception noted below:
+
+| Trim set                               | Cast targets                                                              |
+| -------------------------------------- | ------------------------------------------------------------------------- |
+| Bytes `0x00`-`0x20` and `0x7F` (`DEL`) | `BOOLEAN`, `TINYINT`, `SMALLINT`, `INT`, `BIGINT`, `DATE`, `TIMESTAMP` \* |
+| Bytes `0x00`-`0x20` only               | `FLOAT`, `DOUBLE`, `DECIMAL`                                              |
+
+Neither set includes any non-ASCII whitespace, so padding a value with `U+0085`, `U+00A0`,
+`U+1680`, `U+2000`-`U+200A`, `U+2028`, `U+2029`, `U+202F`, `U+205F` or `U+3000` produces `NULL`
+(or raises under ANSI mode), even though those codepoints are whitespace to Unicode. Whitespace
+inside a value is never trimmed.
+
+\* `CAST(string AS TIMESTAMP)` and `CAST(string AS TIMESTAMP_NTZ)` still trim Unicode whitespace
+in Comet; see [#5149](https://github.com/apache/datafusion-comet/issues/5149).
+
 ## String to Decimal
 
 Comet's native `CAST(string AS DECIMAL)` implementation matches Apache Spark's behavior,
 including:
 
-- Leading and trailing ASCII whitespace is trimmed before parsing.
-- Null bytes (`\u0000`) at the start or end of a string are trimmed, matching Spark's
-  `UTF8String` behavior. Null bytes embedded in the middle of a string produce `NULL`.
+- Leading and trailing bytes `0x00`-`0x20` are trimmed before parsing, matching the
+  `java.lang.String.trim` that Spark applies before handing the value to `BigDecimal`.
+- Null bytes (`\u0000`) at the start or end of a string are therefore trimmed. Null bytes
+  embedded in the middle of a string produce `NULL`.
 - Fullwidth Unicode digits (U+FF10–U+FF19, e.g. `１２３.４５`) are treated as their ASCII
   equivalents, so `CAST('１２３.４５' AS DECIMAL(10,2))` returns `123.45`.
 - Scientific notation (e.g. `1.23E+5`) is supported.
@@ -58,7 +77,7 @@ Supported input formats match Spark exactly:
 
 - `yyyy`, `yyyy-[m]m`, `yyyy-[m]m-[d]d`
 - Optional `T` suffix with arbitrary trailing text (e.g. `2020-01-01T12:34:56`)
-- Leading/trailing whitespace and control characters are trimmed
+- Leading/trailing bytes `0x00`-`0x20` and `0x7F` are trimmed
 - Optional sign prefix (`-` for negative years)
 - Leading zeros (e.g. `0002020-01-01` is year 2020)
 

--- a/docs/source/user-guide/latest/compatibility/index.md
+++ b/docs/source/user-guide/latest/compatibility/index.md
@@ -138,10 +138,11 @@ so users hunting an unexpected value have a single place to check:
   `DECIMAL(1, 1)`) throws `NUMERIC_VALUE_OUT_OF_RANGE` regardless of the eval mode. Spark returns
   `NULL` under legacy and try mode, and only throws under ANSI
   ([#5068](https://github.com/apache/datafusion-comet/issues/5068)).
-- `CAST(string AS boolean)` trims only Unicode whitespace. Spark also trims the ASCII control
-  bytes `0x00-0x08`, `0x0E-0x1F`, and `0x7F`, so a string like `"true"` casts to
-  `true` in Spark and to `NULL` in Comet (or throws under ANSI)
-  ([#4959](https://github.com/apache/datafusion-comet/issues/4959)).
+- `CAST(string AS timestamp)` and `CAST(string AS timestamp_ntz)` trim Unicode whitespace. Spark
+  trims only the bytes `0x00`-`0x20` and `0x7F`, so a value padded with an ASCII control byte
+  casts to a timestamp in Spark and to `NULL` in Comet, while a value padded with non-ASCII
+  whitespace such as `U+3000` casts to `NULL` in Spark and to a timestamp in Comet
+  ([#5149](https://github.com/apache/datafusion-comet/issues/5149)).
 - Native `RANGE` window frames with an explicit `PRECEDING` / `FOLLOWING` offset diverge from
   Spark when the boundary arithmetic overflows for `DATE` or `DECIMAL` `ORDER BY` columns
   ([#5022](https://github.com/apache/datafusion-comet/issues/5022)).

--- a/docs/source/user-guide/latest/compatibility/index.md
+++ b/docs/source/user-guide/latest/compatibility/index.md
@@ -138,10 +138,10 @@ so users hunting an unexpected value have a single place to check:
   `DECIMAL(1, 1)`) throws `NUMERIC_VALUE_OUT_OF_RANGE` regardless of the eval mode. Spark returns
   `NULL` under legacy and try mode, and only throws under ANSI
   ([#5068](https://github.com/apache/datafusion-comet/issues/5068)).
-- `CAST(string AS timestamp)` and `CAST(string AS timestamp_ntz)` trim Unicode whitespace. Spark
-  trims only the bytes `0x00`-`0x20` and `0x7F`, so a value padded with an ASCII control byte
-  casts to a timestamp in Spark and to `NULL` in Comet, while a value padded with non-ASCII
-  whitespace such as `U+3000` casts to `NULL` in Spark and to a timestamp in Comet
+- `CAST(string AS timestamp)`, `CAST(string AS timestamp_ntz)`, `to_time` and `try_to_time` trim
+  Unicode whitespace. Spark trims only the bytes `0x00`-`0x20` and `0x7F`, so a value padded with
+  an ASCII control byte parses in Spark and returns `NULL` in Comet, while a value padded with
+  non-ASCII whitespace such as `U+3000` returns `NULL` in Spark and parses in Comet
   ([#5149](https://github.com/apache/datafusion-comet/issues/5149)).
 - Native `RANGE` window frames with an explicit `PRECEDING` / `FOLLOWING` offset diverge from
   Spark when the boundary arithmetic overflows for `DATE` or `DECIMAL` `ORDER BY` columns

--- a/native/spark-expr/Cargo.toml
+++ b/native/spark-expr/Cargo.toml
@@ -64,6 +64,10 @@ name = "cast_string_to_date"
 harness = false
 
 [[bench]]
+name = "cast_string_to_timestamp"
+harness = false
+
+[[bench]]
 name = "cast_numeric"
 harness = false
 

--- a/native/spark-expr/benches/cast_from_string.rs
+++ b/native/spark-expr/benches/cast_from_string.rs
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::{builder::StringBuilder, RecordBatch};
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::array::RecordBatch;
+use arrow::datatypes::DataType;
 use criterion::{criterion_group, criterion_main, Criterion};
 use datafusion::physical_expr::{expressions::Column, PhysicalExpr};
 use datafusion_comet_spark_expr::{Cast, EvalMode, SparkCastOptions};
@@ -24,17 +24,23 @@ use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 use std::sync::Arc;
 
+#[path = "common/mod.rs"]
+mod common;
+use common::string_batch;
+
+const EVAL_MODES: [(EvalMode, &str); 3] = [
+    (EvalMode::Legacy, "legacy"),
+    (EvalMode::Ansi, "ansi"),
+    (EvalMode::Try, "try"),
+];
+
 fn criterion_benchmark(c: &mut Criterion) {
     let small_int_batch = create_small_int_string_batch();
     let int_batch = create_int_string_batch();
     let decimal_batch = create_decimal_string_batch();
     let expr = Arc::new(Column::new("a", 0));
 
-    for (mode, mode_name) in [
-        (EvalMode::Legacy, "legacy"),
-        (EvalMode::Ansi, "ansi"),
-        (EvalMode::Try, "try"),
-    ] {
+    for (mode, mode_name) in EVAL_MODES {
         let spark_cast_options = SparkCastOptions::new(mode, "", false);
         let cast_to_i8 = Cast::new(
             expr.clone(),
@@ -109,11 +115,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     // str -> decimal benchmark
     let decimal_string_batch = create_decimal_cast_string_batch();
-    for (mode, mode_name) in [
-        (EvalMode::Legacy, "legacy"),
-        (EvalMode::Ansi, "ansi"),
-        (EvalMode::Try, "try"),
-    ] {
+    for (mode, mode_name) in EVAL_MODES {
         let spark_cast_options = SparkCastOptions::new(mode, "", false);
         let mut group = c.benchmark_group(format!("cast_string_to_decimal/{}", mode_name));
         for (data_type, name) in [
@@ -140,11 +142,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let bool_padded_batch = create_boolean_string_batch(true);
     let float_batch = create_float_string_batch(false);
     let float_padded_batch = create_float_string_batch(true);
-    for (mode, mode_name) in [
-        (EvalMode::Legacy, "legacy"),
-        (EvalMode::Ansi, "ansi"),
-        (EvalMode::Try, "try"),
-    ] {
+    for (mode, mode_name) in EVAL_MODES {
         let spark_cast_options = SparkCastOptions::new(mode, "", false);
         let mut group = c.benchmark_group(format!("cast_string_to_bool_and_float/{}", mode_name));
         for (data_type, name, batch) in [
@@ -172,137 +170,86 @@ fn criterion_benchmark(c: &mut Criterion) {
 /// Create batch with the boolean spellings Spark accepts, optionally space-padded
 fn create_boolean_string_batch(padded: bool) -> RecordBatch {
     let words = ["true", "FALSE", "t", "n", "yes", "0", "TRUE", "no"];
-    create_string_batch(|i| {
-        let word = words[i % words.len()];
-        if padded {
-            format!("  {}  ", word)
-        } else {
-            word.to_string()
-        }
+    string_batch(8192, 10, |i| {
+        pad(words[i % words.len()].to_string(), padded)
     })
 }
 
 /// Create batch with floating point strings, optionally space-padded
 fn create_float_string_batch(padded: bool) -> RecordBatch {
     let mut rng = StdRng::seed_from_u64(42);
-    create_string_batch(move |_| {
-        let value = rng.random_range(-1_000_000.0..1_000_000.0f64);
-        if padded {
-            format!("  {}  ", value)
-        } else {
-            format!("{}", value)
-        }
+    string_batch(8192, 10, move |_| {
+        pad(
+            rng.random_range(-1_000_000.0..1_000_000.0f64).to_string(),
+            padded,
+        )
     })
 }
 
-/// Create a single-column Utf8 batch of 8192 rows, every tenth one null
-fn create_string_batch(mut value: impl FnMut(usize) -> String) -> RecordBatch {
-    let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Utf8, true)]));
-    let mut b = StringBuilder::new();
-    for i in 0..8192 {
-        if i % 10 == 0 {
-            b.append_null();
-        } else {
-            b.append_value(value(i));
-        }
+/// Surround `value` with the leading/trailing whitespace that exercises the trim helpers
+fn pad(value: String, padded: bool) -> String {
+    if padded {
+        format!("  {}  ", value)
+    } else {
+        value
     }
-    RecordBatch::try_new(schema, vec![Arc::new(b.finish())]).unwrap()
 }
 
 /// Create batch with small integer strings that fit in i8 range (for i8/i16 benchmarks)
 fn create_small_int_string_batch() -> RecordBatch {
-    let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Utf8, true)]));
-    let mut b = StringBuilder::new();
-    for i in 0..1000 {
-        if i % 10 == 0 {
-            b.append_null();
-        } else {
-            b.append_value(format!("{}", rand::random::<i8>()));
-        }
-    }
-    let array = b.finish();
-    RecordBatch::try_new(schema, vec![Arc::new(array)]).unwrap()
+    string_batch(1000, 10, |_| rand::random::<i8>().to_string())
 }
 
 /// Create batch with valid integer strings (works for all eval modes)
 fn create_int_string_batch() -> RecordBatch {
-    let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Utf8, true)]));
-    let mut b = StringBuilder::new();
-    for i in 0..1000 {
-        if i % 10 == 0 {
-            b.append_null();
-        } else {
-            b.append_value(format!("{}", rand::random::<i32>()));
-        }
-    }
-    let array = b.finish();
-    RecordBatch::try_new(schema, vec![Arc::new(array)]).unwrap()
+    string_batch(1000, 10, |_| rand::random::<i32>().to_string())
 }
 
 /// Create batch with decimal strings (for Legacy mode decimal truncation)
 fn create_decimal_string_batch() -> RecordBatch {
-    let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Utf8, true)]));
-    let mut b = StringBuilder::new();
-    for i in 0..1000 {
-        if i % 10 == 0 {
-            b.append_null();
-        } else {
-            // Generate integers with decimal portions to test truncation
-            let int_part: i32 = rand::random();
-            let dec_part: u32 = rand::random::<u32>() % 1000;
-            b.append_value(format!("{}.{}", int_part, dec_part));
-        }
-    }
-    let array = b.finish();
-    RecordBatch::try_new(schema, vec![Arc::new(array)]).unwrap()
+    // Integers with decimal portions, to test truncation
+    string_batch(1000, 10, |_| {
+        format!("{}.{}", rand::random::<i32>(), rand::random::<u32>() % 1000)
+    })
 }
 
 /// Create batch with decimal strings for string-to-decimal cast perf evaluation
 fn create_decimal_cast_string_batch() -> RecordBatch {
-    let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Utf8, true)]));
     let mut rng = StdRng::seed_from_u64(42);
-    let mut b = StringBuilder::new();
-    for i in 0..8192 {
-        if i % 10 == 0 {
-            b.append_null();
-        } else {
-            // Generate various decimal formats
-            match i % 5 {
-                0 => {
-                    // gen simple decimals (ex :  "123.45"
-                    let int_part = rng.random_range(0..1_000_000u32);
-                    let dec_part = rng.random_range(0..100_000u32);
-                    b.append_value(format!("{}.{}", int_part, dec_part));
-                }
-                1 => {
-                    // gen scientific notation like "123e5"
-                    b.append_value(format!(
-                        "{}.{}E{}",
-                        rng.random_range(0..10u32),
-                        rng.random_range(0..100u32),
-                        rng.random_range(0..10u32)
-                    ));
-                }
-                2 => {
-                    // Negative numbers
-                    let int_part = rng.random_range(0..1_000_000u32);
-                    let dec_part = rng.random_range(0..100_000u32);
-                    b.append_value(format!("-{}.{}", int_part, dec_part));
-                }
-                3 => {
-                    // Ints only
-                    b.append_value(format!("{}", rng.random_range(-1_000_000..1_000_000i32)));
-                }
-                _ => {
-                    // Small decimals (ex : 0.001)
-                    let dec_part = rng.random_range(0..100_000u32);
-                    b.append_value(format!("0.{:05}", dec_part));
-                }
+    string_batch(8192, 10, move |i| {
+        // Generate various decimal formats
+        match i % 5 {
+            0 => {
+                // gen simple decimals (ex :  "123.45"
+                let int_part = rng.random_range(0..1_000_000u32);
+                let dec_part = rng.random_range(0..100_000u32);
+                format!("{}.{}", int_part, dec_part)
+            }
+            1 => {
+                // gen scientific notation like "123e5"
+                format!(
+                    "{}.{}E{}",
+                    rng.random_range(0..10u32),
+                    rng.random_range(0..100u32),
+                    rng.random_range(0..10u32)
+                )
+            }
+            2 => {
+                // Negative numbers
+                let int_part = rng.random_range(0..1_000_000u32);
+                let dec_part = rng.random_range(0..100_000u32);
+                format!("-{}.{}", int_part, dec_part)
+            }
+            3 => {
+                // Ints only
+                format!("{}", rng.random_range(-1_000_000..1_000_000i32))
+            }
+            _ => {
+                // Small decimals (ex : 0.001)
+                format!("0.{:05}", rng.random_range(0..100_000u32))
             }
         }
-    }
-    let array = b.finish();
-    RecordBatch::try_new(schema, vec![Arc::new(array)]).unwrap()
+    })
 }
 
 fn config() -> Criterion {

--- a/native/spark-expr/benches/cast_from_string.rs
+++ b/native/spark-expr/benches/cast_from_string.rs
@@ -133,6 +133,79 @@ fn criterion_benchmark(c: &mut Criterion) {
         }
         group.finish();
     }
+
+    // str -> boolean and str -> float benchmarks, with and without the leading/trailing
+    // whitespace that exercises the trim helpers in `conversion_funcs::trim`
+    let bool_batch = create_boolean_string_batch(false);
+    let bool_padded_batch = create_boolean_string_batch(true);
+    let float_batch = create_float_string_batch(false);
+    let float_padded_batch = create_float_string_batch(true);
+    for (mode, mode_name) in [
+        (EvalMode::Legacy, "legacy"),
+        (EvalMode::Ansi, "ansi"),
+        (EvalMode::Try, "try"),
+    ] {
+        let spark_cast_options = SparkCastOptions::new(mode, "", false);
+        let mut group = c.benchmark_group(format!("cast_string_to_bool_and_float/{}", mode_name));
+        for (data_type, name, batch) in [
+            (DataType::Boolean, "boolean", &bool_batch),
+            (DataType::Boolean, "boolean_padded", &bool_padded_batch),
+            (DataType::Float64, "double", &float_batch),
+            (DataType::Float64, "double_padded", &float_padded_batch),
+        ] {
+            let cast = Cast::new(
+                expr.clone(),
+                data_type,
+                spark_cast_options.clone(),
+                None,
+                None,
+            );
+            group.bench_function(name, |b| {
+                b.iter(|| cast.evaluate(batch).unwrap());
+            });
+        }
+        group.finish();
+    }
+}
+
+/// Create batch with the boolean spellings Spark accepts, optionally space-padded
+fn create_boolean_string_batch(padded: bool) -> RecordBatch {
+    let words = ["true", "FALSE", "t", "n", "yes", "0", "TRUE", "no"];
+    create_string_batch(|i| {
+        let word = words[i % words.len()];
+        if padded {
+            format!("  {}  ", word)
+        } else {
+            word.to_string()
+        }
+    })
+}
+
+/// Create batch with floating point strings, optionally space-padded
+fn create_float_string_batch(padded: bool) -> RecordBatch {
+    let mut rng = StdRng::seed_from_u64(42);
+    create_string_batch(move |_| {
+        let value = rng.random_range(-1_000_000.0..1_000_000.0f64);
+        if padded {
+            format!("  {}  ", value)
+        } else {
+            format!("{}", value)
+        }
+    })
+}
+
+/// Create a single-column Utf8 batch of 8192 rows, every tenth one null
+fn create_string_batch(mut value: impl FnMut(usize) -> String) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Utf8, true)]));
+    let mut b = StringBuilder::new();
+    for i in 0..8192 {
+        if i % 10 == 0 {
+            b.append_null();
+        } else {
+            b.append_value(value(i));
+        }
+    }
+    RecordBatch::try_new(schema, vec![Arc::new(b.finish())]).unwrap()
 }
 
 /// Create batch with small integer strings that fit in i8 range (for i8/i16 benchmarks)

--- a/native/spark-expr/benches/cast_from_string.rs
+++ b/native/spark-expr/benches/cast_from_string.rs
@@ -150,6 +150,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         for (data_type, name, batch) in [
             (DataType::Boolean, "boolean", &bool_batch),
             (DataType::Boolean, "boolean_padded", &bool_padded_batch),
+            (DataType::Float32, "float", &float_batch),
             (DataType::Float64, "double", &float_batch),
             (DataType::Float64, "double_padded", &float_padded_batch),
         ] {

--- a/native/spark-expr/benches/cast_string_to_date.rs
+++ b/native/spark-expr/benches/cast_string_to_date.rs
@@ -15,12 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::{builder::StringBuilder, RecordBatch};
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::array::RecordBatch;
+use arrow::datatypes::DataType;
 use criterion::{criterion_group, criterion_main, Criterion};
 use datafusion::physical_expr::{expressions::Column, PhysicalExpr};
 use datafusion_comet_spark_expr::{Cast, EvalMode, SparkCastOptions};
 use std::sync::Arc;
+
+#[path = "common/mod.rs"]
+mod common;
 
 const BATCH_SIZE: usize = 8192;
 
@@ -60,16 +63,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 }
 
 fn create_batch(f: impl Fn(usize) -> String) -> RecordBatch {
-    let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Utf8, true)]));
-    let mut builder = StringBuilder::new();
-    for i in 0..BATCH_SIZE {
-        if i % 17 == 0 {
-            builder.append_null();
-        } else {
-            builder.append_value(f(i));
-        }
-    }
-    RecordBatch::try_new(schema, vec![Arc::new(builder.finish())]).unwrap()
+    common::string_batch(BATCH_SIZE, 17, f)
 }
 
 fn config() -> Criterion {

--- a/native/spark-expr/benches/cast_string_to_timestamp.rs
+++ b/native/spark-expr/benches/cast_string_to_timestamp.rs
@@ -1,0 +1,210 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::{builder::StringBuilder, RecordBatch};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use criterion::{criterion_group, criterion_main, Criterion};
+use datafusion::physical_expr::{expressions::Column, PhysicalExpr};
+use datafusion_comet_spark_expr::{Cast, EvalMode, SparkCastOptions};
+use std::sync::Arc;
+
+const BATCH_SIZE: usize = 8192;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let expr = Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>;
+
+    // Input shapes, chosen to cover each branch `timestamp_parser` can take: the canonical
+    // form, the fractional-second form, an offset suffix (which takes the extract-offset
+    // path), a date-only string, whitespace padding (the trim), and a mix that includes
+    // invalid values so the null path is measured too.
+    let batches = [
+        (
+            "canonical",
+            create_batch(|i| {
+                format!(
+                    "{:04}-{:02}-{:02} {:02}:{:02}:{:02}",
+                    1970 + i % 60,
+                    i % 12 + 1,
+                    i % 28 + 1,
+                    i % 24,
+                    i % 60,
+                    i % 60
+                )
+            }),
+        ),
+        (
+            "microseconds",
+            create_batch(|i| {
+                format!(
+                    "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:06}",
+                    1970 + i % 60,
+                    i % 12 + 1,
+                    i % 28 + 1,
+                    i % 24,
+                    i % 60,
+                    i % 60,
+                    i % 1_000_000
+                )
+            }),
+        ),
+        (
+            "offset_suffix",
+            create_batch(|i| {
+                format!(
+                    "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}+05:30",
+                    1970 + i % 60,
+                    i % 12 + 1,
+                    i % 28 + 1,
+                    i % 24,
+                    i % 60,
+                    i % 60
+                )
+            }),
+        ),
+        (
+            "date_only",
+            create_batch(|i| format!("{:04}-{:02}-{:02}", 1970 + i % 60, i % 12 + 1, i % 28 + 1)),
+        ),
+        (
+            "padded",
+            create_batch(|i| {
+                format!(
+                    "  {:04}-{:02}-{:02} {:02}:00:00  ",
+                    1970 + i % 60,
+                    i % 12 + 1,
+                    i % 28 + 1,
+                    i % 24
+                )
+            }),
+        ),
+        (
+            "mixed",
+            create_batch(|i| match i % 5 {
+                0 => format!(
+                    "{:04}-{:02}-{:02} 12:34:56",
+                    1970 + i % 60,
+                    i % 12 + 1,
+                    i % 28 + 1
+                ),
+                1 => format!(
+                    "{:04}-{:02}-{:02}T12:34:56.123456Z",
+                    1970 + i % 60,
+                    i % 12 + 1,
+                    i % 28 + 1
+                ),
+                2 => format!(
+                    "  {:04}-{:02}-{:02}  ",
+                    1900 + i % 200,
+                    i % 12 + 1,
+                    i % 28 + 1
+                ),
+                3 => "T12:34:56".to_string(),
+                _ => "not a timestamp".to_string(),
+            }),
+        ),
+    ];
+
+    // Timezone-aware and NTZ go through different parsers (`timestamp_parser` vs
+    // `timestamp_ntz_parser`), and a non-UTC session timezone exercises the offset lookup that
+    // UTC short-circuits, so all three are measured.
+    for (target_name, to_type, timezone) in [
+        (
+            "timestamp",
+            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            "UTC",
+        ),
+        (
+            "timestamp_non_utc",
+            DataType::Timestamp(TimeUnit::Microsecond, Some("America/Los_Angeles".into())),
+            "America/Los_Angeles",
+        ),
+        (
+            "timestamp_ntz",
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            "UTC",
+        ),
+    ] {
+        for (mode, mode_name) in [
+            (EvalMode::Legacy, "legacy"),
+            (EvalMode::Ansi, "ansi"),
+            (EvalMode::Try, "try"),
+        ] {
+            let mut group =
+                c.benchmark_group(format!("cast_string_to_{}/{}", target_name, mode_name));
+            for (name, batch) in &batches {
+                // ANSI raises on the first invalid value, so timing it against a batch that is
+                // mostly invalid would measure the error path rather than the parser.
+                if mode == EvalMode::Ansi && *name == "mixed" {
+                    continue;
+                }
+                let cast = Cast::new(
+                    Arc::clone(&expr),
+                    to_type.clone(),
+                    SparkCastOptions::new(mode, timezone, false),
+                    None,
+                    None,
+                );
+                group.bench_function(*name, |b| {
+                    b.iter(|| cast.evaluate(batch).unwrap());
+                });
+            }
+            group.finish();
+        }
+    }
+
+    // The Spark 4 path adds a leading-whitespace check for T-prefixed time-only strings, so it
+    // is measured separately on the inputs where that check can fire.
+    let mut group = c.benchmark_group("cast_string_to_timestamp/spark4_legacy");
+    for name in ["padded", "mixed"] {
+        let batch = &batches.iter().find(|(n, _)| *n == name).unwrap().1;
+        let cast = Cast::new(
+            Arc::clone(&expr),
+            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            SparkCastOptions::new_with_version(EvalMode::Legacy, "UTC", false, true),
+            None,
+            None,
+        );
+        group.bench_function(name, |b| {
+            b.iter(|| cast.evaluate(batch).unwrap());
+        });
+    }
+    group.finish();
+}
+
+fn create_batch(f: impl Fn(usize) -> String) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Utf8, true)]));
+    let mut builder = StringBuilder::new();
+    for i in 0..BATCH_SIZE {
+        if i % 17 == 0 {
+            builder.append_null();
+        } else {
+            builder.append_value(f(i));
+        }
+    }
+    RecordBatch::try_new(schema, vec![Arc::new(builder.finish())]).unwrap()
+}
+
+fn config() -> Criterion {
+    Criterion::default()
+}
+
+criterion_group! {
+    name = benches;
+    config = config();
+    targets = criterion_benchmark
+}
+criterion_main!(benches);

--- a/native/spark-expr/benches/cast_string_to_timestamp.rs
+++ b/native/spark-expr/benches/cast_string_to_timestamp.rs
@@ -15,12 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::{builder::StringBuilder, RecordBatch};
-use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use arrow::array::RecordBatch;
+use arrow::datatypes::{DataType, TimeUnit};
 use criterion::{criterion_group, criterion_main, Criterion};
 use datafusion::physical_expr::{expressions::Column, PhysicalExpr};
 use datafusion_comet_spark_expr::{Cast, EvalMode, SparkCastOptions};
 use std::sync::Arc;
+
+#[path = "common/mod.rs"]
+mod common;
 
 const BATCH_SIZE: usize = 8192;
 
@@ -186,16 +189,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 }
 
 fn create_batch(f: impl Fn(usize) -> String) -> RecordBatch {
-    let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Utf8, true)]));
-    let mut builder = StringBuilder::new();
-    for i in 0..BATCH_SIZE {
-        if i % 17 == 0 {
-            builder.append_null();
-        } else {
-            builder.append_value(f(i));
-        }
-    }
-    RecordBatch::try_new(schema, vec![Arc::new(builder.finish())]).unwrap()
+    common::string_batch(BATCH_SIZE, 17, f)
 }
 
 fn config() -> Criterion {

--- a/native/spark-expr/benches/common/mod.rs
+++ b/native/spark-expr/benches/common/mod.rs
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Helpers shared by the cast-from-string benchmarks, pulled in with
+//! `#[path = "common/mod.rs"] mod common;`. This lives in a subdirectory so that Cargo's bench
+//! auto-discovery, which only looks at `benches/*.rs`, does not treat it as a bench target.
+
+use arrow::array::{builder::StringBuilder, RecordBatch};
+use arrow::datatypes::{DataType, Field, Schema};
+use std::sync::Arc;
+
+/// A single-column `Utf8` batch of `rows` rows, where row `i` holds `value(i)` unless
+/// `i % null_modulus == 0`, in which case it is null.
+pub fn string_batch(
+    rows: usize,
+    null_modulus: usize,
+    mut value: impl FnMut(usize) -> String,
+) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Utf8, true)]));
+    let mut builder = StringBuilder::new();
+    for i in 0..rows {
+        if i % null_modulus == 0 {
+            builder.append_null();
+        } else {
+            builder.append_value(value(i));
+        }
+    }
+    RecordBatch::try_new(schema, vec![Arc::new(builder.finish())]).unwrap()
+}

--- a/native/spark-expr/src/conversion_funcs/mod.rs
+++ b/native/spark-expr/src/conversion_funcs/mod.rs
@@ -20,4 +20,5 @@ pub mod cast;
 mod numeric;
 mod string;
 mod temporal;
+mod trim;
 mod utils;

--- a/native/spark-expr/src/conversion_funcs/string.rs
+++ b/native/spark-expr/src/conversion_funcs/string.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::conversion_funcs::trim::{
+    is_whitespace_or_iso_control, trim_all, trim_all_bytes, trim_java_string,
+};
 use crate::{timezone, EvalMode, SparkError, SparkResult};
 use arrow::array::{
     Array, ArrayRef, ArrowPrimitiveType, BooleanArray, Decimal128Builder, GenericStringArray,
@@ -207,7 +210,10 @@ where
         if arr.is_null(i) {
             builder.append_null();
         } else {
-            let str_value = arr.value(i).trim();
+            // `Double.parseDouble` calls `String.trim` before parsing, so only bytes <= 0x20
+            // are trimmed here -- `0x7F` is not whitespace to this cast, and no non-ASCII
+            // whitespace is trimmed by any Spark cast.
+            let str_value = trim_java_string(arr.value(i));
             match parse_string_to_float(str_value) {
                 Some(v) => builder.append_value(v),
                 None => {
@@ -268,9 +274,9 @@ where
     let output_array = array
         .iter()
         .map(|value| match value {
-            Some(value) => match value.to_ascii_lowercase().trim() {
-                "t" | "true" | "y" | "yes" | "1" => Ok(Some(true)),
-                "f" | "false" | "n" | "no" | "0" => Ok(Some(false)),
+            Some(value) => match trim_all(value) {
+                v if is_true_string(v) => Ok(Some(true)),
+                v if is_false_string(v) => Ok(Some(false)),
                 _ if eval_mode == EvalMode::Ansi => Err(SparkError::CastInvalidValue {
                     value: value.to_string(),
                     from_type: "STRING".to_string(),
@@ -283,6 +289,28 @@ where
         .collect::<Result<BooleanArray, _>>()?;
 
     Ok(Arc::new(output_array))
+}
+
+/// Equivalent to `org.apache.spark.sql.catalyst.util.StringUtils.isTrueString`, minus the trim
+/// that the caller has already applied.
+#[inline]
+fn is_true_string(trimmed: &str) -> bool {
+    matches_ignore_ascii_case(trimmed, &["t", "true", "y", "yes", "1"])
+}
+
+/// Equivalent to `org.apache.spark.sql.catalyst.util.StringUtils.isFalseString`, minus the trim
+/// that the caller has already applied.
+#[inline]
+fn is_false_string(trimmed: &str) -> bool {
+    matches_ignore_ascii_case(trimmed, &["f", "false", "n", "no", "0"])
+}
+
+/// Spark lowercases with `UTF8String.toLowerCase` before comparing, but every candidate is
+/// ASCII, and no non-ASCII character lowercases into an ASCII one that would complete any of
+/// them, so an ASCII-insensitive comparison gives the same answer without allocating.
+#[inline]
+fn matches_ignore_ascii_case(value: &str, candidates: &[&str]) -> bool {
+    candidates.iter().any(|c| value.eq_ignore_ascii_case(c))
 }
 
 pub(crate) fn cast_string_to_decimal(
@@ -534,23 +562,12 @@ fn is_special_value(trimmed: &str) -> bool {
 /// e.g., "123.45" -> (12345, 2), "-0.001" -> (-1, 3) , 0e50 -> (0,50) etc
 /// Parse a string to decimal following Spark's behavior
 fn parse_string_to_decimal(input_str: &str, precision: u8, scale: i8) -> SparkResult<Option<i128>> {
-    let string_bytes = input_str.as_bytes();
-    let mut start = 0;
-    let mut end = string_bytes.len();
-
-    // Trim ASCII whitespace and null bytes from both ends. Spark's UTF8String
-    // trims null bytes the same way it trims whitespace: "123\u0000" and
-    // "\u0000123" both parse as 123. Null bytes in the middle are not trimmed
-    // and will fail the digit validation in parse_decimal_str, producing NULL.
-    while start < end && (string_bytes[start].is_ascii_whitespace() || string_bytes[start] == 0) {
-        start += 1;
-    }
-    while end > start && (string_bytes[end - 1].is_ascii_whitespace() || string_bytes[end - 1] == 0)
-    {
-        end -= 1;
-    }
-
-    let trimmed = &input_str[start..end];
+    // Spark parses via `new java.math.BigDecimal(str.toString.trim)`, so the trim set is
+    // `String.trim`'s: every byte <= 0x20, which includes the null byte ("123\u0000" and
+    // "\u0000123" both parse as 123) but not 0x7F or any non-ASCII whitespace. Null bytes in
+    // the middle are not trimmed and will fail the digit validation in parse_decimal_str,
+    // producing NULL.
+    let trimmed = trim_java_string(input_str);
 
     // Normalize fullwidth digits to ASCII. Fast path skips the allocation for
     // pure-ASCII strings, which is the common case.
@@ -929,7 +946,7 @@ fn do_parse_string_to_int_legacy<T: Integer + CheckedSub + CheckedNeg + From<u8>
     str: &str,
     min_value: T,
 ) -> SparkResult<Option<T>> {
-    let trimmed_bytes = str.as_bytes().trim_ascii();
+    let trimmed_bytes = trim_all_bytes(str.as_bytes());
 
     let (negative, digits) = match parse_sign(trimmed_bytes) {
         Some(result) => result,
@@ -980,7 +997,7 @@ fn do_parse_string_to_int_ansi<T: Integer + CheckedSub + CheckedNeg + From<u8> +
 ) -> SparkResult<Option<T>> {
     let error = || Err(invalid_value(str, "STRING", type_name));
 
-    let trimmed_bytes = str.as_bytes().trim_ascii();
+    let trimmed_bytes = trim_all_bytes(str.as_bytes());
 
     let (negative, digits) = match parse_sign(trimmed_bytes) {
         Some(result) => result,
@@ -1016,7 +1033,7 @@ fn do_parse_string_to_int_try<T: Integer + CheckedSub + CheckedNeg + From<u8> + 
     str: &str,
     min_value: T,
 ) -> SparkResult<Option<T>> {
-    let trimmed_bytes = str.as_bytes().trim_ascii();
+    let trimmed_bytes = trim_all_bytes(str.as_bytes());
 
     let (negative, digits) = match parse_sign(trimmed_bytes) {
         Some(result) => result,
@@ -1881,6 +1898,8 @@ fn parse_str_to_time_only_timestamp<T: TimeZone>(value: &str, tz: &T) -> SparkRe
 //a string to date parser - port of spark's SparkDateTimeUtils#stringToDate.
 fn date_parser(date_str: &str, eval_mode: EvalMode) -> SparkResult<Option<i32>> {
     // local functions
+    // `SparkDateTimeUtils.getTrimmedStart`/`getTrimmedEnd` trim the same byte set as
+    // `UTF8String.trimAll`; see `is_whitespace_or_iso_control`.
     fn get_trimmed_start(bytes: &[u8]) -> usize {
         let mut start = 0;
         while start < bytes.len() && is_whitespace_or_iso_control(bytes[start]) {
@@ -1895,10 +1914,6 @@ fn date_parser(date_str: &str, eval_mode: EvalMode) -> SparkResult<Option<i32>> 
             end -= 1;
         }
         end + 1
-    }
-
-    fn is_whitespace_or_iso_control(byte: u8) -> bool {
-        byte.is_ascii_whitespace() || byte.is_ascii_control()
     }
 
     /// Decodes a run of ASCII digits, or `None` if any byte is not a digit.
@@ -2200,6 +2215,123 @@ mod tests {
             }
             other => panic!("Expected InvalidInputInCastToDatetime error, got {other:?}"),
         }
+    }
+
+    /// One padding string used to check trim parity with Spark, and which of Spark's two trim
+    /// regimes strips it. See [`crate::conversion_funcs::trim`].
+    struct Pad {
+        text: String,
+        /// Removed by `UTF8String.trimAll`: the boolean, integral and datetime casts.
+        trim_all: bool,
+        /// Removed by `String.trim`: the float, double and decimal casts.
+        java_trim: bool,
+    }
+
+    /// The codepoint matrix from
+    /// <https://github.com/apache/datafusion-comet/issues/5149>: ASCII control bytes (which
+    /// both regimes strip), DELETE (which only `trimAll` strips), and every non-ASCII
+    /// whitespace codepoint (which neither regime strips, so Spark returns NULL / raises).
+    fn trim_pads() -> Vec<Pad> {
+        let mut pads = Vec::new();
+        // 0x00-0x20: stripped by both regimes.
+        for b in 0x00u8..=0x20 {
+            pads.push(Pad {
+                text: String::from(b as char),
+                trim_all: true,
+                java_trim: true,
+            });
+        }
+        // DELETE: `trimAll` only.
+        pads.push(Pad {
+            text: "\u{7f}".to_string(),
+            trim_all: true,
+            java_trim: false,
+        });
+        // Unicode whitespace outside ASCII: never stripped, by either regime.
+        for text in [
+            "\u{85}", "\u{a0}", "\u{1680}", "\u{2000}", "\u{2005}", "\u{200a}", "\u{2028}",
+            "\u{2029}", "\u{202f}", "\u{205f}", "\u{3000}",
+        ] {
+            pads.push(Pad {
+                text: text.to_string(),
+                trim_all: false,
+                java_trim: false,
+            });
+        }
+        pads
+    }
+
+    /// Asserts that padding `valid` with each entry of [`trim_pads`] produces the value in
+    /// every eval mode when Spark trims that padding, and NULL (or an ANSI error) when it does
+    /// not. Interior padding must never parse.
+    fn assert_trim_parity(to_type: &DataType, valid: &str, uses_trim_all: bool) {
+        for pad in trim_pads() {
+            let stripped = if uses_trim_all {
+                pad.trim_all
+            } else {
+                pad.java_trim
+            };
+            let split = valid.char_indices().nth(1).map(|(i, _)| i).unwrap();
+            let cases = [
+                ("leading", format!("{}{valid}", pad.text), stripped),
+                ("trailing", format!("{valid}{}", pad.text), stripped),
+                ("both", format!("{}{valid}{}", pad.text, pad.text), stripped),
+                (
+                    "interior",
+                    format!("{}{}{}", &valid[..split], pad.text, &valid[split..]),
+                    false,
+                ),
+            ];
+            for (position, input, expect_value) in cases {
+                for eval_mode in [EvalMode::Legacy, EvalMode::Try, EvalMode::Ansi] {
+                    let array: ArrayRef = Arc::new(StringArray::from(vec![Some(input.as_str())]));
+                    let options = SparkCastOptions::new(eval_mode, "UTC", false);
+                    let result = cast_array(array, to_type, &options);
+                    let context = format!(
+                        "cast {input:?} ({position} {:?}) to {to_type} in {eval_mode:?} mode",
+                        pad.text
+                    );
+                    if expect_value {
+                        let array = result.unwrap_or_else(|e| panic!("{context}: {e}"));
+                        assert!(!array.is_null(0), "{context}: expected a value, got NULL");
+                    } else if eval_mode == EvalMode::Ansi {
+                        assert!(result.is_err(), "{context}: expected an error");
+                    } else {
+                        let array = result.unwrap_or_else(|e| panic!("{context}: {e}"));
+                        assert!(array.is_null(0), "{context}: expected NULL");
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_cast_string_to_boolean_trim_parity() {
+        assert_trim_parity(&DataType::Boolean, "true", true);
+    }
+
+    #[test]
+    fn test_cast_string_to_int_trim_parity() {
+        for to_type in [
+            DataType::Int8,
+            DataType::Int16,
+            DataType::Int32,
+            DataType::Int64,
+        ] {
+            assert_trim_parity(&to_type, "12", true);
+        }
+    }
+
+    #[test]
+    fn test_cast_string_to_float_trim_parity() {
+        for to_type in [DataType::Float32, DataType::Float64] {
+            assert_trim_parity(&to_type, "1.5", false);
+        }
+    }
+
+    #[test]
+    fn test_cast_string_to_decimal_trim_parity() {
+        assert_trim_parity(&DataType::Decimal128(10, 2), "1.5", false);
     }
 
     #[test]

--- a/native/spark-expr/src/conversion_funcs/string.rs
+++ b/native/spark-expr/src/conversion_funcs/string.rs
@@ -2219,40 +2219,49 @@ mod tests {
 
     /// Asserts that the cast to `to_type` trims each [`trim_pads`] entry exactly when `regime`
     /// -- the trim helper that Spark's cast to `to_type` uses -- trims it: a value in every eval
-    /// mode when it is trimmed, NULL (or an ANSI error) when it is not. Interior padding must
-    /// never parse.
+    /// mode when it is trimmed, NULL (or an ANSI error) when it is not. Interior padding, padding
+    /// on its own and the empty string must never parse.
     fn assert_trim_parity(to_type: &DataType, valid: &str, regime: fn(&str) -> &str) {
         let split = valid.char_indices().nth(1).map(|(i, _)| i).unwrap();
+        // The empty string reaches the same empty-slice branch that fully-trimmed padding does.
+        let mut cases = vec![("empty".to_string(), String::new(), false)];
         for pad in trim_pads() {
             // The regime trims this padding iff trimming the padding alone leaves nothing.
             let trimmed = regime(&pad).is_empty();
-            let cases = [
-                ("leading", format!("{pad}{valid}"), trimmed),
-                ("trailing", format!("{valid}{pad}"), trimmed),
-                ("both", format!("{pad}{valid}{pad}"), trimmed),
+            cases.extend([
+                (format!("leading {pad:?}"), format!("{pad}{valid}"), trimmed),
                 (
-                    "interior",
+                    format!("trailing {pad:?}"),
+                    format!("{valid}{pad}"),
+                    trimmed,
+                ),
+                (
+                    format!("both ends {pad:?}"),
+                    format!("{pad}{valid}{pad}"),
+                    trimmed,
+                ),
+                (
+                    format!("interior {pad:?}"),
                     format!("{}{pad}{}", &valid[..split], &valid[split..]),
                     false,
                 ),
-            ];
-            for (position, input, expect_value) in cases {
-                for eval_mode in [EvalMode::Legacy, EvalMode::Try, EvalMode::Ansi] {
-                    let array: ArrayRef = Arc::new(StringArray::from(vec![Some(input.as_str())]));
-                    let options = SparkCastOptions::new(eval_mode, "UTC", false);
-                    let result = cast_array(array, to_type, &options);
-                    let context = format!(
-                        "cast {input:?} ({position} {pad:?}) to {to_type} in {eval_mode:?}"
-                    );
-                    if expect_value {
-                        let array = result.unwrap_or_else(|e| panic!("{context}: {e}"));
-                        assert!(!array.is_null(0), "{context}: expected a value, got NULL");
-                    } else if eval_mode == EvalMode::Ansi {
-                        assert!(result.is_err(), "{context}: expected an error");
-                    } else {
-                        let array = result.unwrap_or_else(|e| panic!("{context}: {e}"));
-                        assert!(array.is_null(0), "{context}: expected NULL");
-                    }
+                (format!("only {pad:?}"), pad.clone(), false),
+            ]);
+        }
+        for (position, input, expect_value) in cases {
+            for eval_mode in [EvalMode::Legacy, EvalMode::Try, EvalMode::Ansi] {
+                let array: ArrayRef = Arc::new(StringArray::from(vec![Some(input.as_str())]));
+                let options = SparkCastOptions::new(eval_mode, "UTC", false);
+                let result = cast_array(array, to_type, &options);
+                let context = format!("cast {input:?} ({position}) to {to_type} in {eval_mode:?}");
+                if expect_value {
+                    let array = result.unwrap_or_else(|e| panic!("{context}: {e}"));
+                    assert!(!array.is_null(0), "{context}: expected a value, got NULL");
+                } else if eval_mode == EvalMode::Ansi {
+                    assert!(result.is_err(), "{context}: expected an error");
+                } else {
+                    let array = result.unwrap_or_else(|e| panic!("{context}: {e}"));
+                    assert!(array.is_null(0), "{context}: expected NULL");
                 }
             }
         }
@@ -2289,6 +2298,35 @@ mod tests {
             DataType::Decimal128(10, 2),
         ] {
             assert_trim_parity(&to_type, "1.5", trim_java_string);
+        }
+    }
+
+    /// Pins the one trim divergence this PR leaves behind, so that resolving
+    /// <https://github.com/apache/datafusion-comet/issues/5149> has to update this test rather
+    /// than change behaviour silently. `timestamp_parser` and `timestamp_ntz_parser` still use
+    /// `str::trim`, so they accept the non-ASCII whitespace that Spark's
+    /// `SparkDateTimeUtils.getTrimmedStart` / `getTrimmedEnd` leave in place, where Spark returns
+    /// NULL. `CometCastSuite` cannot cover this, because Spark is the oracle there and Comet does
+    /// not fall back -- it silently returns a value.
+    #[test]
+    fn test_cast_string_to_timestamp_unicode_whitespace_divergence() {
+        let to_types = [
+            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+        ];
+        for pad in ["\u{85}", "\u{a0}", "\u{2028}", "\u{3000}"] {
+            for to_type in &to_types {
+                let input = format!("{pad}2020-01-01 12:34:56{pad}");
+                let array: ArrayRef = Arc::new(StringArray::from(vec![Some(input.as_str())]));
+                let options = SparkCastOptions::new(EvalMode::Legacy, "UTC", false);
+                let result = cast_array(array, to_type, &options).unwrap();
+                assert!(
+                    !result.is_null(0),
+                    "cast {input:?} to {to_type}: Comet still trims {pad:?} where Spark returns \
+                     NULL. If this now returns NULL, the parsers have moved to the trim helpers \
+                     -- delete this test and extend `assert_trim_parity` to the timestamp targets."
+                );
+            }
         }
     }
 

--- a/native/spark-expr/src/conversion_funcs/string.rs
+++ b/native/spark-expr/src/conversion_funcs/string.rs
@@ -15,9 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::conversion_funcs::trim::{
-    is_whitespace_or_iso_control, trim_all, trim_all_bytes, trim_java_string,
-};
+use crate::conversion_funcs::trim::{trim_all, trim_all_bytes, trim_all_range, trim_java_string};
 use crate::{timezone, EvalMode, SparkError, SparkResult};
 use arrow::array::{
     Array, ArrayRef, ArrowPrimitiveType, BooleanArray, Decimal128Builder, GenericStringArray,
@@ -293,24 +291,24 @@ where
 
 /// Equivalent to `org.apache.spark.sql.catalyst.util.StringUtils.isTrueString`, minus the trim
 /// that the caller has already applied.
-#[inline]
-fn is_true_string(trimmed: &str) -> bool {
-    matches_ignore_ascii_case(trimmed, &["t", "true", "y", "yes", "1"])
-}
-
-/// Equivalent to `org.apache.spark.sql.catalyst.util.StringUtils.isFalseString`, minus the trim
-/// that the caller has already applied.
-#[inline]
-fn is_false_string(trimmed: &str) -> bool {
-    matches_ignore_ascii_case(trimmed, &["f", "false", "n", "no", "0"])
-}
-
+///
 /// Spark lowercases with `UTF8String.toLowerCase` before comparing, but every candidate is
 /// ASCII, and no non-ASCII character lowercases into an ASCII one that would complete any of
 /// them, so an ASCII-insensitive comparison gives the same answer without allocating.
 #[inline]
-fn matches_ignore_ascii_case(value: &str, candidates: &[&str]) -> bool {
-    candidates.iter().any(|c| value.eq_ignore_ascii_case(c))
+fn is_true_string(trimmed: &str) -> bool {
+    ["t", "true", "y", "yes", "1"]
+        .iter()
+        .any(|v| trimmed.eq_ignore_ascii_case(v))
+}
+
+/// Equivalent to `org.apache.spark.sql.catalyst.util.StringUtils.isFalseString`; see
+/// [`is_true_string`] for why the comparison is ASCII-only.
+#[inline]
+fn is_false_string(trimmed: &str) -> bool {
+    ["f", "false", "n", "no", "0"]
+        .iter()
+        .any(|v| trimmed.eq_ignore_ascii_case(v))
 }
 
 pub(crate) fn cast_string_to_decimal(
@@ -1898,24 +1896,6 @@ fn parse_str_to_time_only_timestamp<T: TimeZone>(value: &str, tz: &T) -> SparkRe
 //a string to date parser - port of spark's SparkDateTimeUtils#stringToDate.
 fn date_parser(date_str: &str, eval_mode: EvalMode) -> SparkResult<Option<i32>> {
     // local functions
-    // `SparkDateTimeUtils.getTrimmedStart`/`getTrimmedEnd` trim the same byte set as
-    // `UTF8String.trimAll`; see `is_whitespace_or_iso_control`.
-    fn get_trimmed_start(bytes: &[u8]) -> usize {
-        let mut start = 0;
-        while start < bytes.len() && is_whitespace_or_iso_control(bytes[start]) {
-            start += 1;
-        }
-        start
-    }
-
-    fn get_trimmed_end(start: usize, bytes: &[u8]) -> usize {
-        let mut end = bytes.len() - 1;
-        while end > start && is_whitespace_or_iso_control(bytes[end]) {
-            end -= 1;
-        }
-        end + 1
-    }
-
     /// Decodes a run of ASCII digits, or `None` if any byte is not a digit.
     fn decode_digits(bytes: &[u8]) -> Option<i64> {
         bytes.iter().try_fold(0i64, |acc, b| {
@@ -1981,8 +1961,10 @@ fn date_parser(date_str: &str, eval_mode: EvalMode) -> SparkResult<Option<i32>> 
 
     let bytes = date_str.as_bytes();
 
-    let mut j = get_trimmed_start(bytes);
-    let str_end_trimmed = get_trimmed_end(j, bytes);
+    // `SparkDateTimeUtils.getTrimmedStart`/`getTrimmedEnd` trim the same byte set as
+    // `UTF8String.trimAll`.
+    let (start, str_end_trimmed) = trim_all_range(bytes);
+    let mut j = start;
 
     if j == str_end_trimmed {
         return return_result(date_str, eval_mode);
@@ -2217,68 +2199,40 @@ mod tests {
         }
     }
 
-    /// One padding string used to check trim parity with Spark, and which of Spark's two trim
-    /// regimes strips it. See [`crate::conversion_funcs::trim`].
-    struct Pad {
-        text: String,
-        /// Removed by `UTF8String.trimAll`: the boolean, integral and datetime casts.
-        trim_all: bool,
-        /// Removed by `String.trim`: the float, double and decimal casts.
-        java_trim: bool,
-    }
-
     /// The codepoint matrix from
-    /// <https://github.com/apache/datafusion-comet/issues/5149>: ASCII control bytes (which
-    /// both regimes strip), DELETE (which only `trimAll` strips), and every non-ASCII
-    /// whitespace codepoint (which neither regime strips, so Spark returns NULL / raises).
-    fn trim_pads() -> Vec<Pad> {
-        let mut pads = Vec::new();
-        // 0x00-0x20: stripped by both regimes.
-        for b in 0x00u8..=0x20 {
-            pads.push(Pad {
-                text: String::from(b as char),
-                trim_all: true,
-                java_trim: true,
-            });
-        }
-        // DELETE: `trimAll` only.
-        pads.push(Pad {
-            text: "\u{7f}".to_string(),
-            trim_all: true,
-            java_trim: false,
-        });
-        // Unicode whitespace outside ASCII: never stripped, by either regime.
-        for text in [
-            "\u{85}", "\u{a0}", "\u{1680}", "\u{2000}", "\u{2005}", "\u{200a}", "\u{2028}",
-            "\u{2029}", "\u{202f}", "\u{205f}", "\u{3000}",
-        ] {
-            pads.push(Pad {
-                text: text.to_string(),
-                trim_all: false,
-                java_trim: false,
-            });
-        }
+    /// <https://github.com/apache/datafusion-comet/issues/5149>: the ASCII control bytes and
+    /// DELETE, plus the non-ASCII codepoints that are whitespace to Unicode but that no Spark
+    /// cast trims. `CometCastSuite` runs the same matrix with Spark itself as the oracle.
+    fn trim_pads() -> Vec<String> {
+        let mut pads: Vec<String> = (0x00u8..=0x20).map(|b| String::from(b as char)).collect();
+        pads.push("\u{7f}".to_string());
+        pads.extend(
+            [
+                "\u{85}", "\u{a0}", "\u{1680}", "\u{2000}", "\u{2005}", "\u{200a}", "\u{2028}",
+                "\u{2029}", "\u{202f}", "\u{205f}", "\u{3000}",
+            ]
+            .iter()
+            .map(|s| s.to_string()),
+        );
         pads
     }
 
-    /// Asserts that padding `valid` with each entry of [`trim_pads`] produces the value in
-    /// every eval mode when Spark trims that padding, and NULL (or an ANSI error) when it does
-    /// not. Interior padding must never parse.
-    fn assert_trim_parity(to_type: &DataType, valid: &str, uses_trim_all: bool) {
+    /// Asserts that the cast to `to_type` trims each [`trim_pads`] entry exactly when `regime`
+    /// -- the trim helper that Spark's cast to `to_type` uses -- trims it: a value in every eval
+    /// mode when it is trimmed, NULL (or an ANSI error) when it is not. Interior padding must
+    /// never parse.
+    fn assert_trim_parity(to_type: &DataType, valid: &str, regime: fn(&str) -> &str) {
+        let split = valid.char_indices().nth(1).map(|(i, _)| i).unwrap();
         for pad in trim_pads() {
-            let stripped = if uses_trim_all {
-                pad.trim_all
-            } else {
-                pad.java_trim
-            };
-            let split = valid.char_indices().nth(1).map(|(i, _)| i).unwrap();
+            // The regime trims this padding iff trimming the padding alone leaves nothing.
+            let trimmed = regime(&pad).is_empty();
             let cases = [
-                ("leading", format!("{}{valid}", pad.text), stripped),
-                ("trailing", format!("{valid}{}", pad.text), stripped),
-                ("both", format!("{}{valid}{}", pad.text, pad.text), stripped),
+                ("leading", format!("{pad}{valid}"), trimmed),
+                ("trailing", format!("{valid}{pad}"), trimmed),
+                ("both", format!("{pad}{valid}{pad}"), trimmed),
                 (
                     "interior",
-                    format!("{}{}{}", &valid[..split], pad.text, &valid[split..]),
+                    format!("{}{pad}{}", &valid[..split], &valid[split..]),
                     false,
                 ),
             ];
@@ -2288,8 +2242,7 @@ mod tests {
                     let options = SparkCastOptions::new(eval_mode, "UTC", false);
                     let result = cast_array(array, to_type, &options);
                     let context = format!(
-                        "cast {input:?} ({position} {:?}) to {to_type} in {eval_mode:?} mode",
-                        pad.text
+                        "cast {input:?} ({position} {pad:?}) to {to_type} in {eval_mode:?}"
                     );
                     if expect_value {
                         let array = result.unwrap_or_else(|e| panic!("{context}: {e}"));
@@ -2307,7 +2260,7 @@ mod tests {
 
     #[test]
     fn test_cast_string_to_boolean_trim_parity() {
-        assert_trim_parity(&DataType::Boolean, "true", true);
+        assert_trim_parity(&DataType::Boolean, "true", trim_all);
     }
 
     #[test]
@@ -2318,20 +2271,25 @@ mod tests {
             DataType::Int32,
             DataType::Int64,
         ] {
-            assert_trim_parity(&to_type, "12", true);
+            assert_trim_parity(&to_type, "12", trim_all);
         }
     }
 
     #[test]
-    fn test_cast_string_to_float_trim_parity() {
-        for to_type in [DataType::Float32, DataType::Float64] {
-            assert_trim_parity(&to_type, "1.5", false);
-        }
+    fn test_cast_string_to_date_trim_parity() {
+        assert_trim_parity(&DataType::Date32, "2020-01-01", trim_all);
     }
 
+    /// Float, double and decimal all use the narrower `String.trim` set, which keeps `0x7F`.
     #[test]
-    fn test_cast_string_to_decimal_trim_parity() {
-        assert_trim_parity(&DataType::Decimal128(10, 2), "1.5", false);
+    fn test_cast_string_to_float_and_decimal_trim_parity() {
+        for to_type in [
+            DataType::Float32,
+            DataType::Float64,
+            DataType::Decimal128(10, 2),
+        ] {
+            assert_trim_parity(&to_type, "1.5", trim_java_string);
+        }
     }
 
     #[test]

--- a/native/spark-expr/src/conversion_funcs/trim.rs
+++ b/native/spark-expr/src/conversion_funcs/trim.rs
@@ -21,30 +21,27 @@
 //! regimes, and neither of them matches Rust's `str::trim` (which trims Unicode whitespace) or
 //! `<[u8]>::trim_ascii` (which omits `0x0B`):
 //!
-//! | Regime               | Trimmed bytes            | Cast targets                                          |
-//! |----------------------|--------------------------|-------------------------------------------------------|
-//! | [`trim_all`]         | `0x00`-`0x20` and `0x7F` | boolean, byte, short, int, long, date, timestamp \*    |
-//! | [`trim_java_string`] | `0x00`-`0x20`            | float, double, decimal                                |
+//! | Regime               | Trimmed bytes            | Cast targets                                       |
+//! |----------------------|--------------------------|----------------------------------------------------|
+//! | [`trim_all`]         | `0x00`-`0x20` and `0x7F` | boolean, byte, short, int, long, date, timestamp \* |
+//! | [`trim_java_string`] | `0x00`-`0x20`            | float, double, decimal                             |
 //!
-//! Crucially, **neither regime trims any non-ASCII whitespace**. `U+0085`, `U+00A0`, `U+1680`,
-//! `U+2000`-`U+200A`, `U+2028`, `U+2029`, `U+202F`, `U+205F` and `U+3000` all leave Spark
-//! returning NULL (or raising under ANSI) for every cast target, so using `str::trim` here
-//! silently produces a value where Spark produces none.
+//! Neither regime trims non-ASCII whitespace (`str::trim` does, which is why it cannot be reused
+//! here). The `String.trim` regime comes from the JDK calls Spark delegates to:
+//! `Double.parseDouble` trims before parsing, and `Decimal.stringToJavaBigDecimal` does
+//! `str.toString.trim`.
 //!
-//! The two regimes differ only in `0x7F` (DELETE), which the `trimAll` set removes and the
-//! `String.trim` set does not. That single byte is why a shared helper cannot be applied
-//! uniformly: trimming it in the float/double/decimal paths would introduce a new divergence.
-//!
-//! \* `timestamp` and `timestamp_ntz` are listed for what Spark does; the Comet parsers for
-//! those two targets still use `str::trim` and have not been migrated to these helpers
+//! \* `timestamp` and `timestamp_ntz` are listed for what Spark does; the Comet parsers for those
+//! two targets have not been migrated to these helpers and still use `str::trim`, as do `to_time`
+//! and `try_to_time` in `datetime_funcs::to_time`
 //! (<https://github.com/apache/datafusion-comet/issues/5149>).
 
 /// True for the bytes trimmed by `org.apache.spark.unsafe.types.UTF8String.trimAll`, i.e. the
-/// bytes `b` for which `Character.isWhitespace(b) || Character.isISOControl(b)` holds.
+/// bytes `b` for which `Character.isWhitespace(b) || Character.isISOControl(b)` holds, which
+/// reduces to `b <= 0x20 || b == 0x7F`.
 ///
-/// `isWhitespace` covers `0x09`-`0x0D`, `0x1C`-`0x1F` and `0x20`; `isISOControl` covers
-/// `0x00`-`0x1F` and `0x7F`; the union is `0x00`-`0x20` plus `0x7F`. Spark widens a *signed*
-/// `byte` into the `int` overload, so bytes `0x80`-`0xFF` arrive negative and are never trimmed.
+/// Spark widens a *signed* `byte` into the `int` overload, so bytes `0x80`-`0xFF` arrive negative
+/// and are never trimmed.
 #[inline]
 const fn is_whitespace_or_iso_control(b: u8) -> bool {
     b <= 0x20 || b == 0x7F
@@ -52,8 +49,9 @@ const fn is_whitespace_or_iso_control(b: u8) -> bool {
 
 /// True for the bytes trimmed by `java.lang.String.trim`, which drops any char `<= U+0020`.
 ///
-/// A char above `U+0020` always encodes to bytes `>= 0x80` in UTF-8, so testing bytes rather
-/// than chars gives the same answer.
+/// In valid UTF-8 a byte `<= 0x20` is always a single-byte codepoint, since the lead and
+/// continuation bytes of a multi-byte sequence are all `>= 0x80`. So testing bytes rather than
+/// chars gives the same answer.
 #[inline]
 const fn is_java_trim_byte(b: u8) -> bool {
     b <= 0x20
@@ -61,8 +59,8 @@ const fn is_java_trim_byte(b: u8) -> bool {
 
 /// Trims the `UTF8String.trimAll` byte set (`0x00`-`0x20` and `0x7F`) from both ends.
 ///
-/// This is the trim used by `CAST(string AS boolean)`, the integral casts and `date_parser`.
-/// See the [module docs](self) for why the other targets need [`trim_java_string`].
+/// See the [module docs](self) for which cast targets use this regime and which use
+/// [`trim_java_string`].
 #[inline]
 pub(crate) fn trim_all(s: &str) -> &str {
     let (start, end) = trim_all_range(s.as_bytes());
@@ -85,9 +83,7 @@ pub(crate) fn trim_all_range(bytes: &[u8]) -> (usize, usize) {
 
 /// Trims the `java.lang.String.trim` byte set (`0x00`-`0x20`, keeping `0x7F`) from both ends.
 ///
-/// This is the trim used by `CAST(string AS float/double)` (via `Double.parseDouble`, which
-/// calls `String.trim` before parsing) and by `CAST(string AS decimal)` (via
-/// `Decimal.stringToJavaBigDecimal`, which does `str.toString.trim`).
+/// See the [module docs](self) for which cast targets use this regime and which use [`trim_all`].
 #[inline]
 pub(crate) fn trim_java_string(s: &str) -> &str {
     let (trimmed, start) = trim_bytes(s.as_bytes(), is_java_trim_byte);

--- a/native/spark-expr/src/conversion_funcs/trim.rs
+++ b/native/spark-expr/src/conversion_funcs/trim.rs
@@ -1,0 +1,188 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Whitespace trimming for casts from string.
+//!
+//! Spark's string casts do not all agree on what "whitespace" means. There are exactly two
+//! regimes, and neither of them matches Rust's `str::trim` (which trims Unicode whitespace) or
+//! `<[u8]>::trim_ascii` (which omits `0x0B`):
+//!
+//! | Regime                      | Trimmed bytes            | Cast targets                                               |
+//! |-----------------------------|--------------------------|------------------------------------------------------------|
+//! | [`trim_all`]                | `0x00`-`0x20` and `0x7F` | boolean, byte, short, int, long, date, timestamp, timestamp_ntz |
+//! | [`trim_java_string`]        | `0x00`-`0x20`            | float, double, decimal                                     |
+//!
+//! Crucially, **neither regime trims any non-ASCII whitespace**. `U+0085`, `U+00A0`, `U+1680`,
+//! `U+2000`-`U+200A`, `U+2028`, `U+2029`, `U+202F`, `U+205F` and `U+3000` all leave Spark
+//! returning NULL (or raising under ANSI) for every cast target, so using `str::trim` here
+//! silently produces a value where Spark produces none.
+//!
+//! The two regimes differ only in `0x7F` (DELETE), which the `trimAll` set removes and the
+//! `String.trim` set does not. That single byte is why a shared helper cannot be applied
+//! uniformly: trimming it in the float/double/decimal paths would introduce a new divergence.
+//!
+//! Both helpers can slice on byte offsets without breaking UTF-8 because every byte either
+//! regime trims is ASCII, and a byte below `0x80` never appears inside a multi-byte sequence.
+
+/// True for the bytes trimmed by `org.apache.spark.unsafe.types.UTF8String.trimAll`, i.e. the
+/// bytes `b` for which `Character.isWhitespace(b) || Character.isISOControl(b)` holds.
+///
+/// `isWhitespace` covers `0x09`-`0x0D`, `0x1C`-`0x1F` and `0x20`; `isISOControl` covers
+/// `0x00`-`0x1F` and `0x7F`; the union is `0x00`-`0x20` plus `0x7F`. Spark widens a *signed*
+/// `byte` into the `int` overload, so bytes `0x80`-`0xFF` arrive negative and are never trimmed.
+#[inline]
+pub(crate) const fn is_whitespace_or_iso_control(b: u8) -> bool {
+    b <= 0x20 || b == 0x7F
+}
+
+/// True for the bytes trimmed by `java.lang.String.trim`, which drops any char `<= U+0020`.
+///
+/// A char above `U+0020` always encodes to bytes `>= 0x80` in UTF-8, so testing bytes rather
+/// than chars gives the same answer.
+#[inline]
+pub(crate) const fn is_java_trim_byte(b: u8) -> bool {
+    b <= 0x20
+}
+
+/// Trims the `UTF8String.trimAll` byte set (`0x00`-`0x20` and `0x7F`) from both ends.
+///
+/// This is the trim used by `CAST(string AS boolean)`, the integral casts, and the datetime
+/// casts. See the [module docs](self) for why the other targets need [`trim_java_string`].
+#[inline]
+pub(crate) fn trim_all(s: &str) -> &str {
+    let (start, end) = trim_range(s.as_bytes(), is_whitespace_or_iso_control);
+    &s[start..end]
+}
+
+/// [`trim_all`] over a byte slice, for parsers that already work on bytes.
+#[inline]
+pub(crate) fn trim_all_bytes(bytes: &[u8]) -> &[u8] {
+    let (start, end) = trim_range(bytes, is_whitespace_or_iso_control);
+    &bytes[start..end]
+}
+
+/// Trims the `java.lang.String.trim` byte set (`0x00`-`0x20`, keeping `0x7F`) from both ends.
+///
+/// This is the trim used by `CAST(string AS float/double)` (via `Double.parseDouble`, which
+/// calls `String.trim` before parsing) and by `CAST(string AS decimal)` (via
+/// `Decimal.stringToJavaBigDecimal`, which does `str.toString.trim`).
+#[inline]
+pub(crate) fn trim_java_string(s: &str) -> &str {
+    let (start, end) = trim_range(s.as_bytes(), is_java_trim_byte);
+    &s[start..end]
+}
+
+/// Byte offsets of `bytes` with every leading and trailing byte matching `trimmed` removed.
+///
+/// Slicing a `&str` on the returned offsets cannot panic as long as `trimmed` only accepts ASCII
+/// bytes, since those never appear inside a multi-byte UTF-8 sequence.
+#[inline]
+fn trim_range(bytes: &[u8], trimmed: fn(u8) -> bool) -> (usize, usize) {
+    let mut start = 0;
+    let mut end = bytes.len();
+    while start < end && trimmed(bytes[start]) {
+        start += 1;
+    }
+    while end > start && trimmed(bytes[end - 1]) {
+        end -= 1;
+    }
+    (start, end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every byte the `trimAll` regime trims, as derived from Java's `Character.isWhitespace`
+    /// and `Character.isISOControl` rather than from the implementation under test.
+    fn expected_trim_all_bytes() -> Vec<u8> {
+        (0..=u8::MAX)
+            .filter(|&b| {
+                let is_whitespace = matches!(b, 0x09..=0x0D | 0x1C..=0x1F | 0x20);
+                let is_iso_control = matches!(b, 0x00..=0x1F | 0x7F);
+                is_whitespace || is_iso_control
+            })
+            .collect()
+    }
+
+    #[test]
+    fn trim_all_matches_spark_byte_set() {
+        for b in 0..=u8::MAX {
+            let expected = expected_trim_all_bytes().contains(&b);
+            assert_eq!(
+                is_whitespace_or_iso_control(b),
+                expected,
+                "byte 0x{b:02X} classified incorrectly"
+            );
+        }
+    }
+
+    #[test]
+    fn java_trim_set_is_trim_all_without_delete() {
+        for b in 0..=u8::MAX {
+            assert_eq!(is_java_trim_byte(b), b <= 0x20, "byte 0x{b:02X}");
+        }
+        // The two regimes differ in exactly one byte: DELETE.
+        let differing: Vec<u8> = (0..=u8::MAX)
+            .filter(|&b| is_whitespace_or_iso_control(b) != is_java_trim_byte(b))
+            .collect();
+        assert_eq!(differing, vec![0x7F]);
+    }
+
+    /// `<[u8]>::trim_ascii` and `str::trim` are both wrong here; pin down how, so that a future
+    /// change back to either is caught.
+    #[test]
+    fn rust_builtins_disagree_with_spark() {
+        // trim_ascii omits the vertical tab, which Spark trims.
+        assert!(is_whitespace_or_iso_control(0x0B));
+        assert!(!0x0Bu8.is_ascii_whitespace());
+        // str::trim removes non-ASCII whitespace, which Spark never trims.
+        assert_eq!("\u{3000}1".trim(), "1");
+        assert_eq!(trim_all("\u{3000}1"), "\u{3000}1");
+        assert_eq!(trim_java_string("\u{3000}1"), "\u{3000}1");
+    }
+
+    #[test]
+    fn trims_both_ends_and_leaves_interior() {
+        assert_eq!(trim_all("\u{0}\u{1}\u{b}\u{7f} 1 2 \u{7f}\u{1f}"), "1 2");
+        assert_eq!(trim_java_string("\u{0}\u{1}\u{b} 1 2 \u{1f}"), "1 2");
+        // Interior bytes are never touched.
+        assert_eq!(trim_all("1\u{0}2"), "1\u{0}2");
+        assert_eq!(trim_java_string("1\u{0}2"), "1\u{0}2");
+    }
+
+    #[test]
+    fn delete_byte_is_trimmed_only_by_trim_all() {
+        assert_eq!(trim_all("\u{7f}123\u{7f}"), "123");
+        assert_eq!(trim_java_string("\u{7f}123\u{7f}"), "\u{7f}123\u{7f}");
+    }
+
+    #[test]
+    fn all_whitespace_input_trims_to_empty() {
+        assert_eq!(trim_all(" \t\u{7f}"), "");
+        assert_eq!(trim_java_string(" \t\n"), "");
+        assert_eq!(trim_all(""), "");
+        assert_eq!(trim_java_string(""), "");
+    }
+
+    #[test]
+    fn multibyte_content_is_preserved() {
+        // A trailing multi-byte char must not be sliced into.
+        assert_eq!(trim_all(" \u{3000}\u{e9} "), "\u{3000}\u{e9}");
+        assert_eq!(trim_java_string(" \u{3000}\u{e9} "), "\u{3000}\u{e9}");
+    }
+}

--- a/native/spark-expr/src/conversion_funcs/trim.rs
+++ b/native/spark-expr/src/conversion_funcs/trim.rs
@@ -15,16 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Whitespace trimming for casts from string.
+//! Whitespace trimming for parsing from string.
 //!
 //! Spark's string casts do not all agree on what "whitespace" means. There are exactly two
 //! regimes, and neither of them matches Rust's `str::trim` (which trims Unicode whitespace) or
 //! `<[u8]>::trim_ascii` (which omits `0x0B`):
 //!
-//! | Regime                      | Trimmed bytes            | Cast targets                                               |
-//! |-----------------------------|--------------------------|------------------------------------------------------------|
-//! | [`trim_all`]                | `0x00`-`0x20` and `0x7F` | boolean, byte, short, int, long, date, timestamp, timestamp_ntz |
-//! | [`trim_java_string`]        | `0x00`-`0x20`            | float, double, decimal                                     |
+//! | Regime               | Trimmed bytes            | Cast targets                                          |
+//! |----------------------|--------------------------|-------------------------------------------------------|
+//! | [`trim_all`]         | `0x00`-`0x20` and `0x7F` | boolean, byte, short, int, long, date, timestamp \*    |
+//! | [`trim_java_string`] | `0x00`-`0x20`            | float, double, decimal                                |
 //!
 //! Crucially, **neither regime trims any non-ASCII whitespace**. `U+0085`, `U+00A0`, `U+1680`,
 //! `U+2000`-`U+200A`, `U+2028`, `U+2029`, `U+202F`, `U+205F` and `U+3000` all leave Spark
@@ -35,8 +35,9 @@
 //! `String.trim` set does not. That single byte is why a shared helper cannot be applied
 //! uniformly: trimming it in the float/double/decimal paths would introduce a new divergence.
 //!
-//! Both helpers can slice on byte offsets without breaking UTF-8 because every byte either
-//! regime trims is ASCII, and a byte below `0x80` never appears inside a multi-byte sequence.
+//! \* `timestamp` and `timestamp_ntz` are listed for what Spark does; the Comet parsers for
+//! those two targets still use `str::trim` and have not been migrated to these helpers
+//! (<https://github.com/apache/datafusion-comet/issues/5149>).
 
 /// True for the bytes trimmed by `org.apache.spark.unsafe.types.UTF8String.trimAll`, i.e. the
 /// bytes `b` for which `Character.isWhitespace(b) || Character.isISOControl(b)` holds.
@@ -45,7 +46,7 @@
 /// `0x00`-`0x1F` and `0x7F`; the union is `0x00`-`0x20` plus `0x7F`. Spark widens a *signed*
 /// `byte` into the `int` overload, so bytes `0x80`-`0xFF` arrive negative and are never trimmed.
 #[inline]
-pub(crate) const fn is_whitespace_or_iso_control(b: u8) -> bool {
+const fn is_whitespace_or_iso_control(b: u8) -> bool {
     b <= 0x20 || b == 0x7F
 }
 
@@ -54,25 +55,32 @@ pub(crate) const fn is_whitespace_or_iso_control(b: u8) -> bool {
 /// A char above `U+0020` always encodes to bytes `>= 0x80` in UTF-8, so testing bytes rather
 /// than chars gives the same answer.
 #[inline]
-pub(crate) const fn is_java_trim_byte(b: u8) -> bool {
+const fn is_java_trim_byte(b: u8) -> bool {
     b <= 0x20
 }
 
 /// Trims the `UTF8String.trimAll` byte set (`0x00`-`0x20` and `0x7F`) from both ends.
 ///
-/// This is the trim used by `CAST(string AS boolean)`, the integral casts, and the datetime
-/// casts. See the [module docs](self) for why the other targets need [`trim_java_string`].
+/// This is the trim used by `CAST(string AS boolean)`, the integral casts and `date_parser`.
+/// See the [module docs](self) for why the other targets need [`trim_java_string`].
 #[inline]
 pub(crate) fn trim_all(s: &str) -> &str {
-    let (start, end) = trim_range(s.as_bytes(), is_whitespace_or_iso_control);
+    let (start, end) = trim_all_range(s.as_bytes());
     &s[start..end]
 }
 
 /// [`trim_all`] over a byte slice, for parsers that already work on bytes.
 #[inline]
 pub(crate) fn trim_all_bytes(bytes: &[u8]) -> &[u8] {
-    let (start, end) = trim_range(bytes, is_whitespace_or_iso_control);
-    &bytes[start..end]
+    trim_bytes(bytes, is_whitespace_or_iso_control).0
+}
+
+/// The byte offsets [`trim_all`] would slice at, for parsers that need to keep a cursor into
+/// the untrimmed input.
+#[inline]
+pub(crate) fn trim_all_range(bytes: &[u8]) -> (usize, usize) {
+    let (trimmed, start) = trim_bytes(bytes, is_whitespace_or_iso_control);
+    (start, start + trimmed.len())
 }
 
 /// Trims the `java.lang.String.trim` byte set (`0x00`-`0x20`, keeping `0x7F`) from both ends.
@@ -82,78 +90,68 @@ pub(crate) fn trim_all_bytes(bytes: &[u8]) -> &[u8] {
 /// `Decimal.stringToJavaBigDecimal`, which does `str.toString.trim`).
 #[inline]
 pub(crate) fn trim_java_string(s: &str) -> &str {
-    let (start, end) = trim_range(s.as_bytes(), is_java_trim_byte);
-    &s[start..end]
+    let (trimmed, start) = trim_bytes(s.as_bytes(), is_java_trim_byte);
+    &s[start..start + trimmed.len()]
 }
 
-/// Byte offsets of `bytes` with every leading and trailing byte matching `trimmed` removed.
+/// `bytes` with every leading and trailing byte matching `trimmed` removed, plus the number of
+/// bytes removed from the front.
 ///
-/// Slicing a `&str` on the returned offsets cannot panic as long as `trimmed` only accepts ASCII
-/// bytes, since those never appear inside a multi-byte UTF-8 sequence.
+/// Written with slice patterns rather than indexing -- the same shape as `<[u8]>::trim_ascii` --
+/// so the scan compiles to a leaf with no bounds checks. These run per row in the cast kernels,
+/// and an indexed version measurably slows the integral casts down.
+///
+/// Slicing a `&str` on the returned offsets cannot panic as long as `trimmed` only accepts
+/// ASCII bytes, since those never appear inside a multi-byte UTF-8 sequence.
 #[inline]
-fn trim_range(bytes: &[u8], trimmed: fn(u8) -> bool) -> (usize, usize) {
+fn trim_bytes(bytes: &[u8], trimmed: impl Fn(u8) -> bool) -> (&[u8], usize) {
     let mut start = 0;
-    let mut end = bytes.len();
-    while start < end && trimmed(bytes[start]) {
+    let mut rest = bytes;
+    while let [first, tail @ ..] = rest {
+        if !trimmed(*first) {
+            break;
+        }
         start += 1;
+        rest = tail;
     }
-    while end > start && trimmed(bytes[end - 1]) {
-        end -= 1;
+    while let [head @ .., last] = rest {
+        if !trimmed(*last) {
+            break;
+        }
+        rest = head;
     }
-    (start, end)
+    (rest, start)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Every byte the `trimAll` regime trims, as derived from Java's `Character.isWhitespace`
-    /// and `Character.isISOControl` rather than from the implementation under test.
-    fn expected_trim_all_bytes() -> Vec<u8> {
-        (0..=u8::MAX)
-            .filter(|&b| {
-                let is_whitespace = matches!(b, 0x09..=0x0D | 0x1C..=0x1F | 0x20);
-                let is_iso_control = matches!(b, 0x00..=0x1F | 0x7F);
-                is_whitespace || is_iso_control
-            })
-            .collect()
-    }
-
     #[test]
-    fn trim_all_matches_spark_byte_set() {
+    fn trim_sets_match_spark() {
         for b in 0..=u8::MAX {
-            let expected = expected_trim_all_bytes().contains(&b);
+            // Derived from Java's `Character.isWhitespace` / `isISOControl` rather than from
+            // the implementation under test.
+            let is_whitespace = matches!(b, 0x09..=0x0D | 0x1C..=0x1F | 0x20);
+            let is_iso_control = matches!(b, 0x00..=0x1F | 0x7F);
             assert_eq!(
                 is_whitespace_or_iso_control(b),
-                expected,
-                "byte 0x{b:02X} classified incorrectly"
+                is_whitespace || is_iso_control,
+                "byte 0x{b:02X} classified incorrectly for the trimAll set"
             );
-        }
-    }
-
-    #[test]
-    fn java_trim_set_is_trim_all_without_delete() {
-        for b in 0..=u8::MAX {
-            assert_eq!(is_java_trim_byte(b), b <= 0x20, "byte 0x{b:02X}");
+            assert_eq!(
+                is_java_trim_byte(b),
+                b <= 0x20,
+                "byte 0x{b:02X} classified incorrectly for the String.trim set"
+            );
         }
         // The two regimes differ in exactly one byte: DELETE.
         let differing: Vec<u8> = (0..=u8::MAX)
             .filter(|&b| is_whitespace_or_iso_control(b) != is_java_trim_byte(b))
             .collect();
         assert_eq!(differing, vec![0x7F]);
-    }
-
-    /// `<[u8]>::trim_ascii` and `str::trim` are both wrong here; pin down how, so that a future
-    /// change back to either is caught.
-    #[test]
-    fn rust_builtins_disagree_with_spark() {
-        // trim_ascii omits the vertical tab, which Spark trims.
-        assert!(is_whitespace_or_iso_control(0x0B));
-        assert!(!0x0Bu8.is_ascii_whitespace());
-        // str::trim removes non-ASCII whitespace, which Spark never trims.
-        assert_eq!("\u{3000}1".trim(), "1");
-        assert_eq!(trim_all("\u{3000}1"), "\u{3000}1");
-        assert_eq!(trim_java_string("\u{3000}1"), "\u{3000}1");
+        // `<[u8]>::trim_ascii` omits the vertical tab, which is why it cannot be used here.
+        assert!(is_whitespace_or_iso_control(0x0B) && !0x0Bu8.is_ascii_whitespace());
     }
 
     #[test]
@@ -163,16 +161,10 @@ mod tests {
         // Interior bytes are never touched.
         assert_eq!(trim_all("1\u{0}2"), "1\u{0}2");
         assert_eq!(trim_java_string("1\u{0}2"), "1\u{0}2");
-    }
-
-    #[test]
-    fn delete_byte_is_trimmed_only_by_trim_all() {
+        // DELETE is trimmed by one regime only.
         assert_eq!(trim_all("\u{7f}123\u{7f}"), "123");
         assert_eq!(trim_java_string("\u{7f}123\u{7f}"), "\u{7f}123\u{7f}");
-    }
-
-    #[test]
-    fn all_whitespace_input_trims_to_empty() {
+        // All-whitespace and empty input trim to empty.
         assert_eq!(trim_all(" \t\u{7f}"), "");
         assert_eq!(trim_java_string(" \t\n"), "");
         assert_eq!(trim_all(""), "");
@@ -180,9 +172,25 @@ mod tests {
     }
 
     #[test]
-    fn multibyte_content_is_preserved() {
-        // A trailing multi-byte char must not be sliced into.
+    fn non_ascii_whitespace_is_preserved() {
+        // `str::trim` would strip U+3000 here; Spark never does. A trailing multi-byte char
+        // must also not be sliced into.
+        assert_eq!("\u{3000}1".trim(), "1");
         assert_eq!(trim_all(" \u{3000}\u{e9} "), "\u{3000}\u{e9}");
         assert_eq!(trim_java_string(" \u{3000}\u{e9} "), "\u{3000}\u{e9}");
+    }
+
+    #[test]
+    fn byte_and_range_helpers_agree_with_str_helper() {
+        for input in ["", " ", "\u{7f}\u{b}x\u{0}", "1 2", "\u{3000}x\u{3000}"] {
+            let bytes = input.as_bytes();
+            let (start, end) = trim_all_range(bytes);
+            assert_eq!(trim_all_bytes(bytes), &bytes[start..end], "{input:?}");
+            assert_eq!(
+                trim_all(input).as_bytes(),
+                trim_all_bytes(bytes),
+                "{input:?}"
+            );
+        }
     }
 }

--- a/spark/src/test/resources/sql-tests/expressions/cast/cast_string_trim.sql
+++ b/spark/src/test/resources/sql-tests/expressions/cast/cast_string_trim.sql
@@ -1,0 +1,69 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- ConfigMatrix: parquet.enable.dictionary=false,true
+
+-- Whitespace trimming in cast(string as <fixed type>). Spark has two trim regimes and neither
+-- trims non-ASCII whitespace, so DEL is trimmed for boolean/int/date but not for double/decimal,
+-- and NBSP / U+3000 are trimmed for nothing. See conversion_funcs::trim in the native crate and
+-- https://github.com/apache/datafusion-comet/issues/5149.
+--
+-- Per-codepoint parity across all three eval modes is covered by the CometCastSuite
+-- "whitespace trim parity" tests; this fixture covers the same regimes over a Parquet column.
+
+statement
+CREATE TABLE cast_trim_pad(name string, pad string) USING parquet
+
+-- The padding is materialized here rather than in the queries, so that the cast operands below
+-- stay inside expressions Comet runs natively.
+statement
+INSERT INTO cast_trim_pad VALUES
+  ('a_none', ''),
+  ('b_nul_0x00', chr(0)),
+  ('c_vtab_0x0b', chr(11)),
+  ('d_us_0x1f', chr(31)),
+  ('e_space_0x20', ' '),
+  ('f_del_0x7f', chr(127)),
+  ('g_nbsp_u00a0', decode(X'C2A0', 'utf-8')),
+  ('h_ideographic_u3000', decode(X'E38080', 'utf-8'))
+
+query
+SELECT
+  name,
+  cast(concat(pad, 'true', pad) as boolean),
+  cast(concat(pad, '12', pad) as tinyint),
+  cast(concat(pad, '12', pad) as smallint),
+  cast(concat(pad, '12', pad) as int),
+  cast(concat(pad, '12', pad) as bigint),
+  cast(concat(pad, '1.5', pad) as float),
+  cast(concat(pad, '1.5', pad) as double),
+  cast(concat(pad, '1.5', pad) as decimal(10,2)),
+  cast(concat(pad, '2020-01-01', pad) as date)
+FROM cast_trim_pad
+
+-- Padding on its own, and padding in the interior, must never parse
+query
+SELECT
+  name,
+  cast(pad as boolean),
+  cast(pad as int),
+  cast(pad as double),
+  cast(pad as decimal(10,2)),
+  cast(pad as date),
+  cast(concat('1', pad, '2') as int),
+  cast(concat('1', pad, '.5') as double)
+FROM cast_trim_pad

--- a/spark/src/test/resources/sql-tests/expressions/cast/cast_string_trim.sql
+++ b/spark/src/test/resources/sql-tests/expressions/cast/cast_string_trim.sql
@@ -29,7 +29,9 @@ statement
 CREATE TABLE cast_trim_pad(name string, pad string) USING parquet
 
 -- The padding is materialized here rather than in the queries, so that the cast operands below
--- stay inside expressions Comet runs natively.
+-- stay inside expressions Comet runs natively. The two multi-byte pads are spelled as casts of
+-- their UTF-8 bytes: `decode(bin, charset)` resolves to a RuntimeReplaceable on Spark 3.4 and
+-- 4.x, which is not foldable, and an inline table only accepts foldable expressions.
 statement
 INSERT INTO cast_trim_pad VALUES
   ('a_none', ''),
@@ -38,8 +40,8 @@ INSERT INTO cast_trim_pad VALUES
   ('d_us_0x1f', chr(31)),
   ('e_space_0x20', ' '),
   ('f_del_0x7f', chr(127)),
-  ('g_nbsp_u00a0', decode(X'C2A0', 'utf-8')),
-  ('h_ideographic_u3000', decode(X'E38080', 'utf-8'))
+  ('g_nbsp_u00a0', cast(X'C2A0' as string)),
+  ('h_ideographic_u3000', cast(X'E38080' as string))
 
 query
 SELECT

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -820,17 +820,12 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
    * Spark itself is the oracle here, so the expectations do not need to be spelled out. See
    * https://github.com/apache/datafusion-comet/issues/5149.
    */
-  private val trimPadding: Seq[String] = {
-    // trimmed by both regimes
-    val asciiControlAndSpace = (0x00 to 0x20).map(cp => cp.toChar.toString)
-    // DELETE: trimmed by the `trimAll` regime only
-    val delete = Seq(0x7f)
-    // whitespace to Unicode, but never trimmed by Spark
-    val nonAsciiWhitespace =
-      Seq(0x85, 0xa0, 0x1680, 0x2000, 0x2005, 0x200a, 0x2028, 0x2029, 0x202f, 0x205f, 0x3000)
-    asciiControlAndSpace ++ (delete ++ nonAsciiWhitespace).map(cp =>
-      new String(Character.toChars(cp)))
-  }
+  private val trimPadding: Seq[String] =
+    ((0x00 to 0x20) ++ // trimmed by both regimes
+      Seq(0x7f) ++ // DELETE: trimmed by the `trimAll` regime only
+      // whitespace to Unicode, but never trimmed by Spark
+      Seq(0x85, 0xa0, 0x1680, 0x2000, 0x2005, 0x200a, 0x2028, 0x2029, 0x202f, 0x205f, 0x3000))
+      .map(_.toChar.toString)
 
   /** `value` with each [[trimPadding]] entry in leading, trailing, both and interior position. */
   private def trimPaddedValues(value: String): Seq[String] =

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -812,13 +812,10 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   /**
-   * Padding used to check that Comet trims exactly the byte set that each Spark cast trims. Spark
-   * has two trim regimes and neither of them trims any non-ASCII whitespace:
-   *   - `UTF8String.trimAll` (bytes `0x00`-`0x20` and `0x7F`) for boolean, integral and datetime
-   *   - `java.lang.String.trim` (bytes `0x00`-`0x20` only) for float, double and decimal
-   *
-   * Spark itself is the oracle here, so the expectations do not need to be spelled out. See
-   * https://github.com/apache/datafusion-comet/issues/5149.
+   * Padding used to check that Comet trims exactly the byte set each Spark cast trims. See
+   * `conversion_funcs::trim` in the native crate for the two regimes and their cast targets, and
+   * https://github.com/apache/datafusion-comet/issues/5149. Spark itself is the oracle here, so
+   * the expectations do not need to be spelled out.
    */
   private val trimPadding: Seq[String] =
     ((0x00 to 0x20) ++ // trimmed by both regimes
@@ -827,10 +824,13 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       Seq(0x85, 0xa0, 0x1680, 0x2000, 0x2005, 0x200a, 0x2028, 0x2029, 0x202f, 0x205f, 0x3000))
       .map(_.toChar.toString)
 
-  /** `value` with each [[trimPadding]] entry in leading, trailing, both and interior position. */
+  /**
+   * `value` with each [[trimPadding]] entry in leading, trailing, both and interior position,
+   * plus the padding on its own and the empty string, which trim to nothing.
+   */
   private def trimPaddedValues(value: String): Seq[String] =
-    trimPadding.flatMap(pad =>
-      Seq(pad + value, value + pad, pad + value + pad, value.take(1) + pad + value.drop(1)))
+    "" +: trimPadding.flatMap(pad =>
+      Seq(pad + value, value + pad, pad + value + pad, value.take(1) + pad + value.drop(1), pad))
 
   test("cast StringType to BooleanType - whitespace trim parity") {
     castTest(trimPaddedValues("true").toDF("a"), DataTypes.BooleanType)

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -811,6 +811,48 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     castTest(testValues, DataTypes.BooleanType)
   }
 
+  /**
+   * Padding used to check that Comet trims exactly the byte set that each Spark cast trims. Spark
+   * has two trim regimes and neither of them trims any non-ASCII whitespace:
+   *   - `UTF8String.trimAll` (bytes `0x00`-`0x20` and `0x7F`) for boolean, integral and datetime
+   *   - `java.lang.String.trim` (bytes `0x00`-`0x20` only) for float, double and decimal
+   *
+   * Spark itself is the oracle here, so the expectations do not need to be spelled out. See
+   * https://github.com/apache/datafusion-comet/issues/5149.
+   */
+  private val trimPadding: Seq[String] = {
+    // trimmed by both regimes
+    val asciiControlAndSpace = (0x00 to 0x20).map(cp => cp.toChar.toString)
+    // DELETE: trimmed by the `trimAll` regime only
+    val delete = Seq(0x7f)
+    // whitespace to Unicode, but never trimmed by Spark
+    val nonAsciiWhitespace =
+      Seq(0x85, 0xa0, 0x1680, 0x2000, 0x2005, 0x200a, 0x2028, 0x2029, 0x202f, 0x205f, 0x3000)
+    asciiControlAndSpace ++ (delete ++ nonAsciiWhitespace).map(cp =>
+      new String(Character.toChars(cp)))
+  }
+
+  /** `value` with each [[trimPadding]] entry in leading, trailing, both and interior position. */
+  private def trimPaddedValues(value: String): Seq[String] =
+    trimPadding.flatMap(pad =>
+      Seq(pad + value, value + pad, pad + value + pad, value.take(1) + pad + value.drop(1)))
+
+  test("cast StringType to BooleanType - whitespace trim parity") {
+    castTest(trimPaddedValues("true").toDF("a"), DataTypes.BooleanType)
+  }
+
+  test("cast StringType to integral types - whitespace trim parity") {
+    val values = trimPaddedValues("12").toDF("a")
+    Seq(DataTypes.ByteType, DataTypes.ShortType, DataTypes.IntegerType, DataTypes.LongType)
+      .foreach(castTest(values, _))
+  }
+
+  test("cast StringType to floating point and decimal types - whitespace trim parity") {
+    val values = trimPaddedValues("1.5").toDF("a")
+    Seq(DataTypes.FloatType, DataTypes.DoubleType, DataTypes.createDecimalType(10, 2))
+      .foreach(castTest(values, _))
+  }
+
   private val castStringToIntegralInputs: Seq[String] = Seq(
     "",
     ".",


### PR DESCRIPTION
## Which issue does this PR close?

Part of #5149. This PR covers the first five subtasks of that epic; the timestamp targets and the latent `to_time.rs` trim are left for follow-ups.

## Rationale for this change

Comet's cast-from-string kernels used four different trim sets, three of which diverge from Spark. Spark has exactly two trim regimes, and neither of them trims any non-ASCII whitespace:

| Regime | Trimmed bytes | Cast targets |
| --- | --- | --- |
| `UTF8String.trimAll` | `0x00`-`0x20` and `0x7F` | boolean, byte, short, int, long, date, timestamp, timestamp_ntz |
| `java.lang.String.trim` | `0x00`-`0x20` | float, double, decimal |

Every affected cast is `Compatible()` in `CometCast.canCastFromString`, so all of them run natively by default. The divergence went in both directions: spurious failures where Spark parses fine, and silent wrong results (with the ANSI error swallowed) where Spark returns `NULL` or raises.

```sql
-- before this PR
SELECT CAST(concat(char(1), 'true') AS boolean);  -- Spark: true,  Comet: NULL (throws under ANSI)
SELECT CAST(concat(char(1), '123')  AS int);      -- Spark: 123,   Comet: NULL (throws under ANSI)
SELECT CAST(concat('　', 'true') AS boolean);     -- Spark: NULL,  Comet: true
SELECT CAST(concat('　', '1.5')  AS double);      -- Spark: NULL,  Comet: 1.5
```

## What changes are included in this PR?

- New `native/spark-expr/src/conversion_funcs/trim.rs` with the two regimes as explicit, documented helpers (`trim_all` / `trim_all_bytes` and `trim_java_string`), unit-tested against the byte sets themselves rather than against cast results.
- `CAST(string AS boolean)` uses the `trimAll` set. The keyword comparison is now allocation-free (`eq_ignore_ascii_case`) instead of `to_ascii_lowercase()` per row.
- `CAST(string AS byte/short/int/long)` uses the `trimAll` set in all three eval modes. `<[u8]>::trim_ascii` was excluding `0x0B`, which Spark trims.
- `CAST(string AS float/double)` and `CAST(string AS decimal)` use the `String.trim` set, leaving `0x7F` untrimmed and preserving the existing NUL handling (NUL is in that set).
- `date_parser` was already correct; it now shares the predicate instead of recomputing it, so there is one definition of the `trimAll` set.
- Docs: the compatibility page documents both regimes; the boolean entry in the known-divergences list is replaced by an entry for the remaining timestamp divergence.

Not in this PR (tracked on #5149): `CAST(string AS timestamp)` / `timestamp_ntz`, including `timestamp_parser`'s Spark-4 leading-whitespace gate, and the latent `to_time.rs` trim.

## How are these changes tested?

- Rust: the trim helpers are tested byte-by-byte against Java's `Character.isWhitespace`/`isISOControl` definitions, plus a parity matrix (leading / trailing / both / interior position × all three eval modes) for every fixed cast target. Reverting any one of the four kernel changes fails the corresponding matrix test.
- Scala: three new `CometCastSuite` tests run the same codepoint matrix through `castTest`, so real Spark is the oracle for values, `NULL`s and ANSI error messages.
- Full `CometCastSuite` and the `cast` SQL-file tests pass on Spark 3.5.
