### PR TITLE
docs: document ReusedExchange caveat and both CometSparkToColumnar names in operator-count exclusions

### DIFF
--- a/docs/source/user-guide/latest/understanding-comet-plans.md
+++ b/docs/source/user-guide/latest/understanding-comet-plans.md
@@ -182,12 +182,22 @@ Not every node in the plan is an eligible operator. The following are excluded
 from both operator counts:
 
 - Transition nodes (`CometColumnarToRow`, `CometNativeColumnarToRow`,
-  `CometSparkRowToColumnar`, `ColumnarToRow`, `RowToColumnar`), which are
-  reported separately as the transition count.
+  `CometSparkRowToColumnar`, `CometSparkColumnarToColumnar`, `ColumnarToRow`,
+  `RowToColumnar`), which are reported separately as the transition count.
+  `CometSparkRowToColumnar` and `CometSparkColumnarToColumnar` are the two names
+  a single operator renders under, depending on whether its child already
+  produces columnar data, and both are excluded.
 - Wrappers that do no work of their own: `AdaptiveSparkPlan`, `InputAdapter`,
   `WholeStageCodegen`, query stages, and `AQEShuffleRead`.
 - The reuse marker `ReusedSubquery`. The subquery it points at is counted where
   that subquery is shown, so the marker itself does not add to the totals.
+- `ReusedExchange`, but with a caveat: it is not cleanly excluded the way the
+  wrappers above are. The node itself is skipped, and yet walking the plan
+  replaces it with the exchange it reuses, so the reused subtree is counted once
+  per reference rather than once for the whole plan. A plan that reuses one
+  exchange in three places contributes that subtree's operators three times.
+  Counting reused exchanges once is tracked as item 3 of
+  [#5203](https://github.com/apache/datafusion-comet/issues/5203).
 
 ### `spark.comet.explain.native.enabled`
 


### PR DESCRIPTION
## Which issue does this PR close?

Docs follow-up to review feedback on #5206, which was deferred to keep that PR's CI
scope small.

## Rationale for this change

#5206 added a section to `understanding-comet-plans.md` listing the nodes excluded from
the operator counts in the extended explain summary. Review raised two gaps in that
list.

## What changes are included in this PR?

1. **Both rendered names of `CometSparkToColumnarExec` are listed.** `nodeName` returns
   `CometSparkColumnarToColumnar` when `child.supportsColumnar` is true and
   `CometSparkRowToColumnar` otherwise, but the transition-nodes bullet only named the
   latter. Both are already excluded today, because `generateTreeString` matches on the
   Scala type rather than the rendered name, so a reader who sees
   `CometSparkColumnarToColumnar` in their own explain output could not tell from the
   list that it was covered. The bullet now names both and says they are one operator
   under two names. This matches the Columnar/Row Transitions table further down, which
   already documents both names.

2. **`ReusedExchange` is now covered, with its caveat.** It is matched in the same
   ignore arm as `AdaptiveSparkPlanExec`, `InputAdapter`, `WholeStageCodegenExec`,
   `QueryStageExec`, and `AQEShuffleReadExec`, but was not mentioned anywhere in the
   section. It also does not behave like those wrappers: `getActualPlan` unwraps it to
   its child, so the reused subtree is counted once per reference rather than once for
   the whole plan. Since the section exists to explain what is excluded and why, the new
   bullet states that the node itself is skipped, spells out the per-reference
   double-counting with a concrete example, and points at item 3 of #5203 as the
   tracking issue.

No prose was removed, and no non-docs files are touched.

## How are these changes tested?

Docs-only. `npx prettier "docs/source/user-guide/latest/understanding-comet-plans.md"
--check` passes. No new in-page anchor links were added: MyST slugifies the
`Columnar/Row Transitions` heading with the slash dropped, so a natural-looking
`#columnar-row-transitions` link would have been broken, and the two node names are
explained inline in the bullet instead.
