### PR TITLE
perf: intern QueryContext SQL text into a per-plan pool (up to 20x smaller serialized plans for TPC-DS)

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -343,6 +343,7 @@ jobs:
               org.apache.comet.CometNativeSuite
               org.apache.comet.CometConfSuite
               org.apache.comet.CometPublicApiSuite
+              org.apache.comet.QueryContextInternerSuite
               org.apache.comet.CometSetOpWithGroupBySuite
               org.apache.comet.CometSparkSessionExtensionsSuite
               org.apache.spark.CometPluginsSuite

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -159,6 +159,7 @@ jobs:
               org.apache.comet.CometNativeSuite
               org.apache.comet.CometConfSuite
               org.apache.comet.CometPublicApiSuite
+              org.apache.comet.QueryContextInternerSuite
               org.apache.comet.CometSetOpWithGroupBySuite
               org.apache.comet.CometSparkSessionExtensionsSuite
               org.apache.spark.CometPluginsSuite

--- a/native/common/src/query_context.rs
+++ b/native/common/src/query_context.rs
@@ -59,9 +59,12 @@ pub struct QueryContext {
 }
 
 impl QueryContext {
+    /// `sql_text` accepts either an owned `String` or an already-shared `Arc<String>`. The plan
+    /// deserializer passes an `Arc` cloned from the plan's SQL text pool so that all the contexts
+    /// in one plan share a single allocation instead of each cloning the full query text.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        sql_text: String,
+        sql_text: impl Into<Arc<String>>,
         start_index: i32,
         stop_index: i32,
         object_type: Option<String>,
@@ -70,7 +73,7 @@ impl QueryContext {
         start_position: i32,
     ) -> Self {
         Self {
-            sql_text: Arc::new(sql_text),
+            sql_text: sql_text.into(),
             start_index,
             stop_index,
             object_type,

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -781,6 +781,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
                 let planner =
                     PhysicalPlanner::new(Arc::clone(&exec_context.session_ctx), partition)
                         .with_exec_id(exec_context_id)
+                        .with_sql_text_pool(&exec_context.spark_plan)
                         .with_task_context(exec_context.task_context.clone());
                 let (scans, shuffle_scans, root_op) = planner.create_plan(
                     &exec_context.spark_plan,

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -240,6 +240,11 @@ pub struct PhysicalPlanner {
     partition: i32,
     session_ctx: Arc<SessionContext>,
     query_context_registry: Arc<datafusion_comet_spark_expr::QueryContextMap>,
+    /// SQL texts referenced by `QueryContext.sql_text_idx`, taken from the root operator's
+    /// `sql_text_pool`. Held as `Arc`s so that every context in the plan shares one allocation
+    /// rather than each cloning the full query text out of the proto. Empty when the plan was
+    /// serialized without interning, in which case contexts carry `sql_text` inline.
+    sql_text_pool: Vec<Arc<String>>,
     /// Captured at `createPlan` time on `ExecutionContext`; see that struct for the
     /// propagation rationale. `None` when no driving Spark task is available.
     task_context: Option<Arc<Global<JObject<'static>>>>,
@@ -258,8 +263,47 @@ impl PhysicalPlanner {
             session_ctx,
             partition,
             query_context_registry: datafusion_comet_spark_expr::create_query_context_map(),
+            sql_text_pool: vec![],
             task_context: None,
         }
+    }
+
+    /// Load the SQL text pool from the root operator of the plan about to be planned. Must be
+    /// called with the *root* operator: the JVM only populates the pool there, and
+    /// `QueryContext.sql_text_idx` values are indices into it.
+    pub fn with_sql_text_pool(mut self, root: &Operator) -> Self {
+        self.sql_text_pool = root
+            .sql_text_pool
+            .iter()
+            .map(|text| Arc::new(text.clone()))
+            .collect();
+        self
+    }
+
+    /// Resolve a serialized `QueryContext` into a `QueryContext`, sharing the pooled SQL text
+    /// when the context refers to the pool by index. Falls back to the inline `sql_text` for
+    /// plans serialized without interning (e.g. `CometNativeWriteExec`, which serializes its
+    /// operator directly rather than through `convertBlock`).
+    fn build_query_context(
+        &self,
+        ctx_proto: &spark_expression::QueryContext,
+    ) -> datafusion_comet_spark_expr::QueryContext {
+        let sql_text: Arc<String> = ctx_proto
+            .sql_text_idx
+            .and_then(|idx| usize::try_from(idx).ok())
+            .and_then(|idx| self.sql_text_pool.get(idx))
+            .map(Arc::clone)
+            .unwrap_or_else(|| Arc::new(ctx_proto.sql_text.clone()));
+
+        datafusion_comet_spark_expr::QueryContext::new(
+            sql_text,
+            ctx_proto.start_index,
+            ctx_proto.stop_index,
+            ctx_proto.object_type.clone(),
+            ctx_proto.object_name.clone(),
+            ctx_proto.line,
+            ctx_proto.start_position,
+        )
     }
 
     pub fn with_exec_id(mut self, exec_context_id: i64) -> Self {
@@ -349,16 +393,7 @@ impl PhysicalPlanner {
         if let (Some(expr_id), Some(ctx_proto)) =
             (spark_expr.expr_id, spark_expr.query_context.as_ref())
         {
-            // Deserialize QueryContext from protobuf
-            let query_ctx = datafusion_comet_spark_expr::QueryContext::new(
-                ctx_proto.sql_text.clone(),
-                ctx_proto.start_index,
-                ctx_proto.stop_index,
-                ctx_proto.object_type.clone(),
-                ctx_proto.object_name.clone(),
-                ctx_proto.line,
-                ctx_proto.start_position,
-            );
+            let query_ctx = self.build_query_context(ctx_proto);
 
             // Register query context for error reporting
             let registry = &self.query_context_registry;
@@ -2395,16 +2430,7 @@ impl PhysicalPlanner {
         if let (Some(expr_id), Some(ctx_proto)) =
             (spark_expr.expr_id, spark_expr.query_context.as_ref())
         {
-            // Deserialize QueryContext from protobuf
-            let query_ctx = datafusion_comet_spark_expr::QueryContext::new(
-                ctx_proto.sql_text.clone(),
-                ctx_proto.start_index,
-                ctx_proto.stop_index,
-                ctx_proto.object_type.clone(),
-                ctx_proto.object_name.clone(),
-                ctx_proto.line,
-                ctx_proto.start_position,
-            );
+            let query_ctx = self.build_query_context(ctx_proto);
 
             // Register query context for error reporting
             let registry = &self.query_context_registry;
@@ -4481,6 +4507,7 @@ mod tests {
     fn test_unpack_dictionary_primitive() {
         let op_scan = Operator {
             plan_id: 0,
+            sql_text_pool: vec![],
             children: vec![],
             op_struct: Some(OpStruct::Scan(spark_operator::Scan {
                 fields: vec![spark_expression::DataType {
@@ -4546,6 +4573,7 @@ mod tests {
     fn test_unpack_dictionary_string() {
         let op_scan = Operator {
             plan_id: 0,
+            sql_text_pool: vec![],
             children: vec![],
             op_struct: Some(OpStruct::Scan(spark_operator::Scan {
                 fields: vec![spark_expression::DataType {
@@ -4696,6 +4724,7 @@ mod tests {
 
         Operator {
             plan_id: 0,
+            sql_text_pool: vec![],
             children: vec![child_op],
             op_struct: Some(OpStruct::Filter(spark_operator::Filter {
                 predicate: Some(expr),
@@ -4722,6 +4751,7 @@ mod tests {
         let op_scan = create_scan();
         let op_join = Operator {
             plan_id: 0,
+            sql_text_pool: vec![],
             children: vec![op_scan.clone(), op_scan.clone()],
             op_struct: Some(OpStruct::HashJoin(spark_operator::HashJoin {
                 left_join_keys: vec![create_bound_reference(0)],
@@ -4758,6 +4788,7 @@ mod tests {
     fn create_scan() -> Operator {
         Operator {
             plan_id: 0,
+            sql_text_pool: vec![],
             children: vec![],
             op_struct: Some(OpStruct::Scan(spark_operator::Scan {
                 fields: vec![create_proto_datatype()],
@@ -4787,6 +4818,7 @@ mod tests {
         // ScanExec: source=[CometScan parquet  (unknown)], schema=[col_0: Int32]
         let op_scan = Operator {
             plan_id: 0,
+            sql_text_pool: vec![],
             children: vec![],
             op_struct: Some(OpStruct::Scan(spark_operator::Scan {
                 fields: vec![
@@ -4834,6 +4866,7 @@ mod tests {
         let projection = Operator {
             children: vec![op_scan],
             plan_id: 0,
+            sql_text_pool: vec![],
             op_struct: Some(OpStruct::Projection(spark_operator::Projection {
                 project_list: vec![spark_expression::Expr {
                     expr_struct: Some(ExprStruct::ScalarFunc(spark_expression::ScalarFunc {
@@ -4908,6 +4941,7 @@ mod tests {
         // Mock scan operator with 3 INT32 columns
         let op_scan = Operator {
             plan_id: 0,
+            sql_text_pool: vec![],
             children: vec![],
             op_struct: Some(OpStruct::Scan(spark_operator::Scan {
                 fields: vec![
@@ -4958,6 +4992,7 @@ mod tests {
         let projection = Operator {
             children: vec![op_scan],
             plan_id: 0,
+            sql_text_pool: vec![],
             op_struct: Some(OpStruct::Projection(spark_operator::Projection {
                 project_list: vec![spark_expression::Expr {
                     expr_struct: Some(ExprStruct::ScalarFunc(spark_expression::ScalarFunc {
@@ -5394,6 +5429,7 @@ mod tests {
         // Create a Scan operator with Date32 (DATE) and Int8 (TINYINT) columns
         let op_scan = Operator {
             plan_id: 0,
+            sql_text_pool: vec![],
             children: vec![],
             op_struct: Some(OpStruct::Scan(spark_operator::Scan {
                 fields: vec![
@@ -5458,6 +5494,7 @@ mod tests {
         let projection = Operator {
             children: vec![op_scan],
             plan_id: 1,
+            sql_text_pool: vec![],
             op_struct: Some(OpStruct::Projection(spark_operator::Projection {
                 project_list: vec![subtract_expr],
             })),

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -137,6 +137,7 @@ use datafusion_comet_spark_expr::{
 };
 use itertools::Itertools;
 use jni::objects::{Global, JObject};
+use log::warn;
 use num::{BigInt, ToPrimitive};
 use object_store::path::Path;
 use std::cmp::max;
@@ -280,20 +281,52 @@ impl PhysicalPlanner {
         self
     }
 
+    /// Register the `QueryContext` carried by a serialized expression, if any, so that native ANSI
+    /// errors raised by it can render Spark's `== SQL ... ==` block. Shared by `create_expr` and
+    /// `create_agg_expr`.
+    fn register_query_context(
+        &self,
+        expr_id: Option<u64>,
+        ctx_proto: Option<&spark_expression::QueryContext>,
+    ) {
+        if let (Some(expr_id), Some(ctx_proto)) = (expr_id, ctx_proto) {
+            self.query_context_registry
+                .register(expr_id, self.build_query_context(ctx_proto));
+        }
+    }
+
     /// Resolve a serialized `QueryContext` into a `QueryContext`, sharing the pooled SQL text
     /// when the context refers to the pool by index. Falls back to the inline `sql_text` for
-    /// plans serialized without interning (e.g. `CometNativeWriteExec`, which serializes its
-    /// operator directly rather than through `convertBlock`).
+    /// plans serialized without interning -- the paths that serialize an operator directly rather
+    /// than through `convertBlock` (e.g. `CometNativeWriteExec`, the native shuffle writer) and
+    /// the bare-`Expr` Parquet filter path, which has no root operator to hang a pool on.
     fn build_query_context(
         &self,
         ctx_proto: &spark_expression::QueryContext,
     ) -> datafusion_comet_spark_expr::QueryContext {
-        let sql_text: Arc<String> = ctx_proto
+        let pooled = ctx_proto
             .sql_text_idx
-            .and_then(|idx| usize::try_from(idx).ok())
-            .and_then(|idx| self.sql_text_pool.get(idx))
-            .map(Arc::clone)
-            .unwrap_or_else(|| Arc::new(ctx_proto.sql_text.clone()));
+            .map(|idx| match usize::try_from(idx).ok() {
+                Some(idx) => self.sql_text_pool.get(idx).map(Arc::clone),
+                None => None,
+            });
+
+        let sql_text: Arc<String> = match pooled {
+            Some(Some(text)) => text,
+            // An index we cannot resolve means the plan was interned against a pool this planner
+            // never saw, so `sql_text` is empty and the error block would silently come out blank.
+            // Warn rather than fail: a degraded error message is better than a failed query.
+            Some(None) => {
+                warn!(
+                    "QueryContext sql_text_idx {:?} is out of range for a SQL text pool of {} \
+                     entries; SQL context will be missing from any error raised by this expression",
+                    ctx_proto.sql_text_idx,
+                    self.sql_text_pool.len()
+                );
+                Arc::new(ctx_proto.sql_text.clone())
+            }
+            None => Arc::new(ctx_proto.sql_text.clone()),
+        };
 
         datafusion_comet_spark_expr::QueryContext::new(
             sql_text,
@@ -389,16 +422,7 @@ impl PhysicalPlanner {
         spark_expr: &Expr,
         input_schema: SchemaRef,
     ) -> Result<Arc<dyn PhysicalExpr>, ExecutionError> {
-        // Register QueryContext if present
-        if let (Some(expr_id), Some(ctx_proto)) =
-            (spark_expr.expr_id, spark_expr.query_context.as_ref())
-        {
-            let query_ctx = self.build_query_context(ctx_proto);
-
-            // Register query context for error reporting
-            let registry = &self.query_context_registry;
-            registry.register(expr_id, query_ctx);
-        }
+        self.register_query_context(spark_expr.expr_id, spark_expr.query_context.as_ref());
 
         // Try to use the modular registry first - this automatically handles any registered expression types
         if ExpressionRegistry::global().can_handle(spark_expr) {
@@ -2426,16 +2450,7 @@ impl PhysicalPlanner {
         spark_expr: &AggExpr,
         schema: SchemaRef,
     ) -> Result<AggregateFunctionExpr, ExecutionError> {
-        // Register QueryContext if present
-        if let (Some(expr_id), Some(ctx_proto)) =
-            (spark_expr.expr_id, spark_expr.query_context.as_ref())
-        {
-            let query_ctx = self.build_query_context(ctx_proto);
-
-            // Register query context for error reporting
-            let registry = &self.query_context_registry;
-            registry.register(expr_id, query_ctx);
-        }
+        self.register_query_context(spark_expr.expr_id, spark_expr.query_context.as_ref());
 
         match spark_expr.expr_struct.as_ref().unwrap() {
             AggExprStruct::Count(expr) => {

--- a/native/proto/src/proto/expr.proto
+++ b/native/proto/src/proto/expr.proto
@@ -109,7 +109,9 @@ message Expr {
 // QueryContext provides SQL query context for error messages.
 // Mirrors Spark's SQLQueryContext for rich error reporting.
 message QueryContext {
-  // Full SQL query text
+  // Full SQL query text. Left empty when `sql_text_idx` is set, which is the normal case for a
+  // plan serialized through `CometNativeExec.convertBlock`. Still used by the paths that serialize
+  // an operator directly without interning (e.g. `CometNativeWriteExec`).
   string sql_text = 1;
 
   // Character offset where expression starts (0-based)
@@ -129,6 +131,11 @@ message QueryContext {
 
   // Column position within the line (0-based)
   int32 start_position = 7;
+
+  // Index into the root `Operator.sql_text_pool` holding this context's SQL text. Set instead of
+  // `sql_text` so that a query text shared by many expressions is serialized once per plan rather
+  // than once per expression.
+  optional int32 sql_text_idx = 8;
 }
 
 message AggExpr {

--- a/native/proto/src/proto/expr.proto
+++ b/native/proto/src/proto/expr.proto
@@ -109,9 +109,11 @@ message Expr {
 // QueryContext provides SQL query context for error messages.
 // Mirrors Spark's SQLQueryContext for rich error reporting.
 message QueryContext {
-  // Full SQL query text. Left empty when `sql_text_idx` is set, which is the normal case for a
-  // plan serialized through `CometNativeExec.convertBlock`. Still used by the paths that serialize
-  // an operator directly without interning (e.g. `CometNativeWriteExec`).
+  // Full SQL query text. Left empty when `sql_text_idx` is set, which is the case for a plan
+  // serialized through `CometNativeExec.convertBlock`. Still used by the paths that serialize an
+  // operator directly without interning (e.g. `CometNativeWriteExec`, the native shuffle writer,
+  // the Iceberg scan's `convertBlock` override) and by the bare-`Expr` Parquet filter path, which
+  // has no root operator to carry a pool.
   string sql_text = 1;
 
   // Character offset where expression starts (0-based)

--- a/native/proto/src/proto/operator.proto
+++ b/native/proto/src/proto/operator.proto
@@ -36,6 +36,16 @@ message Operator {
   // Spark plan ID
   uint32 plan_id = 2;
 
+  // Pool of distinct SQL texts referenced by `QueryContext.sql_text_idx`. Every expression that
+  // carries a QueryContext needs the full query text to render Spark's `== SQL ... ==` error
+  // block, and in a typical plan they all want the *same* text -- embedding it per expression made
+  // the query text over 95% of the serialized plan. The JVM interns the texts into this pool on
+  // the root operator of each serialized native block (see `QueryContextInterner`) and leaves
+  // `QueryContext.sql_text` empty.
+  //
+  // Only populated on the root operator; nested operators leave it empty.
+  repeated string sql_text_pool = 3;
+
   oneof op_struct {
     Scan scan = 100;
     Projection projection = 101;

--- a/spark/src/main/scala/org/apache/comet/serde/QueryContextInterner.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryContextInterner.scala
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.serde
+
+import scala.collection.mutable
+
+import com.google.protobuf.Descriptors.FieldDescriptor
+import com.google.protobuf.Message
+
+import org.apache.comet.serde.OperatorOuterClass.Operator
+
+/**
+ * Deduplicates `QueryContext.sql_text` across a serialized native plan.
+ *
+ * Every expression that Comet converts carries a `QueryContext` so that native ANSI errors can
+ * render Spark's `== SQL (line N, position M) ==` block, and that block prints the *whole* query
+ * text -- so the text cannot be trimmed to a fragment. But in a typical plan every expression
+ * carries the same text, and embedding it per expression made the query text the overwhelming
+ * majority of the serialized plan: on a 778-character query with 90 expressions, 56 KB of a 58 KB
+ * plan (96%) was duplicated SQL text.
+ *
+ * This rewrites the tree so each distinct text appears once, in `Operator.sql_text_pool` on the
+ * root operator, with each `QueryContext` referring to it by `sql_text_idx`. The plan bytes are
+ * shipped in the stage's task binary, re-parsed and re-serialized per task by
+ * `CometExecRDD.compute` whenever the plan contains a native scan, and decoded per task by the
+ * native planner, so the saving is paid back on every task.
+ *
+ * The walk is descriptor-driven rather than a hand-written recursion over `Expr`'s ~75-way
+ * `oneof`: a `QueryContext` can sit on any `Expr` or `AggExpr` at any nesting depth, and a
+ * hand-written walk would silently miss newly added expression variants.
+ * `QueryContextInternerSuite` asserts that no un-pooled context survives in a real plan.
+ */
+object QueryContextInterner {
+
+  /**
+   * Returns `op` with all `QueryContext.sql_text` values hoisted into the root's `sql_text_pool`,
+   * or `op` itself when there is nothing to intern.
+   */
+  def intern(op: Operator): Operator = {
+    // Already interned: only ever true if a caller serializes the same operator twice.
+    if (op.getSqlTextPoolCount > 0) return op
+
+    val pool = mutable.LinkedHashMap.empty[String, Int]
+    val builder = op.toBuilder
+    walk(builder, ctx => pooled(ctx, pool))
+    if (pool.isEmpty) {
+      // No expression carried a context (e.g. a DataFrame-API query, where Spark records no SQL
+      // text). Return the original to avoid paying for a rebuild that changes nothing.
+      op
+    } else {
+      pool.keys.foreach(builder.addSqlTextPool)
+      builder.build()
+    }
+  }
+
+  /**
+   * Returns `message` with every `QueryContext` removed.
+   *
+   * Used to derive content hashes that must agree between the driver and the executor even though
+   * only one side sees the interned form. `CometNativeScanExec` hashes a scan's
+   * `NativeScanCommon` on the driver to produce the `sourceKey` that
+   * `NativeScanPlanDataInjector.getKey` recomputes on the executor from the *serialized* plan --
+   * which by then has been interned, so any hash that includes the context encoding would no
+   * longer match. Dropping contexts entirely makes the hash independent of how they happen to be
+   * encoded.
+   */
+  def stripQueryContexts[T <: Message](message: T): T = {
+    val builder = message.toBuilder
+    walk(builder, _ => None)
+    builder.build().asInstanceOf[T]
+  }
+
+  /**
+   * Depth-first walk over every nested message, applying `f` to each `QueryContext` found on an
+   * `Expr` or `AggExpr`. `f` returns the replacement context, or `None` to clear the field.
+   */
+  private def walk(
+      builder: Message.Builder,
+      f: ExprOuterClass.QueryContext => Option[ExprOuterClass.QueryContext]): Unit = {
+    builder match {
+      case e: ExprOuterClass.Expr.Builder if e.hasQueryContext =>
+        f(e.getQueryContext) match {
+          case Some(ctx) => e.setQueryContext(ctx)
+          case None => e.clearQueryContext()
+        }
+      case a: ExprOuterClass.AggExpr.Builder if a.hasQueryContext =>
+        f(a.getQueryContext) match {
+          case Some(ctx) => a.setQueryContext(ctx)
+          case None => a.clearQueryContext()
+        }
+      case _ =>
+    }
+
+    val fields = builder.getDescriptorForType.getFields.iterator()
+    while (fields.hasNext) {
+      val field = fields.next()
+      // Map fields are repeated messages on the wire but reject `getRepeatedFieldBuilder`, and no
+      // Comet map field has a message value type, so there is nothing to visit inside them.
+      if (field.getJavaType == FieldDescriptor.JavaType.MESSAGE && !field.isMapField) {
+        if (field.isRepeated) {
+          var i = 0
+          val count = builder.getRepeatedFieldCount(field)
+          while (i < count) {
+            walk(builder.getRepeatedFieldBuilder(field, i), f)
+            i += 1
+          }
+        } else if (builder.hasField(field)) {
+          walk(builder.getFieldBuilder(field), f)
+        }
+      }
+    }
+  }
+
+  /** Replaces `sql_text` with an index into `pool`, adding the text to the pool if it is new. */
+  private def pooled(
+      ctx: ExprOuterClass.QueryContext,
+      pool: mutable.LinkedHashMap[String, Int]): Option[ExprOuterClass.QueryContext] = {
+    val idx = pool.getOrElseUpdate(ctx.getSqlText, pool.size)
+    Some(ctx.toBuilder.clearSqlText().setSqlTextIdx(idx).build())
+  }
+}

--- a/spark/src/main/scala/org/apache/comet/serde/QueryContextInterner.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryContextInterner.scala
@@ -54,37 +54,44 @@ object QueryContextInterner {
    * or `op` itself when there is nothing to intern.
    */
   def intern(op: Operator): Operator = {
-    // Already interned: only ever true if a caller serializes the same operator twice.
+    // Defensive no-op so interning is idempotent. Not reachable from the single call site in
+    // `CometNativeExec.convertBlock`, which always starts from the un-interned `nativeOp`.
     if (op.getSqlTextPoolCount > 0) return op
 
-    val pool = mutable.LinkedHashMap.empty[String, Int]
     val builder = op.toBuilder
-    walk(builder, ctx => pooled(ctx, pool))
-    if (pool.isEmpty) {
+    // Each text is appended to the pool the first time it is seen and its position becomes the
+    // index every context referring to it carries, so the pool needs no separate second pass.
+    val indexOf = mutable.Map.empty[String, Int]
+    walk(
+      builder,
+      ctx => {
+        val idx = indexOf.getOrElseUpdate(
+          ctx.getSqlText, {
+            builder.addSqlTextPool(ctx.getSqlText)
+            builder.getSqlTextPoolCount - 1
+          })
+        Some(ctx.toBuilder.clearSqlText().setSqlTextIdx(idx).build())
+      })
+    if (indexOf.isEmpty) {
       // No expression carried a context (e.g. a DataFrame-API query, where Spark records no SQL
-      // text). Return the original to avoid paying for a rebuild that changes nothing.
+      // text). Return the original rather than rebuilding an identical message.
       op
     } else {
-      pool.keys.foreach(builder.addSqlTextPool)
       builder.build()
     }
   }
 
   /**
-   * Returns `message` with every `QueryContext` removed.
+   * Returns `expr` with every `QueryContext` in it removed.
    *
    * Used to derive content hashes that must agree between the driver and the executor even though
-   * only one side sees the interned form. `CometNativeScanExec` hashes a scan's
-   * `NativeScanCommon` on the driver to produce the `sourceKey` that
-   * `NativeScanPlanDataInjector.getKey` recomputes on the executor from the *serialized* plan --
-   * which by then has been interned, so any hash that includes the context encoding would no
-   * longer match. Dropping contexts entirely makes the hash independent of how they happen to be
-   * encoded.
+   * only one side sees the interned form - see `NativeScanPlanDataInjector.sourceKey`. Dropping
+   * contexts makes such a hash independent of how they happen to be encoded.
    */
-  def stripQueryContexts[T <: Message](message: T): T = {
-    val builder = message.toBuilder
+  def stripQueryContexts(expr: ExprOuterClass.Expr): ExprOuterClass.Expr = {
+    val builder = expr.toBuilder
     walk(builder, _ => None)
-    builder.build().asInstanceOf[T]
+    builder.build()
   }
 
   /**
@@ -126,13 +133,5 @@ object QueryContextInterner {
         }
       }
     }
-  }
-
-  /** Replaces `sql_text` with an index into `pool`, adding the text to the pool if it is new. */
-  private def pooled(
-      ctx: ExprOuterClass.QueryContext,
-      pool: mutable.LinkedHashMap[String, Int]): Option[ExprOuterClass.QueryContext] = {
-    val idx = pool.getOrElseUpdate(ctx.getSqlText, pool.size)
-    Some(ctx.toBuilder.clearSqlText().setSqlTextIdx(idx).build())
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
@@ -39,7 +39,6 @@ import com.google.common.base.Objects
 
 import org.apache.comet.parquet.CometParquetUtils
 import org.apache.comet.serde.OperatorOuterClass.Operator
-import org.apache.comet.serde.QueryContextInterner
 import org.apache.comet.serde.QueryPlanSerde.exprToProto
 
 /**
@@ -361,17 +360,8 @@ object CometNativeScanExec {
       scan: CometScanExec): CometNativeScanExec = {
     // Generate unique key for this scan so PlanDataInjector can match common+partition data.
     // Multiple scans of same table with different projections/filters get different keys.
-    // Contexts are stripped so the hash matches the one NativeScanPlanDataInjector.getKey
-    // recomputes on the executor, where the plan has been interned (see QueryContextInterner).
-    val common = QueryContextInterner.stripQueryContexts(nativeOp.getNativeScan.getCommon)
-    val source = common.getSource
-    val keyComponents = Seq(
-      common.getRequiredSchemaList.toString,
-      common.getDataFiltersList.toString,
-      common.getProjectionVectorList.toString,
-      common.getFieldsList.toString)
-    val hashCode = keyComponents.mkString("|").hashCode
-    val sourceKey = s"${source}_${hashCode}"
+    // Derived by the injector that will look it up, so the two sides cannot drift apart.
+    val sourceKey = NativeScanPlanDataInjector.sourceKey(nativeOp.getNativeScan.getCommon)
 
     val batchScanExec = CometNativeScanExec(
       nativeOp,

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
@@ -39,6 +39,7 @@ import com.google.common.base.Objects
 
 import org.apache.comet.parquet.CometParquetUtils
 import org.apache.comet.serde.OperatorOuterClass.Operator
+import org.apache.comet.serde.QueryContextInterner
 import org.apache.comet.serde.QueryPlanSerde.exprToProto
 
 /**
@@ -360,7 +361,9 @@ object CometNativeScanExec {
       scan: CometScanExec): CometNativeScanExec = {
     // Generate unique key for this scan so PlanDataInjector can match common+partition data.
     // Multiple scans of same table with different projections/filters get different keys.
-    val common = nativeOp.getNativeScan.getCommon
+    // Contexts are stripped so the hash matches the one NativeScanPlanDataInjector.getKey
+    // recomputes on the executor, where the plan has been interned (see QueryContextInterner).
+    val common = QueryContextInterner.stripQueryContexts(nativeOp.getNativeScan.getCommon)
     val source = common.getSource
     val keyComponents = Seq(
       common.getRequiredSchemaList.toString,

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -325,19 +325,28 @@ private[comet] object NativeScanPlanDataInjector extends PlanDataInjector {
       op.getNativeScan.hasCommon &&
       !op.getNativeScan.hasFilePartition
 
-  override def getKey(op: Operator): Option[String] = {
-    // Reconstruct the same sourceKey that was used when storing the data. Must mirror
-    // CometNativeScanExec.apply exactly, including stripping query contexts: the plan we are
-    // reading here has been interned, so the context encoding differs from the driver's.
-    val common = QueryContextInterner.stripQueryContexts(op.getNativeScan.getCommon)
-    val source = common.getSource
+  override def getKey(op: Operator): Option[String] = Some(sourceKey(op.getNativeScan.getCommon))
+
+  /**
+   * The key under which a native scan's planning data is stored and looked up. Called on the
+   * driver by `CometNativeScanExec.apply` to store, and on the executor by [[getKey]] to look up
+   * \- both must derive the identical string from the same scan, so this is the single definition
+   * rather than two mirrored copies.
+   *
+   * Data filters are stripped of their `QueryContext` before hashing: the executor reads them
+   * back out of the interned plan (see `QueryContextInterner`) while the driver holds the
+   * un-interned form, so including the context encoding would make the two sides disagree. Only
+   * data filters can carry a context, so the other components are hashed as-is.
+   */
+  private[comet] def sourceKey(common: OperatorOuterClass.NativeScanCommon): String = {
+    val dataFilters = common.getDataFiltersList.asScala
+      .map(QueryContextInterner.stripQueryContexts(_).toString)
     val keyComponents = Seq(
       common.getRequiredSchemaList.toString,
-      common.getDataFiltersList.toString,
+      dataFilters.mkString("[", ", ", "]"),
       common.getProjectionVectorList.toString,
       common.getFieldsList.toString)
-    val hashCode = keyComponents.mkString("|").hashCode
-    Some(s"${source}_${hashCode}")
+    s"${common.getSource}_${keyComponents.mkString("|").hashCode}"
   }
 
   override def inject(
@@ -874,13 +883,7 @@ abstract class CometNativeExec extends CometExec {
         // Hoist duplicated QueryContext SQL text into a pool on the root operator. This is the
         // point where the whole native block is in hand, which is what the pool indices are
         // scoped to.
-        val rootOp = QueryContextInterner.intern(nativeOp)
-        val size = rootOp.getSerializedSize
-        val bytes = new Array[Byte](size)
-        val codedOutput = CodedOutputStream.newInstance(bytes)
-        rootOp.writeTo(codedOutput)
-        codedOutput.checkNoSpaceLeft()
-        SerializedPlan(Some(bytes))
+        SerializedPlan(Some(CometExec.serializeNativePlan(QueryContextInterner.intern(nativeOp))))
       case other: AnyRef => other
       case null => null
     }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -58,7 +58,7 @@ import org.apache.comet.{CometConf, CometExecIterator, CometRuntimeException, Co
 import org.apache.comet.CometSparkSessionExtensions.{isCometShuffleEnabled, withFallbackReason}
 import org.apache.comet.parquet.CometParquetUtils
 import org.apache.comet.rules.CometExecRule
-import org.apache.comet.serde.{CometOperatorSerde, Compatible, Incompatible, OperatorOuterClass, SupportLevel, Unsupported}
+import org.apache.comet.serde.{CometOperatorSerde, Compatible, Incompatible, OperatorOuterClass, QueryContextInterner, SupportLevel, Unsupported}
 import org.apache.comet.serde.OperatorOuterClass.{AggregateMode => CometAggregateMode, Operator}
 import org.apache.comet.serde.QueryPlanSerde
 import org.apache.comet.serde.QueryPlanSerde.{aggExprToProto, exprToProto, isStringCollationType, supportedSortType}
@@ -326,8 +326,10 @@ private[comet] object NativeScanPlanDataInjector extends PlanDataInjector {
       !op.getNativeScan.hasFilePartition
 
   override def getKey(op: Operator): Option[String] = {
-    // Reconstruct the same sourceKey that was used when storing the data
-    val common = op.getNativeScan.getCommon
+    // Reconstruct the same sourceKey that was used when storing the data. Must mirror
+    // CometNativeScanExec.apply exactly, including stripping query contexts: the plan we are
+    // reading here has been interned, so the context encoding differs from the driver's.
+    val common = QueryContextInterner.stripQueryContexts(op.getNativeScan.getCommon)
     val source = common.getSource
     val keyComponents = Seq(
       common.getRequiredSchemaList.toString,
@@ -869,10 +871,14 @@ abstract class CometNativeExec extends CometExec {
   def convertBlock(): CometNativeExec = {
     def transform(arg: Any): AnyRef = arg match {
       case serializedPlan: SerializedPlan if serializedPlan.isEmpty =>
-        val size = nativeOp.getSerializedSize
+        // Hoist duplicated QueryContext SQL text into a pool on the root operator. This is the
+        // point where the whole native block is in hand, which is what the pool indices are
+        // scoped to.
+        val rootOp = QueryContextInterner.intern(nativeOp)
+        val size = rootOp.getSerializedSize
         val bytes = new Array[Byte](size)
         val codedOutput = CodedOutputStream.newInstance(bytes)
-        nativeOp.writeTo(codedOutput)
+        rootOp.writeTo(codedOutput)
         codedOutput.checkNoSpaceLeft()
         SerializedPlan(Some(bytes))
       case other: AnyRef => other

--- a/spark/src/test/scala/org/apache/comet/QueryContextInternerSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/QueryContextInternerSuite.scala
@@ -23,7 +23,6 @@ import scala.collection.mutable
 
 import org.apache.spark.sql.{CometTestBase, DataFrame}
 import org.apache.spark.sql.comet.CometNativeExec
-import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 
 import org.apache.comet.serde.{ExprOuterClass, OperatorOuterClass}
 
@@ -66,34 +65,30 @@ class QueryContextInternerSuite extends CometTestBase {
     found.toSeq
   }
 
-  private def nativeBlocks(df: DataFrame): Seq[Array[Byte]] = {
-    val plan = df.queryExecution.executedPlan match {
-      case a: AdaptiveSparkPlanExec => a.executedPlan
-      case p => p
+  /**
+   * Each native block of `df`'s plan, as the un-interned `nativeOp` (what would have been
+   * serialized before interning) paired with the bytes actually serialized for it.
+   */
+  private def nativeBlocks(df: DataFrame): Seq[(OperatorOuterClass.Operator, Array[Byte])] =
+    stripAQEPlan(df.queryExecution.executedPlan).collect {
+      case n: CometNativeExec if n.serializedPlanOpt.isDefined =>
+        (n.nativeOp, n.serializedPlanOpt.plan.get)
     }
-    plan.collect {
-      case n: CometNativeExec if n.serializedPlanOpt.isDefined => n.serializedPlanOpt.plan.get
-    }
-  }
 
   private def withTestTable(f: => Unit): Unit = {
-    withSQLConf(
-      CometConf.COMET_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_ENABLED.key -> "true") {
-      withTempPath { dir =>
-        spark
-          .range(0, 100)
-          .selectExpr(
-            "cast(id % 17 as int) as k1",
-            "cast(id as decimal(20,4)) as d1",
-            "cast(id % 1000 as int) as i1")
-          .write
-          .mode("overwrite")
-          .parquet(dir.getAbsolutePath)
-        withTempView("t1") {
-          spark.read.parquet(dir.getAbsolutePath).createOrReplaceTempView("t1")
-          f
-        }
+    withTempPath { dir =>
+      spark
+        .range(0, 100)
+        .selectExpr(
+          "cast(id % 17 as int) as k1",
+          "cast(id as decimal(20,4)) as d1",
+          "cast(id % 1000 as int) as i1")
+        .write
+        .mode("overwrite")
+        .parquet(dir.getAbsolutePath)
+      withTempView("t1") {
+        spark.read.parquet(dir.getAbsolutePath).createOrReplaceTempView("t1")
+        f
       }
     }
   }
@@ -104,7 +99,7 @@ class QueryContextInternerSuite extends CometTestBase {
       assert(blocks.nonEmpty, "expected at least one serialized native block")
 
       var sawContext = false
-      blocks.foreach { bytes =>
+      blocks.foreach { case (_, bytes) =>
         val root = OperatorOuterClass.Operator.parseFrom(bytes)
         val contexts = collectContexts(root)
         if (contexts.nonEmpty) {
@@ -127,30 +122,24 @@ class QueryContextInternerSuite extends CometTestBase {
 
   test("interning shrinks the serialized plan") {
     withTestTable {
+      // `nativeOp` is never interned - only the bytes written for it are - so its serialized size
+      // is exactly what the plan weighed before this optimization.
       val blocks = nativeBlocks(spark.sql(sqlText))
-      val interned = blocks.map(_.length).sum
-
-      // What the same plan would serialize to with a copy of the text on every context, which is
-      // what was emitted before interning: the UTF-8 text plus its tag/length prefix per context.
-      val expanded = blocks.map { bytes =>
-        val root = OperatorOuterClass.Operator.parseFrom(bytes)
-        val pool = root.getSqlTextPoolList
-        bytes.length + collectContexts(root).map { ctx =>
-          pool.get(ctx.getSqlTextIdx).getBytes("UTF-8").length + 3
-        }.sum
-      }.sum
+      val before = blocks.map { case (nativeOp, _) => nativeOp.getSerializedSize }.sum
+      val after = blocks.map { case (_, bytes) => bytes.length }.sum
 
       assert(
-        expanded > interned * 4,
-        s"expected interning to shrink the plan substantially: $expanded -> $interned")
+        before > after * 4,
+        s"expected interning to shrink the plan substantially: $before -> $after")
     }
   }
 
   test("ANSI error still reports full SQL context after interning") {
-    withSQLConf(
-      CometConf.COMET_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_ENABLED.key -> "true",
-      "spark.sql.ansi.enabled" -> "true") {
+    // Deliberately its own integer-typed table rather than reusing `withTestTable`: integer
+    // division routes through the native `CheckedBinaryExpr`, which is what consults the
+    // QueryContext registry. Decimal division raises a plain compute error with no SQL context,
+    // so it would not exercise this path at all.
+    withSQLConf("spark.sql.ansi.enabled" -> "true") {
       withTempPath { dir =>
         spark
           .range(1, 10)

--- a/spark/src/test/scala/org/apache/comet/QueryContextInternerSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/QueryContextInternerSuite.scala
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.{CometTestBase, DataFrame}
+import org.apache.spark.sql.comet.CometNativeExec
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
+
+import org.apache.comet.serde.{ExprOuterClass, OperatorOuterClass}
+
+class QueryContextInternerSuite extends CometTestBase {
+
+  private val sqlText =
+    """select k1,
+      |       sum(d1) as sum_d1,
+      |       max(case when i1 > 100 then d1 + 1 else d1 * 2 end) as m1
+      |from t1
+      |where i1 between 1 and 1000 and d1 > 1.0
+      |group by k1
+      |order by sum_d1 desc""".stripMargin
+
+  /** Every `Expr`/`AggExpr` QueryContext in an operator tree, at any nesting depth. */
+  private def collectContexts(
+      root: OperatorOuterClass.Operator): Seq[ExprOuterClass.QueryContext] = {
+    val found = mutable.ArrayBuffer.empty[ExprOuterClass.QueryContext]
+
+    def walk(m: com.google.protobuf.Message): Unit = {
+      m match {
+        case e: ExprOuterClass.Expr if e.hasQueryContext => found += e.getQueryContext
+        case a: ExprOuterClass.AggExpr if a.hasQueryContext => found += a.getQueryContext
+        case _ =>
+      }
+      m.getAllFields.forEach { (_, v) =>
+        v match {
+          case child: com.google.protobuf.Message => walk(child)
+          case list: java.util.List[_] =>
+            list.forEach {
+              case child: com.google.protobuf.Message => walk(child)
+              case _ =>
+            }
+          case _ =>
+        }
+      }
+    }
+
+    walk(root)
+    found.toSeq
+  }
+
+  private def nativeBlocks(df: DataFrame): Seq[Array[Byte]] = {
+    val plan = df.queryExecution.executedPlan match {
+      case a: AdaptiveSparkPlanExec => a.executedPlan
+      case p => p
+    }
+    plan.collect {
+      case n: CometNativeExec if n.serializedPlanOpt.isDefined => n.serializedPlanOpt.plan.get
+    }
+  }
+
+  private def withTestTable(f: => Unit): Unit = {
+    withSQLConf(
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ENABLED.key -> "true") {
+      withTempPath { dir =>
+        spark
+          .range(0, 100)
+          .selectExpr(
+            "cast(id % 17 as int) as k1",
+            "cast(id as decimal(20,4)) as d1",
+            "cast(id % 1000 as int) as i1")
+          .write
+          .mode("overwrite")
+          .parquet(dir.getAbsolutePath)
+        withTempView("t1") {
+          spark.read.parquet(dir.getAbsolutePath).createOrReplaceTempView("t1")
+          f
+        }
+      }
+    }
+  }
+
+  test("SQL text is interned into the root operator pool") {
+    withTestTable {
+      val blocks = nativeBlocks(spark.sql(sqlText))
+      assert(blocks.nonEmpty, "expected at least one serialized native block")
+
+      var sawContext = false
+      blocks.foreach { bytes =>
+        val root = OperatorOuterClass.Operator.parseFrom(bytes)
+        val contexts = collectContexts(root)
+        if (contexts.nonEmpty) {
+          sawContext = true
+          contexts.foreach { ctx =>
+            assert(
+              ctx.hasSqlTextIdx,
+              s"QueryContext was not interned; carries inline sql_text: ${ctx.getSqlText}")
+            assert(ctx.getSqlText.isEmpty, "interned QueryContext should not repeat sql_text")
+            assert(ctx.getSqlTextIdx >= 0 && ctx.getSqlTextIdx < root.getSqlTextPoolCount)
+          }
+          // The query text is stored once for the block, not once per expression.
+          assert(root.getSqlTextPoolCount == 1, s"pool: ${root.getSqlTextPoolList}")
+          assert(root.getSqlTextPool(0).contains("sum(d1)"))
+        }
+      }
+      assert(sawContext, "expected at least one expression to carry a QueryContext")
+    }
+  }
+
+  test("interning shrinks the serialized plan") {
+    withTestTable {
+      val blocks = nativeBlocks(spark.sql(sqlText))
+      val interned = blocks.map(_.length).sum
+
+      // What the same plan would serialize to with a copy of the text on every context, which is
+      // what was emitted before interning: the UTF-8 text plus its tag/length prefix per context.
+      val expanded = blocks.map { bytes =>
+        val root = OperatorOuterClass.Operator.parseFrom(bytes)
+        val pool = root.getSqlTextPoolList
+        bytes.length + collectContexts(root).map { ctx =>
+          pool.get(ctx.getSqlTextIdx).getBytes("UTF-8").length + 3
+        }.sum
+      }.sum
+
+      assert(
+        expanded > interned * 4,
+        s"expected interning to shrink the plan substantially: $expanded -> $interned")
+    }
+  }
+
+  test("ANSI error still reports full SQL context after interning") {
+    withSQLConf(
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ENABLED.key -> "true",
+      "spark.sql.ansi.enabled" -> "true") {
+      withTempPath { dir =>
+        spark
+          .range(1, 10)
+          .selectExpr("cast(id as int) as a", "cast(0 as int) as b")
+          .write
+          .mode("overwrite")
+          .parquet(dir.getAbsolutePath)
+        withTempView("t_div") {
+          spark.read.parquet(dir.getAbsolutePath).createOrReplaceTempView("t_div")
+
+          val query = "select a / b as ratio from t_div"
+          val err = intercept[Exception](spark.sql(query).collect())
+          val msg = Option(err.getMessage).getOrElse("")
+          assert(msg.contains("DIVIDE_BY_ZERO"), msg)
+          // The pooled text must round-trip through native: the summary echoes the full query.
+          assert(msg.contains(query), s"error message lost the SQL context:\n$msg")
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/datafusion-comet/issues/5200. Part of the planner performance audit epic https://github.com/apache/datafusion-comet/issues/5199.

## Rationale for this change

`QueryPlanSerde` attaches a `QueryContext` to **every** expression it converts, and `QueryContext.sql_text` is the *full* SQL text of the query. The same string therefore ends up embedded once per expression in the serialized native plan. On real TPC-DS queries the query text is 85-95% of the plan bytes.

The context itself is needed — `QueryContext::format_summary` prints the whole `sql_text` to build Spark's `== SQL (line N, position M) ==` error block, so it cannot be trimmed to a fragment. The *duplication* is the problem.

This costs more than just bytes:

1. **Plan size.** The `Array[Byte]` is captured by `CometExecRDD` and shipped in the stage's task binary.
2. **Per-task JVM protobuf round trip.** Whenever a plan contains a native scan — essentially every scan-rooted Comet stage — `CometExecRDD.compute` does `Operator.parseFrom(serializedPlan)` → `PlanDataInjector.injectPlanData` → `serializeOperator`, **per task**.
3. **Per-task native decode.** `PhysicalPlanner::create_expr` / `create_agg_expr` did `ctx_proto.sql_text.clone()` into a fresh `String` per expression and registered it in `QueryContextMap`. For q64 below that is 867 identical heap copies of a 3 KB query, per task, held for the lifetime of the query.

## Benchmarks

Real TPC-DS queries (v1.4 SQL from the Spark test resources) planned against empty TPC-DS tables — planning only, no data needed. "before" is the exact byte count obtained by inlining the pooled text back onto every context, so it is the real pre-patch serialization, not an estimate. "round trip" is the parse + re-serialize that `CometExecRDD.compute` performs per task.

| query | SQL chars | `Expr` nodes | with context | plan bytes before | plan bytes after | reduction | per-task round trip before | after |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| q23a | 1654 | 178 | 168 | 284 KB | 32 KB | 8.9x | 0.84 ms | 0.37 ms |
| q23b | 2009 | 240 | 221 | 441 KB | 47 KB | 9.3x | 0.75 ms | 0.32 ms |
| q64 | 3051 | 1112 | 867 | 2,360 KB | 109 KB | 21.5x | 3.02 ms | 0.73 ms |
| q67 | 884 | 258 | 249 | 247 KB | 24 KB | 10.3x | 0.41 ms | 0.20 ms |
| q72 | 1261 | 282 | 263 | 381 KB | 38 KB | 9.8x | 0.59 ms | 0.23 ms |
| q95 | 976 | 168 | 137 | 153 KB | 24 KB | 6.2x | 0.31 ms | 0.17 ms |
| q14a | 3716 | 513 | 393 | 1,446 KB | 95 KB | 15.2x | 1.87 ms | 0.47 ms |
| q47 | 1731 | 306 | 248 | 433 KB | 29 KB | 14.5x | 0.65 ms | 0.34 ms |
| **total** | | | | **5,749 KB** | **401 KB** | **14.3x** | | |

The worst case, q64, went from a **2.4 MB** serialized plan to 109 KB. Its per-task parse + re-serialize drops from 3.0 ms to 0.7 ms; at 10k tasks that is ~23 s of JVM protobuf work per stage removed, before counting the native-side decode and the 867 string clones per task.

Environment: Spark 4.1 / Scala 2.13, JDK 17, macOS arm64, debug native build. Measured with a throwaway ScalaTest suite (not committed — a proper planner benchmark is tracked in the epic); the committed `QueryContextInternerSuite` asserts the size reduction so the property does not silently regress.

## What changes are included in this PR?

Intern the SQL texts into a pool instead of repeating them:

- **proto**: `Operator` gains `repeated string sql_text_pool`, populated only on the root operator of a serialized native block. `QueryContext` gains `optional int32 sql_text_idx`; `sql_text` is cleared when the index is set.
- **`QueryContextInterner`** (new): rewrites an operator tree so each distinct SQL text appears once in the root's pool. Applied in `CometNativeExec.convertBlock()`, which is where the whole block is in hand and where the pool indices are scoped. Doing it as a post-pass means none of the ~90 `QueryPlanSerde` call sites change and no plan-scoped mutable state has to be threaded through `exprToProto`.
- **native**: `PhysicalPlanner` loads the pool from the root operator (`with_sql_text_pool`) and `build_query_context` resolves `sql_text_idx` against it, handing every context a clone of one shared `Arc<String>`. `QueryContext::new` now takes `impl Into<Arc<String>>` so the `Arc` is shared rather than re-allocated per expression — the struct already stored `Arc<String>`, that sharing was just never realised.
- `sql_text` remains a working fallback when `sql_text_idx` is absent, so the paths that serialize an operator directly without going through `convertBlock` (e.g. `CometNativeWriteExec`) are unaffected.
- **`sourceKey` derivation**: `CometNativeScanExec.apply` hashes a scan's `NativeScanCommon` on the driver to produce the key that `NativeScanPlanDataInjector.getKey` recomputes on the executor from the *serialized* plan. Since only the executor's copy is interned, that hash no longer matched and the scan failed with `Missing planning data for key: ...`. Both sides now hash the context-free form via `QueryContextInterner.stripQueryContexts`, which also makes the key robust to any future change in how contexts are encoded.

The interner walk is descriptor-driven rather than a hand-written recursion over `Expr`'s ~75-way `oneof`: a `QueryContext` can sit on any `Expr` or `AggExpr` at any nesting depth, and a hand-written walk would silently miss newly added variants. `QueryContextInternerSuite` asserts that no un-pooled context survives in a real plan, which is what keeps the walk honest.

## How are these changes tested?

New `QueryContextInternerSuite`:
- every `QueryContext` in a real plan carries `sql_text_idx` and no inline `sql_text`, and the pool holds the text once;
- the plan is materially smaller than the inlined equivalent;
- an ANSI `DIVIDE_BY_ZERO` error still reports the full SQL text end-to-end, i.e. the pooled text round-trips JVM → proto → native → error JSON → Spark exception unchanged.

Regressions run locally on Spark 4.1 / Scala 2.13: `CometExpressionSuite`, `SparkErrorConverterSuite`, `CometExecSuite`, `CometAggregateSuite`, `CometCastSuite`, `CometJoinSuite`, `CometNativeReaderSuite`, `ParquetReadSuite`, and the full `cargo test` suite.

Error messages are unchanged; this is purely a wire-format deduplication.

## Additional context

The per-expression `QueryContext` was introduced in https://github.com/apache/datafusion-comet/pull/3580 ("feat: [ANSI] Ansi sql error messages"), which added the SQL context needed for Spark-compatible ANSI error messages. That behaviour is preserved here — only the encoding changes.
