### PR TITLE
fix: [branch-1.0] seed native Parquet scan reader options from session config (#5107)

### DIFF
--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -576,6 +576,20 @@ fn prepare_datafusion_session_context(
             &ScalarValue::Float64(Some(1.1)),
         );
 
+    // Translate the Comet-namespaced row-level pushdown flag into the equivalent
+    // DataFusion session options. `pushdown_filters` enables the parquet reader's
+    // RowFilter evaluation during decode (late materialization); `reorder_filters`
+    // is only meaningful when pushdown_filters is on, so they move together. Set
+    // before the `spark.comet.datafusion.*` testing escape hatch pass-through below,
+    // so an explicit override of either key wins instead of being silently forced
+    // back to `true`.
+    if spark_config.get_bool(COMET_PARQUET_ROW_FILTER_PUSHDOWN_ENABLED) {
+        session_config =
+            session_config.set_str("datafusion.execution.parquet.pushdown_filters", "true");
+        session_config =
+            session_config.set_str("datafusion.execution.parquet.reorder_filters", "true");
+    }
+
     // Pass through DataFusion configs from Spark.
     // e.g: spark-shell --conf spark.comet.datafusion.sql_parser.parse_float_as_decimal=true
     // becomes datafusion.sql_parser.parse_float_as_decimal=true
@@ -585,16 +599,6 @@ fn prepare_datafusion_session_context(
             let df_key = format!("datafusion.{df_key}");
             session_config = session_config.set_str(&df_key, value);
         }
-    }
-
-    // Translate the Comet-namespaced row-level pushdown flag into the equivalent
-    // DataFusion session options. `pushdown_filters` enables the parquet reader's
-    // RowFilter evaluation during decode (late materialization); `reorder_filters`
-    // is only meaningful when pushdown_filters is on, so they move together.
-    if spark_config.get_bool(COMET_PARQUET_ROW_FILTER_PUSHDOWN_ENABLED) {
-        session_config = session_config
-            .set_str("datafusion.execution.parquet.pushdown_filters", "true")
-            .set_str("datafusion.execution.parquet.reorder_filters", "true");
     }
 
     let runtime = rt_config.build()?;

--- a/native/core/src/parquet/parquet_exec.rs
+++ b/native/core/src/parquet/parquet_exec.rs
@@ -21,7 +21,7 @@ use crate::parquet::encryption_support::{CometEncryptionConfig, ENCRYPTION_FACTO
 use crate::parquet::parquet_support::SparkParquetOptions;
 use crate::parquet::schema_adapter::SparkPhysicalExprAdapterFactory;
 use arrow::datatypes::{Field, SchemaRef};
-use datafusion::config::TableParquetOptions;
+use datafusion::config::{ParquetOptions, TableParquetOptions};
 use datafusion::datasource::listing::PartitionedFile;
 use datafusion::datasource::physical_plan::{
     FileGroup, FileScanConfigBuilder, FileSource, ParquetSource,
@@ -76,6 +76,11 @@ pub(crate) fn init_datasource_exec(
     use_field_id: bool,
     ignore_missing_field_id: bool,
 ) -> Result<Arc<DataSourceExec>, ExecutionError> {
+    // Computed once and reused below for `try_pushdown_filters`. `copied_config()` clones only
+    // `SessionConfig` (an `Arc<ConfigOptions>` plus a small extensions map); `SessionContext::
+    // state()` would clone the whole `SessionState`, including the function registries (~250+
+    // UDFs) and optimizer rules, on every scan init.
+    let session_config = session_ctx.copied_config();
     let (table_parquet_options, mut spark_parquet_options) = get_options(
         session_timezone,
         case_sensitive,
@@ -84,6 +89,7 @@ pub(crate) fn init_datasource_exec(
         allow_timestamp_ltz_to_ntz,
         &object_store_url,
         encryption_enabled,
+        &session_config.options().execution.parquet,
     );
     spark_parquet_options.use_field_id = use_field_id;
     spark_parquet_options.ignore_missing_field_id = ignore_missing_field_id;
@@ -175,9 +181,8 @@ pub(crate) fn init_datasource_exec(
     // correct without us inserting a FilterExec here.
     let file_source: Arc<dyn FileSource> = match data_filters {
         Some(filters) if !filters.is_empty() => {
-            let state = session_ctx.state();
             let propagation =
-                parquet_source.try_pushdown_filters(filters, state.config_options())?;
+                parquet_source.try_pushdown_filters(filters, session_config.options())?;
             // `updated_node` is `None` when every filter classified as `No`
             // (nothing pushable); keep the unmodified source in that case.
             propagation
@@ -212,6 +217,7 @@ pub(crate) fn init_datasource_exec(
     Ok(data_source_exec)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn get_options(
     session_timezone: &str,
     case_sensitive: bool,
@@ -220,8 +226,41 @@ fn get_options(
     allow_timestamp_ltz_to_ntz: bool,
     object_store_url: &ObjectStoreUrl,
     encryption_enabled: bool,
+    session_parquet_options: &ParquetOptions,
 ) -> (TableParquetOptions, SparkParquetOptions) {
     let mut table_parquet_options = TableParquetOptions::new();
+
+    // Reader options that reach `ParquetSource`'s actual per-file execution path
+    // (`ParquetMorselizer`, built from `table_parquet_options.global`) rather than only
+    // `ParquetFormat::infer_schema`'s schema-inference path, which Comet never calls (Comet
+    // always supplies its own schema, translated from Spark's catalog). Seeded from the
+    // session so `spark.comet.datafusion.execution.parquet.*` (behind
+    // `spark.comet.exec.respectDataFusionConfigs`) and `spark.comet.parquet.
+    // rowFilterPushdown.enabled` actually take effect on the native scan (#4990); a fresh
+    // `TableParquetOptions::new()` ignored the session entirely.
+    //
+    // Deliberately an allowlist, not `table_parquet_options.global = session_parquet_options.
+    // clone()`: a new DataFusion reader option should be silently ignored here until someone
+    // checks whether it is safe to pass through for Spark semantics (as `coerce_int96`/
+    // `coerce_int96_tz` below are not), not silently active. Recheck this list against
+    // `ParquetOptions` whenever the DataFusion dependency version changes.
+    table_parquet_options.global.pushdown_filters = session_parquet_options.pushdown_filters;
+    table_parquet_options.global.reorder_filters = session_parquet_options.reorder_filters;
+    table_parquet_options.global.force_filter_selections =
+        session_parquet_options.force_filter_selections;
+    table_parquet_options.global.bloom_filter_on_read =
+        session_parquet_options.bloom_filter_on_read;
+    table_parquet_options.global.max_predicate_cache_size =
+        session_parquet_options.max_predicate_cache_size;
+    // Only gates whether the page index is used for row-group/page pruning
+    // (datafusion's `enable_page_index` check around `page_pruning_predicate`). It does not
+    // stop the index from being fetched: `EagerPageIndexReaderFactory` always forces
+    // `PageIndexPolicy::Optional` on unencrypted files regardless of the requested policy, so
+    // disabling this reduces pruning, not read I/O.
+    table_parquet_options.global.enable_page_index = session_parquet_options.enable_page_index;
+    table_parquet_options.global.pruning = session_parquet_options.pruning;
+
+    // Hardcoded for Spark compatibility, not session-overridable.
     table_parquet_options.global.coerce_int96 = Some("us".to_string());
     // INT96 columns encode UTC-adjusted instants; attaching the UTC timezone
     // preserves that signal at the Arrow level so the schema adapter can
@@ -262,6 +301,51 @@ mod tests {
     use parquet::arrow::ArrowWriter;
     use parquet::file::properties::{EnabledStatistics, WriterProperties};
     use std::fs::File;
+
+    // Regression test for #4990: a fresh `TableParquetOptions::new()` ignored session-level
+    // `datafusion.execution.parquet.*` settings entirely, so `spark.comet.datafusion.
+    // execution.parquet.*` (behind `respectDataFusionConfigs`) and `spark.comet.parquet.
+    // rowFilterPushdown.enabled` had no effect on the native scan.
+    #[test]
+    fn seeds_allowlisted_fields_from_session_but_protects_spark_compat_fields() {
+        let session_parquet_options = ParquetOptions {
+            pushdown_filters: true,
+            reorder_filters: true,
+            force_filter_selections: true,
+            bloom_filter_on_read: false,
+            max_predicate_cache_size: Some(0),
+            enable_page_index: false,
+            pruning: false,
+            // An escape-hatch attempt to override Spark-compat fields; must not take effect.
+            coerce_int96: None,
+            coerce_int96_tz: None,
+            ..Default::default()
+        };
+
+        let (table_parquet_options, _) = get_options(
+            "UTC",
+            true,
+            false,
+            false,
+            false,
+            &ObjectStoreUrl::local_filesystem(),
+            false,
+            &session_parquet_options,
+        );
+
+        let global = &table_parquet_options.global;
+        assert!(global.pushdown_filters);
+        assert!(global.reorder_filters);
+        assert!(global.force_filter_selections);
+        assert!(!global.bloom_filter_on_read);
+        assert_eq!(global.max_predicate_cache_size, Some(0));
+        assert!(!global.enable_page_index);
+        assert!(!global.pruning);
+
+        // Spark-compat fields stay hardcoded regardless of the session.
+        assert_eq!(global.coerce_int96, Some("us".to_string()));
+        assert_eq!(global.coerce_int96_tz, Some("UTC".to_string()));
+    }
 
     // Regression test for #3978: DataFusion's opener requests `PageIndexPolicy::Skip` on the
     // initial metadata load and only loads the page index later, on demand, when row-group

--- a/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
@@ -829,6 +829,78 @@ class CometNativeReaderSuite extends CometTestBase with AdaptiveSparkPlanHelper 
     }
   }
 
+  test("row-level pushdown reaches native scan when rowFilterPushdown.enabled is set") {
+    // Regression test for #4990: `table_parquet_options.global` never saw session-level
+    // `datafusion.execution.parquet.*` settings, so `pushdown_filters`/`reorder_filters` set via
+    // `spark.comet.parquet.rowFilterPushdown.enabled` never reached the reader even though the
+    // flag was translated into the DataFusion session config.
+    withTempPath { dir =>
+      spark
+        .range(0, 1000)
+        .toDF("c1")
+        .repartition(1)
+        .write
+        .format("parquet")
+        .save(dir.toString)
+
+      def rowLevelPushdownMetrics(): (Long, Long) = {
+        val df = spark.read.parquet(dir.toString).where("c1 > 500")
+        val (_, cometPlan) = checkSparkAnswerAndOperator(df)
+        val nativeScans = cometPlan.collect { case n: CometNativeScanExec => n }
+        assert(nativeScans.nonEmpty, "Expected a CometNativeScanExec")
+        val metrics = nativeScans.head.metrics
+        (metrics("pushdown_rows_pruned").value, metrics("pushdown_rows_matched").value)
+      }
+
+      // Default: rowFilterPushdown.enabled is false, so no per-row RowFilter evaluation
+      // happens at the scan; CometFilter above the scan does the row-level reduction instead.
+      val (prunedDefault, matchedDefault) = rowLevelPushdownMetrics()
+      assert(
+        prunedDefault == 0 && matchedDefault == 0,
+        "Expected no row-level pushdown by default, got " +
+          s"pruned=$prunedDefault matched=$matchedDefault")
+
+      withSQLConf(CometConf.COMET_PARQUET_ROW_FILTER_PUSHDOWN_ENABLED.key -> "true") {
+        val (pruned, matched) = rowLevelPushdownMetrics()
+        assert(
+          pruned + matched > 0,
+          "Expected row-level pushdown to fire once rowFilterPushdown.enabled is set")
+      }
+    }
+  }
+
+  test("datafusion escape hatch override wins over rowFilterPushdown.enabled") {
+    // Regression test for the precedence fix: an explicit `spark.comet.datafusion.
+    // execution.parquet.pushdown_filters=false` (behind respectDataFusionConfigs) must not be
+    // silently forced back to `true` by rowFilterPushdown.enabled.
+    withTempPath { dir =>
+      spark
+        .range(0, 1000)
+        .toDF("c1")
+        .repartition(1)
+        .write
+        .format("parquet")
+        .save(dir.toString)
+
+      withSQLConf(
+        CometConf.COMET_PARQUET_ROW_FILTER_PUSHDOWN_ENABLED.key -> "true",
+        CometConf.COMET_RESPECT_DATAFUSION_CONFIGS.key -> "true",
+        "spark.comet.datafusion.execution.parquet.pushdown_filters" -> "false") {
+        val df = spark.read.parquet(dir.toString).where("c1 > 500")
+        val (_, cometPlan) = checkSparkAnswerAndOperator(df)
+        val nativeScans = cometPlan.collect { case n: CometNativeScanExec => n }
+        assert(nativeScans.nonEmpty, "Expected a CometNativeScanExec")
+        val metrics = nativeScans.head.metrics
+        val pruned = metrics("pushdown_rows_pruned").value
+        val matched = metrics("pushdown_rows_matched").value
+        assert(
+          pruned == 0 && matched == 0,
+          "Expected the explicit pushdown_filters=false override to win over " +
+            s"rowFilterPushdown.enabled, got pruned=$pruned matched=$matched")
+      }
+    }
+  }
+
   test("row-group statistics pruning fires for native Parquet scan dataFilters") {
     // Regression test for the identity-cast pruning gap. DataFusion's default
     // PhysicalExprAdapter inserts a CastExpr around Column refs whenever the logical
@@ -874,6 +946,54 @@ class CometNativeReaderSuite extends CometTestBase with AdaptiveSparkPlanHelper 
           pruned > 0,
           "Row-group statistics pruning did not fire " +
             s"(pruned=$pruned, matched=$matched of $numRowGroups total)")
+      }
+    }
+  }
+
+  test("datafusion escape hatch pruning=false disables row-group statistics pruning") {
+    // Regression test pinning the `pruning` field of the newly-plumbed session
+    // `ParquetOptions` at the level users care about: an explicit
+    // `spark.comet.datafusion.execution.parquet.pruning=false` must actually turn off
+    // row-group statistics pruning at the native scan, not just be copied into
+    // `get_options()`'s output.
+    withTempPath { dir =>
+      withSQLConf(SQLConf.LEAF_NODE_DEFAULT_PARALLELISM.key -> "1") {
+        spark
+          .range(0, 1000)
+          .toDF("c1")
+          .repartition(1)
+          .write
+          .option("parquet.block.size", "1024")
+          .format("parquet")
+          .save(dir.toString)
+
+        val parquetFile = dir
+          .listFiles()
+          .find(_.getName.endsWith(".parquet"))
+          .getOrElse(fail("No parquet file was written"))
+        val reader = ParquetFileReader.open(
+          org.apache.parquet.hadoop.util.HadoopInputFile
+            .fromPath(new Path(parquetFile.getAbsolutePath), spark.sessionState.newHadoopConf()))
+        val numRowGroups =
+          try reader.getRowGroups.size()
+          finally reader.close()
+        assert(numRowGroups > 1, s"Test setup needs >1 row groups, got $numRowGroups")
+
+        withSQLConf(
+          CometConf.COMET_RESPECT_DATAFUSION_CONFIGS.key -> "true",
+          "spark.comet.datafusion.execution.parquet.pruning" -> "false") {
+          val df = spark.read.parquet(dir.toString).where("c1 > 500")
+          val (_, cometPlan) = checkSparkAnswerAndOperator(df)
+          val nativeScans = cometPlan.collect { case n: CometNativeScanExec => n }
+          assert(nativeScans.nonEmpty, "Expected a CometNativeScanExec")
+          val metrics = nativeScans.head.metrics
+          val pruned = metrics("row_groups_pruned_statistics").value
+          val matched = metrics("row_groups_matched_statistics").value
+          assert(
+            pruned == 0 && matched == numRowGroups,
+            "Expected the explicit pruning=false override to disable row-group statistics " +
+              s"pruning, got pruned=$pruned matched=$matched of $numRowGroups total")
+        }
       }
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?

Backport of #5107 (merged to `main` as `0b2a50608`) onto `branch-1.0`. Closes #4990 for the 1.0.0 release branch.

## Rationale for this change

Comet's native Parquet scan built a fresh `TableParquetOptions::new()` per scan and never looked at the session's `datafusion.execution.parquet.*` config. `pushdown_filters` appeared to work only because `ParquetSource::try_pushdown_filters` happens to OR the session value in independently; every other reader option (`reorder_filters`, `force_filter_selections`, `bloom_filter_on_read`, `max_predicate_cache_size`, `enable_page_index`, `pruning`) was silently inert, including when driven by `spark.comet.parquet.rowFilterPushdown.enabled`.

That means `spark.comet.parquet.rowFilterPushdown.enabled` — a user-facing config on `branch-1.0` — does not actually enable row-level pushdown at the native scan, and the `spark.comet.datafusion.execution.parquet.*` escape hatch (behind `spark.comet.exec.respectDataFusionConfigs`) is inert for every reader option. Worth carrying into 1.0.0 rather than shipping configs that silently do nothing.

Fixing this also exposed a precedence bug: the `rowFilterPushdown.enabled` flag unconditionally overwrote the raw `spark.comet.datafusion.execution.parquet.{pushdown_filters,reorder_filters}` escape hatch, even when a developer set those keys explicitly for testing.

## What changes are included in this PR?

A clean `git cherry-pick -x` of `0b2a50608`. No conflicts and no adaptation was needed — `git diff` against the commit on `main` is byte-identical.

- `native/core/src/parquet/parquet_exec.rs`: `get_options()` now takes the session's `ParquetOptions` and seeds `table_parquet_options.global` for the fields confirmed to reach `ParquetSource`'s actual per-file execution path (`pushdown_filters`, `reorder_filters`, `force_filter_selections`, `bloom_filter_on_read`, `max_predicate_cache_size`, `enable_page_index`, `pruning`). Deliberately an allowlist rather than a wholesale `global = session.clone()`, so a new DataFusion reader option is ignored until someone checks it is safe for Spark semantics. `coerce_int96`/`coerce_int96_tz` stay hardcoded afterward, non-overridable, for Spark INT96 compatibility.
- Not wired up: `schema_force_view_types`, `binary_as_string`, `skip_metadata`, `global.metadata_size_hint`. All four are only consumed by `ParquetFormat::infer_schema`, which Comet's scan construction never calls (Comet always supplies its own schema translated from Spark's catalog), so seeding them would be a no-op.
- `init_datasource_exec` now computes `session_ctx.copied_config()` once and reuses it for both `get_options()` and `try_pushdown_filters`, instead of calling `session_ctx.state()` — which clones the whole `SessionState`, including the function registries and optimizer rules — on every scan init.
- `native/core/src/execution/jni_api.rs`: the `rowFilterPushdown.enabled` translation moves to *before* the `spark.comet.datafusion.*` pass-through loop, so an explicit override of `pushdown_filters`/`reorder_filters` wins instead of being silently forced back to `true`.

## How are these changes tested?

By the tests added in #5107, verified on this branch:

- `cargo test -p datafusion-comet --lib parquet_exec` — 2 passed, including the new `seeds_allowlisted_fields_from_session_but_protects_spark_compat_fields`, which asserts `get_options()` carries the allowlisted fields through from the session while keeping `coerce_int96`/`coerce_int96_tz` hardcoded.
- `CometNativeReaderSuite` under `-Pspark-3.5` — 54 passed, 2 canceled (pre-existing version-gated cancellations). Includes the three new tests: row-level pushdown only fires at the native scan once `rowFilterPushdown.enabled` is set (the core #4990 regression), an explicit `pushdown_filters=false` override wins over that flag, and an explicit `pruning=false` override actually disables row-group statistics pruning.
- `cargo clippy --all-targets --workspace -- -D warnings` — clean.

JDK 11 locally, hence `-Pspark-3.5`; the Spark 4.x lanes are left to CI.
