### PR TITLE
fix: release task-shared memory pool references via RAII guard

### DIFF
--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -97,7 +97,7 @@ use tokio::runtime::{Handle, Runtime};
 use tokio::sync::mpsc;
 
 use crate::execution::memory_pools::{
-    create_memory_pool, handle_task_shared_pool_release, parse_memory_pool_config, MemoryPoolConfig,
+    create_memory_pool, parse_memory_pool_config, TaskSharedPoolRef,
 };
 use crate::execution::operators::{ScanExec, ShuffleScanExec};
 use crate::execution::shuffle::{read_ipc_compressed, CompressionCodec};
@@ -301,8 +301,6 @@ fn collect_op_names<'a>(op: &'a Operator, names: &mut std::collections::BTreeSet
 struct ExecutionContext {
     /// The id of the execution context.
     pub id: i64,
-    /// Task attempt id
-    pub task_attempt_id: i64,
     /// The deserialized Spark plan
     pub spark_plan: Operator,
     /// The number of partitions
@@ -335,8 +333,6 @@ struct ExecutionContext {
     pub debug_native: bool,
     /// Whether to write native plans with metrics to stdout
     pub explain_native: bool,
-    /// Memory pool config
-    pub memory_pool_config: MemoryPoolConfig,
     /// Whether to log memory usage on each call to execute_plan
     pub tracing_enabled: bool,
     /// Rust thread ID, used for aggregating tracing metrics per thread
@@ -352,6 +348,11 @@ struct ExecutionContext {
     /// cheap to clone; the underlying `Global<JObject>` releases its JNI global ref on drop
     /// via `jni`'s `Drop` impl.
     pub task_context: Option<Arc<Global<JObject<'static>>>>,
+    /// This plan's reference to the task-shared memory pool, for task-shared pool types. Never
+    /// read: it exists so that dropping the context releases the reference. Declared last so it
+    /// drops after `session_ctx`, ensuring the pool's own reservations are all released before the
+    /// last reference removes it from the task-shared map.
+    pub _task_shared_pool_ref: Option<TaskSharedPoolRef>,
 }
 
 /// Accept serialized query plan and return the address of the native query plan.
@@ -431,7 +432,10 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
                 memory_limit,
                 memory_limit_per_task,
             )?;
-            let memory_pool =
+            // `task_shared_pool_ref` is moved onto the `ExecutionContext` below. Every fallible
+            // step between here and there must leave it owned by this scope so that unwinding
+            // releases the task-shared pool reference rather than stranding it.
+            let (memory_pool, task_shared_pool_ref) =
                 create_memory_pool(&memory_pool_config, task_memory_manager, task_attempt_id);
 
             let memory_pool = if logging_memory_pool {
@@ -511,7 +515,6 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
 
             let exec_context = Box::new(ExecutionContext {
                 id,
-                task_attempt_id,
                 spark_plan,
                 partition_count: partition_count as usize,
                 root_op: None,
@@ -528,7 +531,6 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
                 session_ctx: session,
                 debug_native,
                 explain_native,
-                memory_pool_config,
                 tracing_enabled,
                 rust_thread_id,
                 tracing_memory_metric_name: format!(
@@ -536,6 +538,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
                 ),
                 tracing_event_name,
                 task_context,
+                _task_shared_pool_ref: task_shared_pool_ref,
             });
 
             Ok(Box::into_raw(exec_context) as i64)
@@ -945,15 +948,11 @@ pub extern "system" fn Java_org_apache_comet_Native_releasePlan(
     exec_context: jlong,
 ) {
     try_unwrap_or_throw(&e, |env| unsafe {
-        let execution_context = get_execution_context(exec_context);
-
-        // Update metrics
-        update_metrics(env, execution_context)?;
-
-        handle_task_shared_pool_release(
-            execution_context.memory_pool_config.pool_type,
-            execution_context.task_attempt_id,
-        );
+        // Reclaim ownership of the context up front so that it is always freed, even if updating
+        // metrics below fails. Dropping it releases this plan's reference to the task-shared
+        // memory pool along with every JNI global ref the context holds.
+        let mut execution_context: Box<ExecutionContext> =
+            Box::from_raw(get_execution_context(exec_context));
 
         // Unregister this context's pool and emit the remaining total for the thread
         if execution_context.tracing_enabled {
@@ -965,8 +964,8 @@ pub extern "system" fn Java_org_apache_comet_Native_releasePlan(
             );
         }
 
-        let _: Box<ExecutionContext> = Box::from_raw(execution_context);
-        Ok(())
+        // Flush metrics last, as it is the only fallible step here.
+        update_metrics(env, &mut execution_context)
     })
 }
 

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -349,9 +349,13 @@ struct ExecutionContext {
     /// via `jni`'s `Drop` impl.
     pub task_context: Option<Arc<Global<JObject<'static>>>>,
     /// This plan's reference to the task-shared memory pool, for task-shared pool types. Never
-    /// read: it exists so that dropping the context releases the reference. Declared last so it
-    /// drops after `session_ctx`, ensuring the pool's own reservations are all released before the
-    /// last reference removes it from the task-shared map.
+    /// read: it exists so that dropping the context releases the reference.
+    ///
+    /// Keep this declared last. Fields drop in declaration order, and releasing the reference
+    /// before `session_ctx` (and the `root_op`/`stream` that hold reservations against the pool)
+    /// would remove the pool from the task-shared map while it is still in use, so the next plan
+    /// in the same task attempt would build a second pool with a full budget and the task could
+    /// exceed its per-task limit.
     pub _task_shared_pool_ref: Option<TaskSharedPoolRef>,
 }
 
@@ -432,9 +436,8 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
                 memory_limit,
                 memory_limit_per_task,
             )?;
-            // `task_shared_pool_ref` is moved onto the `ExecutionContext` below. Every fallible
-            // step between here and there must leave it owned by this scope so that unwinding
-            // releases the task-shared pool reference rather than stranding it.
+            // Held by this scope until it is moved onto the `ExecutionContext` below, so that
+            // unwinding from any fallible step in between releases the pool reference.
             let (memory_pool, task_shared_pool_ref) =
                 create_memory_pool(&memory_pool_config, task_memory_manager, task_attempt_id);
 
@@ -952,7 +955,7 @@ pub extern "system" fn Java_org_apache_comet_Native_releasePlan(
         // metrics below fails. Dropping it releases this plan's reference to the task-shared
         // memory pool along with every JNI global ref the context holds.
         let mut execution_context: Box<ExecutionContext> =
-            Box::from_raw(get_execution_context(exec_context));
+            Box::from_raw(exec_context as *mut ExecutionContext);
 
         // Unregister this context's pool and emit the remaining total for the thread
         if execution_context.tracing_enabled {

--- a/native/core/src/execution/memory_pools/config.rs
+++ b/native/core/src/execution/memory_pools/config.rs
@@ -17,7 +17,7 @@
 
 use crate::errors::{CometError, CometResult};
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum MemoryPoolType {
     GreedyUnified,
     FairUnified,

--- a/native/core/src/execution/memory_pools/config.rs
+++ b/native/core/src/execution/memory_pools/config.rs
@@ -17,7 +17,7 @@
 
 use crate::errors::{CometError, CometResult};
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub(crate) enum MemoryPoolType {
     GreedyUnified,
     FairUnified,
@@ -28,18 +28,6 @@ pub(crate) enum MemoryPoolType {
     GreedyGlobal,
     FairSpillGlobal,
     Unbounded,
-}
-
-impl MemoryPoolType {
-    pub(crate) fn is_task_shared(&self) -> bool {
-        matches!(
-            self,
-            MemoryPoolType::GreedyTaskShared
-                | MemoryPoolType::FairSpillTaskShared
-                | MemoryPoolType::FairUnified
-                | MemoryPoolType::GreedyUnified
-        )
-    }
 }
 
 pub(crate) struct MemoryPoolConfig {

--- a/native/core/src/execution/memory_pools/mod.rs
+++ b/native/core/src/execution/memory_pools/mod.rs
@@ -53,39 +53,36 @@ pub(crate) fn create_memory_pool(
         ))
     }
 
+    /// Acquires the pool shared by every plan in the task, keeping the reference that releases it.
+    fn task_shared(
+        task_attempt_id: i64,
+        create: impl FnOnce() -> Arc<dyn MemoryPool>,
+    ) -> (Arc<dyn MemoryPool>, Option<TaskSharedPoolRef>) {
+        let (pool, pool_ref) = acquire_task_shared_pool(task_attempt_id, create);
+        (pool, Some(pool_ref))
+    }
+
     let pool_type = memory_pool_config.pool_type;
     let pool_size = memory_pool_config.pool_size;
 
     match pool_type {
-        MemoryPoolType::GreedyUnified => {
-            let (pool, pool_ref) = acquire_task_shared_pool(pool_type, task_attempt_id, || {
-                tracked(CometUnifiedMemoryPool::new(
-                    comet_task_memory_manager,
-                    task_attempt_id,
-                ))
-            });
-            (pool, Some(pool_ref))
-        }
-        MemoryPoolType::FairUnified => {
-            let (pool, pool_ref) = acquire_task_shared_pool(pool_type, task_attempt_id, || {
-                tracked(CometFairMemoryPool::new(
-                    comet_task_memory_manager,
-                    pool_size,
-                ))
-            });
-            (pool, Some(pool_ref))
-        }
-        MemoryPoolType::GreedyTaskShared => {
-            let (pool, pool_ref) = acquire_task_shared_pool(pool_type, task_attempt_id, || {
-                tracked(GreedyMemoryPool::new(pool_size))
-            });
-            (pool, Some(pool_ref))
-        }
+        MemoryPoolType::GreedyUnified => task_shared(task_attempt_id, || {
+            tracked(CometUnifiedMemoryPool::new(
+                comet_task_memory_manager,
+                task_attempt_id,
+            ))
+        }),
+        MemoryPoolType::FairUnified => task_shared(task_attempt_id, || {
+            tracked(CometFairMemoryPool::new(
+                comet_task_memory_manager,
+                pool_size,
+            ))
+        }),
+        MemoryPoolType::GreedyTaskShared => task_shared(task_attempt_id, || {
+            tracked(GreedyMemoryPool::new(pool_size))
+        }),
         MemoryPoolType::FairSpillTaskShared => {
-            let (pool, pool_ref) = acquire_task_shared_pool(pool_type, task_attempt_id, || {
-                tracked(FairSpillPool::new(pool_size))
-            });
-            (pool, Some(pool_ref))
+            task_shared(task_attempt_id, || tracked(FairSpillPool::new(pool_size)))
         }
         MemoryPoolType::Greedy => (tracked(GreedyMemoryPool::new(pool_size)), None),
         MemoryPoolType::FairSpill => (tracked(FairSpillPool::new(pool_size)), None),

--- a/native/core/src/execution/memory_pools/mod.rs
+++ b/native/core/src/execution/memory_pools/mod.rs
@@ -34,94 +34,73 @@ use unified_pool::CometUnifiedMemoryPool;
 pub(crate) use config::*;
 pub(crate) use task_shared::*;
 
+/// Creates the memory pool for a native plan.
+///
+/// For task-shared pool types the returned [`TaskSharedPoolRef`] must be kept alive for as long as
+/// the plan uses the pool; dropping it releases the plan's reference. It is `None` for pool types
+/// that are not task-shared.
 pub(crate) fn create_memory_pool(
     memory_pool_config: &MemoryPoolConfig,
     comet_task_memory_manager: Arc<Global<JObject<'static>>>,
     task_attempt_id: i64,
-) -> Arc<dyn MemoryPool> {
+) -> (Arc<dyn MemoryPool>, Option<TaskSharedPoolRef>) {
     const NUM_TRACKED_CONSUMERS: usize = 10;
-    match memory_pool_config.pool_type {
+
+    fn tracked(pool: impl MemoryPool + 'static) -> Arc<dyn MemoryPool> {
+        Arc::new(TrackConsumersPool::new(
+            pool,
+            NonZeroUsize::new(NUM_TRACKED_CONSUMERS).unwrap(),
+        ))
+    }
+
+    let pool_type = memory_pool_config.pool_type;
+    let pool_size = memory_pool_config.pool_size;
+
+    match pool_type {
         MemoryPoolType::GreedyUnified => {
-            let mut memory_pool_map = TASK_SHARED_MEMORY_POOLS.lock().unwrap();
-            let per_task_memory_pool =
-                memory_pool_map.entry(task_attempt_id).or_insert_with(|| {
-                    let pool: Arc<dyn MemoryPool> = Arc::new(TrackConsumersPool::new(
-                        CometUnifiedMemoryPool::new(
-                            Arc::clone(&comet_task_memory_manager),
-                            task_attempt_id,
-                        ),
-                        NonZeroUsize::new(NUM_TRACKED_CONSUMERS).unwrap(),
-                    ));
-                    PerTaskMemoryPool::new(pool)
-                });
-            per_task_memory_pool.num_plans += 1;
-            Arc::clone(&per_task_memory_pool.memory_pool)
-        }
-        MemoryPoolType::FairUnified => {
-            let mut memory_pool_map = TASK_SHARED_MEMORY_POOLS.lock().unwrap();
-            let per_task_memory_pool =
-                memory_pool_map.entry(task_attempt_id).or_insert_with(|| {
-                    let pool: Arc<dyn MemoryPool> = Arc::new(TrackConsumersPool::new(
-                        CometFairMemoryPool::new(
-                            Arc::clone(&comet_task_memory_manager),
-                            memory_pool_config.pool_size,
-                        ),
-                        NonZeroUsize::new(NUM_TRACKED_CONSUMERS).unwrap(),
-                    ));
-                    PerTaskMemoryPool::new(pool)
-                });
-            per_task_memory_pool.num_plans += 1;
-            Arc::clone(&per_task_memory_pool.memory_pool)
-        }
-        MemoryPoolType::Greedy => Arc::new(TrackConsumersPool::new(
-            GreedyMemoryPool::new(memory_pool_config.pool_size),
-            NonZeroUsize::new(NUM_TRACKED_CONSUMERS).unwrap(),
-        )),
-        MemoryPoolType::FairSpill => Arc::new(TrackConsumersPool::new(
-            FairSpillPool::new(memory_pool_config.pool_size),
-            NonZeroUsize::new(NUM_TRACKED_CONSUMERS).unwrap(),
-        )),
-        MemoryPoolType::GreedyGlobal => {
-            static GLOBAL_MEMORY_POOL_GREEDY: OnceCell<Arc<dyn MemoryPool>> = OnceCell::new();
-            let memory_pool = GLOBAL_MEMORY_POOL_GREEDY.get_or_init(|| {
-                Arc::new(TrackConsumersPool::new(
-                    GreedyMemoryPool::new(memory_pool_config.pool_size),
-                    NonZeroUsize::new(NUM_TRACKED_CONSUMERS).unwrap(),
+            let (pool, pool_ref) = acquire_task_shared_pool(pool_type, task_attempt_id, || {
+                tracked(CometUnifiedMemoryPool::new(
+                    comet_task_memory_manager,
+                    task_attempt_id,
                 ))
             });
-            Arc::clone(memory_pool)
+            (pool, Some(pool_ref))
+        }
+        MemoryPoolType::FairUnified => {
+            let (pool, pool_ref) = acquire_task_shared_pool(pool_type, task_attempt_id, || {
+                tracked(CometFairMemoryPool::new(
+                    comet_task_memory_manager,
+                    pool_size,
+                ))
+            });
+            (pool, Some(pool_ref))
+        }
+        MemoryPoolType::GreedyTaskShared => {
+            let (pool, pool_ref) = acquire_task_shared_pool(pool_type, task_attempt_id, || {
+                tracked(GreedyMemoryPool::new(pool_size))
+            });
+            (pool, Some(pool_ref))
+        }
+        MemoryPoolType::FairSpillTaskShared => {
+            let (pool, pool_ref) = acquire_task_shared_pool(pool_type, task_attempt_id, || {
+                tracked(FairSpillPool::new(pool_size))
+            });
+            (pool, Some(pool_ref))
+        }
+        MemoryPoolType::Greedy => (tracked(GreedyMemoryPool::new(pool_size)), None),
+        MemoryPoolType::FairSpill => (tracked(FairSpillPool::new(pool_size)), None),
+        MemoryPoolType::GreedyGlobal => {
+            static GLOBAL_MEMORY_POOL_GREEDY: OnceCell<Arc<dyn MemoryPool>> = OnceCell::new();
+            let memory_pool =
+                GLOBAL_MEMORY_POOL_GREEDY.get_or_init(|| tracked(GreedyMemoryPool::new(pool_size)));
+            (Arc::clone(memory_pool), None)
         }
         MemoryPoolType::FairSpillGlobal => {
             static GLOBAL_MEMORY_POOL_FAIR: OnceCell<Arc<dyn MemoryPool>> = OnceCell::new();
-            let memory_pool = GLOBAL_MEMORY_POOL_FAIR.get_or_init(|| {
-                Arc::new(TrackConsumersPool::new(
-                    FairSpillPool::new(memory_pool_config.pool_size),
-                    NonZeroUsize::new(NUM_TRACKED_CONSUMERS).unwrap(),
-                ))
-            });
-            Arc::clone(memory_pool)
+            let memory_pool =
+                GLOBAL_MEMORY_POOL_FAIR.get_or_init(|| tracked(FairSpillPool::new(pool_size)));
+            (Arc::clone(memory_pool), None)
         }
-        MemoryPoolType::GreedyTaskShared | MemoryPoolType::FairSpillTaskShared => {
-            let mut memory_pool_map = TASK_SHARED_MEMORY_POOLS.lock().unwrap();
-            let per_task_memory_pool =
-                memory_pool_map.entry(task_attempt_id).or_insert_with(|| {
-                    let pool: Arc<dyn MemoryPool> =
-                        if memory_pool_config.pool_type == MemoryPoolType::GreedyTaskShared {
-                            Arc::new(TrackConsumersPool::new(
-                                GreedyMemoryPool::new(memory_pool_config.pool_size),
-                                NonZeroUsize::new(NUM_TRACKED_CONSUMERS).unwrap(),
-                            ))
-                        } else {
-                            Arc::new(TrackConsumersPool::new(
-                                FairSpillPool::new(memory_pool_config.pool_size),
-                                NonZeroUsize::new(NUM_TRACKED_CONSUMERS).unwrap(),
-                            ))
-                        };
-                    PerTaskMemoryPool::new(pool)
-                });
-            per_task_memory_pool.num_plans += 1;
-            Arc::clone(&per_task_memory_pool.memory_pool)
-        }
-        MemoryPoolType::Unbounded => Arc::new(UnboundedMemoryPool::default()),
+        MemoryPoolType::Unbounded => (Arc::new(UnboundedMemoryPool::default()), None),
     }
 }

--- a/native/core/src/execution/memory_pools/task_shared.rs
+++ b/native/core/src/execution/memory_pools/task_shared.rs
@@ -17,44 +17,165 @@
 
 use crate::execution::memory_pools::MemoryPoolType;
 use datafusion::execution::memory_pool::MemoryPool;
+use log::warn;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 /// The per-task memory pools keyed by task attempt id.
-pub(crate) static TASK_SHARED_MEMORY_POOLS: Lazy<Mutex<HashMap<i64, PerTaskMemoryPool>>> =
+static TASK_SHARED_MEMORY_POOLS: Lazy<Mutex<HashMap<i64, PerTaskMemoryPool>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
-pub(crate) struct PerTaskMemoryPool {
-    pub(crate) memory_pool: Arc<dyn MemoryPool>,
-    pub(crate) num_plans: usize,
+/// Locks the pool map, recovering from poisoning rather than propagating it.
+///
+/// A panic while the map is locked would otherwise poison the mutex permanently, and because
+/// every `createPlan` and plan release goes through this map that would take down all subsequent
+/// native execution in the executor. The map holds only a refcount and an `Arc`, so a poisoned
+/// state is still safe to observe.
+fn lock_pools() -> MutexGuard<'static, HashMap<i64, PerTaskMemoryPool>> {
+    TASK_SHARED_MEMORY_POOLS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
 }
 
-impl PerTaskMemoryPool {
-    pub(crate) fn new(memory_pool: Arc<dyn MemoryPool>) -> Self {
-        Self {
-            memory_pool,
-            num_plans: 0,
+struct PerTaskMemoryPool {
+    memory_pool: Arc<dyn MemoryPool>,
+    num_plans: usize,
+}
+
+/// One native plan's reference to a task-shared memory pool.
+///
+/// Dropping this releases the reference, removing the pool from the map once the last plan using
+/// it is gone. It is stored on the `ExecutionContext` so the reference is released whenever that
+/// context is freed -- both when `releasePlan` frees it normally and when `createPlan` fails
+/// partway through and unwinds.
+///
+/// Tying the release to a guard rather than an explicit call at plan-release time matters because
+/// a stranded map entry is never reclaimed: keys are unique task attempt ids and nothing prunes
+/// the map, and each entry holds a JNI global ref to the task's `CometTaskMemoryManager`, which
+/// transitively pins its `TaskMemoryManager` and `TaskContext`.
+pub(crate) struct TaskSharedPoolRef {
+    pool_type: MemoryPoolType,
+    task_attempt_id: i64,
+}
+
+impl Drop for TaskSharedPoolRef {
+    fn drop(&mut self) {
+        let mut memory_pool_map = lock_pools();
+        match memory_pool_map.get_mut(&self.task_attempt_id) {
+            Some(per_task_memory_pool) => {
+                // `saturating_sub` rather than `-=`: the refcount is balanced by construction
+                // (one increment per `TaskSharedPoolRef`, one decrement on drop), but underflow
+                // here would panic while holding the map lock.
+                per_task_memory_pool.num_plans = per_task_memory_pool.num_plans.saturating_sub(1);
+                if per_task_memory_pool.num_plans == 0 {
+                    // Last plan using this pool, so drop it from the map. This releases the
+                    // map's `Arc`; the pool itself is freed once the owning session context has
+                    // also dropped its clone.
+                    memory_pool_map.remove(&self.task_attempt_id);
+                }
+            }
+            None => warn!(
+                "Task {} released a {:?} memory pool reference but no pool was registered",
+                self.task_attempt_id, self.pool_type
+            ),
         }
     }
 }
 
-// This function reduces the refcount of a per-task memory pool when a native plan is released.
-// If the refcount reaches zero, the memory pool is removed from the map and dropped.
-pub(crate) fn handle_task_shared_pool_release(pool_type: MemoryPoolType, task_attempt_id: i64) {
-    if !pool_type.is_task_shared() {
-        return;
+/// Returns the memory pool shared by every native plan in `task_attempt_id`, creating it with
+/// `create` if this is the first plan in the task, along with a reference that releases it on
+/// drop.
+///
+/// `create` is only called when no pool exists for the task yet, so the pool size and type come
+/// from the first plan in the task; later plans reuse that pool.
+pub(crate) fn acquire_task_shared_pool(
+    pool_type: MemoryPoolType,
+    task_attempt_id: i64,
+    create: impl FnOnce() -> Arc<dyn MemoryPool>,
+) -> (Arc<dyn MemoryPool>, TaskSharedPoolRef) {
+    debug_assert!(pool_type.is_task_shared());
+
+    let mut memory_pool_map = lock_pools();
+    let per_task_memory_pool =
+        memory_pool_map
+            .entry(task_attempt_id)
+            .or_insert_with(|| PerTaskMemoryPool {
+                memory_pool: create(),
+                num_plans: 0,
+            });
+    per_task_memory_pool.num_plans += 1;
+
+    (
+        Arc::clone(&per_task_memory_pool.memory_pool),
+        TaskSharedPoolRef {
+            pool_type,
+            task_attempt_id,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::execution::memory_pool::UnboundedMemoryPool;
+
+    /// Tests share the process-wide pool map, so each uses its own task attempt id.
+    fn acquire(task_attempt_id: i64) -> (Arc<dyn MemoryPool>, TaskSharedPoolRef) {
+        acquire_task_shared_pool(MemoryPoolType::GreedyTaskShared, task_attempt_id, || {
+            Arc::new(UnboundedMemoryPool::default())
+        })
     }
 
-    // Decrement the number of native plans using the per-task shared memory pool, and
-    // remove the memory pool if the released native plan is the last native plan using it.
-    let mut memory_pool_map = TASK_SHARED_MEMORY_POOLS.lock().unwrap();
-    if let Some(per_task_memory_pool) = memory_pool_map.get_mut(&task_attempt_id) {
-        per_task_memory_pool.num_plans -= 1;
-        if per_task_memory_pool.num_plans == 0 {
-            // Drop the memory pool from the per-task memory pool map if there are no
-            // more native plans using it.
-            memory_pool_map.remove(&task_attempt_id);
+    fn is_registered(task_attempt_id: i64) -> bool {
+        lock_pools().contains_key(&task_attempt_id)
+    }
+
+    #[test]
+    fn plans_in_the_same_task_share_one_pool() {
+        let (first, _first_ref) = acquire(-1001);
+        let (second, _second_ref) = acquire(-1001);
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(lock_pools()[&-1001].num_plans, 2);
+    }
+
+    #[test]
+    fn plans_in_different_tasks_get_different_pools() {
+        let (first, _first_ref) = acquire(-1002);
+        let (second, _second_ref) = acquire(-1003);
+        assert!(!Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn pool_is_removed_only_once_the_last_plan_releases_it() {
+        let (_pool, first_ref) = acquire(-1004);
+        let (_pool, second_ref) = acquire(-1004);
+
+        drop(first_ref);
+        assert!(
+            is_registered(-1004),
+            "pool must outlive the first plan to release it"
+        );
+
+        drop(second_ref);
+        assert!(!is_registered(-1004));
+    }
+
+    #[test]
+    fn dropping_the_reference_releases_the_pool() {
+        // Stands in for `createPlan` failing after the pool was acquired: nothing calls a release
+        // path, the `ExecutionContext` is simply never built, and the guard drops on unwind.
+        {
+            let (_pool, _pool_ref) = acquire(-1005);
+            assert!(is_registered(-1005));
         }
+        assert!(!is_registered(-1005));
+    }
+
+    #[test]
+    fn releasing_an_unregistered_pool_does_not_panic() {
+        let (_pool, pool_ref) = acquire(-1006);
+        lock_pools().remove(&-1006);
+        drop(pool_ref);
     }
 }

--- a/native/core/src/execution/memory_pools/task_shared.rs
+++ b/native/core/src/execution/memory_pools/task_shared.rs
@@ -15,28 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::execution::memory_pools::MemoryPoolType;
 use datafusion::execution::memory_pool::MemoryPool;
 use log::warn;
 use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::Arc;
 
 /// The per-task memory pools keyed by task attempt id.
 static TASK_SHARED_MEMORY_POOLS: Lazy<Mutex<HashMap<i64, PerTaskMemoryPool>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
-
-/// Locks the pool map, recovering from poisoning rather than propagating it.
-///
-/// A panic while the map is locked would otherwise poison the mutex permanently, and because
-/// every `createPlan` and plan release goes through this map that would take down all subsequent
-/// native execution in the executor. The map holds only a refcount and an `Arc`, so a poisoned
-/// state is still safe to observe.
-fn lock_pools() -> MutexGuard<'static, HashMap<i64, PerTaskMemoryPool>> {
-    TASK_SHARED_MEMORY_POOLS
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-}
 
 struct PerTaskMemoryPool {
     memory_pool: Arc<dyn MemoryPool>,
@@ -55,29 +44,25 @@ struct PerTaskMemoryPool {
 /// the map, and each entry holds a JNI global ref to the task's `CometTaskMemoryManager`, which
 /// transitively pins its `TaskMemoryManager` and `TaskContext`.
 pub(crate) struct TaskSharedPoolRef {
-    pool_type: MemoryPoolType,
     task_attempt_id: i64,
 }
 
 impl Drop for TaskSharedPoolRef {
     fn drop(&mut self) {
-        let mut memory_pool_map = lock_pools();
-        match memory_pool_map.get_mut(&self.task_attempt_id) {
-            Some(per_task_memory_pool) => {
-                // `saturating_sub` rather than `-=`: the refcount is balanced by construction
-                // (one increment per `TaskSharedPoolRef`, one decrement on drop), but underflow
-                // here would panic while holding the map lock.
-                per_task_memory_pool.num_plans = per_task_memory_pool.num_plans.saturating_sub(1);
-                if per_task_memory_pool.num_plans == 0 {
+        match TASK_SHARED_MEMORY_POOLS.lock().entry(self.task_attempt_id) {
+            Entry::Occupied(mut entry) => {
+                let num_plans = entry.get().num_plans.saturating_sub(1);
+                entry.get_mut().num_plans = num_plans;
+                if num_plans == 0 {
                     // Last plan using this pool, so drop it from the map. This releases the
                     // map's `Arc`; the pool itself is freed once the owning session context has
                     // also dropped its clone.
-                    memory_pool_map.remove(&self.task_attempt_id);
+                    entry.remove();
                 }
             }
-            None => warn!(
-                "Task {} released a {:?} memory pool reference but no pool was registered",
-                self.task_attempt_id, self.pool_type
+            Entry::Vacant(_) => warn!(
+                "Task {} released a memory pool reference but no pool was registered",
+                self.task_attempt_id
             ),
         }
     }
@@ -90,13 +75,10 @@ impl Drop for TaskSharedPoolRef {
 /// `create` is only called when no pool exists for the task yet, so the pool size and type come
 /// from the first plan in the task; later plans reuse that pool.
 pub(crate) fn acquire_task_shared_pool(
-    pool_type: MemoryPoolType,
     task_attempt_id: i64,
     create: impl FnOnce() -> Arc<dyn MemoryPool>,
 ) -> (Arc<dyn MemoryPool>, TaskSharedPoolRef) {
-    debug_assert!(pool_type.is_task_shared());
-
-    let mut memory_pool_map = lock_pools();
+    let mut memory_pool_map = TASK_SHARED_MEMORY_POOLS.lock();
     let per_task_memory_pool =
         memory_pool_map
             .entry(task_attempt_id)
@@ -108,10 +90,7 @@ pub(crate) fn acquire_task_shared_pool(
 
     (
         Arc::clone(&per_task_memory_pool.memory_pool),
-        TaskSharedPoolRef {
-            pool_type,
-            task_attempt_id,
-        },
+        TaskSharedPoolRef { task_attempt_id },
     )
 }
 
@@ -122,13 +101,13 @@ mod tests {
 
     /// Tests share the process-wide pool map, so each uses its own task attempt id.
     fn acquire(task_attempt_id: i64) -> (Arc<dyn MemoryPool>, TaskSharedPoolRef) {
-        acquire_task_shared_pool(MemoryPoolType::GreedyTaskShared, task_attempt_id, || {
-            Arc::new(UnboundedMemoryPool::default())
-        })
+        acquire_task_shared_pool(task_attempt_id, || Arc::new(UnboundedMemoryPool::default()))
     }
 
     fn is_registered(task_attempt_id: i64) -> bool {
-        lock_pools().contains_key(&task_attempt_id)
+        TASK_SHARED_MEMORY_POOLS
+            .lock()
+            .contains_key(&task_attempt_id)
     }
 
     #[test]
@@ -136,7 +115,7 @@ mod tests {
         let (first, _first_ref) = acquire(-1001);
         let (second, _second_ref) = acquire(-1001);
         assert!(Arc::ptr_eq(&first, &second));
-        assert_eq!(lock_pools()[&-1001].num_plans, 2);
+        assert_eq!(TASK_SHARED_MEMORY_POOLS.lock()[&-1001].num_plans, 2);
     }
 
     #[test]
@@ -175,7 +154,7 @@ mod tests {
     #[test]
     fn releasing_an_unregistered_pool_does_not_panic() {
         let (_pool, pool_ref) = acquire(-1006);
-        lock_pools().remove(&-1006);
+        TASK_SHARED_MEMORY_POOLS.lock().remove(&-1006);
         drop(pool_ref);
     }
 }

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -230,13 +230,31 @@ class CometExecIterator(
       // dangling pointer.
       closed = true
 
-      if (currentBatch != null) {
-        currentBatch.close()
-        currentBatch = null
+      var failure: Throwable = null
+      try {
+        if (currentBatch != null) {
+          currentBatch.close()
+          currentBatch = null
+        }
+        nativeUtil.close()
+        shuffleBlockIterators.values.foreach(_.close())
+      } catch {
+        case t: Throwable => failure = t
       }
-      nativeUtil.close()
-      shuffleBlockIterators.values.foreach(_.close())
-      nativeLib.releasePlan(plan)
+
+      // Release the native plan even if the teardown above failed. Since this is the only chance
+      // to do so, skipping it would strand the native execution context, which owns this plan's
+      // task-shared memory pool reference and several JNI global refs.
+      try {
+        nativeLib.releasePlan(plan)
+      } catch {
+        case t: Throwable =>
+          if (failure == null) failure = t else failure.addSuppressed(t)
+      }
+
+      if (failure != null) {
+        throw failure
+      }
 
       if (tracingEnabled) {
         traceMemoryUsage()

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -224,6 +224,12 @@ class CometExecIterator(
 
   def close(): Unit = synchronized {
     if (!closed) {
+      // Mark closed before tearing anything down. If a step below throws, this iterator must not
+      // remain eligible for a second close() from the task completion listener, because
+      // releasePlan() frees the native execution context and calling it twice would operate on a
+      // dangling pointer.
+      closed = true
+
       if (currentBatch != null) {
         currentBatch.close()
         currentBatch = null
@@ -240,8 +246,6 @@ class CometExecIterator(
       if (memInUse != 0) {
         logWarning(s"CometExecIterator closed with non-zero memory usage : $memInUse")
       }
-
-      closed = true
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion-comet/issues/5212 (positions 2, 3 and 8).

## Rationale for this change

Entries in `TASK_SHARED_MEMORY_POOLS` leak whenever a plan's lifecycle does not run to completion, and a stranded entry is never reclaimed: keys are unique task attempt ids and nothing prunes the map. Each entry holds an `Arc<Global<JObject>>` for the task's `CometTaskMemoryManager`, which transitively pins its `TaskMemoryManager` and `TaskContext`, so this accumulates JVM objects for the lifetime of the executor.

There were two leak paths.

**`createPlan` failing after the pool was acquired.** `create_memory_pool` increments the refcount, but `createPlan` can still fail afterwards — `local_dirs` decoding, `prepare_datafusion_session_context`, and the key-unwrapper global ref all use `?`. On the JVM side `plan` is a field initializer (`CometExecIterator.scala:87`) evaluated *before* the task-completion listener is registered (`:139`), so when `createPlan` throws there is no `releasePlan` and no listener — the refcount is never decremented.

**`releasePlan` failing before the release.** It ran `update_metrics(env, execution_context)?` *before* `handle_task_shared_pool_release`, so a metrics failure stranded the entry and skipped the `Box::from_raw` that frees the context.

## What changes are included in this PR?

**Tie the release to a guard rather than an explicit call.** `create_memory_pool` now returns a `TaskSharedPoolRef` alongside the pool, stored on the `ExecutionContext`. Dropping the context releases the reference, so both paths above are covered by construction: `createPlan` unwinding drops the guard, and `releasePlan` dropping the box drops the guard.

The guard is declared as the last field on `ExecutionContext` so it drops *after* `session_ctx` and the `root_op`/`stream` that hold reservations. If it dropped first, the pool would leave the map while still in use and the next plan in the same task attempt would build a second full-budget pool, letting the task exceed its per-task limit. The field comment says so.

**`releasePlan` reclaims the `Box` up front and flushes metrics last**, so the context is freed even when the metrics update fails.

**`CometExecIterator.close` sets `closed` first and releases the native plan unconditionally.** This is position 8 in the epic, and it has to land with this change rather than separately: now that the `Box` is always freed, a second `releasePlan` on the same pointer is a use-after-free rather than a leak, and `close()` previously set `closed = true` only after `releasePlan` and `traceMemoryUsage()`.

Setting `closed` first alone would have traded that double-release for a guaranteed leak — a throw from `currentBatch.close()`, `nativeUtil.close()` or a shuffle block iterator would skip `releasePlan` entirely with no retry, stranding the very context this PR frees. So the release now runs even when teardown fails, with the teardown exception propagated and any release failure attached as a suppressed exception.

**Deletions that fall out of the above:**

- `MemoryPoolType::is_task_shared` and the `debug_assert` that was its only remaining caller. Task-sharedness is now encoded solely by which `create_memory_pool` arms return a guard, so the predicate had become a second source of truth reconciled only by an assertion that compiles out in release builds. `config.rs` is now a net deletion.
- `ExecutionContext::task_attempt_id` and `memory_pool_config` — both existed only to feed the old explicit release call.

**Smaller items:** the duplicated task-shared arms of `create_memory_pool` collapse behind an `acquire_task_shared_pool` helper (which is also what makes the refcounting unit testable, since it takes the pool factory as a closure); `TASK_SHARED_MEMORY_POOLS` moves to `parking_lot::Mutex`, matching `fair_pool.rs` in the same module and the sibling `THREAD_MEMORY_POOLS` registry, which removes the need for poison handling entirely; the refcount uses `saturating_sub`; and the release path uses the `Entry` API so it hashes the key once.

## How are these changes tested?

Five new unit tests in `task_shared.rs` covering the refcount lifecycle: plans in the same task share one pool, plans in different tasks do not, the pool survives until the last plan releases it, dropping the guard alone releases the pool (the `createPlan`-unwind case), and releasing an already-removed entry does not panic.

Full native crate suite passes (140 passed, 4 ignored). `cargo clippy --all-targets -- -D warnings` clean, as are `spotless:check` and `scalastyle:check`.

JVM suites exercising plan create/release against the default on-heap `greedy_task_shared` pool:

- `CometAggregateSuite` — 88 succeeded, 0 failed
- `CometNativeShuffleSuite` — 27 succeeded, 0 failed

**What is not directly tested:** the leak paths themselves. Both require injecting a failure into `createPlan` or `update_metrics`, which there is no hook for, so the unit test for the unwind case exercises the guard in isolation rather than through `createPlan`. Likewise the new `close()` behaviour is not covered by a test that makes `nativeUtil.close()` throw. The guard makes the release unconditional at the type level, which is the property I would want a test to establish, but it is verified by construction and inspection rather than by a test that reproduces the leak.

I also have not measured the leak's magnitude on a real workload — it requires plan-creation or metrics failures, which are not the normal path. The severity comes from entries never being reclaimed once stranded, not from a high rate of stranding.

## Are there any user-facing changes?

No API or configuration changes. Long-running executors that hit `createPlan` or metrics failures will no longer accumulate memory pool entries and pinned JVM task objects.

## Deliberately left for follow-up

**`THREAD_MEMORY_POOLS` has the same leak and is not converted here.** `register_memory_pool` (`jni_api.rs:494`) registers a `(thread_id, context_id)` entry holding an `Arc<dyn MemoryPool>`, and the `jni_new_global_ref!` for `task_context` a few lines later can still fail before the `ExecutionContext` exists — stranding an entry in a map nothing prunes, exactly as described above. It only affects runs with tracing enabled, and converting it is a second guard rather than a change to this one, so I have kept it out to keep this diff reviewable and will add it to #5212 as its own item. Flagging it explicitly rather than leaving the inconsistency silent: after this PR, one of the two per-plan global registries is RAII-managed and the other is not.

**Sibling close paths now differ in discipline.** `ArrowReaderIterator` and `NativeBatchDecoderIterator` set their closed flag last, and `NativeBase` uses `compareAndSet`. Only `CometExecIterator` owns a native context whose double-free matters, so I have not touched the others, but converging on one idiom would be worthwhile.
