### PR TITLE
chore: update documentation links for 1.0.0 release

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -29,6 +29,8 @@ rm -rf comet-0.13
 rm -rf comet-0.14
 rm -rf comet-0.15
 rm -rf comet-0.16
+rm -rf comet-0.17
+rm -rf comet-1.0
 python3 generate-versions.py
 
 # Generate dynamic content (configs, compatibility matrices) for latest docs

--- a/docs/generate-versions.py
+++ b/docs/generate-versions.py
@@ -154,6 +154,6 @@ This is **out-of-date** documentation. The latest Comet release is version {late
 if __name__ == "__main__":
     print("Generating versioned user guide docs...")
     snapshot_version = get_version_from_pom()
-    latest_released_version = "0.17.0"
-    previous_versions = ["0.13.0", "0.14.0", "0.15.0", "0.16.0"]
+    latest_released_version = "1.0.0"
+    previous_versions = ["0.13.0", "0.14.0", "0.15.0", "0.16.0", "0.17.0"]
     generate_docs(snapshot_version, latest_released_version, previous_versions)

--- a/docs/source/contributor-guide/release_process.md
+++ b/docs/source/contributor-guide/release_process.md
@@ -285,14 +285,24 @@ it to GitHub Container Registry at https://github.com/apache/datafusion-comet/pk
 
 In `docs` directory:
 
-- Update `docs/source/index.rst` and add a new navigation menu link for the new release in the section `_toc.user-guide-links-versioned`
-- Add a new line to `build.sh` to delete the locally cloned `comet-*` branch for the new release e.g. `comet-0.13`
-- Update the main method in `generate-versions.py`:
+- Update the main method in `generate-versions.py` to promote the new release to the current one and move the
+  previously current release into the list of older versions:
 
 ```python
     latest_released_version = "0.13.0"
-    previous_versions = ["0.11.0", "0.12.0"]
+    previous_versions = ["0.10.0", "0.11.0", "0.12.0"]
 ```
+
+- Add a new line to `build.sh` to delete the locally cloned `comet-*` branch for the new release e.g. `comet-0.13`.
+  Every version referenced in `generate-versions.py` needs a line here, otherwise a rebuild reuses the stale clone
+  from the previous run.
+- Update `docs/source/user-guide/index.md`: change the "current stable release" sentence and the versioned entry in
+  the toctree (e.g. `0.13.x (current) <0.13/index>`).
+- Update `docs/source/user-guide/older-versions.md`: point the "current stable release" link at the new release and
+  add the previously current release to the toctree.
+
+Note that older user guides are kept rather than dropped, so the lists in `generate-versions.py`, `build.sh`, and
+`older-versions.md` grow with each release.
 
 Test the documentation build locally, following the instructions in `docs/README.md`.
 

--- a/docs/source/user-guide/index.md
+++ b/docs/source/user-guide/index.md
@@ -22,7 +22,7 @@ under the License.
 The Comet user guide covers installation, configuration, supported data sources, supported operators
 and expressions, and tuning advice for running Apache Spark with Comet acceleration.
 
-The **current stable release** is 0.17.x. Most users should start there. The **development snapshot**
+The **current stable release** is 1.0.x. Most users should start there. The **development snapshot**
 tracks the upcoming release and may include features and fixes that are not yet generally available.
 User guides for **older releases** are kept for reference under [Older Versions](older-versions).
 
@@ -31,7 +31,7 @@ User guides for **older releases** are kept for reference under [Older Versions]
 :caption: User Guide
 :hidden:
 
-0.17.x (current) <0.17/index>
+1.0.x (current) <1.0/index>
 Development Snapshot <latest/index>
 Older Versions <older-versions>
 ```

--- a/docs/source/user-guide/older-versions.md
+++ b/docs/source/user-guide/older-versions.md
@@ -20,11 +20,12 @@ under the License.
 # Older Versions
 
 These user guides are kept for reference. They are not maintained: use the
-[current stable release](0.17/index) for production guidance.
+[current stable release](1.0/index) for production guidance.
 
 ```{toctree}
 :maxdepth: 1
 
+0.17.x <0.17/index>
 0.16.x <0.16/index>
 0.15.x <0.15/index>
 0.14.x <0.14/index>


### PR DESCRIPTION
## Which issue does this PR close?

N/A — release chore for 1.0.0.

## Rationale for this change

Publishes the 1.0.0 user guide and makes it the default (current stable) version in the
documentation, following the "Publishing Documentation" step of the
[release process](https://github.com/apache/datafusion-comet/blob/main/docs/source/contributor-guide/release_process.md).
Mirrors the pattern from #4698 (0.17.0) and #4314 (0.16.0).

## What changes are included in this PR?

- `docs/generate-versions.py`: `latest_released_version = "1.0.0"`, and `0.17.0` moves into `previous_versions`
  (older guides are kept, per #4704).
- `docs/build.sh`: clean up the locally cloned `comet-0.17` and `comet-1.0` branch dirs before regenerating.
  `comet-0.17` was missing because the rm list historically only tracked `previous_versions`; without a line per
  cloned version a rebuild silently reuses the stale clone from the previous run.
- `docs/source/user-guide/index.md`: current stable release is now 1.0.x, sidebar entry points at `1.0/index`.
- `docs/source/user-guide/older-versions.md`: point the "current stable release" link at 1.0 and add 0.17.x to the list.
- `docs/source/contributor-guide/release_process.md`: refresh the "Publishing Documentation" instructions, which
  still referred to `docs/source/index.rst` and the `_toc.user-guide-links-versioned` section — neither exists since
  the sidebar overhaul. The section now lists the four files actually involved.

Not included (separate follow-ups per the release process): bringing `docs/source/changelog/1.0.0.md` into `main`,
which happens after the vote passes.

## How are these changes tested?

`branch-1.0` exists and has generated (frozen) user guide content under `docs/source/user-guide/latest/`, including
`index.rst` and the per-Spark-version compatibility pages, so the versioned guide will render. The docs build itself
is exercised by the documentation CI workflow.
