### PR TITLE
chore: [branch-1.0] change version from 1.0.0-SNAPSHOT to 1.0.0

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -26,7 +26,7 @@ under the License.
   <parent>
     <groupId>org.apache.datafusion</groupId>
     <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dev/diffs/3.4.3.diff
+++ b/dev/diffs/3.4.3.diff
@@ -7,7 +7,7 @@ index d3544881af1..ff963395ec3 100644
      <ivy.version>2.5.1</ivy.version>
      <oro.version>2.0.8</oro.version>
 +    <spark.version.short>3.4</spark.version.short>
-+    <comet.version>1.0.0-SNAPSHOT</comet.version>
++    <comet.version>1.0.0</comet.version>
      <!--
      If you changes codahale.metrics.version, you also need to change
      the link to metrics.dropwizard.io in docs/monitoring.md.

--- a/dev/diffs/3.5.9.diff
+++ b/dev/diffs/3.5.9.diff
@@ -7,7 +7,7 @@ index 49eca0f7555..ba234805889 100644
      <ivy.version>2.5.3</ivy.version>
      <oro.version>2.0.8</oro.version>
 +    <spark.version.short>3.5</spark.version.short>
-+    <comet.version>1.0.0-SNAPSHOT</comet.version>
++    <comet.version>1.0.0</comet.version>
      <!--
      If you changes codahale.metrics.version, you also need to change
      the link to metrics.dropwizard.io in docs/monitoring.md.

--- a/dev/diffs/4.0.4.diff
+++ b/dev/diffs/4.0.4.diff
@@ -47,7 +47,7 @@ index 046f357ff79..02dffbf9510 100644
      <ivy.version>2.5.3</ivy.version>
      <oro.version>2.0.8</oro.version>
 +    <spark.version.short>4.0</spark.version.short>
-+    <comet.version>1.0.0-SNAPSHOT</comet.version>
++    <comet.version>1.0.0</comet.version>
      <!--
      If you change codahale.metrics.version, you also need to change
      the link to metrics.dropwizard.io in docs/monitoring.md.

--- a/dev/diffs/4.1.3.diff
+++ b/dev/diffs/4.1.3.diff
@@ -47,7 +47,7 @@ index 370bfa4397f..8447b5c375e 100644
      <ivy.version>2.5.3</ivy.version>
      <oro.version>2.0.8</oro.version>
 +    <spark.version.short>4.1</spark.version.short>
-+    <comet.version>1.0.0-SNAPSHOT</comet.version>
++    <comet.version>1.0.0</comet.version>
      <!--
      If you change codahale.metrics.version, you also need to change
      the link to metrics.dropwizard.io in docs/monitoring.md.

--- a/dev/diffs/iceberg/1.10.0.diff
+++ b/dev/diffs/iceberg/1.10.0.diff
@@ -7,7 +7,7 @@ index eeabe54f5f..a76d7bdcbc 100644
  caffeine = "2.9.3"
  calcite = "1.40.0"
 -comet = "0.8.1"
-+comet = "1.0.0-SNAPSHOT"
++comet = "1.0.0"
  datasketches = "6.2.0"
  delta-standalone = "3.3.2"
  delta-spark = "3.3.2"

--- a/dev/diffs/iceberg/1.11.0.diff
+++ b/dev/diffs/iceberg/1.11.0.diff
@@ -6,7 +6,7 @@ index db659dc06b..78f5e3440f 100644
  bson-ver = "4.11.5"
  caffeine = "2.9.3"
  calcite = "1.41.0"
-+comet = "1.0.0-SNAPSHOT"
++comet = "1.0.0"
  datasketches = "6.2.0"
  delta-standalone = "3.3.2"
  delta-spark = "3.3.2"

--- a/dev/diffs/iceberg/1.8.1.diff
+++ b/dev/diffs/iceberg/1.8.1.diff
@@ -6,7 +6,7 @@ index 04ffa8f4ed..5a925fd594 100644
  awssdk-s3accessgrants = "2.3.0"
  caffeine = "2.9.3"
  calcite = "1.10.0"
-+comet = "1.0.0-SNAPSHOT"
++comet = "1.0.0"
  datasketches = "6.2.0"
  delta-standalone = "3.3.0"
  delta-spark = "3.3.0"

--- a/dev/diffs/iceberg/1.9.1.diff
+++ b/dev/diffs/iceberg/1.9.1.diff
@@ -6,7 +6,7 @@ index c50991c5fc..2892f11068 100644
  bson-ver = "4.11.5"
  caffeine = "2.9.3"
  calcite = "1.39.0"
-+comet = "1.0.0-SNAPSHOT"
++comet = "1.0.0"
  datasketches = "6.2.0"
  delta-standalone = "3.3.1"
  delta-spark = "3.3.1"

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ under the License.
   </parent>
   <groupId>org.apache.datafusion</groupId>
   <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>pom</packaging>
   <name>Comet Project Parent POM</name>
 

--- a/spark-integration/pom.xml
+++ b/spark-integration/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.datafusion</groupId>
         <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -26,7 +26,7 @@ under the License.
   <parent>
     <groupId>org.apache.datafusion</groupId>
     <artifactId>comet-parent-spark${spark.version.short}_${scala.binary.version}</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
## Which issue does this PR close?

N/A - this is a release process step for the 1.0.0 release.

## Rationale for this change

The [release process](https://github.com/apache/datafusion-comet/blob/main/docs/source/contributor-guide/release_process.md#update-maven-version) requires that the Maven version on the release branch is changed from `1.0.0-SNAPSHOT` to `1.0.0` before the release candidate is tagged, so that the staged Maven artifacts and the source tarball carry the final release version.

This was previously done in #5105, but `branch-1.0` has since been re-cut from `main`, so the bump needs to be reapplied.

## What changes are included in this PR?

- Change the Maven version from `1.0.0-SNAPSHOT` to `1.0.0` in `pom.xml`, `common/pom.xml`, `spark/pom.xml`, and `spark-integration/pom.xml`.
- Update `comet.version` in the Spark test diffs (`dev/diffs/3.4.3.diff`, `3.5.9.diff`, `4.0.4.diff`, `4.1.3.diff`).
- Update the `comet` version in the Iceberg diffs (`dev/diffs/iceberg/1.8.1.diff`, `1.9.1.diff`, `1.10.0.diff`, `1.11.0.diff`).

The Rust crate versions in `native/Cargo.toml` are already `1.0.0` and do not need to change.

`git grep -n '1.0.0-SNAPSHOT' -- . ':!docs/source/changelog'` now returns no hits. The PyArrow UDF jar-resolution fix from #5105 (`spark/src/test/resources/pyspark/conftest.py`) already landed on `main`, so it is not needed here.

## How are these changes tested?

`./mvnw validate` passes. Otherwise existing CI: the Spark SQL and Iceberg test workflows apply the updated diffs and build against the new version, so they cover the version references in both the poms and the diff files.
