### PR TITLE
chore: supply explicit empty argument lists for 2.13

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -80,7 +80,7 @@ class CometExecIterator(
   private val memoryMXBean = ManagementFactory.getMemoryMXBean
   private val nativeLib = new Native()
   private val nativeUtil = new NativeUtil()
-  private val taskAttemptId = TaskContext.get().taskAttemptId
+  private val taskAttemptId = TaskContext.get().taskAttemptId()
   private val taskCPUs = TaskContext.get().cpus()
   private val cometTaskMemoryManager = new CometTaskMemoryManager(id, taskAttemptId)
 

--- a/spark/src/main/scala/org/apache/comet/serde/unixtime.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/unixtime.scala
@@ -54,7 +54,7 @@ object CometFromUnixTime extends CometExpressionSerde[FromUnixTime] with Codegen
   // only appear on the format argument, and any collated format is a non-default format, which is
   // already `Unsupported` here.
   override def getSupportLevel(expr: FromUnixTime): SupportLevel = {
-    if (expr.format != Literal(TimestampFormatter.defaultPattern)) {
+    if (expr.format != Literal(TimestampFormatter.defaultPattern())) {
       Unsupported(Some(formatReason))
     } else {
       Incompatible(Some(timestampRangeReason))
@@ -73,7 +73,7 @@ object CometFromUnixTime extends CometExpressionSerde[FromUnixTime] with Codegen
     val formatExpr = exprToProtoInternal(Literal("%Y-%m-%d %H:%M:%S"), inputs, binding)
     val timeZone = exprToProtoInternal(Literal(expr.timeZoneId.orNull), inputs, binding)
 
-    if (expr.format != Literal(TimestampFormatter.defaultPattern)) {
+    if (expr.format != Literal(TimestampFormatter.defaultPattern())) {
       withFallbackReason(expr, formatReason)
       None
     } else if (secExpr.isDefined && formatExpr.isDefined) {

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
@@ -231,7 +231,7 @@ class CometNativeShuffleWriter[K, V](
     } else {
       shuffleWriterBuilder.setCodec(CompressionCodec.None)
     }
-    shuffleWriterBuilder.setCompressionLevel(CometConf.COMET_SHUFFLE_COMPRESSION_ZSTD_LEVEL.get)
+    shuffleWriterBuilder.setCompressionLevel(CometConf.COMET_SHUFFLE_COMPRESSION_ZSTD_LEVEL.get())
     shuffleWriterBuilder.setWriteBufferSize(
       CometConf.COMET_SHUFFLE_NATIVE_WRITE_BUFFER_SIZE.get().min(Int.MaxValue).toInt)
     shuffleWriterBuilder.setMaxBufferBytes(CometConf.COMET_SHUFFLE_NATIVE_MAX_BUFFER_BYTES.get())

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/NativeBatchDecoderIterator.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/NativeBatchDecoderIterator.scala
@@ -55,7 +55,7 @@ case class NativeBatchDecoderIterator(
     null
   }
 
-  def hasNext(): Boolean = {
+  override def hasNext: Boolean = {
     if (channel == null || isClosed) {
       return false
     }

--- a/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
@@ -598,7 +598,7 @@ class CometNativeReaderSuite extends CometTestBase with AdaptiveSparkPlanHelper 
   test("SPARK-18053: ARRAY equality is broken") {
     withTable("array_tbl") {
       spark.range(10).select(array(col("id")).as("arr")).write.saveAsTable("array_tbl")
-      assert(sql("SELECT * FROM array_tbl where arr = ARRAY(1L)").count == 1)
+      assert(sql("SELECT * FROM array_tbl where arr = ARRAY(1L)").count() == 1)
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/CometTPCQueryBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTPCQueryBase.scala
@@ -52,7 +52,8 @@ trait CometTPCQueryBase extends Logging {
         "spark.shuffle.manager",
         "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
 
-    val sparkSession = SparkSession.builder
+    val sparkSession = SparkSession
+      .builder()
       .config(conf)
       .withExtensions(new CometSparkSessionExtensions)
       .getOrCreate()

--- a/spark/src/test/scala/org/apache/spark/sql/Tables.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/Tables.scala
@@ -169,7 +169,7 @@ abstract class Tables(
           // in case data has more than maxRecordsPerFile, split into multiple writers to improve
           // datagen speed files will be truncated to maxRecordsPerFile value, so the final result
           // will be the same
-          val numRows = data.count
+          val numRows = data.count()
           val maxRecordPerFile =
             Try(sqlContext.getConf("spark.sql.files.maxRecordsPerFile").toInt).getOrElse(0)
 

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
@@ -61,7 +61,8 @@ trait CometBenchmarkBase
         "spark.shuffle.manager",
         "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
 
-    val sparkSession = SparkSession.builder
+    val sparkSession = SparkSession
+      .builder()
       .config(conf)
       .withExtensions(new CometSparkSessionExtensions)
       .getOrCreate()
@@ -98,7 +99,7 @@ trait CometBenchmarkBase
       import spark.implicits._
       spark
         .range(values)
-        .map(_ => if (useDictionary) Random.nextLong % 5 else Random.nextLong)
+        .map(_ => if (useDictionary) Random.nextLong() % 5 else Random.nextLong())
         .createOrReplaceTempView(tbl)
       runBenchmark(benchmarkName)(f(values))
     }

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBroadcastHashJoinBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBroadcastHashJoinBenchmark.scala
@@ -44,7 +44,8 @@ object CometBroadcastHashJoinBenchmark extends CometBenchmarkBase {
         "spark.shuffle.manager",
         "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
 
-    val sparkSession = SparkSession.builder
+    val sparkSession = SparkSession
+      .builder()
       .config(conf)
       .withExtensions(new CometSparkSessionExtensions)
       .getOrCreate()

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBroadcastNestedLoopJoinBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBroadcastNestedLoopJoinBenchmark.scala
@@ -45,7 +45,8 @@ object CometBroadcastNestedLoopJoinBenchmark extends CometBenchmarkBase {
         "spark.shuffle.manager",
         "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
 
-    val sparkSession = SparkSession.builder
+    val sparkSession = SparkSession
+      .builder()
       .config(conf)
       .withExtensions(new CometSparkSessionExtensions)
       .getOrCreate()

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometColumnarToRowBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometColumnarToRowBenchmark.scala
@@ -49,7 +49,8 @@ object CometColumnarToRowBenchmark extends CometBenchmarkBase {
       .set("spark.memory.offHeap.enabled", "true")
       .set("spark.memory.offHeap.size", "2g")
 
-    val sparkSession = SparkSession.builder
+    val sparkSession = SparkSession
+      .builder()
       .config(conf)
       .withExtensions(new CometSparkSessionExtensions)
       .getOrCreate()

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometExecBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometExecBenchmark.scala
@@ -48,7 +48,8 @@ object CometExecBenchmark extends CometBenchmarkBase {
         "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
       .set("spark.comet.shuffle.jvm.spillThreshold", "30000")
 
-    val sparkSession = SparkSession.builder
+    val sparkSession = SparkSession
+      .builder()
       .config(conf)
       .withExtensions(new CometSparkSessionExtensions)
       .getOrCreate()

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometHashJoinBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometHashJoinBenchmark.scala
@@ -44,7 +44,8 @@ object CometHashJoinBenchmark extends CometBenchmarkBase {
         "spark.shuffle.manager",
         "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
 
-    val sparkSession = SparkSession.builder
+    val sparkSession = SparkSession
+      .builder()
       .config(conf)
       .withExtensions(new CometSparkSessionExtensions)
       .getOrCreate()

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometReadBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometReadBenchmark.scala
@@ -347,7 +347,7 @@ class CometReadBaseBenchmark extends CometBenchmarkBase {
     runBenchmark("SQL Decimal Column Scan") {
       withTempTable(tbl) {
         import spark.implicits._
-        spark.range(1024 * 1024 * 15).map(_ => Random.nextInt).createOrReplaceTempView(tbl)
+        spark.range(1024 * 1024 * 15).map(_ => Random.nextInt()).createOrReplaceTempView(tbl)
 
         Seq((5, 2), (18, 4), (20, 8)).foreach { case (precision, scale) =>
           decimalScanBenchmark(1024 * 1024 * 15, precision, scale)

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometRegExpExtractBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometRegExpExtractBenchmark.scala
@@ -74,7 +74,7 @@ object CometRegExpExtractBenchmark extends CometBenchmarkBase {
         "spark.shuffle.manager",
         "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
 
-    val sparkSession = SparkSession.builder.config(conf).getOrCreate()
+    val sparkSession = SparkSession.builder().config(conf).getOrCreate()
     sparkSession.conf.set(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key, "true")
     sparkSession.conf.set(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key, "true")
     sparkSession.conf.set(CometConf.COMET_ENABLED.key, "false")

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometShuffleBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometShuffleBenchmark.scala
@@ -55,7 +55,8 @@ object CometShuffleBenchmark extends CometBenchmarkBase {
         "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
       .set("spark.comet.shuffle.jvm.spillThreshold", "30000")
 
-    val sparkSession = SparkSession.builder
+    val sparkSession = SparkSession
+      .builder()
       .config(conf)
       .withExtensions(new CometSparkSessionExtensions)
       .getOrCreate()

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometSortMergeJoinBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometSortMergeJoinBenchmark.scala
@@ -44,7 +44,8 @@ object CometSortMergeJoinBenchmark extends CometBenchmarkBase {
         "spark.shuffle.manager",
         "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
 
-    val sparkSession = SparkSession.builder
+    val sparkSession = SparkSession
+      .builder()
       .config(conf)
       .withExtensions(new CometSparkSessionExtensions)
       .getOrCreate()


### PR DESCRIPTION
## Which issue does this PR close?

No issue filed — mechanical compiler-warning cleanup, split out of #5141. Follows #5168, #5170 and #5173.

## Rationale for this change

Scala 2.13 deprecates *auto-application*: writing `foo` where the method is declared `def foo()`. Comet does this at 20 sites — the largest remaining group of warnings under the 2.13 profiles.

Auto-application is purely syntactic: the method is already being invoked, so adding `()` cannot change behaviour or evaluation order. That makes 19 of these a genuine one-token fix. The 20th is the interesting one, and it is a declaration rather than a call.

## What changes are included in this PR?

**`()` added at the call site (19 sites, 19 warnings):**

- `SparkSession.builder` → `builder()` in nine benchmark/TPC session builders.
- `Random.nextLong` / `Random.nextInt` in `CometBenchmarkBase` (×2) and `CometReadBenchmark`.
- `Dataset.count` in `CometNativeReaderSuite` and `Tables`.
- `TaskContext.get().taskAttemptId` in `CometExecIterator` — the very next line already reads `TaskContext.get().cpus()`.
- `TimestampFormatter.defaultPattern` in `unixtime.scala` (×2).
- `CometConf.COMET_SHUFFLE_COMPRESSION_ZSTD_LEVEL.get` in `CometNativeShuffleWriter` — the following two lines already read `.get()`.

**`NativeBatchDecoderIterator` (2 warnings, 1 fix):** it declares `def hasNext(): Boolean` while `Iterator` declares `hasNext` *without* a parameter list. That mismatch warns twice — once on the declaration (*"method with a single empty parameter list overrides method hasNext in trait Iterator defined without a parameter list"*) and again on the internal `if (!hasNext)` call, which is then an auto-application. Dropping the parameter list from the override fixes both. This is the one change here that could in principle break a caller, so I checked: the only consumer is `CometBlockStoreShuffleReader`, which uses the iterator through `Iterator.flatMap` and never calls `hasNext` directly. Java callers would be unaffected either way — the JVM signature is unchanged.

`spotless:apply` reflows the nine `SparkSession.builder()` calls onto their own line (`SparkSession` / `.builder()`), since the extra parens push the chain over scalafmt's threshold. That is the only formatting change in the diff.

## How are these changes tested?

No new tests — no intended behavior change.

- Warnings under the default profile (Spark 4.1 / Scala 2.13): **127 → 106**, all 21 gone and none added, verified by diffing the full sorted warning list before and after.
- Scala 2.12 (`-Pspark-3.5`): warning list **byte-identical** (15 → 15). Auto-application is not deprecated on 2.12, and `Iterator.hasNext` is parameterless there too.
- `test-compile` passes on all five profiles: default, `-Pspark-3.4`, `-Pspark-3.5`, `-Pspark-3.5 -Pscala-2.13`, `-Pspark-4.0`.
- `spotless:check` and `scalastyle:check` pass.
- 265 tests pass across the suites covering the four main-source changes: `CometNativeShuffleSuite` and `CometShuffleSuite` (the `NativeBatchDecoderIterator` read path and the shuffle writer's compression level), `CometNativeReaderSuite`, and `CometExpressionSuite` (`from_unixtime`, both the default-pattern and non-default-pattern branches). `CometExecIterator` is exercised by every one of them.
- The benchmark files are compile-only in CI; they are covered by `test-compile` above.
