### PR TITLE
fix: support Utf8/LargeUtf8/Utf8View in native RLike without panicking

### DIFF
--- a/native/spark-expr/src/predicate_funcs/rlike.rs
+++ b/native/spark-expr/src/predicate_funcs/rlike.rs
@@ -18,10 +18,15 @@
 use crate::SparkError;
 use arrow::array::builder::BooleanBuilder;
 use arrow::array::types::Int32Type;
-use arrow::array::{Array, BooleanArray, DictionaryArray, RecordBatch, StringArray};
+use arrow::array::{
+    Array, ArrayAccessor, ArrayRef, BooleanArray, RecordBatch, StringArrayType,
+};
 use arrow::compute::take;
 use arrow::datatypes::{DataType, Schema};
-use datafusion::common::{internal_err, Result, ScalarValue};
+use datafusion::common::cast::{
+    as_dictionary_array, as_large_string_array, as_string_array, as_string_view_array,
+};
+use datafusion::common::{exec_err, internal_err, Result, ScalarValue};
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_plan::ColumnarValue;
 use regex::Regex;
@@ -37,6 +42,11 @@ use std::sync::Arc;
 /// regular expression engine, which are documented at:
 ///
 /// https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
+///
+/// Array matching keeps the plan-time compiled [`Regex`] and loops over Utf8 /
+/// LargeUtf8 / Utf8View inputs. Arrow's `regexp_is_match(_scalar)` was considered
+/// but recompiles the pattern per batch; criterion benches showed regressions on
+/// common patterns such as character classes (see issue #5102).
 #[derive(Debug)]
 pub struct RLike {
     child: Arc<dyn PhysicalExpr>,
@@ -71,7 +81,14 @@ impl RLike {
         })
     }
 
-    fn is_match(&self, inputs: &StringArray) -> BooleanArray {
+    /// Match the pre-compiled pattern against a string array of any Arrow string layout.
+    ///
+    /// Keeps the plan-time compiled [`Regex`] rather than calling Arrow's
+    /// `regexp_is_match(_scalar)`, which recompiles the pattern on every batch.
+    fn is_match<'a, S>(&'a self, inputs: &'a S) -> BooleanArray
+    where
+        &'a S: StringArrayType<'a>,
+    {
         let mut builder = BooleanBuilder::with_capacity(inputs.len());
         if inputs.is_nullable() {
             for i in 0..inputs.len() {
@@ -87,6 +104,15 @@ impl RLike {
             }
         }
         builder.finish()
+    }
+
+    fn is_match_array(&self, array: &ArrayRef) -> Result<BooleanArray> {
+        match array.data_type() {
+            DataType::Utf8 => Ok(self.is_match(as_string_array(array)?)),
+            DataType::LargeUtf8 => Ok(self.is_match(as_large_string_array(array)?)),
+            DataType::Utf8View => Ok(self.is_match(as_string_view_array(array)?)),
+            other => exec_err!("RLike requires string type for input, got {other:?}"),
+        }
     }
 }
 
@@ -111,29 +137,19 @@ impl PhysicalExpr for RLike {
 
     fn evaluate(&self, batch: &RecordBatch) -> Result<ColumnarValue> {
         match self.child.evaluate(batch)? {
-            ColumnarValue::Array(array) if array.as_any().is::<DictionaryArray<Int32Type>>() => {
-                let dict_array = array
-                    .as_any()
-                    .downcast_ref::<DictionaryArray<Int32Type>>()
-                    .expect("dict array");
-                let dict_values = dict_array
-                    .values()
-                    .as_any()
-                    .downcast_ref::<StringArray>()
-                    .expect("strings");
+            ColumnarValue::Array(array)
+                if matches!(array.data_type(), DataType::Dictionary(_, _)) =>
+            {
+                let dict_array = as_dictionary_array::<Int32Type>(&array)?;
                 // evaluate the regexp pattern against the dictionary values
-                let new_values = self.is_match(dict_values);
+                let new_values = self.is_match_array(dict_array.values())?;
                 // convert to conventional (not dictionary-encoded) array
                 let result = take(&new_values, dict_array.keys(), None)?;
                 Ok(ColumnarValue::Array(result))
             }
             ColumnarValue::Array(array) => {
-                let inputs = array
-                    .as_any()
-                    .downcast_ref::<StringArray>()
-                    .expect("string array");
-                let array = self.is_match(inputs);
-                Ok(ColumnarValue::Array(Arc::new(array)))
+                let result = self.is_match_array(&array)?;
+                Ok(ColumnarValue::Array(Arc::new(result)))
             }
             ColumnarValue::Scalar(scalar) => {
                 if scalar.is_null() {
@@ -180,7 +196,22 @@ impl PhysicalExpr for RLike {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion::physical_expr::expressions::Literal;
+    use arrow::array::{LargeStringArray, StringArray, StringViewArray};
+    use arrow::datatypes::Field;
+    use datafusion::physical_expr::expressions::{Column, Literal};
+
+    fn assert_bool_array_rose_null(result: ColumnarValue) {
+        let ColumnarValue::Array(arr) = result else {
+            panic!("expected array result");
+        };
+        let bools = arr
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .expect("boolean array");
+        assert_eq!(bools.len(), 2);
+        assert!(bools.value(0));
+        assert!(bools.is_null(1));
+    }
 
     #[test]
     fn test_rlike_scalar_string_variants() {
@@ -224,5 +255,57 @@ mod tests {
 
         let result = expr.evaluate(&RecordBatch::new_empty(Arc::new(Schema::empty())));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rlike_utf8_array() {
+        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8, true)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(StringArray::from(vec![Some("Rose"), None]))],
+        )
+        .unwrap();
+
+        let expr = RLike::try_new(Arc::new(Column::new("s", 0)), "R[a-z]+").unwrap();
+        assert_bool_array_rose_null(expr.evaluate(&batch).unwrap());
+    }
+
+    #[test]
+    fn test_rlike_large_utf8_array() {
+        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::LargeUtf8, true)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(LargeStringArray::from(vec![Some("Rose"), None]))],
+        )
+        .unwrap();
+
+        let expr = RLike::try_new(Arc::new(Column::new("s", 0)), "R[a-z]+").unwrap();
+        assert_bool_array_rose_null(expr.evaluate(&batch).unwrap());
+    }
+
+    #[test]
+    fn test_rlike_utf8_view_array() {
+        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8View, true)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(StringViewArray::from(vec![Some("Rose"), None]))],
+        )
+        .unwrap();
+
+        let expr = RLike::try_new(Arc::new(Column::new("s", 0)), "R[a-z]+").unwrap();
+        assert_bool_array_rose_null(expr.evaluate(&batch).unwrap());
+    }
+
+    #[test]
+    fn test_rlike_array_non_string_error() {
+        let schema = Arc::new(Schema::new(vec![Field::new("b", DataType::Boolean, true)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(BooleanArray::from(vec![Some(true), None]))],
+        )
+        .unwrap();
+
+        let expr = RLike::try_new(Arc::new(Column::new("b", 0)), "R[a-z]+").unwrap();
+        assert!(expr.evaluate(&batch).is_err());
     }
 }

--- a/native/spark-expr/src/predicate_funcs/rlike.rs
+++ b/native/spark-expr/src/predicate_funcs/rlike.rs
@@ -18,9 +18,7 @@
 use crate::SparkError;
 use arrow::array::builder::BooleanBuilder;
 use arrow::array::types::Int32Type;
-use arrow::array::{
-    Array, ArrayAccessor, ArrayRef, BooleanArray, RecordBatch, StringArrayType,
-};
+use arrow::array::{Array, ArrayAccessor, ArrayRef, BooleanArray, RecordBatch, StringArrayType};
 use arrow::compute::take;
 use arrow::datatypes::{DataType, Schema};
 use datafusion::common::cast::{
@@ -272,7 +270,11 @@ mod tests {
 
     #[test]
     fn test_rlike_large_utf8_array() {
-        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::LargeUtf8, true)]));
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "s",
+            DataType::LargeUtf8,
+            true,
+        )]));
         let batch = RecordBatch::try_new(
             Arc::clone(&schema),
             vec![Arc::new(LargeStringArray::from(vec![Some("Rose"), None]))],

--- a/native/spark-expr/src/predicate_funcs/rlike.rs
+++ b/native/spark-expr/src/predicate_funcs/rlike.rs
@@ -36,7 +36,6 @@ use std::sync::Arc;
 /// regular expression engine, which are documented at:
 ///
 /// https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
-///
 #[derive(Debug)]
 pub struct RLike {
     child: Arc<dyn PhysicalExpr>,
@@ -304,6 +303,9 @@ mod tests {
 
         let utf8_values: ArrayRef = Arc::new(StringArray::from(vec!["Rose", "Daisy"]));
         let utf8_view_values: ArrayRef = Arc::new(StringViewArray::from(vec!["Rose", "Daisy"]));
+        // Null in dictionary values (keys all valid): is_match emits null, take carries it.
+        let utf8_values_with_null: ArrayRef =
+            Arc::new(StringArray::from(vec![Some("Rose"), None, Some("Daisy")]));
 
         let cases: Vec<(DataType, ArrayRef)> = vec![
             (
@@ -325,6 +327,13 @@ mod tests {
                 Arc::new(DictionaryArray::<Int8Type>::new(
                     Int8Array::from(vec![Some(0), None, Some(1)]),
                     Arc::clone(&utf8_values),
+                )),
+            ),
+            (
+                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                Arc::new(DictionaryArray::<Int32Type>::new(
+                    Int32Array::from(vec![Some(0), Some(1), Some(2)]),
+                    utf8_values_with_null,
                 )),
             ),
         ];

--- a/native/spark-expr/src/predicate_funcs/rlike.rs
+++ b/native/spark-expr/src/predicate_funcs/rlike.rs
@@ -16,15 +16,11 @@
 // under the License.
 
 use crate::SparkError;
-use arrow::array::builder::BooleanBuilder;
-use arrow::array::types::Int32Type;
-use arrow::array::{Array, ArrayAccessor, ArrayRef, BooleanArray, RecordBatch, StringArrayType};
+use arrow::array::{Array, ArrayRef, AsArray, BooleanArray, RecordBatch, StringArrayType};
 use arrow::compute::take;
 use arrow::datatypes::{DataType, Schema};
-use datafusion::common::cast::{
-    as_dictionary_array, as_large_string_array, as_string_array, as_string_view_array,
-};
-use datafusion::common::{exec_err, internal_err, Result, ScalarValue};
+use datafusion::common::cast::{as_large_string_array, as_string_array, as_string_view_array};
+use datafusion::common::{internal_err, Result, ScalarValue};
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_plan::ColumnarValue;
 use regex::Regex;
@@ -41,10 +37,6 @@ use std::sync::Arc;
 ///
 /// https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
 ///
-/// Array matching keeps the plan-time compiled [`Regex`] and loops over Utf8 /
-/// LargeUtf8 / Utf8View inputs. Arrow's `regexp_is_match(_scalar)` was considered
-/// but recompiles the pattern per batch; criterion benches showed regressions on
-/// common patterns such as character classes (see issue #5102).
 #[derive(Debug)]
 pub struct RLike {
     child: Arc<dyn PhysicalExpr>,
@@ -83,25 +75,14 @@ impl RLike {
     ///
     /// Keeps the plan-time compiled [`Regex`] rather than calling Arrow's
     /// `regexp_is_match(_scalar)`, which recompiles the pattern on every batch.
-    fn is_match<'a, S>(&'a self, inputs: &'a S) -> BooleanArray
+    fn is_match<'a, S>(&self, inputs: &'a S) -> BooleanArray
     where
         &'a S: StringArrayType<'a>,
     {
-        let mut builder = BooleanBuilder::with_capacity(inputs.len());
-        if inputs.is_nullable() {
-            for i in 0..inputs.len() {
-                if inputs.is_null(i) {
-                    builder.append_null();
-                } else {
-                    builder.append_value(self.pattern.is_match(inputs.value(i)));
-                }
-            }
-        } else {
-            for i in 0..inputs.len() {
-                builder.append_value(self.pattern.is_match(inputs.value(i)));
-            }
-        }
-        builder.finish()
+        inputs
+            .iter()
+            .map(|v| v.map(|s| self.pattern.is_match(s)))
+            .collect()
     }
 
     fn is_match_array(&self, array: &ArrayRef) -> Result<BooleanArray> {
@@ -109,7 +90,9 @@ impl RLike {
             DataType::Utf8 => Ok(self.is_match(as_string_array(array)?)),
             DataType::LargeUtf8 => Ok(self.is_match(as_large_string_array(array)?)),
             DataType::Utf8View => Ok(self.is_match(as_string_view_array(array)?)),
-            other => exec_err!("RLike requires string type for input, got {other:?}"),
+            other => {
+                internal_err!("RLike requires string type for input, got {other:?}")
+            }
         }
     }
 }
@@ -138,7 +121,7 @@ impl PhysicalExpr for RLike {
             ColumnarValue::Array(array)
                 if matches!(array.data_type(), DataType::Dictionary(_, _)) =>
             {
-                let dict_array = as_dictionary_array::<Int32Type>(&array)?;
+                let dict_array = array.as_any_dictionary();
                 // evaluate the regexp pattern against the dictionary values
                 let new_values = self.is_match_array(dict_array.values())?;
                 // convert to conventional (not dictionary-encoded) array
@@ -194,11 +177,13 @@ impl PhysicalExpr for RLike {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{LargeStringArray, StringArray, StringViewArray};
-    use arrow::datatypes::Field;
+    use arrow::array::{
+        DictionaryArray, Int32Array, Int8Array, LargeStringArray, StringArray, StringViewArray,
+    };
+    use arrow::datatypes::{Field, Int32Type, Int8Type};
     use datafusion::physical_expr::expressions::{Column, Literal};
 
-    fn assert_bool_array_rose_null(result: ColumnarValue) {
+    fn assert_bool_results(result: ColumnarValue, expected: &[Option<bool>]) {
         let ColumnarValue::Array(arr) = result else {
             panic!("expected array result");
         };
@@ -206,9 +191,16 @@ mod tests {
             .as_any()
             .downcast_ref::<BooleanArray>()
             .expect("boolean array");
-        assert_eq!(bools.len(), 2);
-        assert!(bools.value(0));
-        assert!(bools.is_null(1));
+        assert_eq!(bools.len(), expected.len());
+        for (i, exp) in expected.iter().enumerate() {
+            match exp {
+                Some(v) => {
+                    assert!(!bools.is_null(i), "row {i} should not be null");
+                    assert_eq!(bools.value(i), *v, "row {i}");
+                }
+                None => assert!(bools.is_null(i), "row {i} should be null"),
+            }
+        }
     }
 
     #[test]
@@ -256,46 +248,93 @@ mod tests {
     }
 
     #[test]
-    fn test_rlike_utf8_array() {
-        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8, true)]));
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![Arc::new(StringArray::from(vec![Some("Rose"), None]))],
-        )
-        .unwrap();
+    fn test_rlike_string_array_layouts() {
+        let pattern = "R[a-z]+";
+        let cases: Vec<(DataType, ArrayRef)> = vec![
+            (
+                DataType::Utf8,
+                Arc::new(StringArray::from(vec![Some("Rose"), None, Some("Daisy")])),
+            ),
+            (
+                DataType::LargeUtf8,
+                Arc::new(LargeStringArray::from(vec![
+                    Some("Rose"),
+                    None,
+                    Some("Daisy"),
+                ])),
+            ),
+            (
+                DataType::Utf8View,
+                Arc::new(StringViewArray::from(vec![
+                    Some("Rose"),
+                    None,
+                    Some("Daisy"),
+                ])),
+            ),
+        ];
 
-        let expr = RLike::try_new(Arc::new(Column::new("s", 0)), "R[a-z]+").unwrap();
-        assert_bool_array_rose_null(expr.evaluate(&batch).unwrap());
+        for (data_type, array) in cases {
+            let schema = Arc::new(Schema::new(vec![Field::new("s", data_type, true)]));
+            let batch = RecordBatch::try_new(Arc::clone(&schema), vec![array]).unwrap();
+            let expr = RLike::try_new(Arc::new(Column::new("s", 0)), pattern).unwrap();
+            assert_bool_results(
+                expr.evaluate(&batch).unwrap(),
+                &[Some(true), None, Some(false)],
+            );
+        }
     }
 
     #[test]
-    fn test_rlike_large_utf8_array() {
-        let schema = Arc::new(Schema::new(vec![Field::new(
-            "s",
-            DataType::LargeUtf8,
-            true,
-        )]));
+    fn test_rlike_string_array_no_nulls() {
+        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8, false)]));
         let batch = RecordBatch::try_new(
             Arc::clone(&schema),
-            vec![Arc::new(LargeStringArray::from(vec![Some("Rose"), None]))],
+            vec![Arc::new(StringArray::from(vec!["Rose", "Daisy"]))],
         )
         .unwrap();
 
         let expr = RLike::try_new(Arc::new(Column::new("s", 0)), "R[a-z]+").unwrap();
-        assert_bool_array_rose_null(expr.evaluate(&batch).unwrap());
+        assert_bool_results(expr.evaluate(&batch).unwrap(), &[Some(true), Some(false)]);
     }
 
     #[test]
-    fn test_rlike_utf8_view_array() {
-        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8View, true)]));
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![Arc::new(StringViewArray::from(vec![Some("Rose"), None]))],
-        )
-        .unwrap();
+    fn test_rlike_dictionary_arrays() {
+        let pattern = "R[a-z]+";
+        let expected = [Some(true), None, Some(false)];
 
-        let expr = RLike::try_new(Arc::new(Column::new("s", 0)), "R[a-z]+").unwrap();
-        assert_bool_array_rose_null(expr.evaluate(&batch).unwrap());
+        let utf8_values: ArrayRef = Arc::new(StringArray::from(vec!["Rose", "Daisy"]));
+        let utf8_view_values: ArrayRef = Arc::new(StringViewArray::from(vec!["Rose", "Daisy"]));
+
+        let cases: Vec<(DataType, ArrayRef)> = vec![
+            (
+                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                Arc::new(DictionaryArray::<Int32Type>::new(
+                    Int32Array::from(vec![Some(0), None, Some(1)]),
+                    Arc::clone(&utf8_values),
+                )),
+            ),
+            (
+                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8View)),
+                Arc::new(DictionaryArray::<Int32Type>::new(
+                    Int32Array::from(vec![Some(0), None, Some(1)]),
+                    Arc::clone(&utf8_view_values),
+                )),
+            ),
+            (
+                DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
+                Arc::new(DictionaryArray::<Int8Type>::new(
+                    Int8Array::from(vec![Some(0), None, Some(1)]),
+                    Arc::clone(&utf8_values),
+                )),
+            ),
+        ];
+
+        for (data_type, array) in cases {
+            let schema = Arc::new(Schema::new(vec![Field::new("s", data_type, true)]));
+            let batch = RecordBatch::try_new(Arc::clone(&schema), vec![array]).unwrap();
+            let expr = RLike::try_new(Arc::new(Column::new("s", 0)), pattern).unwrap();
+            assert_bool_results(expr.evaluate(&batch).unwrap(), &expected);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5102.

## Rationale for this change

Native `RLike` array evaluation hard-downcasted to `StringArray` and panicked on other Arrow string layouts (`LargeUtf8` / `Utf8View`). This PR keeps the plan-time compiled `Regex` (instead of Arrow's per-batch `regexp_is_match`) and hardens layout / dictionary handling so those inputs return correct results or a typed error instead of panicking.

Today's common Spark `string` / Parquet path still shows up as `Utf8`, and the planner currently casts some `Utf8View` UDF results back to `Utf8`, so `LargeUtf8` / `Utf8View` may not be easy to hit end-to-end yet. The change is still useful hardening for the layouts called out in #5102, plus correct dictionary key-type handling.

## What changes are included in this PR?

- Generalize array matching over `Utf8` / `LargeUtf8` / `Utf8View` via `StringArrayType`.
- Use `as` values longer than 12 bytes to exercise the out-of-line `Utf8View` representation.
- Use `as_any_dictionary()` on the dictionary path so any key type works (match dictionary values, then `take`); scalar input still uses the precompiled `Regex`.
- Return `internal_err!` for non-string inputs on both the array and scalar paths (invalid plan rather than a user-facing execution error).
- Simplify `is_match` to `iter` / `map` / `collect`, matching the `process_parse_url` style.
- Keep the Spark-compatibility caveat on the struct rustdoc; keep the "why not Arrow kernel" note only on`is_match`.

## Performance notes

The RLike benchmark added by #5598 (originally requested in #5246) was run during review against the previous and current is_match loops.

Both binaries were built from the same source tree with only `rlike.rs` swapped, then measured in an interleaved run at 65,536 rows:

| Input | Previous loop | This PR | Difference |
|---|---:|---:|---:|
| `no_nulls` | 2.820 ms | 2.924 ms | +3.7% |
| `sparse` | 2.640 ms | 2.687 ms | +1.8% |
| `all_null` | 142.4 µs | 74.2 µs | 1.9× faster |

The iterator-based implementation has a small cost for non-null inputs and a substantial improvement for all-null input. This is considered a reasonable trade-off for the broader layout and dictionary support and the removal of panic paths.

These are local, directional measurements rather than CI performance thresholds. Interleaving the two pre-built binaries was used because sequential Criterion baseline comparisons were too noisy to resolve differences of this size reliably.

## How are these changes tested?

- Unit coverage for the `Utf8`, `LargeUtf8`, and `Utf8View` layouts.
- Direct and dictionary `Utf8View` cases with values longer than 12 bytes, exercising the out-of-line representation.
- An all-valid input assertion confirming that the result remains null-buffer-free.
- Dictionary coverage for:
  - `Dictionary(Int32, Utf8)`
  - `Dictionary(Int32, Utf8View)`
  - `Dictionary(Int8, Utf8)`
  - `Dictionary(UInt64, Utf8)`
  - nulls in dictionary values
  - a dictionary sliced with a non-zero offset
- `cargo fmt --check`
- `cargo test -p datafusion-comet-spark-expr --lib rlike`
- `cargo clippy -p datafusion-comet-spark-expr --lib --tests -- -D warnings`