### PR TITLE
feat: support make_interval via codegen dispatch

### DIFF
--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -277,7 +277,7 @@ The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `deci
 | `localtimestamp` | ✅ | — |  |
 | `make_date` | ✅ | Native |  |
 | `make_dt_interval` | ✅ | Codegen dispatch |  |
-| `make_interval` | 🔜 | — | Produces legacy CalendarInterval; tracked by [#5061](https://github.com/apache/datafusion-comet/issues/5061) |
+| `make_interval` | ✅ | Codegen dispatch |  |
 | `make_time` | 🔜 | — | Spark 4.1 TIME type; tracked by [#4288](https://github.com/apache/datafusion-comet/issues/4288) |
 | `make_timestamp` | ✅ | Hybrid |  |
 | `make_timestamp_ltz` | ✅ | — | 2-arg TIME form falls back |

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -303,6 +303,7 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
       classOf[MakeTimestamp] -> CometMakeTimestamp,
       classOf[MakeYMInterval] -> CometMakeYMInterval,
       classOf[MakeDTInterval] -> CometMakeDTInterval,
+      classOf[MakeInterval] -> CometMakeInterval,
       classOf[MultiplyDTInterval] -> CometMultiplyDTInterval,
       classOf[MicrosToTimestamp] -> CometMicrosToTimestamp,
       classOf[MillisToTimestamp] -> CometMillisToTimestamp,

--- a/spark/src/main/scala/org/apache/comet/serde/datetime.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/datetime.scala
@@ -21,7 +21,7 @@ package org.apache.comet.serde
 
 import java.util.Locale
 
-import org.apache.spark.sql.catalyst.expressions.{AddMonths, Attribute, ConvertTimezone, DateAdd, DateDiff, DateFormatClass, DateFromUnixDate, DateSub, DayOfMonth, DayOfWeek, DayOfYear, Days, Expression, FromUTCTimestamp, GetDateField, GetTimestamp, Hour, Hours, LastDay, Literal, MakeDate, MakeDTInterval, MakeTimestamp, MakeYMInterval, MicrosToTimestamp, MillisToTimestamp, Minute, Month, MonthsBetween, MultiplyDTInterval, NextDay, PreciseTimestampConversion, Quarter, Second, SecondsToTimestamp, ToUnixTimestamp, ToUTCTimestamp, TruncDate, TruncTimestamp, UnixDate, UnixMicros, UnixMillis, UnixSeconds, UnixTimestamp, WeekDay, WeekOfYear, Year}
+import org.apache.spark.sql.catalyst.expressions.{AddMonths, Attribute, ConvertTimezone, DateAdd, DateDiff, DateFormatClass, DateFromUnixDate, DateSub, DayOfMonth, DayOfWeek, DayOfYear, Days, Expression, FromUTCTimestamp, GetDateField, GetTimestamp, Hour, Hours, LastDay, Literal, MakeDate, MakeDTInterval, MakeInterval, MakeTimestamp, MakeYMInterval, MicrosToTimestamp, MillisToTimestamp, Minute, Month, MonthsBetween, MultiplyDTInterval, NextDay, PreciseTimestampConversion, Quarter, Second, SecondsToTimestamp, ToUnixTimestamp, ToUTCTimestamp, TruncDate, TruncTimestamp, UnixDate, UnixMicros, UnixMillis, UnixSeconds, UnixTimestamp, WeekDay, WeekOfYear, Year}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, DateType, DoubleType, FloatType, IntegerType, LongType, StringType, TimestampNTZType, TimestampType}
 import org.apache.spark.unsafe.types.UTF8String
@@ -967,6 +967,8 @@ object CometGetTimestamp extends CometCodegenDispatch[GetTimestamp]
 object CometMakeYMInterval extends CometCodegenDispatch[MakeYMInterval]
 
 object CometMakeDTInterval extends CometCodegenDispatch[MakeDTInterval]
+
+object CometMakeInterval extends CometCodegenDispatch[MakeInterval]
 
 object CometMultiplyDTInterval extends CometCodegenDispatch[MultiplyDTInterval]
 

--- a/spark/src/test/resources/sql-tests/expressions/datetime/make_interval.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/make_interval.sql
@@ -1,0 +1,83 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- make_interval runs through the codegen dispatcher and produces CalendarIntervalType.
+-- The suite disables ANSI mode, so MakeInterval.failOnError is false here and overflow
+-- yields NULL. See make_interval_ansi.sql for the throwing path.
+-- Config: spark.comet.exec.scalaUDF.codegen.enabled=true
+
+statement
+CREATE TABLE test_make_interval(y int, mo int, w int, d int, h int, mi int, s decimal(18,6)) USING parquet
+
+statement
+INSERT INTO test_make_interval VALUES
+  (1, 2, 3, 4, 5, 6, 7.008009),
+  (30, 25, 0, -100, 40, 80, 299.889987),
+  (0, -1, 0, 1, 0, 0, -1.000000),
+  (-1, -2, -3, -4, -5, -6, -7.500000),
+  (0, 0, 0, 0, 0, 0, 0.000000),
+  (NULL, 2, 3, 4, 5, 6, 7.008009),
+  (1, 2, 3, 4, 5, 6, NULL)
+
+-- all seven arguments as columns
+query
+SELECT make_interval(y, mo, w, d, h, mi, s) FROM test_make_interval
+
+-- the shorter arities filled in by MakeInterval's auxiliary constructors
+query
+SELECT
+  make_interval(y),
+  make_interval(y, mo),
+  make_interval(y, mo, w),
+  make_interval(y, mo, w, d),
+  make_interval(y, mo, w, d, h),
+  make_interval(y, mo, w, d, h, mi)
+FROM test_make_interval
+
+-- mixed literal and column arguments
+query
+SELECT
+  make_interval(1, mo, 3, d, 5, mi, 7.008009),
+  make_interval(y, 2, w, 4, h, 6, s)
+FROM test_make_interval
+
+-- literal arguments (constant folding is disabled by the test suite)
+query
+SELECT
+  make_interval(1, 2, 3, 4, 5, 6, 7.008009),
+  make_interval(0, 0, 0, 0, 0, 0, 0),
+  make_interval(-1, -2, -3, -4, -5, -6, -7.5),
+  make_interval(0, 13, 0, 0, 25, 61, 61.5)
+
+-- NULL arguments propagate. These have to come from nullable columns rather than NULL
+-- literals: MakeInterval is NullIntolerant, so NullPropagation rewrites any call with a
+-- literal NULL argument to a null interval literal and the expression never reaches Comet.
+-- Such a literal currently fails natively rather than falling back, tracked by #5058.
+query
+SELECT
+  make_interval(y, 2, 3, 4, 5, 6, 7.008009),
+  make_interval(1, 2, 3, 4, 5, 6, s),
+  make_interval(y)
+FROM test_make_interval
+
+-- years * 12 exceeds the int range. Outside ANSI mode MakeInterval swallows the
+-- ArithmeticException and returns NULL.
+query
+SELECT
+  make_interval(200000000, 0, 0, 0, 0, 0, 0),
+  make_interval(y + 200000000, mo, w, d, h, mi, s)
+FROM test_make_interval

--- a/spark/src/test/resources/sql-tests/expressions/datetime/make_interval_ansi.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/make_interval_ansi.sql
@@ -1,0 +1,49 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- MakeInterval.failOnError defaults to SQLConf.get.ansiEnabled, so in ANSI mode overflow
+-- raises ARITHMETIC_OVERFLOW instead of returning NULL. The exception has to cross out of
+-- the generated kernel and surface as the same Spark error.
+-- See make_interval.sql for the non-ANSI coverage.
+-- Config: spark.sql.ansi.enabled=true
+-- Config: spark.comet.exec.scalaUDF.codegen.enabled=true
+
+statement
+CREATE TABLE test_make_interval_ansi(y int, mo int, w int, d int, h int, mi int, s decimal(18,6)) USING parquet
+
+statement
+INSERT INTO test_make_interval_ansi VALUES
+  (1, 2, 3, 4, 5, 6, 7.008009),
+  (-1, -2, -3, -4, -5, -6, -7.500000),
+  (NULL, 2, 3, 4, 5, 6, 7.008009)
+
+-- valid inputs still evaluate normally under ANSI, and act as the sentinel proving the
+-- expression is not silently falling back to Spark
+query
+SELECT make_interval(y, mo, w, d, h, mi, s) FROM test_make_interval_ansi
+
+query
+SELECT make_interval(1, 2, 3, 4, 5, 6, 7.008009)
+
+-- years * 12 overflows the int range. Spark 3.5 renders ARITHMETIC_OVERFLOW without the
+-- condition name in the message, so match on the shared "overflow" text instead.
+query expect_error(overflow)
+SELECT make_interval(200000000, 0, 0, 0, 0, 0, 0)
+
+-- weeks * 7 overflows the int range
+query expect_error(overflow)
+SELECT make_interval(0, 0, 400000000, 0, 0, 0, 0)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #3099. Part of the interval support epic #5061.

Split out of #5030, which originally carried this alongside `timestampadd` and `timestampdiff`. Those two are unrelated to `make_interval` beyond sharing the codegen-dispatch mechanism, so they now travel separately.

Note there is an alternative native implementation in #5039, which wires `make_interval` to DataFusion's `SparkMakeInterval`. The two approaches are mutually exclusive; see the trade-off below.

## Rationale for this change

`MakeInterval` has no Comet handler today, so any query using `make_interval` falls the entire operator back to Spark. It is a regular expression, not `RuntimeReplaceable`, so it reaches serde directly.

This PR routes it through the JVM codegen dispatcher rather than adding a native implementation. The dispatcher runs Spark's own generated code inside the native Comet pipeline, which keeps the operator native while guaranteeing bit-for-bit Spark compatibility. For `make_interval` specifically this covers three behaviors that are easy to diverge on natively:

- the `seconds` argument is a `Decimal(18, 6)` scaled to microseconds, with its own overflow check;
- `failOnError` (defaulting to `SQLConf.ansiEnabled`) chooses between raising `ARITHMETIC_OVERFLOW` and returning NULL, and it must be the same exception Spark raises;
- the `years * 12` and `weeks * 7` products overflow `int` independently of one another.

`make_interval` produces `CalendarIntervalType`, which Comet's columnar layer gained support for in #4898. With that in place the dispatcher can carry its output.

The trade-off against #5039: codegen dispatch gives exact Spark semantics for free but runs JVM code per batch, so it is slower than a native kernel. A native implementation is the better end state if it can match Spark on the decimal scaling and both ANSI paths. This PR is the low-risk option and can be superseded.

## What changes are included in this PR?

- `CometMakeInterval` codegen-dispatch serde in `datetime.scala`, registered in `QueryPlanSerde`'s `temporalExpressions` map.
- `make_interval.sql` and `make_interval_ansi.sql` Comet SQL file tests.
- The `make_interval` row in the Supported Spark Expressions guide.

## How are these changes tested?

New Comet SQL file tests run each query through both Spark and Comet, verify the results match, and verify Comet executes the expression through the dispatcher rather than falling back.

`make_interval.sql` (non-ANSI, so `failOnError` is false) covers:

- all seven arguments as columns, and each of the shorter arities filled in by `MakeInterval`'s auxiliary constructors;
- mixed literal/column arguments and all-literal arguments (the suite disables constant folding, so these still reach Comet);
- negative and zero components, and values that carry across units (25 months, 80 minutes, 299.889987 seconds);
- NULL propagation from nullable columns. It has to come from columns rather than NULL literals: `MakeInterval` is `NullIntolerant`, so `NullPropagation` rewrites any call with a literal NULL argument into a null interval literal that never reaches Comet. That literal currently fails natively, tracked separately by #5058.
- overflow returning NULL when `years * 12` exceeds the int range.

`make_interval_ansi.sql` pins `spark.sql.ansi.enabled=true` so `failOnError` is true, and asserts the overflow raises the same error Spark does for both the `years * 12` and `weeks * 7` products. Each error query sits alongside valid-input queries in the same file so the case cannot pass vacuously through a fallback.

Verified green on Spark 3.5 and 4.1 locally, along with the pre-existing `calendar_interval.sql` fixture and the `explain comet` test in `CometExpressionSuite`, both of which use `make_interval`.
