### PR TITLE
docs: clarify SparkPhysicalExprAdapter cast checks differ from CometCast.isSupported

### DIFF
--- a/native/core/src/parquet/schema_adapter.rs
+++ b/native/core/src/parquet/schema_adapter.rs
@@ -623,6 +623,16 @@ impl SparkPhysicalExprAdapter {
     }
 
     /// Replace CastExpr (DataFusion's cast) with Spark's Cast expression.
+    ///
+    /// The accept/reject logic below mirrors Spark's vectorized Parquet reader
+    /// (`ParquetVectorUpdaterFactory.getUpdater`), not `CometCast.isSupported`. Those are
+    /// different Spark surfaces: this function reconciles a file's physical schema against
+    /// the table's declared schema (schema evolution), a decision Spark itself makes inside
+    /// the vectorized reader and never routes through Catalyst's `Cast` expression or
+    /// codegen. `CometCast.isSupported` governs actual `Cast` expression nodes (explicit
+    /// `CAST()`, implicit analyzer casts) and has no bearing here. When extending the
+    /// accept/reject rules below, check them against the vectorized reader's updater
+    /// matrix, not the cast-expression compatibility matrix in `CometCast.scala`.
     fn replace_with_spark_cast(
         &self,
         expr: Arc<dyn PhysicalExpr>,

--- a/native/spark-expr/src/conversion_funcs/cast.rs
+++ b/native/spark-expr/src/conversion_funcs/cast.rs
@@ -467,9 +467,13 @@ pub(crate) fn cast_array(
             Ok(cast_with_options(&array, to_type, &native_cast_options)?)
         }
         _ => {
-            // we should never reach this code because the Scala code should be checking
-            // for supported cast operations and falling back to Spark for anything that
-            // is not yet supported
+            // This invariant is upheld by two independent callers, not one shared gate:
+            // - the expression path, where `CometCast.isSupported` (Scala) checks before a
+            //   `Cast` node is ever emitted into the plan;
+            // - the scan schema-adapter path (schema_adapter.rs), which checks against
+            //   Spark's vectorized-reader legality instead, for pairs arising from Parquet
+            //   schema evolution rather than a `CAST()` expression.
+            // Reaching this arm means one of those callers let an unsupported pair through.
             Err(SparkError::Internal(format!(
                 "Native cast invoked for unsupported cast from {from_type:?} to {to_type:?}"
             )))


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

`SparkPhysicalExprAdapter::replace_with_spark_cast` (native, scan-time Parquet schema evolution) and `CometCast.isSupported` (Scala, Catalyst `Cast` expression legality) enforce two different Spark surfaces but feed the same native cast kernel, which made it easy to assume they should cross-check each other. Nothing is broken today, but neither function said which Spark reference it is supposed to track, inviting a future change to conflate the two.

## What changes are included in this PR?

- Doc comment on `replace_with_spark_cast` noting it mirrors Spark's vectorized Parquet reader (`ParquetVectorUpdaterFactory.getUpdater`) for schema-evolution casts, not `CometCast.isSupported`.
- Doc comment on the catch-all arm in `cast_array` naming both independent callers (`CometCast.isSupported` for the expression path, the schema adapter for the scan path) that are expected to have already gated the cast before it reaches the native kernel.

## How are these changes tested?

Comment-only change, no behavior change. No new tests.
