### PR TITLE
perf: avoid rebuilding untouched operators in PlanDataInjector.injectPlanData

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -83,7 +83,13 @@ private[comet] trait PlanDataInjector {
   /** Extract the key used to look up planning data for this operator. */
   def getKey(op: Operator): Option[String]
 
-  /** Inject common + partition data into the operator node. */
+  /**
+   * Inject common + partition data into the operator node.
+   *
+   * Implementations must return the node with its child list unchanged -- `injectPlanData` walks
+   * the returned node's children, and relies on child reference identity to decide which
+   * operators need rebuilding.
+   */
   def inject(op: Operator, commonBytes: Array[Byte], partitionBytes: Array[Byte]): Operator
 }
 
@@ -133,10 +139,8 @@ private[comet] object PlanDataInjector extends Logging {
    * Supports joins over multiple tables by matching each operator with its corresponding data
    * based on a key (e.g., metadata_location for Iceberg).
    *
-   * Operators are protobuf messages, hence immutable, so any subtree that needs no injection is
-   * returned by reference rather than rebuilt. Since a plan typically has one or two leaf scans
-   * awaiting injection, this leaves only the root-to-scan paths to rebuild instead of every
-   * operator in the tree -- worth doing because this runs once per task on the executor.
+   * Operators are immutable protobuf messages, so any subtree needing no injection is returned by
+   * reference rather than rebuilt; only the root-to-scan paths are rebuilt.
    */
   def injectPlanData(
       op: Operator,
@@ -162,29 +166,23 @@ private[comet] object PlanDataInjector extends Logging {
 
     // Recursively process children, rebuilding this node only if one of them actually changed.
     // Injectors preserve children, so `injectedOp` has the same child list as `op` either way.
+    // The builder is created on the first changed child, so unchanged nodes allocate nothing.
     val children = injectedOp.getChildrenList
     val numChildren = children.size()
-    if (numChildren == 0) {
-      injectedOp
-    } else {
-      val injectedChildren = new Array[Operator](numChildren)
-      var childrenChanged = false
-      var i = 0
-      while (i < numChildren) {
-        val child = children.get(i)
-        val injectedChild = injectPlanData(child, commonByKey, partitionByKey)
-        childrenChanged |= (injectedChild ne child)
-        injectedChildren(i) = injectedChild
-        i += 1
+    var builder: Operator.Builder = null
+    var i = 0
+    while (i < numChildren) {
+      val child = children.get(i)
+      val injectedChild = injectPlanData(child, commonByKey, partitionByKey)
+      if (injectedChild ne child) {
+        if (builder == null) {
+          builder = injectedOp.toBuilder
+        }
+        builder.setChildren(i, injectedChild)
       }
-      if (!childrenChanged) {
-        injectedOp
-      } else {
-        val builder = injectedOp.toBuilder.clearChildren()
-        injectedChildren.foreach(builder.addChildren)
-        builder.build()
-      }
+      i += 1
     }
+    if (builder == null) injectedOp else builder.build()
   }
 
   def serializeOperator(op: Operator): Array[Byte] = {

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -132,40 +132,59 @@ private[comet] object PlanDataInjector extends Logging {
    *
    * Supports joins over multiple tables by matching each operator with its corresponding data
    * based on a key (e.g., metadata_location for Iceberg).
+   *
+   * Operators are protobuf messages, hence immutable, so any subtree that needs no injection is
+   * returned by reference rather than rebuilt. Since a plan typically has one or two leaf scans
+   * awaiting injection, this leaves only the root-to-scan paths to rebuild instead of every
+   * operator in the tree -- worth doing because this runs once per task on the executor.
    */
   def injectPlanData(
       op: Operator,
       commonByKey: Map[String, Array[Byte]],
       partitionByKey: Map[String, Array[Byte]]): Operator = {
-    val builder = op.toBuilder
 
     // O(1) by op kind, then a canInject confirm (which may inspect detail fields like `hasCommon`
     // / `!hasFilePartition`). Most operators in any tree are non-scan and skip the lookup body.
-    injectorsByKind.get(op.getOpStructCase) match {
+    val injectedOp = injectorsByKind.get(op.getOpStructCase) match {
       case Some(injector) if injector.canInject(op) =>
         injector.getKey(op) match {
           case Some(key) =>
             (commonByKey.get(key), partitionByKey.get(key)) match {
               case (Some(commonBytes), Some(partitionBytes)) =>
-                val injectedOp = injector.inject(op, commonBytes, partitionBytes)
-                // Copy the injected operator's fields to our builder
-                builder.clear()
-                builder.mergeFrom(injectedOp)
+                injector.inject(op, commonBytes, partitionBytes)
               case _ =>
                 throw new CometRuntimeException(s"Missing planning data for key: $key")
             }
-          case None =>
+          case None => op
         }
-      case _ =>
+      case _ => op
     }
 
-    // Recursively process children
-    builder.clearChildren()
-    op.getChildrenList.asScala.foreach { child =>
-      builder.addChildren(injectPlanData(child, commonByKey, partitionByKey))
+    // Recursively process children, rebuilding this node only if one of them actually changed.
+    // Injectors preserve children, so `injectedOp` has the same child list as `op` either way.
+    val children = injectedOp.getChildrenList
+    val numChildren = children.size()
+    if (numChildren == 0) {
+      injectedOp
+    } else {
+      val injectedChildren = new Array[Operator](numChildren)
+      var childrenChanged = false
+      var i = 0
+      while (i < numChildren) {
+        val child = children.get(i)
+        val injectedChild = injectPlanData(child, commonByKey, partitionByKey)
+        childrenChanged |= (injectedChild ne child)
+        injectedChildren(i) = injectedChild
+        i += 1
+      }
+      if (!childrenChanged) {
+        injectedOp
+      } else {
+        val builder = injectedOp.toBuilder.clearChildren()
+        injectedChildren.foreach(builder.addChildren)
+        builder.build()
+      }
     }
-
-    builder.build()
   }
 
   def serializeOperator(op: Operator): Array[Byte] = {

--- a/spark/src/test/scala/org/apache/spark/sql/comet/PlanDataInjectorSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/PlanDataInjectorSuite.scala
@@ -72,15 +72,13 @@ class PlanDataInjectorSuite extends AnyFunSuite {
 
     val result = PlanDataInjector.injectPlanData(root, Map.empty, Map.empty)
 
-    assert(result == root, "non-scan operator tree should be returned unchanged")
     assert(
       result eq root,
       "a tree with nothing to inject should be returned by reference, not rebuilt")
   }
 
   test("injectPlanData rebuilds only the path to the injected scan") {
-    // Operators are immutable protobuf messages, so subtrees that need no injection are shared
-    // rather than rebuilt. Only the root-to-scan path may be new.
+    // Operators are immutable protobuf messages, so subtrees that need no injection are shared.
     val scanOp = icebergScanOp("s3://table/metadata/v1.json", scanHashCode = 111)
     val (commonBytes, partitionBytes) =
       icebergPlanData(
@@ -109,7 +107,6 @@ class PlanDataInjectorSuite extends AnyFunSuite {
     assert(
       result.getChildren(1) eq untouchedSibling,
       "a sibling subtree with no injectable scan should be shared, not rebuilt")
-    assert(result.getChildren(0) ne filter, "the path to the injected scan must be rebuilt")
     val injectedScan = result.getChildren(0).getChildren(0)
     assert(injectedScan.getIcebergScan.getCommon.getRequiredSchemaCount == 2)
     assert(injectedScan.getIcebergScan.getFileScanTasks(0).getDataFilePath == "data.parquet")

--- a/spark/src/test/scala/org/apache/spark/sql/comet/PlanDataInjectorSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/PlanDataInjectorSuite.scala
@@ -73,6 +73,49 @@ class PlanDataInjectorSuite extends AnyFunSuite {
     val result = PlanDataInjector.injectPlanData(root, Map.empty, Map.empty)
 
     assert(result == root, "non-scan operator tree should be returned unchanged")
+    assert(
+      result eq root,
+      "a tree with nothing to inject should be returned by reference, not rebuilt")
+  }
+
+  test("injectPlanData rebuilds only the path to the injected scan") {
+    // Operators are immutable protobuf messages, so subtrees that need no injection are shared
+    // rather than rebuilt. Only the root-to-scan path may be new.
+    val scanOp = icebergScanOp("s3://table/metadata/v1.json", scanHashCode = 111)
+    val (commonBytes, partitionBytes) =
+      icebergPlanData(
+        "s3://table/metadata/v1.json",
+        scanHashCode = 111,
+        columnNames = Seq("id", "v"),
+        dataFilePath = "data.parquet")
+    val key = IcebergPlanDataInjector.getKey(scanOp).get
+
+    val filter = Operator.newBuilder().setPlanId(2).addChildren(scanOp).build()
+    val untouchedSibling = Operator
+      .newBuilder()
+      .setPlanId(3)
+      .addChildren(Operator.newBuilder().setPlanId(4).build())
+      .build()
+    val root = Operator
+      .newBuilder()
+      .setPlanId(1)
+      .addChildren(filter)
+      .addChildren(untouchedSibling)
+      .build()
+
+    val result =
+      PlanDataInjector.injectPlanData(root, Map(key -> commonBytes), Map(key -> partitionBytes))
+
+    assert(
+      result.getChildren(1) eq untouchedSibling,
+      "a sibling subtree with no injectable scan should be shared, not rebuilt")
+    assert(result.getChildren(0) ne filter, "the path to the injected scan must be rebuilt")
+    val injectedScan = result.getChildren(0).getChildren(0)
+    assert(injectedScan.getIcebergScan.getCommon.getRequiredSchemaCount == 2)
+    assert(injectedScan.getIcebergScan.getFileScanTasks(0).getDataFilePath == "data.parquet")
+    // Everything outside the injected scan is preserved verbatim.
+    assert(result.getPlanId == 1)
+    assert(result.getChildren(0).getPlanId == 2)
   }
 
   test("each registered injector is reachable by its opStructCase") {


### PR DESCRIPTION
## Which issue does this PR close?

Addresses item 6 of #5199.

## Rationale for this change

`PlanDataInjector.injectPlanData` runs once per task on the executor. It recursed into every subtree and rebuilt every operator through a builder (`op.toBuilder` ... `clearChildren()` ... `build()`), even though at most one or two leaf scans in a plan actually receive injected data. Every `Filter`, `Projection`, `HashJoin`, etc. above and beside the scans was reconstructed for nothing, once per task.

## What changes are included in this PR?

Operators are protobuf messages and therefore immutable, so a subtree that needs no injection can be returned by reference rather than rebuilt. `injectPlanData` now creates a node's builder lazily, on the first child that actually changed, and sets only the changed slots — so a node whose subtree needed no injection is returned as-is and allocates nothing.

Only the root-to-scan paths are rebuilt; untouched siblings and their descendants are shared with the input tree. The injection logic, key lookup, and the "missing planning data" error are unchanged.

The `PlanDataInjector.inject` scaladoc now states the invariant the walker relies on (implementations must return the node with its child list unchanged), since contribs implement that trait via `ServiceLoader` and would otherwise not see the constraint.

Local measurement of `injectPlanData` alone (new vs. old implementation, warmed up, interleaved rounds; synthetic plan = N unary operators over a hash join of two native scans with C columns each):

| plan shape | old | new | speedup |
| --- | --- | --- | --- |
| 60 ops, 1 col | 8.32 us | 4.85 us | 1.72x |
| 20 ops, 1 col | 3.56 us | 2.52 us | 1.41x |
| 60 ops, 20 cols | 21.98 us | 18.78 us | 1.17x |
| 20 ops, 50 cols | 39.57 us | 38.55 us | 1.03x |
| 5 ops, 200 cols | 149.26 us | 146.97 us | 1.02x |

The saving is the tree rebuild, so it grows with plan size and shrinks in relative terms as the injection itself (parsing the scan's common bytes, which scales with schema width) comes to dominate. It also removes the corresponding garbage from the per-task path.

Worth noting for the epic: after this change the dominant per-task cost in `CometExecRDD.compute` is the full `Operator.parseFrom` + re-serialize that brackets the injection, and `NativeScanPlanDataInjector.getKey` recomputing its string key per scan per task. Both are separate follow-ups.

## How are these changes tested?

- `PlanDataInjectorSuite` — the existing "non-scan operator tree unchanged" test now asserts reference identity, and a new test injects into a scan nested under a filter beside an untouched sibling subtree, asserting the sibling is shared, the injected data is correct, and surrounding fields are preserved. This suite is already in the `pr_build_linux` / `pr_build_macos` matrices.
- Existing suites pass locally (Spark 4.1, JDK 17): `PlanDataInjectorSuite`, `CometScanWithPlanDataSuite`, `CometExecSuite` + `CometJoinSuite` (172 tests).