### PR TITLE
fix: propagate the Spark task ClassLoader to JVM UDF calls

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -401,6 +401,7 @@ jobs:
               org.apache.comet.CometCodegenHOFSuite
               org.apache.comet.CometFuzzMathSuite
               org.apache.comet.CometCodegenFuzzSuite
+              org.apache.comet.CometScalaUDFClassLoaderSuite
               org.apache.comet.codegen.CometSpecializedGettersDispatchSuite
               org.apache.comet.CometStringDecodeSuite
               org.apache.comet.CometWidthBucketSuite

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -217,6 +217,7 @@ jobs:
               org.apache.comet.CometCodegenHOFSuite
               org.apache.comet.CometFuzzMathSuite
               org.apache.comet.CometCodegenFuzzSuite
+              org.apache.comet.CometScalaUDFClassLoaderSuite
               org.apache.comet.codegen.CometSpecializedGettersDispatchSuite
               org.apache.comet.CometStringDecodeSuite
               org.apache.comet.CometWidthBucketSuite

--- a/docs/source/user-guide/latest/scala_java_udfs.md
+++ b/docs/source/user-guide/latest/scala_java_udfs.md
@@ -54,6 +54,7 @@ When a UDF is rejected, the reason surfaces through Comet's standard fallback di
 
 - Non-deterministic expressions referenced from the argument tree (`rand`, `uuid`, `monotonically_increasing_id`) produce per-partition sequences consistent with Spark.
 - `TaskContext.get()` inside the user function returns the driving Spark task's context.
+- The Spark task thread's context ClassLoader is propagated to the thread that runs the user function, so functions defined in jars supplied with `--jars` / `spark.jars` resolve the same way they do under Spark's own execution.
 - The user function must be closure-serializable; the same function that works with Spark's executor execution works here.
 
 ## Known limitations

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -352,14 +352,10 @@ struct ExecutionContext {
     /// cheap to clone; the underlying `Global<JObject>` releases its JNI global ref on drop
     /// via `jni`'s `Drop` impl.
     pub task_context: Option<Arc<Global<JObject<'static>>>>,
-    /// Context `ClassLoader` of the driving Spark task thread, captured at `createPlan` time.
-    /// Threaded into every JVM scalar UDF the planner builds so the JNI bridge can install it on
-    /// the Tokio worker running the UDF. Tokio workers attach through JNI and an attached thread
-    /// has no context `ClassLoader`, so without this the bridge cannot see classes from user jars
-    /// (`--jars` / `spark.jars`): deserializing a `ScalaUDF` closure captured by a user class
-    /// fails, as does resolving a user-supplied `CometUDF` implementation. `None` when no driving
-    /// Spark task is present (unit tests, direct native driver runs). The `Arc` is cheap to clone;
-    /// the underlying `Global<JObject>` releases its JNI global ref on drop.
+    /// Context `ClassLoader` of the driving Spark task thread, captured at `createPlan` time and
+    /// threaded into every JVM scalar UDF the planner builds; see `CometUdfBridge.evaluate` for why
+    /// it has to travel with the plan. `None` when no driving Spark task is present (unit tests,
+    /// direct native driver runs). Lifetime is as for `task_context` above.
     pub class_loader: Option<Arc<Global<JObject<'static>>>>,
 }
 

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -352,6 +352,15 @@ struct ExecutionContext {
     /// cheap to clone; the underlying `Global<JObject>` releases its JNI global ref on drop
     /// via `jni`'s `Drop` impl.
     pub task_context: Option<Arc<Global<JObject<'static>>>>,
+    /// Context `ClassLoader` of the driving Spark task thread, captured at `createPlan` time.
+    /// Threaded into every JVM scalar UDF the planner builds so the JNI bridge can install it on
+    /// the Tokio worker running the UDF. Tokio workers attach through JNI and an attached thread
+    /// has no context `ClassLoader`, so without this the bridge cannot see classes from user jars
+    /// (`--jars` / `spark.jars`): deserializing a `ScalaUDF` closure captured by a user class
+    /// fails, as does resolving a user-supplied `CometUDF` implementation. `None` when no driving
+    /// Spark task is present (unit tests, direct native driver runs). The `Arc` is cheap to clone;
+    /// the underlying `Global<JObject>` releases its JNI global ref on drop.
+    pub class_loader: Option<Arc<Global<JObject<'static>>>>,
 }
 
 /// Accept serialized query plan and return the address of the native query plan.
@@ -379,6 +388,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
     task_cpus: jlong,
     key_unwrapper_obj: JObject,
     task_context_obj: JObject,
+    class_loader_obj: JObject,
 ) -> jlong {
     try_unwrap_or_throw(&e, |env| {
         // Deserialize Spark configs
@@ -500,11 +510,17 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
                 String::new()
             };
 
-            // Capture the driving Spark task's TaskContext as a JNI global reference when
-            // non-null. The `Arc<Global<JObject>>` releases its global ref on drop, so cleanup
-            // is automatic when the ExecutionContext drops.
+            // Capture the driving Spark task's TaskContext and context ClassLoader as JNI global
+            // references when non-null. The `Arc<Global<JObject>>` releases its global ref on
+            // drop, so cleanup is automatic when the ExecutionContext drops.
             let task_context = if !task_context_obj.is_null() {
                 Some(Arc::new(jni_new_global_ref!(env, task_context_obj)?))
+            } else {
+                None
+            };
+
+            let class_loader = if !class_loader_obj.is_null() {
+                Some(Arc::new(jni_new_global_ref!(env, class_loader_obj)?))
             } else {
                 None
             };
@@ -536,6 +552,7 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_createPlan(
                 ),
                 tracing_event_name,
                 task_context,
+                class_loader,
             });
 
             Ok(Box::into_raw(exec_context) as i64)
@@ -782,7 +799,8 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_executePlan(
                     PhysicalPlanner::new(Arc::clone(&exec_context.session_ctx), partition)
                         .with_exec_id(exec_context_id)
                         .with_sql_text_pool(&exec_context.spark_plan)
-                        .with_task_context(exec_context.task_context.clone());
+                        .with_task_context(exec_context.task_context.clone())
+                        .with_class_loader(exec_context.class_loader.clone());
                 let (scans, shuffle_scans, root_op) = planner.create_plan(
                     &exec_context.spark_plan,
                     &mut exec_context.input_sources.clone(),

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -361,10 +361,9 @@ impl PhysicalPlanner {
         self
     }
 
-    /// Attach the driving Spark task thread's context `ClassLoader` as a global reference. Called
-    /// by the JNI `executePlan` entry with whatever was captured at `createPlan` time. The planner
-    /// clones this `Option` into every `JvmScalarUdfExpr` it builds so the JNI bridge can install
-    /// it on the Tokio worker, which has no context `ClassLoader` of its own.
+    /// Attach the driving Spark task thread's context `ClassLoader` as a global reference. Mirrors
+    /// `with_task_context`: called by the JNI `executePlan` entry with whatever was captured at
+    /// `createPlan` time, and cloned into every `JvmScalarUdfExpr` the planner builds.
     pub fn with_class_loader(
         mut self,
         class_loader: Option<Arc<Global<JObject<'static>>>>,
@@ -898,12 +897,9 @@ impl PhysicalPlanner {
                 // the only context in which they may legitimately be None (unit tests, direct
                 // native driver runs).
                 debug_assert!(
-                    self.task_context.is_some() || self.exec_context_id == TEST_EXEC_CONTEXT_ID,
-                    "task_context must be set for non-test execution"
-                );
-                debug_assert!(
-                    self.class_loader.is_some() || self.exec_context_id == TEST_EXEC_CONTEXT_ID,
-                    "class_loader must be set for non-test execution"
+                    (self.task_context.is_some() && self.class_loader.is_some())
+                        || self.exec_context_id == TEST_EXEC_CONTEXT_ID,
+                    "task_context and class_loader must be set for non-test execution"
                 );
                 Ok(Arc::new(JvmScalarUdfExpr::new(
                     udf.class_name.clone(),

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -250,6 +250,10 @@ pub struct PhysicalPlanner {
     /// Captured at `createPlan` time on `ExecutionContext`; see that struct for the
     /// propagation rationale. `None` when no driving Spark task is available.
     task_context: Option<Arc<Global<JObject<'static>>>>,
+    /// Context `ClassLoader` of the driving Spark task thread, captured at `createPlan` time on
+    /// `ExecutionContext`; see that struct for the propagation rationale. `None` when no driving
+    /// Spark task is available.
+    class_loader: Option<Arc<Global<JObject<'static>>>>,
 }
 
 impl Default for PhysicalPlanner {
@@ -267,6 +271,7 @@ impl PhysicalPlanner {
             query_context_registry: datafusion_comet_spark_expr::create_query_context_map(),
             sql_text_pool: vec![],
             task_context: None,
+            class_loader: None,
         }
     }
 
@@ -353,6 +358,18 @@ impl PhysicalPlanner {
         task_context: Option<Arc<Global<JObject<'static>>>>,
     ) -> Self {
         self.task_context = task_context;
+        self
+    }
+
+    /// Attach the driving Spark task thread's context `ClassLoader` as a global reference. Called
+    /// by the JNI `executePlan` entry with whatever was captured at `createPlan` time. The planner
+    /// clones this `Option` into every `JvmScalarUdfExpr` it builds so the JNI bridge can install
+    /// it on the Tokio worker, which has no context `ClassLoader` of its own.
+    pub fn with_class_loader(
+        mut self,
+        class_loader: Option<Arc<Global<JObject<'static>>>>,
+    ) -> Self {
+        self.class_loader = class_loader;
         self
     }
 
@@ -876,12 +893,17 @@ impl PhysicalPlanner {
                     to_arrow_datatype(udf.return_type.as_ref().ok_or_else(|| {
                         GeneralError("JvmScalarUdf missing return_type".to_string())
                     })?);
-                // Invariant: task_context is propagated for every JvmScalarUdfExpr built during
-                // normal execution. The TEST_EXEC_CONTEXT_ID path is the only context in which
-                // task_context may legitimately be None (unit tests, direct native driver runs).
+                // Invariant: task_context and class_loader are propagated for every
+                // JvmScalarUdfExpr built during normal execution. The TEST_EXEC_CONTEXT_ID path is
+                // the only context in which they may legitimately be None (unit tests, direct
+                // native driver runs).
                 debug_assert!(
                     self.task_context.is_some() || self.exec_context_id == TEST_EXEC_CONTEXT_ID,
                     "task_context must be set for non-test execution"
+                );
+                debug_assert!(
+                    self.class_loader.is_some() || self.exec_context_id == TEST_EXEC_CONTEXT_ID,
+                    "class_loader must be set for non-test execution"
                 );
                 Ok(Arc::new(JvmScalarUdfExpr::new(
                     udf.class_name.clone(),
@@ -889,6 +911,7 @@ impl PhysicalPlanner {
                     return_type,
                     udf.return_nullable,
                     self.task_context.clone(),
+                    self.class_loader.clone(),
                 )))
             }
             expr => Err(GeneralError(format!("Not implemented: {expr:?}"))),

--- a/native/jni-bridge/src/comet_udf_bridge.rs
+++ b/native/jni-bridge/src/comet_udf_bridge.rs
@@ -41,7 +41,9 @@ impl<'a> CometUdfBridge<'a> {
             method_evaluate: env.get_static_method_id(
                 JNIString::new(Self::JVM_CLASS),
                 jni::jni_str!("evaluate"),
-                jni::jni_sig!("(Ljava/lang/String;[J[JJJILorg/apache/spark/TaskContext;)V"),
+                jni::jni_sig!(
+                    "(Ljava/lang/String;[J[JJJILorg/apache/spark/TaskContext;Ljava/lang/ClassLoader;)V"
+                ),
             )?,
             method_evaluate_ret: ReturnType::Primitive(Primitive::Void),
             class,

--- a/native/spark-expr/src/jvm_udf/mod.rs
+++ b/native/spark-expr/src/jvm_udf/mod.rs
@@ -49,11 +49,9 @@ pub struct JvmScalarUdfExpr {
     /// returns in place.
     task_context: Option<Arc<Global<JObject<'static>>>>,
     /// Context `ClassLoader` of the driving Spark task thread, captured at `createPlan` time and
-    /// threaded here by the planner. Tokio workers attach to the JVM through JNI and an attached
-    /// thread has no context `ClassLoader`, so without this the bridge cannot reach classes that
-    /// live in user jars (`--jars` / `spark.jars`) - deserializing a `ScalaUDF` closure captured
-    /// by a user class then fails. `None` when no driving Spark task is available (unit tests,
-    /// direct native driver runs); the bridge then leaves the worker's `ClassLoader` alone.
+    /// threaded here by the planner. See `CometUdfBridge.evaluate`, which installs it for the
+    /// duration of the call. `None` when no driving Spark task is available (unit tests, direct
+    /// native driver runs); the bridge then installs nothing.
     class_loader: Option<Arc<Global<JObject<'static>>>>,
 }
 
@@ -207,9 +205,8 @@ impl PhysicalExpr for JvmScalarUdfExpr {
                 .map_err(|e| CometError::JNI { source: e })?;
 
             // Resolve the TaskContext and ClassLoader references once before building the arg
-            // array so the borrows live until `call_static_method_unchecked` returns. When
-            // neither was propagated, pass a null object so the bridge's null-guards leave the
-            // worker thread's thread-local / ClassLoader alone.
+            // array so the borrows live until `call_static_method_unchecked` returns. Absent
+            // values are passed as a null object, which the bridge's null-guards skip.
             let null_obj = JObject::null();
             let task_context_ref: &JObject = match &self.task_context {
                 Some(gref) => gref.as_obj(),

--- a/native/spark-expr/src/jvm_udf/mod.rs
+++ b/native/spark-expr/src/jvm_udf/mod.rs
@@ -48,6 +48,13 @@ pub struct JvmScalarUdfExpr {
     /// Spark task is available; the bridge then leaves whatever `TaskContext.get()` already
     /// returns in place.
     task_context: Option<Arc<Global<JObject<'static>>>>,
+    /// Context `ClassLoader` of the driving Spark task thread, captured at `createPlan` time and
+    /// threaded here by the planner. Tokio workers attach to the JVM through JNI and an attached
+    /// thread has no context `ClassLoader`, so without this the bridge cannot reach classes that
+    /// live in user jars (`--jars` / `spark.jars`) - deserializing a `ScalaUDF` closure captured
+    /// by a user class then fails. `None` when no driving Spark task is available (unit tests,
+    /// direct native driver runs); the bridge then leaves the worker's `ClassLoader` alone.
+    class_loader: Option<Arc<Global<JObject<'static>>>>,
 }
 
 impl JvmScalarUdfExpr {
@@ -57,6 +64,7 @@ impl JvmScalarUdfExpr {
         return_type: DataType,
         return_nullable: bool,
         task_context: Option<Arc<Global<JObject<'static>>>>,
+        class_loader: Option<Arc<Global<JObject<'static>>>>,
     ) -> Self {
         debug_assert!(
             !class_name.is_empty(),
@@ -68,6 +76,7 @@ impl JvmScalarUdfExpr {
             return_type,
             return_nullable,
             task_context,
+            class_loader,
         }
     }
 }
@@ -197,14 +206,18 @@ impl PhysicalExpr for JvmScalarUdfExpr {
                 .set_region(env, 0, &in_sch_ptrs)
                 .map_err(|e| CometError::JNI { source: e })?;
 
-            // Resolve the TaskContext reference once before building the arg array so the
-            // borrow lives until `call_static_method_unchecked` returns. When no TaskContext
-            // was propagated, pass a null object so the bridge's null-guard leaves the thread-
-            // local alone.
-            let null_task_context = JObject::null();
+            // Resolve the TaskContext and ClassLoader references once before building the arg
+            // array so the borrows live until `call_static_method_unchecked` returns. When
+            // neither was propagated, pass a null object so the bridge's null-guards leave the
+            // worker thread's thread-local / ClassLoader alone.
+            let null_obj = JObject::null();
             let task_context_ref: &JObject = match &self.task_context {
                 Some(gref) => gref.as_obj(),
-                None => &null_task_context,
+                None => &null_obj,
+            };
+            let class_loader_ref: &JObject = match &self.class_loader {
+                Some(gref) => gref.as_obj(),
+                None => &null_obj,
             };
             let ret = unsafe {
                 env.call_static_method_unchecked(
@@ -219,6 +232,7 @@ impl PhysicalExpr for JvmScalarUdfExpr {
                         JValue::Long(out_sch_ptr).as_jni(),
                         JValue::Int(batch.num_rows() as i32).as_jni(),
                         JValue::Object(task_context_ref).as_jni(),
+                        JValue::Object(class_loader_ref).as_jni(),
                     ],
                 )
             };
@@ -255,6 +269,7 @@ impl PhysicalExpr for JvmScalarUdfExpr {
             self.return_type.clone(),
             self.return_nullable,
             self.task_context.clone(),
+            self.class_loader.clone(),
         )))
     }
 }

--- a/spark/src/main/java/org/apache/comet/udf/CometUdfBridge.java
+++ b/spark/src/main/java/org/apache/comet/udf/CometUdfBridge.java
@@ -31,6 +31,8 @@ import org.apache.spark.TaskContext;
 import org.apache.spark.comet.CometTaskContextShim;
 import org.apache.spark.util.TaskCompletionListener;
 
+import org.apache.comet.util.ClassLoaders;
+
 /**
  * JNI entry point for native execution to invoke a {@link CometUDF}. Matches the static-method
  * pattern used by CometScalarSubquery so the native side can dispatch via
@@ -95,9 +97,13 @@ public class CometUdfBridge {
    *     null} outside a Spark task. Installed as this thread's context ClassLoader for the duration
    *     of the call, with the prior value restored in {@code finally}. Tokio workers attach through
    *     JNI and an attached thread has no context ClassLoader, so without this every lookup falls
-   *     back to the ClassLoader that loaded Comet, which never holds user jars (`--jars` /
-   *     `spark.jars`). Both the {@code CometUDF} resolution below and the closure deserialization
-   *     in {@code CometScalaUDFCodegen} depend on it.
+   *     back to the ClassLoader that loaded Comet, which never holds user jars ({@code --jars} /
+   *     {@code spark.jars}). Both the {@code CometUDF} resolution below and the closure
+   *     deserialization in {@code CometScalaUDFCodegen} depend on it. Installed per call rather
+   *     than once when the worker attaches, because the Tokio runtime is process-global: one worker
+   *     interleaves work from task attempts of different jobs, and under Spark Connect from
+   *     sessions with different artifact ClassLoaders. The loader is a property of the plan, not of
+   *     the thread.
    */
   public static void evaluate(
       String udfClassName,
@@ -132,6 +138,7 @@ public class CometUdfBridge {
     if (classLoader != null) {
       currentThread.setContextClassLoader(classLoader);
     }
+
     try {
       evaluateInternal(
           udfClassName,
@@ -142,9 +149,9 @@ public class CometUdfBridge {
           numRows,
           taskContext);
     } finally {
-      if (classLoader != null) {
-        currentThread.setContextClassLoader(priorLoader);
-      }
+      // Unconditional: a no-op when nothing was installed, and it also undoes any change the
+      // user function made to the ClassLoader of a worker that outlives this call.
+      currentThread.setContextClassLoader(priorLoader);
       if (taskContext != null) {
         if (prior != null) {
           CometTaskContextShim.set(prior);
@@ -192,14 +199,10 @@ public class CometUdfBridge {
             udfClassName,
             name -> {
               try {
-                // Resolve via the executor's context classloader so user-supplied UDF jars
-                // (added via spark.jars / --jars) are visible.
-                ClassLoader cl = Thread.currentThread().getContextClassLoader();
-                if (cl == null) {
-                  cl = CometUdfBridge.class.getClassLoader();
-                }
+                // Resolves through the context ClassLoader installed by `evaluate`, so a
+                // user-supplied CometUDF shipped in a user jar is visible.
                 return (CometUDF)
-                    Class.forName(name, true, cl).getDeclaredConstructor().newInstance();
+                    ClassLoaders.loadClass(name).getDeclaredConstructor().newInstance();
               } catch (ReflectiveOperationException e) {
                 throw new RuntimeException("Failed to instantiate CometUDF: " + name, e);
               }

--- a/spark/src/main/java/org/apache/comet/udf/CometUdfBridge.java
+++ b/spark/src/main/java/org/apache/comet/udf/CometUdfBridge.java
@@ -91,6 +91,13 @@ public class CometUdfBridge {
    *     left on a worker by a previous task. Its task attempt ID also keys the UDF-instance cache,
    *     so a UDF holding per-task state in fields sees a consistent instance for every call within
    *     the task regardless of which Tokio worker is polling.
+   * @param classLoader context ClassLoader captured on the driving Spark task thread, or {@code
+   *     null} outside a Spark task. Installed as this thread's context ClassLoader for the duration
+   *     of the call, with the prior value restored in {@code finally}. Tokio workers attach through
+   *     JNI and an attached thread has no context ClassLoader, so without this every lookup falls
+   *     back to the ClassLoader that loaded Comet, which never holds user jars (`--jars` /
+   *     `spark.jars`). Both the {@code CometUDF} resolution below and the closure deserialization
+   *     in {@code CometScalaUDFCodegen} depend on it.
    */
   public static void evaluate(
       String udfClassName,
@@ -99,7 +106,8 @@ public class CometUdfBridge {
       long outArrayPtr,
       long outSchemaPtr,
       int numRows,
-      TaskContext taskContext) {
+      TaskContext taskContext,
+      ClassLoader classLoader) {
     assert udfClassName != null && !udfClassName.isEmpty() : "udfClassName must be non-empty";
     assert inputArrayPtrs != null && inputSchemaPtrs != null
         : "input pointer arrays must be non-null";
@@ -111,12 +119,18 @@ public class CometUdfBridge {
 
     // Save-and-restore rather than only-install-if-null: the propagated `taskContext` is the
     // ground truth for this call. Any value already on the thread is either (a) the same object
-    // on a Spark task thread, or (b) stale from a prior task on a reused Tokio worker.
+    // on a Spark task thread, or (b) stale from a prior task on a reused Tokio worker. The same
+    // reasoning applies to the propagated `classLoader`.
     TaskContext prior = TaskContext.get();
     if (taskContext != null) {
       CometTaskContextShim.set(taskContext);
       assert TaskContext.get() == taskContext
           : "TaskContext install did not take effect on this thread";
+    }
+    Thread currentThread = Thread.currentThread();
+    ClassLoader priorLoader = currentThread.getContextClassLoader();
+    if (classLoader != null) {
+      currentThread.setContextClassLoader(classLoader);
     }
     try {
       evaluateInternal(
@@ -128,6 +142,9 @@ public class CometUdfBridge {
           numRows,
           taskContext);
     } finally {
+      if (classLoader != null) {
+        currentThread.setContextClassLoader(priorLoader);
+      }
       if (taskContext != null) {
         if (prior != null) {
           CometTaskContextShim.set(prior);

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -84,6 +84,15 @@ class CometExecIterator(
   private val taskCPUs = TaskContext.get().cpus()
   private val cometTaskMemoryManager = new CometTaskMemoryManager(id, taskAttemptId)
 
+  /**
+   * Context ClassLoader of the Spark task thread that constructs this iterator. Spark installs
+   * the executor's user ClassLoader (which holds `--jars` / `spark.jars` classes) on task threads
+   * only, so it has to be read here rather than from a Tokio worker. Falls back to the
+   * ClassLoader that loaded Comet when the task thread has none.
+   */
+  private val taskClassLoader: ClassLoader =
+    Option(Thread.currentThread().getContextClassLoader).getOrElse(getClass.getClassLoader)
+
   private val plan = {
     val conf = SparkEnv.get.conf
     val localDiskDirs = SparkEnv.get.blockManager.getLocalDiskDirs
@@ -126,7 +135,11 @@ class CometExecIterator(
       keyUnwrapper,
       // Propagated to Tokio workers running JVM UDFs so they see this Spark task's
       // TaskContext. See CometUdfBridge.evaluate.
-      TaskContext.get())
+      TaskContext.get(),
+      // Likewise for this task thread's context ClassLoader, which is what reaches classes
+      // from user jars (--jars / spark.jars). Captured here because `CometExecIterator` is
+      // constructed on the Spark task thread; a JNI-attached Tokio worker has none.
+      taskClassLoader)
   }
 
   private var nextBatch: Option[ColumnarBatch] = None

--- a/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
+++ b/spark/src/main/scala/org/apache/comet/CometExecIterator.scala
@@ -84,15 +84,6 @@ class CometExecIterator(
   private val taskCPUs = TaskContext.get().cpus()
   private val cometTaskMemoryManager = new CometTaskMemoryManager(id, taskAttemptId)
 
-  /**
-   * Context ClassLoader of the Spark task thread that constructs this iterator. Spark installs
-   * the executor's user ClassLoader (which holds `--jars` / `spark.jars` classes) on task threads
-   * only, so it has to be read here rather than from a Tokio worker. Falls back to the
-   * ClassLoader that loaded Comet when the task thread has none.
-   */
-  private val taskClassLoader: ClassLoader =
-    Option(Thread.currentThread().getContextClassLoader).getOrElse(getClass.getClassLoader)
-
   private val plan = {
     val conf = SparkEnv.get.conf
     val localDiskDirs = SparkEnv.get.blockManager.getLocalDiskDirs
@@ -134,12 +125,11 @@ class CometExecIterator(
       taskCPUs,
       keyUnwrapper,
       // Propagated to Tokio workers running JVM UDFs so they see this Spark task's
-      // TaskContext. See CometUdfBridge.evaluate.
+      // TaskContext and context ClassLoader. Read here because this class is only ever
+      // constructed on a Spark task thread (see `taskAttemptId` above); a JNI-attached Tokio
+      // worker has neither. See CometUdfBridge.evaluate.
       TaskContext.get(),
-      // Likewise for this task thread's context ClassLoader, which is what reaches classes
-      // from user jars (--jars / spark.jars). Captured here because `CometExecIterator` is
-      // constructed on the Spark task thread; a JNI-attached Tokio worker has none.
-      taskClassLoader)
+      Thread.currentThread().getContextClassLoader)
   }
 
   private var nextBatch: Option[ColumnarBatch] = None

--- a/spark/src/main/scala/org/apache/comet/Native.scala
+++ b/spark/src/main/scala/org/apache/comet/Native.scala
@@ -48,6 +48,12 @@ class Native extends NativeBase {
    * @param taskMemoryManager
    *   the task-level memory manager that is responsible for tracking memory usage across JVM and
    *   native side.
+   * @param taskContext
+   *   the driving Spark task's `TaskContext`, propagated to Tokio workers running JVM UDFs.
+   * @param classLoader
+   *   the calling Spark task thread's context ClassLoader, propagated to Tokio workers running
+   *   JVM UDFs. Must be captured on the task thread: Tokio workers attach through JNI and have no
+   *   context ClassLoader of their own, so without this they cannot reach classes from user jars.
    * @return
    *   the address to native query plan.
    */
@@ -70,7 +76,8 @@ class Native extends NativeBase {
       taskAttemptId: Long,
       taskCPUs: Long,
       keyUnwrapper: CometFileKeyUnwrapper,
-      taskContext: TaskContext): Long
+      taskContext: TaskContext,
+      classLoader: ClassLoader): Long
   // scalastyle:on
 
   /**

--- a/spark/src/main/scala/org/apache/comet/Native.scala
+++ b/spark/src/main/scala/org/apache/comet/Native.scala
@@ -52,8 +52,7 @@ class Native extends NativeBase {
    *   the driving Spark task's `TaskContext`, propagated to Tokio workers running JVM UDFs.
    * @param classLoader
    *   the calling Spark task thread's context ClassLoader, propagated to Tokio workers running
-   *   JVM UDFs. Must be captured on the task thread: Tokio workers attach through JNI and have no
-   *   context ClassLoader of their own, so without this they cannot reach classes from user jars.
+   *   JVM UDFs. Must be read on the task thread; see `CometUdfBridge.evaluate`.
    * @return
    *   the address to native query plan.
    */

--- a/spark/src/test/scala/org/apache/comet/CometScalaUDFClassLoaderSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometScalaUDFClassLoaderSuite.scala
@@ -19,21 +19,19 @@
 
 package org.apache.comet
 
-import java.io.{File, FileOutputStream}
+import java.io.File
 import java.net.URLClassLoader
+import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{Files, Path}
-import java.util.jar.{JarEntry, JarOutputStream}
 import javax.tools.ToolProvider
 
-import scala.jdk.CollectionConverters._
-
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.{CometTestBase, Encoders}
 import org.apache.spark.sql.catalyst.expressions.Expression
 
 /**
- * Regression coverage for UDF closures whose capturing class lives in a user jar. Before the
- * task-thread ClassLoader was propagated to Tokio workers, these queries failed with:
+ * Regression coverage for UDF closures whose capturing class lives in a user jar, which used to
+ * fail with:
  *
  * {{{
  * java.lang.ClassCastException: cannot assign instance of java.lang.invoke.SerializedLambda
@@ -41,25 +39,16 @@ import org.apache.spark.sql.catalyst.expressions.Expression
  *   at org.apache.comet.udf.codegen.CometScalaUDFCodegen.lookupOrCompile
  * }}}
  *
- * It took two conditions together:
+ * That exception is a masked `ClassNotFoundException`: when the deserializing ClassLoader cannot
+ * resolve a lambda's capturing class, `ObjectInputStream` records the CNFE against the object
+ * handle, therefore skips `SerializedLambda.readResolve`, and the raw `SerializedLambda` then
+ * fails the field-type check in `defaultCheckFieldValues`. The classloading rationale lives on
+ * `CometUdfBridge.evaluate`.
  *
- *   1. The class that captured the UDF lambda lives in a user jar, so it is reachable from
- *      Spark's executor ClassLoader but not from the ClassLoader that loaded Comet and
- *      spark-catalyst. `spark.executor.extraClassPath` is the local-mode equivalent of a `--jars`
- *      submission: `LocalSchedulerBackend` feeds it into the executor's `MutableURLClassLoader`,
- *      which becomes the task thread's context ClassLoader.
- *   1. The dispatcher's `evaluate` runs on a Tokio worker rather than the Spark task thread.
- *      Tokio workers attach to the JVM through JNI and an attached thread has no context
- *      ClassLoader of its own, so `CometScalaUDFCodegen.lookupOrCompile` fell back to
- *      `classOf[Expression].getClassLoader`, which cannot see the user jar. That is the normal
- *      case when the stage's leaf is a native scan (`CometNativeScan`, `CometIcebergNativeScan`).
- *
- * The underlying `ClassNotFoundException` on the capturing class was masked: `ObjectInputStream`
- * records it against the handle, skips `SerializedLambda.readResolve`, and the raw
- * `SerializedLambda` then fails the field-type check in `defaultCheckFieldValues`.
- *
- * `CometExecIterator` now captures the task thread's context ClassLoader and `CometUdfBridge`
- * installs it on the calling thread for the duration of each UDF call.
+ * The fixture puts the capturing class on `spark.executor.extraClassPath`, the local-mode
+ * equivalent of a `--jars` submission: `LocalSchedulerBackend` feeds it into the executor's
+ * `MutableURLClassLoader`, which becomes the task thread's context ClassLoader while staying
+ * invisible to the ClassLoader that loaded Comet.
  */
 class CometScalaUDFClassLoaderSuite extends CometTestBase {
 
@@ -68,47 +57,40 @@ class CometScalaUDFClassLoaderSuite extends CometTestBase {
   override protected def sparkConf: SparkConf =
     super.sparkConf
       .set(CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key, "true")
-      // Visible to executor task threads, invisible to Comet's own ClassLoader.
-      .set("spark.executor.extraClassPath", hiddenJar.getAbsolutePath)
+      .set("spark.executor.extraClassPath", hiddenClassesDir.toString)
 
-  /** Registers a UDF whose lambda was captured by a class living only in the user jar. */
-  private def withHiddenUdf(name: String)(f: => Unit): Unit = {
-    val loader = new URLClassLoader(Array(hiddenJar.toURI.toURL), getClass.getClassLoader)
-    val fn = loader
-      .loadClass(HiddenClassName)
-      .getMethod("make")
-      .invoke(null)
-      .asInstanceOf[String => String]
-    spark.udf.register(name, fn)
-    try f
-    finally loader.close()
+  private def withHiddenUdfTable(f: => Unit): Unit = {
+    spark.udf.register("hiddenUdf", hiddenFn)
+    withTable("t") {
+      sql("CREATE TABLE t (s STRING) USING parquet")
+      sql("INSERT INTO t VALUES ('a'), ('b'), (NULL)")
+      f
+    }
   }
 
-  test("sanity: the hidden class is reachable from task threads but not from Comet's loader") {
-    // `classOf[Expression].getClassLoader` is exactly the fallback `lookupOrCompile` uses when the
-    // calling thread has no context ClassLoader.
+  test("fixture: hidden class reachable from task threads, not from Comet's ClassLoader") {
+    // Guards the tests below from passing vacuously. `classOf[Expression].getClassLoader` is the
+    // fallback `lookupOrCompile` uses when the calling thread has no context ClassLoader.
     intercept[ClassNotFoundException] {
       Class.forName(HiddenClassName, false, classOf[Expression].getClassLoader)
     }
     val reachable = spark
       .range(4)
       .repartition(2)
-      .mapPartitions(_ => Iterator(canLoadHiddenClassOnThisThread))(
-        org.apache.spark.sql.Encoders.scalaBoolean)
+      .mapPartitions(_ => Iterator(canLoadHiddenClass))(Encoders.scalaBoolean)
       .collect()
     assert(reachable.forall(identity), s"task threads could not load $HiddenClassName")
   }
 
-  test("ScalaUDF whose capturing class is only in the user jar, native scan leaf") {
-    // Fails without ClassLoader propagation: the dispatcher deserializes the closure on a Tokio
-    // worker, which sees no user jar, and the resulting ClassNotFoundException surfaces as
-    // `cannot assign instance of java.lang.invoke.SerializedLambda to field ScalaUDF.f`.
-    withHiddenUdf("hiddenUdf") {
-      withTable("t") {
-        sql("CREATE TABLE t (s STRING) USING parquet")
-        sql("INSERT INTO t VALUES ('a'), ('b'), (NULL)")
-        // Stage leaf is CometNativeScan, so the dispatcher runs on a Tokio worker.
-        checkSparkAnswer(sql("SELECT hiddenUdf(s) FROM t"))
+  // Both leaf shapes matter. With the native scan the dispatcher runs on a Tokio worker, which has
+  // no context ClassLoader of its own and depends on the propagated one; without it the dispatcher
+  // runs on the Spark task thread, which already has the executor's ClassLoader installed.
+  Seq(true, false).foreach { nativeScan =>
+    test(s"ScalaUDF closure captured by a user-jar class, nativeScan=$nativeScan") {
+      withSQLConf(CometConf.COMET_NATIVE_SCAN_ENABLED.key -> nativeScan.toString) {
+        withHiddenUdfTable {
+          checkSparkAnswer(sql("SELECT hiddenUdf(s) FROM t"))
+        }
       }
     }
   }
@@ -117,27 +99,11 @@ class CometScalaUDFClassLoaderSuite extends CometTestBase {
     // Pins the propagation itself rather than its symptom: the UDF body reports whether the
     // ClassLoader installed on whatever thread invoked it can reach the user jar.
     spark.udf.register("loaderProbe", (_: String) => loaderReport())
-    withTable("t") {
-      sql("CREATE TABLE t (s STRING) USING parquet")
-      sql("INSERT INTO t VALUES ('a'), ('b'), ('c'), ('d')")
+    withHiddenUdfTable {
       val reports = sql("SELECT loaderProbe(s) FROM t").collect().map(_.getString(0)).distinct
       assert(
         reports.forall(_.startsWith("loaded|")),
         s"UDF thread could not load $HiddenClassName: ${reports.mkString(", ")}")
-    }
-  }
-
-  test("control: same UDF evaluated on the Spark task thread") {
-    // With the native scan disabled the dispatcher runs on the task thread, whose context
-    // ClassLoader includes the user jar, so deserialization resolves the capturing class.
-    withSQLConf(CometConf.COMET_NATIVE_SCAN_ENABLED.key -> "false") {
-      withHiddenUdf("hiddenUdf2") {
-        withTable("t2") {
-          sql("CREATE TABLE t2 (s STRING) USING parquet")
-          sql("INSERT INTO t2 VALUES ('a'), ('b'), (NULL)")
-          checkSparkAnswer(sql("SELECT hiddenUdf2(s) FROM t2"))
-        }
-      }
     }
   }
 }
@@ -147,25 +113,25 @@ object CometScalaUDFClassLoaderSuite {
   val HiddenClassName = "hidden.HiddenUdf"
 
   /**
-   * Jar holding a serializable `scala.Function1` lambda. The lambda's capturing class exists only
-   * inside this jar, so it is visible only to ClassLoaders the jar is wired into. Built once,
-   * before the SparkSession starts, because `spark.executor.extraClassPath` is read at session
-   * creation.
+   * Directory holding the compiled capturing class. Compiled once per JVM, before the
+   * SparkSession starts, because `spark.executor.extraClassPath` is read at session creation. A
+   * directory works as a classpath entry, so there is no need to package a jar.
    */
-  lazy val hiddenJar: File = buildHiddenUdfJar(Files.createTempDirectory("comet-hidden-udf"))
+  lazy val hiddenClassesDir: Path = compileHiddenClass()
 
   /**
-   * Reports whether the current thread's context ClassLoader can reach the user jar, tagged with
-   * the thread name so a failure says which thread was missing it. Kept on the companion so the
-   * UDF closure captures nothing from the suite.
+   * The UDF, obtained through a ClassLoader over `hiddenClassesDir` alone. Deliberately not
+   * closed: the loaded class stays live in the registered UDF for the rest of the JVM's life.
    */
-  def loaderReport(): String = {
-    val status = if (canLoadHiddenClassOnThisThread) "loaded" else "MISSING"
-    s"$status|${Thread.currentThread().getName}"
-  }
+  lazy val hiddenFn: String => String =
+    new URLClassLoader(Array(hiddenClassesDir.toUri.toURL), getClass.getClassLoader)
+      .loadClass(HiddenClassName)
+      .getMethod("make")
+      .invoke(null)
+      .asInstanceOf[String => String]
 
-  /** Runs on a Spark task thread; kept on the companion so the closure captures nothing. */
-  def canLoadHiddenClassOnThisThread: Boolean =
+  /** Runs on Spark threads; kept on the companion so the closures capture nothing. */
+  def canLoadHiddenClass: Boolean =
     try {
       Class.forName(HiddenClassName, false, Thread.currentThread().getContextClassLoader)
       true
@@ -173,55 +139,54 @@ object CometScalaUDFClassLoaderSuite {
       case _: ClassNotFoundException => false
     }
 
-  private def buildHiddenUdfJar(workDir: Path): File = {
+  /**
+   * Reports whether the current thread's context ClassLoader reaches the user jar, tagged with
+   * the thread name so a failure says which thread was missing it.
+   */
+  def loaderReport(): String = {
+    val status = if (canLoadHiddenClass) "loaded" else "MISSING"
+    s"$status|${Thread.currentThread().getName}"
+  }
+
+  private def compileHiddenClass(): Path = {
+    val workDir = Files.createTempDirectory("comet-hidden-udf")
     val src = workDir.resolve("HiddenUdf.java")
+    // The intersection cast is what makes the lambda serializable, and therefore what makes
+    // `hidden.HiddenUdf` the capturing class recorded in the SerializedLambda.
     Files.write(
       src,
-      ("""package hidden;
+      """package hidden;
         |
         |import java.io.Serializable;
         |import scala.Function1;
         |
         |public class HiddenUdf {
-        |  public interface SerFn extends Function1<Object, Object>, Serializable {}
-        |
         |  public static Function1<Object, Object> make() {
-        |    return (SerFn) (Object o) -> (o == null ? null : "hidden:" + o);
+        |    return (Function1<Object, Object> & Serializable)
+        |        (Object o) -> (o == null ? null : "hidden:" + o);
         |  }
         |}
-        |""".stripMargin).getBytes("UTF-8"))
+        |""".stripMargin.getBytes(UTF_8))
 
     val classesDir = Files.createDirectories(workDir.resolve("classes"))
     val compiler = ToolProvider.getSystemJavaCompiler
     assert(compiler != null, "test must run on a JDK (needs the javax.tools compiler)")
-    val rc = compiler.run(
-      null,
-      null,
-      null,
-      "-cp",
-      System.getProperty("java.class.path"),
-      "-d",
-      classesDir.toString,
-      src.toString)
+    // Only scala-library is needed. Handing javac the whole test classpath makes it open and index
+    // every jar on it, which costs more than the compile itself.
+    val classpath = Option(classOf[Function1[_, _]].getProtectionDomain.getCodeSource)
+      .map(_.getLocation.getPath)
+      .getOrElse(System.getProperty("java.class.path"))
+    val rc =
+      compiler.run(null, null, null, "-cp", classpath, "-d", classesDir.toString, src.toString)
     assert(rc == 0, s"javac failed with exit code $rc")
 
-    val jar = workDir.resolve("hidden-udf.jar").toFile
-    val jos = new JarOutputStream(new FileOutputStream(jar))
-    try {
-      Files
-        .walk(classesDir)
-        .iterator()
-        .asScala
-        .filter(Files.isRegularFile(_))
-        .foreach { p =>
-          jos.putNextEntry(new JarEntry(classesDir.relativize(p).toString))
-          jos.write(Files.readAllBytes(p))
-          jos.closeEntry()
-        }
-    } finally {
-      jos.close()
-    }
-    jar.deleteOnExit()
-    jar
+    deleteOnExitRecursively(workDir.toFile)
+    classesDir
+  }
+
+  /** Parents are registered before children, and deletion runs in reverse registration order. */
+  private def deleteOnExitRecursively(file: File): Unit = {
+    file.deleteOnExit()
+    Option(file.listFiles()).foreach(_.foreach(deleteOnExitRecursively))
   }
 }

--- a/spark/src/test/scala/org/apache/comet/CometScalaUDFClassLoaderSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometScalaUDFClassLoaderSuite.scala
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet
+
+import java.io.{File, FileOutputStream}
+import java.net.URLClassLoader
+import java.nio.file.{Files, Path}
+import java.util.jar.{JarEntry, JarOutputStream}
+import javax.tools.ToolProvider
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.catalyst.expressions.Expression
+
+/**
+ * Regression coverage for UDF closures whose capturing class lives in a user jar. Before the
+ * task-thread ClassLoader was propagated to Tokio workers, these queries failed with:
+ *
+ * {{{
+ * java.lang.ClassCastException: cannot assign instance of java.lang.invoke.SerializedLambda
+ *   to field org.apache.spark.sql.catalyst.expressions.ScalaUDF.f of type scala.Function1
+ *   at org.apache.comet.udf.codegen.CometScalaUDFCodegen.lookupOrCompile
+ * }}}
+ *
+ * It took two conditions together:
+ *
+ *   1. The class that captured the UDF lambda lives in a user jar, so it is reachable from
+ *      Spark's executor ClassLoader but not from the ClassLoader that loaded Comet and
+ *      spark-catalyst. `spark.executor.extraClassPath` is the local-mode equivalent of a `--jars`
+ *      submission: `LocalSchedulerBackend` feeds it into the executor's `MutableURLClassLoader`,
+ *      which becomes the task thread's context ClassLoader.
+ *   1. The dispatcher's `evaluate` runs on a Tokio worker rather than the Spark task thread.
+ *      Tokio workers attach to the JVM through JNI and an attached thread has no context
+ *      ClassLoader of its own, so `CometScalaUDFCodegen.lookupOrCompile` fell back to
+ *      `classOf[Expression].getClassLoader`, which cannot see the user jar. That is the normal
+ *      case when the stage's leaf is a native scan (`CometNativeScan`, `CometIcebergNativeScan`).
+ *
+ * The underlying `ClassNotFoundException` on the capturing class was masked: `ObjectInputStream`
+ * records it against the handle, skips `SerializedLambda.readResolve`, and the raw
+ * `SerializedLambda` then fails the field-type check in `defaultCheckFieldValues`.
+ *
+ * `CometExecIterator` now captures the task thread's context ClassLoader and `CometUdfBridge`
+ * installs it on the calling thread for the duration of each UDF call.
+ */
+class CometScalaUDFClassLoaderSuite extends CometTestBase {
+
+  import CometScalaUDFClassLoaderSuite._
+
+  override protected def sparkConf: SparkConf =
+    super.sparkConf
+      .set(CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key, "true")
+      // Visible to executor task threads, invisible to Comet's own ClassLoader.
+      .set("spark.executor.extraClassPath", hiddenJar.getAbsolutePath)
+
+  /** Registers a UDF whose lambda was captured by a class living only in the user jar. */
+  private def withHiddenUdf(name: String)(f: => Unit): Unit = {
+    val loader = new URLClassLoader(Array(hiddenJar.toURI.toURL), getClass.getClassLoader)
+    val fn = loader
+      .loadClass(HiddenClassName)
+      .getMethod("make")
+      .invoke(null)
+      .asInstanceOf[String => String]
+    spark.udf.register(name, fn)
+    try f
+    finally loader.close()
+  }
+
+  test("sanity: the hidden class is reachable from task threads but not from Comet's loader") {
+    // `classOf[Expression].getClassLoader` is exactly the fallback `lookupOrCompile` uses when the
+    // calling thread has no context ClassLoader.
+    intercept[ClassNotFoundException] {
+      Class.forName(HiddenClassName, false, classOf[Expression].getClassLoader)
+    }
+    val reachable = spark
+      .range(4)
+      .repartition(2)
+      .mapPartitions(_ => Iterator(canLoadHiddenClassOnThisThread))(
+        org.apache.spark.sql.Encoders.scalaBoolean)
+      .collect()
+    assert(reachable.forall(identity), s"task threads could not load $HiddenClassName")
+  }
+
+  test("ScalaUDF whose capturing class is only in the user jar, native scan leaf") {
+    // Fails without ClassLoader propagation: the dispatcher deserializes the closure on a Tokio
+    // worker, which sees no user jar, and the resulting ClassNotFoundException surfaces as
+    // `cannot assign instance of java.lang.invoke.SerializedLambda to field ScalaUDF.f`.
+    withHiddenUdf("hiddenUdf") {
+      withTable("t") {
+        sql("CREATE TABLE t (s STRING) USING parquet")
+        sql("INSERT INTO t VALUES ('a'), ('b'), (NULL)")
+        // Stage leaf is CometNativeScan, so the dispatcher runs on a Tokio worker.
+        checkSparkAnswer(sql("SELECT hiddenUdf(s) FROM t"))
+      }
+    }
+  }
+
+  test("the thread running the UDF sees the task thread's context ClassLoader") {
+    // Pins the propagation itself rather than its symptom: the UDF body reports whether the
+    // ClassLoader installed on whatever thread invoked it can reach the user jar.
+    spark.udf.register("loaderProbe", (_: String) => loaderReport())
+    withTable("t") {
+      sql("CREATE TABLE t (s STRING) USING parquet")
+      sql("INSERT INTO t VALUES ('a'), ('b'), ('c'), ('d')")
+      val reports = sql("SELECT loaderProbe(s) FROM t").collect().map(_.getString(0)).distinct
+      assert(
+        reports.forall(_.startsWith("loaded|")),
+        s"UDF thread could not load $HiddenClassName: ${reports.mkString(", ")}")
+    }
+  }
+
+  test("control: same UDF evaluated on the Spark task thread") {
+    // With the native scan disabled the dispatcher runs on the task thread, whose context
+    // ClassLoader includes the user jar, so deserialization resolves the capturing class.
+    withSQLConf(CometConf.COMET_NATIVE_SCAN_ENABLED.key -> "false") {
+      withHiddenUdf("hiddenUdf2") {
+        withTable("t2") {
+          sql("CREATE TABLE t2 (s STRING) USING parquet")
+          sql("INSERT INTO t2 VALUES ('a'), ('b'), (NULL)")
+          checkSparkAnswer(sql("SELECT hiddenUdf2(s) FROM t2"))
+        }
+      }
+    }
+  }
+}
+
+object CometScalaUDFClassLoaderSuite {
+
+  val HiddenClassName = "hidden.HiddenUdf"
+
+  /**
+   * Jar holding a serializable `scala.Function1` lambda. The lambda's capturing class exists only
+   * inside this jar, so it is visible only to ClassLoaders the jar is wired into. Built once,
+   * before the SparkSession starts, because `spark.executor.extraClassPath` is read at session
+   * creation.
+   */
+  lazy val hiddenJar: File = buildHiddenUdfJar(Files.createTempDirectory("comet-hidden-udf"))
+
+  /**
+   * Reports whether the current thread's context ClassLoader can reach the user jar, tagged with
+   * the thread name so a failure says which thread was missing it. Kept on the companion so the
+   * UDF closure captures nothing from the suite.
+   */
+  def loaderReport(): String = {
+    val status = if (canLoadHiddenClassOnThisThread) "loaded" else "MISSING"
+    s"$status|${Thread.currentThread().getName}"
+  }
+
+  /** Runs on a Spark task thread; kept on the companion so the closure captures nothing. */
+  def canLoadHiddenClassOnThisThread: Boolean =
+    try {
+      Class.forName(HiddenClassName, false, Thread.currentThread().getContextClassLoader)
+      true
+    } catch {
+      case _: ClassNotFoundException => false
+    }
+
+  private def buildHiddenUdfJar(workDir: Path): File = {
+    val src = workDir.resolve("HiddenUdf.java")
+    Files.write(
+      src,
+      ("""package hidden;
+        |
+        |import java.io.Serializable;
+        |import scala.Function1;
+        |
+        |public class HiddenUdf {
+        |  public interface SerFn extends Function1<Object, Object>, Serializable {}
+        |
+        |  public static Function1<Object, Object> make() {
+        |    return (SerFn) (Object o) -> (o == null ? null : "hidden:" + o);
+        |  }
+        |}
+        |""".stripMargin).getBytes("UTF-8"))
+
+    val classesDir = Files.createDirectories(workDir.resolve("classes"))
+    val compiler = ToolProvider.getSystemJavaCompiler
+    assert(compiler != null, "test must run on a JDK (needs the javax.tools compiler)")
+    val rc = compiler.run(
+      null,
+      null,
+      null,
+      "-cp",
+      System.getProperty("java.class.path"),
+      "-d",
+      classesDir.toString,
+      src.toString)
+    assert(rc == 0, s"javac failed with exit code $rc")
+
+    val jar = workDir.resolve("hidden-udf.jar").toFile
+    val jos = new JarOutputStream(new FileOutputStream(jar))
+    try {
+      Files
+        .walk(classesDir)
+        .iterator()
+        .asScala
+        .filter(Files.isRegularFile(_))
+        .foreach { p =>
+          jos.putNextEntry(new JarEntry(classesDir.relativize(p).toString))
+          jos.write(Files.readAllBytes(p))
+          jos.closeEntry()
+        }
+    } finally {
+      jos.close()
+    }
+    jar.deleteOnExit()
+    jar
+  }
+}

--- a/spark/src/test/scala/org/apache/comet/CometScalaUDFClassLoaderSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometScalaUDFClassLoaderSuite.scala
@@ -22,7 +22,7 @@ package org.apache.comet
 import java.io.File
 import java.net.URLClassLoader
 import java.nio.charset.StandardCharsets.UTF_8
-import java.nio.file.{Files, Path}
+import java.nio.file.{Files, Path, Paths}
 import javax.tools.ToolProvider
 
 import org.apache.spark.SparkConf
@@ -149,7 +149,10 @@ object CometScalaUDFClassLoaderSuite {
   }
 
   private def compileHiddenClass(): Path = {
-    val workDir = Files.createTempDirectory("comet-hidden-udf")
+    // createTempDirectory does not create its parent (java.io.tmpdir, pinned to target/tmp by the
+    // pom), which does not exist yet on a fresh checkout, so make it up front.
+    val tmpRoot = Files.createDirectories(Paths.get(System.getProperty("java.io.tmpdir")))
+    val workDir = Files.createTempDirectory(tmpRoot, "comet-hidden-udf")
     val src = workDir.resolve("HiddenUdf.java")
     // The intersection cast is what makes the lambda serializable, and therefore what makes
     // `hidden.HiddenUdf` the capturing class recorded in the SerializedLambda.


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5281.

## Rationale for this change

A `ScalaUDF` (or Java UDF) whose closure was captured by a class from a user jar (`--jars` / `spark.jars`) fails at execution time:

```
java.lang.ClassCastException: cannot assign instance of java.lang.invoke.SerializedLambda to field
  org.apache.spark.sql.catalyst.expressions.ScalaUDF.f of type scala.Function1
	...
	at org.apache.comet.udf.codegen.CometScalaUDFCodegen.lookupOrCompile(CometScalaUDFCodegen.scala:160)
	at org.apache.comet.udf.CometUdfBridge.evaluateInternal(CometUdfBridge.java:203)
```

That `ClassCastException` is a **masked `ClassNotFoundException`**. When the deserializing classloader cannot resolve a lambda's *capturing class*, `ObjectInputStream` records the CNFE against the object handle, therefore skips `SerializedLambda.readResolve()`, and the raw `SerializedLambda` then fails the field-type check in `defaultCheckFieldValues`. The CNFE never surfaces.

The classloader is wrong because of which thread runs the deserialization. `CometUdfBridge.evaluate` is invoked from a Tokio worker, which attaches to the JVM through JNI, and **an attached thread has no context classloader**. `lookupOrCompile` therefore fell back to `classOf[Expression].getClassLoader` — the loader that loaded spark-catalyst and Comet, which never contains user jars. Spark installs the executor's `MutableURLClassLoader` on task threads only.

Measured by returning thread identity from inside a UDF body:

| stage leaf | thread running the UDF | context classloader |
| --- | --- | --- |
| `CometNativeScan` | `Thread-28..32` (Tokio workers) | **null** |
| shuffle read / join build side | `Executor task launch worker …` | `MutableURLClassLoader` |
| native scan disabled | `Executor task launch worker …` | `MutableURLClassLoader` |

So any plan whose stage leaf is a native scan (`CometNativeScan`, `CometIcebergNativeScan`) hits this on every UDF call. `CometUdfBridge` already propagates `TaskContext` across the JNI boundary for exactly this reason; the classloader was not propagated.

This is invisible to Comet's existing test suites because they register UDFs from test classes already on the application classpath.

## What changes are included in this PR?

The task thread's context classloader is now propagated to the Tokio worker, following the same path as `TaskContext`:

- `CometExecIterator` captures `Thread.currentThread().getContextClassLoader` (it is constructed on the Spark task thread) and passes it to `createPlan`.
- `Native.createPlan` gains a `classLoader` parameter; `jni_api.rs` holds it as a JNI global ref on `ExecutionContext` and hands it to the planner via `with_class_loader`.
- `PhysicalPlanner` clones it into every `JvmScalarUdfExpr`, under the same `debug_assert` invariant already used for `task_context`.
- `JvmScalarUdfExpr` passes it through the bridge call; the JNI signature gains `Ljava/lang/ClassLoader;`.
- `CometUdfBridge.evaluate` installs it as the calling thread's context classloader for the duration of the call, restoring the prior value in `finally` — the same save-and-restore shape used for `TaskContext`.

Installing it on the thread rather than passing it down to the deserializer fixes both affected lookups at once: the closure deserialization in `CometScalaUDFCodegen`, and the `Class.forName(udfClassName)` in `CometUdfBridge`, which had the same latent bug for a user-supplied `CometUDF` implementation shipped in a user jar. It also means user code inside a UDF that relies on the context classloader behaves as it does under Spark's own execution.

One line was added to the "Behavior" section of `docs/source/user-guide/latest/scala_java_udfs.md`, alongside the existing `TaskContext.get()` guarantee.

## How are these changes tested?

New suite `CometScalaUDFClassLoaderSuite`, which compiles a class holding a serializable `scala.Function1` lambda into a jar at test time and wires it in via `spark.executor.extraClassPath` — the local-mode equivalent of a `--jars` submission, since `LocalSchedulerBackend` feeds it into the executor's `MutableURLClassLoader`. Four tests:

1. sanity — the class is loadable from task threads and raises `ClassNotFoundException` from `classOf[Expression].getClassLoader` (the old fallback), so the fixture reproduces the production classloader topology.
1. the failing query: `SELECT hiddenUdf(s) FROM t` with a `CometNativeScan` leaf.
1. the propagation itself: the UDF body reports whether the classloader installed on whatever thread invoked it can reach the user jar.
1. control: the same UDF with the native scan disabled, which runs on the task thread and passed even before this change — isolating the failure to classloader propagation rather than class availability.

The two new behavioral tests were confirmed to fail without the fix (reverting only the loader install), reporting `MISSING|Thread-53, MISSING|Thread-28, …` and naming the Tokio workers.

Existing coverage run locally on Spark 4.1 / Scala 2.13: `CometCodegenSuite`, `CometCodegenHOFSuite`, `CometCodegenSourceSuite`, `CometCodegenFuzzSuite` plus the new suite (180 tests), and `CometExecSuite` (143 tests), which exercises the changed `createPlan` signature broadly. `cargo fmt --check` and `cargo clippy --all-targets -D warnings` are clean.
