### PR TITLE
fix: codegen dispatcher null short-circuit swallowed ANSI errors, plus two latent TIME-type gaps

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -400,6 +400,7 @@ jobs:
               org.apache.comet.CometCodegenHOFSuite
               org.apache.comet.CometFuzzMathSuite
               org.apache.comet.CometCodegenFuzzSuite
+              org.apache.comet.codegen.CometSpecializedGettersDispatchSuite
               org.apache.comet.CometStringDecodeSuite
               org.apache.comet.CometWidthBucketSuite
               org.apache.comet.CometUuidExpressionSuite

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -216,6 +216,7 @@ jobs:
               org.apache.comet.CometCodegenHOFSuite
               org.apache.comet.CometFuzzMathSuite
               org.apache.comet.CometCodegenFuzzSuite
+              org.apache.comet.codegen.CometSpecializedGettersDispatchSuite
               org.apache.comet.CometStringDecodeSuite
               org.apache.comet.CometWidthBucketSuite
               org.apache.comet.CometUuidExpressionSuite

--- a/spark/src/main/scala/org/apache/comet/codegen/CometBatchKernelCodegen.scala
+++ b/spark/src/main/scala/org/apache/comet/codegen/CometBatchKernelCodegen.scala
@@ -337,9 +337,10 @@ object CometBatchKernelCodegen extends Logging with CometExprTraitShim with Come
   }
 
   /**
-   * Per-row body. For `NullIntolerant` expressions over a single input ordinal, prepends a
-   * short-circuit on that ordinal so the whole `ev.code` cost is skipped on null rows. Otherwise
-   * the standard shape: run `ev.code`, then `setNull` or write based on `ev.isNull`.
+   * Per-row body. For `NullIntolerant` expressions whose input nulls fully determine a null
+   * output (see [[canShortCircuitNulls]]), prepends a short-circuit on those ordinals so the
+   * whole `ev.code` cost is skipped on null rows. Otherwise the standard shape: run `ev.code`,
+   * then `setNull` or write based on `ev.isNull`.
    *
    * `subExprsCode` is the CSE helper-invocation block. It must run before `ev.code`. Inside the
    * short-circuit it lives in the else branch so null rows skip CSE too.
@@ -356,9 +357,13 @@ object CometBatchKernelCodegen extends Logging with CometExprTraitShim with Come
       // exposes `isNullAt(int)` rather than the raw Arrow `isNull(int)`. Pick the right method
       // for the ordinal so the short-circuit compiles for timestamp / int / float columns too,
       // not just VarChar / Decimal vectors that stay as raw Arrow types.
-      val ord = inputOrdinals.head
-      val nullCheck =
-        s"this.col$ord.${CometBatchKernelCodegenInput.nullCheckMethod(inputSchema(ord))}(i)"
+      //
+      // Multi-ordinal trees test the disjunction of their ordinals. That is only reachable for
+      // leaf-only-children roots, where it is exact; see [[canShortCircuitNulls]].
+      val nullCheck = inputOrdinals
+        .map(ord =>
+          s"this.col$ord.${CometBatchKernelCodegenInput.nullCheckMethod(inputSchema(ord))}(i)")
+        .mkString(" || ")
       // `NullIntolerant` only constrains "any input null -> output null"; it does NOT promise
       // that non-null inputs always produce non-null output. `MakeTimestamp(failOnError=false)`
       // is `NullIntolerant=true` but its `doGenCode` catches `DateTimeException` for invalid
@@ -414,24 +419,57 @@ object CometBatchKernelCodegen extends Logging with CometExprTraitShim with Come
   }
 
   /**
-   * Gates the [[defaultBody]] null short-circuit. Three conditions, all necessary:
+   * Gates the [[defaultBody]] null short-circuit ("any input null implies null output", tested as
+   * the disjunction of the tree's input ordinals before `ev.code` runs).
    *
-   *   - The tree reads exactly one input ordinal. Spark's null handling is per-node and
-   *     left-to-right (`BinaryExpression.nullSafeCodeGen` emits the left child's code
-   *     unconditionally, then tests the left child's null, then the right child's), so a
-   *     short-circuit on the union of several ordinals is not equivalent: it skips a subtree that
-   *     Spark would have evaluated, and with it any error that subtree raises. Under ANSI,
-   *     `add_months(cast(s as date), i)` on `('notadate', NULL)` raises `CAST_INVALID_INPUT` in
-   *     Spark, so returning null here would be wrong. With a single ordinal there is nothing left
-   *     for Spark to evaluate ahead of that ordinal's own null check, so the short-circuit is
-   *     exact. (A literal-only subtree that raises would be the one exception, but Catalyst's
-   *     `ConstantFolding` evaluates those at analysis time and never leaves one in the tree.)
+   * The short-circuit is only equivalent to Spark when no subtree that Spark would have evaluated
+   * ahead of a null check gets skipped. Spark's null handling is per-node and left-to-right:
+   * `BinaryExpression.nullSafeCodeGen` emits the left child's code unconditionally, then tests
+   * the left child's null, then the right child's. So for `add_months(cast(s as date), i)` on
+   * `('notadate', NULL)` Spark evaluates the cast and, under ANSI, raises `CAST_INVALID_INPUT`; a
+   * short-circuit on the union of ordinals would skip the cast and return null, swallowing the
+   * error (#5218).
+   *
+   * Conditions, all necessary:
+   *
+   *   - The tree reads at least one input ordinal. A literal-only tree has nothing to test.
+   *     (Catalyst's `ConstantFolding` evaluates those at analysis time, so this is defensive.)
    *   - The root is `NullIntolerant`, so a null input really does mean a null result.
    *   - Every node in the tree is null-propagating ([[allNullIntolerant]]); a `Coalesce` / `If` /
    *     `CaseWhen` anywhere would break the chain.
+   *   - Either the tree reads exactly one ordinal, or every direct child of the root is a leaf
+   *     ([[rootChildrenAreLeaves]]). Both shapes make the short-circuit exact:
+   *     - One ordinal: there is nothing left for Spark to evaluate ahead of that ordinal's own
+   *       null check.
+   *     - Leaf-only children: the tree is one level deep, so the only code Spark runs ahead of
+   *       its null checks is `BoundReference` / `Literal` reads, which cannot raise. Any error
+   *       comes from the root's own logic, which runs only once every input is known non-null --
+   *       in both Spark's shape and ours. This keeps the fast path for the common no-cast
+   *       multi-argument case (`pmod(a, b)`, `conv(a, b, c)`, `make_timestamp(y, m, d, h, mi,
+   *       s)`) across the ~70 expressions that route through this dispatcher.
+   *
+   * The leaf-only rule relies on a `NullIntolerant` root not raising before it has checked every
+   * input for null. Spark's own generated code honors that even where it reorders children: the
+   * divide/remainder family (`DivModLike.doGenCode`, and `Pmod.doGenCode`, which carries its own
+   * copy of the same shape) evaluates the divisor first, but still tests the dividend's null
+   * *before* its divide/remainder-by-zero throw, so `pmod(NULL, 0)` returns null rather than
+   * raising. A root that raised ahead of its null checks would contradict `NullIntolerant`.
    */
   private def canShortCircuitNulls(expr: Expression, inputOrdinals: Seq[Int]): Boolean =
-    inputOrdinals.size == 1 && isNullIntolerant(expr) && allNullIntolerant(expr)
+    inputOrdinals.nonEmpty && isNullIntolerant(expr) && allNullIntolerant(expr) &&
+      (inputOrdinals.size == 1 || rootChildrenAreLeaves(expr))
+
+  /**
+   * True iff every direct child of the root is a leaf (`BoundReference` or `Literal`), i.e. the
+   * tree is one level deep with no subtree between the root and its inputs. One of the conditions
+   * on [[canShortCircuitNulls]]: it is what makes a multi-ordinal short-circuit exact, because a
+   * leaf read cannot raise an error that Spark's left-to-right evaluation would have surfaced.
+   */
+  private def rootChildrenAreLeaves(expr: Expression): Boolean =
+    expr.children.forall {
+      case _: BoundReference | _: Literal => true
+      case _ => false
+    }
 
   /**
    * True iff every node in the tree propagates nulls (`NullIntolerant`, `BoundReference`, or

--- a/spark/src/main/scala/org/apache/comet/codegen/CometBatchKernelCodegen.scala
+++ b/spark/src/main/scala/org/apache/comet/codegen/CometBatchKernelCodegen.scala
@@ -337,10 +337,9 @@ object CometBatchKernelCodegen extends Logging with CometExprTraitShim with Come
   }
 
   /**
-   * Per-row body. For `NullIntolerant` expressions where the entire tree propagates nulls,
-   * prepends a short-circuit on the union of input ordinals so the whole `ev.code` cost is
-   * skipped on null rows. Otherwise the standard shape: run `ev.code`, then `setNull` or write
-   * based on `ev.isNull`.
+   * Per-row body. For `NullIntolerant` expressions over a single input ordinal, prepends a
+   * short-circuit on that ordinal so the whole `ev.code` cost is skipped on null rows. Otherwise
+   * the standard shape: run `ev.code`, then `setNull` or write based on `ev.isNull`.
    *
    * `subExprsCode` is the CSE helper-invocation block. It must run before `ev.code`. Inside the
    * short-circuit it lives in the else branch so null rows skip CSE too.
@@ -351,82 +350,94 @@ object CometBatchKernelCodegen extends Logging with CometExprTraitShim with Come
       ev: ExprCode,
       writeSnippet: String,
       subExprsCode: String): String = {
-    boundExpr match {
-      case _ if isNullIntolerant(boundExpr) && allNullIntolerant(boundExpr) =>
-        // Every node from root to leaf is `NullIntolerant` or a leaf, so "any BoundReference null
-        // -> whole expression null". A non-null-propagating node like `coalesce` or `if` would
-        // make this incorrect (`coalesce(null, x)` is `x`); `allNullIntolerant` rejects those.
-        val inputOrdinals =
-          boundExpr.collect { case b: BoundReference => b.ordinal }.distinct
-        // Primitive Arrow vectors are wrapped in `CometPlainVector` at input-cast time, which
-        // exposes `isNullAt(int)` rather than the raw Arrow `isNull(int)`. Pick the right method
-        // per ordinal so the short-circuit compiles for timestamp / int / float columns too,
-        // not just VarChar / Decimal vectors that stay as raw Arrow types.
-        def nullCheckCall(ord: Int): String = {
-          val method = CometBatchKernelCodegenInput.nullCheckMethod(inputSchema(ord))
-          s"this.col$ord.$method(i)"
-        }
-        val nullCheck =
-          if (inputOrdinals.isEmpty) "false"
-          else inputOrdinals.map(nullCheckCall).mkString(" || ")
-        // `NullIntolerant` only constrains "any input null -> output null"; it does NOT promise
-        // that non-null inputs always produce non-null output. `MakeTimestamp(failOnError=false)`
-        // is `NullIntolerant=true` but its `doGenCode` catches `DateTimeException` for invalid
-        // year/month/day/hour/min/sec components and sets `ev.isNull = true`. Honor `ev.isNull`
-        // post-eval whenever the expression is nullable; skip the guard only when the root is
-        // statically non-nullable (`ev.isNull` is then a literal `false`).
-        if (boundExpr.nullable) {
-          s"""
-             |if ($nullCheck) {
-             |  output.setNull(i);
-             |} else {
-             |  $subExprsCode
-             |  ${ev.code}
-             |  if (${ev.isNull}) {
-             |    output.setNull(i);
-             |  } else {
-             |    $writeSnippet
-             |  }
-             |}
+    val inputOrdinals = boundExpr.collect { case b: BoundReference => b.ordinal }.distinct
+    if (canShortCircuitNulls(boundExpr, inputOrdinals)) {
+      // Primitive Arrow vectors are wrapped in `CometPlainVector` at input-cast time, which
+      // exposes `isNullAt(int)` rather than the raw Arrow `isNull(int)`. Pick the right method
+      // for the ordinal so the short-circuit compiles for timestamp / int / float columns too,
+      // not just VarChar / Decimal vectors that stay as raw Arrow types.
+      val ord = inputOrdinals.head
+      val nullCheck =
+        s"this.col$ord.${CometBatchKernelCodegenInput.nullCheckMethod(inputSchema(ord))}(i)"
+      // `NullIntolerant` only constrains "any input null -> output null"; it does NOT promise
+      // that non-null inputs always produce non-null output. `MakeTimestamp(failOnError=false)`
+      // is `NullIntolerant=true` but its `doGenCode` catches `DateTimeException` for invalid
+      // year/month/day/hour/min/sec components and sets `ev.isNull = true`. Honor `ev.isNull`
+      // post-eval whenever the expression is nullable; skip the guard only when the root is
+      // statically non-nullable (`ev.isNull` is then a literal `false`).
+      if (boundExpr.nullable) {
+        s"""
+           |if ($nullCheck) {
+           |  output.setNull(i);
+           |} else {
+           |  $subExprsCode
+           |  ${ev.code}
+           |  if (${ev.isNull}) {
+           |    output.setNull(i);
+           |  } else {
+           |    $writeSnippet
+           |  }
+           |}
            """.stripMargin
-        } else {
-          s"""
-             |if ($nullCheck) {
-             |  output.setNull(i);
-             |} else {
-             |  $subExprsCode
-             |  ${ev.code}
-             |  $writeSnippet
-             |}
+      } else {
+        s"""
+           |if ($nullCheck) {
+           |  output.setNull(i);
+           |} else {
+           |  $subExprsCode
+           |  ${ev.code}
+           |  $writeSnippet
+           |}
            """.stripMargin
-        }
-      case _ =>
-        // NonNullableOutputShortCircuit: when `nullable = false`, drop the `if (ev.isNull)`
-        // guard at source level rather than relying on JIT folding.
-        if (!boundExpr.nullable) {
-          s"""
-             |$subExprsCode
-             |${ev.code}
-             |$writeSnippet
+      }
+    } else {
+      // NonNullableOutputShortCircuit: when `nullable = false`, drop the `if (ev.isNull)`
+      // guard at source level rather than relying on JIT folding.
+      if (!boundExpr.nullable) {
+        s"""
+           |$subExprsCode
+           |${ev.code}
+           |$writeSnippet
            """.stripMargin
-        } else {
-          s"""
-             |$subExprsCode
-             |${ev.code}
-             |if (${ev.isNull}) {
-             |  output.setNull(i);
-             |} else {
-             |  $writeSnippet
-             |}
+      } else {
+        s"""
+           |$subExprsCode
+           |${ev.code}
+           |if (${ev.isNull}) {
+           |  output.setNull(i);
+           |} else {
+           |  $writeSnippet
+           |}
            """.stripMargin
-        }
+      }
     }
   }
 
   /**
+   * Gates the [[defaultBody]] null short-circuit. Three conditions, all necessary:
+   *
+   *   - The tree reads exactly one input ordinal. Spark's null handling is per-node and
+   *     left-to-right (`BinaryExpression.nullSafeCodeGen` emits the left child's code
+   *     unconditionally, then tests the left child's null, then the right child's), so a
+   *     short-circuit on the union of several ordinals is not equivalent: it skips a subtree that
+   *     Spark would have evaluated, and with it any error that subtree raises. Under ANSI,
+   *     `add_months(cast(s as date), i)` on `('notadate', NULL)` raises `CAST_INVALID_INPUT` in
+   *     Spark, so returning null here would be wrong. With a single ordinal there is nothing left
+   *     for Spark to evaluate ahead of that ordinal's own null check, so the short-circuit is
+   *     exact. (A literal-only subtree that raises would be the one exception, but Catalyst's
+   *     `ConstantFolding` evaluates those at analysis time and never leaves one in the tree.)
+   *   - The root is `NullIntolerant`, so a null input really does mean a null result.
+   *   - Every node in the tree is null-propagating ([[allNullIntolerant]]); a `Coalesce` / `If` /
+   *     `CaseWhen` anywhere would break the chain.
+   */
+  private def canShortCircuitNulls(expr: Expression, inputOrdinals: Seq[Int]): Boolean =
+    inputOrdinals.size == 1 && isNullIntolerant(expr) && allNullIntolerant(expr)
+
+  /**
    * True iff every node in the tree propagates nulls (`NullIntolerant`, `BoundReference`, or
-   * `Literal`). Gates the [[defaultBody]] short-circuit, which is only correct when no node
-   * (`Coalesce`, `If`, `CaseWhen`, `Concat`, ...) breaks the propagation chain.
+   * `Literal`). One of the conditions on [[canShortCircuitNulls]]: the short-circuit is only
+   * correct when no node (`Coalesce`, `If`, `CaseWhen`, `Concat`, ...) breaks the propagation
+   * chain.
    */
   private def allNullIntolerant(expr: Expression): Boolean =
     !expr.exists {

--- a/spark/src/main/scala/org/apache/comet/codegen/CometSpecializedGettersDispatch.scala
+++ b/spark/src/main/scala/org/apache/comet/codegen/CometSpecializedGettersDispatch.scala
@@ -22,17 +22,23 @@ package org.apache.comet.codegen
 import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
 import org.apache.spark.sql.types._
 
+import org.apache.comet.shims.CometTypeShim
+
 /**
  * Shared `SpecializedGetters.get(ordinal, dataType)` dispatch used by [[CometInternalRow]] and
  * [[CometArrayData]]. Spark codegen paths (notably `SafeProjection` for ScalaUDF struct args) and
  * interpreted-eval fallbacks (`ArrayDistinct.nullSafeEval` etc.) call the generic `get` instead
  * of the typed getter, so both kernel-side bases need a non-throwing implementation.
  *
+ * The type surface here must stay in step with `CometBatchKernelCodegen.isSupportedDataType`,
+ * which is what gates the expression at plan time. A type accepted there but missing here throws
+ * at execute time, after the plan has already committed to the kernel.
+ *
  * For complex types, the typed getter allocates a fresh `InputStruct_*` / `InputArray_*` /
  * `InputMap_*` per call (`ColumnarRow`-style), so retain-by-reference consumers like
  * `OpenHashSet` get distinct identities.
  */
-private[codegen] object CometSpecializedGettersDispatch {
+private[codegen] object CometSpecializedGettersDispatch extends CometTypeShim {
 
   def get(g: SpecializedGetters, ordinal: Int, dataType: DataType): AnyRef = {
     if (g.isNullAt(ordinal)) return null
@@ -45,6 +51,10 @@ private[codegen] object CometSpecializedGettersDispatch {
       case LongType | TimestampType | TimestampNTZType | _: DayTimeIntervalType =>
         java.lang.Long.valueOf(g.getLong(ordinal))
       case CalendarIntervalType => g.getInterval(ordinal)
+      // Spark 4.1's `TimeType` is nanos-since-midnight in a long, read through `getLong` just
+      // like the other long-backed temporal types. Matches `elementGetterCall` and
+      // `emitSpecializedGetterExpr`, which both route time types to `getLong`.
+      case dt if isTimeType(dt) => java.lang.Long.valueOf(g.getLong(ordinal))
       case FloatType => java.lang.Float.valueOf(g.getFloat(ordinal))
       case DoubleType => java.lang.Double.valueOf(g.getDouble(ordinal))
       case _: StringType => g.getUTF8String(ordinal)

--- a/spark/src/main/scala/org/apache/comet/udf/codegen/CometScalaUDFCodegen.scala
+++ b/spark/src/main/scala/org/apache/comet/udf/codegen/CometScalaUDFCodegen.scala
@@ -185,6 +185,11 @@ class CometScalaUDFCodegen extends CometUDF with Logging {
   /**
    * Build the compile-time spec for one input Arrow vector. Recurses on complex types.
    *
+   * The vector classes matched here must cover every Spark type
+   * `CometBatchKernelCodegen.isSupportedDataType` admits, because that predicate is what
+   * `canHandle` gates the plan on. A type accepted at plan time but unmatched here throws at
+   * execute time, when the operator can no longer fall back to Spark.
+   *
    * Top-level `nullable=true` is hardcoded: the cache key does not specialize on per-batch null
    * density. Schema-declared nullability still reaches the kernel via `BoundReference.nullable`
    * embedded in `bytesKey`, so `BoundReference.doGenCode` elides its own `isNullAt` probe on
@@ -219,8 +224,9 @@ class CometScalaUDFCodegen extends CometUDF with Logging {
       StructColumnSpec(nullable = true, fieldSpecs)
     case _: BitVector | _: TinyIntVector | _: SmallIntVector | _: IntVector | _: BigIntVector |
         _: Float4Vector | _: Float8Vector | _: DecimalVector | _: VarCharVector |
-        _: VarBinaryVector | _: DateDayVector | _: DurationVector | _: TimeStampMicroVector |
-        _: TimeStampMicroTZVector | _: IntervalYearVector | _: IntervalMonthDayNanoVector =>
+        _: VarBinaryVector | _: DateDayVector | _: DurationVector | _: TimeNanoVector |
+        _: TimeStampMicroVector | _: TimeStampMicroTZVector | _: IntervalYearVector |
+        _: IntervalMonthDayNanoVector =>
       ScalarColumnSpec(v.getClass.asInstanceOf[Class[_ <: ValueVector]], nullable = true)
     case other =>
       throw new UnsupportedOperationException(

--- a/spark/src/test/scala/org/apache/comet/CometCodegenSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCodegenSourceSuite.scala
@@ -41,8 +41,9 @@ import org.apache.comet.udf.codegen.CometScalaUDFCodegen
  * assert on the emitted Java directly, without invoking Janino. The goal is to catch regressions
  * in the optimizations we claim the dispatcher applies:
  *
- *   - `NullIntolerant` short-circuit wraps `ev.code` in `if (any-input-null) { setNull } else {
- *     ev.code; write }`.
+ *   - `NullIntolerant` short-circuit over a single input ordinal wraps `ev.code` in `if
+ *     (input-null) { setNull } else { ev.code; write }`, and is *not* emitted for trees that read
+ *     more than one ordinal (see the multi-input test for why).
  *   - Non-nullable column declaration emits `return false;` from `isNullAt(ord)`, and a
  *     `BoundReference.nullable=false` (Catalyst sets this from schema-declared nullability) makes
  *     Spark's `doGenCode` skip emitting its own `row.isNullAt(ord)` probe entirely.
@@ -164,6 +165,32 @@ class CometCodegenSourceSuite extends AnyFunSuite {
       !src.contains("this.col0.isNull(i) || this.col1.isNull(i)"),
       "expected no pre-null short-circuit when Concat breaks the NullIntolerant chain; " +
         s"got:\n$src")
+  }
+
+  test("NullIntolerant short-circuit skipped for a multi-input tree (#5218)") {
+    // Even when every node is NullIntolerant, a short-circuit on the *union* of input ordinals is
+    // not equivalent to Spark. Spark's null handling is per-node and left-to-right:
+    // `BinaryExpression.nullSafeCodeGen` emits the left child's code unconditionally, then tests
+    // the left child's null, then the right child's. So for `Add(cast(c0 AS INT), c1)` on a row
+    // where c0 = 'abc' and c1 IS NULL, Spark evaluates the cast first and (under ANSI) raises
+    // CAST_INVALID_INPUT. A union short-circuit would skip the cast and return null, swallowing
+    // the error. See CometCodegenSuite's add_months test for the end-to-end witness.
+    //
+    // `Add` over two BoundReferences is the minimal shape: NullIntolerant root, NullIntolerant
+    // (leaf-only) children, two distinct ordinals.
+    val intCol = ArrowColumnSpec(
+      CometBatchKernelCodegen.vectorClassBySimpleName("IntVector"),
+      nullable = true)
+    val expr = Add(
+      BoundReference(0, IntegerType, nullable = true),
+      BoundReference(1, IntegerType, nullable = true))
+    val src = gen(expr, intCol, intCol)
+    assert(
+      !src.contains("this.col0.isNullAt(i) || this.col1.isNullAt(i)"),
+      s"expected no union-of-inputs short-circuit for a two-input tree; got:\n$src")
+    assert(
+      !src.contains("if (this.col0.isNullAt(i))") && !src.contains("if (this.col1.isNullAt(i))"),
+      s"expected no pre-eval input-null short-circuit at all for a two-input tree; got:\n$src")
   }
 
   test("canHandle accepts CodegenFallback expressions (delegates to eval(row))") {
@@ -396,14 +423,14 @@ class CometCodegenSourceSuite extends AnyFunSuite {
         CodeFormatter.format(result.code))
   }
 
-  test("nullable NullIntolerant root keeps post-eval isNull guard inside short-circuit (#4554)") {
+  test("nullable NullIntolerant root keeps post-eval isNull guard (#4554)") {
     // `NullIntolerant` only constrains "null in -> null out". An expression can still set
     // `ev.isNull = true` from non-null inputs — `MakeTimestamp(failOnError = false)` does this in
     // its `doGenCode` catch block when year/month/day/hour/min/sec components are out of range
     // (issue #4554). The dispatcher previously assumed NullIntolerant + non-null inputs implied a
     // non-null output and dropped the post-eval guard; that wrote stale `ev.value` bytes for
-    // every invalid row. The short-circuit on input nulls must coexist with a post-eval
-    // `if (ev.isNull) setNull` check whenever the expression itself is nullable.
+    // every invalid row. A nullable root must always keep a post-eval `if (ev.isNull) setNull`
+    // check, whether or not the input-null short-circuit also applies.
     val expr = MakeTimestamp(
       BoundReference(0, IntegerType, nullable = true),
       BoundReference(1, IntegerType, nullable = true),
@@ -426,14 +453,47 @@ class CometCodegenSourceSuite extends AnyFunSuite {
       IndexedSeq(intCol, intCol, intCol, intCol, intCol, decCol))
     val src = result.body
     val formatted = CodeFormatter.format(result.code)
-    // Two distinct setNull sites must exist: the input-null short-circuit before `ev.code` runs,
-    // and the post-eval guard that propagates `ev.isNull = true` set by MakeTimestamp's catch
-    // block on invalid components. Pre-fix there was only one (the input short-circuit).
+    // This tree reads six ordinals, so there is no input-null short-circuit (#5218). Exactly one
+    // setNull site must remain: the post-eval guard that propagates the `ev.isNull = true` set by
+    // MakeTimestamp's catch block on invalid components. Pre-#4554 there were none.
+    val setNullOccurrences = "output\\.setNull\\(i\\);".r.findAllIn(src).length
+    assert(
+      setNullOccurrences == 1,
+      "expected exactly one setNull site (the post-eval ev.isNull guard, with no multi-input " +
+        s"short-circuit); found $setNullOccurrences. Source:\n$formatted")
+    assert(
+      !src.contains("if (this.col0.isNullAt(i))"),
+      s"expected no input-null short-circuit for a six-input tree; source:\n$formatted")
+  }
+
+  test("single-input nullable NullIntolerant root emits both short-circuit and post-eval guard") {
+    // Counterpart to the test above, for the shape that does keep the short-circuit: one input
+    // ordinal. Two distinct setNull sites must exist -- the input-null short-circuit before
+    // `ev.code` runs, and the post-eval `ev.isNull` guard.
+    val expr = MakeTimestamp(
+      BoundReference(0, IntegerType, nullable = true),
+      Literal(1),
+      Literal(1),
+      Literal(0),
+      Literal(0),
+      Literal(Decimal(0, 8, 6), DecimalType(8, 6)),
+      timezone = None,
+      timeZoneId = Some("UTC"),
+      failOnError = false)
+    assert(expr.nullable, "MakeTimestamp(failOnError=false) must be nullable for this test")
+    val intCol = ArrowColumnSpec(
+      CometBatchKernelCodegen.vectorClassBySimpleName("IntVector"),
+      nullable = true)
+    val result = CometBatchKernelCodegen.generateSource(expr, IndexedSeq(intCol))
+    val src = result.body
+    assert(
+      src.contains("if (this.col0.isNullAt(i))"),
+      s"expected input-null short-circuit for the single-input tree; got:\n$src")
     val setNullOccurrences = "output\\.setNull\\(i\\);".r.findAllIn(src).length
     assert(
       setNullOccurrences >= 2,
-      "expected at least two setNull sites (input short-circuit + post-eval ev.isNull guard); " +
-        s"found $setNullOccurrences. Source:\n$formatted")
+      "expected two setNull sites (input short-circuit + post-eval ev.isNull guard); " +
+        s"found $setNullOccurrences. Source:\n${CodeFormatter.format(result.code)}")
   }
 
   test("ArrayType(StringType) output emits ListVector startNewValue/endValue recursion") {

--- a/spark/src/test/scala/org/apache/comet/CometCodegenSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCodegenSourceSuite.scala
@@ -24,7 +24,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.apache.spark.SparkConf
 import org.apache.spark.serializer.JavaSerializer
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Add, AddMonths, BoundReference, Coalesce, Concat, CreateArray, CreateMap, DateFormatClass, ElementAt, Expression, GetStructField, LeafExpression, Length, Literal, MakeTimestamp, MicrosToTimestamp, MillisToTimestamp, MonthsBetween, Nondeterministic, Rand, Size, ToUnixTimestamp, Unevaluable, UnixMicros, UnixMillis, UnixSeconds, Upper}
+import org.apache.spark.sql.catalyst.expressions.{Add, AddMonths, BoundReference, Cast, Coalesce, Concat, CreateArray, CreateMap, DateFormatClass, ElementAt, Expression, GetStructField, LeafExpression, Length, Literal, MakeTimestamp, MicrosToTimestamp, MillisToTimestamp, MonthsBetween, Nondeterministic, Rand, Size, ToUnixTimestamp, Unevaluable, UnixMicros, UnixMillis, UnixSeconds, Upper}
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodeFormatter, CodegenContext, CodegenFallback, ExprCode}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
@@ -41,9 +41,10 @@ import org.apache.comet.udf.codegen.CometScalaUDFCodegen
  * assert on the emitted Java directly, without invoking Janino. The goal is to catch regressions
  * in the optimizations we claim the dispatcher applies:
  *
- *   - `NullIntolerant` short-circuit over a single input ordinal wraps `ev.code` in `if
- *     (input-null) { setNull } else { ev.code; write }`, and is *not* emitted for trees that read
- *     more than one ordinal (see the multi-input test for why).
+ *   - `NullIntolerant` short-circuit wraps `ev.code` in `if (input-null) { setNull } else {
+ *     ev.code; write }`. It is emitted for a tree reading a single ordinal, and for a
+ *     multi-ordinal tree whose root has only leaf children; it is *not* emitted once a subtree
+ *     sits between the root and a leaf (see the multi-input tests for why).
  *   - Non-nullable column declaration emits `return false;` from `isNullAt(ord)`, and a
  *     `BoundReference.nullable=false` (Catalyst sets this from schema-declared nullability) makes
  *     Spark's `doGenCode` skip emitting its own `row.isNullAt(ord)` probe entirely.
@@ -167,17 +168,41 @@ class CometCodegenSourceSuite extends AnyFunSuite {
         s"got:\n$src")
   }
 
-  test("NullIntolerant short-circuit skipped for a multi-input tree (#5218)") {
+  test("NullIntolerant short-circuit skipped when a subtree sits between root and leaf (#5218)") {
     // Even when every node is NullIntolerant, a short-circuit on the *union* of input ordinals is
-    // not equivalent to Spark. Spark's null handling is per-node and left-to-right:
-    // `BinaryExpression.nullSafeCodeGen` emits the left child's code unconditionally, then tests
-    // the left child's null, then the right child's. So for `Add(cast(c0 AS INT), c1)` on a row
-    // where c0 = 'abc' and c1 IS NULL, Spark evaluates the cast first and (under ANSI) raises
-    // CAST_INVALID_INPUT. A union short-circuit would skip the cast and return null, swallowing
-    // the error. See CometCodegenSuite's add_months test for the end-to-end witness.
+    // not equivalent to Spark once a real subtree sits between the root and a leaf. Spark's null
+    // handling is per-node and left-to-right: `BinaryExpression.nullSafeCodeGen` emits the left
+    // child's code unconditionally, then tests the left child's null, then the right child's. So
+    // for `Add(cast(c0 AS INT), c1)` on a row where c0 = 'abc' and c1 IS NULL, Spark evaluates the
+    // cast first and (under ANSI) raises CAST_INVALID_INPUT. A union short-circuit would skip the
+    // cast and return null, swallowing the error. See CometCodegenSuite's add_months test for the
+    // end-to-end witness.
     //
-    // `Add` over two BoundReferences is the minimal shape: NullIntolerant root, NullIntolerant
-    // (leaf-only) children, two distinct ordinals.
+    // The `Cast` is what disqualifies the short-circuit here: it is a non-leaf child of the root
+    // that can raise on its own. The sibling test below covers the leaf-only-children shape, which
+    // keeps the short-circuit.
+    val strCol = ArrowColumnSpec(varCharVectorClass, nullable = true)
+    val intCol = ArrowColumnSpec(
+      CometBatchKernelCodegen.vectorClassBySimpleName("IntVector"),
+      nullable = true)
+    val expr = Add(
+      Cast(BoundReference(0, StringType, nullable = true), IntegerType, ansiEnabled = true),
+      BoundReference(1, IntegerType, nullable = true))
+    val src = gen(expr, strCol, intCol)
+    assert(
+      !src.contains("this.col0.isNull(i) || this.col1.isNullAt(i)"),
+      s"expected no union-of-inputs short-circuit when a Cast sits under the root; got:\n$src")
+    assert(
+      !src.contains("if (this.col0.isNull(i))") && !src.contains("if (this.col1.isNullAt(i))"),
+      s"expected no pre-eval input-null short-circuit at all for this shape; got:\n$src")
+  }
+
+  test("NullIntolerant short-circuit kept for a multi-input leaf-only tree (#5218)") {
+    // Counterpart to the test above. When every direct child of the root is a `BoundReference` or
+    // `Literal`, the tree is one level deep: the only code Spark runs ahead of its own null checks
+    // is leaf reads, which cannot raise. Any error comes from the root's own logic, which runs only
+    // once every input is known non-null -- in Spark's shape and in ours alike. So the union
+    // short-circuit is exact and worth keeping for the common no-cast multi-argument case.
     val intCol = ArrowColumnSpec(
       CometBatchKernelCodegen.vectorClassBySimpleName("IntVector"),
       nullable = true)
@@ -186,11 +211,8 @@ class CometCodegenSourceSuite extends AnyFunSuite {
       BoundReference(1, IntegerType, nullable = true))
     val src = gen(expr, intCol, intCol)
     assert(
-      !src.contains("this.col0.isNullAt(i) || this.col1.isNullAt(i)"),
-      s"expected no union-of-inputs short-circuit for a two-input tree; got:\n$src")
-    assert(
-      !src.contains("if (this.col0.isNullAt(i))") && !src.contains("if (this.col1.isNullAt(i))"),
-      s"expected no pre-eval input-null short-circuit at all for a two-input tree; got:\n$src")
+      src.contains("if (this.col0.isNullAt(i) || this.col1.isNullAt(i))"),
+      s"expected union-of-inputs short-circuit for a leaf-only two-input tree; got:\n$src")
   }
 
   test("canHandle accepts CodegenFallback expressions (delegates to eval(row))") {
@@ -423,14 +445,17 @@ class CometCodegenSourceSuite extends AnyFunSuite {
         CodeFormatter.format(result.code))
   }
 
-  test("nullable NullIntolerant root keeps post-eval isNull guard (#4554)") {
+  test("nullable NullIntolerant root keeps post-eval isNull guard inside short-circuit (#4554)") {
     // `NullIntolerant` only constrains "null in -> null out". An expression can still set
     // `ev.isNull = true` from non-null inputs — `MakeTimestamp(failOnError = false)` does this in
     // its `doGenCode` catch block when year/month/day/hour/min/sec components are out of range
     // (issue #4554). The dispatcher previously assumed NullIntolerant + non-null inputs implied a
     // non-null output and dropped the post-eval guard; that wrote stale `ev.value` bytes for
-    // every invalid row. A nullable root must always keep a post-eval `if (ev.isNull) setNull`
-    // check, whether or not the input-null short-circuit also applies.
+    // every invalid row. The short-circuit on input nulls must coexist with a post-eval
+    // `if (ev.isNull) setNull` check whenever the expression itself is nullable.
+    //
+    // All six children are `BoundReference`s, so this is a leaf-only tree and keeps the
+    // union-of-ordinals short-circuit (#5218).
     val expr = MakeTimestamp(
       BoundReference(0, IntegerType, nullable = true),
       BoundReference(1, IntegerType, nullable = true),
@@ -453,17 +478,55 @@ class CometCodegenSourceSuite extends AnyFunSuite {
       IndexedSeq(intCol, intCol, intCol, intCol, intCol, decCol))
     val src = result.body
     val formatted = CodeFormatter.format(result.code)
-    // This tree reads six ordinals, so there is no input-null short-circuit (#5218). Exactly one
-    // setNull site must remain: the post-eval guard that propagates the `ev.isNull = true` set by
-    // MakeTimestamp's catch block on invalid components. Pre-#4554 there were none.
+    // Two distinct setNull sites must exist: the input-null short-circuit before `ev.code` runs,
+    // and the post-eval guard that propagates `ev.isNull = true` set by MakeTimestamp's catch
+    // block on invalid components. Pre-#4554 there was only one (the input short-circuit).
+    val setNullOccurrences = "output\\.setNull\\(i\\);".r.findAllIn(src).length
+    assert(
+      setNullOccurrences >= 2,
+      "expected at least two setNull sites (input short-circuit + post-eval ev.isNull guard); " +
+        s"found $setNullOccurrences. Source:\n$formatted")
+    // The short-circuit must test every ordinal the tree reads, not just the first.
+    assert(
+      src.contains(
+        "if (this.col0.isNullAt(i) || this.col1.isNullAt(i) || " +
+          "this.col2.isNullAt(i) || this.col3.isNullAt(i) || this.col4.isNullAt(i) || " +
+          "this.col5.isNull(i))"),
+      s"expected the short-circuit to test all six ordinals; source:\n$formatted")
+  }
+
+  test("multi-input tree with a non-leaf child keeps only the post-eval guard (#5218)") {
+    // The counterpart to the test above: the same nullable-NullIntolerant-root shape, but with a
+    // `Cast` between the root and one leaf. That disqualifies the short-circuit, so exactly one
+    // setNull site remains -- the post-eval `ev.isNull` guard, which is the actual #4554
+    // regression and must survive independently of the short-circuit.
+    val expr = MakeTimestamp(
+      Cast(BoundReference(0, StringType, nullable = true), IntegerType, ansiEnabled = true),
+      BoundReference(1, IntegerType, nullable = true),
+      BoundReference(2, IntegerType, nullable = true),
+      Literal(0),
+      Literal(0),
+      Literal(Decimal(0, 8, 6), DecimalType(8, 6)),
+      timezone = None,
+      timeZoneId = Some("UTC"),
+      failOnError = false)
+    assert(expr.nullable, "MakeTimestamp(failOnError=false) must be nullable for this test")
+    val strCol = ArrowColumnSpec(varCharVectorClass, nullable = true)
+    val intCol = ArrowColumnSpec(
+      CometBatchKernelCodegen.vectorClassBySimpleName("IntVector"),
+      nullable = true)
+    val result =
+      CometBatchKernelCodegen.generateSource(expr, IndexedSeq(strCol, intCol, intCol))
+    val src = result.body
+    val formatted = CodeFormatter.format(result.code)
     val setNullOccurrences = "output\\.setNull\\(i\\);".r.findAllIn(src).length
     assert(
       setNullOccurrences == 1,
-      "expected exactly one setNull site (the post-eval ev.isNull guard, with no multi-input " +
-        s"short-circuit); found $setNullOccurrences. Source:\n$formatted")
+      "expected exactly one setNull site (the post-eval ev.isNull guard, with no short-circuit); " +
+        s"found $setNullOccurrences. Source:\n$formatted")
     assert(
-      !src.contains("if (this.col0.isNullAt(i))"),
-      s"expected no input-null short-circuit for a six-input tree; source:\n$formatted")
+      !src.contains("if (this.col0.isNull(i))"),
+      s"expected no input-null short-circuit when a Cast sits under the root; source:\n$formatted")
   }
 
   test("single-input nullable NullIntolerant root emits both short-circuit and post-eval guard") {

--- a/spark/src/test/scala/org/apache/comet/CometCodegenSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCodegenSuite.scala
@@ -22,7 +22,7 @@ package org.apache.comet
 import scala.util.Random
 
 import org.apache.arrow.vector._
-import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.{SparkConf, SparkEnv, TaskContext}
 import org.apache.spark.sql.CometTestBase
 import org.apache.spark.sql.api.java.UDF1
 import org.apache.spark.sql.catalyst.expressions.{BoundReference, CreateArray, CreateMap, CreateNamedStruct, Expression, Literal, MapConcat}
@@ -1321,6 +1321,86 @@ class CometCodegenSuite
       assertCodegenRan {
         checkSparkAnswerAndOperator(sql("SELECT idDec30(array_max(flatten(a))) FROM t"))
       }
+    }
+  }
+
+  test("multi-input NullIntolerant tree does not swallow an ANSI error (#5218)") {
+    // `add_months` is NullIntolerant and a plain BinaryExpression, so Spark's `nullSafeCodeGen`
+    // emits the LEFT child's code unconditionally before testing the right child's null. On the
+    // ('notadate', NULL) row Spark therefore evaluates the cast and raises CAST_INVALID_INPUT.
+    // The dispatcher used to short-circuit on the union of input ordinals, see the null on `i`,
+    // and return NULL -- silently losing the error. Note `pmod` / `div` are not witnesses here:
+    // `DivModLike` deliberately evaluates its right child first, so Spark also returns NULL.
+    withTable("t") {
+      sql("CREATE TABLE t (s STRING, i INT) USING parquet")
+      sql("INSERT INTO t VALUES ('notadate', NULL), ('2024-01-31', 1)")
+      withSQLConf("spark.sql.ansi.enabled" -> "true") {
+        CometScalaUDFCodegen.resetStats()
+        val (sparkErr, cometErr) =
+          checkSparkAnswerMaybeThrows(sql("SELECT add_months(CAST(s AS DATE), i) FROM t"))
+        val stats = CometScalaUDFCodegen.stats()
+        assert(
+          stats.compileCount + stats.cacheHitCount >= 1,
+          s"expected the codegen dispatcher to run for this query, got $stats")
+        assert(
+          sparkErr.isDefined,
+          "expected Spark to raise on the invalid ANSI cast; the test row is no longer a witness")
+        assert(
+          cometErr.isDefined,
+          "Comet returned a value where Spark raised: the null short-circuit swallowed the error")
+        assert(
+          cometErr.get.getMessage.contains("CAST_INVALID_INPUT"),
+          s"expected the same CAST_INVALID_INPUT error Spark raises, got: ${cometErr.get}")
+      }
+    }
+  }
+
+  test("single-input NullIntolerant tree still short-circuits nulls") {
+    // Guards against over-correcting #5218: the single-ordinal short-circuit is exact (Spark also
+    // evaluates nothing when that one input is null) and must be preserved.
+    withSubjects("abc", null, "xyz") {
+      assertCodegenRan {
+        checkSparkAnswerAndOperator(sql("SELECT upper(substring(s, 1, 2)) FROM t"))
+      }
+    }
+  }
+
+  test("TIME input column routes through the dispatcher (#5218)") {
+    assume(
+      org.apache.comet.CometSparkSessionExtensions.isSpark41Plus,
+      "TimeType requires Spark 4.1+")
+    // `canHandle` accepts TIME (`isSupportedDataType`) and `emitTypedGetters` emits a getLong
+    // case for `TimeNanoVector`, but `CometScalaUDFCodegen.specFor` used to omit the vector class
+    // and throw `UnsupportedOperationException` at execute time -- after the plan had already
+    // committed to the kernel, so there was no fallback. Driven through the dispatcher directly
+    // because Spark 4.1 still rejects TIME columns in file-based data sources, so no SQL query
+    // can produce a TIME input today.
+    val timeVec = new TimeNanoVector("tm", CometArrowAllocator)
+    val exprVec = new VarBinaryVector("expr", CometArrowAllocator)
+    var out: ValueVector = null
+    try {
+      timeVec.allocateNew()
+      timeVec.setSafe(0, 45296000000000L) // 12:34:56
+      timeVec.setNull(1)
+      timeVec.setValueCount(2)
+
+      val timeType = org.apache.spark.sql.comet.util.Utils.fromArrowField(timeVec.getField)
+      val expr = BoundReference(0, timeType, nullable = true)
+      val serialized = SparkEnv.get.closureSerializer.newInstance().serialize(expr)
+      val bytes = new Array[Byte](serialized.remaining())
+      serialized.get(bytes)
+      exprVec.allocateNew()
+      exprVec.setSafe(0, bytes)
+      exprVec.setValueCount(1)
+
+      out = new CometScalaUDFCodegen().evaluate(Array(exprVec, timeVec), 2)
+      val comet = CometVector.getVector(out.asInstanceOf[FieldVector], null)
+      assert(comet.getLong(0) === 45296000000000L)
+      assert(comet.isNullAt(1))
+    } finally {
+      if (out != null) out.close()
+      exprVec.close()
+      timeVec.close()
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/CometCodegenSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCodegenSuite.scala
@@ -1365,6 +1365,59 @@ class CometCodegenSuite
     }
   }
 
+  test("multi-input leaf-only NullIntolerant tree short-circuits nulls correctly (#5218)") {
+    // The leaf-only-children shape keeps the union-of-ordinals short-circuit, because the only
+    // code Spark runs ahead of its own null checks is `BoundReference` reads. Exercises every
+    // null combination across two ordinals to confirm the disjunction matches Spark's per-node
+    // left-to-right null handling row for row. Wrapped in a UDF so the argument expression is
+    // guaranteed to route through the dispatcher rather than Comet's native path.
+    spark.udf.register("idInt", (i: Integer) => i)
+    withTable("t") {
+      sql("CREATE TABLE t (a INT, b INT) USING parquet")
+      sql(
+        "INSERT INTO t VALUES (7, 3), (NULL, 3), (7, NULL), (NULL, NULL), " +
+          "(-7, 3), (7, -3), (0, 3)")
+      assertCodegenRan {
+        checkSparkAnswerAndOperator(sql("SELECT idInt(pmod(a, b)) FROM t"))
+      }
+      assertCodegenRan {
+        checkSparkAnswerAndOperator(sql("SELECT idInt(a + b) FROM t"))
+      }
+    }
+  }
+
+  test("leaf-only short-circuit preserves ANSI remainder-by-zero behaviour (#5218)") {
+    // The one shape where a `NullIntolerant` root's error check is not simply gated behind
+    // "all inputs non-null": `Pmod.doGenCode` evaluates the divisor first and throws
+    // REMAINDER_BY_ZERO under ANSI. It still tests the dividend's null *before* that throw, so
+    // `pmod(NULL, 0)` returns NULL in Spark and the union short-circuit stays exact. The
+    // (NULL, 0) row pins the non-raising case, the (7, 0) row the raising one.
+    spark.udf.register("idInt", (i: Integer) => i)
+    withTable("t") {
+      sql("CREATE TABLE t (a INT, b INT) USING parquet")
+      sql("INSERT INTO t VALUES (NULL, 0)")
+      withSQLConf("spark.sql.ansi.enabled" -> "true") {
+        assertCodegenRan {
+          checkSparkAnswerAndOperator(sql("SELECT idInt(pmod(a, b)) FROM t"))
+        }
+      }
+      sql("INSERT INTO t VALUES (7, 0)")
+      withSQLConf("spark.sql.ansi.enabled" -> "true") {
+        val (sparkErr, cometErr) =
+          checkSparkAnswerMaybeThrows(sql("SELECT idInt(pmod(a, b)) FROM t"))
+        assert(
+          sparkErr.isDefined,
+          "expected Spark to raise on pmod by zero under ANSI; the test row is no longer a witness")
+        assert(
+          cometErr.isDefined,
+          "Comet returned a value where Spark raised: the null short-circuit swallowed the error")
+        assert(
+          cometErr.get.getMessage.contains("REMAINDER_BY_ZERO"),
+          s"expected the same REMAINDER_BY_ZERO error Spark raises, got: ${cometErr.get}")
+      }
+    }
+  }
+
   test("TIME input column routes through the dispatcher (#5218)") {
     assume(
       org.apache.comet.CometSparkSessionExtensions.isSpark41Plus,

--- a/spark/src/test/scala/org/apache/comet/CometCodegenSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCodegenSuite.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
+import org.apache.comet.CometSparkSessionExtensions.isSpark41Plus
 import org.apache.comet.codegen.CometBatchKernelCodegen
 import org.apache.comet.codegen.CometBatchKernelCodegen.ArrowColumnSpec
 import org.apache.comet.udf.codegen.CometScalaUDFCodegen
@@ -1388,10 +1389,15 @@ class CometCodegenSuite
 
   test("leaf-only short-circuit preserves ANSI remainder-by-zero behaviour (#5218)") {
     // The one shape where a `NullIntolerant` root's error check is not simply gated behind
-    // "all inputs non-null": `Pmod.doGenCode` evaluates the divisor first and throws
-    // REMAINDER_BY_ZERO under ANSI. It still tests the dividend's null *before* that throw, so
+    // "all inputs non-null": `Pmod.doGenCode` evaluates the divisor first and throws on a zero
+    // divisor under ANSI. It still tests the dividend's null *before* that throw, so
     // `pmod(NULL, 0)` returns NULL in Spark and the union short-circuit stays exact. The
     // (NULL, 0) row pins the non-raising case, the (7, 0) row the raising one.
+    //
+    // Spark 4.1 introduced REMAINDER_BY_ZERO; older versions raise DIVIDE_BY_ZERO for `pmod`.
+    // The error comes from Spark's own generated code running inside the kernel, so the class
+    // tracks the Spark version under test.
+    val expectedError = if (isSpark41Plus) "REMAINDER_BY_ZERO" else "DIVIDE_BY_ZERO"
     spark.udf.register("idInt", (i: Integer) => i)
     withTable("t") {
       sql("CREATE TABLE t (a INT, b INT) USING parquet")
@@ -1412,16 +1418,17 @@ class CometCodegenSuite
           cometErr.isDefined,
           "Comet returned a value where Spark raised: the null short-circuit swallowed the error")
         assert(
-          cometErr.get.getMessage.contains("REMAINDER_BY_ZERO"),
-          s"expected the same REMAINDER_BY_ZERO error Spark raises, got: ${cometErr.get}")
+          cometErr.get.getMessage.contains(expectedError),
+          s"expected the same $expectedError error Spark raises, got: ${cometErr.get}")
+        assert(
+          sparkErr.get.getMessage.contains(expectedError),
+          s"expected Spark to raise $expectedError, got: ${sparkErr.get}")
       }
     }
   }
 
   test("TIME input column routes through the dispatcher (#5218)") {
-    assume(
-      org.apache.comet.CometSparkSessionExtensions.isSpark41Plus,
-      "TimeType requires Spark 4.1+")
+    assume(isSpark41Plus, "TimeType requires Spark 4.1+")
     // `canHandle` accepts TIME (`isSupportedDataType`) and `emitTypedGetters` emits a getLong
     // case for `TimeNanoVector`, but `CometScalaUDFCodegen.specFor` used to omit the vector class
     // and throw `UnsupportedOperationException` at execute time -- after the plan had already

--- a/spark/src/test/scala/org/apache/comet/codegen/CometSpecializedGettersDispatchSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/codegen/CometSpecializedGettersDispatchSuite.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.codegen
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.arrow.vector.types.TimeUnit
+import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType}
+import org.apache.spark.sql.comet.util.Utils
+import org.apache.spark.sql.types.{DataType, DateType, LongType}
+
+import org.apache.comet.CometSparkSessionExtensions.isSpark41Plus
+
+/**
+ * Unit coverage for the generic `SpecializedGetters.get(ordinal, dataType)` dispatch the kernel
+ * bases delegate to. Spark reaches it from `SafeProjection` (for ScalaUDF struct arguments) and
+ * from every `CodegenFallback.eval(row)`, including higher-order functions, so its type surface
+ * has to match what `CometBatchKernelCodegen.isSupportedDataType` admits at plan time. A type
+ * accepted there but missing here throws at execute time, when there is no longer a fallback.
+ */
+class CometSpecializedGettersDispatchSuite extends AnyFunSuite {
+
+  /** Minimal `CometInternalRow` over one fixed long, to drive the dispatch through `get`. */
+  private class StubRow(value: Long, isNull: Boolean = false) extends CometInternalRow {
+    override def numFields: Int = 1
+    override def isNullAt(ordinal: Int): Boolean = isNull
+    override def getLong(ordinal: Int): Long = value
+    override def getInt(ordinal: Int): Int = value.toInt
+  }
+
+  /** Spark `DataType` for Arrow `Time(NANOSECOND, 64)`, resolved without a 4.1 compile dep. */
+  private def timeType: DataType =
+    Utils.fromArrowField(
+      new Field(
+        "t",
+        FieldType.nullable(new ArrowType.Time(TimeUnit.NANOSECOND, 64)),
+        java.util.Collections.emptyList[Field]()))
+
+  test("get dispatches TimeType through getLong (#5218)") {
+    assume(isSpark41Plus, "TimeType requires Spark 4.1+")
+    val row = new StubRow(45296000000000L) // 12:34:56
+    assert(row.get(0, timeType) === java.lang.Long.valueOf(45296000000000L))
+  }
+
+  test("get returns null for a null TimeType slot") {
+    assume(isSpark41Plus, "TimeType requires Spark 4.1+")
+    val row = new StubRow(45296000000000L, isNull = true)
+    assert(row.get(0, timeType) == null)
+  }
+
+  test("get still dispatches the long- and int-backed temporal types") {
+    // Guards against the TimeType case being inserted ahead of a case it would shadow.
+    val row = new StubRow(19723L) // 2024-01-31 as an epoch day
+    assert(row.get(0, LongType) === java.lang.Long.valueOf(19723L))
+    assert(row.get(0, DateType) === java.lang.Integer.valueOf(19723))
+  }
+}


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5218.

## Rationale for this change

#5218 bundles three independent defects in the `CometCodegenDispatch` code path. This PR fixes all three. They share no code path with each other, so each section below is independently testable and revertable.

### 1. The null short-circuit swallowed errors Spark raises

`CometBatchKernelCodegen.defaultBody` applied an "any input null implies null output" short-circuit on the **union of input ordinals** whenever every node in the bound tree was `NullIntolerant`:

```java
if (this.col0.isNull(i) || this.col1.isNullAt(i)) { output.setNull(i); } else { ev.code; write }
```

Spark's null handling is **per-node and left-to-right**. `BinaryExpression.nullSafeCodeGen` emits the left child's code unconditionally, then tests the left child's null, then the right child's. A short-circuit over the union of ordinals therefore skips a subtree Spark would have evaluated, and with it any error that subtree raises.

Under ANSI, `add_months(CAST(s AS DATE), i)` on the row `('notadate', NULL)` raises `CAST_INVALID_INPUT` in Spark. Comet returned `NULL`. ANSI is on by default in Spark 4, and roughly 70 built-in expressions route through `CometCodegenDispatch` (math, arrays, maps, strings, json, csv, xpath, datetime), many of them `NullIntolerant` with error paths: `AddMonths`, `MonthsBetween`, `MakeTimestamp`, `GetTimestamp`, `MakeDTInterval`, `ToNumber`, `Conv`, `WidthBucket`, `Pmod`.

Values were never wrong, only errors were lost: a `NullIntolerant` node that ignored one of its inputs would already be a Spark bug. I checked `nanvl` specifically, since it ignores its second argument when the first is non-NaN, and it is correctly *not* `NullIntolerant`.

The defect needs a subtree between the root and a leaf that can raise independently of nullness, like the `Cast` above. A `BoundReference` or `Literal` read cannot raise on its own, so a one-level-deep tree is still safe to short-circuit; see the fix below.

### 2 and 3. Two TIME-type gaps in the same dispatcher

In both cases the plan-time gate accepted a type the runtime rejected. Because `canHandle` greenlights the expression before the plan commits, both were execute-time failures with no fallback.

Both are latent today: Spark 4.1.3 rejects TIME columns in file-based data sources (`UNSUPPORTED_TIME_TYPE`), so no SQL query can produce a TIME input to the dispatcher yet. They become live as soon as Spark supports TIME in Parquet or a native operator emits a TIME column.

## What changes are included in this PR?

**1. The short-circuit fix.** On top of the existing `NullIntolerant` root and `allNullIntolerant` tree conditions, `canShortCircuitNulls` now requires the tree to read **either exactly one input ordinal, or have only leaf children on the root**. Both shapes make the short-circuit exact:

- *One ordinal*: there is nothing left for Spark to evaluate ahead of that ordinal's own null check. Keeps the fast path for the common unary shapes (`upper`, `length`, `date_format`).
- *Leaf-only children* (every direct child of the root is a `BoundReference` or `Literal`): the tree is one level deep, so the only code Spark runs ahead of its null checks is leaf reads, which cannot raise. Any error comes from the root's own logic, which runs only once every input is known non-null — in Spark's shape and in ours alike. Keeps the fast path for the common no-cast multi-argument case (`pmod(a, b)`, `conv(a, b, c)`, `make_timestamp(y, m, d, h, mi, s)`).

Anything else — a real subtree between the root and a leaf, which is what makes an error reachable ahead of a null check — falls back to the plain `ev.code` plus `ev.isNull` body, which is what Spark's own generated code does. `defaultBody` now emits the disjunction over every ordinal the tree reads rather than only the first.

The leaf-only rule leans on a `NullIntolerant` root not raising before it has checked every input for null. I verified that against Spark's generated code for the one family that reorders its children: `DivModLike.doGenCode`, and `Pmod.doGenCode` which carries its own copy of the same shape, evaluate the divisor first but still test the dividend's null *before* the divide/remainder-by-zero throw, so `pmod(NULL, 0)` returns NULL rather than raising. A root that raised ahead of its null checks would contradict `NullIntolerant`.

**2. `CometScalaUDFCodegen.specFor` missing `TimeNanoVector`.** It fell into `case other => throw new UnsupportedOperationException`, even though `isSupportedDataType` accepts time types, `primitiveArrowClasses` includes the vector class, and `emitTypedGetters` emits a `getLong` case for it.

**3. `CometSpecializedGettersDispatch.get` missing a time-type branch,** so `get(ordinal, TimeType)` threw. That is the path `SafeProjection` (for ScalaUDF struct arguments) and every `CodegenFallback.eval(row)` use, including higher-order functions. `emitSpecializedGetterExpr` and `elementGetterCall` already routed time types to `getLong`, so only the generic dispatch was missing.

Doc comments were added on `specFor` and the dispatch object noting that their type surface has to stay in step with `isSupportedDataType`.

## How are these changes tested?

Four new tests, each verified to fail against the pre-fix behaviour and pass after:

- `CometCodegenSuite`: "multi-input NullIntolerant tree does not swallow an ANSI error (#5218)" runs the `add_months(CAST(s AS DATE), i)` query through `checkSparkAnswerMaybeThrows` under ANSI and asserts Comet raises the same `CAST_INVALID_INPUT` Spark does, plus asserts the dispatcher actually ran for the query. Pre-fix this returned `cometErr=None`.
- `CometCodegenSuite`: "single-input NullIntolerant tree still short-circuits nulls" guards against over-correcting.
- `CometCodegenSuite`: "multi-input leaf-only NullIntolerant tree short-circuits nulls correctly (#5218)" runs `pmod(a, b)` and `a + b` over every null combination across two ordinals, confirming the restored fast path matches Spark row for row.
- `CometCodegenSuite`: "leaf-only short-circuit preserves ANSI remainder-by-zero behaviour (#5218)" pins the `Pmod` reordering case from both sides — `(NULL, 0)` must return NULL, `(7, 0)` must raise `REMAINDER_BY_ZERO`.
- `CometCodegenSourceSuite`: "NullIntolerant short-circuit skipped when a subtree sits between root and leaf (#5218)" and "NullIntolerant short-circuit kept for a multi-input leaf-only tree (#5218)" pin both emitted source shapes.
- `CometCodegenSuite`: "TIME input column routes through the dispatcher (#5218)" drives `CometScalaUDFCodegen.evaluate` with a `TimeNanoVector` directly, since no SQL query can reach it. Gated on `isSpark41Plus`.
- New `spark/src/test/scala/org/apache/comet/codegen/CometSpecializedGettersDispatchSuite.scala` covers `get` for `TimeType`, the null slot, and the neighbouring long/int-backed temporal types so a future reordering that shadows a case is caught.

The #4554 regression test ("nullable NullIntolerant root keeps post-eval isNull guard inside short-circuit") keeps its original two-`setNull`-site assertion: its `MakeTimestamp` over six `BoundReference`s is a leaf-only tree, so it still gets the short-circuit. It now additionally asserts the short-circuit tests all six ordinals, not just the first. A new sibling test, "multi-input tree with a non-leaf child keeps only the post-eval guard (#5218)", covers the same root with a `Cast` under it and pins the single-`setNull` shape, so the post-eval guard is verified to survive independently of the short-circuit.

I confirmed the new source-level assertions discriminate: reverting `canShortCircuitNulls` to the single-ordinal-only rule fails exactly the two tests that pin the restored fast path, and nothing else.

Suite runs on the default profile (Spark 4.1 / Scala 2.13, JDK 17):

- `CometCodegenSuite`, `CometCodegenSourceSuite`, `CometCodegenHOFSuite`, `CometCodegenFuzzSuite`, `CometSpecializedGettersDispatchSuite`: 175 tests, 0 failures.
- Because the change touches the shared code path for every `CometCodegenDispatch` expression, also ran `CometTemporalExpressionSuite`, `CometStringExpressionSuite`, `CometMathExpressionSuite`, `CometArrayExpressionSuite`, `CometMapExpressionSuite`, `CometJsonExpressionSuite`, `CometCsvExpressionSuite`: 137 tests, 0 failures.
