### PR TITLE
docs: add contributor guide pages for Arrow usage, memory management, and shuffle invariants

### DIFF
--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -47,6 +47,7 @@ Development Guide <development>
 Comet Plugin Overview <plugin_overview>
 Arrow FFI <ffi>
 Working with Arrow <working_with_arrow>
+Memory Management <memory_management>
 JVM Shuffle <jvm_shuffle>
 Native Shuffle <native_shuffle>
 ANSI Error Propagation <sql_error_propagation>

--- a/docs/source/contributor-guide/index.md
+++ b/docs/source/contributor-guide/index.md
@@ -46,6 +46,7 @@ Development Guide <development>
 
 Comet Plugin Overview <plugin_overview>
 Arrow FFI <ffi>
+Working with Arrow <working_with_arrow>
 JVM Shuffle <jvm_shuffle>
 Native Shuffle <native_shuffle>
 ANSI Error Propagation <sql_error_propagation>

--- a/docs/source/contributor-guide/memory_management.md
+++ b/docs/source/contributor-guide/memory_management.md
@@ -36,10 +36,14 @@ relying on the summary here.
 distinguish them.
 
 The first axis is the allocation policy. Greedy pools are first come, first served up to the pool
-size. Fair pools cap a request against a divided share of the pool so that one operator cannot
-starve the others. Only two of the nine are Comet's own implementations
-(`CometUnifiedMemoryPool` and `CometFairMemoryPool`); the rest are DataFusion's `GreedyMemoryPool`,
-`FairSpillPool`, and `UnboundedMemoryPool`.
+size. Fair pools divide the pool size by the number of registered consumers, but the two fair
+implementations apply that share differently. DataFusion's `FairSpillPool` compares it against the
+calling reservation, so one operator cannot starve the others. `CometFairMemoryPool` compares it
+against the pool-wide total instead, which caps the pool as a whole rather than any one operator.
+`CometFairMemoryPool` is one of only two pools selectable in off-heap mode, so read the exact
+arithmetic under "How native memory relates to Spark's" below before reasoning about it. Only two
+of the nine are Comet's own implementations (`CometUnifiedMemoryPool` and `CometFairMemoryPool`);
+the rest are DataFusion's `GreedyMemoryPool`, `FairSpillPool`, and `UnboundedMemoryPool`.
 
 The second axis is scope, meaning how many native plans share one pool instance. `create_memory_pool`
 in `native/core/src/execution/memory_pools/mod.rs` implements three scopes:
@@ -67,10 +71,13 @@ in `native/core/src/execution/memory_pools/mod.rs` implements three scopes:
 | `unbounded`              | on-heap  | DataFusion `UnboundedMemoryPool` | per plan    | unlimited               |
 
 `memory_limit` and `memory_limit_per_task` are computed on the JVM in
-`CometExecIterator.getMemoryConfig` and passed to `createPlan` as separate arguments.
-`memory_limit_per_task` is `memory_limit * spark.task.cpus / cores`. In off-heap mode
-`memory_limit_per_task` crosses JNI but `parse_memory_pool_config` never reads it: the off-heap
-branch sizes from `memory_limit` only.
+`CometExecIterator.getMemoryConfig` and passed to `createPlan` as separate arguments. Which two
+values those are depends on the mode: in off-heap mode `memory_limit` is
+`spark.memory.offHeap.size` times `spark.comet.exec.memoryPool.fraction`, and in on-heap mode it is
+`CometSparkSessionExtensions.getCometMemoryOverhead`. `memory_limit_per_task` is
+`memory_limit * spark.task.cpus / cores` in both. In off-heap mode `memory_limit_per_task` crosses
+JNI but `parse_memory_pool_config` never reads it: the off-heap branch sizes from `memory_limit`
+only.
 
 Every pool is wrapped in DataFusion's `TrackConsumersPool` with `NUM_TRACKED_CONSUMERS = 10`
 (`memory_pools/mod.rs`). That wrapper does not change any allocation decision. Its only effect is
@@ -170,8 +177,9 @@ they have one, their spill logic. `HashJoinExec` is the exception worth knowing 
 side calls `state.reservation.try_grow(batch_size)?` and propagates the error, so a hash join that
 does not fit fails rather than spills. DataFusion's `ExternalSorter` is the model for the ones that
 do spill: `reserve_memory_for_batch_and_maybe_spill` calls `reservation.try_grow(size)`, and on any
-`Err` it spills the in-memory batches and retries the same `try_grow` once. Spill files land in the
-directories Comet passes down from Spark's `blockManager.getLocalDiskDirs`, configured through
+`Err` it spills the in-memory batches, if it has any, and retries the same `try_grow` once. Spill
+files land in the directories Comet passes down from Spark's `blockManager.getLocalDiskDirs`,
+configured through
 `DiskManagerBuilder` in `prepare_datafusion_session_context` and capped by
 `spark.comet.maxTempDirectorySize`.
 

--- a/docs/source/contributor-guide/memory_management.md
+++ b/docs/source/contributor-guide/memory_management.md
@@ -1,0 +1,264 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Native Memory Management
+
+Comet's native code allocates from a DataFusion `MemoryPool` that is created per native plan in
+`Java_org_apache_comet_Native_createPlan`
+(`native/core/src/execution/jni_api.rs`). Which pool it gets, how large it is, how long it lives,
+and whether it talks to Spark at all are all decided by
+`native/core/src/execution/memory_pools/`. This page covers that accounting layer: how pools are
+chosen and sized, how the two JVM-backed pools reach Spark's `TaskMemoryManager`, and what a
+native operator has to do so its buffers are visible to the pool.
+
+Everything below is grounded in specific files. Where a claim cites a file, read that file before
+relying on the summary here.
+
+## Pool types
+
+`MemoryPoolType` in `native/core/src/execution/memory_pools/config.rs` has nine variants. Two axes
+distinguish them.
+
+The first axis is the allocation policy. Greedy pools are first come, first served up to the pool
+size. Fair pools cap a request against a divided share of the pool so that one operator cannot
+starve the others. Only two of the nine are Comet's own implementations
+(`CometUnifiedMemoryPool` and `CometFairMemoryPool`); the rest are DataFusion's `GreedyMemoryPool`,
+`FairSpillPool`, and `UnboundedMemoryPool`.
+
+The second axis is scope, meaning how many native plans share one pool instance. `create_memory_pool`
+in `native/core/src/execution/memory_pools/mod.rs` implements three scopes:
+
+- **Per plan.** A fresh pool is constructed on every `createPlan` call.
+- **Per task.** The pool is memoized in the `TASK_SHARED_MEMORY_POOLS` map keyed by
+  `task_attempt_id` (`memory_pools/task_shared.rs`), with a `num_plans` refcount incremented on
+  create and decremented in `handle_task_shared_pool_release`, which `releasePlan` calls
+  (`jni_api.rs`). The entry is removed when the count reaches zero. This matters because a single
+  Spark task can run more than one native plan at a time, for example a plan feeding a shuffle
+  writer plan.
+- **Per process.** The pool lives in a `OnceCell` static, so the first plan to run in the executor
+  initializes it and every later plan in that JVM reuses it.
+
+| Config value             | Mode     | Implementation                   | Scope       | Sized from              |
+| ------------------------ | -------- | -------------------------------- | ----------- | ----------------------- |
+| `fair_unified`           | off-heap | `CometFairMemoryPool`            | per task    | `memory_limit`          |
+| `greedy_unified`         | off-heap | `CometUnifiedMemoryPool`         | per task    | no size, see below      |
+| `greedy`                 | on-heap  | DataFusion `GreedyMemoryPool`    | per plan    | `memory_limit_per_task` |
+| `fair_spill`             | on-heap  | DataFusion `FairSpillPool`       | per plan    | `memory_limit_per_task` |
+| `greedy_task_shared`     | on-heap  | DataFusion `GreedyMemoryPool`    | per task    | `memory_limit_per_task` |
+| `fair_spill_task_shared` | on-heap  | DataFusion `FairSpillPool`       | per task    | `memory_limit_per_task` |
+| `greedy_global`          | on-heap  | DataFusion `GreedyMemoryPool`    | per process | `memory_limit`          |
+| `fair_spill_global`      | on-heap  | DataFusion `FairSpillPool`       | per process | `memory_limit`          |
+| `unbounded`              | on-heap  | DataFusion `UnboundedMemoryPool` | per plan    | unlimited               |
+
+`memory_limit` and `memory_limit_per_task` are computed on the JVM in
+`CometExecIterator.getMemoryConfig` and passed to `createPlan` as separate arguments.
+`memory_limit_per_task` is `memory_limit * spark.task.cpus / cores`. In off-heap mode
+`memory_limit_per_task` crosses JNI but `parse_memory_pool_config` never reads it: the off-heap
+branch sizes from `memory_limit` only.
+
+Every pool is wrapped in DataFusion's `TrackConsumersPool` with `NUM_TRACKED_CONSUMERS = 10`
+(`memory_pools/mod.rs`). That wrapper does not change any allocation decision. Its only effect is
+on error text: its `try_grow` matches specifically on `DataFusionError::ResourcesExhausted` and
+appends a report of the top consumers by reservation size. An inner pool that returns any other
+error variant gets no report.
+
+Setting `spark.comet.debug.memory` wraps the result in `LoggingMemoryPool`
+(`memory_pools/logging_pool.rs`), which logs every `register`, `grow`, `shrink`, and `try_grow`
+against the consumer name and task attempt id. That is the fastest way to see what a new operator
+is actually reserving.
+
+## On-heap and off-heap mode
+
+The split is hard. `parse_memory_pool_config` branches on `off_heap_mode` first, and each branch
+matches only its own names. In off-heap mode anything other than `fair_unified` and
+`greedy_unified` returns `CometError::Config("Unsupported memory pool type for off-heap mode: ...")`.
+In on-heap mode the two unified names hit the same fallthrough with the on-heap wording. There is
+no fallback to a default pool, and no shared pool name across the two modes.
+
+The mode is not a Comet setting. `CometSparkSessionExtensions.isOffHeapEnabled` reads Spark's own
+`spark.memory.offHeap.enabled`. On-heap mode is a testing configuration: `CometDriverPlugin.init`
+disables the plugin outright when off-heap mode is off unless
+`spark.comet.exec.onHeap.enabled` is also set, and both that flag and
+`spark.comet.exec.onHeap.memoryPool` are declared under the testing config category in
+`CometConf.scala`. The two config keys are separate per mode:
+`spark.comet.exec.memoryPool` for off-heap and `spark.comet.exec.onHeap.memoryPool` for on-heap.
+Read the current defaults from `CometConf.scala` or from the generated
+[configuration reference](../user-guide/latest/configs.md) rather than assuming them.
+
+The practical consequence for a contributor: adding a pool type is not one edit. The variant goes
+in `MemoryPoolType`, the name goes in exactly one branch of `parse_memory_pool_config`, the
+construction goes in `create_memory_pool`, and if it is task shared it also has to be listed in
+`MemoryPoolType::is_task_shared` or `handle_task_shared_pool_release` will return early and the
+entry will never be evicted from `TASK_SHARED_MEMORY_POOLS`.
+
+## How native memory relates to Spark's
+
+Only `CometUnifiedMemoryPool` and `CometFairMemoryPool` talk to Spark. Both hold a JNI global
+reference to a `CometTaskMemoryManager` and call two methods on it:
+
+- `acquire_memory(size) -> i64`, which calls
+  `TaskMemoryManager.acquireExecutionMemory(size, nativeMemoryConsumer)` and returns the number of
+  bytes actually granted (`spark/src/main/java/org/apache/spark/CometTaskMemoryManager.java`).
+- `release_memory(size)`, which calls `releaseExecutionMemory`.
+
+Spark is allowed to grant less than requested. Both pools treat a partial grant as a failure with
+the same three steps: release the bytes that were granted, return a `ResourcesExhausted` error, and
+leave the retry to the caller (`memory_pools/unified_pool.rs`, `memory_pools/fair_pool.rs`). A
+partial grant is never usable memory in Comet.
+
+Two consequences that are easy to get wrong:
+
+**Spark cannot make Comet spill.** The `MemoryConsumer` that `CometTaskMemoryManager` registers with
+Spark is `NativeMemoryConsumer`, whose `spill` method returns `0` unconditionally. The class comment
+states the reason: Comet native does not share Spark's spill API, so when either side acquires
+memory, spilling can only be triggered from JVM operators. Pressure flows one way. Native code
+learns about pressure only by asking for memory and being told no.
+
+**`greedy_unified` carries pool size 0 on purpose.** `parse_memory_pool_config` constructs it with a
+size of zero, and the comment there explains that the pool interacts with Spark's pool to allocate
+memory and so does not need a size; the shared size is set by `spark.memory.offHeap.size`.
+`CometUnifiedMemoryPool::new` takes no size argument at all, so the zero is inert. The pool imposes
+no ceiling of its own: `try_grow` asks Spark and succeeds whenever Spark grants the full amount.
+
+`fair_unified` does impose a ceiling, and its arithmetic is worth reading before you reason about
+it. `CometFairMemoryPool::try_grow` computes `limit = pool_size / num`, where `num` is the count of
+registered consumers, and rejects the request when `limit < used + additional`. `used` is the
+pool's own running total across all consumers, not the size of the calling reservation. The
+in-file comments explain the switch away from `reservation.size()`: DataFusion 53 and later call
+`try_grow` before incrementing the reservation's atomic size and decrement it before calling
+`shrink`, so the reservation's own counter is not usable at those points. The effect is that each
+additional registered consumer lowers the ceiling for the whole pool rather than only for that
+consumer.
+
+`CometFairMemoryPool` also differs from DataFusion's `FairSpillPool` in what it counts. DataFusion
+increments its divisor only for consumers with `can_spill == true` and lets non-spilling consumers
+draw against the rest of the pool. Comet's `register` ignores `can_spill` and counts every consumer.
+
+Note that the `CometTaskMemoryManager` a plan passes to `createPlan` is not necessarily the one its
+pool uses. `CometExecIterator` constructs a new `CometTaskMemoryManager` per plan, but
+`create_memory_pool` only captures the handle inside the `or_insert_with` closure, so for a
+task-shared pool the second and later plans in a task hand over a manager that is dropped. Their
+allocations are still accounted against Spark correctly, because every `CometTaskMemoryManager` in
+a task delegates to the same `TaskContext.taskMemoryManager()`, but the per-instance `used` counter
+on the later managers stays at zero.
+
+## Spilling
+
+There is no spill machinery in `memory_pools/`. The pools only grant or deny. Spilling is
+implemented by the operators, and there are two kinds in Comet.
+
+Most spilling is DataFusion's. Comet's planner builds DataFusion's `SortExec`, `AggregateExec`,
+`SortMergeJoinExec`, `NestedLoopJoinExec`, and `HashJoinExec`
+(`native/core/src/execution/planner.rs`), and those operators own their reservations and, where
+they have one, their spill logic. `HashJoinExec` is the exception worth knowing about: its build
+side calls `state.reservation.try_grow(batch_size)?` and propagates the error, so a hash join that
+does not fit fails rather than spills. DataFusion's `ExternalSorter` is the model for the ones that
+do spill: `reserve_memory_for_batch_and_maybe_spill` calls `reservation.try_grow(size)`, and on any
+`Err` it spills the in-memory batches and retries the same `try_grow` once. Spill files land in the
+directories Comet passes down from Spark's `blockManager.getLocalDiskDirs`, configured through
+`DiskManagerBuilder` in `prepare_datafusion_session_context` and capped by
+`spark.comet.maxTempDirectorySize`.
+
+The one Comet-owned spilling operator is the native shuffle writer. `MultiPartitionShuffleRepartitioner`
+in `native/shuffle/src/partitioners/multi_partition.rs` is the only place in Comet's own native
+code that registers a `MemoryConsumer`, and it is the reference for what an operator that buffers
+data has to do:
+
+```rust
+let reservation = MemoryConsumer::new(format!("ShuffleRepartitioner[{partition}]"))
+    .with_can_spill(true)
+    .register(&runtime.memory_pool);
+```
+
+After buffering a batch it grows the reservation and spills when either the grow fails or a
+configured byte limit is reached:
+
+```rust
+if self.reservation.try_grow(mem_growth).is_err()
+    || self
+        .max_buffer_bytes
+        .is_some_and(|limit| self.reservation.size() >= limit)
+{
+    self.spill()?;
+}
+```
+
+`try_grow` is evaluated first so the reservation is charged either way, which means the writer can
+overshoot by at most one batch. `spill` writes every partition out and then calls
+`self.reservation.free()`. The `max_buffer_bytes` limit comes from
+`spark.comet.shuffle.native.maxBufferBytes`, where the default of `0` disables it and leaves a
+denied allocation as the only spill trigger.
+
+The subtle part of that operator is not the spill, it is the measurement. `count_new_buffers` sums
+the capacities of the backing buffers a batch newly pins, keyed by buffer start address across all
+buffered batches, and the function's doc comment records why the two obvious alternatives are both
+wrong. A partial `HashAggregate` emits one group-values buffer sliced into `batch_size` chunks that
+all share the allocation, so `RecordBatch::get_array_memory_size` charges that allocation once per
+chunk and spills spuriously, while summing `ArrayData::get_slice_memory_size` charges only live rows
+and undercounts, because holding a slice pins the whole allocation and the underlying `Vec` rounds
+capacity up to a power of two.
+
+## Rules and common mistakes
+
+- **Reserve through the pool or the memory is invisible.** A buffer that is not charged to a
+  `MemoryReservation` is invisible to the pool, to `TrackConsumersPool`'s top-consumer report, and
+  in off-heap mode to Spark's `TaskMemoryManager`. If you add a native operator that holds batches
+  across calls, register a `MemoryConsumer` the way `MultiPartitionShuffleRepartitioner::try_new`
+  does.
+- **Use `try_grow`, never `grow`, in code that can run under the unified pools.**
+  `MemoryReservation::grow` is infallible in DataFusion's API and delegates straight to
+  `MemoryPool::grow`. Both of Comet's JVM-backed pools implement `grow` as
+  `self.try_grow(reservation, additional).unwrap()` (`unified_pool.rs`, `fair_pool.rs`), so when
+  Spark declines the request the native thread panics instead of returning an error that an
+  operator could spill on. DataFusion's own pools never fail `grow`, so this hazard is specific to
+  Comet's pools and is invisible in a test that uses a `GreedyMemoryPool`.
+- **Treat any `Err` from `try_grow` as the signal to spill, not as a fatal error.** That is the
+  contract the pools are written against: both Comet pools' comments say the error is returned in
+  the hope of triggering spilling from the caller side, and DataFusion's `ExternalSorter` and
+  Comet's shuffle writer both implement exactly that. An operator that propagates the error without
+  first trying to free memory turns a recoverable condition into a query failure.
+- **Return `ResourcesExhausted` from pool code.** The variant is load bearing in two places.
+  `TrackConsumersPool::try_grow` matches on it to attach the top-consumer report, and
+  `NestedLoopJoinExec::can_fallback_to_spill` requires the error's root to be `ResourcesExhausted`
+  before it will switch to its disk-backed mode. A pool that signals exhaustion with any other
+  variant loses the diagnostic and disables that join's fallback. Use `resources_err!` or
+  `resources_datafusion_err!`, as both Comet pools do.
+- **Do not size a reservation with `get_array_memory_size` or with a sum of slice sizes.** See
+  `count_new_buffers` above for the two failure modes and the measure that works.
+- **Global pools are initialized once per executor process.** `greedy_global` and
+  `fair_spill_global` are built inside a `OnceCell`, so the first plan in the JVM fixes the size for
+  every later plan. A test that changes the memory limit between queries and expects the new limit
+  to take effect will silently keep the old one.
+- **Every `createPlan` that takes a task-shared pool needs its matching `releasePlan`.** The
+  refcount in `PerTaskMemoryPool::num_plans` is the only thing that evicts the entry from the
+  process-wide `TASK_SHARED_MEMORY_POOLS` map. A path that creates a plan without releasing it
+  leaks the pool for the life of the executor, and under the two unified pools it also leaks the
+  `CometTaskMemoryManager` global reference that pool holds.
+
+## Further reading
+
+- [Arrow FFI](ffi.md) for buffer ownership across the JVM and native boundary. That page covers
+  who owns a buffer and when it is freed; this page covers who is charged for it. The two do not
+  overlap: importing a batch over FFI does not reserve memory from the pool.
+- [Native Shuffle](native_shuffle.md) for the shuffle writer that the spilling example above comes
+  from.
+- [Tuning Guide](../user-guide/latest/tuning.md) for the operator-facing view of pool selection and
+  sizing.
+- [Tracing](tracing.md) for the per-thread memory totals that `createPlan` registers when
+  `spark.comet.tracing.enabled` is set.

--- a/docs/source/contributor-guide/native_shuffle.md
+++ b/docs/source/contributor-guide/native_shuffle.md
@@ -146,9 +146,11 @@ These files live in the `datafusion-comet-shuffle` crate. `native/core` re-expor
 
 2. **Native execution**: A single `CometExecIterator` per partition runs the unified plan.
 
-3. **Partitioning**: `ShuffleWriterExec` receives batches and routes to the appropriate partitioner:
-   - `MultiPartitionShuffleRepartitioner`: For hash/range/round-robin partitioning
+3. **Partitioning**: `ShuffleWriterExec` receives batches and routes to the appropriate partitioner,
+   checked in this order:
+   - `EmptySchemaShufflePartitioner`: For zero-column input, whatever partitioning was requested
    - `SinglePartitionShufflePartitioner`: For single partition (simpler path)
+   - `MultiPartitionShuffleRepartitioner`: For hash/range/round-robin partitioning
 
 4. **Buffering and spilling**: The partitioner buffers rows per partition. When memory pressure
    exceeds the threshold, partitions spill to temporary files.
@@ -256,7 +258,7 @@ Native shuffle supports multiple compression codecs configured via
 The compression codec is applied uniformly to all partitions. Each partition's data is
 independently compressed, allowing parallel decompression during reads.
 
-## Rules and common mistakes
+## Rules and Common Mistakes
 
 Shuffle carries more cross-boundary invariants than most of the native code, because its output has
 to satisfy Spark's planner, its bytes have to satisfy two separate readers, and neither side
@@ -324,10 +326,10 @@ the passthrough assertion. That is the signal the workaround for that function c
 
 `ShuffleBlockWriter::write_batch` (`native/shuffle/src/writers/shuffle_block_writer.rs`) emits each
 block as an 8-byte little-endian length, an 8-byte field count, a 4-byte ASCII codec tag (`ZSTD`,
-`LZ4_`, `SNAP`, or `NONE`), and then one complete Arrow IPC stream compressed as a single frame. The length covers everything after itself.
-The field count is written because the JVM reader has to know how many array addresses to allocate,
-and `NativeBatchDecoderIterator` reads both headers before handing the remainder, starting at the
-codec tag, to native code.
+`LZ4_`, `SNAP`, or `NONE`), and then one complete Arrow IPC stream compressed as a single frame.
+The length covers everything after itself. The field count is written because the JVM reader has to
+know how many array addresses to allocate, and `NativeBatchDecoderIterator` reads both headers
+before handing the remainder, starting at the codec tag, to native code.
 
 Compression wraps the whole IPC stream rather than individual buffers. `read_ipc_compressed`
 (`native/shuffle/src/ipc.rs`) dispatches on the 4-byte tag, wraps the rest in the matching frame

--- a/docs/source/contributor-guide/native_shuffle.md
+++ b/docs/source/contributor-guide/native_shuffle.md
@@ -275,13 +275,15 @@ all three have to match Spark:
    column, feeding each value's little-endian bytes at a width fixed by the arrow data type.
    `hash_array_primitive!` (`native/spark-expr/src/hash_funcs/utils.rs`) widens `Int8`, `Int16`, and
    `Int32` to `i32` and hashes four bytes, and `Int64` to `i64` and hashes eight. The finalizer mixes
-   the byte length in, so the same numeric value at a different width yields a different hash. Null
-   slots are skipped and leave the running hash unchanged.
+   the byte length in, so the same numeric value hashed as `Int32` versus `Int64` yields a different
+   hash. Null slots are skipped and leave the running hash unchanged.
 3. `pmod` (`native/shuffle/src/comet_partitioning.rs`) reinterprets the `u32` hash as `i32` before
    taking the remainder, then folds a negative result back into range. The signed reinterpretation is
-   load bearing: Spark's `Murmur3Hash` returns a signed `Int`, so dropping the `as i32` moves every
-   hash at or above 2^31 to a different partition. `test_pmod` in that file pins five hashes against
-   the partition ids Spark produces for `n = 200`.
+   load bearing: Spark's `Murmur3Hash` returns a signed `Int`, so dropping the `as i32` moves hashes
+   at or above 2^31 to a different partition for any partition count that is not a power of two,
+   including 200, Spark's default. A power of two divides 2^32 exactly, which is why testing this
+   with `repartition(1024)` shows no difference at all. `test_pmod` in that file pins five hashes,
+   all of them above 2^31, against the partition ids Spark produces for `n = 200`.
 
 Round-robin partitioning runs the same three steps over the first `max_hash_columns` columns, so it
 inherits all of them.
@@ -320,10 +322,9 @@ the passthrough assertion. That is the signal the workaround for that function c
 
 ### The block format is deliberately not stock Arrow IPC
 
-Each block `ShuffleBlockWriter::write_batch`
-(`native/shuffle/src/writers/shuffle_block_writer.rs`) emits is an 8-byte little-endian length, an
-8-byte field count, a 4-byte ASCII codec tag (`ZSTD`, `LZ4_`, `SNAP`, or `NONE`), and then one
-complete Arrow IPC stream compressed as a single frame. The length covers everything after itself.
+`ShuffleBlockWriter::write_batch` (`native/shuffle/src/writers/shuffle_block_writer.rs`) emits each
+block as an 8-byte little-endian length, an 8-byte field count, a 4-byte ASCII codec tag (`ZSTD`,
+`LZ4_`, `SNAP`, or `NONE`), and then one complete Arrow IPC stream compressed as a single frame. The length covers everything after itself.
 The field count is written because the JVM reader has to know how many array addresses to allocate,
 and `NativeBatchDecoderIterator` reads both headers before handing the remainder, starting at the
 codec tag, to native code.
@@ -404,10 +405,10 @@ Where a kernel does fit, one is already used: the per-partition row gather is
 `interleave_record_batch` (`partitioners/partitioned_batch_iterator.rs`), and `SchemaAlignExec` casts
 with `cast_with_options`. Add a new hand-rolled loop only with a reason of the same kind.
 
-Two items that #5104 files under "shuffle" are not part of this path. The radix sort over packed
-record pointers is `Java_org_apache_comet_Native_sortRowPartitionsNative`
+The radix sort over packed record pointers, which #5104 lists under shuffle, is not part of this
+path: it is `Java_org_apache_comet_Native_sortRowPartitionsNative`
 (`native/core/src/execution/jni_api.rs`), which sorts the in-memory partition id array of
-`CometShuffleExternalSorter`, and the CRC32, CRC32C, and Adler32 checksums in
+`CometShuffleExternalSorter`. Separately, the CRC32, CRC32C, and Adler32 checksums in
 `native/shuffle/src/writers/checksum.rs` are reached only from `process_sorted_row_partition`, called
 by `Java_org_apache_comet_Native_writeSortedFileNative`. Both belong to
 [JVM Shuffle](jvm_shuffle.md). The native shuffle writer emits no checksums at all: it commits with

--- a/docs/source/contributor-guide/native_shuffle.md
+++ b/docs/source/contributor-guide/native_shuffle.md
@@ -49,7 +49,6 @@ Native shuffle (`CometExchange`) is selected when all of the following condition
    columnar output. Row-based Spark operators require JVM shuffle.
 
 3. **Supported partitioning type**: Native shuffle supports:
-
    - `HashPartitioning`
    - `RangePartitioning`
    - `SinglePartition`
@@ -116,11 +115,18 @@ Native shuffle (`CometExchange`) is selected when all of the following condition
 
 ### Rust Side
 
-| File                    | Location                             | Description                                                                          |
-| ----------------------- | ------------------------------------ | ------------------------------------------------------------------------------------ |
-| `shuffle_writer.rs`     | `native/core/src/execution/shuffle/` | `ShuffleWriterExec` plan and partitioners. Main shuffle logic.                       |
-| `codec.rs`              | `native/core/src/execution/shuffle/` | `ShuffleBlockWriter` for Arrow IPC encoding with compression. Also handles decoding. |
-| `comet_partitioning.rs` | `native/core/src/execution/shuffle/` | `CometPartitioning` enum defining partition schemes (Hash, Range, Single).           |
+| File                              | Location              | Description                                                                                                 |
+| --------------------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `shuffle_writer.rs`               | `native/shuffle/src/` | `ShuffleWriterExec` plan and the partitioner selection in `external_shuffle`.                               |
+| `partitioners/`                   | `native/shuffle/src/` | `MultiPartitionShuffleRepartitioner`, `SinglePartitionShufflePartitioner`, `EmptySchemaShufflePartitioner`. |
+| `writers/shuffle_block_writer.rs` | `native/shuffle/src/` | `ShuffleBlockWriter`: Arrow IPC encoding plus the block header and whole-stream compression.                |
+| `ipc.rs`                          | `native/shuffle/src/` | `read_ipc_compressed`, the decode half of the block format.                                                 |
+| `comet_partitioning.rs`           | `native/shuffle/src/` | `CometPartitioning` enum defining partition schemes (Hash, Range, RoundRobin, Single), and `pmod`.          |
+| `schema_align.rs`                 | `native/shuffle/src/` | `SchemaAlignExec`, which reshapes the writer's input to the schema Spark catalyst declared.                 |
+
+These files live in the `datafusion-comet-shuffle` crate. `native/core` re-exports it as
+`execution::shuffle` (`native/core/src/execution/mod.rs`), so paths such as
+`crate::execution::shuffle::ShuffleBlockWriter` in `native/core` resolve into `native/shuffle/src/`.
 
 ## Data Flow
 
@@ -129,7 +135,6 @@ Native shuffle (`CometExchange`) is selected when all of the following condition
 1. **Plan construction**: `CometNativeShuffleWriter` builds a protobuf operator tree with a
    `ShuffleWriter` operator at the root and `childNativeOp` as its child. `childNativeOp` takes
    one of two shapes:
-
    - The child plan's `nativeOp` directly, when `CometShuffleExchangeExec`'s child is a
      `CometNativeExec` subtree. The upstream operators run inside the same `CometExecIterator`
      as the writer, with no JVM-to-native batch boundary between them.
@@ -142,7 +147,6 @@ Native shuffle (`CometExchange`) is selected when all of the following condition
 2. **Native execution**: A single `CometExecIterator` per partition runs the unified plan.
 
 3. **Partitioning**: `ShuffleWriterExec` receives batches and routes to the appropriate partitioner:
-
    - `MultiPartitionShuffleRepartitioner`: For hash/range/round-robin partitioning
    - `SinglePartitionShufflePartitioner`: For single partition (simpler path)
 
@@ -150,13 +154,11 @@ Native shuffle (`CometExchange`) is selected when all of the following condition
    exceeds the threshold, partitions spill to temporary files.
 
 5. **Encoding**: `ShuffleBlockWriter` encodes each partition's data as compressed Arrow IPC:
-
    - Writes compression type header
    - Writes field count header
    - Writes compressed IPC stream
 
 6. **Output files**: Two files are produced:
-
    - **Data file**: Concatenated partition data
    - **Index file**: Array of 8-byte little-endian offsets marking partition boundaries
 
@@ -168,7 +170,6 @@ Native shuffle (`CometExchange`) is selected when all of the following condition
 1. `CometBlockStoreShuffleReader` fetches shuffle blocks via `ShuffleBlockFetcherIterator`.
 
 2. For each block, `NativeBatchDecoderIterator`:
-
    - Reads the 8-byte compressed length header
    - Reads the 8-byte field count header
    - Reads the compressed IPC data
@@ -186,7 +187,9 @@ Native shuffle implements Spark-compatible hash partitioning:
 
 - Uses Murmur3 hash function with seed 42 (matching Spark)
 - Computes hash of partition key columns
-- Applies modulo by partition count: `partition_id = hash % num_partitions`
+- Applies Spark's positive modulo by partition count: `partition_id = pmod(hash, num_partitions)`,
+  where `pmod` reinterprets the hash as a signed 32-bit integer and folds a negative remainder back
+  into range
 
 ### Range Partitioning
 
@@ -206,8 +209,9 @@ simply concatenates batches to reach the configured batch size.
 
 Comet implements round robin partitioning using hash-based assignment for determinism:
 
-1. Computes a Murmur3 hash of columns (using seed 42)
-2. Assigns partitions directly using the hash: `partition_id = hash % num_partitions`
+1. Computes a Murmur3 hash of columns (using seed 42), over the first `max_hash_columns` columns,
+   where `0` means all of them
+2. Assigns partitions directly using the hash, through the same `pmod` as hash partitioning
 
 This approach guarantees determinism across retries, which is critical for fault tolerance.
 However, unlike true round robin which cycles through partitions row-by-row, hash-based
@@ -217,21 +221,25 @@ sizes.
 
 ## Memory Management
 
-Native shuffle uses DataFusion's memory management with spilling support:
+`MultiPartitionShuffleRepartitioner` is the only operator in Comet's own native code that registers
+a DataFusion `MemoryConsumer`, so it is also the reference for how a buffering native operator
+reserves memory. See [Native Memory Management](memory_management.md) for how pools are chosen and
+sized, what `try_grow` returning an error means, and how the reservation reaches Spark's
+`TaskMemoryManager`.
 
-- **Memory pool**: Tracks memory usage across the shuffle operation.
+The shuffle-specific parts:
+
 - **Spill triggers**: Partitions spill to disk when the memory pool denies an allocation, or
   when the buffered bytes reach `spark.comet.shuffle.native.maxBufferBytes`. That config defaults to
   0, which disables the fixed limit and leaves memory pressure as the only trigger.
-- **Per-partition spilling**: Each partition has its own spill file. Multiple spills for a
-  partition are concatenated when writing the final output.
-- **Scratch space**: Reusable buffers for partition ID computation to reduce allocations.
-
-The `MultiPartitionShuffleRepartitioner` manages:
-
-- `PartitionBuffer`: In-memory buffer for each partition
-- `SpillFile`: Temporary file for spilled data
-- Memory tracking via `MemoryConsumer` trait
+- **Per-partition spilling**: Each partition has its own spill file (`writers/local/spill.rs`).
+  Multiple spills for a partition are concatenated when writing the final output.
+- **Scratch space**: Reusable buffers for partition ID computation to reduce allocations
+  (`ScratchSpace` in `partitioners/multi_partition.rs`).
+- **What is charged**: the reservation covers the batches held in `buffered_batches` plus the
+  per-partition row index vectors. `count_new_buffers` sums each distinct backing allocation once,
+  keyed by buffer start address, rather than using `RecordBatch::get_array_memory_size` or a sum of
+  slice sizes; its doc comment records why both of those measures are wrong here.
 
 ## Compression
 
@@ -247,6 +255,163 @@ Native shuffle supports multiple compression codecs configured via
 
 The compression codec is applied uniformly to all partitions. Each partition's data is
 independently compressed, allowing parallel decompression during reads.
+
+## Rules and common mistakes
+
+Shuffle carries more cross-boundary invariants than most of the native code, because its output has
+to satisfy Spark's planner, its bytes have to satisfy two separate readers, and neither side
+re-checks the other. Every rule below is grounded in a specific file. Where a rule cites a file,
+read that file before relying on the summary here.
+
+### Reproduce Spark's hash exactly, or rows land in the wrong reducer
+
+`MultiPartitionShuffleRepartitioner::partitioning_batch`
+(`native/shuffle/src/partitioners/multi_partition.rs`) derives a partition id in three steps, and
+all three have to match Spark:
+
+1. The hash buffer is filled with `42` before hashing (`hashes_buf.fill(42_u32)`), which is the seed
+   Spark's `Murmur3Hash` uses.
+2. `create_murmur3_hashes` (`native/spark-expr/src/hash_funcs/murmur3.rs`) chains one hash per
+   column, feeding each value's little-endian bytes at a width fixed by the arrow data type.
+   `hash_array_primitive!` (`native/spark-expr/src/hash_funcs/utils.rs`) widens `Int8`, `Int16`, and
+   `Int32` to `i32` and hashes four bytes, and `Int64` to `i64` and hashes eight. The finalizer mixes
+   the byte length in, so the same numeric value at a different width yields a different hash. Null
+   slots are skipped and leave the running hash unchanged.
+3. `pmod` (`native/shuffle/src/comet_partitioning.rs`) reinterprets the `u32` hash as `i32` before
+   taking the remainder, then folds a negative result back into range. The signed reinterpretation is
+   load bearing: Spark's `Murmur3Hash` returns a signed `Int`, so dropping the `as i32` moves every
+   hash at or above 2^31 to a different partition. `test_pmod` in that file pins five hashes against
+   the partition ids Spark produces for `n = 200`.
+
+Round-robin partitioning runs the same three steps over the first `max_hash_columns` columns, so it
+inherits all of them.
+
+Nothing downstream re-checks the assignment. `CometShuffleExchangeExec` extends `ShuffleExchangeLike`
+and overrides `outputPartitioning` with the `Partitioning` object Spark's planner handed it, so
+`EnsureRequirements` treats the exchange as already satisfying that distribution, and the read path
+only decodes blocks. A partition id that disagrees with Spark's therefore surfaces as a wrong answer,
+typically rows missing from a join or a group split across reducers, not as an error. Verify changes
+here by comparing full query results against Spark, not with a unit test of the Rust function alone.
+
+### Align the writer's input schema before partitioning
+
+`SchemaAlignExec` (`native/shuffle/src/schema_align.rs`) casts each writer input column to the type
+Spark catalyst declared. `align_shuffle_writer_input` in
+`native/core/src/execution/planner.rs` inserts it around the writer's child, and `create_partitioning`
+is then called with `writer_input.schema()`, so both the hash expressions and the range
+`SortField`s are built from the aligned types. That ordering is the point of the operator.
+
+Everywhere else in the native runtime a return-type drift from DataFusion or `datafusion-spark` is
+self-healing, because the `ScanExec` that imports the batch on the other side of the JVM boundary
+casts every column to the catalyst-declared type. Shuffle is the exception on two counts:
+
+- The partition id depends on the arrow type, per the hashing rule above, so a drifted type routes
+  rows to the wrong partition, and a read-side cast cannot undo a partition assignment.
+- The read side does not cast. `ShuffleScanExec::get_next`
+  (`native/core/src/execution/operators/shuffle_scan.rs`) decodes the block, unpacks any
+  dictionary-encoded column to its value type, and then stamps the protobuf-declared schema on with
+  `RecordBatch::try_new_with_options`, which fails on any data type that does not match. Dictionary
+  unpacking is the only conversion on that path.
+
+[Issue #4515](https://github.com/apache/datafusion-comet/issues/4515) is the running list of
+functions whose return types drift. The tests in `schema_align.rs` are written so that when a drift
+pair becomes identical, `try_new_or_passthrough` returns the child unwrapped and the test flips to
+the passthrough assertion. That is the signal the workaround for that function can be deleted.
+
+### The block format is deliberately not stock Arrow IPC
+
+Each block `ShuffleBlockWriter::write_batch`
+(`native/shuffle/src/writers/shuffle_block_writer.rs`) emits is an 8-byte little-endian length, an
+8-byte field count, a 4-byte ASCII codec tag (`ZSTD`, `LZ4_`, `SNAP`, or `NONE`), and then one
+complete Arrow IPC stream compressed as a single frame. The length covers everything after itself.
+The field count is written because the JVM reader has to know how many array addresses to allocate,
+and `NativeBatchDecoderIterator` reads both headers before handing the remainder, starting at the
+codec tag, to native code.
+
+Compression wraps the whole IPC stream rather than individual buffers. `read_ipc_compressed`
+(`native/shuffle/src/ipc.rs`) dispatches on the 4-byte tag, wraps the rest in the matching frame
+decoder, and feeds it to a single arrow `StreamReader`. Arrow's own IPC compression is a different
+byte layout, applied per buffer and recorded in the flatbuffer message, and it offers no Snappy
+codec. `IpcWriteOptions::try_with_compression` is called nowhere in the native tree. Refactoring the
+writer onto arrow's IPC compression would change the bytes on disk and break both readers, so this
+divergence is settled; it is on the verified-intentional list in
+[epic #5104](https://github.com/apache/datafusion-comet/issues/5104).
+
+The decoder also runs with `with_skip_validation(true)`, which is why the `StreamReader` construction
+sits in an `unsafe` block: it trusts the writer to have produced a well-formed stream. Anything that
+changes what the writer emits has to keep that true.
+
+### The pre-encoded schema path must stay byte-identical
+
+For a schema with no dictionary types anywhere in its flattened field tree,
+`ShuffleBlockWriter::try_new` encodes the IPC schema message once and `encode_ipc_stream` writes
+those bytes verbatim at the start of every block, followed by the record batch message and an 8-byte
+end-of-stream marker. This is a fast path that avoids re-serializing the schema per block, not a
+format change: it uses the same `IpcDataGenerator` and the same `IpcWriteOptions` that
+`StreamWriter` would, and spells the end-of-stream marker out as the `IPC_EOS` constant. That
+constant is only correct for metadata version V5 with non-legacy framing, which is why `try_new`
+pins `IpcWriteOptions::try_new(64, false, MetadataVersion::V5)` instead of taking the arrow default.
+Schemas that do contain dictionary types fall back to `StreamWriter`, because the schema and the
+batch have to share a dictionary tracker.
+
+Two properties to preserve if you touch this. The output has to remain what `StreamWriter` would
+have produced, since both readers parse it as an ordinary IPC stream. And both arms of
+`SchemaEncoding` hold their payload behind an `Arc`, because the writer is cloned once per output
+partition and a shuffle can request millions of partitions; `clone_shares_buffers` in the same file
+asserts that a clone shares those buffers rather than deep-copying them.
+
+### Range bounds come out of a private Spark field by reflection
+
+`prepareNativeShuffleDependency` in
+`.../shuffle/CometShuffleExchangeExec.scala` constructs a real Spark `RangePartitioner` on the driver
+over a dedicated sampling RDD, then reads its private `rangeBounds` array with
+`getDeclaredField("rangeBounds")` and `setAccessible(true)`. The bounds are serialized into the
+native plan, and the native side reproduces `RangePartitioner.getPartition` as
+`bounds.partition_point(|bound| bound.row() <= row)` over arrow `Row`s. The boundary rows and the
+incoming batches are encoded by the same `RowConverter`, whose `SortField`s carry each column's sort
+options (`create_partitioning` in `native/core/src/execution/planner.rs`), which is what makes the
+byte comparison reproduce the Spark ordering.
+
+There is no fallback around the reflection, so a Spark version that renames or restructures that
+field fails at run time rather than mispartitioning silently. Check it when adding support for a new
+Spark version.
+
+### Zero-column batches still carry a row count
+
+`external_shuffle` (`native/shuffle/src/shuffle_writer.rs`) selects the partitioner with a guarded
+`match`, and the empty-schema guard is checked first, ahead of the single-partition guard.
+A zero-column input therefore gets `EmptySchemaShufflePartitioner` whatever partitioning was
+requested. That partitioner accumulates row counts and writes one zero-column IPC batch carrying the
+total to partition 0, leaving every other partition empty in the index file. This is what lets
+`count(*)`-shaped queries survive a shuffle after column pruning has removed every column, so
+preserve the guard order when adding a partitioner.
+
+### Kernel-first still applies, but here the answer is often no
+
+[Working with Arrow in Native Code](working_with_arrow.md) says to look for an existing arrow-rs or
+DataFusion kernel before writing array code by hand. Shuffle is one of the places where that search
+legitimately comes back empty, and the #5104 audit confirmed the remaining hand-rolled pieces are
+intentional:
+
+- The block format above is fixed by the JVM reader, so arrow's IPC compression is not usable.
+- Grouping rows by partition is a counting sort.
+  `ScratchSpace::map_partition_ids_to_starts_and_indices` in `partitioners/multi_partition.rs` counts
+  rows per partition, prefix-sums the counts into partition ends, then places every row index in one
+  reverse pass. That is linear in the number of rows, where sorting a batch by partition id with a
+  kernel is `n log n`.
+
+Where a kernel does fit, one is already used: the per-partition row gather is
+`interleave_record_batch` (`partitioners/partitioned_batch_iterator.rs`), and `SchemaAlignExec` casts
+with `cast_with_options`. Add a new hand-rolled loop only with a reason of the same kind.
+
+Two items that #5104 files under "shuffle" are not part of this path. The radix sort over packed
+record pointers is `Java_org_apache_comet_Native_sortRowPartitionsNative`
+(`native/core/src/execution/jni_api.rs`), which sorts the in-memory partition id array of
+`CometShuffleExternalSorter`, and the CRC32, CRC32C, and Adler32 checksums in
+`native/shuffle/src/writers/checksum.rs` are reached only from `process_sorted_row_partition`, called
+by `Java_org_apache_comet_Native_writeSortedFileNative`. Both belong to
+[JVM Shuffle](jvm_shuffle.md). The native shuffle writer emits no checksums at all: it commits with
+an empty checksum array in `CometNativeShuffleWriter.scala`.
 
 ## Configuration
 

--- a/docs/source/contributor-guide/working_with_arrow.md
+++ b/docs/source/contributor-guide/working_with_arrow.md
@@ -92,9 +92,9 @@ them in review, and do not "simplify" them into an arrow call without new eviden
   DST rules.
 - **Shuffle byte formats**: whole-stream compression framing (arrow IPC per-buffer compression is
   a different byte format and has no Snappy), the pre-encoded schema fast path (byte-identical to
-  `StreamWriter`, exists to avoid re-encoding), radix sort over packed record pointers (not over
-  arrow arrays), and counting-sort partition grouping (linear versus the kernel route's
-  `n log n`). Row gather already uses `interleave_record_batch`.
+  `StreamWriter`, exists to avoid re-encoding), radix sort over packed record pointers on the JVM
+  shuffle path (not over arrow arrays), and counting-sort partition grouping (linear versus the
+  kernel route's `n log n`). Row gather already uses `interleave_record_batch`.
 - **columnar_to_row**: the `UnsafeRow` and `UnsafeArrayData` writers emit Spark's byte format.
   `arrow_row::RowConverter` produces arrow's row format and is not applicable.
 - **Aggregates**: decimal sum and avg per-row overflow checks (batch-level checking would change

--- a/docs/source/contributor-guide/working_with_arrow.md
+++ b/docs/source/contributor-guide/working_with_arrow.md
@@ -1,0 +1,172 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Working with Arrow in Native Code
+
+This page covers two decisions that come up in almost every native change: whether to write
+array-manipulating code at all, and how to write it correctly when you must. Both are places
+where Comet has repeatedly gotten it wrong. An audit of the native crates
+([epic #5104](https://github.com/apache/datafusion-comet/issues/5104)) filed sixteen follow-ups
+for hand-rolled logic that duplicates an existing arrow-rs or DataFusion implementation, two of
+them carrying real correctness bugs that the upstream implementation does not have.
+
+The rules below are grounded in specific files and issues. Where a rule cites a file, read that
+file before relying on the summary here.
+
+## Check for an existing kernel first
+
+Before writing a loop over an Arrow array, work down this list and stop at the first hit:
+
+1. **arrow-rs compute kernels.** The workspace is on arrow `58.4.0` (`native/Cargo.toml`). Kernel
+   availability claims on this page are specific to that version. Check
+   `arrow::compute::kernels` and the type-level helpers on `PrimitiveArray` before anything else.
+2. **DataFusion.** If arrow has no kernel for the shape, DataFusion may already implement the
+   function or a close relative.
+3. **The `datafusion-spark` crate.** Comet depends on `datafusion-spark` `54.1.0`
+   (`native/Cargo.toml`) and registers its functions in
+   `native/core/src/execution/jni_api.rs`, which currently imports 33 of its functions. If the
+   function you need exists upstream, wire it instead of writing it. See
+   [Adding a New Expression](adding_a_new_expression.md).
+4. **Write it in Comet**, and only then.
+
+Run this check even when you are touching code that already exists. Some of Comet's hand-rolled
+code predates the public availability of the API it duplicates, so the duplication was correct
+when it was written and is not correct now. Verified examples:
+
+- `native/spark-expr/src/timezone.rs` is a copy of arrow-array's `Tz` and `TzOffset`. Its own
+  header says "This is basically from arrow-array::timezone (private)". In arrow 58 that module
+  is public with the `chrono-tz` feature, which the workspace already enables, and
+  `native/spark-expr/src/kernels/temporal.rs` already imports arrow's version. The crate now
+  carries two parallel, incompatible `Tz` types
+  ([#5088](https://github.com/apache/datafusion-comet/issues/5088)).
+- `is_valid_decimal_precision` in `native/spark-expr/src/utils.rs` is a copy of arrow's
+  implementation. Its comment says to remove it "once we upgrade to a version of arrow-rs that
+  includes https://github.com/apache/arrow-rs/pull/6419". That PR shipped well before arrow 58
+  ([#5089](https://github.com/apache/datafusion-comet/issues/5089)).
+- `native/spark-expr/src/datetime_funcs/date_from_unix_date.rs` reinterprets Int32 as Date32 by
+  hand, and `native/spark-expr/src/utils.rs` converts milliseconds to microseconds with
+  `arity::unary(millis_array, |v| v * 1000)`. Arrow's `cast` kernel performs both bit-identically
+  ([#5090](https://github.com/apache/datafusion-comet/issues/5090)).
+
+If you decide to keep a local implementation because the upstream one is wrong, record why in the
+file, with a pointer to the upstream issue and the condition under which the file can be deleted.
+`native/spark-expr/src/array_funcs/array_slice.rs` is the model: its header states the exact
+behavioral difference from `datafusion-spark`'s `SparkSlice`, the upstream version it was checked
+against, and that the file can be dropped once upstream is fixed.
+
+### Where Comet diverges from arrow on purpose
+
+Much of Comet's native code looks like a reimplementation of an arrow kernel but is not one. It
+implements Spark semantics that arrow deliberately does not have: ANSI errors, HALF_UP rounding,
+Java string formats, Spark timezone rules, and Spark-mandated byte formats. The #5104 audit
+examined each of the following and confirmed it is intentional. These are settled. Do not re-raise
+them in review, and do not "simplify" them into an arrow call without new evidence.
+
+- **Cast string parsing and formatting** (`conversion_funcs/string.rs`, float and decimal to
+  string): ports of `UTF8String.toInt`, `stringToDate`, `stringToTimestamp`, Java
+  `Double.toString` and `BigDecimal.toString`. `arrow_cast::parse` and the arrow display
+  implementations are not Spark-compatible for any of these.
+- **Legacy wrap-around int casts, seconds-based numeric to timestamp, and NTZ/TZ timestamp
+  handling**: arrow either has no wrapping mode, interprets values in target-unit ticks, or
+  wall-clock-adjusts where Spark needs a relabel or a session-timezone conversion under Spark's
+  DST rules.
+- **Shuffle byte formats**: whole-stream compression framing (arrow IPC per-buffer compression is
+  a different byte format and has no Snappy), the pre-encoded schema fast path (byte-identical to
+  `StreamWriter`, exists to avoid re-encoding), radix sort over packed record pointers (not over
+  arrow arrays), and counting-sort partition grouping (linear versus the kernel route's
+  `n log n`). Row gather already uses `interleave_record_batch`.
+- **columnar_to_row**: the `UnsafeRow` and `UnsafeArrayData` writers emit Spark's byte format.
+  `arrow_row::RowConverter` produces arrow's row format and is not applicable.
+- **Aggregates**: decimal sum and avg per-row overflow checks (batch-level checking would change
+  which inputs go null), Spark ROUND_HALF_UP average, Welford recurrences, and
+  percentile/HLL++/QuantileSummaries, which are Spark sketch formats. `GroupsAccumulator` per-group
+  loops stay because arrow has no grouped kernels.
+- **Hashes and bloom filter**: seed-chained murmur3 and xxhash64 dispatch, plus the Spark
+  `BitArray` and bloom serialization formats, are Spark-mandated.
+- **String functions with Spark grammars**: base64 (MIME 76-character CRLF chunking), the
+  `regexp_extract` family (Spark group, no-match, and error semantics plus all-matches extraction
+  that arrow lacks), `split` (Spark limit semantics), read-side padding (arrow has no lpad/rpad;
+  this is a deliberate performance design), `is_nan` (null to false is Spark-specific), and
+  `get_json_object` (Spark JSONPath).
+- **Math type-widening and rounding**: abs, ceil, floor, round, decimal division, and wide decimal
+  binary operations have no arrow kernel for the shape, or need Spark's type-widening and rounding
+  rules. `checkoverflow` needs the offending value for its ANSI error text. `normalize_nan` and
+  `unscaled_value` have no arrow equivalent. The array paths already use arity helpers.
+- **Datetime grammars and floor division**: `unix_timestamp` needs floor division where arrow's
+  cast truncates; `hours`, `seconds_to_timestamp`, `make_date`, `make_time`, `next_day`, `to_time`,
+  and the day and month name functions carry Spark grammars, error texts, and locale tables.
+  `extract_date_part` already uses arrow `date_part`.
+- **Copy and scan operators**: these are already built on `MutableArrayData` and
+  `cast_with_options`. Their extra copies exist to break FFI buffer ownership, not by oversight.
+  See [Arrow FFI](ffi.md).
+
+## Using Arrow APIs correctly
+
+### Values under null slots are arbitrary
+
+A null slot's underlying value buffer holds whatever bytes are there: zero, a leftover from
+before a filter or a slice, or data that arrived over FFI. Nothing guarantees it is a benign
+value. Two consequences:
+
+**Fallible logic must consult the validity buffer before reading the value.** Comet has a live
+bug from ignoring this. The `check_overflow!` macro in
+`native/spark-expr/src/math_funcs/negative.rs` loops `for i in 0..typed_array.len()` and compares
+`typed_array.value(i)` against the type's `MIN` with no validity check, so an ANSI-mode negation
+raises `ARITHMETIC_OVERFLOW` when a `MIN` value happens to sit under a null slot. Spark returns
+null for that row ([#5093](https://github.com/apache/datafusion-comet/issues/5093)).
+
+`native/spark-expr/src/math_funcs/checked_arithmetic.rs` shows the correct shape. It unions the
+input null buffers up front and gates the error on `nulls.as_ref().is_none_or(|n| n.is_valid(i))`,
+so a garbage value under a null cannot raise. The behavior is pinned by
+`test_null_row_with_garbage_value_does_not_error_in_ansi_mode`. Add an equivalent test whenever
+you write a fallible per-row path.
+
+**Arrow's infallible arity helpers do not save you.** In arrow 58.4.0, `unary` and `binary`
+evaluate the closure on every element including nulls, by design: the arrow docs state the cost of
+the operation is lower than the cost of branching, and require `op` to be infallible for all
+possible input values. `try_unary` is the one that applies the closure only to valid rows
+(`PrimitiveArray::try_unary` iterates via `try_for_each_valid_idx`). Use `try_unary` for anything
+that can error, and never put a panicking or erroring operation inside `unary`.
+
+### Rebuilding a nested array means rebuilding every null buffer in it
+
+When you construct a nested array by hand rather than letting a kernel do it, each level of the
+structure has its own validity, and each one has to be carried explicitly. Carrying only the
+outermost one silently drops data.
+
+`cast_map_to_map` in `native/spark-expr/src/conversion_funcs/cast.rs` does exactly this. It passes
+`map_array.nulls().cloned()` when it builds the output `MapArray`, which is correct, but a few
+lines earlier it passes `None` for the entries `StructArray`'s null buffer, dropping
+`map_array.entries().nulls()`. It also propagates the source's `sorted` flag rather than the
+target's ([#5097](https://github.com/apache/datafusion-comet/issues/5097)). Arrow's Map-to-Map
+`cast_with_options` handles both correctly, which is the other reason to prefer the kernel: it
+carries structure you may not have thought about.
+
+The general rule follows from the first section. Prefer the kernel; reach for a hand-built array
+only when Spark semantics require it, and when you do, enumerate every null buffer and every
+metadata flag in the type you are constructing and account for each one.
+
+## Further reading
+
+- [Arrow FFI](ffi.md) for buffer ownership across the JVM and native boundary, and why some
+  operators copy deliberately.
+- [Optimizing Scalar Expressions](optimizing_expressions.md) for the benchmark and no-regression
+  rules that apply when you replace hand-rolled code with a kernel for speed.
+- [Epic #5104](https://github.com/apache/datafusion-comet/issues/5104) for the full audit,
+  including the open issues for each duplicated site.

--- a/docs/source/contributor-guide/working_with_arrow.md
+++ b/docs/source/contributor-guide/working_with_arrow.md
@@ -51,8 +51,8 @@ when it was written and is not correct now. Verified examples:
 
 - `native/spark-expr/src/timezone.rs` is a copy of arrow-array's `Tz` and `TzOffset`. Its own
   header says "This is basically from arrow-array::timezone (private)". In arrow 58 that module
-  is public with the `chrono-tz` feature, which the workspace already enables, and
-  `native/spark-expr/src/kernels/temporal.rs` already imports arrow's version. The crate now
+  is public, and with the `chrono-tz` feature the workspace already enables it resolves named
+  zones. `native/spark-expr/src/kernels/temporal.rs` already imports arrow's version. The crate now
   carries two parallel, incompatible `Tz` types
   ([#5088](https://github.com/apache/datafusion-comet/issues/5088)).
 - `is_valid_decimal_precision` in `native/spark-expr/src/utils.rs` is a copy of arrow's
@@ -61,8 +61,12 @@ when it was written and is not correct now. Verified examples:
   ([#5089](https://github.com/apache/datafusion-comet/issues/5089)).
 - `native/spark-expr/src/datetime_funcs/date_from_unix_date.rs` reinterprets Int32 as Date32 by
   hand, and `native/spark-expr/src/utils.rs` converts milliseconds to microseconds with
-  `arity::unary(millis_array, |v| v * 1000)`. Arrow's `cast` kernel performs both bit-identically
-  ([#5090](https://github.com/apache/datafusion-comet/issues/5090)).
+  `arity::unary(millis_array, |v| v * 1000)`. Arrow's `cast` kernel covers both; see
+  [#5090](https://github.com/apache/datafusion-comet/issues/5090) for the equivalence argument and
+  the timezone caveats. Note that the two are not equivalent on overflow: the plain `unary`
+  multiply wraps, while arrow's timestamp unit cast uses `unary_opt` with `checked_mul` in safe
+  mode (null on overflow) and `try_unary` with `mul_checked` otherwise (error). Confirm which
+  behavior you want before swapping a loop for the kernel.
 
 If you decide to keep a local implementation because the upstream one is wrong, record why in the
 file, with a pointer to the upstream issue and the condition under which the file can be deleted.
@@ -131,11 +135,19 @@ bug from ignoring this. The `check_overflow!` macro in
 raises `ARITHMETIC_OVERFLOW` when a `MIN` value happens to sit under a null slot. Spark returns
 null for that row ([#5093](https://github.com/apache/datafusion-comet/issues/5093)).
 
-`native/spark-expr/src/math_funcs/checked_arithmetic.rs` shows the correct shape. It unions the
-input null buffers up front and gates the error on `nulls.as_ref().is_none_or(|n| n.is_valid(i))`,
-so a garbage value under a null cannot raise. The behavior is pinned by
-`test_null_row_with_garbage_value_does_not_error_in_ansi_mode`. Add an equivalent test whenever
-you write a fallible per-row path.
+`native/spark-expr/src/math_funcs/checked_arithmetic.rs` shows the correct shape, and the shape is
+not "add a validity check to the loop". `checked_binary` returns early for the ANSI path at lines
+64 to 72, delegating to `arrow::compute::kernels::arity::try_binary` and mapping the resulting
+`ArrowError` back to a Spark error. The kernel is what guarantees the null behavior: when either
+input has a non-zero null count, `try_binary` unions the null buffers and drives the closure
+through `nulls.try_for_each_valid_idx`, so `op` is never applied to a null slot. The behavior is
+pinned by `test_null_row_with_garbage_value_does_not_error_in_ansi_mode` in the same file. The
+hand-rolled loop below the early return is the non-ANSI path, where an overflow marks the row null
+instead of raising.
+
+The fix proposed for #5093 is the same move: replace the manual scan with arrow's checked `neg`,
+which skips invalid slots. Prefer delegating the fallible path to a kernel over guarding a loop by
+hand, and add an equivalent garbage-value-under-a-null test whenever you write one.
 
 **Arrow's infallible arity helpers do not save you.** In arrow 58.4.0, `unary` and `binary`
 evaluate the closure on every element including nulls, by design: the arrow docs state the cost of
@@ -155,8 +167,11 @@ outermost one silently drops data.
 lines earlier it passes `None` for the entries `StructArray`'s null buffer, dropping
 `map_array.entries().nulls()`. It also propagates the source's `sorted` flag rather than the
 target's ([#5097](https://github.com/apache/datafusion-comet/issues/5097)). Arrow's Map-to-Map
-`cast_with_options` handles both correctly, which is the other reason to prefer the kernel: it
-carries structure you may not have thought about.
+`cast_with_options` carries the entries validity through (`cast/map.rs` passes
+`from.entries().nulls().cloned()`), and it refuses a sortedness change outright rather than
+silently taking the source's: `cast/mod.rs` matches Map to Map only when the two `ordered` flags
+are equal, in both `can_cast_types` and the cast dispatch. That is the other reason to prefer the
+kernel: it carries structure you may not have thought about, and rejects what it cannot express.
 
 The general rule follows from the first section. Prefer the kernel; reach for a hand-built array
 only when Spark semantics require it, and when you do, enumerate every null buffer and every


### PR DESCRIPTION
## Which issue does this PR close?

Part of #5178.

## Rationale for this change

The contributor guide explains how Comet's subsystems work but does not record the invariants that must hold when changing them. `native_shuffle.md` and `ffi.md` are architectural explainers, there was no page covering native memory management at all, and nothing described when native code should defer to arrow-rs or DataFusion instead of hand-rolling logic.

That gap costs twice. Reviewers re-derive the same invariants on every PR, and contributors who have not read the relevant subsystem produce code that looks correct while violating rules nobody wrote down. The audit behind #5104 filed sixteen follow-ups, two of them real bugs, and none of that knowledge lived anywhere a contributor would look.

Each page follows the shape of `optimizing_expressions.md`: enough narrative to orient someone new, then a rules section carrying the checkable content.

## What changes are included in this PR?

Three contributor guide changes.

**`working_with_arrow.md` (new)** covers deciding whether to write native array code at all, then writing it correctly. The reuse half gives the order to check arrow-rs, DataFusion, and `datafusion-spark` before hand-rolling, and reproduces the list of places Comet diverges from arrow deliberately so those are not re-raised in review. The correctness half covers the Arrow API traps that produced real bugs, including that `unary` and `binary` run the closure on null slots while `try_unary` and `try_binary` skip them, which is what separates #5093 from the code that gets it right.

**`memory_management.md` (new)** covers the nine native pool types along the two axes that actually distinguish them (greedy versus fair spill, and scope), the hard split where off-heap mode accepts only the two unified pools and on-heap accepts the other seven, how native accounting reaches Spark through `CometTaskMemoryManager`, and where spilling is actually implemented. It cross-references `ffi.md` rather than restating buffer ownership: that page covers who owns a buffer, this one covers who is charged for it.

**`native_shuffle.md` (extended)** gains a rules section covering the invariants that keep shuffle output readable by Spark, and its existing memory section now links to the new memory management page instead of explaining pool mechanics inline.

Every rule in all three pages cites the source file it was verified against, a filed issue, or both. Rules that could not be grounded in real code were dropped rather than softened into general advice.

Writing the shuffle rules surfaced three pre-existing errors on that page, each of which would have contradicted the new section, so they are corrected here: the Rust-side table pointed at `native/core/src/execution/shuffle/`, which is now a re-export of `native/shuffle/`; the partitioning description said `hash % num_partitions` where the code uses `pmod`; and the memory section named a `PartitionBuffer` type that no longer exists.

The section also records a scoping correction. The radix sort that #5104 lists under shuffle, and the CRC32, CRC32C, and Adler32 checksums, are both reachable only from `CometShuffleExternalSorter`, so they belong to JVM shuffle rather than the native path. The native writer currently emits no checksums at all.

Finally, `native_shuffle.md` picks up six blank-line deletions from `prettier --write`. The file already failed `prettier --check` on `main` because of prettier version drift, so editing it meant absorbing the reformat.

## How are these changes tested?

Documentation only, no code changes.

The docs build was verified locally with Sphinx. The build succeeds, the new pages resolve in the toctree, and the cross-references between the three pages resolve with no new warnings relative to `main` (the repo carries 55 pre-existing warnings from generated user-guide pages that a source-only build skips). `prettier --check` passes on the contributor guide.

The factual claims were verified by reading the source each rule cites, including tracing control flow to confirm that a cited mechanism is actually reachable and actually produces the stated effect.
