### PR TITLE
fix: align wide-decimal ANSI overflow value with Spark (#5211)

### DIFF
--- a/native/core/src/execution/expressions/arithmetic.rs
+++ b/native/core/src/execution/expressions/arithmetic.rs
@@ -45,6 +45,10 @@ impl CheckedBinaryExpr {
             query_context,
         }
     }
+
+    pub(crate) fn child(&self) -> &Arc<dyn PhysicalExpr> {
+        &self.child
+    }
 }
 
 impl Display for CheckedBinaryExpr {

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -101,6 +101,7 @@ use datafusion::physical_expr::expressions::{Literal, StatsType};
 use datafusion::physical_expr::window::WindowExpr;
 use datafusion::physical_expr::LexOrdering;
 
+use crate::execution::expressions::arithmetic::CheckedBinaryExpr;
 use crate::parquet::parquet_exec::init_datasource_exec;
 use arrow::array::{
     new_empty_array, Array, ArrayRef, BinaryBuilder, BooleanArray, Date32Array, Decimal128Array,
@@ -517,13 +518,17 @@ impl PhysicalPlanner {
                     self.create_expr(expr.child.as_ref().unwrap(), Arc::clone(&input_schema))?;
                 let data_type = to_arrow_datatype(expr.datatype.as_ref().unwrap());
                 let fail_on_error = expr.fail_on_error;
+                let query_context = spark_expr.expr_id.and_then(|expr_id| {
+                    let registry = &self.query_context_registry;
+                    registry.get(expr_id)
+                });
 
                 // WideDecimalBinaryExpr already handles overflow — skip redundant check
                 // but only if its output type matches CheckOverflow's declared type
                 if child.downcast_ref::<WideDecimalBinaryExpr>().is_some() {
                     let child_type = child.data_type(&input_schema)?;
                     if child_type == data_type {
-                        return Ok(child);
+                        return Ok(Arc::new(CheckedBinaryExpr::new(child, query_context)));
                     }
                 }
 
@@ -548,14 +553,8 @@ impl PhysicalPlanner {
                     }
                 }
 
-                // Look up query context from registry if expr_id is present
-                let query_context = spark_expr.expr_id.and_then(|expr_id| {
-                    let registry = &self.query_context_registry;
-                    registry.get(expr_id)
-                });
-
                 Ok(Arc::new(CheckOverflow::new(
-                    child,
+                    Arc::new(CheckedBinaryExpr::new(child, query_context.clone())),
                     data_type,
                     fail_on_error,
                     spark_expr.expr_id,
@@ -1034,7 +1033,6 @@ impl PhysicalPlanner {
                     ));
 
                     // Wrap with CheckedBinaryExpr to add query_context to errors
-                    use crate::execution::expressions::arithmetic::CheckedBinaryExpr;
                     Ok(Arc::new(CheckedBinaryExpr::new(scalar_expr, query_context)))
                 } else {
                     Ok(Arc::new(BinaryExpr::new(left, op, right)))

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -525,15 +525,32 @@ impl PhysicalPlanner {
 
                 // WideDecimalBinaryExpr already handles overflow — skip redundant check
                 // but only if its output type matches CheckOverflow's declared type
-                if child.downcast_ref::<WideDecimalBinaryExpr>().is_some() {
+                let is_wide_decimal = child.downcast_ref::<WideDecimalBinaryExpr>().is_some()
+                    || child
+                        .downcast_ref::<CheckedBinaryExpr>()
+                        .is_some_and(|checked| {
+                            checked
+                                .child()
+                                .downcast_ref::<WideDecimalBinaryExpr>()
+                                .is_some()
+                        });
+                if is_wide_decimal {
                     let child_type = child.data_type(&input_schema)?;
                     if child_type == data_type {
-                        return Ok(Arc::new(CheckedBinaryExpr::new(child, query_context)));
+                        return if query_context.is_some()
+                            && child.downcast_ref::<CheckedBinaryExpr>().is_none()
+                        {
+                            Ok(Arc::new(CheckedBinaryExpr::new(child, query_context)))
+                        } else {
+                            Ok(child)
+                        };
                     }
                 }
 
                 // Fuse Cast(Decimal128→Decimal128) + CheckOverflow into single rescale+check
-                // Only fuse when the Cast target type matches the CheckOverflow output type
+                // Only fuse when the Cast target type matches the CheckOverflow output type.
+                // Spark 3.4+ does not currently emit this shape, but keep its errors typed and
+                // contextualized in case a future serializer makes the fusion reachable.
                 if let Some(cast) = child.downcast_ref::<Cast>() {
                     if let (
                         DataType::Decimal128(p_out, s_out),
@@ -542,19 +559,35 @@ impl PhysicalPlanner {
                     {
                         let cast_target = cast.data_type(&input_schema)?;
                         if cast_target == data_type {
-                            return Ok(Arc::new(DecimalRescaleCheckOverflow::new(
-                                Arc::clone(&cast.child),
-                                s_in,
-                                *p_out,
-                                *s_out,
-                                fail_on_error,
-                            )));
+                            let fused: Arc<dyn PhysicalExpr> =
+                                Arc::new(DecimalRescaleCheckOverflow::new(
+                                    Arc::clone(&cast.child),
+                                    s_in,
+                                    *p_out,
+                                    *s_out,
+                                    fail_on_error,
+                                ));
+                            return if query_context.is_some() {
+                                Ok(Arc::new(CheckedBinaryExpr::new(fused, query_context)))
+                            } else {
+                                Ok(fused)
+                            };
                         }
                     }
                 }
 
+                // Generated child protos may not carry an expression id of their own, so retain
+                // the outer CheckOverflow context as a fallback for bare child SparkErrors.
+                let child = if query_context.is_some()
+                    && child.downcast_ref::<CheckedBinaryExpr>().is_none()
+                {
+                    Arc::new(CheckedBinaryExpr::new(child, query_context.clone()))
+                        as Arc<dyn PhysicalExpr>
+                } else {
+                    child
+                };
                 Ok(Arc::new(CheckOverflow::new(
-                    Arc::new(CheckedBinaryExpr::new(child, query_context.clone())),
+                    child,
                     data_type,
                     fail_on_error,
                     spark_expr.expr_id,
@@ -932,9 +965,14 @@ impl PhysicalPlanner {
                     DataFusionOperator::Multiply => WideDecimalOp::Multiply,
                     _ => unreachable!(),
                 };
-                Ok(Arc::new(WideDecimalBinaryExpr::new(
+                let expr: Arc<dyn PhysicalExpr> = Arc::new(WideDecimalBinaryExpr::new(
                     left, right, wide_op, p_out, s_out, eval_mode,
-                )))
+                ));
+                if query_context.is_some() {
+                    Ok(Arc::new(CheckedBinaryExpr::new(expr, query_context)))
+                } else {
+                    Ok(expr)
+                }
             }
             (
                 DataFusionOperator::Divide,
@@ -959,13 +997,18 @@ impl PhysicalPlanner {
                     Some(options.check_divide_overflow),
                     eval_mode,
                 )?;
-                Ok(Arc::new(ScalarFunctionExpr::new(
+                let expr: Arc<dyn PhysicalExpr> = Arc::new(ScalarFunctionExpr::new(
                     func_name,
                     fun_expr,
                     vec![left, right],
                     Arc::new(Field::new(func_name, data_type, true)),
                     Arc::new(ConfigOptions::default()),
-                )))
+                ));
+                if query_context.is_some() {
+                    Ok(Arc::new(CheckedBinaryExpr::new(expr, query_context)))
+                } else {
+                    Ok(expr)
+                }
             }
             // Date +/- Int8/Int16/Int32: DataFusion 52's arrow-arith kernels only
             // support Date32 +/- Interval types, not raw integers. Use the Spark
@@ -1032,8 +1075,11 @@ impl PhysicalPlanner {
                         Arc::new(ConfigOptions::default()),
                     ));
 
-                    // Wrap with CheckedBinaryExpr to add query_context to errors
-                    Ok(Arc::new(CheckedBinaryExpr::new(scalar_expr, query_context)))
+                    if query_context.is_some() {
+                        Ok(Arc::new(CheckedBinaryExpr::new(scalar_expr, query_context)))
+                    } else {
+                        Ok(scalar_expr)
+                    }
                 } else {
                     Ok(Arc::new(BinaryExpr::new(left, op, right)))
                 }

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -524,7 +524,9 @@ impl PhysicalPlanner {
                 });
 
                 // WideDecimalBinaryExpr already handles overflow — skip redundant check
-                // but only if its output type matches CheckOverflow's declared type
+                // but only if its output type matches CheckOverflow's declared type. A binary
+                // expression with query context is already wrapped in CheckedBinaryExpr, so
+                // inspect through that single layer too.
                 let is_wide_decimal = child.downcast_ref::<WideDecimalBinaryExpr>().is_some()
                     || child
                         .downcast_ref::<CheckedBinaryExpr>()

--- a/native/spark-expr/src/conversion_funcs/cast.rs
+++ b/native/spark-expr/src/conversion_funcs/cast.rs
@@ -21,7 +21,7 @@ use crate::conversion_funcs::boolean::{
 use crate::conversion_funcs::numeric::{
     cast_decimal128_to_utf8, cast_decimal_to_timestamp, cast_float32_to_decimal128,
     cast_float64_to_decimal128, cast_float_to_timestamp, cast_int_to_decimal128,
-    cast_int_to_timestamp, format_decimal_str, is_df_cast_from_decimal_spark_compatible,
+    cast_int_to_timestamp, is_df_cast_from_decimal_spark_compatible,
     is_df_cast_from_float_spark_compatible, is_df_cast_from_int_spark_compatible,
     spark_cast_decimal_to_boolean, spark_cast_float32_to_utf8, spark_cast_float64_to_utf8,
     spark_cast_int_to_int, spark_cast_nonintegral_numeric_to_integral,
@@ -45,7 +45,9 @@ use arrow::array::{
     new_null_array, BinaryBuilder, DictionaryArray, GenericByteArray, ListArray, MapArray,
     StringArray, StructArray,
 };
-use arrow::datatypes::{ArrowDictionaryKeyType, ArrowNativeType, DataType, Schema};
+use arrow::datatypes::{
+    format_decimal_str, ArrowDictionaryKeyType, ArrowNativeType, DataType, Schema,
+};
 use arrow::datatypes::{Field, Fields, GenericBinaryType};
 use arrow::error::ArrowError;
 use arrow::{
@@ -784,6 +786,8 @@ impl PhysicalExpr for Cast {
     }
 
     fn evaluate(&self, batch: &RecordBatch) -> DataFusionResult<ColumnarValue> {
+        // `CometIntegralDivide` builds its inner `CheckOverflow` without an expression id, so a
+        // bare child `SparkError` deliberately inherits the outer Cast's query context here.
         let result = self
             .child
             .evaluate(batch)
@@ -949,32 +953,52 @@ mod tests {
 
     #[test]
     fn test_cast_decimal_to_decimal_ansi_overflow_returns_spark_error() {
-        let input: ArrayRef = Arc::new(
-            Decimal128Array::from(vec![Some(123_456_789)])
-                .with_data_type(DataType::Decimal128(10, 4)),
-        );
+        let cases = [
+            (
+                vec![None, Some(1), Some(-123_456_789)],
+                DataType::Decimal128(10, 4),
+                DataType::Decimal128(6, 2),
+                "-12345.6789",
+                6,
+                2,
+            ),
+            (
+                vec![None, Some(1), Some(-999)],
+                DataType::Decimal128(3, 0),
+                DataType::Decimal128(3, 2),
+                "-999",
+                3,
+                2,
+            ),
+        ];
 
-        let error = cast_array(
-            input,
-            &DataType::Decimal128(6, 2),
-            &SparkCastOptions::new_without_timezone(EvalMode::Ansi, false),
-        )
-        .unwrap_err();
+        for (values, input_type, output_type, expected_value, expected_precision, expected_scale) in
+            cases
+        {
+            let input: ArrayRef =
+                Arc::new(Decimal128Array::from(values).with_data_type(input_type));
+            let error = cast_array(
+                input,
+                &output_type,
+                &SparkCastOptions::new_without_timezone(EvalMode::Ansi, false),
+            )
+            .unwrap_err();
 
-        match error {
-            DataFusionError::External(error) => match error.downcast_ref::<SparkError>() {
-                Some(SparkError::NumericValueOutOfRange {
-                    value,
-                    precision,
-                    scale,
-                }) => {
-                    assert_eq!(value, "12345.6789");
-                    assert_eq!(*precision, 6);
-                    assert_eq!(*scale, 2);
-                }
-                other => panic!("expected NumericValueOutOfRange, got {other:?}"),
-            },
-            other => panic!("expected external SparkError, got {other:?}"),
+            match error {
+                DataFusionError::External(error) => match error.downcast_ref::<SparkError>() {
+                    Some(SparkError::NumericValueOutOfRange {
+                        value,
+                        precision,
+                        scale,
+                    }) => {
+                        assert_eq!(value, expected_value);
+                        assert_eq!(*precision, expected_precision);
+                        assert_eq!(*scale, expected_scale);
+                    }
+                    other => panic!("expected NumericValueOutOfRange, got {other:?}"),
+                },
+                other => panic!("expected external SparkError, got {other:?}"),
+            }
         }
     }
 

--- a/native/spark-expr/src/conversion_funcs/cast.rs
+++ b/native/spark-expr/src/conversion_funcs/cast.rs
@@ -21,7 +21,7 @@ use crate::conversion_funcs::boolean::{
 use crate::conversion_funcs::numeric::{
     cast_decimal128_to_utf8, cast_decimal_to_timestamp, cast_float32_to_decimal128,
     cast_float64_to_decimal128, cast_float_to_timestamp, cast_int_to_decimal128,
-    cast_int_to_timestamp, is_df_cast_from_decimal_spark_compatible,
+    cast_int_to_timestamp, format_decimal_str, is_df_cast_from_decimal_spark_compatible,
     is_df_cast_from_float_spark_compatible, is_df_cast_from_int_spark_compatible,
     spark_cast_decimal_to_boolean, spark_cast_float32_to_utf8, spark_cast_float64_to_utf8,
     spark_cast_int_to_int, spark_cast_nonintegral_numeric_to_integral,
@@ -50,10 +50,10 @@ use arrow::datatypes::{Field, Fields, GenericBinaryType};
 use arrow::error::ArrowError;
 use arrow::{
     array::{
-        cast::AsArray, types::Int32Type, Array, ArrayRef, Int16Array, Int32Array, Int64Array,
-        Int8Array, OffsetSizeTrait, PrimitiveArray,
+        cast::AsArray, types::Decimal128Type, types::Int32Type, Array, ArrayRef, Int16Array,
+        Int32Array, Int64Array, Int8Array, OffsetSizeTrait, PrimitiveArray,
     },
-    compute::{cast_with_options, take, CastOptions},
+    compute::{cast_with_options, rescale_decimal, take, CastOptions},
     record_batch::RecordBatch,
     util::display::FormatOptions,
 };
@@ -338,6 +338,38 @@ pub(crate) fn cast_array(
         }
         (Utf8 | LargeUtf8, Decimal256(precision, scale)) => {
             cast_string_to_decimal(&array, to_type, precision, scale, eval_mode)
+        }
+        (Decimal128(input_precision, input_scale), Decimal128(output_precision, output_scale))
+            if eval_mode == EvalMode::Ansi =>
+        {
+            cast_with_options(&array, to_type, &native_cast_options).map_err(|error| {
+                array
+                    .as_primitive::<Decimal128Type>()
+                    .iter()
+                    .flatten()
+                    .find(|value| {
+                        rescale_decimal::<Decimal128Type, Decimal128Type>(
+                            *value,
+                            *input_precision,
+                            *input_scale,
+                            *output_precision,
+                            *output_scale,
+                        )
+                        .is_none()
+                    })
+                    .map_or_else(
+                        || error.into(),
+                        |value| SparkError::NumericValueOutOfRange {
+                            value: format_decimal_str(
+                                &value.to_string(),
+                                *input_precision as usize,
+                                *input_scale,
+                            ),
+                            precision: *output_precision,
+                            scale: *output_scale,
+                        },
+                    )
+            })
         }
         (Int64, Int32)
         | (Int64, Int16)
@@ -752,8 +784,10 @@ impl PhysicalExpr for Cast {
     }
 
     fn evaluate(&self, batch: &RecordBatch) -> DataFusionResult<ColumnarValue> {
-        let arg = self.child.evaluate(batch)?;
-        let result = spark_cast(arg, &self.data_type, &self.cast_options);
+        let result = self
+            .child
+            .evaluate(batch)
+            .and_then(|arg| spark_cast(arg, &self.data_type, &self.cast_options));
 
         // If there's an error and we have query_context, wrap it
         match result {
@@ -908,10 +942,41 @@ fn cast_binary_to_string<O: OffsetSizeTrait>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{BinaryArray, ListArray, NullArray, StringArray};
+    use arrow::array::{BinaryArray, Decimal128Array, ListArray, NullArray, StringArray};
     use arrow::buffer::OffsetBuffer;
     use arrow::datatypes::TimestampMicrosecondType;
     use arrow::datatypes::{Field, Fields};
+
+    #[test]
+    fn test_cast_decimal_to_decimal_ansi_overflow_returns_spark_error() {
+        let input: ArrayRef = Arc::new(
+            Decimal128Array::from(vec![Some(123_456_789)])
+                .with_data_type(DataType::Decimal128(10, 4)),
+        );
+
+        let error = cast_array(
+            input,
+            &DataType::Decimal128(6, 2),
+            &SparkCastOptions::new_without_timezone(EvalMode::Ansi, false),
+        )
+        .unwrap_err();
+
+        match error {
+            DataFusionError::External(error) => match error.downcast_ref::<SparkError>() {
+                Some(SparkError::NumericValueOutOfRange {
+                    value,
+                    precision,
+                    scale,
+                }) => {
+                    assert_eq!(value, "12345.6789");
+                    assert_eq!(*precision, 6);
+                    assert_eq!(*scale, 2);
+                }
+                other => panic!("expected NumericValueOutOfRange, got {other:?}"),
+            },
+            other => panic!("expected external SparkError, got {other:?}"),
+        }
+    }
 
     #[test]
     fn test_cast_binary_to_string_replaces_invalid_utf8_jvm_compatibly() {

--- a/native/spark-expr/src/conversion_funcs/mod.rs
+++ b/native/spark-expr/src/conversion_funcs/mod.rs
@@ -18,7 +18,6 @@
 mod boolean;
 pub mod cast;
 mod numeric;
-pub(crate) use numeric::format_decimal_str;
 mod string;
 mod temporal;
 mod utils;

--- a/native/spark-expr/src/conversion_funcs/mod.rs
+++ b/native/spark-expr/src/conversion_funcs/mod.rs
@@ -18,6 +18,7 @@
 mod boolean;
 pub mod cast;
 mod numeric;
+pub(crate) use numeric::format_decimal_str;
 mod string;
 mod temporal;
 mod utils;

--- a/native/spark-expr/src/conversion_funcs/numeric.rs
+++ b/native/spark-expr/src/conversion_funcs/numeric.rs
@@ -24,8 +24,8 @@ use arrow::array::{
     OffsetSizeTrait, PrimitiveArray, StringBuilder, TimestampMicrosecondBuilder,
 };
 use arrow::datatypes::{
-    i256, is_validate_decimal_precision, ArrowPrimitiveType, DataType, Decimal128Type, Float32Type,
-    Float64Type, Int16Type, Int32Type, Int64Type, Int8Type,
+    format_decimal_str, i256, is_validate_decimal_precision, ArrowPrimitiveType, DataType,
+    Decimal128Type, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type,
 };
 use num::{cast::AsPrimitive, ToPrimitive, Zero};
 use std::sync::Arc;
@@ -557,30 +557,6 @@ macro_rules! cast_decimal_to_int32_up {
         };
         Ok(Arc::new(output_array) as ArrayRef)
     }};
-}
-
-// copied from arrow::dataTypes::Decimal128Type since Decimal128Type::format_decimal can't be called directly
-pub(crate) fn format_decimal_str(value_str: &str, precision: usize, scale: i8) -> String {
-    let (sign, rest) = match value_str.strip_prefix('-') {
-        Some(stripped) => ("-", stripped),
-        None => ("", value_str),
-    };
-    let bound = precision.min(rest.len()) + sign.len();
-    let value_str = &value_str[0..bound];
-
-    if scale == 0 {
-        value_str.to_string()
-    } else if scale < 0 {
-        let padding = value_str.len() + scale.unsigned_abs() as usize;
-        format!("{value_str:0<padding$}")
-    } else if rest.len() > scale as usize {
-        // Decimal separator is in the middle of the string
-        let (whole, decimal) = value_str.split_at(value_str.len() - scale as usize);
-        format!("{whole}.{decimal}")
-    } else {
-        // String has to be padded
-        format!("{}0.{:0>width$}", sign, rest, width = scale as usize)
-    }
 }
 
 /// Casts a Decimal128 array to string using Java's BigDecimal.toString() semantics,

--- a/native/spark-expr/src/error.rs
+++ b/native/spark-expr/src/error.rs
@@ -19,3 +19,15 @@
 pub use datafusion_comet_common::{
     decimal_overflow_error, SparkError, SparkErrorWithContext, SparkResult,
 };
+
+use arrow::error::ArrowError;
+use datafusion::common::DataFusionError;
+
+/// Arrow's `try_*` kernels require closure errors to be `ArrowError`, so a `SparkError`
+/// travels through `ExternalError`. Unwrap it again so JNI sees the direct `SparkError`.
+pub(crate) fn unwrap_arrow_external_error(error: ArrowError) -> DataFusionError {
+    match error {
+        ArrowError::ExternalError(error) => DataFusionError::External(error),
+        error => error.into(),
+    }
+}

--- a/native/spark-expr/src/math_funcs/div.rs
+++ b/native/spark-expr/src/math_funcs/div.rs
@@ -61,9 +61,9 @@ fn quotient_to_i128<T: ToPrimitive>(
 ) -> Result<i128, ArrowError> {
     let res = res.to_i128().unwrap_or(i128::MAX);
     if check_divide_overflow && i64::try_from(res).is_err() {
-        return Err(ArrowError::ComputeError(
-            integral_divide_overflow_error().to_string(),
-        ));
+        return Err(ArrowError::ExternalError(Box::new(
+            integral_divide_overflow_error(),
+        )));
     }
     Ok(res)
 }
@@ -100,7 +100,7 @@ fn spark_decimal_div_internal(
 
     let l_exp = ((s2 + s3 + 1) as u32).saturating_sub(s1 as u32);
     let r_exp = (s1 as u32).saturating_sub((s2 + s3 + 1) as u32);
-    let result: Decimal128Array = if p1 as u32 + l_exp > DECIMAL128_MAX_PRECISION as u32
+    let result = if p1 as u32 + l_exp > DECIMAL128_MAX_PRECISION as u32
         || p2 as u32 + r_exp > DECIMAL128_MAX_PRECISION as u32
     {
         let ten = BigInt::from(10);
@@ -116,7 +116,7 @@ fn spark_decimal_div_internal(
             // Spark throws DIVIDE_BY_ZERO for both `/` and `div` when ANSI is enabled, so
             // the `is_integral_div` guard was wrong and has been removed.
             if eval_mode == EvalMode::Ansi && r.is_zero() {
-                return Err(ArrowError::ComputeError(divide_by_zero_error().to_string()));
+                return Err(ArrowError::ExternalError(Box::new(divide_by_zero_error())));
             }
             // Non-ANSI: zero divisors have already been replaced with null by the
             // `nullIfWhenPrimitive` wrapper applied in the Scala serde layer, so
@@ -131,7 +131,7 @@ fn spark_decimal_div_internal(
                 div + &five
             } / &ten;
             quotient_to_i128(&res, check_divide_overflow)
-        })?
+        })
     } else {
         let l_mul = 10_i128.pow(l_exp);
         let r_mul = 10_i128.pow(r_exp);
@@ -143,7 +143,7 @@ fn spark_decimal_div_internal(
             // Spark throws DIVIDE_BY_ZERO for both `/` and `div` when ANSI is enabled, so
             // the `is_integral_div` guard was wrong and has been removed.
             if eval_mode == EvalMode::Ansi && r == 0 {
-                return Err(ArrowError::ComputeError(divide_by_zero_error().to_string()));
+                return Err(ArrowError::ExternalError(Box::new(divide_by_zero_error())));
             }
             // Non-ANSI: zero divisors have already been replaced with null by the
             // `nullIfWhenPrimitive` wrapper applied in the Scala serde layer, so
@@ -158,8 +158,59 @@ fn spark_decimal_div_internal(
                 div + 5
             } / 10;
             quotient_to_i128(&res, check_divide_overflow)
-        })?
+        })
     };
+    let result: Decimal128Array = result.map_err(|error| match error {
+        ArrowError::ExternalError(error) => DataFusionError::External(error),
+        error => error.into(),
+    })?;
     let result = result.with_data_type(DataType::Decimal128(p3, s3));
     Ok(ColumnarValue::Array(Arc::new(result)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SparkError;
+
+    fn decimal(value: i128, precision: u8, scale: i8) -> ColumnarValue {
+        ColumnarValue::Array(Arc::new(
+            Decimal128Array::from(vec![Some(value)])
+                .with_data_type(DataType::Decimal128(precision, scale)),
+        ))
+    }
+
+    fn spark_error(result: Result<ColumnarValue, DataFusionError>) -> SparkError {
+        match result.unwrap_err() {
+            DataFusionError::External(error) => *error
+                .downcast::<SparkError>()
+                .expect("expected external SparkError"),
+            error => panic!("expected external SparkError, got {error:?}"),
+        }
+    }
+
+    #[test]
+    fn test_decimal_divide_by_zero_returns_spark_error() {
+        // Exercise both the i128 and BigInt kernels.
+        for (precision, scale) in [(10, 2), (38, 0)] {
+            let result = spark_decimal_div(
+                &[decimal(100, precision, scale), decimal(0, precision, scale)],
+                &DataType::Decimal128(precision, scale),
+                EvalMode::Ansi,
+            );
+            assert!(matches!(spark_error(result), SparkError::DivideByZero));
+        }
+    }
+
+    #[test]
+    fn test_integral_divide_overflow_returns_spark_error() {
+        let result = quotient_to_i128(&(i64::MAX as i128 + 1), true);
+        match result.unwrap_err() {
+            ArrowError::ExternalError(error) => assert!(matches!(
+                error.downcast_ref::<SparkError>(),
+                Some(SparkError::IntegralDivideOverflow)
+            )),
+            error => panic!("expected external SparkError, got {error:?}"),
+        }
+    }
 }

--- a/native/spark-expr/src/math_funcs/div.rs
+++ b/native/spark-expr/src/math_funcs/div.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::error::unwrap_arrow_external_error;
 use crate::math_funcs::utils::get_precision_scale;
 use crate::{divide_by_zero_error, integral_divide_overflow_error, EvalMode};
 use arrow::array::{Array, Decimal128Array};
@@ -160,10 +161,7 @@ fn spark_decimal_div_internal(
             quotient_to_i128(&res, check_divide_overflow)
         })
     };
-    let result: Decimal128Array = result.map_err(|error| match error {
-        ArrowError::ExternalError(error) => DataFusionError::External(error),
-        error => error.into(),
-    })?;
+    let result: Decimal128Array = result.map_err(unwrap_arrow_external_error)?;
     let result = result.with_data_type(DataType::Decimal128(p3, s3));
     Ok(ColumnarValue::Array(Arc::new(result)))
 }

--- a/native/spark-expr/src/math_funcs/internal/decimal_rescale_check.rs
+++ b/native/spark-expr/src/math_funcs/internal/decimal_rescale_check.rs
@@ -20,8 +20,10 @@
 //! Replaces the pattern `CheckOverflow(Cast(expr, Decimal128(p2,s2)), Decimal128(p2,s2))`
 //! with a single expression that rescales and validates precision in one pass.
 
+use crate::error::unwrap_arrow_external_error;
+use crate::SparkError;
 use arrow::array::{as_primitive_array, Array, ArrayRef, Decimal128Array};
-use arrow::datatypes::{DataType, Decimal128Type, Schema};
+use arrow::datatypes::{format_decimal_str, DataType, Decimal128Type, Schema};
 use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, ScalarValue};
@@ -110,20 +112,33 @@ fn precision_bound(precision: u8) -> i128 {
 #[inline]
 fn rescale_and_check(
     value: i128,
-    delta: i8,
-    scale_factor: i128,
+    input_scale: i8,
+    scale_factor: Option<i128>,
     bound: i128,
+    output_precision: u8,
+    output_scale: i8,
     fail_on_error: bool,
 ) -> Result<i128, ArrowError> {
+    let overflow_error = || {
+        let unscaled = value.to_string();
+        // Preserve every digit of the value that is already known to overflow.
+        let digits = unscaled.trim_start_matches('-').len();
+        ArrowError::ExternalError(Box::new(SparkError::NumericValueOutOfRange {
+            value: format_decimal_str(&unscaled, digits, input_scale),
+            precision: output_precision,
+            scale: output_scale,
+        }))
+    };
+    let delta = output_scale as i16 - input_scale as i16;
+
     let rescaled = if delta > 0 {
         // Scale up: multiply. Check for overflow.
-        match value.checked_mul(scale_factor) {
+        match scale_factor.and_then(|factor| value.checked_mul(factor)) {
             Some(v) => v,
+            None if value == 0 => 0,
             None => {
                 if fail_on_error {
-                    return Err(ArrowError::ComputeError(
-                        "Decimal overflow during rescale".to_string(),
-                    ));
+                    return Err(overflow_error());
                 }
                 return Ok(i128::MAX); // sentinel
             }
@@ -131,10 +146,14 @@ fn rescale_and_check(
     } else if delta < 0 {
         // Scale down with HALF_UP rounding
         // divisor = 10^(-delta), half = divisor / 2
-        let divisor = scale_factor; // already 10^abs(delta)
-        let half = divisor / 2;
-        let sign = value.signum();
-        (value + sign * half) / divisor
+        match scale_factor {
+            Some(divisor) => {
+                let half = divisor / 2;
+                let sign = value.signum();
+                (value + sign * half) / divisor
+            }
+            None => 0,
+        }
     } else {
         value
     };
@@ -142,9 +161,7 @@ fn rescale_and_check(
     // Precision check
     if rescaled.abs() > bound {
         if fail_on_error {
-            return Err(ArrowError::ComputeError(
-                "Decimal overflow: value does not fit in precision".to_string(),
-            ));
+            return Err(overflow_error());
         }
         Ok(i128::MAX) // sentinel for null_if_overflow_precision
     } else {
@@ -170,17 +187,9 @@ impl PhysicalExpr for DecimalRescaleCheckOverflow {
 
     fn evaluate(&self, batch: &RecordBatch) -> datafusion::common::Result<ColumnarValue> {
         let arg = self.child.evaluate(batch)?;
-        let delta = self.output_scale - self.input_scale;
+        let delta = self.output_scale as i16 - self.input_scale as i16;
         let abs_delta = delta.unsigned_abs();
-        // If abs_delta > 38, the scale factor overflows i128. In that case,
-        // any non-zero value will overflow the output precision, so we treat
-        // it as an immediate overflow condition.
-        if abs_delta > 38 {
-            return Err(DataFusionError::Execution(format!(
-                "DecimalRescaleCheckOverflow: scale delta {delta} exceeds maximum supported range"
-            )));
-        }
-        let scale_factor = 10i128.pow(abs_delta as u32);
+        let scale_factor = (abs_delta <= 38).then(|| 10i128.pow(abs_delta as u32));
         let bound = precision_bound(self.output_precision);
         let fail_on_error = self.fail_on_error;
         let p_out = self.output_precision;
@@ -194,8 +203,17 @@ impl PhysicalExpr for DecimalRescaleCheckOverflow {
 
                 let result: Decimal128Array =
                     arrow::compute::kernels::arity::try_unary(decimal_array, |value| {
-                        rescale_and_check(value, delta, scale_factor, bound, fail_on_error)
-                    })?;
+                        rescale_and_check(
+                            value,
+                            self.input_scale,
+                            scale_factor,
+                            bound,
+                            p_out,
+                            s_out,
+                            fail_on_error,
+                        )
+                    })
+                    .map_err(unwrap_arrow_external_error)?;
 
                 let result = if !fail_on_error && result.values().contains(&i128::MAX) {
                     // The rescale pass writes i128::MAX as an overflow sentinel for values that
@@ -218,8 +236,16 @@ impl PhysicalExpr for DecimalRescaleCheckOverflow {
             ColumnarValue::Scalar(ScalarValue::Decimal128(v, _precision, _scale)) => {
                 let new_v = match v {
                     Some(val) => {
-                        let r = rescale_and_check(val, delta, scale_factor, bound, fail_on_error)
-                            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+                        let r = rescale_and_check(
+                            val,
+                            self.input_scale,
+                            scale_factor,
+                            bound,
+                            p_out,
+                            s_out,
+                            fail_on_error,
+                        )
+                        .map_err(unwrap_arrow_external_error)?;
                         if r == i128::MAX {
                             None
                         } else {
@@ -269,6 +295,29 @@ mod tests {
     use arrow::datatypes::{Field, Schema};
     use arrow::record_batch::RecordBatch;
     use datafusion::physical_expr::expressions::Column;
+
+    fn assert_numeric_value_out_of_range(
+        error: DataFusionError,
+        expected_value: &str,
+        expected_precision: u8,
+        expected_scale: i8,
+    ) {
+        match error {
+            DataFusionError::External(error) => match error.downcast_ref::<SparkError>() {
+                Some(SparkError::NumericValueOutOfRange {
+                    value,
+                    precision,
+                    scale,
+                }) => {
+                    assert_eq!(value, expected_value);
+                    assert_eq!(*precision, expected_precision);
+                    assert_eq!(*scale, expected_scale);
+                }
+                other => panic!("expected NumericValueOutOfRange, got {other:?}"),
+            },
+            other => panic!("expected external SparkError, got {other:?}"),
+        }
+    }
 
     fn make_batch(values: Vec<Option<i128>>, precision: u8, scale: i8) -> RecordBatch {
         let arr =
@@ -344,9 +393,9 @@ mod tests {
 
     #[test]
     fn test_overflow_error_in_ansi_mode() {
-        let batch = make_batch(vec![Some(10)], 38, 0);
-        let result = eval_expr(&batch, 0, 3, 2, true);
-        assert!(result.is_err());
+        let batch = make_batch(vec![Some(-1000)], 10, 2);
+        let error = eval_expr(&batch, 2, 3, 2, true).unwrap_err();
+        assert_numeric_value_out_of_range(error, "-10.00", 3, 2);
     }
 
     #[test]
@@ -491,26 +540,34 @@ mod tests {
 
     #[test]
     fn test_scalar_overflow_ansi_returns_error() {
-        // fail_on_error=true must propagate the error, not silently return None
         let schema = Schema::new(vec![Field::new("col", DataType::Decimal128(38, 0), true)]);
         let batch = RecordBatch::new_empty(Arc::new(schema));
+        let value = 10i128.pow(38) - 1;
         let expr = DecimalRescaleCheckOverflow::new(
-            Arc::new(ScalarChild(Some(10), 38, 0)),
+            Arc::new(ScalarChild(Some(value), 38, 0)),
             0,
-            3,
-            2,
-            true, // fail_on_error = true
+            38,
+            1,
+            true,
         );
-        let result = expr.evaluate(&batch);
-        assert!(result.is_err()); // must be error, not Ok(None)
+        let error = expr.evaluate(&batch).unwrap_err();
+        assert_numeric_value_out_of_range(error, &value.to_string(), 38, 1);
     }
 
     #[test]
-    fn test_large_scale_delta_returns_error() {
-        // delta = output_scale - input_scale = 38 - (-1) = 39
-        // 10i128.pow(39) would overflow, so we must reject gracefully
-        let batch = make_batch(vec![Some(1)], 38, -1);
-        let result = eval_expr(&batch, -1, 38, 38, false);
-        assert!(result.is_err());
+    fn test_large_scale_delta() {
+        let scale_up = make_batch(vec![Some(1), Some(0), None], 38, -1);
+        let result = eval_expr(&scale_up, -1, 38, 38, false).unwrap();
+        let result = result.as_primitive::<Decimal128Type>();
+        assert!(result.is_null(0));
+        assert_eq!(result.value(1), 0);
+        assert!(result.is_null(2));
+
+        let error = eval_expr(&scale_up, -1, 38, 38, true).unwrap_err();
+        assert_numeric_value_out_of_range(error, "10", 38, 38);
+
+        let scale_down = make_batch(vec![Some(1)], 38, 38);
+        let result = eval_expr(&scale_down, 38, 38, -1, false).unwrap();
+        assert_eq!(result.as_primitive::<Decimal128Type>().value(0), 0);
     }
 }

--- a/native/spark-expr/src/math_funcs/wide_decimal_binary_expr.rs
+++ b/native/spark-expr/src/math_funcs/wide_decimal_binary_expr.rs
@@ -20,13 +20,14 @@
 //! Instead of building a 4-node expression tree (Cast→BinaryExpr→Cast→Cast), this performs
 //! i256 intermediate arithmetic in a single expression, producing only one output array.
 
+use crate::conversion_funcs::format_decimal_str;
 use crate::math_funcs::utils::get_precision_scale;
-use crate::EvalMode;
+use crate::{EvalMode, SparkError};
 use arrow::array::{Array, ArrayRef, AsArray, Decimal128Array};
 use arrow::datatypes::{i256, DataType, Decimal128Type, Schema};
 use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
-use datafusion::common::Result;
+use datafusion::common::{DataFusionError, Result};
 use datafusion::logical_expr::ColumnarValue;
 use datafusion::physical_expr::PhysicalExpr;
 use std::fmt::{Display, Formatter};
@@ -215,7 +216,7 @@ impl PhysicalExpr for WideDecimalBinaryExpr {
         let bound = max_for_precision(p_out);
         let neg_bound = i256::ZERO.wrapping_sub(bound);
 
-        let result: Decimal128Array = match op {
+        let result: std::result::Result<Decimal128Array, ArrowError> = match op {
             WideDecimalOp::Add | WideDecimalOp::Subtract => {
                 let max_scale = std::cmp::max(s1, s2);
                 let l_scale_up = i256_pow10((max_scale - s1) as u32);
@@ -249,8 +250,8 @@ impl PhysicalExpr for WideDecimalBinaryExpr {
                     } else {
                         raw
                     };
-                    check_overflow_and_convert(result, bound, neg_bound, eval_mode)
-                })?
+                    check_overflow_and_convert(result, bound, neg_bound, p_out, s_out, eval_mode)
+                })
             }
             WideDecimalOp::Multiply => {
                 let natural_scale = s1 + s2;
@@ -276,10 +277,16 @@ impl PhysicalExpr for WideDecimalBinaryExpr {
                     } else {
                         raw
                     };
-                    check_overflow_and_convert(result, bound, neg_bound, eval_mode)
-                })?
+                    check_overflow_and_convert(result, bound, neg_bound, p_out, s_out, eval_mode)
+                })
             }
         };
+        let result = result.map_err(|error| -> DataFusionError {
+            match error {
+                ArrowError::ExternalError(error) => DataFusionError::External(error),
+                error => error.into(),
+            }
+        })?;
 
         let result = if eval_mode != EvalMode::Ansi {
             result.null_if_overflow_precision(p_out)
@@ -336,11 +343,21 @@ fn check_overflow_and_convert(
     result: i256,
     bound: i256,
     neg_bound: i256,
+    precision: u8,
+    scale: i8,
     eval_mode: EvalMode,
 ) -> Result<i128, ArrowError> {
     if result > bound || result < neg_bound {
         if eval_mode == EvalMode::Ansi {
-            return Err(ArrowError::ComputeError("Arithmetic overflow".to_string()));
+            let unscaled = result.to_string();
+            let digits = unscaled.trim_start_matches('-').len();
+            return Err(ArrowError::ExternalError(Box::new(
+                SparkError::NumericValueOutOfRange {
+                    value: format_decimal_str(&unscaled, digits, scale),
+                    precision,
+                    scale,
+                },
+            )));
         }
         // Sentinel value — will be nullified by null_if_overflow_precision
         Ok(i128::MAX)
@@ -507,10 +524,26 @@ mod tests {
     }
 
     #[test]
-    fn test_overflow_ansi_mode_returns_error() {
-        let batch = make_batch(vec![Some(5)], 38, 0, vec![Some(5)], 38, 0);
-        let result = eval_expr(&batch, WideDecimalOp::Add, 1, 0, EvalMode::Ansi);
-        assert!(result.is_err());
+    fn test_overflow_ansi_mode_returns_spark_error() {
+        // 0.5 + 0.5 = 1.0, which does not fit Decimal(1, 1). The error must report
+        // the scaled decimal value rather than its raw unscaled integer (10).
+        let batch = make_batch(vec![Some(5)], 38, 1, vec![Some(5)], 38, 1);
+        let result = eval_expr(&batch, WideDecimalOp::Add, 1, 1, EvalMode::Ansi);
+        match result {
+            Err(DataFusionError::External(error)) => match error.downcast_ref::<SparkError>() {
+                Some(SparkError::NumericValueOutOfRange {
+                    value,
+                    precision,
+                    scale,
+                }) => {
+                    assert_eq!(value, "1.0");
+                    assert_eq!(*precision, 1);
+                    assert_eq!(*scale, 1);
+                }
+                other => panic!("expected NumericValueOutOfRange, got {other:?}"),
+            },
+            other => panic!("expected external SparkError, got {other:?}"),
+        }
     }
 
     #[test]

--- a/native/spark-expr/src/math_funcs/wide_decimal_binary_expr.rs
+++ b/native/spark-expr/src/math_funcs/wide_decimal_binary_expr.rs
@@ -20,14 +20,14 @@
 //! Instead of building a 4-node expression tree (Cast→BinaryExpr→Cast→Cast), this performs
 //! i256 intermediate arithmetic in a single expression, producing only one output array.
 
-use crate::conversion_funcs::format_decimal_str;
+use crate::error::unwrap_arrow_external_error;
 use crate::math_funcs::utils::get_precision_scale;
 use crate::{EvalMode, SparkError};
 use arrow::array::{Array, ArrayRef, AsArray, Decimal128Array};
-use arrow::datatypes::{i256, DataType, Decimal128Type, Schema};
+use arrow::datatypes::{format_decimal_str, i256, DataType, Decimal128Type, Schema};
 use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
-use datafusion::common::{DataFusionError, Result};
+use datafusion::common::Result;
 use datafusion::logical_expr::ColumnarValue;
 use datafusion::physical_expr::PhysicalExpr;
 use std::fmt::{Display, Formatter};
@@ -281,12 +281,7 @@ impl PhysicalExpr for WideDecimalBinaryExpr {
                 })
             }
         };
-        let result = result.map_err(|error| -> DataFusionError {
-            match error {
-                ArrowError::ExternalError(error) => DataFusionError::External(error),
-                error => error.into(),
-            }
-        })?;
+        let result = result.map_err(unwrap_arrow_external_error)?;
 
         let result = if eval_mode != EvalMode::Ansi {
             result.null_if_overflow_precision(p_out)
@@ -350,6 +345,8 @@ fn check_overflow_and_convert(
     if result > bound || result < neg_bound {
         if eval_mode == EvalMode::Ansi {
             let unscaled = result.to_string();
+            // Arrow's formatter truncates to its precision argument. This value is already
+            // known to overflow, so pass its actual digit count to preserve every digit.
             let digits = unscaled.trim_start_matches('-').len();
             return Err(ArrowError::ExternalError(Box::new(
                 SparkError::NumericValueOutOfRange {
@@ -372,6 +369,7 @@ mod tests {
     use arrow::array::Decimal128Array;
     use arrow::datatypes::{Field, Schema};
     use arrow::record_batch::RecordBatch;
+    use datafusion::common::DataFusionError;
     use datafusion::physical_expr::expressions::Column;
 
     fn make_batch(
@@ -525,24 +523,40 @@ mod tests {
 
     #[test]
     fn test_overflow_ansi_mode_returns_spark_error() {
-        // 0.5 + 0.5 = 1.0, which does not fit Decimal(1, 1). The error must report
-        // the scaled decimal value rather than its raw unscaled integer (10).
-        let batch = make_batch(vec![Some(5)], 38, 1, vec![Some(5)], 38, 1);
-        let result = eval_expr(&batch, WideDecimalOp::Add, 1, 1, EvalMode::Ansi);
-        match result {
-            Err(DataFusionError::External(error)) => match error.downcast_ref::<SparkError>() {
-                Some(SparkError::NumericValueOutOfRange {
-                    value,
-                    precision,
-                    scale,
-                }) => {
-                    assert_eq!(value, "1.0");
-                    assert_eq!(*precision, 1);
-                    assert_eq!(*scale, 1);
-                }
-                other => panic!("expected NumericValueOutOfRange, got {other:?}"),
-            },
-            other => panic!("expected external SparkError, got {other:?}"),
+        let cases = [
+            (
+                make_batch(vec![Some(5)], 38, 1, vec![Some(5)], 38, 1),
+                WideDecimalOp::Add,
+                1,
+                1,
+                "1.0",
+            ),
+            (
+                make_batch(vec![Some(99)], 2, 1, vec![Some(10)], 2, 1),
+                WideDecimalOp::Multiply,
+                1,
+                0,
+                "10",
+            ),
+        ];
+
+        for (batch, op, precision, scale, expected_value) in cases {
+            let result = eval_expr(&batch, op, precision, scale, EvalMode::Ansi);
+            match result {
+                Err(DataFusionError::External(error)) => match error.downcast_ref::<SparkError>() {
+                    Some(SparkError::NumericValueOutOfRange {
+                        value,
+                        precision: actual_precision,
+                        scale: actual_scale,
+                    }) => {
+                        assert_eq!(value, expected_value);
+                        assert_eq!(*actual_precision, precision);
+                        assert_eq!(*actual_scale, scale);
+                    }
+                    other => panic!("expected NumericValueOutOfRange, got {other:?}"),
+                },
+                other => panic!("expected external SparkError, got {other:?}"),
+            }
         }
     }
 

--- a/native/spark-expr/src/math_funcs/wide_decimal_binary_expr.rs
+++ b/native/spark-expr/src/math_funcs/wide_decimal_binary_expr.rs
@@ -347,6 +347,8 @@ fn check_overflow_and_convert(
             let unscaled = result.to_string();
             // Arrow's formatter truncates to its precision argument. This value is already
             // known to overflow, so pass its actual digit count to preserve every digit.
+            // Spark reports the pre-toPrecision value instead; see
+            // https://github.com/apache/datafusion-comet/issues/5211.
             let digits = unscaled.trim_start_matches('-').len();
             return Err(ArrowError::ExternalError(Box::new(
                 SparkError::NumericValueOutOfRange {

--- a/native/spark-expr/src/math_funcs/wide_decimal_binary_expr.rs
+++ b/native/spark-expr/src/math_funcs/wide_decimal_binary_expr.rs
@@ -250,7 +250,9 @@ impl PhysicalExpr for WideDecimalBinaryExpr {
                     } else {
                         raw
                     };
-                    check_overflow_and_convert(result, bound, neg_bound, p_out, s_out, eval_mode)
+                    check_overflow_and_convert(
+                        result, bound, neg_bound, p_out, s_out, raw, max_scale, false, eval_mode,
+                    )
                 })
             }
             WideDecimalOp::Multiply => {
@@ -277,7 +279,17 @@ impl PhysicalExpr for WideDecimalBinaryExpr {
                     } else {
                         raw
                     };
-                    check_overflow_and_convert(result, bound, neg_bound, p_out, s_out, eval_mode)
+                    check_overflow_and_convert(
+                        result,
+                        bound,
+                        neg_bound,
+                        p_out,
+                        s_out,
+                        raw,
+                        natural_scale,
+                        true,
+                        eval_mode,
+                    )
                 })
             }
         };
@@ -330,9 +342,12 @@ impl PhysicalExpr for WideDecimalBinaryExpr {
     }
 }
 
-/// Check if the i256 result fits in the output precision. In Ansi mode, return an error
-/// on overflow. In Legacy/Try mode, return i128::MAX as a sentinel value that will be
+/// Check if the rescaled i256 result fits in the output precision. In Ansi mode, return an
+/// error on overflow. In Legacy/Try mode, return i128::MAX as a sentinel value that will be
 /// nullified by `null_if_overflow_precision`.
+///
+/// ANSI overflow messages format `report_value` at `report_scale` (Spark's pre-toPrecision
+/// intermediate), not the rescaled result. Multiply also applies Spark's MathContext(39, DOWN).
 #[inline]
 fn check_overflow_and_convert(
     result: i256,
@@ -340,19 +355,23 @@ fn check_overflow_and_convert(
     neg_bound: i256,
     precision: u8,
     scale: i8,
+    report_value: i256,
+    report_scale: i8,
+    apply_spark_multiply_math_context: bool,
     eval_mode: EvalMode,
 ) -> Result<i128, ArrowError> {
     if result > bound || result < neg_bound {
         if eval_mode == EvalMode::Ansi {
-            let unscaled = result.to_string();
-            // Arrow's formatter truncates to its precision argument. This value is already
-            // known to overflow, so pass its actual digit count to preserve every digit.
-            // Spark reports the pre-toPrecision value instead; see
-            // https://github.com/apache/datafusion-comet/issues/5211.
-            let digits = unscaled.trim_start_matches('-').len();
+            let value = if apply_spark_multiply_math_context {
+                spark_multiply_overflow_value(&report_value.to_string(), report_scale)
+            } else {
+                let unscaled = report_value.to_string();
+                let digits = unscaled.trim_start_matches('-').len();
+                format_decimal_str(&unscaled, digits, report_scale)
+            };
             return Err(ArrowError::ExternalError(Box::new(
                 SparkError::NumericValueOutOfRange {
-                    value: format_decimal_str(&unscaled, digits, scale),
+                    value,
                     precision,
                     scale,
                 },
@@ -363,6 +382,30 @@ fn check_overflow_and_convert(
     } else {
         Ok(result.to_i128().unwrap())
     }
+}
+
+/// Emulate Spark multiply's `MathContext(39, DOWN)` before `toPlainString()`.
+fn spark_multiply_overflow_value(unscaled: &str, scale: i8) -> String {
+    const MC_PRECISION: usize = 39; // DecimalType.MAX_PRECISION + 1
+    let negative = unscaled.starts_with('-');
+    let digits = unscaled.trim_start_matches('-');
+    if digits.is_empty() {
+        return "0".to_string();
+    }
+
+    if digits.len() <= MC_PRECISION {
+        return format_decimal_str(unscaled, digits.len(), scale);
+    }
+
+    let truncated = &digits[..MC_PRECISION];
+    let dropped = digits.len() - MC_PRECISION;
+    let new_scale = scale as i32 - dropped as i32;
+    let truncated = if negative {
+        format!("-{truncated}")
+    } else {
+        truncated.to_string()
+    };
+    format_decimal_str(&truncated, MC_PRECISION, new_scale as i8)
 }
 
 #[cfg(test)]
@@ -538,6 +581,41 @@ mod tests {
                 WideDecimalOp::Multiply,
                 1,
                 0,
+                "9.90",
+            ),
+            (
+                make_batch(
+                    vec![Some(11_000_000_000_000_000_000)],
+                    20,
+                    0,
+                    vec![Some(11_000_000_000_000_000_000)],
+                    20,
+                    0,
+                ),
+                WideDecimalOp::Multiply,
+                38,
+                6,
+                "121000000000000000000000000000000000000",
+            ),
+            (
+                make_batch(
+                    vec![Some(11_000_000_000_000_000_000i128 * 10i128.pow(18))],
+                    38,
+                    18,
+                    vec![Some(11_000_000_000_000_000_000i128 * 10i128.pow(18))],
+                    38,
+                    18,
+                ),
+                WideDecimalOp::Multiply,
+                38,
+                6,
+                "121000000000000000000000000000000000000",
+            ),
+            (
+                make_batch(vec![Some(5)], 38, 0, vec![Some(5)], 38, 0),
+                WideDecimalOp::Add,
+                1,
+                2,
                 "10",
             ),
         ];

--- a/spark/src/main/spark-3.4/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
+++ b/spark/src/main/spark-3.4/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
@@ -105,7 +105,8 @@ trait ShimSparkErrorConverter {
         Some(QueryExecutionErrors.overflowInSumOfDecimalError(sqlCtx(context)))
 
       case "NumericValueOutOfRange" =>
-        val decimal = Decimal(params("value").toString)
+        // Use Java BigDecimal to avoid Scala BigDecimal's DECIMAL128 MathContext rewriting.
+        val decimal = Decimal(new java.math.BigDecimal(params("value").toString))
         Some(
           QueryExecutionErrors.cannotChangeDecimalPrecisionError(
             decimal,

--- a/spark/src/main/spark-3.5/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
+++ b/spark/src/main/spark-3.5/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
@@ -105,7 +105,8 @@ trait ShimSparkErrorConverter {
         Some(QueryExecutionErrors.overflowInSumOfDecimalError(sqlCtx(context)))
 
       case "NumericValueOutOfRange" =>
-        val decimal = Decimal(params("value").toString)
+        // Use Java BigDecimal to avoid Scala BigDecimal's DECIMAL128 MathContext rewriting.
+        val decimal = Decimal(new java.math.BigDecimal(params("value").toString))
         Some(
           QueryExecutionErrors.cannotChangeDecimalPrecisionError(
             decimal,

--- a/spark/src/main/spark-4.x/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
+++ b/spark/src/main/spark-4.x/org/apache/spark/sql/comet/shims/ShimSparkErrorConverter.scala
@@ -127,7 +127,8 @@ trait ShimSparkErrorConverter {
             .overflowInSumOfDecimalError(context.headOption.orNull, s"try_$functionName"))
 
       case "NumericValueOutOfRange" =>
-        val decimal = Decimal(params("value").toString)
+        // Use Java BigDecimal to avoid Scala BigDecimal's DECIMAL128 MathContext rewriting.
+        val decimal = Decimal(new java.math.BigDecimal(params("value").toString))
         Some(
           QueryExecutionErrors.cannotChangeDecimalPrecisionError(
             decimal,

--- a/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCastSuite.scala
@@ -1602,7 +1602,7 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       spark.sparkContext.parallelize(rowData),
       StructType(Seq(StructField("a", DataTypes.createDecimalType(10, 4)))))
 
-    castTest(df, DecimalType(6, 2))
+    castTest(df, DecimalType(6, 2), expectAnsiFailure = true)
   }
 
   test("cast between decimals with higher precision than source") {
@@ -2417,25 +2417,19 @@ class CometCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
               val cometMessage =
                 if (cometException.getCause != null) cometException.getCause.getMessage
                 else cometException.getMessage
-              // this if branch should only check decimal to decimal cast and errors when output precision, scale causes overflow.
-              if (df.schema("a").dataType.typeName.contains("decimal") && toType.typeName
-                  .contains("decimal") && sparkMessage.contains("cannot be represented as")) {
-                assert(cometMessage.contains("too large to store"))
+              if (CometSparkSessionExtensions.isSpark40Plus) {
+                // for Spark 4 we expect to sparkException carries the message
+                assert(sparkMessage.contains("SQLSTATE"))
+                // we compare a subset of the error message. Comet grabs the query
+                // context eagerly so it displays the call site at the
+                // line of code where the cast method was called, whereas spark grabs the context
+                // lazily and displays the call site at the line of code where the error is checked.
+                assert(
+                  sparkMessage.startsWith(
+                    cometMessage.substring(0, math.min(40, cometMessage.length))))
               } else {
-                if (CometSparkSessionExtensions.isSpark40Plus) {
-                  // for Spark 4 we expect to sparkException carries the message
-                  assert(sparkMessage.contains("SQLSTATE"))
-                  // we compare a subset of the error message. Comet grabs the query
-                  // context eagerly so it displays the call site at the
-                  // line of code where the cast method was called, whereas spark grabs the context
-                  // lazily and displays the call site at the line of code where the error is checked.
-                  assert(
-                    sparkMessage.startsWith(
-                      cometMessage.substring(0, math.min(40, cometMessage.length))))
-                } else {
-                  // for Spark 3.4 we expect to reproduce the error message exactly
-                  assert(cometMessage == sparkMessage)
-                }
+                // for Spark 3.4 we expect to reproduce the error message exactly
+                assert(cometMessage == sparkMessage)
               }
           }
         }

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -24,6 +24,7 @@ import java.time.{Duration, Period}
 import scala.util.Random
 
 import org.apache.hadoop.fs.Path
+import org.apache.spark.SparkThrowable
 import org.apache.spark.sql.{Column, CometTestBase, DataFrame, Row}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Cast, FromUnixTime, Literal, StructsToJson, TruncDate, TruncTimestamp}
 import org.apache.spark.sql.catalyst.optimizer.{ConvertToLocalRelation, OptimizeIn, SimplifyExtractValueOps}
@@ -45,6 +46,17 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     """[ARITHMETIC_OVERFLOW] integer overflow. If necessary set "spark.sql.ansi.enabled" to "false" to bypass this error"""
   val DIVIDE_BY_ZERO_EXCEPTION_MSG =
     """Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead"""
+
+  private def arithmeticError(error: Throwable): SparkThrowable =
+    Iterator
+      .iterate[Throwable](error)(_.getCause)
+      .takeWhile(_ != null)
+      .collectFirst {
+        case error: SparkThrowable
+            if error.getClass.getName == "org.apache.spark.SparkArithmeticException" =>
+          error
+      }
+      .getOrElse(fail(s"Expected SparkArithmeticException, got $error"))
 
   // Temporary test to verify checkSparkAnswer failure output labels Comet/Spark correctly.
   ignore("check output labels on mismatch") {
@@ -199,6 +211,29 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
               checkSparkSchema(cometDf)
               checkSparkAnswerAndOperator(cometDf)
             }
+          }
+        }
+      }
+    }
+  }
+
+  test("ANSI decimal divide by zero raises a Spark error") {
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+      withTable("decimal_div_zero") {
+        sql("CREATE TABLE decimal_div_zero (a DECIMAL(10, 2), b DECIMAL(10, 2)) USING PARQUET")
+        sql("INSERT INTO decimal_div_zero VALUES (1.00, 0.00)")
+
+        Seq("a / b", "a div b").foreach { expression =>
+          val df = sql(s"SELECT $expression FROM decimal_div_zero")
+          checkCometOperators(stripAQEPlan(df.queryExecution.executedPlan))
+          checkSparkAnswerMaybeThrows(df) match {
+            case (Some(sparkException), Some(cometException)) =>
+              val expected = arithmeticError(sparkException)
+              val actual = arithmeticError(cometException)
+              assert(actual.getErrorClass == expected.getErrorClass)
+              assert(actual.getSqlState == expected.getSqlState)
+              assert(actual.getQueryContext.exists(_.fragment().contains(expression)))
+            case errors => fail(s"Expected Spark and Comet divide-by-zero errors, got $errors")
           }
         }
       }
@@ -1401,14 +1436,18 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     // 1.1e19 * 1.1e19 = 1.21e38 overflows DECIMAL(38,0). With ANSI mode on, both Spark and
     // Comet must throw — Comet must not panic or silently return null. Spark reports
     // NUMERIC_VALUE_OUT_OF_RANGE; Comet's WideDecimalBinaryExpr catches the overflow first
-    // and surfaces it as an arithmetic overflow error.
+    // and must surface the same structured Spark error.
     withSQLConf(CometConf.COMET_ENABLED.key -> "true", SQLConf.ANSI_ENABLED.key -> "true") {
       withParquetTable(Seq((BigDecimal("11000000000000000000"), 0)), "tbl") {
         val res = sql("SELECT _1 * _1 FROM tbl")
+        checkCometOperators(stripAQEPlan(res.queryExecution.executedPlan))
         checkSparkAnswerMaybeThrows(res) match {
           case (Some(sparkExc), Some(cometExc)) =>
-            assert(sparkExc.getMessage.contains("NUMERIC_VALUE_OUT_OF_RANGE"))
-            assert(cometExc.getMessage.toLowerCase.contains("overflow"))
+            val expected = arithmeticError(sparkExc)
+            val actual = arithmeticError(cometExc)
+            assert(actual.getErrorClass == expected.getErrorClass)
+            assert(actual.getSqlState == expected.getSqlState)
+            assert(actual.getQueryContext.exists(_.fragment().contains("_1 * _1")))
           case _ =>
             fail("Expected exception for decimal overflow in ANSI mode")
         }

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -52,6 +52,8 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       .iterate[Throwable](error)(_.getCause)
       .takeWhile(_ != null)
       .collectFirst {
+        // SparkArithmeticException is private[spark] in Spark 3.4, so this cross-version test
+        // cannot pattern match on its type directly.
         case error: SparkThrowable
             if error.getClass.getName == "org.apache.spark.SparkArithmeticException" =>
           error
@@ -1445,6 +1447,8 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
           case (Some(sparkExc), Some(cometExc)) =>
             val expected = arithmeticError(sparkExc)
             val actual = arithmeticError(cometExc)
+            // Spark formats its pre-toPrecision Decimal, while Comet formats the rescaled i256
+            // value. This regression covers the structured error fields and query context.
             assert(actual.getErrorClass == expected.getErrorClass)
             assert(actual.getSqlState == expected.getSqlState)
             assert(actual.getQueryContext.exists(_.fragment().contains("_1 * _1")))

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1435,10 +1435,8 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   test("scalar decimal overflow - ANSI mode throws ArithmeticException") {
-    // 1.1e19 * 1.1e19 = 1.21e38 overflows DECIMAL(38,0). With ANSI mode on, both Spark and
-    // Comet must throw — Comet must not panic or silently return null. Spark reports
-    // NUMERIC_VALUE_OUT_OF_RANGE; Comet's WideDecimalBinaryExpr catches the overflow first
-    // and must surface the same structured Spark error.
+    // 1.1e19 * 1.1e19 overflows Decimal(38, 6); ANSI must raise NUMERIC_VALUE_OUT_OF_RANGE
+    // with the same pre-toPrecision `value` as Spark (#5211).
     withSQLConf(CometConf.COMET_ENABLED.key -> "true", SQLConf.ANSI_ENABLED.key -> "true") {
       withParquetTable(Seq((BigDecimal("11000000000000000000"), 0)), "tbl") {
         val res = sql("SELECT _1 * _1 FROM tbl")
@@ -1447,12 +1445,15 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
           case (Some(sparkExc), Some(cometExc)) =>
             val expected = arithmeticError(sparkExc)
             val actual = arithmeticError(cometExc)
-            // Spark formats its pre-toPrecision Decimal, while Comet formats the rescaled i256
-            // value (https://github.com/apache/datafusion-comet/issues/5211). This regression
-            // covers the structured error fields and query context.
             assert(actual.getErrorClass == expected.getErrorClass)
             assert(actual.getSqlState == expected.getSqlState)
             assert(actual.getQueryContext.exists(_.fragment().contains("_1 * _1")))
+            val actualValue = actual.getMessageParameters.get("value")
+            val expectedValue = expected.getMessageParameters.get("value")
+            assert(
+              actualValue == expectedValue,
+              s"value mismatch: comet=$actualValue spark=$expectedValue")
+            assert(!actualValue.contains(".000000"))
           case _ =>
             fail("Expected exception for decimal overflow in ANSI mode")
         }

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -1448,7 +1448,8 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
             val expected = arithmeticError(sparkExc)
             val actual = arithmeticError(cometExc)
             // Spark formats its pre-toPrecision Decimal, while Comet formats the rescaled i256
-            // value. This regression covers the structured error fields and query context.
+            // value (https://github.com/apache/datafusion-comet/issues/5211). This regression
+            // covers the structured error fields and query context.
             assert(actual.getErrorClass == expected.getErrorClass)
             assert(actual.getSqlState == expected.getSqlState)
             assert(actual.getQueryContext.exists(_.fragment().contains("_1 * _1")))


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5211.

## Rationale for this change

This is a follow-up to #5072 and #5169.

Under ANSI mode, wide-decimal overflow raises `NUMERIC_VALUE_OUT_OF_RANGE`, but the `value` reported by Comet did not match Spark.

Spark reports the pre-`toPrecision` intermediate value using `toPlainString`. Comet instead formatted the already-rescaled `i256` value at the output scale, which introduced a spurious all zero fractional suffix, such as `.000000`.

For multiplication, Spark also applies `MathContext(39, DOWN)` before formatting the reported value. Without this step, values with high storage scales, such as `Decimal(38, 18)`, retained a long `.000…` suffix that Spark does not emit.

## What changes are included in this PR?

* Format ANSI overflow values using the pre-rescale intermediate value at its natural scale, rather than the rescaled output-scale value.
* For multiplication, apply Spark's `MathContext(39, DOWN)` when constructing the reported `value`.
* Parse `NumericValueOutOfRange` parameters using `java.math.BigDecimal` shims so that Scala `BigDecimal`'s default `DECIMAL128` `MathContext` does not rewrite large integer values.
* Strengthen `CometExpressionSuite` to verify that the `value` parameter matches Spark and does not contain a spurious `.000000` suffix.

> **Note:** This branch is based on #5169. If #5169 has not been merged yet, please review and merge it first, or update this PR's base branch accordingly.

## How are these changes tested?

* Native unit tests in `wide_decimal_binary_expr.rs` covering overflow-value formatting for addition and multiplication, including the `Decimal(38, 18)` multiplication case.
* Scalar decimal overflow tests in `CometExpressionSuite` for both legacy and ANSI modes.
