### PR TITLE
chore: remove Array -> Seq round trips flagged by the 2.13 copy deprecation

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometLocalTableScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometLocalTableScanExec.scala
@@ -51,12 +51,12 @@ case class CometLocalTableScanExec(
   override lazy val metrics: Map[String, SQLMetric] = Map(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
 
-  @transient private lazy val unsafeRows: Array[InternalRow] = {
+  @transient private lazy val unsafeRows: IndexedSeq[InternalRow] = {
     if (rows.isEmpty) {
-      Array.empty
+      IndexedSeq.empty
     } else {
       val proj = UnsafeProjection.create(output, output)
-      rows.map(r => proj(r).copy()).toArray
+      rows.iterator.map(r => proj(r).copy()).toIndexedSeq
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometScanExec.scala
@@ -92,13 +92,15 @@ case class CometScanExec(
     val optimizerMetadataTimeNs = relation.location.metadataOpsTimeNs.getOrElse(0L)
     val startTime = System.nanoTime()
     val ret =
-      relation.location.listFiles(partitionFilters.filterNot(isDynamicPruningFilter), dataFilters)
+      relation.location
+        .listFiles(partitionFilters.filterNot(isDynamicPruningFilter), dataFilters)
+        .toArray
     setFilesNumAndSizeMetric(ret, true)
     val timeTakenMs =
       NANOSECONDS.toMillis((System.nanoTime() - startTime) + optimizerMetadataTimeNs)
     driverMetrics("metadataTime") = timeTakenMs
     ret
-  }.toArray
+  }
 
   // We can only determine the actual partitions at runtime when a dynamic partition filter is
   // present. This is because such a filter relies on information that is only available at run
@@ -214,7 +216,7 @@ case class CometScanExec(
 
   /** Helper for computing total number and size of files in selected partitions. */
   private def setFilesNumAndSizeMetric(
-      partitions: Seq[PartitionDirectory],
+      partitions: Array[PartitionDirectory],
       static: Boolean): Unit = {
     val filesNum = partitions.map(_.files.size.toLong).sum
     val filesSize = partitions.map(_.files.map(_.getLen).sum).sum
@@ -331,9 +333,13 @@ case class CometScanExec(
   private def createFilePartitionsForNonBucketedScan(
       selectedPartitions: Array[PartitionDirectory],
       fsRelation: HadoopFsRelation): Seq[FilePartition] = {
+    // FilePartition.maxSplitBytes and FilePartition.getFilePartitions both take a Seq and only
+    // read from it, so the partition array is converted once here and splitFiles below is built
+    // as a Seq.
+    val partitions = selectedPartitions.toSeq
     val openCostInBytes = fsRelation.sparkSession.sessionState.conf.filesOpenCostInBytes
     val maxSplitBytes =
-      FilePartition.maxSplitBytes(fsRelation.sparkSession, selectedPartitions)
+      FilePartition.maxSplitBytes(fsRelation.sparkSession, partitions)
     logInfo(
       s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
         s"open cost is considered as scanning $openCostInBytes bytes.")
@@ -348,7 +354,7 @@ case class CometScanExec(
         _ => true
     }
 
-    val splitFiles = selectedPartitions
+    val splitFiles = partitions
       .flatMap { partition =>
         partition.files.flatMap { file =>
           // getPath() is very expensive so we only want to call it once in this block:

--- a/spark/src/main/scala/org/apache/spark/sql/comet/util/Utils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/util/Utils.scala
@@ -58,7 +58,7 @@ object Utils extends CometTypeShim with Logging {
   }
 
   def stringToSeq(str: String): Seq[String] = {
-    str.split(",").map(_.trim()).filter(_.nonEmpty)
+    str.split(",").iterator.map(_.trim()).filter(_.nonEmpty).toList
   }
 
   /** bridges the function call to Spark's Util */

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -118,11 +118,11 @@ abstract class CometTestBase
       excludedClasses: Seq[Class[_]] = Seq.empty,
       withTol: Option[Double] = None): (SparkPlan, SparkPlan) = {
 
-    var expected: Array[Row] = Array.empty
+    var expected: Seq[Row] = Seq.empty
     var sparkPlan = null.asInstanceOf[SparkPlan]
     withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
       val dfSpark = datasetOfRows(spark, df.logicalPlan)
-      expected = dfSpark.collect()
+      expected = dfSpark.collect().toSeq
       sparkPlan = dfSpark.queryExecution.executedPlan
     }
     val dfComet = datasetOfRows(spark, df.logicalPlan)

--- a/spark/src/test/scala/org/apache/spark/sql/Tables.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/Tables.scala
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.expressions.GenericRow
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 
@@ -72,7 +73,7 @@ abstract class Tables(
       val rows = generatedData.mapPartitions { iter =>
         iter.map { l =>
           if (convertToSchema) {
-            val values = l.split("\\|", -1).dropRight(1).map { v =>
+            val values: Array[Any] = l.split("\\|", -1).dropRight(1).map { v =>
               if (v.equals("")) {
                 // If the string value is an empty string, we turn it to a null
                 null
@@ -80,7 +81,9 @@ abstract class Tables(
                 v
               }
             }
-            Row.fromSeq(values)
+            // Row.fromSeq copies its argument into a new array; GenericRow, which is what it
+            // wraps the values in, takes the array as-is.
+            new GenericRow(values)
           } else {
             Row.fromSeq(Seq(l))
           }
@@ -94,7 +97,9 @@ abstract class Tables(
             StructType(schema.fields.map(f => StructField(f.name, StringType))))
 
         val convertedData = {
-          val columns = schema.fields.map { f =>
+          // StructType is itself a Seq[StructField], so mapping it yields a Seq[Column] that can
+          // be splatted directly.
+          val columns = schema.map { f =>
             col(f.name).cast(f.dataType).as(f.name)
           }
           stringData.select(columns: _*)


### PR DESCRIPTION
## Which issue does this PR close?

No issue filed — mechanical compiler-warning cleanup, split out of #5141.

## Rationale for this change

Scala 2.13 deprecates the implicit `Array` → `immutable.IndexedSeq` conversion because it silently copies. Comet triggers it at 8 sites, plus one related *"passing an explicit array value to a Scala varargs method"* deprecation, for **9 of the 127 warnings** under the 2.13 profiles.

The compiler suggests `.toIndexedSeq`. That is a no-op change: the deprecated implicit is defined as

```scala
implicit def copyArrayToImmutableIndexedSeq[T](xs: Array[T]): IndexedSeq[T] =
  if (xs eq null) null
  else new ArrayOps(xs).toIndexedSeq
```

so `.toIndexedSeq` performs exactly the copy that is already happening — it just makes it visible. (The only behavioral difference is `null`: the implicit yields a `null` Seq, the explicit call NPEs. None of these nine arrays can be `null`.) So the copies are all *correct* today; the question is whether they are *needed*.

At 7 of the 9 sites they are not — an `Array` is materialized and then immediately has to become a `Seq` again, so this PR removes the round trip rather than annotating it.

## What changes are included in this PR?

**Round trips removed (7 sites):**

- `CometLocalTableScanExec.unsafeRows` is built as an `IndexedSeq` instead of an `Array`, since its only consumers are `.length` and `SparkContext.parallelize`, which needs a `Seq`. Drops one copy of the projected rows.
- `CometScanExec.setFilesNumAndSizeMetric` is private to Comet and only sums file counts/sizes, so it now takes an `Array[PartitionDirectory]` and `selectedPartitions` converts the `listFiles` result once (the `.toArray` moves from the end of the block onto the `listFiles` call). Same number of copies as before, two fewer conversions.
- `Utils.stringToSeq` splits, trims and filters through an iterator, so the two intermediate arrays are gone.
- `CometTestBase.internalCheckSparkAnswer` holds the collected rows as a `Seq[Row]`, which is what both `checkAnswerWithTolerance` and `checkCometAnswer` take.
- `Tables.df` hands its per-row values array directly to `GenericRow` — which is what `Row.fromSeq` wraps it in anyway — removing two array copies per generated row on the TPC-H/TPC-DS data generation path. It also maps over the `StructType` (itself a `Seq[StructField]`) rather than over `schema.fields`, which is what removes the varargs warning.

**Copies kept (2 sites):** `FilePartition.maxSplitBytes` and `FilePartition.getFilePartitions` are Spark APIs that take a `Seq` and only read from it. `createFilePartitionsForNonBucketedScan` converts the (small) partition array once with `.toSeq` and uses that for both — which also means `splitFiles`, the much larger collection, is built as a `Seq` and never copied. `.toSeq` rather than `.toIndexedSeq` because on 2.12 `Array.toSeq` wraps instead of copying, and neither form is deprecated.

### Alternatives considered

- **`ArraySeq.unsafeWrapArray`**, which the deprecation message recommends: `scala.collection.immutable.ArraySeq` does not exist in 2.12, so this would not cross-build.
- **Spark's `.toImmutableArraySeq`** (`org.apache.spark.util.ArrayImplicits`), which is how Spark itself fixed these: only present in Spark 4.x — I checked the 3.4.3 and 3.5.8 jars and the class is absent — so it would need a shim to save a planning-time copy.
- **Retyping `CometScanExec.selectedPartitions` to `Seq[PartitionDirectory]`**, which would eliminate all three conversions in that file: rejected because the bucketed path feeds `FilePartition(bucketId, files: Array[PartitionedFile])`, so `groupBy` over a `Seq` would trade one array copy for one copy per bucket.

## How are these changes tested?

No new tests — no intended behavior change.

- Warnings under the default profile (Spark 4.1 / Scala 2.13): **127 → 118**, with all 9 of these gone and none added. Verified by diffing the full sorted warning list before and after.
- Scala 2.12 (`-Pspark-3.5`): **15 → 15** — these warnings do not exist on 2.12, and none were introduced.
- `test-compile` passes on all five profiles: default, `-Pspark-3.4`, `-Pspark-3.5`, `-Pspark-3.5 -Pscala-2.13`, `-Pspark-4.0`.
- `spotless:check` and `scalastyle:check` pass.
- 207 tests pass across `CometExecSuite` (covers the bucketed scan, dynamic partition pruning and local table scan paths), `ParquetReadV1Suite` (V1 scan planning) and `CometConfSuite` (`stringToSeq` via the seq-valued configs). Every one of them also exercises the changed `CometTestBase` helper.
- `Tables.scala` is only reachable with `dbgen`/`dsdgen` present, so it is not covered by CI; it is compile-checked and the `GenericRow` substitution is what `Row.fromSeq` expands to.
