### PR TITLE
chore: remove unused spark.comet.exceptionOnDatetimeRebase config

### DIFF
--- a/docs/source/user-guide/latest/compatibility/scans.md
+++ b/docs/source/user-guide/latest/compatibility/scans.md
@@ -57,9 +57,7 @@ The following limitation may produce incorrect results without falling back to S
   if they were written using the Proleptic Gregorian calendar. This produces silently-wrong
   values for dates before October 15, 1582 in both projections and predicates. Comet also
   ignores `spark.sql.parquet.datetimeRebaseModeInRead` and the file-level
-  `org.apache.spark.legacyDateTime` metadata that would tell it to rebase. The
-  `spark.comet.exceptionOnDatetimeRebase` config is currently dead code and does not raise on
-  legacy-calendar data. Tracked by
+  `org.apache.spark.legacyDateTime` metadata that would tell it to rebase. Tracked by
   [#5010](https://github.com/apache/datafusion-comet/issues/5010).
 
 The following limitations raise an error at scan time rather than falling back to Spark:

--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -715,18 +715,6 @@ object CometConf extends ShimCometConf {
     .booleanConf
     .createWithDefault(false)
 
-  val COMET_EXCEPTION_ON_LEGACY_DATE_TIMESTAMP: ConfigEntry[Boolean] =
-    conf("spark.comet.exceptionOnDatetimeRebase")
-      .category(CATEGORY_EXEC)
-      .doc("Whether to throw exception when seeing dates/timestamps from the legacy hybrid " +
-        "(Julian + Gregorian) calendar. Since Spark 3, dates/timestamps were written according " +
-        "to the Proleptic Gregorian calendar. When this is true, Comet will " +
-        "throw exceptions when seeing these dates/timestamps that were written by Spark version " +
-        "before 3.0. If this is false, these dates/timestamps will be read as if they were " +
-        "written to the Proleptic Gregorian calendar and will not be rebased.")
-      .booleanConf
-      .createWithDefault(false)
-
   val COMET_ENABLE_PARTIAL_HASH_AGGREGATE: ConfigEntry[Boolean] =
     conf("spark.comet.testing.aggregate.partialMode.enabled")
       .internal()


### PR DESCRIPTION
## Which issue does this PR close?

Related to #5010.

## Rationale for this change

`spark.comet.exceptionOnDatetimeRebase` is declared in `CometConf` but is never read anywhere in the codebase — JVM or native. Setting it to `true` had no effect: Comet did not raise on dates/timestamps written with the legacy hybrid (Julian + Gregorian) calendar, it silently read them as Proleptic Gregorian. The config therefore advertised a safety guard that does not exist, which is worse than not offering one at all.

The real gap — no datetime rebasing in the native Parquet scan — is tracked by #5010 and remains documented in the scan compatibility guide.

## What changes are included in this PR?

- Remove `COMET_EXCEPTION_ON_LEGACY_DATE_TIMESTAMP` / `spark.comet.exceptionOnDatetimeRebase` from `CometConf.scala`.
- Drop the sentence in `docs/source/user-guide/latest/compatibility/scans.md` that called out the config as dead code. The surrounding paragraph already describes the missing rebasing support and links to #5010.

No upgrade guide entry is added: removing the key is not a behavior change, since no code path ever consulted it, and Spark ignores unrecognized `spark.comet.*` keys that users may still have set.

## How are these changes tested?

Nothing referenced the config, so there is no behavior to test. Verified with a repo-wide grep for both the key string and the Scala symbol (only the two edited sites matched) and confirmed `common` + `spark` compile cleanly.