### PR TITLE
fix: normalize signed zero in nested float array comparisons

### DIFF
--- a/native/spark-expr/src/array_funcs/array_position.rs
+++ b/native/spark-expr/src/array_funcs/array_position.rs
@@ -33,6 +33,8 @@ use num::Float;
 use std::cmp::Ordering;
 use std::sync::Arc;
 
+use super::nested_float_normalize::normalize_negative_zero;
+
 /// Spark array_position() function that returns the 1-based position of an element in an array.
 /// Returns 0 if the element is not found (Spark behavior differs from DataFusion which returns null).
 fn spark_array_position(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
@@ -273,7 +275,13 @@ fn position_fallback<O: OffsetSizeTrait>(
     let num_rows = list_array.len();
     let nulls = combined_nulls(list_array.nulls(), element.nulls());
     let mut result = vec![0i64; num_rows];
-    let comparator = make_comparator(values.as_ref(), element.as_ref(), SortOptions::default())?;
+    let values_normalized = normalize_negative_zero(values);
+    let element_normalized = normalize_negative_zero(element);
+    let comparator = make_comparator(
+        values_normalized.as_ref(),
+        element_normalized.as_ref(),
+        SortOptions::default(),
+    )?;
 
     for (row_index, w) in offsets.windows(2).enumerate() {
         if nulls.as_ref().is_some_and(|n| n.is_null(row_index)) {
@@ -301,8 +309,6 @@ mod tests {
 
     #[test]
     fn test_nested_float_and_null_position() -> DataFusionResult<()> {
-        // Arrow and the previous ScalarValue fallback distinguish signed zeros, so the second
-        // row matches at position 2 rather than position 1.
         let values = ListArray::from_iter_primitive::<Float64Type, _, _>([
             Some(vec![Some(1.0)]),
             Some(vec![Some(f64::NAN)]),
@@ -324,7 +330,44 @@ mod tests {
 
         let result = array_position_inner(&[Arc::new(array), Arc::new(element)])?;
         let result = result.as_any().downcast_ref::<Int64Array>().unwrap();
-        assert_eq!(result, &Int64Array::from(vec![2, 2, 1]));
+        assert_eq!(result, &Int64Array::from(vec![2, 1, 1]));
+        Ok(())
+    }
+
+    #[test]
+    fn test_struct_float_field_signed_zero_position() -> DataFusionResult<()> {
+        use arrow::array::{Float64Builder, StructBuilder};
+
+        let fields = vec![Arc::new(Field::new("a", DataType::Float64, true))];
+        let mut values_builder =
+            StructBuilder::new(fields.clone(), vec![Box::new(Float64Builder::new())]);
+        for v in [-0.0, 1.0] {
+            values_builder
+                .field_builder::<Float64Builder>(0)
+                .unwrap()
+                .append_value(v);
+            values_builder.append(true);
+        }
+        let values = Arc::new(values_builder.finish());
+        let array = ListArray::new(
+            Arc::new(Field::new("item", values.data_type().clone(), true)),
+            OffsetBuffer::new(vec![0, 2].into()),
+            values,
+            None,
+        );
+
+        let mut element_builder = StructBuilder::new(fields, vec![Box::new(Float64Builder::new())]);
+        element_builder
+            .field_builder::<Float64Builder>(0)
+            .unwrap()
+            .append_value(0.0);
+        element_builder.append(true);
+        let element = element_builder.finish();
+
+        let result = array_position_inner(&[Arc::new(array), Arc::new(element)])?;
+        let result = result.as_any().downcast_ref::<Int64Array>().unwrap();
+        // {-0.0} is the first element and now matches {0.0}, matching Spark.
+        assert_eq!(result, &Int64Array::from(vec![1]));
         Ok(())
     }
 }

--- a/native/spark-expr/src/array_funcs/array_position.rs
+++ b/native/spark-expr/src/array_funcs/array_position.rs
@@ -33,7 +33,7 @@ use num::Float;
 use std::cmp::Ordering;
 use std::sync::Arc;
 
-use super::nested_float_normalize::normalize_negative_zero;
+use super::nested_float_normalize::{has_float_leaf, normalize_nested_floats};
 
 /// Spark array_position() function that returns the 1-based position of an element in an array.
 /// Returns 0 if the element is not found (Spark behavior differs from DataFusion which returns null).
@@ -275,11 +275,13 @@ fn position_fallback<O: OffsetSizeTrait>(
     let num_rows = list_array.len();
     let nulls = combined_nulls(list_array.nulls(), element.nulls());
     let mut result = vec![0i64; num_rows];
-    let values_normalized = normalize_negative_zero(values);
-    let element_normalized = normalize_negative_zero(element);
+    let values_normalized =
+        has_float_leaf(values.data_type()).then(|| normalize_nested_floats(values));
+    let element_normalized =
+        has_float_leaf(element.data_type()).then(|| normalize_nested_floats(element));
     let comparator = make_comparator(
-        values_normalized.as_ref(),
-        element_normalized.as_ref(),
+        values_normalized.as_ref().unwrap_or(values).as_ref(),
+        element_normalized.as_ref().unwrap_or(element).as_ref(),
         SortOptions::default(),
     )?;
 

--- a/native/spark-expr/src/array_funcs/array_position.rs
+++ b/native/spark-expr/src/array_funcs/array_position.rs
@@ -336,6 +336,9 @@ mod tests {
         Ok(())
     }
 
+    // array_position over array<struct<...>> currently falls back to Spark
+    // (ArraysBase.isTypeSupported rejects StructType, see #1307), so this only
+    // exercises position_fallback directly and isn't reachable from a SQL query.
     #[test]
     fn test_struct_float_field_signed_zero_position() -> DataFusionResult<()> {
         use arrow::array::{Float64Builder, StructBuilder};

--- a/native/spark-expr/src/array_funcs/arrays_overlap.rs
+++ b/native/spark-expr/src/array_funcs/arrays_overlap.rs
@@ -51,6 +51,8 @@ use std::hash::Hash;
 use std::ops::Range;
 use std::sync::Arc;
 
+use super::nested_float_normalize::normalize_negative_zero;
+
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct SparkArraysOverlap {
     signature: Signature,
@@ -429,9 +431,11 @@ fn arrays_overlap_list_generic<OffsetSize: OffsetSizeTrait>(
         };
 
         let comparator = if needs_comparator(probe.data_type()) {
+            let probe_normalized = normalize_negative_zero(probe);
+            let search_normalized = normalize_negative_zero(search);
             Some(make_comparator(
-                probe.as_ref(),
-                search.as_ref(),
+                probe_normalized.as_ref(),
+                search_normalized.as_ref(),
                 SortOptions::default(),
             )?)
         } else {
@@ -706,8 +710,7 @@ mod tests {
 
     #[test]
     fn test_nested_float_total_order() -> Result<()> {
-        // Preserve the existing Arrow total-order behavior: NaN matches itself, while signed
-        // zeros are distinct.
+        // NaN matches itself, and signed zeros are equal, matching Spark.
         let left = make_nested_float_list(&[&[f64::NAN]]);
         let right = make_nested_float_list(&[&[f64::NAN]]);
         let result = arrays_overlap_list::<i32>(&left, &right)?;
@@ -718,7 +721,7 @@ mod tests {
         let right = make_nested_float_list(&[&[-0.0]]);
         let result = arrays_overlap_list::<i32>(&left, &right)?;
         let result = result.as_any().downcast_ref::<BooleanArray>().unwrap();
-        assert!(!result.value(0));
+        assert!(result.value(0));
         Ok(())
     }
 
@@ -897,6 +900,37 @@ mod tests {
         // [{1,2}, {1,NULL}] vs [{1,2}] => true (definite match on {1,2})
         let left = make_struct_list(vec![Some((Some(1), Some(2))), Some((Some(1), None))]);
         let right = make_struct_list(vec![Some((Some(1), Some(2)))]);
+
+        let result = arrays_overlap_list::<i32>(&left, &right)?;
+        let result = result.as_any().downcast_ref::<BooleanArray>().unwrap();
+        assert!(result.is_valid(0));
+        assert!(result.value(0));
+        Ok(())
+    }
+
+    /// Build a single-row ListArray of structs: List<Struct<a: Float64>>
+    fn make_struct_float_list(elements: Vec<Option<f64>>) -> ListArray {
+        let fields = vec![Arc::new(Field::new("a", DataType::Float64, true))];
+        let struct_builder =
+            StructBuilder::new(fields.clone(), vec![Box::new(Float64Builder::new())]);
+        let mut list_builder = ListBuilder::new(struct_builder);
+
+        for elem in &elements {
+            let sb = list_builder.values();
+            sb.field_builder::<Float64Builder>(0)
+                .unwrap()
+                .append_option(*elem);
+            sb.append(true);
+        }
+        list_builder.append(true);
+        list_builder.finish()
+    }
+
+    #[test]
+    fn test_struct_float_field_signed_zero_overlap() -> Result<()> {
+        // [{-0.0}] vs [{0.0}] => true, matching Spark
+        let left = make_struct_float_list(vec![Some(-0.0)]);
+        let right = make_struct_float_list(vec![Some(0.0)]);
 
         let result = arrays_overlap_list::<i32>(&left, &right)?;
         let result = result.as_any().downcast_ref::<BooleanArray>().unwrap();

--- a/native/spark-expr/src/array_funcs/arrays_overlap.rs
+++ b/native/spark-expr/src/array_funcs/arrays_overlap.rs
@@ -407,6 +407,10 @@ fn normalize_list_element_floats<OffsetSize: OffsetSizeTrait>(
 }
 
 /// Fallback for nested and otherwise unhandled element types.
+///
+/// note: Spark's flat arrays_overlap (HashSet<Double>) treats -0.0 and 0.0 as different,
+/// only the nested path here treats them as equal. this normalization can't move into the
+/// flat fast path in arrays_overlap_list without breaking that difference.
 fn arrays_overlap_list_generic<OffsetSize: OffsetSizeTrait>(
     left: &GenericListArray<OffsetSize>,
     right: &GenericListArray<OffsetSize>,

--- a/native/spark-expr/src/array_funcs/arrays_overlap.rs
+++ b/native/spark-expr/src/array_funcs/arrays_overlap.rs
@@ -51,7 +51,7 @@ use std::hash::Hash;
 use std::ops::Range;
 use std::sync::Arc;
 
-use super::nested_float_normalize::normalize_negative_zero;
+use super::nested_float_normalize::{has_float_leaf, normalize_nested_floats};
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct SparkArraysOverlap {
@@ -390,11 +390,34 @@ where
     }
 }
 
+fn normalize_list_element_floats<OffsetSize: OffsetSizeTrait>(
+    list: &GenericListArray<OffsetSize>,
+) -> GenericListArray<OffsetSize> {
+    let field = match list.data_type() {
+        DataType::List(f) | DataType::LargeList(f) => Arc::clone(f),
+        _ => unreachable!("GenericListArray always has List or LargeList data type"),
+    };
+    let normalized_values = normalize_nested_floats(list.values());
+    GenericListArray::new(
+        field,
+        list.offsets().clone(),
+        normalized_values,
+        list.nulls().cloned(),
+    )
+}
+
 /// Fallback for nested and otherwise unhandled element types.
 fn arrays_overlap_list_generic<OffsetSize: OffsetSizeTrait>(
     left: &GenericListArray<OffsetSize>,
     right: &GenericListArray<OffsetSize>,
 ) -> Result<ArrayRef> {
+    let left_owned =
+        has_float_leaf(left.values().data_type()).then(|| normalize_list_element_floats(left));
+    let left: &GenericListArray<OffsetSize> = left_owned.as_ref().unwrap_or(left);
+    let right_owned =
+        has_float_leaf(right.values().data_type()).then(|| normalize_list_element_floats(right));
+    let right: &GenericListArray<OffsetSize> = right_owned.as_ref().unwrap_or(right);
+
     let len = left.len();
     let mut builder = BooleanArray::builder(len);
 
@@ -431,11 +454,9 @@ fn arrays_overlap_list_generic<OffsetSize: OffsetSizeTrait>(
         };
 
         let comparator = if needs_comparator(probe.data_type()) {
-            let probe_normalized = normalize_negative_zero(probe);
-            let search_normalized = normalize_negative_zero(search);
             Some(make_comparator(
-                probe_normalized.as_ref(),
-                search_normalized.as_ref(),
+                probe.as_ref(),
+                search.as_ref(),
                 SortOptions::default(),
             )?)
         } else {
@@ -719,6 +740,17 @@ mod tests {
 
         let left = make_nested_float_list(&[&[0.0]]);
         let right = make_nested_float_list(&[&[-0.0]]);
+        let result = arrays_overlap_list::<i32>(&left, &right)?;
+        let result = result.as_any().downcast_ref::<BooleanArray>().unwrap();
+        assert!(result.value(0));
+        Ok(())
+    }
+
+    #[test]
+    fn test_nested_float_signed_nan_total_order() -> Result<()> {
+        // [[-NaN]] vs [[NaN]] => true
+        let left = make_nested_float_list(&[&[-f64::NAN]]);
+        let right = make_nested_float_list(&[&[f64::NAN]]);
         let result = arrays_overlap_list::<i32>(&left, &right)?;
         let result = result.as_any().downcast_ref::<BooleanArray>().unwrap();
         assert!(result.value(0));

--- a/native/spark-expr/src/array_funcs/arrays_overlap.rs
+++ b/native/spark-expr/src/array_funcs/arrays_overlap.rs
@@ -734,7 +734,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_float_total_order() -> Result<()> {
+    fn test_nested_float_spark_equality() -> Result<()> {
         // NaN matches itself, and signed zeros are equal, matching Spark.
         let left = make_nested_float_list(&[&[f64::NAN]]);
         let right = make_nested_float_list(&[&[f64::NAN]]);
@@ -751,7 +751,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_float_signed_nan_total_order() -> Result<()> {
+    fn test_nested_float_signed_nan_spark_equality() -> Result<()> {
         // [[-NaN]] vs [[NaN]] => true
         let left = make_nested_float_list(&[&[-f64::NAN]]);
         let right = make_nested_float_list(&[&[f64::NAN]]);

--- a/native/spark-expr/src/array_funcs/mod.rs
+++ b/native/spark-expr/src/array_funcs/mod.rs
@@ -23,6 +23,7 @@ mod arrays_zip;
 mod flatten;
 mod get_array_struct_fields;
 mod list_extract;
+mod nested_float_normalize;
 mod size;
 
 pub use array_insert::ArrayInsert;

--- a/native/spark-expr/src/array_funcs/nested_float_normalize.rs
+++ b/native/spark-expr/src/array_funcs/nested_float_normalize.rs
@@ -15,36 +15,42 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::math_funcs::internal::normalize_float;
 use arrow::array::{
     Array, ArrayRef, AsArray, FixedSizeListArray, Float32Array, Float64Array, LargeListArray,
     ListArray, StructArray,
 };
-use arrow::datatypes::DataType;
+use arrow::datatypes::{DataType, Float32Type, Float64Type};
 use std::sync::Arc;
 
-/// Recursively rebuilds nested arrays with `-0.0` normalized to `0.0` in any
-/// Float32/Float64 leaves, leaving NaN untouched.
-pub(super) fn normalize_negative_zero(array: &ArrayRef) -> ArrayRef {
+pub(super) fn has_float_leaf(dt: &DataType) -> bool {
+    match dt {
+        DataType::Float32 | DataType::Float64 => true,
+        DataType::List(field) | DataType::LargeList(field) | DataType::FixedSizeList(field, _) => {
+            has_float_leaf(field.data_type())
+        }
+        DataType::Struct(fields) => fields.iter().any(|f| has_float_leaf(f.data_type())),
+        _ => false,
+    }
+}
+
+/// Recursively rebuilds nested arrays with `-0.0` normalized to `0.0` and NaN canonicalized
+/// in any Float32/Float64 leaves.
+pub(super) fn normalize_nested_floats(array: &ArrayRef) -> ArrayRef {
     match array.data_type() {
         DataType::Float32 => {
-            let arr = array.as_primitive::<arrow::datatypes::Float32Type>();
-            let normalized: Float32Array = arr
-                .iter()
-                .map(|v| v.map(|v| if v == 0.0 { 0.0f32 } else { v }))
-                .collect();
+            let normalized: Float32Array =
+                array.as_primitive::<Float32Type>().unary(normalize_float);
             Arc::new(normalized)
         }
         DataType::Float64 => {
-            let arr = array.as_primitive::<arrow::datatypes::Float64Type>();
-            let normalized: Float64Array = arr
-                .iter()
-                .map(|v| v.map(|v| if v == 0.0 { 0.0f64 } else { v }))
-                .collect();
+            let normalized: Float64Array =
+                array.as_primitive::<Float64Type>().unary(normalize_float);
             Arc::new(normalized)
         }
         DataType::List(field) => {
             let list = array.as_list::<i32>();
-            let normalized_values = normalize_negative_zero(list.values());
+            let normalized_values = normalize_nested_floats(list.values());
             Arc::new(ListArray::new(
                 Arc::clone(field),
                 list.offsets().clone(),
@@ -54,7 +60,7 @@ pub(super) fn normalize_negative_zero(array: &ArrayRef) -> ArrayRef {
         }
         DataType::LargeList(field) => {
             let list = array.as_list::<i64>();
-            let normalized_values = normalize_negative_zero(list.values());
+            let normalized_values = normalize_nested_floats(list.values());
             Arc::new(LargeListArray::new(
                 Arc::clone(field),
                 list.offsets().clone(),
@@ -64,7 +70,7 @@ pub(super) fn normalize_negative_zero(array: &ArrayRef) -> ArrayRef {
         }
         DataType::FixedSizeList(field, size) => {
             let list = array.as_fixed_size_list();
-            let normalized_values = normalize_negative_zero(list.values());
+            let normalized_values = normalize_nested_floats(list.values());
             Arc::new(FixedSizeListArray::new(
                 Arc::clone(field),
                 *size,
@@ -75,7 +81,7 @@ pub(super) fn normalize_negative_zero(array: &ArrayRef) -> ArrayRef {
         DataType::Struct(_) => {
             let s = array.as_struct();
             let normalized_columns: Vec<ArrayRef> =
-                s.columns().iter().map(normalize_negative_zero).collect();
+                s.columns().iter().map(normalize_nested_floats).collect();
             Arc::new(StructArray::new(
                 s.fields().clone(),
                 normalized_columns,
@@ -94,45 +100,70 @@ mod tests {
     use arrow::datatypes::Field;
 
     #[test]
+    fn test_has_float_leaf() {
+        assert!(has_float_leaf(&DataType::Float64));
+        assert!(has_float_leaf(&DataType::List(Arc::new(Field::new(
+            "item",
+            DataType::Float32,
+            true
+        )))));
+        assert!(has_float_leaf(&DataType::Struct(
+            vec![
+                Arc::new(Field::new("a", DataType::Int32, true)),
+                Arc::new(Field::new("b", DataType::Float64, true)),
+            ]
+            .into()
+        )));
+        assert!(!has_float_leaf(&DataType::Int32));
+        assert!(!has_float_leaf(&DataType::List(Arc::new(Field::new(
+            "item",
+            DataType::Int32,
+            true
+        )))));
+    }
+
+    #[test]
     fn test_normalize_flat_floats() {
         let arr: ArrayRef = Arc::new(Float64Array::from(vec![
             Some(-0.0),
             Some(0.0),
             Some(f64::NAN),
+            Some(-f64::NAN),
             None,
             Some(1.5),
         ]));
-        let normalized = normalize_negative_zero(&arr);
-        let normalized = normalized.as_primitive::<arrow::datatypes::Float64Type>();
+        let normalized = normalize_nested_floats(&arr);
+        let normalized = normalized.as_primitive::<Float64Type>();
 
         assert_eq!(normalized.value(0).to_bits(), 0.0f64.to_bits());
         assert_eq!(normalized.value(1).to_bits(), 0.0f64.to_bits());
-        assert!(normalized.value(2).is_nan());
-        assert!(normalized.is_null(3));
-        assert_eq!(normalized.value(4), 1.5);
+        assert_eq!(normalized.value(2).to_bits(), f64::NAN.to_bits());
+        assert_eq!(normalized.value(3).to_bits(), f64::NAN.to_bits());
+        assert!(normalized.is_null(4));
+        assert_eq!(normalized.value(5), 1.5);
     }
 
     #[test]
     fn test_normalize_nested_list_floats() {
         let mut builder = ListBuilder::new(Float64Builder::new());
         builder.values().append_value(-0.0);
-        builder.values().append_value(f64::NAN);
+        builder.values().append_value(-f64::NAN);
         builder.append(true);
         let arr: ArrayRef = Arc::new(builder.finish());
 
-        let normalized = normalize_negative_zero(&arr);
+        let normalized = normalize_nested_floats(&arr);
         let normalized = normalized.as_list::<i32>();
         let inner = normalized.value(0);
-        let inner = inner.as_primitive::<arrow::datatypes::Float64Type>();
+        let inner = inner.as_primitive::<Float64Type>();
 
         assert_eq!(inner.value(0).to_bits(), 0.0f64.to_bits());
-        assert!(inner.value(1).is_nan());
+        assert_eq!(inner.value(1).to_bits(), f64::NAN.to_bits());
     }
 
     #[test]
     fn test_normalize_struct_floats() {
         let a = Float64Array::from(vec![Some(-0.0), Some(1.0)]);
-        let b = Float64Array::from(vec![Some(f64::NAN), Some(-0.0)]);
+        let b = Float64Array::from(vec![Some(-f64::NAN), Some(-0.0)]);
         let fields = vec![
             Arc::new(Field::new("a", DataType::Float64, true)),
             Arc::new(Field::new("b", DataType::Float64, true)),
@@ -143,24 +174,20 @@ mod tests {
             None,
         ));
 
-        let normalized = normalize_negative_zero(&arr);
+        let normalized = normalize_nested_floats(&arr);
         let normalized = normalized.as_struct();
-        let col_a = normalized
-            .column(0)
-            .as_primitive::<arrow::datatypes::Float64Type>();
-        let col_b = normalized
-            .column(1)
-            .as_primitive::<arrow::datatypes::Float64Type>();
+        let col_a = normalized.column(0).as_primitive::<Float64Type>();
+        let col_b = normalized.column(1).as_primitive::<Float64Type>();
 
         assert_eq!(col_a.value(0).to_bits(), 0.0f64.to_bits());
         assert_eq!(col_a.value(1), 1.0);
-        assert!(col_b.value(0).is_nan());
+        assert_eq!(col_b.value(0).to_bits(), f64::NAN.to_bits());
         assert_eq!(col_b.value(1).to_bits(), 0.0f64.to_bits());
     }
 
     #[test]
     fn test_normalize_fixed_size_list_floats() {
-        let values = Float64Array::from(vec![Some(-0.0), Some(f64::NAN), Some(1.0), Some(-0.0)]);
+        let values = Float64Array::from(vec![Some(-0.0), Some(-f64::NAN), Some(1.0), Some(-0.0)]);
         let field = Arc::new(Field::new("item", DataType::Float64, true));
         let arr: ArrayRef = Arc::new(FixedSizeListArray::new(
             Arc::clone(&field),
@@ -169,14 +196,12 @@ mod tests {
             None,
         ));
 
-        let normalized = normalize_negative_zero(&arr);
+        let normalized = normalize_nested_floats(&arr);
         let normalized = normalized.as_fixed_size_list();
-        let flat = normalized
-            .values()
-            .as_primitive::<arrow::datatypes::Float64Type>();
+        let flat = normalized.values().as_primitive::<Float64Type>();
 
         assert_eq!(flat.value(0).to_bits(), 0.0f64.to_bits());
-        assert!(flat.value(1).is_nan());
+        assert_eq!(flat.value(1).to_bits(), f64::NAN.to_bits());
         assert_eq!(flat.value(2), 1.0);
         assert_eq!(flat.value(3).to_bits(), 0.0f64.to_bits());
     }

--- a/native/spark-expr/src/array_funcs/nested_float_normalize.rs
+++ b/native/spark-expr/src/array_funcs/nested_float_normalize.rs
@@ -1,0 +1,183 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::{
+    Array, ArrayRef, AsArray, FixedSizeListArray, Float32Array, Float64Array, LargeListArray,
+    ListArray, StructArray,
+};
+use arrow::datatypes::DataType;
+use std::sync::Arc;
+
+/// Recursively rebuilds nested arrays with `-0.0` normalized to `0.0` in any
+/// Float32/Float64 leaves, leaving NaN untouched.
+pub(super) fn normalize_negative_zero(array: &ArrayRef) -> ArrayRef {
+    match array.data_type() {
+        DataType::Float32 => {
+            let arr = array.as_primitive::<arrow::datatypes::Float32Type>();
+            let normalized: Float32Array = arr
+                .iter()
+                .map(|v| v.map(|v| if v == 0.0 { 0.0f32 } else { v }))
+                .collect();
+            Arc::new(normalized)
+        }
+        DataType::Float64 => {
+            let arr = array.as_primitive::<arrow::datatypes::Float64Type>();
+            let normalized: Float64Array = arr
+                .iter()
+                .map(|v| v.map(|v| if v == 0.0 { 0.0f64 } else { v }))
+                .collect();
+            Arc::new(normalized)
+        }
+        DataType::List(field) => {
+            let list = array.as_list::<i32>();
+            let normalized_values = normalize_negative_zero(list.values());
+            Arc::new(ListArray::new(
+                Arc::clone(field),
+                list.offsets().clone(),
+                normalized_values,
+                list.nulls().cloned(),
+            ))
+        }
+        DataType::LargeList(field) => {
+            let list = array.as_list::<i64>();
+            let normalized_values = normalize_negative_zero(list.values());
+            Arc::new(LargeListArray::new(
+                Arc::clone(field),
+                list.offsets().clone(),
+                normalized_values,
+                list.nulls().cloned(),
+            ))
+        }
+        DataType::FixedSizeList(field, size) => {
+            let list = array.as_fixed_size_list();
+            let normalized_values = normalize_negative_zero(list.values());
+            Arc::new(FixedSizeListArray::new(
+                Arc::clone(field),
+                *size,
+                normalized_values,
+                list.nulls().cloned(),
+            ))
+        }
+        DataType::Struct(_) => {
+            let s = array.as_struct();
+            let normalized_columns: Vec<ArrayRef> =
+                s.columns().iter().map(normalize_negative_zero).collect();
+            Arc::new(StructArray::new(
+                s.fields().clone(),
+                normalized_columns,
+                s.nulls().cloned(),
+            ))
+        }
+        _ => Arc::clone(array),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Float64Builder;
+    use arrow::array::ListBuilder;
+    use arrow::datatypes::Field;
+
+    #[test]
+    fn test_normalize_flat_floats() {
+        let arr: ArrayRef = Arc::new(Float64Array::from(vec![
+            Some(-0.0),
+            Some(0.0),
+            Some(f64::NAN),
+            None,
+            Some(1.5),
+        ]));
+        let normalized = normalize_negative_zero(&arr);
+        let normalized = normalized.as_primitive::<arrow::datatypes::Float64Type>();
+
+        assert_eq!(normalized.value(0).to_bits(), 0.0f64.to_bits());
+        assert_eq!(normalized.value(1).to_bits(), 0.0f64.to_bits());
+        assert!(normalized.value(2).is_nan());
+        assert!(normalized.is_null(3));
+        assert_eq!(normalized.value(4), 1.5);
+    }
+
+    #[test]
+    fn test_normalize_nested_list_floats() {
+        let mut builder = ListBuilder::new(Float64Builder::new());
+        builder.values().append_value(-0.0);
+        builder.values().append_value(f64::NAN);
+        builder.append(true);
+        let arr: ArrayRef = Arc::new(builder.finish());
+
+        let normalized = normalize_negative_zero(&arr);
+        let normalized = normalized.as_list::<i32>();
+        let inner = normalized.value(0);
+        let inner = inner.as_primitive::<arrow::datatypes::Float64Type>();
+
+        assert_eq!(inner.value(0).to_bits(), 0.0f64.to_bits());
+        assert!(inner.value(1).is_nan());
+    }
+
+    #[test]
+    fn test_normalize_struct_floats() {
+        let a = Float64Array::from(vec![Some(-0.0), Some(1.0)]);
+        let b = Float64Array::from(vec![Some(f64::NAN), Some(-0.0)]);
+        let fields = vec![
+            Arc::new(Field::new("a", DataType::Float64, true)),
+            Arc::new(Field::new("b", DataType::Float64, true)),
+        ];
+        let arr: ArrayRef = Arc::new(StructArray::new(
+            fields.into(),
+            vec![Arc::new(a), Arc::new(b)],
+            None,
+        ));
+
+        let normalized = normalize_negative_zero(&arr);
+        let normalized = normalized.as_struct();
+        let col_a = normalized
+            .column(0)
+            .as_primitive::<arrow::datatypes::Float64Type>();
+        let col_b = normalized
+            .column(1)
+            .as_primitive::<arrow::datatypes::Float64Type>();
+
+        assert_eq!(col_a.value(0).to_bits(), 0.0f64.to_bits());
+        assert_eq!(col_a.value(1), 1.0);
+        assert!(col_b.value(0).is_nan());
+        assert_eq!(col_b.value(1).to_bits(), 0.0f64.to_bits());
+    }
+
+    #[test]
+    fn test_normalize_fixed_size_list_floats() {
+        let values = Float64Array::from(vec![Some(-0.0), Some(f64::NAN), Some(1.0), Some(-0.0)]);
+        let field = Arc::new(Field::new("item", DataType::Float64, true));
+        let arr: ArrayRef = Arc::new(FixedSizeListArray::new(
+            Arc::clone(&field),
+            2,
+            Arc::new(values),
+            None,
+        ));
+
+        let normalized = normalize_negative_zero(&arr);
+        let normalized = normalized.as_fixed_size_list();
+        let flat = normalized
+            .values()
+            .as_primitive::<arrow::datatypes::Float64Type>();
+
+        assert_eq!(flat.value(0).to_bits(), 0.0f64.to_bits());
+        assert!(flat.value(1).is_nan());
+        assert_eq!(flat.value(2), 1.0);
+        assert_eq!(flat.value(3).to_bits(), 0.0f64.to_bits());
+    }
+}

--- a/spark/src/test/resources/sql-tests/expressions/array/array_position.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_position.sql
@@ -254,6 +254,23 @@ INSERT INTO test_ap_nested_str VALUES
 query
 SELECT array_position(arr, val) FROM test_ap_nested_str
 
+-- nested double array column: -0.0 and 0.0 are equal under Spark's nested ordering
+statement
+CREATE TABLE test_ap_nested_dbl(arr array<array<double>>, val array<double>) USING parquet
+
+statement
+INSERT INTO test_ap_nested_dbl VALUES
+  (array(array(1.0), array(double('-0.0'))), array(double('0.0'))),
+  (array(array(double('-0.0')), array(1.0)), array(double('0.0'))),
+  (array(array(double('0.0')), array(1.0)), array(double('-0.0'))),
+  (array(array(double('NaN'))), array(double('NaN'))),
+  (array(array(1.0)), array(2.0)),
+  (NULL, array(double('0.0'))),
+  (array(array(double('0.0'))), NULL)
+
+query
+SELECT array_position(arr, val) FROM test_ap_nested_dbl
+
 -- timestamp arrays
 statement
 CREATE TABLE test_ap_ts(arr array<timestamp>, val timestamp) USING parquet

--- a/spark/src/test/resources/sql-tests/expressions/array/arrays_overlap.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/arrays_overlap.sql
@@ -117,7 +117,7 @@ statement
 CREATE TABLE test_overlap_dbl(a array<double>, b array<double>) USING parquet
 
 statement
-INSERT INTO test_overlap_dbl VALUES (array(1.0, 2.0), array(2.0, 3.0)), (array(1.0, double('NaN')), array(double('NaN'), 2.0)), (array(double('Infinity'), 1.0), array(double('Infinity'))), (array(double('-Infinity')), array(double('Infinity'))), (array(0.0), array(-0.0)), (array(1.0, NULL), array(2.0, NULL))
+INSERT INTO test_overlap_dbl VALUES (array(1.0, 2.0), array(2.0, 3.0)), (array(1.0, double('NaN')), array(double('NaN'), 2.0)), (array(double('Infinity'), 1.0), array(double('Infinity'))), (array(double('-Infinity')), array(double('Infinity'))), (array(double('0.0')), array(double('-0.0'))), (array(1.0, NULL), array(2.0, NULL))
 
 query
 SELECT a, b, arrays_overlap(a, b) FROM test_overlap_dbl
@@ -181,6 +181,38 @@ INSERT INTO test_overlap_nested VALUES (array(array(1, 2), array(3, 4)), array(a
 
 query
 SELECT a, b, arrays_overlap(a, b) FROM test_overlap_nested
+
+-- nested double arrays: Spark's nested path uses ordering.equiv, where -0.0 == 0.0
+statement
+CREATE TABLE test_overlap_nested_dbl(a array<array<double>>, b array<array<double>>) USING parquet
+
+statement
+INSERT INTO test_overlap_nested_dbl VALUES
+  (array(array(double('-0.0'))), array(array(double('0.0')))),
+  (array(array(double('0.0'))), array(array(double('-0.0')))),
+  (array(array(1.0, double('-0.0'))), array(array(1.0, 0.0))),
+  (array(array(double('NaN'))), array(array(double('NaN')))),
+  (array(array(1.0)), array(array(2.0))),
+  (array(array(double('-0.0')), cast(NULL as array<double>)), array(array(double('0.0')))),
+  (array(cast(NULL as array<double>)), array(array(double('0.0'))))
+
+query
+SELECT a, b, arrays_overlap(a, b) FROM test_overlap_nested_dbl
+
+-- struct element with a double field
+statement
+CREATE TABLE test_overlap_struct_dbl(a array<struct<x:double>>, b array<struct<x:double>>) USING parquet
+
+statement
+INSERT INTO test_overlap_struct_dbl VALUES
+  (array(named_struct('x', double('-0.0'))), array(named_struct('x', double('0.0')))),
+  (array(named_struct('x', double('0.0'))), array(named_struct('x', double('-0.0')))),
+  (array(named_struct('x', double('NaN'))), array(named_struct('x', double('NaN')))),
+  (array(named_struct('x', 1.0)), array(named_struct('x', 2.0))),
+  (array(cast(NULL as struct<x:double>)), array(named_struct('x', double('0.0'))))
+
+query
+SELECT a, b, arrays_overlap(a, b) FROM test_overlap_struct_dbl
 
 -- struct element arrays
 statement


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5191.

## Rationale for this change

Arrow's nested comparator (`make_comparator`, used by `arrays_overlap`'s nested path and `array_position`'s nested fallback) orders floats by total order, where `-0.0` and `0.0` are distinct. Spark's `ordering.equiv` (used for structural equality of nested elements) checks numeric equality first, so `-0.0 == 0.0` there, while `NaN == NaN` still holds in both.

## What changes are included in this PR?

- Add `nested_float_normalize.rs`: recursively rebuilds nested (List/LargeList/FixedSizeList/Struct) arrays with `-0.0` normalized to `0.0` in Float32/Float64 leaves, leaving NaN untouched.
- `arrays_overlap.rs`: normalize both sides before building the nested comparator; update `test_nested_float_total_order` to assert `-0.0` and `0.0` now overlap; add `test_struct_float_field_signed_zero_overlap` covering a struct field.
- `array_position.rs`: normalize both sides before building the fallback comparator; update `test_nested_float_and_null_position` (result changes from `[2, 2, 1]` to `[2, 1, 1]` since row 1's `-0.0` vs `0.0` now matches at position 1); add `test_struct_float_field_signed_zero_position` covering a struct field.

Note: #5194 is a separate issue (#5101, comparator-hoisting for perf) but touches the same comparator-construction code path. Happy to rebase on top of whichever lands first.

## How are these changes tested?

- `cargo test -p datafusion-comet-spark-expr` — all 600+ tests pass, including the new/updated ones above.
- `cargo clippy -p datafusion-comet-spark-expr --lib -- -D warnings` — clean.
- `cargo fmt -p datafusion-comet-spark-expr -- --check` — clean.
- `cargo check --workspace` — clean.