### PR TITLE
chore: drop deprecated .toIterable from protobuf builder calls

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -626,9 +626,9 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
         val info = DataTypeInfo.newBuilder()
         val struct = StructInfo.newBuilder()
 
-        val fieldNames = s.fields.map(_.name).toIterable.asJava
-        val fieldDatatypes = s.fields.map(f => serializeDataType(f.dataType)).toSeq
-        val fieldNullable = s.fields.map(f => Boolean.box(f.nullable)).toIterable.asJava
+        val fieldNames = s.map(_.name).asJava
+        val fieldDatatypes = s.map(f => serializeDataType(f.dataType))
+        val fieldNullable = s.map(f => Boolean.box(f.nullable)).asJava
 
         if (fieldDatatypes.exists(_.isEmpty)) {
           return None

--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometNativeScan.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometNativeScan.scala
@@ -143,17 +143,18 @@ object CometNativeScan extends CometOperatorSerde[CometScanExec] with Logging {
         // Our schema has default values. Serialize two lists, one with the default values
         // and another with the indexes in the schema so the native side can map missing
         // columns to these default values.
-        val (defaultValues, indexes) = possibleDefaultValues.zipWithIndex
+        val (defaultValues, indexes) = possibleDefaultValues.iterator.zipWithIndex
           .filter { case (expr, _) => expr != null }
           .map { case (expr, index) =>
             // ResolveDefaultColumnsUtil.getExistenceDefaultValues has evaluated these
             // expressions and they should now just be literals.
             (Literal(expr), index.toLong.asInstanceOf[java.lang.Long])
           }
+          .toList
           .unzip
         commonBuilder.addAllDefaultValues(
-          defaultValues.flatMap(exprToProto(_, scan.output)).toIterable.asJava)
-        commonBuilder.addAllDefaultValuesIndexes(indexes.toIterable.asJava)
+          defaultValues.flatMap(exprToProto(_, scan.output)).asJava)
+        commonBuilder.addAllDefaultValuesIndexes(indexes.asJava)
       }
 
       // Extract object store options from first file (S3 configs apply to all files in scan).
@@ -164,29 +165,27 @@ object CometNativeScan extends CometOperatorSerde[CometScanExec] with Logging {
         .headOption
         .map(_.getPath.toUri)
 
-      val partitionSchema = schema2Proto(scan.relation.partitionSchema.fields)
-      val requiredSchema = schema2Proto(scan.requiredSchema.fields)
-      val dataSchema = schema2Proto(scan.relation.dataSchema.fields)
+      val partitionSchema = schema2Proto(scan.relation.partitionSchema)
+      val requiredSchema = schema2Proto(scan.requiredSchema)
+      val dataSchema = schema2Proto(scan.relation.dataSchema)
 
-      val dataSchemaIndexes = scan.requiredSchema.fields.map(field => {
+      val dataSchemaIndexes = scan.requiredSchema.map(field => {
         scan.relation.dataSchema.fieldIndex(field.name)
       })
-      val partitionSchemaIndexes = Array
-        .range(
-          scan.relation.dataSchema.fields.length,
-          scan.relation.dataSchema.length + scan.relation.partitionSchema.fields.length)
+      val partitionSchemaIndexes = scan.relation.dataSchema.fields.length until
+        (scan.relation.dataSchema.length + scan.relation.partitionSchema.fields.length)
 
       val projectionVector = (dataSchemaIndexes ++ partitionSchemaIndexes).map(idx =>
         idx.toLong.asInstanceOf[java.lang.Long])
 
-      commonBuilder.addAllProjectionVector(projectionVector.toIterable.asJava)
+      commonBuilder.addAllProjectionVector(projectionVector.asJava)
 
       // In `CometScanRule`, we ensure partitionSchema is supported.
       assert(partitionSchema.length == scan.relation.partitionSchema.fields.length)
 
-      commonBuilder.addAllDataSchema(dataSchema.toIterable.asJava)
-      commonBuilder.addAllRequiredSchema(requiredSchema.toIterable.asJava)
-      commonBuilder.addAllPartitionSchema(partitionSchema.toIterable.asJava)
+      commonBuilder.addAllDataSchema(dataSchema.asJava)
+      commonBuilder.addAllRequiredSchema(requiredSchema.asJava)
+      commonBuilder.addAllPartitionSchema(partitionSchema.asJava)
       commonBuilder.setSessionTimezone(scan.conf.getConfString("spark.sql.session.timeZone"))
       commonBuilder.setCaseSensitive(scan.conf.getConf[Boolean](SQLConf.CASE_SENSITIVE))
 

--- a/spark/src/main/scala/org/apache/comet/serde/operator/package.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/package.scala
@@ -29,7 +29,7 @@ import org.apache.comet.serde.QueryPlanSerde.{exprToProto, serializeDataType}
 
 package object operator {
 
-  def schema2Proto(fields: Array[StructField]): Array[OperatorOuterClass.SparkStructField] = {
+  def schema2Proto(fields: Seq[StructField]): Seq[OperatorOuterClass.SparkStructField] = {
     val fieldBuilder = OperatorOuterClass.SparkStructField.newBuilder()
     fields.map { field =>
       fieldBuilder.setName(field.name)

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometCsvNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometCsvNativeScanExec.scala
@@ -94,14 +94,14 @@ object CometCsvNativeScanExec extends CometOperatorSerde[CometBatchScanExec] {
     }
     val filePartitions = op.inputPartitions.map(_.asInstanceOf[FilePartition])
     val csvOptionsProto = csvOptions2Proto(options)
-    val dataSchemaProto = schema2Proto(csvScan.dataSchema.fields)
+    val dataSchemaProto = schema2Proto(csvScan.dataSchema)
     val readSchemaFieldNames = csvScan.readDataSchema.fieldNames
-    val projectionVector = csvScan.dataSchema.fields.zipWithIndex
+    val projectionVector = csvScan.dataSchema.zipWithIndex
       .filter { case (field, _) =>
         readSchemaFieldNames.contains(field.name)
       }
       .map(_._2.asInstanceOf[Integer])
-    val partitionSchemaProto = schema2Proto(csvScan.readPartitionSchema.fields)
+    val partitionSchemaProto = schema2Proto(csvScan.readPartitionSchema)
     val partitionsProto = filePartitions.map(partition2Proto(_, csvScan.readPartitionSchema))
 
     val objectStoreOptions = filePartitions.headOption
@@ -116,9 +116,9 @@ object CometCsvNativeScanExec extends CometOperatorSerde[CometBatchScanExec] {
     csvScanBuilder.putAllObjectStoreOptions(objectStoreOptions.asJava)
     csvScanBuilder.setCsvOptions(csvOptionsProto)
     csvScanBuilder.addAllFilePartitions(partitionsProto.asJava)
-    csvScanBuilder.addAllDataSchema(dataSchemaProto.toIterable.asJava)
-    csvScanBuilder.addAllProjectionVector(projectionVector.toIterable.asJava)
-    csvScanBuilder.addAllPartitionSchema(partitionSchemaProto.toIterable.asJava)
+    csvScanBuilder.addAllDataSchema(dataSchemaProto.asJava)
+    csvScanBuilder.addAllProjectionVector(projectionVector.asJava)
+    csvScanBuilder.addAllPartitionSchema(partitionSchemaProto.asJava)
     Some(builder.setCsvScan(csvScanBuilder).build())
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometWindowExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometWindowExec.scala
@@ -49,12 +49,12 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
       childOp: OperatorOuterClass.Operator*): Option[OperatorOuterClass.Operator] = {
     val output = op.child.output
 
-    val winExprs: Array[WindowExpressionInfo] = op.windowExpression.map { expr =>
+    val winExprs: Seq[WindowExpressionInfo] = op.windowExpression.map { expr =>
       extractWindowExpression(expr).getOrElse {
         withFallbackReason(op, s"Unsupported window expression: $expr", expr)
         return None
       }
-    }.toArray
+    }
 
     if (winExprs.length != op.windowExpression.length) {
       withFallbackReason(op, "Unsupported window expression(s)")
@@ -69,7 +69,7 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
     if (windowExprProto.forall(_.isDefined) && partitionExprs.forall(_.isDefined)
       && sortOrders.forall(_.isDefined)) {
       val windowBuilder = OperatorOuterClass.Window.newBuilder()
-      windowBuilder.addAllWindowExpr(windowExprProto.map(_.get).toIterable.asJava)
+      windowBuilder.addAllWindowExpr(windowExprProto.map(_.get).asJava)
       windowBuilder.addAllPartitionByList(partitionExprs.map(_.get).asJava)
       windowBuilder.addAllOrderByList(sortOrders.map(_.get).asJava)
       Some(builder.setWindow(windowBuilder).build())

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
@@ -346,7 +346,6 @@ class CometNativeShuffleWriter[K, V](
     // declared return type drifts from Spark catalyst (see comet#4515).
     val expectedFields = outputAttributes
       .map(a => StructField(a.name, a.dataType, a.nullable, a.metadata))
-      .toArray
     schema2Proto(expectedFields).foreach(shuffleWriterBuilder.addExpectedOutputSchema)
 
     OperatorOuterClass.Operator


### PR DESCRIPTION
## Which issue does this PR close?

No issue filed — mechanical compiler-warning cleanup, split out of #5141. Follows #5168 and #5170.

## Rationale for this change

Scala 2.13 deprecates `Iterable.toIterable` (it is being made protected). Comet calls it at 12 sites, all of them `xs.toIterable.asJava` when handing a collection to a protobuf `addAll*` builder — **12 of the 127 warnings** under the 2.13 profiles.

The interesting part is what *not* to do. At all 12 sites the receiver is an `Array`, so `.toIterable` resolves through `Predef.wrapRefArray` (the non-deprecated `Array` → `mutable.ArraySeq` wrap) and then `Iterable.toIterable` returns `this`. **The call is already free**, and the obvious fix of `.toSeq` would *add* a copy on 2.13, since `ArrayOps.toSeq` is `toIndexedSeq`. `.asJava` cannot be called on an `Array` directly either — that would need two chained implicit conversions.

So rather than convert the arrays, this PR removes them. Every one of these `addAll*` calls then takes `.asJava` on a `Seq`, which is what the neighbouring `addAll*` calls in the same methods already do (e.g. `addAllFields(scanTypes.asJava)`, `addAllPartitionByList(partitionExprs.map(_.get).asJava)`).

## What changes are included in this PR?

- **`schema2Proto`** takes and returns a `Seq[StructField]` / `Seq[SparkStructField]`. All five callers already hold a `StructType`, which *is* a `Seq[StructField]`, so they pass it straight in instead of unwrapping `.fields`; `CometNativeShuffleWriter` drops a `.toArray` on the way in. This clears 6 of the 12 warnings on its own (`CometNativeScan` ×3, `CometCsvNativeScanExec` ×2, and it is the same array that `addAllDataSchema` and friends were wrapping).
- **`QueryPlanSerde.serializeDataType`** maps over the `StructType` instead of `s.fields` for the struct field names/datatypes/nullability. That also drops a `.toSeq` (a real copy) on `fieldDatatypes`.
- **Projection vectors** are built from the `StructType` in both scan serdes, and in `CometNativeScan` from a `Range` rather than `Array.range` — same values, no array.
- **`CometNativeScan` default values**: the `zipWithIndex`/`filter`/`map`/`unzip` chain runs on an iterator and materializes once, so the three intermediate arrays are gone.
- **`CometWindowExec.winExprs`** keeps the `Seq` that `op.windowExpression.map` returns instead of `.toArray`-ing it; it is only used for `.length` and `.map`.

Net effect: 12 deprecation warnings gone, several array copies removed from the per-plan serde path, and no conversion added anywhere.

## How are these changes tested?

No new tests — no intended behavior change; the protobuf messages built are identical.

- Warnings under the default profile (Spark 4.1 / Scala 2.13): **127 → 115**, all 12 of these gone and none added, verified by diffing the full sorted warning list before and after.
- Scala 2.12 (`-Pspark-3.5`): warning list **byte-identical** (15 → 15).
- `test-compile` passes on all five profiles: default, `-Pspark-3.4`, `-Pspark-3.5`, `-Pspark-3.5 -Pscala-2.13`, `-Pspark-4.0`.
- `spotless:check` and `scalastyle:check` pass.
- 333 tests pass across the suites covering every touched serde path: `CometExecSuite` and `CometWindowExecSuite` (window serde), `CometCsvNativeReadSuite` and `CometCsvExpressionSuite` (`CometCsvNativeScanExec`, including its projection vector and both schema protos), `CometNativeShuffleSuite` (`schema2Proto` via `addExpectedOutputSchema`), `ParquetReadV1Suite` and `CometNativeReaderSuite` (`CometNativeScan` schemas, projection vector and default values, plus `serializeDataType` on nested structs).
