### PR TITLE
chore: load Comet on demand

### DIFF
--- a/native/core/src/lib.rs
+++ b/native/core/src/lib.rs
@@ -142,7 +142,7 @@ const LOG_PATTERN: &str = "{d(%y/%m/%d %H:%M:%S)} {l} {f}: {m}{n}";
 /// * `1` (true) if the feature is enabled
 /// * `0` (false) if the feature is disabled or unknown
 #[no_mangle]
-pub extern "system" fn Java_org_apache_comet_NativeBase_nativeIsFeatureEnabled(
+pub extern "system" fn Java_org_apache_comet_NativeBase_isFeatureEnabledImpl(
     env: EnvUnowned,
     _: JClass,
     feature_name: JString,
@@ -170,7 +170,7 @@ pub extern "system" fn Java_org_apache_comet_NativeBase_nativeIsFeatureEnabled(
 /// hardcoding -- and drifting from -- the object_store-supported scheme set. (hdfs / libhdfs
 /// schemes are handled separately on the JVM side via the user's libhdfs scheme config.)
 #[no_mangle]
-pub extern "system" fn Java_org_apache_comet_NativeBase_nativeIsObjectStoreSchemeSupported(
+pub extern "system" fn Java_org_apache_comet_NativeBase_isObjectStoreSchemeSupportedImpl(
     env: EnvUnowned,
     _: JClass,
     url: JString,

--- a/native/core/src/lib.rs
+++ b/native/core/src/lib.rs
@@ -142,7 +142,7 @@ const LOG_PATTERN: &str = "{d(%y/%m/%d %H:%M:%S)} {l} {f}: {m}{n}";
 /// * `1` (true) if the feature is enabled
 /// * `0` (false) if the feature is disabled or unknown
 #[no_mangle]
-pub extern "system" fn Java_org_apache_comet_NativeBase_isFeatureEnabled(
+pub extern "system" fn Java_org_apache_comet_NativeBase_nativeIsFeatureEnabled(
     env: EnvUnowned,
     _: JClass,
     feature_name: JString,
@@ -170,7 +170,7 @@ pub extern "system" fn Java_org_apache_comet_NativeBase_isFeatureEnabled(
 /// hardcoding -- and drifting from -- the object_store-supported scheme set. (hdfs / libhdfs
 /// schemes are handled separately on the JVM side via the user's libhdfs scheme config.)
 #[no_mangle]
-pub extern "system" fn Java_org_apache_comet_NativeBase_isObjectStoreSchemeSupported(
+pub extern "system" fn Java_org_apache_comet_NativeBase_nativeIsObjectStoreSchemeSupported(
     env: EnvUnowned,
     _: JClass,
     url: JString,

--- a/spark/src/main/java/org/apache/comet/NativeBase.java
+++ b/spark/src/main/java/org/apache/comet/NativeBase.java
@@ -53,30 +53,19 @@ public abstract class NativeBase {
   private static final AtomicBoolean released = new AtomicBoolean(false);
 
   static {
-    // Arrow reads `arrow.enable_unsafe_memory_access` and `arrow.enable_null_check_for_get` in
-    // the static initializers of `BoundsChecking` and `NullCheckingForGet`. Once those Arrow
-    // classes are class-loaded the properties are latched and later writes are silently ignored.
-    // These are pure JVM system properties and do not require the native library, so set them
-    // here at `NativeBase` class-load time -- the earliest point Comet code runs -- rather than
-    // deferring to `load()` where the ordering would depend on which Comet path happens to run
-    // first on each executor.
+    // Arrow's BoundsChecking / NullCheckingForGet latch these in their static initializers, so
+    // later writes are silently ignored. Set them here (not in load()) so ordering does not
+    // depend on which Comet path runs first. These are pure JVM properties, no native lib needed.
     if (!(boolean) CometConf.COMET_DEBUG_ENABLED().get()) {
       setArrowProperties();
     }
   }
 
   /**
-   * Force the native library to load when a subclass (`Native`) is instantiated. Native execution
-   * paths that need JNI always go through `new Native()`, so this is the natural point to trigger
-   * the load. Loading is deliberately deferred out of the static initializer so that classes that
-   * merely reference `NativeBase` (e.g. the plugin's shutdown path) do not eagerly load the library
-   * and log the "Comet native library version ... initialized" message when Comet is otherwise
-   * disabled. This lazy design also matches Spark's `DriverPlugin.init` guidance to postpone
-   * expensive work until the application is actually using the feature.
-   *
-   * The library loads at most once per JVM per classloader: `ensureLoaded()` short-circuits on
-   * `loaded || loadErr != null` and `load()` short-circuits on `loaded`, so any concurrent or
-   * repeat `new Native()` after the first is a guarded no-op.
+   * Loading is deferred out of the static initializer so that merely referencing `NativeBase` (e.g.
+   * from the plugin's shutdown path) does not fire the JNI init and its "initialized" log when
+   * Comet is disabled. `new Native()` is the entry point for every native code path, so its
+   * super-constructor is the natural trigger. Loads at most once per JVM per classloader.
    */
   protected NativeBase() {
     ensureLoaded();
@@ -107,8 +96,7 @@ public abstract class NativeBase {
   // Only for testing
   static synchronized void setLoaded(boolean b) {
     loaded = b;
-    // Reset the cached load failure too, otherwise a prior forced-failure test would leave a
-    // sticky throwable that later `isLoaded()` / `ensureLoaded()` calls rethrow.
+    // Also reset loadErr so a prior forced-failure test does not leave a sticky throwable.
     loadErr = null;
   }
 
@@ -333,9 +321,8 @@ public abstract class NativeBase {
 
   /** Release native resources */
   public static void releaseNative() {
-    // Do not trigger a lazy load just to release. If the library was never loaded on this JVM
-    // (e.g. Comet was disabled) there is nothing to release, and forcing a load here would emit
-    // the native "initialized" log at shutdown when the user has already opted out of Comet.
+    // Do not go through isLoaded() -- that would lazy-load the library at shutdown just to
+    // release it, defeating the whole point of deferred loading when Comet is disabled.
     if (!loaded) {
       return;
     }

--- a/spark/src/main/java/org/apache/comet/NativeBase.java
+++ b/spark/src/main/java/org/apache/comet/NativeBase.java
@@ -56,9 +56,9 @@ public abstract class NativeBase {
    * Force the native library to load when a subclass (`Native`) is instantiated. Native execution
    * paths that need JNI always go through `new Native()`, so this is the natural point to trigger
    * the load. Loading is deliberately deferred out of the static initializer so that classes that
-   * merely reference `NativeBase` (e.g. the plugin's shutdown path) do not eagerly load the
-   * library and log the "Comet native library version ... initialized" message when Comet is
-   * otherwise disabled.
+   * merely reference `NativeBase` (e.g. the plugin's shutdown path) do not eagerly load the library
+   * and log the "Comet native library version ... initialized" message when Comet is otherwise
+   * disabled.
    */
   protected NativeBase() {
     ensureLoaded();
@@ -339,10 +339,10 @@ public abstract class NativeBase {
    */
   public static boolean isFeatureEnabled(String featureName) {
     ensureLoaded();
-    return nativeIsFeatureEnabled(featureName);
+    return isFeatureEnabledImpl(featureName);
   }
 
-  private static native boolean nativeIsFeatureEnabled(String featureName);
+  private static native boolean isFeatureEnabledImpl(String featureName);
 
   /**
    * Check whether Comet's native object_store layer recognizes the given URL's scheme (i.e. the
@@ -355,8 +355,8 @@ public abstract class NativeBase {
    */
   public static boolean isObjectStoreSchemeSupported(String url) {
     ensureLoaded();
-    return nativeIsObjectStoreSchemeSupported(url);
+    return isObjectStoreSchemeSupportedImpl(url);
   }
 
-  private static native boolean nativeIsObjectStoreSchemeSupported(String url);
+  private static native boolean isObjectStoreSchemeSupportedImpl(String url);
 }

--- a/spark/src/main/java/org/apache/comet/NativeBase.java
+++ b/spark/src/main/java/org/apache/comet/NativeBase.java
@@ -52,13 +52,31 @@ public abstract class NativeBase {
   private static final String searchPattern = "libcomet-";
   private static final AtomicBoolean released = new AtomicBoolean(false);
 
+  static {
+    // Arrow reads `arrow.enable_unsafe_memory_access` and `arrow.enable_null_check_for_get` in
+    // the static initializers of `BoundsChecking` and `NullCheckingForGet`. Once those Arrow
+    // classes are class-loaded the properties are latched and later writes are silently ignored.
+    // These are pure JVM system properties and do not require the native library, so set them
+    // here at `NativeBase` class-load time -- the earliest point Comet code runs -- rather than
+    // deferring to `load()` where the ordering would depend on which Comet path happens to run
+    // first on each executor.
+    if (!(boolean) CometConf.COMET_DEBUG_ENABLED().get()) {
+      setArrowProperties();
+    }
+  }
+
   /**
    * Force the native library to load when a subclass (`Native`) is instantiated. Native execution
    * paths that need JNI always go through `new Native()`, so this is the natural point to trigger
    * the load. Loading is deliberately deferred out of the static initializer so that classes that
    * merely reference `NativeBase` (e.g. the plugin's shutdown path) do not eagerly load the library
    * and log the "Comet native library version ... initialized" message when Comet is otherwise
-   * disabled.
+   * disabled. This lazy design also matches Spark's `DriverPlugin.init` guidance to postpone
+   * expensive work until the application is actually using the feature.
+   *
+   * The library loads at most once per JVM per classloader: `ensureLoaded()` short-circuits on
+   * `loaded || loadErr != null` and `load()` short-circuits on `loaded`, so any concurrent or
+   * repeat `new Native()` after the first is a guarded no-op.
    */
   protected NativeBase() {
     ensureLoaded();
@@ -89,6 +107,9 @@ public abstract class NativeBase {
   // Only for testing
   static synchronized void setLoaded(boolean b) {
     loaded = b;
+    // Reset the cached load failure too, otherwise a prior forced-failure test would leave a
+    // sticky throwable that later `isLoaded()` / `ensureLoaded()` calls rethrow.
+    loadErr = null;
   }
 
   static synchronized void load() {
@@ -117,10 +138,6 @@ public abstract class NativeBase {
     }
 
     initWithLogConf();
-    // Only set the Arrow properties when debugging mode is off
-    if (!(boolean) CometConf.COMET_DEBUG_ENABLED().get()) {
-      setArrowProperties();
-    }
   }
 
   /**

--- a/spark/src/main/java/org/apache/comet/NativeBase.java
+++ b/spark/src/main/java/org/apache/comet/NativeBase.java
@@ -52,7 +52,22 @@ public abstract class NativeBase {
   private static final String searchPattern = "libcomet-";
   private static final AtomicBoolean released = new AtomicBoolean(false);
 
-  static {
+  /**
+   * Force the native library to load when a subclass (`Native`) is instantiated. Native execution
+   * paths that need JNI always go through `new Native()`, so this is the natural point to trigger
+   * the load. Loading is deliberately deferred out of the static initializer so that classes that
+   * merely reference `NativeBase` (e.g. the plugin's shutdown path) do not eagerly load the
+   * library and log the "Comet native library version ... initialized" message when Comet is
+   * otherwise disabled.
+   */
+  protected NativeBase() {
+    ensureLoaded();
+  }
+
+  private static synchronized void ensureLoaded() {
+    if (loaded || loadErr != null) {
+      return;
+    }
     try {
       load();
     } catch (Throwable th) {
@@ -64,6 +79,7 @@ public abstract class NativeBase {
   }
 
   public static synchronized boolean isLoaded() throws Throwable {
+    ensureLoaded();
     if (loadErr != null) {
       throw loadErr;
     }
@@ -299,13 +315,19 @@ public abstract class NativeBase {
   static native void release();
 
   /** Release native resources */
-  public static void releaseNative() throws Throwable {
-    if (!isLoaded()) {
+  public static void releaseNative() {
+    // Do not trigger a lazy load just to release. If the library was never loaded on this JVM
+    // (e.g. Comet was disabled) there is nothing to release, and forcing a load here would emit
+    // the native "initialized" log at shutdown when the user has already opted out of Comet.
+    if (!loaded) {
       return;
     }
-
     if (released.compareAndSet(false, true)) {
-      release();
+      try {
+        release();
+      } catch (Throwable th) {
+        LOG.warn("Failed to release comet library", th);
+      }
     }
   }
 
@@ -315,7 +337,12 @@ public abstract class NativeBase {
    * @param featureName The name of the feature to check (e.g., "jemalloc", "hdfs-opendal")
    * @return true if the feature is enabled, false otherwise
    */
-  public static native boolean isFeatureEnabled(String featureName);
+  public static boolean isFeatureEnabled(String featureName) {
+    ensureLoaded();
+    return nativeIsFeatureEnabled(featureName);
+  }
+
+  private static native boolean nativeIsFeatureEnabled(String featureName);
 
   /**
    * Check whether Comet's native object_store layer recognizes the given URL's scheme (i.e. the
@@ -326,5 +353,10 @@ public abstract class NativeBase {
    * @param url a fully-qualified URL whose scheme should be checked (e.g. "s3://bucket/path")
    * @return true if object_store can construct a store for this scheme, false otherwise
    */
-  public static native boolean isObjectStoreSchemeSupported(String url);
+  public static boolean isObjectStoreSchemeSupported(String url) {
+    ensureLoaded();
+    return nativeIsObjectStoreSchemeSupported(url);
+  }
+
+  private static native boolean nativeIsObjectStoreSchemeSupported(String url);
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5274 

## Rationale for this change



 Fixes a misleading log line where the Rust "Comet native library version ... initialized" INFO appeared even when Comet was disabled (via `spark.comet.enabled=false` or the plugin's off-heap gate). The line
  came from the JNI `init` call, which was fired unconditionally by `NativeBase`'s eager static initializer. The static initializer ran on any first touch of `NativeBase` — including the plugin's shutdown path
  (`NativeBase.releaseNative()`) — so users who had opted out of Comet still saw the message.
  
  The fix makes native-library loading lazy: it now happens only when a Comet code path that actually needs JNI runs. The message is preserved for users who do use Comet; it just no longer fires when Comet is
  disabled.

  ## Changes

  ### `spark/src/main/java/org/apache/comet/NativeBase.java`

  - Removed the static initializer's `load()` call.
  - Added a new static block that sets the Arrow system properties (`arrow.enable_unsafe_memory_access`, `arrow.enable_null_check_for_get`) at `NativeBase` class-load time. Arrow latches these in
  `BoundsChecking` / `NullCheckingForGet` static initializers, so writing them later is silently ignored. Keeping this in a static block (independent of `load()`) preserves the previous ordering guarantee.
  These are pure JVM properties and do not require the native library.
  - Added a `protected NativeBase()` constructor that calls a new `ensureLoaded()`. This makes `new Native()` — the entry point for every native code path — the natural trigger for the load. Documented at the
  constructor that the library loads at most once per JVM per classloader (both `ensureLoaded()` and `load()` short-circuit on `loaded`).
  - `isLoaded()` now calls `ensureLoaded()`, so `CometSparkSessionExtensions.isCometLoaded` also triggers the load lazily. That method is already gated on `COMET_ENABLED` and platform/shuffle checks, so the
  load only fires when Comet is actually enabled.
  - `releaseNative()` reads the `loaded` field directly instead of via `isLoaded()`, so plugin shutdown does not force a lazy load of a library that was never used. Dropped `throws Throwable` and wrapped
  `release()` in try/catch — shutdown never propagates.
  - `setLoaded()` now also resets `loadErr`. Without this, a test that forces a load failure (e.g. `os.name=foo` in `CometSparkSessionExtensionsSuite`) leaves a sticky throwable that later `isLoaded()` calls
  rethrow, breaking downstream tests in the same JVM.
  - `isFeatureEnabled` and `isObjectStoreSchemeSupported` are now Java wrappers that call `ensureLoaded()` before delegating to private static native methods `isFeatureEnabledImpl` /
  `isObjectStoreSchemeSupportedImpl`. This keeps the public API stable and prevents `UnsatisfiedLinkError` if a caller happens to hit them before any other trigger.

  ### `native/core/src/lib.rs`

  - Renamed the two corresponding JNI symbols to `Java_org_apache_comet_NativeBase_isFeatureEnabledImpl` and `Java_org_apache_comet_NativeBase_isObjectStoreSchemeSupportedImpl` to match the Java-side renames.

  ## Design rationale

  Spark's `DriverPlugin.init` javadoc recommends "postponing [expensive operations] until the application has fully started." Deferring native-library load to first use aligns with that guidance and avoids
  paying the cost (or emitting the log) in configurations where Comet is registered but not exercised.

  `NativeBase` is loaded at most once per JVM per classloader. The load is triggered by either `new Native()` (the constructor path used by every executor code path) or `NativeBase.isLoaded` (used by the
  planning-time check). Both go through `ensureLoaded()`, which is `static synchronized` and guarded on `loaded || loadErr != null`. `load()` itself is `static synchronized` and guarded on `loaded`. Concurrent
  first-touch callers serialize on the class monitor; the winner sets `loaded=true` before returning; losers re-check and no-op.
  
  Behavior per configuration:

  - `spark.plugins=org.apache.spark.CometPlugin` unset — `NativeBase` is never referenced. No log.
  - Plugin registered, off-heap and on-heap both disabled — plugin init returns early. Shutdown's `releaseNative()` returns without loading. No log.
  - Plugin registered, off-heap enabled, `spark.comet.enabled=false` — extension rules return early inside `isCometLoaded` before touching `NativeBase.isLoaded`. No log.
  - Comet enabled — first `isCometLoaded` on the driver or first `new Native()` on the executor triggers the load. One log per JVM.

  ## Compatibility

  - `NativeBase.releaseNative()` loses `throws Throwable`. Both callers are in `Plugins.scala` (Scala, no checked-exception impact).
  - `NativeBase.isFeatureEnabled` / `NativeBase.isObjectStoreSchemeSupported` keep the same signature. The private native implementations were renamed with an `Impl` suffix; the JNI symbols follow.


