### PR TITLE
fix: reduce log verbosity at per-task logging callsites

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -293,7 +293,7 @@ object CometExecIterator extends Logging {
       val memoryLimit = (offHeapSize * memoryFraction).toLong
       val memoryLimitPerTask = (memoryLimit.toDouble * coresPerTask / numCores).toLong
       val memoryPoolType = COMET_OFFHEAP_MEMORY_POOL_TYPE.get()
-      logInfo(
+      logDebug(
         s"memoryPoolType=$memoryPoolType, " +
           s"offHeapSize=${toMB(offHeapSize)}, " +
           s"memoryFraction=$memoryFraction, " +
@@ -308,7 +308,7 @@ object CometExecIterator extends Logging {
       // in memory_limit_per_task = 16 GB * 4 / 16 = 16 GB / 4 = 4GB
       val memoryLimitPerTask = (memoryLimit.toDouble * coresPerTask / numCores).toLong
       val memoryPoolType = COMET_ONHEAP_MEMORY_POOL_TYPE.get()
-      logInfo(
+      logDebug(
         s"memoryPoolType=$memoryPoolType, " +
           s"memoryLimit=${toMB(memoryLimit)}, " +
           s"memoryLimitPerTask=${toMB(memoryLimitPerTask)}")

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeWriteExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeWriteExec.scala
@@ -289,7 +289,7 @@ case class CometNativeWriteExec(
                   // Commit the task and add message to accumulator
                   val message = committer.commitTask(ctx)
                   capturedAccumulator.add(message)
-                  logInfo(s"Task ${ctx.getTaskAttemptID} committed successfully")
+                  logDebug(s"Task ${ctx.getTaskAttemptID} committed successfully")
                 } else {
                   // Abort the task
                   committer.abortTask(ctx)


### PR DESCRIPTION
## Which issue does this PR close?

Part of #4082.

## Rationale for this change

Ahead of the 1.0 release, Comet's logging should be consistent with Spark's own conventions: informational messages that fire once per query or plan node are fine at INFO, but messages that fire once per task should not be, since they scale with partition count and can produce an unreasonable number of log lines for large jobs. Spark's `FileFormatWriter.executeTask` has no equivalent per-task success log, only a `logError` on abort, so Comet's per-task INFO logs are out of step with that convention.

## What changes are included in this PR?

- `CometExecIterator.getMemoryConfig` logged the computed memory pool configuration at INFO on every task (it runs once per `CometExecIterator` construction, i.e. once per native-exec task per stage). Changed to `logDebug`.
- `CometNativeWriteExec` logged `"Task ... committed successfully"` at INFO for every successful write task. Changed to `logDebug` to match Spark's `FileFormatWriter`, which stays silent on task-commit success.

## How are these changes tested?

No behavior change, only log levels. Existing test suite covers the surrounding code paths.
