### PR TITLE
feat: support S3 compliant filesystems

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -430,6 +430,7 @@ jobs:
               org.apache.spark.sql.comet.util.UtilsSuite
               org.apache.comet.vector.NativeUtilSuite
               org.apache.comet.objectstore.NativeConfigSuite
+              org.apache.comet.serde.operator.CometIcebergNativeScanSuite
               org.apache.comet.serde.operator.CometNativeScanSuite
               org.apache.spark.sql.CometToPrettyStringSuite
               org.apache.spark.sql.CometCollationSuite

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -203,6 +203,7 @@ jobs:
               org.apache.spark.sql.comet.util.UtilsSuite
               org.apache.comet.vector.NativeUtilSuite
               org.apache.comet.objectstore.NativeConfigSuite
+              org.apache.comet.serde.operator.CometIcebergNativeScanSuite
               org.apache.comet.serde.operator.CometNativeScanSuite
               org.apache.spark.sql.CometToPrettyStringSuite
               org.apache.spark.sql.CometCollationSuite

--- a/docs/source/user-guide/latest/datasources.md
+++ b/docs/source/user-guide/latest/datasources.md
@@ -216,6 +216,68 @@ Beyond credential providers, Comet's Parquet scan supports additional S3 configu
 
 All configuration options support bucket-specific overrides using the pattern `fs.s3a.bucket.{bucket-name}.{option}`.
 
+### S3-Compliant Filesystem Schemes
+
+Some environments front an S3-compatible service (MinIO, Ceph RGW, Cloudflare R2, Wasabi, and
+similar) with a vendor-branded Hadoop filesystem client that registers its own URL scheme, for
+example `blob://`, instead of `s3://` or `s3a://`. Comet can treat such schemes as aliases for
+`s3://` so the native Parquet and Iceberg scans read them directly, without the caller rewriting
+URLs.
+
+This is opt-in and disabled by default. Enable it by listing the schemes to treat as S3-compliant
+aliases in `spark.hadoop.fs.comet.s3Compliant.schemes` (Hadoop key
+`fs.comet.s3Compliant.schemes`), a comma-separated, case-insensitive list. This mirrors the
+existing `fs.comet.libhdfs.schemes` config.
+
+```shell
+--conf spark.hadoop.fs.comet.s3Compliant.schemes=blob
+```
+
+Multiple schemes can be listed together:
+
+```shell
+--conf spark.hadoop.fs.comet.s3Compliant.schemes=blob,minio,r2
+```
+
+With no configuration, Comet claims none of these aliases, so for example a `blob://` path falls
+back to Spark unchanged. The empty default is deliberate: short scheme names like `blob` are not
+unique to S3-compatible storage. Azure Blob Storage is the clearest example, so claiming `blob://`
+unconditionally would risk misrouting paths that were never meant for Comet's S3 client. Only add a
+scheme here if you intend Comet to treat it as S3-compatible.
+
+For each scheme `<s>` listed in `fs.comet.s3Compliant.schemes`, Comet also reads vendor-style,
+per-authority Hadoop keys of the form `fs.<s>.<authority>.<property>` (the authority is typically
+the bucket or account name from the URL) and translates them into the `fs.s3a.*` surface described
+above. The recognized vendor-style properties and their `fs.s3a.*` targets are:
+
+| Vendor property (`fs.<s>.<authority>.<property>`) | Translated `fs.s3a.*` suffix |
+| ------------------------------------------------- | ---------------------------- |
+| `awsAccessKeyId`                                  | `access.key`                 |
+| `awsSecretAccessKey`                              | `secret.key`                 |
+| `awsSessionToken`                                 | `session.token`              |
+| `endpoint`                                        | `endpoint`                   |
+| `region`                                          | `endpoint.region`            |
+| `pathStyleAccess`                                 | `path.style.access`          |
+
+Unrecognized `fs.<s>.<authority>.*` properties are ignored.
+
+A URL with no authority, such as the triple-slash `blob:///bucket/key` form, reports its authority
+as the literal string `default`. For that case, list the keys under `fs.<s>.default.<property>`.
+Comet resolves `default` to the bucket taken from the URL path (`bucket` here) and applies the
+translated settings at that bucket's scope, exactly as if they had been written under
+`fs.<s>.bucket.<property>`.
+
+When `fs.<s>.<authority>.endpoint` is set, Comet defaults path-style access to enabled for that
+bucket, since most non-AWS S3-compatible services require it. This is only a default: set
+`fs.s3a.bucket.<bucket>.path.style.access` (or the equivalent per-scheme key) explicitly to
+override it.
+
+Once translated, these values are applied at the same `fs.s3a.bucket.{bucket-name}.*` scope
+described in [Additional S3 Configuration Options](#additional-s3-configuration-options), so the
+credential providers and options documented above also apply to alias-scheme URLs. The same
+translation feeds the native Iceberg scan; see
+[Object store configuration (S3)](iceberg.md#object-store-configuration-s3) in the Iceberg guide.
+
 ### Examples
 
 The following examples demonstrate how to configure S3 access using different authentication methods.

--- a/docs/source/user-guide/latest/iceberg.md
+++ b/docs/source/user-guide/latest/iceberg.md
@@ -144,7 +144,7 @@ scala> spark.sql("SELECT * FROM rest_cat.db.test_table").show()
 
 ### Object store configuration (S3)
 
-The native reader has its own Rust object store client and does not go through Iceberg's JVM FileIO, neither `S3FileIO` nor the older Hadoop S3A filesystem. It configures that client from the catalog's `s3.*` properties (the same keys `S3FileIO` reads) or from `spark.hadoop.fs.s3a.*` settings, so S3 configuration only reaches the native reader through one of those two channels.
+The native reader has its own Rust object store client and does not go through Iceberg's JVM FileIO, neither `S3FileIO` nor the older Hadoop S3A filesystem. It configures that client from the catalog's `s3.*` properties (the same keys `S3FileIO` reads), from `spark.hadoop.fs.s3a.*` settings, or, for a scheme opted into `spark.hadoop.fs.comet.s3Compliant.schemes`, from vendor-style `fs.<scheme>.<authority>.*` keys (see [S3-Compliant Filesystem Schemes](datasources.md#s3-compliant-filesystem-schemes)). That third source is translated into the same `fs.s3a.*` shape as the second before it reaches the reader. S3 configuration therefore reaches the native reader through one of these three channels.
 
 For a custom S3-compatible endpoint, configure the catalog with the endpoint, path-style access, region, and credentials (Hive shown):
 

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1989,11 +1989,13 @@ dependencies = [
  "rand 0.10.2",
  "reqsign-core",
  "reqwest 0.12.28",
+ "serde",
  "serde_json",
  "tempfile",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
+ "typetag",
  "url",
  "uuid",
 ]

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -79,6 +79,10 @@ iceberg = { workspace = true }
 iceberg-storage-opendal = { workspace = true }
 reqsign-core = { workspace = true }
 serde_json = "1.0"
+# serde derive + typetag are required to implement iceberg's `Storage`/`StorageFactory` traits,
+# which carry `typetag::Serialize`/`Deserialize` supertraits (see BlobHostPromotingS3Storage).
+serde = { version = "1.0", features = ["derive"] }
+typetag = "0.2"
 uuid = "1.23.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/native/core/src/cloud/mod.rs
+++ b/native/core/src/cloud/mod.rs
@@ -19,5 +19,10 @@
 //!
 //! Today this hosts the JNI bridge to the JVM `CometS3CredentialDispatcher` SPI, which is reused
 //! by the raw Parquet (`object_store`) path and the Iceberg (`opendal` via `iceberg-rust`) path.
+//!
+//! The other cross-path S3 helper, S3-compliant scheme aliasing
+//! (`fs.comet.s3Compliant.schemes`), currently lives in
+//! `crate::parquet::objectstore::s3_blob_fs_support` next to the URL rewrite the Parquet scan
+//! needs; the Iceberg operators import it from there.
 
 pub mod s3;

--- a/native/core/src/execution/operators/iceberg_common.rs
+++ b/native/core/src/execution/operators/iceberg_common.rs
@@ -25,6 +25,9 @@ use iceberg::io::{FileIO, FileIOBuilder, StorageFactory};
 use iceberg_storage_opendal::{CustomAwsCredentialLoader, OpenDalStorageFactory};
 
 use crate::cloud::s3::credential_bridge::{AccessMode, CometS3CredentialBridge};
+use crate::parquet::objectstore::s3_blob_fs_support::{
+    is_s3_compliant_alias_scheme, BlobHostPromotingS3StorageFactory,
+};
 
 /// Activation key for the `CometS3CredentialProvider` SPI, read from a catalog's `s3.*` property
 /// bag.
@@ -46,21 +49,29 @@ pub(crate) fn storage_factory_for(
     catalog_name: &str,
     access_mode: AccessMode,
 ) -> Result<Arc<dyn StorageFactory>, DataFusionError> {
-    let scheme = if path.contains("://") {
-        path.split("://").next().unwrap_or("file")
-    } else {
-        "file"
-    };
+    let scheme = scheme_of(path);
+    // s3, s3a, and any opted-in s3-compliant alias (e.g. blob) all route to the S3 backend.
+    // Host-bearing paths reach iceberg-storage-opendal's scheme-agnostic S3 operator RAW (it
+    // takes the bucket from `Url::host_str`), so `blob://bucket/key` opens directly. Aliases
+    // additionally get a wrapper (BlobHostPromotingS3Storage) that promotes a HOSTLESS
+    // `blob:///bucket/key` into the host only at the open boundary. Both leave the recorded
+    // string iceberg-rust matches deletes against untouched -- see s3_blob_fs_support for that
+    // delete-safety rationale.
+    if is_s3_family_scheme(scheme, catalog_properties) {
+        let customized_credential_load =
+            build_s3_credential_loader(path, catalog_properties, catalog_name, access_mode)?;
+        if is_s3_compliant_alias_scheme(scheme, catalog_properties) {
+            return Ok(Arc::new(BlobHostPromotingS3StorageFactory::new(
+                customized_credential_load,
+            )));
+        }
+        return Ok(Arc::new(OpenDalStorageFactory::S3 {
+            customized_credential_load,
+        }));
+    }
     match scheme {
         "file" => Ok(Arc::new(OpenDalStorageFactory::Fs)),
         "memory" => Ok(Arc::new(OpenDalStorageFactory::Memory)),
-        "s3" | "s3a" => {
-            let customized_credential_load =
-                build_s3_credential_loader(path, catalog_properties, catalog_name, access_mode)?;
-            Ok(Arc::new(OpenDalStorageFactory::S3 {
-                customized_credential_load,
-            }))
-        }
         "gs" => Ok(Arc::new(OpenDalStorageFactory::Gcs)),
         // Reads keep the OSS backend they have always had (CometScanRule admits `oss` scan
         // locations through HadoopFileIO). Writes fail closed: Comet does not forward `oss.*`
@@ -107,6 +118,25 @@ pub(crate) fn load_file_io(
         if STORAGE_PROPERTY_PREFIXES.iter().any(|p| key.starts_with(p)) {
             file_io_builder = file_io_builder.with_prop(key, value);
         }
+    }
+
+    // Object-store's AmazonS3Builder defaults the SigV4 region to `us-east-1` when unset;
+    // iceberg-storage-opendal's S3 factory instead errors with `region is missing. Please
+    // find it by S3::detect_region() or set them in env.` Non-AWS S3-compliant storage
+    // services accept any region in the credential, so default to `us-east-1` -- but ONLY when
+    // neither the catalog NOR the AWS environment supplies a region. opendal/reqsign reads
+    // `AWS_REGION` / `AWS_DEFAULT_REGION`, so forcing `us-east-1` unconditionally would
+    // override an `AWS_REGION=us-west-2` and break auth for AWS buckets outside us-east-1.
+    // Both catalog key spellings iceberg-rust reads (`client.region` wins over `s3.region`).
+    let region_forwarded = catalog_properties.contains_key("s3.region")
+        || catalog_properties.contains_key("client.region")
+        || env_region_present();
+    // s3, s3a, and any opted-in s3-compliant alias (e.g. blob) hit the S3 backend and need the
+    // region default. reference_path reaches here raw (see storage_factory_for), so match the
+    // alias schemes too.
+    let scheme = scheme_of(reference_path);
+    if !region_forwarded && is_s3_family_scheme(scheme, catalog_properties) {
+        file_io_builder = file_io_builder.with_prop("s3.region", "us-east-1");
     }
 
     Ok(file_io_builder.build())
@@ -170,6 +200,43 @@ fn build_s3_credential_loader(
     }
 }
 
+/// True if the AWS environment supplies a region (`AWS_REGION` / `AWS_DEFAULT_REGION`).
+///
+/// opendal's S3 service reads these via reqsign, so Comet must not clobber them with a forced
+/// `us-east-1` default when the catalog omits a region (see the region defaulting in
+/// `load_file_io`).
+fn env_region_present() -> bool {
+    ["AWS_REGION", "AWS_DEFAULT_REGION"]
+        .iter()
+        .any(|k| std::env::var(k).is_ok_and(|v| !v.is_empty()))
+}
+
+/// Extracts the URI scheme, defaulting to `file` for schemeless local paths (e.g. `/tmp/x`). Both
+/// `storage_factory_for` (backend routing) and `load_file_io` (region defaulting) classify by
+/// scheme, so they share this to admit exactly the same set.
+///
+/// Splits on the first `:` (RFC 3986), NOT `://`: hostless vendor forms like `blob:/bucket/key`
+/// (opaque, empty authority) carry no `://`, and treating them as `file` would route an
+/// S3-compliant scan to the local filesystem. A `/` before the `:` means there is no scheme (the
+/// `:` sits inside a path segment, e.g. `/tmp/a:b`), so those and truly schemeless paths default
+/// to `file`.
+fn scheme_of(path: &str) -> &str {
+    match path.split_once(':') {
+        Some((scheme, _)) if !scheme.is_empty() && !scheme.contains('/') => scheme,
+        _ => "file",
+    }
+}
+
+/// True if `scheme` routes to the S3 backend: `s3`/`s3a`, or any opted-in s3-compliant alias
+/// (`fs.comet.s3Compliant.schemes`). Both the storage-factory selection and the region default use
+/// this, so they admit the same schemes. The Scala `NativeConfig.isS3FamilyScheme` additionally
+/// treats `s3n` as S3-family for bucket resolution; `s3n` is intentionally omitted here because
+/// iceberg-rust's storage factory has no `s3n` backend and the Scala Iceberg scheme gate
+/// (`isIcebergReadableScheme`) rejects `s3n` before a path ever reaches this operator.
+fn is_s3_family_scheme(scheme: &str, catalog_properties: &HashMap<String, String>) -> bool {
+    matches!(scheme, "s3" | "s3a") || is_s3_compliant_alias_scheme(scheme, catalog_properties)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -209,5 +276,19 @@ mod tests {
             err.contains("Unsupported storage scheme"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn scheme_of_extracts_scheme_from_all_uri_forms() {
+        // Host-bearing and hostless/opaque vendor forms must resolve to the same scheme, so an
+        // S3-compliant scan is not misrouted to the local FS. `blob:/bucket/key` (single slash, the
+        // hostless vendor form) regressed here: splitting on `://` returned `file`.
+        assert_eq!(scheme_of("blob://bucket/key"), "blob");
+        assert_eq!(scheme_of("blob:/bucket/key"), "blob");
+        assert_eq!(scheme_of("s3://bucket/key"), "s3");
+        assert_eq!(scheme_of("file:///tmp/x"), "file");
+        // Schemeless and colon-in-path locals default to the local FS.
+        assert_eq!(scheme_of("/tmp/no-scheme"), "file");
+        assert_eq!(scheme_of("/tmp/a:b"), "file");
     }
 }

--- a/native/core/src/execution/operators/iceberg_common.rs
+++ b/native/core/src/execution/operators/iceberg_common.rs
@@ -50,26 +50,26 @@ pub(crate) fn storage_factory_for(
     access_mode: AccessMode,
 ) -> Result<Arc<dyn StorageFactory>, DataFusionError> {
     let scheme = scheme_of(path);
-    // s3, s3a, and any opted-in s3-compliant alias (e.g. blob) all route to the S3 backend.
-    // Host-bearing paths reach iceberg-storage-opendal's scheme-agnostic S3 operator RAW (it
-    // takes the bucket from `Url::host_str`), so `blob://bucket/key` opens directly. Aliases
-    // additionally get a wrapper (BlobHostPromotingS3Storage) that promotes a HOSTLESS
-    // `blob:///bucket/key` into the host only at the open boundary. Both leave the recorded
-    // string iceberg-rust matches deletes against untouched -- see s3_blob_fs_support for that
-    // delete-safety rationale.
-    if is_s3_family_scheme(scheme, catalog_properties) {
-        let customized_credential_load =
-            build_s3_credential_loader(path, catalog_properties, catalog_name, access_mode)?;
-        if is_s3_compliant_alias_scheme(scheme, catalog_properties) {
-            return Ok(Arc::new(BlobHostPromotingS3StorageFactory::new(
-                customized_credential_load,
-            )));
-        }
-        return Ok(Arc::new(OpenDalStorageFactory::S3 {
-            customized_credential_load,
-        }));
-    }
     match scheme {
+        // s3, s3a, and any opted-in s3-compliant alias (e.g. blob) all route to the S3 backend.
+        // Host-bearing paths reach iceberg-storage-opendal's scheme-agnostic S3 operator RAW (it
+        // takes the bucket from `Url::host_str`), so `blob://bucket/key` opens directly. An alias
+        // additionally gets a wrapper that promotes a HOSTLESS `blob:///bucket/key` into the host
+        // at the open boundary. Both leave the recorded string iceberg-rust matches deletes
+        // against untouched -- see s3_blob_fs_support for that delete-safety rationale.
+        s if is_s3_family_scheme(s, catalog_properties) => {
+            let customized_credential_load =
+                build_s3_credential_loader(path, catalog_properties, catalog_name, access_mode)?;
+            if is_s3_compliant_alias_scheme(s, catalog_properties) {
+                Ok(Arc::new(BlobHostPromotingS3StorageFactory::new(
+                    customized_credential_load,
+                )))
+            } else {
+                Ok(Arc::new(OpenDalStorageFactory::S3 {
+                    customized_credential_load,
+                }))
+            }
+        }
         "file" => Ok(Arc::new(OpenDalStorageFactory::Fs)),
         "memory" => Ok(Arc::new(OpenDalStorageFactory::Memory)),
         "gs" => Ok(Arc::new(OpenDalStorageFactory::Gcs)),

--- a/native/core/src/execution/operators/iceberg_common.rs
+++ b/native/core/src/execution/operators/iceberg_common.rs
@@ -131,9 +131,7 @@ pub(crate) fn load_file_io(
     let region_forwarded = catalog_properties.contains_key("s3.region")
         || catalog_properties.contains_key("client.region")
         || env_region_present();
-    // s3, s3a, and any opted-in s3-compliant alias (e.g. blob) hit the S3 backend and need the
-    // region default. reference_path reaches here raw (see storage_factory_for), so match the
-    // alias schemes too.
+    // reference_path reaches here raw (see storage_factory_for), so alias schemes must match too.
     let scheme = scheme_of(reference_path);
     if !region_forwarded && is_s3_family_scheme(scheme, catalog_properties) {
         file_io_builder = file_io_builder.with_prop("s3.region", "us-east-1");
@@ -200,11 +198,7 @@ fn build_s3_credential_loader(
     }
 }
 
-/// True if the AWS environment supplies a region (`AWS_REGION` / `AWS_DEFAULT_REGION`).
-///
-/// opendal's S3 service reads these via reqsign, so Comet must not clobber them with a forced
-/// `us-east-1` default when the catalog omits a region (see the region defaulting in
-/// `load_file_io`).
+/// True if the AWS environment supplies a region (see the region defaulting in `load_file_io`).
 fn env_region_present() -> bool {
     ["AWS_REGION", "AWS_DEFAULT_REGION"]
         .iter()

--- a/native/core/src/execution/operators/iceberg_common.rs
+++ b/native/core/src/execution/operators/iceberg_common.rs
@@ -43,6 +43,11 @@ const STORAGE_PROPERTY_PREFIXES: &[&str] = &["s3.", "gcs.", "adls.", "client."];
 /// stay entirely in-process. For S3, the Comet credential bridge is wired in when a provider
 /// class is configured; `access_mode` is forwarded to the JVM SPI so the read and write paths can
 /// be granted different (e.g. read-only vs read-write) credentials.
+///
+/// The JVM planner mirrors the schemes admitted here by hand, so that it can decline a scan
+/// cleanly instead of failing at execution. Changing the arms below means updating
+/// `CometScanRule.icebergReadableSchemes` (reads) and
+/// `CometIcebergNativeWrite.SupportedStorageSchemes` (writes).
 pub(crate) fn storage_factory_for(
     path: &str,
     catalog_properties: &HashMap<String, String>,
@@ -51,25 +56,6 @@ pub(crate) fn storage_factory_for(
 ) -> Result<Arc<dyn StorageFactory>, DataFusionError> {
     let scheme = scheme_of(path);
     match scheme {
-        // s3, s3a, and any opted-in s3-compliant alias (e.g. blob) all route to the S3 backend.
-        // Host-bearing paths reach iceberg-storage-opendal's scheme-agnostic S3 operator RAW (it
-        // takes the bucket from `Url::host_str`), so `blob://bucket/key` opens directly. An alias
-        // additionally gets a wrapper that promotes a HOSTLESS `blob:///bucket/key` into the host
-        // at the open boundary. Both leave the recorded string iceberg-rust matches deletes
-        // against untouched -- see s3_blob_fs_support for that delete-safety rationale.
-        s if is_s3_family_scheme(s, catalog_properties) => {
-            let customized_credential_load =
-                build_s3_credential_loader(path, catalog_properties, catalog_name, access_mode)?;
-            if is_s3_compliant_alias_scheme(s, catalog_properties) {
-                Ok(Arc::new(BlobHostPromotingS3StorageFactory::new(
-                    customized_credential_load,
-                )))
-            } else {
-                Ok(Arc::new(OpenDalStorageFactory::S3 {
-                    customized_credential_load,
-                }))
-            }
-        }
         "file" => Ok(Arc::new(OpenDalStorageFactory::Fs)),
         "memory" => Ok(Arc::new(OpenDalStorageFactory::Memory)),
         "gs" => Ok(Arc::new(OpenDalStorageFactory::Gcs)),
@@ -86,6 +72,24 @@ pub(crate) fn storage_factory_for(
                     .to_string(),
             )),
         },
+        // s3, s3a, and any opted-in s3-compliant alias (e.g. blob) route to the S3 backend. Listed
+        // last so the built-in backends above stay authoritative even if one of their schemes is
+        // also named in `fs.comet.s3Compliant.schemes`. An alias additionally gets a wrapper that
+        // promotes a HOSTLESS `blob:///bucket/key` into the host at the open boundary -- see
+        // s3_blob_fs_support for why that never touches the recorded delete-matching string.
+        s if is_s3_family_scheme(s, catalog_properties) => {
+            let customized_credential_load =
+                build_s3_credential_loader(path, catalog_properties, catalog_name, access_mode)?;
+            if is_s3_compliant_alias_scheme(s, catalog_properties) {
+                Ok(Arc::new(BlobHostPromotingS3StorageFactory::new(
+                    customized_credential_load,
+                )))
+            } else {
+                Ok(Arc::new(OpenDalStorageFactory::S3 {
+                    customized_credential_load,
+                }))
+            }
+        }
         _ => Err(DataFusionError::Execution(format!(
             "Unsupported storage scheme: {scheme}"
         ))),
@@ -128,12 +132,15 @@ pub(crate) fn load_file_io(
     // `AWS_REGION` / `AWS_DEFAULT_REGION`, so forcing `us-east-1` unconditionally would
     // override an `AWS_REGION=us-west-2` and break auth for AWS buckets outside us-east-1.
     // Both catalog key spellings iceberg-rust reads (`client.region` wins over `s3.region`).
-    let region_forwarded = catalog_properties.contains_key("s3.region")
-        || catalog_properties.contains_key("client.region")
-        || env_region_present();
+    //
     // reference_path reaches here raw (see storage_factory_for), so alias schemes must match too.
+    // Scheme is tested first so a file://, gs:// or oss:// FileIO does not pay the env lookups.
     let scheme = scheme_of(reference_path);
-    if !region_forwarded && is_s3_family_scheme(scheme, catalog_properties) {
+    if is_s3_family_scheme(scheme, catalog_properties)
+        && !catalog_properties.contains_key("s3.region")
+        && !catalog_properties.contains_key("client.region")
+        && !env_region_present()
+    {
         file_io_builder = file_io_builder.with_prop("s3.region", "us-east-1");
     }
 
@@ -205,9 +212,7 @@ fn env_region_present() -> bool {
         .any(|k| std::env::var(k).is_ok_and(|v| !v.is_empty()))
 }
 
-/// Extracts the URI scheme, defaulting to `file` for schemeless local paths (e.g. `/tmp/x`). Both
-/// `storage_factory_for` (backend routing) and `load_file_io` (region defaulting) classify by
-/// scheme, so they share this to admit exactly the same set.
+/// Extracts the URI scheme, defaulting to `file` for schemeless local paths (e.g. `/tmp/x`).
 ///
 /// Splits on the first `:` (RFC 3986), NOT `://`: hostless vendor forms like `blob:/bucket/key`
 /// (opaque, empty authority) carry no `://`, and treating them as `file` would route an
@@ -222,9 +227,8 @@ fn scheme_of(path: &str) -> &str {
 }
 
 /// True if `scheme` routes to the S3 backend: `s3`/`s3a`, or any opted-in s3-compliant alias
-/// (`fs.comet.s3Compliant.schemes`). Both the storage-factory selection and the region default use
-/// this, so they admit the same schemes. The Scala `NativeConfig.isS3FamilyScheme` additionally
-/// treats `s3n` as S3-family for bucket resolution; `s3n` is intentionally omitted here because
+/// (`fs.comet.s3Compliant.schemes`). The Scala `NativeConfig.isS3FamilyScheme` additionally treats
+/// `s3n` as S3-family for bucket resolution; `s3n` is intentionally omitted here because
 /// iceberg-rust's storage factory has no `s3n` backend and the Scala Iceberg scheme gate
 /// (`isIcebergReadableScheme`) rejects `s3n` before a path ever reaches this operator.
 fn is_s3_family_scheme(scheme: &str, catalog_properties: &HashMap<String, String>) -> bool {

--- a/native/core/src/execution/operators/iceberg_scan.rs
+++ b/native/core/src/execution/operators/iceberg_scan.rs
@@ -255,7 +255,7 @@ impl IcebergScanExec {
         };
         match scheme {
             "file" => Ok(Arc::new(OpenDalStorageFactory::Fs)),
-            "s3" | "s3a" => {
+            "s3" | "s3a" | "blob" => {
                 let customized_credential_load =
                     build_s3_credential_loader(path, catalog_properties, catalog_name);
                 Ok(Arc::new(OpenDalStorageFactory::S3 {
@@ -366,6 +366,22 @@ impl IcebergScanExec {
             if STORAGE_PROPERTY_PREFIXES.iter().any(|p| key.starts_with(p)) {
                 file_io_builder = file_io_builder.with_prop(key, value);
             }
+        }
+
+        // Object-store's AmazonS3Builder defaults the SigV4 region to `us-east-1` when unset;
+        // iceberg-storage-opendal's S3 factory instead errors with `region is missing. Please
+        // find it by S3::detect_region() or set them in env.` Non-AWS S3-compliant storage
+        // services accept any region in the credential, so default to `us-east-1` when the
+        // catalog didn't ship one. Both key spellings iceberg-rust reads (`client.region`
+        // wins over `s3.region`).
+        let region_forwarded = catalog_properties.contains_key("s3.region")
+            || catalog_properties.contains_key("client.region");
+        let is_s3_family = matches!(
+            metadata_location.split_once("://"),
+            Some(("s3" | "s3a" | "blob", _))
+        );
+        if !region_forwarded && is_s3_family {
+            file_io_builder = file_io_builder.with_prop("s3.region", "us-east-1");
         }
 
         Ok(file_io_builder.build())

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -98,6 +98,7 @@ use iceberg::expr::Bind;
 use crate::execution::operators::ExecutionError::GeneralError;
 use crate::execution::shuffle::{CometPartitioning, CompressionCodec};
 use crate::execution::spark_plan::SparkPlan;
+use crate::parquet::objectstore::s3_blob_fs_support::normalize_object_store_url;
 use crate::parquet::parquet_support::prepare_object_store_with_configs;
 use datafusion::common::scalar::ScalarStructBuilder;
 use datafusion::common::{
@@ -158,7 +159,6 @@ use num::{BigInt, ToPrimitive};
 use object_store::path::Path;
 use std::cmp::max;
 use std::{collections::HashMap, sync::Arc};
-use url::Url;
 
 // For clippy error on type_complexity.
 type PhyAggResult = Result<Vec<AggregateFunctionExpr>, ExecutionError>;
@@ -450,6 +450,7 @@ impl PhysicalPlanner {
     fn get_partitioned_files(
         &self,
         partition: &SparkFilePartition,
+        object_store_options: &HashMap<String, String>,
     ) -> Result<Vec<PartitionedFile>, ExecutionError> {
         let mut files = Vec::with_capacity(partition.partitioned_file.len());
         partition.partitioned_file.iter().try_for_each(|file| {
@@ -462,10 +463,11 @@ impl PhysicalPlanner {
                 file.start + file.length,
             );
 
-            // Spark sends the path over as URL-encoded, parse that first.
-            let url =
-                Url::parse(file.file_path.as_ref()).map_err(|e| GeneralError(e.to_string()))?;
-            // Convert that to a Path object to use in the PartitionedFile.
+            // Apply the same alias/s3a scheme rewrite the object store construction uses, so the
+            // object-store key we hand DataFusion is stripped of the bucket prefix. Skipping this
+            // would leave `bucket/key` as the object key, and path-style S3 GETs would double the
+            // bucket (`<endpoint>/bucket/bucket/key`).
+            let url = normalize_object_store_url(&file.file_path, object_store_options)?;
             let path = Path::from_url_path(url.path()).map_err(|e| GeneralError(e.to_string()))?;
             partitioned_file.object_meta.location = path;
 
@@ -1714,7 +1716,7 @@ impl PhysicalPlanner {
                 )?;
 
                 // Get files for this partition
-                let files = self.get_partitioned_files(partition_files)?;
+                let files = self.get_partitioned_files(partition_files, &object_store_options)?;
                 let file_groups: Vec<Vec<PartitionedFile>> = vec![files];
 
                 let scan = init_datasource_exec(
@@ -1768,8 +1770,10 @@ impl PhysicalPlanner {
                     one_file,
                     &object_store_options,
                 )?;
-                let files =
-                    self.get_partitioned_files(&scan.file_partitions[self.partition as usize])?;
+                let files = self.get_partitioned_files(
+                    &scan.file_partitions[self.partition as usize],
+                    &object_store_options,
+                )?;
                 let file_groups: Vec<Vec<PartitionedFile>> = vec![files];
                 let scan = init_csv_datasource_exec(
                     object_store_url,
@@ -1841,6 +1845,11 @@ impl PhysicalPlanner {
                     .iter()
                     .map(|(k, v)| (k.clone(), v.clone()))
                     .collect();
+                // Passed RAW to the native scan. `storage_factory_for` routes an opted-in alias
+                // (e.g. blob://, carried in catalog_properties) to the S3 backend by scheme, and
+                // iceberg-storage-opendal's S3 operator is scheme-agnostic, so no URL rewrite is
+                // needed here. Not rewriting keeps data-file and delete-file paths byte-identical,
+                // which iceberg-rust requires to match deletes.
                 let metadata_location = common.metadata_location.clone();
                 let catalog_name = common.catalog_name.clone();
                 let tasks = parse_file_scan_tasks_from_common(common, &scan.file_scan_tasks)?;
@@ -4309,6 +4318,8 @@ fn parse_file_scan_tasks_from_common(
             };
 
             Ok(iceberg::scan::FileScanTaskDeleteFile {
+                // Passed RAW, like `data_file_path` below (same exact-string delete-matching
+                // constraint -- see there).
                 file_path: del.file_path.clone(),
                 file_type,
                 // Not serialized; filled in by IcebergScanExec::fill_delete_file_sizes.
@@ -4530,6 +4541,11 @@ fn parse_file_scan_tasks_from_common(
 
             Ok(iceberg::scan::FileScanTask {
                 file_size_in_bytes: proto_task.file_size_in_bytes,
+                // RAW data-file path -- do NOT rewrite the alias to s3://. iceberg-rust matches
+                // positional deletes by comparing this against the path recorded inside the delete
+                // file, so changing the scheme drops deletes. The S3 backend opens a raw alias path
+                // fine (bucket from host, key sliced verbatim), and `metadata_location` above
+                // already selected the storage factory.
                 data_file_path: proto_task.data_file_path.clone(),
                 start: proto_task.start,
                 length: proto_task.length,

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -85,6 +85,9 @@ use iceberg::expr::Bind;
 use crate::execution::operators::ExecutionError::GeneralError;
 use crate::execution::shuffle::{CometPartitioning, CompressionCodec};
 use crate::execution::spark_plan::SparkPlan;
+use crate::parquet::objectstore::blob_alias::{
+    normalize_object_store_url, normalize_object_store_url_string,
+};
 use crate::parquet::parquet_support::prepare_object_store_with_configs;
 use datafusion::common::scalar::ScalarStructBuilder;
 use datafusion::common::{
@@ -143,7 +146,6 @@ use num::{BigInt, ToPrimitive};
 use object_store::path::Path;
 use std::cmp::max;
 use std::{collections::HashMap, sync::Arc};
-use url::Url;
 
 // For clippy error on type_complexity.
 type PhyAggResult = Result<Vec<AggregateFunctionExpr>, ExecutionError>;
@@ -388,6 +390,10 @@ impl PhysicalPlanner {
         partition: &SparkFilePartition,
     ) -> Result<Vec<PartitionedFile>, ExecutionError> {
         let mut files = Vec::with_capacity(partition.partitioned_file.len());
+        // Empty object-store configs are fine here: the only thing `normalize_object_store_url`
+        // consults them for is `is_hdfs_scheme`, and blob/s3a rewriting is the only shape
+        // we care about for the object-store key. HDFS-routed schemes are handled elsewhere.
+        let empty_configs: HashMap<String, String> = HashMap::new();
         partition.partitioned_file.iter().try_for_each(|file| {
             assert!(file.start + file.length <= file.file_size);
 
@@ -398,10 +404,12 @@ impl PhysicalPlanner {
                 file.start + file.length,
             );
 
-            // Spark sends the path over as URL-encoded, parse that first.
-            let url =
-                Url::parse(file.file_path.as_ref()).map_err(|e| GeneralError(e.to_string()))?;
-            // Convert that to a Path object to use in the PartitionedFile.
+            // Apply the same blob/s3a scheme rewrite and three-slash normalization the object
+            // store construction uses, so the object-store key we hand DataFusion is stripped of
+            // the bucket prefix. Skipping this here means paths like `blob:///bucket/key` end up
+            // with `bucket/key` as the object key, and path-style S3 GETs double the bucket
+            // (`<endpoint>/bucket/bucket/key`).
+            let url = normalize_object_store_url(&file.file_path, &empty_configs)?;
             let path = Path::from_url_path(url.path()).map_err(|e| GeneralError(e.to_string()))?;
             partitioned_file.object_meta.location = path;
 
@@ -1752,7 +1760,13 @@ impl PhysicalPlanner {
                     .iter()
                     .map(|(k, v)| (k.clone(), v.clone()))
                     .collect();
-                let metadata_location = common.metadata_location.clone();
+                // Normalize blob/s3a aliases (including Java's `blob:/bucket/key` single-slash
+                // form that Iceberg manifests store) to canonical `s3://bucket/key`. Without
+                // this, storage_factory_for's `contains("://")` check falls back to LocalFs and
+                // iceberg-storage-opendal's fs branch strips one char with `&path[1..]`,
+                // producing `lob:/...` errors.
+                let metadata_location =
+                    normalize_object_store_url_string(&common.metadata_location)?;
                 let catalog_name = common.catalog_name.clone();
                 let tasks = parse_file_scan_tasks_from_common(common, &scan.file_scan_tasks)?;
                 let data_file_concurrency_limit = common.data_file_concurrency_limit as usize;
@@ -3919,7 +3933,8 @@ fn parse_file_scan_tasks_from_common(
             };
 
             Ok(iceberg::scan::FileScanTaskDeleteFile {
-                file_path: del.file_path.clone(),
+                // Normalize blob/s3a aliases so iceberg-rust routes through S3, not LocalFs.
+                file_path: normalize_object_store_url_string(&del.file_path)?,
                 file_type,
                 // Not serialized; filled in by IcebergScanExec::fill_delete_file_sizes.
                 file_size_in_bytes: 0,
@@ -4140,7 +4155,8 @@ fn parse_file_scan_tasks_from_common(
 
             Ok(iceberg::scan::FileScanTask {
                 file_size_in_bytes: proto_task.file_size_in_bytes,
-                data_file_path: proto_task.data_file_path.clone(),
+                // Normalize blob/s3a aliases so iceberg-rust routes through S3, not LocalFs.
+                data_file_path: normalize_object_store_url_string(&proto_task.data_file_path)?,
                 start: proto_task.start,
                 length: proto_task.length,
                 record_count: proto_task.record_count,

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -1845,11 +1845,9 @@ impl PhysicalPlanner {
                     .iter()
                     .map(|(k, v)| (k.clone(), v.clone()))
                     .collect();
-                // Passed RAW to the native scan. `storage_factory_for` routes an opted-in alias
-                // (e.g. blob://, carried in catalog_properties) to the S3 backend by scheme, and
-                // iceberg-storage-opendal's S3 operator is scheme-agnostic, so no URL rewrite is
-                // needed here. Not rewriting keeps data-file and delete-file paths byte-identical,
-                // which iceberg-rust requires to match deletes.
+                // Passed RAW, like every other Iceberg location (see `data_file_path` in
+                // `parse_file_scan_tasks_from_common`). `storage_factory_for` routes an opted-in
+                // alias to the S3 backend by scheme, so no URL rewrite is needed here.
                 let metadata_location = common.metadata_location.clone();
                 let catalog_name = common.catalog_name.clone();
                 let tasks = parse_file_scan_tasks_from_common(common, &scan.file_scan_tasks)?;

--- a/native/core/src/lib.rs
+++ b/native/core/src/lib.rs
@@ -160,15 +160,16 @@ pub extern "system" fn Java_org_apache_comet_NativeBase_isFeatureEnabled(
     })
 }
 
-/// JNI method: does object_store recognize this URL's scheme?
+/// JNI: does object_store recognize this URL's scheme?
 ///
-/// This is the source of truth for the JVM planner's "can Comet's native reader handle this
-/// filesystem?" check. Comet's `prepare_object_store_with_configs` dispatches non-hdfs/non-s3
-/// schemes to object_store's `parse_url`, which is driven by `ObjectStoreScheme::parse`; an
-/// unrecognized scheme (e.g. a custom Hadoop FileSystem) fails there at execution time. By
-/// answering from `ObjectStoreScheme::parse` here, the planner can decline early without
-/// hardcoding -- and drifting from -- the object_store-supported scheme set. (hdfs / libhdfs
-/// schemes are handled separately on the JVM side via the user's libhdfs scheme config.)
+/// Source of truth for the JVM planner's "can the native reader handle this filesystem?" check.
+/// `prepare_object_store_with_configs` dispatches non-hdfs/non-s3 schemes to object_store's
+/// `parse_url` (driven by `ObjectStoreScheme::parse`), so answering from the same parser lets the
+/// planner decline early without hardcoding the supported set. (hdfs/libhdfs are handled JVM-side.)
+///
+/// Alias schemes (e.g. `blob`) are NOT answered here: this gate has no config. Their opt-in lives
+/// in the JVM `CometScanRule` via `fs.comet.s3Compliant.schemes`, and opted-in schemes are
+/// rewritten to `s3://` before reaching `prepare_object_store_with_configs`.
 #[no_mangle]
 pub extern "system" fn Java_org_apache_comet_NativeBase_isObjectStoreSchemeSupported(
     env: EnvUnowned,

--- a/native/core/src/lib.rs
+++ b/native/core/src/lib.rs
@@ -160,16 +160,22 @@ pub extern "system" fn Java_org_apache_comet_NativeBase_isFeatureEnabled(
     })
 }
 
-/// JNI: does object_store recognize this URL's scheme?
+/// JNI: can object_store build a store AND an object key for this URL?
 ///
 /// Source of truth for the JVM planner's "can the native reader handle this filesystem?" check.
 /// `prepare_object_store_with_configs` dispatches non-hdfs/non-s3 schemes to object_store's
 /// `parse_url` (driven by `ObjectStoreScheme::parse`), so answering from the same parser lets the
 /// planner decline early without hardcoding the supported set. (hdfs/libhdfs are handled JVM-side.)
 ///
+/// `ObjectStoreScheme::parse` validates the PATH as well as the scheme -- it ends in
+/// `Path::from_url_path` -- so a recognized scheme carrying a key object_store forbids (e.g. a
+/// directory name with a newline) answers false. `CometScanRule` relies on both halves: it probes
+/// a synthetic scheme-only URL for the cached scheme gate and the real URL for the path gate.
+///
 /// Alias schemes (e.g. `blob`) are NOT answered here: this gate has no config. Their opt-in lives
-/// in the JVM `CometScanRule` via `fs.comet.s3Compliant.schemes`, and opted-in schemes are
-/// rewritten to `s3://` before reaching `prepare_object_store_with_configs`.
+/// in the JVM `CometScanRule` via `fs.comet.s3Compliant.schemes`; natively they are rewritten to
+/// `s3://` by `normalize_object_store_url`, the first step of
+/// `prepare_object_store_with_configs`.
 #[no_mangle]
 pub extern "system" fn Java_org_apache_comet_NativeBase_isObjectStoreSchemeSupported(
     env: EnvUnowned,

--- a/native/core/src/lib.rs
+++ b/native/core/src/lib.rs
@@ -169,6 +169,9 @@ pub extern "system" fn Java_org_apache_comet_NativeBase_isFeatureEnabled(
 /// answering from `ObjectStoreScheme::parse` here, the planner can decline early without
 /// hardcoding -- and drifting from -- the object_store-supported scheme set. (hdfs / libhdfs
 /// schemes are handled separately on the JVM side via the user's libhdfs scheme config.)
+///
+/// `blob` is not recognized by `ObjectStoreScheme::parse`, but Comet treats it as a synonym
+/// for `s3` (rewritten in `prepare_object_store_with_configs`), so report it as supported.
 #[no_mangle]
 pub extern "system" fn Java_org_apache_comet_NativeBase_isObjectStoreSchemeSupported(
     env: EnvUnowned,
@@ -179,7 +182,7 @@ pub extern "system" fn Java_org_apache_comet_NativeBase_isObjectStoreSchemeSuppo
         let url_str: String = url.try_to_string(env)?;
         let supported = url::Url::parse(&url_str)
             .ok()
-            .map(|u| object_store::ObjectStoreScheme::parse(&u).is_ok())
+            .map(|u| u.scheme() == "blob" || object_store::ObjectStoreScheme::parse(&u).is_ok())
             .unwrap_or(false);
         Ok(supported)
     })

--- a/native/core/src/parquet/objectstore/blob_alias.rs
+++ b/native/core/src/parquet/objectstore/blob_alias.rs
@@ -1,0 +1,130 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! S3-compatible filesystem alias handling.
+//!
+//! Comet treats `blob://` and `s3a://` as aliases for `s3://` -- they route through the same
+//! `object_store::AmazonS3` / `iceberg-storage-opendal::S3` code paths but the aliased forms are
+//! not directly recognized by those crates. This module rewrites the URL shape (scheme +
+//! `blob:/bucket/key` single-slash form that Java's `URI.toString()` produces from
+//! `blob:///bucket/key` and Iceberg manifests store) so downstream code can treat everything as
+//! canonical `s3://bucket/key`.
+//!
+//! The actual S3 store construction lives in [`super::s3`]; this module is only about URL shape
+//! so all the alias code has one home instead of drifting across `parquet_support.rs`,
+//! `execution/planner.rs`, and `execution/operators/iceberg_scan.rs`.
+
+use std::collections::HashMap;
+
+use url::Url;
+
+use crate::execution::operators::ExecutionError;
+use crate::parquet::parquet_support::is_hdfs_scheme;
+
+/// Parses `url_str` and rewrites `blob`/`s3a` schemes (and the awkward three-slash
+/// `blob:///bucket/key` form that `ObjectStoreScheme::parse` rejects because host=None) to the
+/// canonical `s3://bucket/key`. Non-alias schemes are returned unchanged.
+///
+/// `object_store_configs` is consulted only via `is_hdfs_scheme`: if the user routed `s3a`
+/// through libhdfs via `fs.comet.libhdfs.schemes`, we must NOT rewrite it to `s3` -- HDFS
+/// handling takes over.
+pub(crate) fn normalize_object_store_url(
+    url_str: &str,
+    object_store_configs: &HashMap<String, String>,
+) -> Result<Url, ExecutionError> {
+    let mut url = Url::parse(url_str)
+        .map_err(|e| ExecutionError::GeneralError(format!("Error parsing URL {url_str}: {e}")))?;
+    if is_hdfs_scheme(&url, object_store_configs) {
+        return Ok(url);
+    }
+    let scheme = url.scheme();
+    if scheme != "s3a" && scheme != "blob" {
+        return Ok(url);
+    }
+    let original = scheme.to_string();
+    let needs_host_promotion = url.host_str().is_none();
+    url.set_scheme("s3").map_err(|_| {
+        ExecutionError::GeneralError(format!("Could not convert scheme from {original} to s3"))
+    })?;
+    if needs_host_promotion {
+        // Some deployments emit `blob:///bucket/key` (three slashes, empty authority) or Java
+        // collapses that to `blob:/bucket/key` (opaque form) in Iceberg manifests. In both,
+        // `url::Url` reports host=None and path=`/bucket/key`, but `ObjectStoreScheme::parse`
+        // requires a non-empty host. Lift the first path segment into the host.
+        let trimmed = url.path().trim_start_matches('/').to_string();
+        let (bucket, key) = match trimmed.split_once('/') {
+            Some((b, k)) => (b.to_string(), k.to_string()),
+            None => (trimmed, String::new()),
+        };
+        if bucket.is_empty() {
+            return Err(ExecutionError::GeneralError(format!(
+                "{original}:// URL is missing bucket name: {url}"
+            )));
+        }
+        url = Url::parse(&format!("s3://{bucket}/{key}")).map_err(|e| {
+            ExecutionError::GeneralError(format!("Could not normalize {original}:// URL: {e}"))
+        })?;
+    }
+    Ok(url)
+}
+
+/// String-returning wrapper: iceberg-rust stores paths as owned strings on
+/// `FileScanTask`/`FileScanTaskDeleteFile`, and iceberg-storage-opendal's `storage_factory_for`
+/// picks the LocalFs backend for any path without `://` -- so a single-slash `blob:/...` path
+/// lands in the fs backend and gets its first character stripped (`&path[1..]`), producing
+/// errors like `path: lob:/...`. Rewrite before handing paths to iceberg-rust.
+pub(crate) fn normalize_object_store_url_string(path: &str) -> Result<String, ExecutionError> {
+    Ok(normalize_object_store_url(path, &HashMap::new())?.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_object_store_url_string_blob_single_slash_form() {
+        // Java's URI.toString() collapses `blob:///bucket/key` to `blob:/bucket/key` (opaque form
+        // with a leading slash on the path), and that's exactly what Iceberg manifests store.
+        // Iceberg-storage-opendal's `storage_factory_for` uses `path.contains("://")` to detect
+        // the scheme, so a `blob:/...` path routes to the LocalFs backend and its `&path[1..]`
+        // fallback strips the first char, producing `lob:/...` errors. Guard: this string helper
+        // must produce the canonical `s3://bucket/key` before the path reaches iceberg-rust.
+        let out = normalize_object_store_url_string(
+            "blob:/mybucket/tmp/warehouse/db/test_table/data/part-0.parquet",
+        )
+        .expect("single-slash blob URL should normalize");
+        assert_eq!(
+            out,
+            "s3://mybucket/tmp/warehouse/db/test_table/data/part-0.parquet"
+        );
+
+        // Two-slash form (authority present) also normalizes to s3://.
+        let out = normalize_object_store_url_string("blob://bucket/key.parquet").unwrap();
+        assert_eq!(out, "s3://bucket/key.parquet");
+
+        // s3a shares the alias path and gets rewritten too.
+        let out = normalize_object_store_url_string("s3a://bucket/key.parquet").unwrap();
+        assert_eq!(out, "s3://bucket/key.parquet");
+
+        // Non-alias schemes pass through unchanged so file:// / memory:/ Iceberg paths keep
+        // working with iceberg-storage-opendal's Fs / Memory backends.
+        let out = normalize_object_store_url_string("file:///tmp/warehouse/db/t").unwrap();
+        assert_eq!(out, "file:///tmp/warehouse/db/t");
+        let out = normalize_object_store_url_string("s3://bucket/key.parquet").unwrap();
+        assert_eq!(out, "s3://bucket/key.parquet");
+    }
+}

--- a/native/core/src/parquet/objectstore/mod.rs
+++ b/native/core/src/parquet/objectstore/mod.rs
@@ -17,3 +17,4 @@
 
 pub mod azure;
 pub mod s3;
+pub mod s3_blob_fs_support;

--- a/native/core/src/parquet/objectstore/mod.rs
+++ b/native/core/src/parquet/objectstore/mod.rs
@@ -16,4 +16,5 @@
 // under the License.
 
 pub mod azure;
+pub mod blob_alias;
 pub mod s3;

--- a/native/core/src/parquet/objectstore/s3.rs
+++ b/native/core/src/parquet/objectstore/s3.rs
@@ -120,7 +120,13 @@ pub fn create_store(
             .block_on(resolve_bucket_region(bucket))
             .map_err(|e| object_store::Error::Generic {
                 store: "S3",
-                source: format!("Failed to resolve region: {e}").into(),
+                source: format!(
+                    "Failed to resolve region: {e}. If '{bucket}' is on a non-AWS S3-compatible \
+                     service, set fs.s3a.endpoint (and optionally fs.s3a.endpoint.region, \
+                     fs.s3a.path.style.access) or the per-bucket variants \
+                     fs.s3a.bucket.{bucket}.endpoint[.region] so Comet skips the AWS HEAD probe."
+                )
+                .into(),
             })?;
         debug!("resolved region: {region:?}");
         builder = builder.with_config(AmazonS3ConfigKey::Region, region.to_string());

--- a/native/core/src/parquet/objectstore/s3_blob_fs_support.rs
+++ b/native/core/src/parquet/objectstore/s3_blob_fs_support.rs
@@ -22,9 +22,8 @@
 //! `ObjectStoreScheme::parse` does not recognize them.
 //!
 //! On the Parquet scan path, [`normalize_object_store_url`] rewrites those aliases (and `s3a`) to
-//! `s3://bucket/key` so `prepare_object_store_with_configs`'s `scheme == "s3"` dispatch fires. Its
-//! callers consume only `url.scheme()`/`url.path()`, so re-serialization through `url::Url` is
-//! harmless.
+//! `s3://bucket/key`. Its callers consume only `url.scheme()`/`url.path()`, so re-serialization
+//! through `url::Url` is harmless.
 //!
 //! The Iceberg path never rewrites the recorded location string that iceberg-rust holds, because
 //! deletes are matched against it by exact string compare (see `planner.rs`'s `data_file_path`).
@@ -35,12 +34,11 @@
 //! Some vendor blob filesystems record HOSTLESS locations (`blob:///bucket/key`, bucket as first
 //! path segment) that operator cannot open. For alias scans, [`BlobHostPromotingS3Storage`] wraps
 //! the S3 backend and promotes the bucket from the first path segment (via
-//! [`promote_hostless_alias_url`]) ONLY at the open boundary, so the string iceberg-rust matches
-//! deletes against is still the raw recorded location.
+//! [`promote_hostless_alias_url`]) at the open boundary.
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -87,8 +85,6 @@ pub(crate) fn is_s3_compliant_alias_scheme(
     object_store_configs: &HashMap<String, String>,
 ) -> bool {
     const COMET_S3_COMPLIANT_SCHEMES_KEY: &str = "fs.comet.s3Compliant.schemes";
-    // Nothing is an alias until the user opts in, so settle that first: the default (key absent)
-    // case returns without scanning the special-scheme list below.
     let configured = match object_store_configs.get(COMET_S3_COMPLIANT_SCHEMES_KEY) {
         Some(schemes) => schemes,
         None => return false,
@@ -128,9 +124,8 @@ fn rewrite_alias_to_s3(mut url: Url) -> Result<Url, ExecutionError> {
             ))
         });
     }
-    // Host-bearing (`blob://bucket/key`): swap only the scheme. s3 and the aliases are all
-    // non-special, so `set_scheme` succeeds and the host/path are preserved verbatim. On failure
-    // `url` is untouched, so it still reports the original scheme.
+    // s3 and the aliases are all non-special, so `set_scheme` succeeds and the host/path are
+    // preserved verbatim. On failure `url` is untouched, so it still reports the original scheme.
     if url.set_scheme("s3").is_err() {
         return Err(ExecutionError::GeneralError(format!(
             "Could not convert scheme from {} to s3",
@@ -146,10 +141,9 @@ fn rewrite_alias_to_s3(mut url: Url) -> Result<Url, ExecutionError> {
 /// `blob:/<bucket>/<key>` (opaque) -- keeping the bucket as the first path segment, which the
 /// operator fails to open with a missing-bucket error.
 ///
-/// Host-bearing locations (`blob://<bucket>/<key>`, `s3://...`) are returned unchanged. This runs
-/// ONLY at the storage open boundary inside [`BlobHostPromotingS3Storage`], never on the raw
-/// recorded string iceberg-rust matches positional/equality deletes against, so promotion cannot
-/// desync the two and silently drop deletes.
+/// This runs ONLY at the storage open boundary inside [`BlobHostPromotingS3Storage`], never on the
+/// raw recorded string iceberg-rust matches positional/equality deletes against, so promotion
+/// cannot desync the two and silently drop deletes.
 pub(crate) fn promote_hostless_alias_url(path: &str) -> Result<Cow<'_, str>, ExecutionError> {
     let url = Url::parse(path)
         .map_err(|e| ExecutionError::GeneralError(format!("Error parsing URL {path}: {e}")))?;
@@ -160,11 +154,9 @@ pub(crate) fn promote_hostless_alias_url(path: &str) -> Result<Cow<'_, str>, Exe
 }
 
 /// [`StorageFactory`] for hostless-capable s3-compliant-alias Iceberg scans
-/// (`fs.comet.s3Compliant.schemes`, e.g. `blob`). It builds the crate's scheme-agnostic opendal S3
-/// storage and wraps it in [`BlobHostPromotingS3Storage`] so a hostless alias location is opened by
-/// promoting the bucket from the first path segment. Only alias schemes route here; plain
-/// `s3`/`s3a` keep the unwrapped [`OpenDalStorageFactory::S3`] (see
-/// `iceberg_common::storage_factory_for`).
+/// (`fs.comet.s3Compliant.schemes`, e.g. `blob`). Wraps [`OpenDalStorageFactory::S3`] in
+/// [`BlobHostPromotingS3Storage`]. Only alias schemes route here; plain `s3`/`s3a` keep the
+/// unwrapped factory (see `iceberg_common::storage_factory_for`).
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct BlobHostPromotingS3StorageFactory {
     #[serde(skip)]
@@ -182,45 +174,24 @@ impl BlobHostPromotingS3StorageFactory {
 #[typetag::serde(name = "CometBlobHostPromotingS3StorageFactory")]
 impl StorageFactory for BlobHostPromotingS3StorageFactory {
     fn build(&self, config: &StorageConfig) -> IcebergResult<Arc<dyn Storage>> {
-        Ok(Arc::new(BlobHostPromotingS3Storage {
-            props: config.props().clone(),
-            inner: OnceLock::new(),
+        let inner = OpenDalStorageFactory::S3 {
             customized_credential_load: self.customized_credential_load.clone(),
-        }))
+        }
+        .build(config)?;
+        Ok(Arc::new(BlobHostPromotingS3Storage { inner }))
     }
 }
 
 /// [`Storage`] that promotes hostless s3-compliant-alias locations (see
-/// [`promote_hostless_alias_url`]) at the open boundary, then delegates to the crate's opendal S3
-/// storage, which it builds lazily and caches. `props`/`customized_credential_load` mirror
-/// [`OpenDalStorageFactory::S3`]'s inputs so the wrapped storage is exactly the one it would build.
-/// Serde mirrors the crate's `OpenDalResolvingStorage` (props carried, operator cache and
-/// credential loader skipped) only to satisfy the `Storage` typetag supertraits; Comet never
-/// serializes storage during a scan.
+/// [`promote_hostless_alias_url`]) at the open boundary, then delegates to the opendal S3 storage
+/// [`OpenDalStorageFactory::S3`] built from the same [`StorageConfig`]. Serde exists only to
+/// satisfy the `Storage` typetag supertraits; Comet never serializes storage during a scan.
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct BlobHostPromotingS3Storage {
-    props: HashMap<String, String>,
-    #[serde(skip, default)]
-    inner: OnceLock<Arc<dyn Storage>>,
-    #[serde(skip)]
-    customized_credential_load: Option<CustomAwsCredentialLoader>,
+    inner: Arc<dyn Storage>,
 }
 
 impl BlobHostPromotingS3Storage {
-    /// Lazily build and cache the wrapped opendal S3 storage from the same inputs
-    /// [`OpenDalStorageFactory::S3`] uses. A first-call race builds twice and discards the loser;
-    /// `get_or_init`'s closure cannot fail, so the fallible build must happen outside it.
-    fn inner(&self) -> IcebergResult<&Arc<dyn Storage>> {
-        if let Some(inner) = self.inner.get() {
-            return Ok(inner);
-        }
-        let built = OpenDalStorageFactory::S3 {
-            customized_credential_load: self.customized_credential_load.clone(),
-        }
-        .build(&StorageConfig::from_props(self.props.clone()))?;
-        Ok(self.inner.get_or_init(|| built))
-    }
-
     /// Promote a hostless path, surfacing failures as an iceberg [`Error`].
     fn promote<'a>(&self, path: &'a str) -> IcebergResult<Cow<'a, str>> {
         promote_hostless_alias_url(path)
@@ -232,37 +203,35 @@ impl BlobHostPromotingS3Storage {
 #[typetag::serde(name = "CometBlobHostPromotingS3Storage")]
 impl Storage for BlobHostPromotingS3Storage {
     async fn exists(&self, path: &str) -> IcebergResult<bool> {
-        self.inner()?.exists(self.promote(path)?.as_ref()).await
+        self.inner.exists(self.promote(path)?.as_ref()).await
     }
 
     async fn metadata(&self, path: &str) -> IcebergResult<FileMetadata> {
-        self.inner()?.metadata(self.promote(path)?.as_ref()).await
+        self.inner.metadata(self.promote(path)?.as_ref()).await
     }
 
     async fn read(&self, path: &str) -> IcebergResult<Bytes> {
-        self.inner()?.read(self.promote(path)?.as_ref()).await
+        self.inner.read(self.promote(path)?.as_ref()).await
     }
 
     async fn reader(&self, path: &str) -> IcebergResult<Box<dyn FileRead>> {
-        self.inner()?.reader(self.promote(path)?.as_ref()).await
+        self.inner.reader(self.promote(path)?.as_ref()).await
     }
 
     async fn write(&self, path: &str, bs: Bytes) -> IcebergResult<()> {
-        self.inner()?.write(self.promote(path)?.as_ref(), bs).await
+        self.inner.write(self.promote(path)?.as_ref(), bs).await
     }
 
     async fn writer(&self, path: &str) -> IcebergResult<Box<dyn FileWrite>> {
-        self.inner()?.writer(self.promote(path)?.as_ref()).await
+        self.inner.writer(self.promote(path)?.as_ref()).await
     }
 
     async fn delete(&self, path: &str) -> IcebergResult<()> {
-        self.inner()?.delete(self.promote(path)?.as_ref()).await
+        self.inner.delete(self.promote(path)?.as_ref()).await
     }
 
     async fn delete_prefix(&self, path: &str) -> IcebergResult<()> {
-        self.inner()?
-            .delete_prefix(self.promote(path)?.as_ref())
-            .await
+        self.inner.delete_prefix(self.promote(path)?.as_ref()).await
     }
 
     async fn delete_stream(&self, paths: BoxStream<'static, String>) -> IcebergResult<()> {
@@ -273,26 +242,21 @@ impl Storage for BlobHostPromotingS3Storage {
             let rewritten = promote_hostless_alias_url(&p).map(Cow::into_owned);
             rewritten.unwrap_or(p)
         });
-        self.inner()?.delete_stream(promoted.boxed()).await
+        self.inner.delete_stream(promoted.boxed()).await
     }
 
     fn new_input(&self, path: &str) -> IcebergResult<InputFile> {
-        self.inner()?.new_input(self.promote(path)?.as_ref())
+        self.inner.new_input(self.promote(path)?.as_ref())
     }
 
     fn new_output(&self, path: &str) -> IcebergResult<OutputFile> {
-        self.inner()?.new_output(self.promote(path)?.as_ref())
+        self.inner.new_output(self.promote(path)?.as_ref())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Config opting `blob` in as an s3-compliant alias (`fs.comet.s3Compliant.schemes=blob`).
-    fn blob_alias_configs() -> HashMap<String, String> {
-        configs_with("blob")
-    }
 
     fn normalized(url: &str, configs: &HashMap<String, String>) -> String {
         normalize_object_store_url(url, configs)
@@ -301,6 +265,7 @@ mod tests {
             .to_string()
     }
 
+    /// Config opting the given comma-separated schemes in as s3-compliant aliases.
     fn configs_with(schemes: &str) -> HashMap<String, String> {
         let mut configs = HashMap::new();
         configs.insert(
@@ -312,7 +277,7 @@ mod tests {
 
     #[test]
     fn test_normalize_object_store_url() {
-        let blob = blob_alias_configs();
+        let blob = configs_with("blob");
         let empty = HashMap::new();
         for (input, configs, expected) in [
             // Opt-in: blob is left alone until the user lists it, and the list is comma-separated,
@@ -356,71 +321,61 @@ mod tests {
     }
 
     #[test]
-    fn test_is_s3_compliant_alias_scheme_opt_in() {
-        let empty = HashMap::new();
-        assert!(!is_s3_compliant_alias_scheme("blob", &empty));
-
-        let configs = blob_alias_configs();
-        assert!(is_s3_compliant_alias_scheme("blob", &configs));
-        // Case-insensitive; s3a is intentionally NOT reported here (callers special-case it).
-        assert!(is_s3_compliant_alias_scheme("BLOB", &configs));
-        assert!(!is_s3_compliant_alias_scheme("s3a", &configs));
-    }
-
-    #[test]
-    fn test_is_s3_compliant_alias_scheme_excludes_url_special_schemes() {
-        // A URL-spec special scheme is never an alias even if the user lists it: it cannot be
-        // rewritten to `s3` (`Url::set_scheme` refuses it), so admitting it would turn a clean
-        // fallback into a hard error. Guards against a stray `file`/`https` in the list.
-        let configs = configs_with("file,http,https,ftp,ws,wss,blob");
-        for special in ["file", "http", "https", "ftp", "ws", "wss"] {
-            assert!(
-                !is_s3_compliant_alias_scheme(special, &configs),
-                "{special} must not be treated as an s3-compliant alias"
+    fn test_is_s3_compliant_alias_scheme() {
+        // Opt-in and case-insensitive; `s3a` is intentionally NOT reported (callers special-case
+        // it). A URL-spec special scheme is never an alias even when the user lists it: it cannot
+        // be rewritten to `s3` (`Url::set_scheme` refuses it), so admitting one would turn a clean
+        // fallback into a hard error.
+        let special = "file,http,https,ftp,ws,wss,blob";
+        for (scheme, configured, expected) in [
+            ("blob", "", false),
+            ("blob", "blob", true),
+            ("BLOB", "blob", true),
+            ("s3a", "blob", false),
+            ("file", special, false),
+            ("http", special, false),
+            ("https", special, false),
+            ("ftp", special, false),
+            ("ws", special, false),
+            ("wss", special, false),
+            // A non-special scheme in the same list is still honored.
+            ("blob", special, true),
+        ] {
+            let configs = if configured.is_empty() {
+                HashMap::new()
+            } else {
+                configs_with(configured)
+            };
+            assert_eq!(
+                is_s3_compliant_alias_scheme(scheme, &configs),
+                expected,
+                "scheme {scheme} with list {configured:?}"
             );
         }
-        // A non-special scheme in the same list is still honored.
-        assert!(is_s3_compliant_alias_scheme("blob", &configs));
-    }
-
-    fn promoted(path: &str) -> String {
-        promote_hostless_alias_url(path).unwrap().into_owned()
     }
 
     #[test]
-    fn test_promote_hostless_alias_url_promotes_hostless_forms() {
-        // Both hostless spellings (host=None) promote the first path segment into the host so the
+    fn test_promote_hostless_alias_url() {
+        // Hostless spellings (host=None) promote the first path segment into the host so the
         // opendal S3 operator finds the bucket: the empty-authority `blob:///bucket/key` form (the
         // vendor default store) and the opaque single-slash `blob:/bucket/key` form java.net.URI
-        // re-renders it to.
-        assert_eq!(
-            promoted("blob:///sparkinsightdev/tmp/warehouse/x.parquet"),
-            "s3://sparkinsightdev/tmp/warehouse/x.parquet"
-        );
-        assert_eq!(
-            promoted("blob:/bucket/a/b/c.parquet"),
-            "s3://bucket/a/b/c.parquet"
-        );
-    }
-
-    #[test]
-    fn test_promote_hostless_alias_url_passthrough_when_host_present() {
-        // Host-bearing locations are opened as-is: promotion runs only when the URL is hostless.
-        for p in [
-            "blob://bucket/key.parquet",
-            "s3://bucket/key.parquet",
-            "s3a://bucket/key.parquet",
+        // re-renders it to. Host-bearing locations are opened as-is.
+        for (input, expected) in [
+            (
+                "blob:///sparkinsightdev/tmp/warehouse/x.parquet",
+                "s3://sparkinsightdev/tmp/warehouse/x.parquet",
+            ),
+            ("blob:/bucket/a/b/c.parquet", "s3://bucket/a/b/c.parquet"),
+            ("blob://bucket/key.parquet", "blob://bucket/key.parquet"),
+            ("s3://bucket/key.parquet", "s3://bucket/key.parquet"),
+            ("s3a://bucket/key.parquet", "s3a://bucket/key.parquet"),
         ] {
             assert_eq!(
-                promoted(p),
-                p,
-                "host-bearing {p} must pass through unchanged"
+                promote_hostless_alias_url(input).unwrap(),
+                expected,
+                "input: {input}"
             );
         }
-    }
-
-    #[test]
-    fn test_promote_hostless_alias_url_requires_a_bucket_segment() {
         // A hostless URL with no promotable first segment errors, so the scan fails loudly rather
         // than opening a bucketless URL. (The JVM gate already declines these; defense in depth.)
         assert!(promote_hostless_alias_url("blob:///").is_err());

--- a/native/core/src/parquet/objectstore/s3_blob_fs_support.rs
+++ b/native/core/src/parquet/objectstore/s3_blob_fs_support.rs
@@ -26,19 +26,17 @@
 //! callers consume only `url.scheme()`/`url.path()`, so re-serialization through `url::Url` is
 //! harmless.
 //!
-//! The Iceberg path never rewrites the recorded location string that iceberg-rust holds.
-//! iceberg-rust matches positional/equality deletes by an exact string comparison of a delete
-//! file's recorded `file_path` against the `data_file_path` Comet supplies, so rewriting that
-//! string would desync the two and silently drop deletes. `iceberg_common::storage_factory_for`
-//! routes an alias scheme to its S3 backend (via [`is_s3_compliant_alias_scheme`]), and
-//! iceberg-storage-opendal's scheme-agnostic S3 operator opens a host-bearing `blob://bucket/key`
-//! as-is (bucket from `Url::host_str`, key prefix from the path's own scheme).
+//! The Iceberg path never rewrites the recorded location string that iceberg-rust holds, because
+//! deletes are matched against it by exact string compare (see `planner.rs`'s `data_file_path`).
+//! `iceberg_common::storage_factory_for` routes an alias scheme to its S3 backend (via
+//! [`is_s3_compliant_alias_scheme`]), and iceberg-storage-opendal's scheme-agnostic S3 operator
+//! opens a host-bearing `blob://bucket/key` as-is (bucket from `Url::host_str`).
 //!
 //! Some vendor blob filesystems record HOSTLESS locations (`blob:///bucket/key`, bucket as first
 //! path segment) that operator cannot open. For alias scans, [`BlobHostPromotingS3Storage`] wraps
 //! the S3 backend and promotes the bucket from the first path segment (via
-//! [`promote_hostless_alias_url`]) ONLY at the open boundary. The string iceberg-rust matches
-//! deletes against is still the raw recorded location, so deletes stay correct.
+//! [`promote_hostless_alias_url`]) ONLY at the open boundary, so the string iceberg-rust matches
+//! deletes against is still the raw recorded location.
 
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -58,7 +56,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::execution::operators::ExecutionError;
-use crate::parquet::parquet_support::is_hdfs_scheme;
+use crate::parquet::parquet_support::{is_hdfs_scheme, scheme_in_list};
 
 /// Rewrites `s3a` and the configured s3-compliant aliases to `s3://bucket/key`, promoting a missing
 /// authority into the host. Non-alias schemes are returned unchanged. `s3a` routed through libhdfs
@@ -79,13 +77,11 @@ pub(crate) fn normalize_object_store_url(
     rewrite_alias_to_s3(url)
 }
 
-/// True if `scheme` is a configured s3-compliant alias (`fs.comet.s3Compliant.schemes`,
-/// comma-separated, case-insensitive; empty/unset means none). These route to `AmazonS3` but are
-/// not recognized by `ObjectStoreScheme::parse`. `s3a` is excluded -- object_store knows it and
-/// callers special-case it. The URL-spec special schemes (`file`, `http`, `https`, `ftp`, `ws`,
-/// `wss`) are excluded too: they cannot be rewritten to `s3` (see the body). Shared by the Parquet
-/// normalizer above and the Iceberg storage-factory gate (`iceberg_common::storage_factory_for`)
-/// so both admit the same schemes.
+/// True if `scheme` is a configured s3-compliant alias (`fs.comet.s3Compliant.schemes`; empty or
+/// unset means none). These route to `AmazonS3` but are not recognized by
+/// `ObjectStoreScheme::parse`. `s3a` is excluded -- object_store knows it and callers special-case
+/// it. Shared by the Parquet normalizer above and the Iceberg storage-factory gate
+/// (`iceberg_common::storage_factory_for`) so both admit the same schemes.
 pub(crate) fn is_s3_compliant_alias_scheme(
     scheme: &str,
     object_store_configs: &HashMap<String, String>,
@@ -97,15 +93,11 @@ pub(crate) fn is_s3_compliant_alias_scheme(
         Some(schemes) => schemes,
         None => return false,
     };
-    // The URL spec's "special" schemes can never be an alias. `Url::set_scheme` refuses to rewrite
-    // between a special scheme and a non-special one, so `rewrite_alias_to_s3` returns `Err` for
-    // every URL of such a scheme -- and since `normalize_object_store_url` and its callers
-    // propagate that error, a stray `file`/`https`/... in the user-typed list would turn every
-    // matching scan into a hard failure instead of a clean fallback (a `file` entry would take down
-    // every local Parquet scan). It is load-bearing for the Iceberg caller too, which never
-    // rewrites: without it a listed `file` would be admitted by `is_s3_family_scheme` and routed to
-    // S3 in `storage_factory_for`, misdirecting local reads. Excluded for the same reason `s3a` is.
-    // These six are the spec-fixed WHATWG special set (mirrors `url`'s internal `SchemeType::from`).
+    // The WHATWG "special" schemes can never be an alias: `Url::set_scheme` refuses to rewrite
+    // between a special and a non-special scheme, so admitting a stray `file`/`https` from the
+    // user-typed list would turn every matching scan into a hard error instead of a clean
+    // fallback. Load-bearing for the Iceberg caller too, which never rewrites: a listed `file`
+    // would otherwise be routed to S3 and misdirect local reads.
     const URL_SPEC_SPECIAL_SCHEMES: [&str; 6] = ["file", "http", "https", "ftp", "ws", "wss"];
     if URL_SPEC_SPECIAL_SCHEMES
         .iter()
@@ -113,9 +105,7 @@ pub(crate) fn is_s3_compliant_alias_scheme(
     {
         return false;
     }
-    configured
-        .split(',')
-        .any(|s| s.trim().eq_ignore_ascii_case(scheme))
+    scheme_in_list(configured, scheme)
 }
 
 /// Rewrites a parsed alias URL (`s3a` or a configured alias) to `s3://bucket/key`. When it has no
@@ -123,8 +113,6 @@ pub(crate) fn is_s3_compliant_alias_scheme(
 /// the first path segment is promoted into the host. Defensive: object-store URLs normally have one.
 fn rewrite_alias_to_s3(mut url: Url) -> Result<Url, ExecutionError> {
     if url.host_str().is_none() {
-        // host=None (empty-authority `blob:///bucket/key` or opaque `blob:/bucket/key`): lift the
-        // first path segment into the host for `ObjectStoreScheme::parse`.
         let trimmed = url.path().trim_start_matches('/');
         let (bucket, key) = trimmed.split_once('/').unwrap_or((trimmed, ""));
         if bucket.is_empty() {
@@ -153,23 +141,19 @@ fn rewrite_alias_to_s3(mut url: Url) -> Result<Url, ExecutionError> {
 }
 
 /// Promote a HOSTLESS s3-compliant-alias location so the scheme-agnostic opendal S3 operator can
-/// derive the bucket from the URL host. Some vendor blob filesystems (e.g. the Spark McQueen
-/// connector) record data/delete file locations WITHOUT a URL host -- `blob:///<bucket>/<key>`
-/// (empty authority) or `blob:/<bucket>/<key>` (opaque) -- keeping the bucket as the first path
-/// segment. `iceberg-storage-opendal`'s S3 operator reads the bucket from `Url::host_str`, so such
-/// a location fails with a missing-bucket error. This lifts the first path segment into the host
-/// (yielding `s3://<bucket>/<key>`), reusing [`rewrite_alias_to_s3`].
+/// derive the bucket from the URL host. Some vendor blob filesystems record data/delete file
+/// locations WITHOUT a URL host -- `blob:///<bucket>/<key>` (empty authority) or
+/// `blob:/<bucket>/<key>` (opaque) -- keeping the bucket as the first path segment, which the
+/// operator fails to open with a missing-bucket error.
 ///
 /// Host-bearing locations (`blob://<bucket>/<key>`, `s3://...`) are returned unchanged. This runs
 /// ONLY at the storage open boundary inside [`BlobHostPromotingS3Storage`], never on the raw
-/// recorded string iceberg-rust matches positional/equality deletes against (the FileScanTask
-/// `data_file_path` and the delete file's stored `file_path` column), so promotion cannot desync
-/// the two and silently drop deletes.
+/// recorded string iceberg-rust matches positional/equality deletes against, so promotion cannot
+/// desync the two and silently drop deletes.
 pub(crate) fn promote_hostless_alias_url(path: &str) -> Result<Cow<'_, str>, ExecutionError> {
     let url = Url::parse(path)
         .map_err(|e| ExecutionError::GeneralError(format!("Error parsing URL {path}: {e}")))?;
     if url.host_str().is_some() {
-        // Already addressable by host (e.g. blob://bucket/key): open as-is.
         return Ok(Cow::Borrowed(path));
     }
     Ok(Cow::Owned(rewrite_alias_to_s3(url)?.to_string()))
@@ -224,16 +208,17 @@ pub(crate) struct BlobHostPromotingS3Storage {
 
 impl BlobHostPromotingS3Storage {
     /// Lazily build and cache the wrapped opendal S3 storage from the same inputs
-    /// [`OpenDalStorageFactory::S3`] uses.
-    fn inner(&self) -> IcebergResult<Arc<dyn Storage>> {
+    /// [`OpenDalStorageFactory::S3`] uses. A first-call race builds twice and discards the loser;
+    /// `get_or_init`'s closure cannot fail, so the fallible build must happen outside it.
+    fn inner(&self) -> IcebergResult<&Arc<dyn Storage>> {
         if let Some(inner) = self.inner.get() {
-            return Ok(Arc::clone(inner));
+            return Ok(inner);
         }
         let built = OpenDalStorageFactory::S3 {
             customized_credential_load: self.customized_credential_load.clone(),
         }
         .build(&StorageConfig::from_props(self.props.clone()))?;
-        Ok(Arc::clone(self.inner.get_or_init(|| built)))
+        Ok(self.inner.get_or_init(|| built))
     }
 
     /// Promote a hostless path, surfacing failures as an iceberg [`Error`].
@@ -247,51 +232,37 @@ impl BlobHostPromotingS3Storage {
 #[typetag::serde(name = "CometBlobHostPromotingS3Storage")]
 impl Storage for BlobHostPromotingS3Storage {
     async fn exists(&self, path: &str) -> IcebergResult<bool> {
-        let inner = self.inner()?;
-        let promoted = self.promote(path)?;
-        inner.exists(promoted.as_ref()).await
+        self.inner()?.exists(self.promote(path)?.as_ref()).await
     }
 
     async fn metadata(&self, path: &str) -> IcebergResult<FileMetadata> {
-        let inner = self.inner()?;
-        let promoted = self.promote(path)?;
-        inner.metadata(promoted.as_ref()).await
+        self.inner()?.metadata(self.promote(path)?.as_ref()).await
     }
 
     async fn read(&self, path: &str) -> IcebergResult<Bytes> {
-        let inner = self.inner()?;
-        let promoted = self.promote(path)?;
-        inner.read(promoted.as_ref()).await
+        self.inner()?.read(self.promote(path)?.as_ref()).await
     }
 
     async fn reader(&self, path: &str) -> IcebergResult<Box<dyn FileRead>> {
-        let inner = self.inner()?;
-        let promoted = self.promote(path)?;
-        inner.reader(promoted.as_ref()).await
+        self.inner()?.reader(self.promote(path)?.as_ref()).await
     }
 
     async fn write(&self, path: &str, bs: Bytes) -> IcebergResult<()> {
-        let inner = self.inner()?;
-        let promoted = self.promote(path)?;
-        inner.write(promoted.as_ref(), bs).await
+        self.inner()?.write(self.promote(path)?.as_ref(), bs).await
     }
 
     async fn writer(&self, path: &str) -> IcebergResult<Box<dyn FileWrite>> {
-        let inner = self.inner()?;
-        let promoted = self.promote(path)?;
-        inner.writer(promoted.as_ref()).await
+        self.inner()?.writer(self.promote(path)?.as_ref()).await
     }
 
     async fn delete(&self, path: &str) -> IcebergResult<()> {
-        let inner = self.inner()?;
-        let promoted = self.promote(path)?;
-        inner.delete(promoted.as_ref()).await
+        self.inner()?.delete(self.promote(path)?.as_ref()).await
     }
 
     async fn delete_prefix(&self, path: &str) -> IcebergResult<()> {
-        let inner = self.inner()?;
-        let promoted = self.promote(path)?;
-        inner.delete_prefix(promoted.as_ref()).await
+        self.inner()?
+            .delete_prefix(self.promote(path)?.as_ref())
+            .await
     }
 
     async fn delete_stream(&self, paths: BoxStream<'static, String>) -> IcebergResult<()> {
@@ -306,15 +277,11 @@ impl Storage for BlobHostPromotingS3Storage {
     }
 
     fn new_input(&self, path: &str) -> IcebergResult<InputFile> {
-        let inner = self.inner()?;
-        let promoted = self.promote(path)?;
-        inner.new_input(promoted.as_ref())
+        self.inner()?.new_input(self.promote(path)?.as_ref())
     }
 
     fn new_output(&self, path: &str) -> IcebergResult<OutputFile> {
-        let inner = self.inner()?;
-        let promoted = self.promote(path)?;
-        inner.new_output(promoted.as_ref())
+        self.inner()?.new_output(self.promote(path)?.as_ref())
     }
 }
 
@@ -324,12 +291,7 @@ mod tests {
 
     /// Config opting `blob` in as an s3-compliant alias (`fs.comet.s3Compliant.schemes=blob`).
     fn blob_alias_configs() -> HashMap<String, String> {
-        let mut configs = HashMap::new();
-        configs.insert(
-            "fs.comet.s3Compliant.schemes".to_string(),
-            "blob".to_string(),
-        );
-        configs
+        configs_with("blob")
     }
 
     fn normalized(url: &str, configs: &HashMap<String, String>) -> String {
@@ -339,56 +301,58 @@ mod tests {
             .to_string()
     }
 
-    #[test]
-    fn test_normalize_object_store_url_alias_is_opt_in() {
-        // Empty config => blob is NOT an alias and is returned unchanged.
-        let empty = HashMap::new();
-        assert_eq!(
-            normalized("blob://bucket/key.parquet", &empty),
-            "blob://bucket/key.parquet"
-        );
-
-        // The list is comma-separated, whitespace-trimmed, and case-insensitive.
+    fn configs_with(schemes: &str) -> HashMap<String, String> {
         let mut configs = HashMap::new();
         configs.insert(
             "fs.comet.s3Compliant.schemes".to_string(),
-            " cos , BLOB ".to_string(),
+            schemes.to_string(),
         );
-        assert_eq!(
-            normalized("blob://bucket/key.parquet", &configs),
-            "s3://bucket/key.parquet"
-        );
+        configs
     }
 
     #[test]
-    fn test_normalize_object_store_url_rewrites_s3a_always() {
-        // s3a is rewritten to s3 regardless of the alias config (object_store dispatches on s3).
+    fn test_normalize_object_store_url() {
+        let blob = blob_alias_configs();
         let empty = HashMap::new();
-        assert_eq!(
-            normalized("s3a://bucket/key.parquet", &empty),
-            "s3://bucket/key.parquet"
-        );
-    }
-
-    #[test]
-    fn test_normalize_object_store_url_passes_through_non_alias_schemes() {
-        // s3:// and file:// are not aliases and round-trip unchanged.
-        let configs = blob_alias_configs();
-        let s3 = "s3://bucket/key.parquet";
-        assert_eq!(normalized(s3, &configs), s3);
-        let file = "file:///tmp/warehouse/db/t";
-        assert_eq!(normalized(file, &configs), file);
-    }
-
-    #[test]
-    fn test_normalize_object_store_url_promotes_authorityless_alias() {
-        // The opaque single-slash `blob:/bucket/key` form (host=None) lifts the first path segment
-        // into the host so `ObjectStoreScheme::parse` accepts the result.
-        let configs = blob_alias_configs();
-        assert_eq!(
-            normalized("blob:/bucket/key.parquet", &configs),
-            "s3://bucket/key.parquet"
-        );
+        for (input, configs, expected) in [
+            // Opt-in: blob is left alone until the user lists it, and the list is comma-separated,
+            // whitespace-trimmed, and case-insensitive.
+            (
+                "blob://bucket/key.parquet",
+                &empty,
+                "blob://bucket/key.parquet",
+            ),
+            (
+                "blob://bucket/key.parquet",
+                &configs_with(" cos , BLOB "),
+                "s3://bucket/key.parquet",
+            ),
+            // s3a is rewritten regardless of the alias config (object_store dispatches on s3).
+            (
+                "s3a://bucket/key.parquet",
+                &empty,
+                "s3://bucket/key.parquet",
+            ),
+            // Non-alias schemes round-trip unchanged.
+            ("s3://bucket/key.parquet", &blob, "s3://bucket/key.parquet"),
+            (
+                "file:///tmp/warehouse/db/t",
+                &blob,
+                "file:///tmp/warehouse/db/t",
+            ),
+            // Listing a URL-spec special scheme must not hard-error local scans: the URL comes back
+            // unchanged so the caller falls back, rather than failing in `set_scheme`.
+            (
+                "file:///tmp/warehouse/db/t",
+                &configs_with("file"),
+                "file:///tmp/warehouse/db/t",
+            ),
+            // Hostless alias: the first path segment is lifted into the host so
+            // `ObjectStoreScheme::parse` accepts the result.
+            ("blob:/bucket/key.parquet", &blob, "s3://bucket/key.parquet"),
+        ] {
+            assert_eq!(normalized(input, configs), expected, "input: {input}");
+        }
     }
 
     #[test]
@@ -408,11 +372,7 @@ mod tests {
         // A URL-spec special scheme is never an alias even if the user lists it: it cannot be
         // rewritten to `s3` (`Url::set_scheme` refuses it), so admitting it would turn a clean
         // fallback into a hard error. Guards against a stray `file`/`https` in the list.
-        let mut configs = HashMap::new();
-        configs.insert(
-            "fs.comet.s3Compliant.schemes".to_string(),
-            "file,http,https,ftp,ws,wss,blob".to_string(),
-        );
+        let configs = configs_with("file,http,https,ftp,ws,wss,blob");
         for special in ["file", "http", "https", "ftp", "ws", "wss"] {
             assert!(
                 !is_s3_compliant_alias_scheme(special, &configs),
@@ -423,21 +383,6 @@ mod tests {
         assert!(is_s3_compliant_alias_scheme("blob", &configs));
     }
 
-    #[test]
-    fn test_normalize_object_store_url_special_scheme_alias_falls_back() {
-        // Listing `file` must not hard-error local scans: normalize returns the URL unchanged so the
-        // caller falls back, rather than failing in `set_scheme`.
-        let mut configs = HashMap::new();
-        configs.insert(
-            "fs.comet.s3Compliant.schemes".to_string(),
-            "file".to_string(),
-        );
-        assert_eq!(
-            normalized("file:///tmp/warehouse/db/t", &configs),
-            "file:///tmp/warehouse/db/t"
-        );
-    }
-
     fn promoted(path: &str) -> String {
         promote_hostless_alias_url(path).unwrap().into_owned()
     }
@@ -446,7 +391,7 @@ mod tests {
     fn test_promote_hostless_alias_url_promotes_hostless_forms() {
         // Both hostless spellings (host=None) promote the first path segment into the host so the
         // opendal S3 operator finds the bucket: the empty-authority `blob:///bucket/key` form (the
-        // McQueen default store) and the opaque single-slash `blob:/bucket/key` form java.net.URI
+        // vendor default store) and the opaque single-slash `blob:/bucket/key` form java.net.URI
         // re-renders it to.
         assert_eq!(
             promoted("blob:///sparkinsightdev/tmp/warehouse/x.parquet"),
@@ -479,15 +424,5 @@ mod tests {
         // A hostless URL with no promotable first segment errors, so the scan fails loudly rather
         // than opening a bucketless URL. (The JVM gate already declines these; defense in depth.)
         assert!(promote_hostless_alias_url("blob:///").is_err());
-    }
-
-    #[test]
-    fn test_blob_host_promoting_factory_builds_storage() {
-        // The factory constructs a storage without eagerly building the inner operator (lazy), so
-        // this smoke test does not require any live backend.
-        let factory = BlobHostPromotingS3StorageFactory::new(None);
-        assert!(factory
-            .build(&StorageConfig::from_props(HashMap::new()))
-            .is_ok());
     }
 }

--- a/native/core/src/parquet/objectstore/s3_blob_fs_support.rs
+++ b/native/core/src/parquet/objectstore/s3_blob_fs_support.rs
@@ -1,0 +1,498 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! S3-compatible filesystem alias handling.
+//!
+//! Operators mark extra schemes as `s3://` aliases via `fs.comet.s3Compliant.schemes`
+//! (comma-separated, case-insensitive, opt-in). They route to `object_store::AmazonS3`, but
+//! `ObjectStoreScheme::parse` does not recognize them.
+//!
+//! On the Parquet scan path, [`normalize_object_store_url`] rewrites those aliases (and `s3a`) to
+//! `s3://bucket/key` so `prepare_object_store_with_configs`'s `scheme == "s3"` dispatch fires. Its
+//! callers consume only `url.scheme()`/`url.path()`, so re-serialization through `url::Url` is
+//! harmless.
+//!
+//! The Iceberg path never rewrites the recorded location string that iceberg-rust holds.
+//! iceberg-rust matches positional/equality deletes by an exact string comparison of a delete
+//! file's recorded `file_path` against the `data_file_path` Comet supplies, so rewriting that
+//! string would desync the two and silently drop deletes. `iceberg_common::storage_factory_for`
+//! routes an alias scheme to its S3 backend (via [`is_s3_compliant_alias_scheme`]), and
+//! iceberg-storage-opendal's scheme-agnostic S3 operator opens a host-bearing `blob://bucket/key`
+//! as-is (bucket from `Url::host_str`, key prefix from the path's own scheme).
+//!
+//! Some vendor blob filesystems record HOSTLESS locations (`blob:///bucket/key`, bucket as first
+//! path segment) that operator cannot open. For alias scans, [`BlobHostPromotingS3Storage`] wraps
+//! the S3 backend and promotes the bucket from the first path segment (via
+//! [`promote_hostless_alias_url`]) ONLY at the open boundary. The string iceberg-rust matches
+//! deletes against is still the raw recorded location, so deletes stay correct.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use futures::StreamExt;
+use iceberg::io::{
+    FileMetadata, FileRead, FileWrite, InputFile, OutputFile, Storage, StorageConfig,
+    StorageFactory,
+};
+use iceberg::{Error, ErrorKind, Result as IcebergResult};
+use iceberg_storage_opendal::{CustomAwsCredentialLoader, OpenDalStorageFactory};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::execution::operators::ExecutionError;
+use crate::parquet::parquet_support::is_hdfs_scheme;
+
+/// Rewrites `s3a` and the configured s3-compliant aliases to `s3://bucket/key`, promoting a missing
+/// authority into the host. Non-alias schemes are returned unchanged. `s3a` routed through libhdfs
+/// (`fs.comet.libhdfs.schemes`) is left alone.
+pub(crate) fn normalize_object_store_url(
+    url_str: &str,
+    object_store_configs: &HashMap<String, String>,
+) -> Result<Url, ExecutionError> {
+    let url = Url::parse(url_str)
+        .map_err(|e| ExecutionError::GeneralError(format!("Error parsing URL {url_str}: {e}")))?;
+    if is_hdfs_scheme(&url, object_store_configs) {
+        return Ok(url);
+    }
+    // Callers consume only `url.scheme()`/`url.path()`, so re-serialization through `url::Url` is
+    // harmless here (the Iceberg path avoids this function precisely because it must preserve raw
+    // bytes; it routes aliases by scheme in `storage_factory_for` instead).
+    let scheme = url.scheme();
+    if scheme != "s3a" && !is_s3_compliant_alias_scheme(scheme, object_store_configs) {
+        return Ok(url);
+    }
+    rewrite_alias_to_s3(url)
+}
+
+/// True if `scheme` is a configured s3-compliant alias (`fs.comet.s3Compliant.schemes`,
+/// comma-separated, case-insensitive; empty/unset means none). These route to `AmazonS3` but are
+/// not recognized by `ObjectStoreScheme::parse`. `s3a` is excluded -- object_store knows it and
+/// callers special-case it. The URL-spec special schemes (`file`, `http`, `https`, `ftp`, `ws`,
+/// `wss`) are excluded too: they cannot be rewritten to `s3` (see the body). Shared by the Parquet
+/// normalizer above and the Iceberg storage-factory gate (`iceberg_common::storage_factory_for`)
+/// so both admit the same schemes.
+pub(crate) fn is_s3_compliant_alias_scheme(
+    scheme: &str,
+    object_store_configs: &HashMap<String, String>,
+) -> bool {
+    const COMET_S3_COMPLIANT_SCHEMES_KEY: &str = "fs.comet.s3Compliant.schemes";
+    // The URL spec's "special" schemes can never be an alias. `Url::set_scheme` refuses to rewrite
+    // between a special scheme and a non-special one, so `rewrite_alias_to_s3` returns `Err` for
+    // every URL of such a scheme -- and since `normalize_object_store_url` and its callers
+    // propagate that error, a stray `file`/`https`/... in the user-typed list would turn every
+    // matching scan into a hard failure instead of a clean fallback (a `file` entry would take down
+    // every local Parquet scan). It is load-bearing for the Iceberg caller too, which never
+    // rewrites: without it a listed `file` would be admitted by `is_s3_family_scheme` and routed to
+    // S3 in `storage_factory_for`, misdirecting local reads. Excluded for the same reason `s3a` is.
+    // These six are the spec-fixed WHATWG special set (mirrors `url`'s internal `SchemeType::from`).
+    const URL_SPEC_SPECIAL_SCHEMES: [&str; 6] = ["file", "http", "https", "ftp", "ws", "wss"];
+    if URL_SPEC_SPECIAL_SCHEMES
+        .iter()
+        .any(|s| s.eq_ignore_ascii_case(scheme))
+    {
+        return false;
+    }
+    match object_store_configs.get(COMET_S3_COMPLIANT_SCHEMES_KEY) {
+        Some(schemes) => schemes
+            .split(',')
+            .any(|s| s.trim().eq_ignore_ascii_case(scheme)),
+        None => false,
+    }
+}
+
+/// Rewrites a parsed alias URL (`s3a` or a configured alias) to `s3://bucket/key`. When it has no
+/// authority (empty-authority `blob:///bucket/key` or opaque `blob:/bucket/key`, both host=None)
+/// the first path segment is promoted into the host. Defensive: object-store URLs normally have one.
+fn rewrite_alias_to_s3(mut url: Url) -> Result<Url, ExecutionError> {
+    let original = url.scheme().to_string();
+    if url.host_str().is_none() {
+        // host=None (empty-authority `blob:///bucket/key` or opaque `blob:/bucket/key`): lift the
+        // first path segment into the host for `ObjectStoreScheme::parse`.
+        let trimmed = url.path().trim_start_matches('/');
+        let (bucket, key) = trimmed.split_once('/').unwrap_or((trimmed, ""));
+        if bucket.is_empty() {
+            return Err(ExecutionError::GeneralError(format!(
+                "{original}:// URL is missing bucket name: {url}"
+            )));
+        }
+        return Url::parse(&format!("s3://{bucket}/{key}")).map_err(|e| {
+            ExecutionError::GeneralError(format!("Could not normalize {original}:// URL: {e}"))
+        });
+    }
+    // Host-bearing (`blob://bucket/key`): swap only the scheme. s3 and the aliases are all
+    // non-special, so `set_scheme` succeeds and the host/path are preserved verbatim.
+    url.set_scheme("s3").map_err(|_| {
+        ExecutionError::GeneralError(format!("Could not convert scheme from {original} to s3"))
+    })?;
+    Ok(url)
+}
+
+/// Promote a HOSTLESS s3-compliant-alias location so the scheme-agnostic opendal S3 operator can
+/// derive the bucket from the URL host. Some vendor blob filesystems (e.g. the Spark McQueen
+/// connector) record data/delete file locations WITHOUT a URL host -- `blob:///<bucket>/<key>`
+/// (empty authority) or `blob:/<bucket>/<key>` (opaque) -- keeping the bucket as the first path
+/// segment. `iceberg-storage-opendal`'s S3 operator reads the bucket from `Url::host_str`, so such
+/// a location fails with a missing-bucket error. This lifts the first path segment into the host
+/// (yielding `s3://<bucket>/<key>`), reusing [`rewrite_alias_to_s3`].
+///
+/// Host-bearing locations (`blob://<bucket>/<key>`, `s3://...`) are returned unchanged. This runs
+/// ONLY at the storage open boundary inside [`BlobHostPromotingS3Storage`], never on the raw
+/// recorded string iceberg-rust matches positional/equality deletes against (the FileScanTask
+/// `data_file_path` and the delete file's stored `file_path` column), so promotion cannot desync
+/// the two and silently drop deletes.
+pub(crate) fn promote_hostless_alias_url(path: &str) -> Result<Cow<'_, str>, ExecutionError> {
+    let url = Url::parse(path)
+        .map_err(|e| ExecutionError::GeneralError(format!("Error parsing URL {path}: {e}")))?;
+    if url.host_str().is_some() {
+        // Already addressable by host (e.g. blob://bucket/key): open as-is.
+        return Ok(Cow::Borrowed(path));
+    }
+    Ok(Cow::Owned(rewrite_alias_to_s3(url)?.to_string()))
+}
+
+/// [`StorageFactory`] for hostless-capable s3-compliant-alias Iceberg scans
+/// (`fs.comet.s3Compliant.schemes`, e.g. `blob`). It builds the crate's scheme-agnostic opendal S3
+/// storage and wraps it in [`BlobHostPromotingS3Storage`] so a hostless alias location is opened by
+/// promoting the bucket from the first path segment. Only alias schemes route here; plain
+/// `s3`/`s3a` keep the unwrapped [`OpenDalStorageFactory::S3`] (see
+/// `iceberg_common::storage_factory_for`).
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct BlobHostPromotingS3StorageFactory {
+    #[serde(skip)]
+    customized_credential_load: Option<CustomAwsCredentialLoader>,
+}
+
+impl BlobHostPromotingS3StorageFactory {
+    pub(crate) fn new(customized_credential_load: Option<CustomAwsCredentialLoader>) -> Self {
+        Self {
+            customized_credential_load,
+        }
+    }
+}
+
+#[typetag::serde(name = "CometBlobHostPromotingS3StorageFactory")]
+impl StorageFactory for BlobHostPromotingS3StorageFactory {
+    fn build(&self, config: &StorageConfig) -> IcebergResult<Arc<dyn Storage>> {
+        Ok(Arc::new(BlobHostPromotingS3Storage {
+            props: config.props().clone(),
+            inner: OnceLock::new(),
+            customized_credential_load: self.customized_credential_load.clone(),
+        }))
+    }
+}
+
+/// [`Storage`] that promotes hostless s3-compliant-alias locations (see
+/// [`promote_hostless_alias_url`]) at the open boundary, then delegates to the crate's opendal S3
+/// storage, which it builds lazily and caches. `props`/`customized_credential_load` mirror
+/// [`OpenDalStorageFactory::S3`]'s inputs so the wrapped storage is exactly the one it would build.
+/// Serde mirrors the crate's `OpenDalResolvingStorage` (props carried, operator cache and
+/// credential loader skipped) only to satisfy the `Storage` typetag supertraits; Comet never
+/// serializes storage during a scan.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct BlobHostPromotingS3Storage {
+    props: HashMap<String, String>,
+    #[serde(skip, default)]
+    inner: OnceLock<Arc<dyn Storage>>,
+    #[serde(skip)]
+    customized_credential_load: Option<CustomAwsCredentialLoader>,
+}
+
+impl BlobHostPromotingS3Storage {
+    /// Lazily build and cache the wrapped opendal S3 storage from the same inputs
+    /// [`OpenDalStorageFactory::S3`] uses.
+    fn inner(&self) -> IcebergResult<Arc<dyn Storage>> {
+        if let Some(inner) = self.inner.get() {
+            return Ok(Arc::clone(inner));
+        }
+        let built = OpenDalStorageFactory::S3 {
+            customized_credential_load: self.customized_credential_load.clone(),
+        }
+        .build(&StorageConfig::from_props(self.props.clone()))?;
+        let _ = self.inner.set(built);
+        Ok(Arc::clone(self.inner.get().unwrap()))
+    }
+
+    /// Promote a hostless path, surfacing failures as an iceberg [`Error`].
+    fn promote<'a>(&self, path: &'a str) -> IcebergResult<Cow<'a, str>> {
+        promote_hostless_alias_url(path)
+            .map_err(|e| Error::new(ErrorKind::DataInvalid, e.to_string()))
+    }
+}
+
+#[async_trait]
+#[typetag::serde(name = "CometBlobHostPromotingS3Storage")]
+impl Storage for BlobHostPromotingS3Storage {
+    async fn exists(&self, path: &str) -> IcebergResult<bool> {
+        let inner = self.inner()?;
+        let promoted = self.promote(path)?;
+        inner.exists(promoted.as_ref()).await
+    }
+
+    async fn metadata(&self, path: &str) -> IcebergResult<FileMetadata> {
+        let inner = self.inner()?;
+        let promoted = self.promote(path)?;
+        inner.metadata(promoted.as_ref()).await
+    }
+
+    async fn read(&self, path: &str) -> IcebergResult<Bytes> {
+        let inner = self.inner()?;
+        let promoted = self.promote(path)?;
+        inner.read(promoted.as_ref()).await
+    }
+
+    async fn reader(&self, path: &str) -> IcebergResult<Box<dyn FileRead>> {
+        let inner = self.inner()?;
+        let promoted = self.promote(path)?;
+        inner.reader(promoted.as_ref()).await
+    }
+
+    async fn write(&self, path: &str, bs: Bytes) -> IcebergResult<()> {
+        let inner = self.inner()?;
+        let promoted = self.promote(path)?;
+        inner.write(promoted.as_ref(), bs).await
+    }
+
+    async fn writer(&self, path: &str) -> IcebergResult<Box<dyn FileWrite>> {
+        let inner = self.inner()?;
+        let promoted = self.promote(path)?;
+        inner.writer(promoted.as_ref()).await
+    }
+
+    async fn delete(&self, path: &str) -> IcebergResult<()> {
+        let inner = self.inner()?;
+        let promoted = self.promote(path)?;
+        inner.delete(promoted.as_ref()).await
+    }
+
+    async fn delete_prefix(&self, path: &str) -> IcebergResult<()> {
+        let inner = self.inner()?;
+        let promoted = self.promote(path)?;
+        inner.delete_prefix(promoted.as_ref()).await
+    }
+
+    async fn delete_stream(&self, paths: BoxStream<'static, String>) -> IcebergResult<()> {
+        // Not used by read scans; promote each path best-effort (a parse failure keeps the original
+        // so the inner storage surfaces it) to stay correct if a caller ever deletes via an alias.
+        let promoted = paths.map(|p| {
+            // Compute an owned result first so `p`'s borrow ends before the fallback move.
+            let rewritten = promote_hostless_alias_url(&p).map(Cow::into_owned);
+            rewritten.unwrap_or(p)
+        });
+        self.inner()?.delete_stream(promoted.boxed()).await
+    }
+
+    fn new_input(&self, path: &str) -> IcebergResult<InputFile> {
+        let inner = self.inner()?;
+        let promoted = self.promote(path)?;
+        inner.new_input(promoted.as_ref())
+    }
+
+    fn new_output(&self, path: &str) -> IcebergResult<OutputFile> {
+        let inner = self.inner()?;
+        let promoted = self.promote(path)?;
+        inner.new_output(promoted.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Config opting `blob` in as an s3-compliant alias (`fs.comet.s3Compliant.schemes=blob`).
+    fn blob_alias_configs() -> HashMap<String, String> {
+        let mut configs = HashMap::new();
+        configs.insert(
+            "fs.comet.s3Compliant.schemes".to_string(),
+            "blob".to_string(),
+        );
+        configs
+    }
+
+    fn normalized(url: &str, configs: &HashMap<String, String>) -> String {
+        normalize_object_store_url(url, configs)
+            .unwrap()
+            .as_str()
+            .to_string()
+    }
+
+    #[test]
+    fn test_normalize_object_store_url_rewrites_configured_alias() {
+        // A configured alias (blob) is rewritten to canonical s3:// so
+        // `prepare_object_store_with_configs` dispatches on `scheme == "s3"`.
+        let configs = blob_alias_configs();
+        assert_eq!(
+            normalized("blob://bucket/key.parquet", &configs),
+            "s3://bucket/key.parquet"
+        );
+    }
+
+    #[test]
+    fn test_normalize_object_store_url_alias_is_opt_in() {
+        // Empty config => blob is NOT an alias and is returned unchanged.
+        let empty = HashMap::new();
+        assert_eq!(
+            normalized("blob://bucket/key.parquet", &empty),
+            "blob://bucket/key.parquet"
+        );
+
+        // The list is comma-separated, whitespace-trimmed, and case-insensitive.
+        let mut configs = HashMap::new();
+        configs.insert(
+            "fs.comet.s3Compliant.schemes".to_string(),
+            " cos , BLOB ".to_string(),
+        );
+        assert_eq!(
+            normalized("blob://bucket/key.parquet", &configs),
+            "s3://bucket/key.parquet"
+        );
+    }
+
+    #[test]
+    fn test_normalize_object_store_url_rewrites_s3a_always() {
+        // s3a is rewritten to s3 regardless of the alias config (object_store dispatches on s3).
+        let empty = HashMap::new();
+        assert_eq!(
+            normalized("s3a://bucket/key.parquet", &empty),
+            "s3://bucket/key.parquet"
+        );
+    }
+
+    #[test]
+    fn test_normalize_object_store_url_passes_through_non_alias_schemes() {
+        // s3:// and file:// are not aliases and round-trip unchanged.
+        let configs = blob_alias_configs();
+        let s3 = "s3://bucket/key.parquet";
+        assert_eq!(normalized(s3, &configs), s3);
+        let file = "file:///tmp/warehouse/db/t";
+        assert_eq!(normalized(file, &configs), file);
+    }
+
+    #[test]
+    fn test_normalize_object_store_url_promotes_authorityless_alias() {
+        // The opaque single-slash `blob:/bucket/key` form (host=None) lifts the first path segment
+        // into the host so `ObjectStoreScheme::parse` accepts the result.
+        let configs = blob_alias_configs();
+        assert_eq!(
+            normalized("blob:/bucket/key.parquet", &configs),
+            "s3://bucket/key.parquet"
+        );
+    }
+
+    #[test]
+    fn test_is_s3_compliant_alias_scheme_opt_in() {
+        let empty = HashMap::new();
+        assert!(!is_s3_compliant_alias_scheme("blob", &empty));
+
+        let configs = blob_alias_configs();
+        assert!(is_s3_compliant_alias_scheme("blob", &configs));
+        // Case-insensitive; s3a is intentionally NOT reported here (callers special-case it).
+        assert!(is_s3_compliant_alias_scheme("BLOB", &configs));
+        assert!(!is_s3_compliant_alias_scheme("s3a", &configs));
+    }
+
+    #[test]
+    fn test_is_s3_compliant_alias_scheme_excludes_url_special_schemes() {
+        // A URL-spec special scheme is never an alias even if the user lists it: it cannot be
+        // rewritten to `s3` (`Url::set_scheme` refuses it), so admitting it would turn a clean
+        // fallback into a hard error. Guards against a stray `file`/`https` in the list.
+        let mut configs = HashMap::new();
+        configs.insert(
+            "fs.comet.s3Compliant.schemes".to_string(),
+            "file,http,https,ftp,ws,wss,blob".to_string(),
+        );
+        for special in ["file", "http", "https", "ftp", "ws", "wss"] {
+            assert!(
+                !is_s3_compliant_alias_scheme(special, &configs),
+                "{special} must not be treated as an s3-compliant alias"
+            );
+        }
+        // A non-special scheme in the same list is still honored.
+        assert!(is_s3_compliant_alias_scheme("blob", &configs));
+    }
+
+    #[test]
+    fn test_normalize_object_store_url_special_scheme_alias_falls_back() {
+        // Listing `file` must not hard-error local scans: normalize returns the URL unchanged so the
+        // caller falls back, rather than failing in `set_scheme`.
+        let mut configs = HashMap::new();
+        configs.insert(
+            "fs.comet.s3Compliant.schemes".to_string(),
+            "file".to_string(),
+        );
+        assert_eq!(
+            normalized("file:///tmp/warehouse/db/t", &configs),
+            "file:///tmp/warehouse/db/t"
+        );
+    }
+
+    fn promoted(path: &str) -> String {
+        promote_hostless_alias_url(path).unwrap().into_owned()
+    }
+
+    #[test]
+    fn test_promote_hostless_alias_url_promotes_hostless_forms() {
+        // Both hostless spellings (host=None) promote the first path segment into the host so the
+        // opendal S3 operator finds the bucket: the empty-authority `blob:///bucket/key` form (the
+        // McQueen default store) and the opaque single-slash `blob:/bucket/key` form java.net.URI
+        // re-renders it to.
+        assert_eq!(
+            promoted("blob:///sparkinsightdev/tmp/warehouse/x.parquet"),
+            "s3://sparkinsightdev/tmp/warehouse/x.parquet"
+        );
+        assert_eq!(
+            promoted("blob:/bucket/a/b/c.parquet"),
+            "s3://bucket/a/b/c.parquet"
+        );
+    }
+
+    #[test]
+    fn test_promote_hostless_alias_url_passthrough_when_host_present() {
+        // Host-bearing locations are opened as-is: promotion runs only when the URL is hostless.
+        for p in [
+            "blob://bucket/key.parquet",
+            "s3://bucket/key.parquet",
+            "s3a://bucket/key.parquet",
+        ] {
+            assert_eq!(
+                promoted(p),
+                p,
+                "host-bearing {p} must pass through unchanged"
+            );
+        }
+    }
+
+    #[test]
+    fn test_promote_hostless_alias_url_requires_a_bucket_segment() {
+        // A hostless URL with no promotable first segment errors, so the scan fails loudly rather
+        // than opening a bucketless URL. (The JVM gate already declines these; defense in depth.)
+        assert!(promote_hostless_alias_url("blob:///").is_err());
+    }
+
+    #[test]
+    fn test_blob_host_promoting_factory_builds_storage() {
+        // The factory constructs a storage without eagerly building the inner operator (lazy), so
+        // this smoke test does not require any live backend.
+        let factory = BlobHostPromotingS3StorageFactory::new(None);
+        assert!(factory
+            .build(&StorageConfig::from_props(HashMap::new()))
+            .is_ok());
+    }
+}

--- a/native/core/src/parquet/objectstore/s3_blob_fs_support.rs
+++ b/native/core/src/parquet/objectstore/s3_blob_fs_support.rs
@@ -72,9 +72,6 @@ pub(crate) fn normalize_object_store_url(
     if is_hdfs_scheme(&url, object_store_configs) {
         return Ok(url);
     }
-    // Callers consume only `url.scheme()`/`url.path()`, so re-serialization through `url::Url` is
-    // harmless here (the Iceberg path avoids this function precisely because it must preserve raw
-    // bytes; it routes aliases by scheme in `storage_factory_for` instead).
     let scheme = url.scheme();
     if scheme != "s3a" && !is_s3_compliant_alias_scheme(scheme, object_store_configs) {
         return Ok(url);
@@ -94,6 +91,12 @@ pub(crate) fn is_s3_compliant_alias_scheme(
     object_store_configs: &HashMap<String, String>,
 ) -> bool {
     const COMET_S3_COMPLIANT_SCHEMES_KEY: &str = "fs.comet.s3Compliant.schemes";
+    // Nothing is an alias until the user opts in, so settle that first: the default (key absent)
+    // case returns without scanning the special-scheme list below.
+    let configured = match object_store_configs.get(COMET_S3_COMPLIANT_SCHEMES_KEY) {
+        Some(schemes) => schemes,
+        None => return false,
+    };
     // The URL spec's "special" schemes can never be an alias. `Url::set_scheme` refuses to rewrite
     // between a special scheme and a non-special one, so `rewrite_alias_to_s3` returns `Err` for
     // every URL of such a scheme -- and since `normalize_object_store_url` and its callers
@@ -110,19 +113,15 @@ pub(crate) fn is_s3_compliant_alias_scheme(
     {
         return false;
     }
-    match object_store_configs.get(COMET_S3_COMPLIANT_SCHEMES_KEY) {
-        Some(schemes) => schemes
-            .split(',')
-            .any(|s| s.trim().eq_ignore_ascii_case(scheme)),
-        None => false,
-    }
+    configured
+        .split(',')
+        .any(|s| s.trim().eq_ignore_ascii_case(scheme))
 }
 
 /// Rewrites a parsed alias URL (`s3a` or a configured alias) to `s3://bucket/key`. When it has no
 /// authority (empty-authority `blob:///bucket/key` or opaque `blob:/bucket/key`, both host=None)
 /// the first path segment is promoted into the host. Defensive: object-store URLs normally have one.
 fn rewrite_alias_to_s3(mut url: Url) -> Result<Url, ExecutionError> {
-    let original = url.scheme().to_string();
     if url.host_str().is_none() {
         // host=None (empty-authority `blob:///bucket/key` or opaque `blob:/bucket/key`): lift the
         // first path segment into the host for `ObjectStoreScheme::parse`.
@@ -130,18 +129,26 @@ fn rewrite_alias_to_s3(mut url: Url) -> Result<Url, ExecutionError> {
         let (bucket, key) = trimmed.split_once('/').unwrap_or((trimmed, ""));
         if bucket.is_empty() {
             return Err(ExecutionError::GeneralError(format!(
-                "{original}:// URL is missing bucket name: {url}"
+                "{}:// URL is missing bucket name: {url}",
+                url.scheme()
             )));
         }
         return Url::parse(&format!("s3://{bucket}/{key}")).map_err(|e| {
-            ExecutionError::GeneralError(format!("Could not normalize {original}:// URL: {e}"))
+            ExecutionError::GeneralError(format!(
+                "Could not normalize {}:// URL: {e}",
+                url.scheme()
+            ))
         });
     }
     // Host-bearing (`blob://bucket/key`): swap only the scheme. s3 and the aliases are all
-    // non-special, so `set_scheme` succeeds and the host/path are preserved verbatim.
-    url.set_scheme("s3").map_err(|_| {
-        ExecutionError::GeneralError(format!("Could not convert scheme from {original} to s3"))
-    })?;
+    // non-special, so `set_scheme` succeeds and the host/path are preserved verbatim. On failure
+    // `url` is untouched, so it still reports the original scheme.
+    if url.set_scheme("s3").is_err() {
+        return Err(ExecutionError::GeneralError(format!(
+            "Could not convert scheme from {} to s3",
+            url.scheme()
+        )));
+    }
     Ok(url)
 }
 
@@ -226,8 +233,7 @@ impl BlobHostPromotingS3Storage {
             customized_credential_load: self.customized_credential_load.clone(),
         }
         .build(&StorageConfig::from_props(self.props.clone()))?;
-        let _ = self.inner.set(built);
-        Ok(Arc::clone(self.inner.get().unwrap()))
+        Ok(Arc::clone(self.inner.get_or_init(|| built)))
     }
 
     /// Promote a hostless path, surfacing failures as an iceberg [`Error`].
@@ -331,17 +337,6 @@ mod tests {
             .unwrap()
             .as_str()
             .to_string()
-    }
-
-    #[test]
-    fn test_normalize_object_store_url_rewrites_configured_alias() {
-        // A configured alias (blob) is rewritten to canonical s3:// so
-        // `prepare_object_store_with_configs` dispatches on `scheme == "s3"`.
-        let configs = blob_alias_configs();
-        assert_eq!(
-            normalized("blob://bucket/key.parquet", &configs),
-            "s3://bucket/key.parquet"
-        );
     }
 
     #[test]

--- a/native/core/src/parquet/parquet_support.rs
+++ b/native/core/src/parquet/parquet_support.rs
@@ -598,16 +598,12 @@ pub(crate) fn prepare_object_store_with_configs(
     url: String,
     object_store_configs: &HashMap<String, String>,
 ) -> Result<(ObjectStoreUrl, Path), ExecutionError> {
-    let mut url = Url::parse(url.as_str())
-        .map_err(|e| ExecutionError::GeneralError(format!("Error parsing URL {url}: {e}")))?;
+    let url = super::objectstore::s3_blob_fs_support::normalize_object_store_url(
+        url.as_str(),
+        object_store_configs,
+    )?;
     let is_hdfs_scheme = is_hdfs_scheme(&url, object_store_configs);
-    let mut scheme = url.scheme();
-    if !is_hdfs_scheme && scheme == "s3a" {
-        scheme = "s3";
-        url.set_scheme("s3").map_err(|_| {
-            ExecutionError::GeneralError("Could not convert scheme from s3a to s3".to_string())
-        })?;
-    }
+    let scheme = url.scheme();
     let url_key = format!(
         "{}://{}",
         scheme,
@@ -794,5 +790,56 @@ mod tests {
         assert_eq!(converted_child.data_type(), &micros_type);
         assert!(converted_child.is_null(0), "overflow must become NULL");
         assert!(converted_child.is_null(1));
+    }
+
+    #[cfg(not(feature = "hdfs-opendal"))]
+    #[test]
+    #[cfg_attr(miri, ignore)] // AWS credential providers and object_store call foreign functions
+    fn test_prepare_object_store_rewrites_blob_alias_to_s3() {
+        // `fs.comet.s3Compliant.schemes` opts `blob` in, so `prepare_object_store_with_configs`
+        // must rewrite the alias to `s3://`. Otherwise `ObjectStoreScheme::parse` rejects the URL
+        // and the native scan fails at runtime (`Unsupported filesystem schemes: blob`). Two forms
+        // must both land on `s3://bucket/key`: the canonical `blob://bucket/key`, and the empty-
+        // authority `blob:///bucket/key` (host=None), whose first path segment is promoted into the
+        // host because object_store 0.13 needs a `Some(host)` (a naive `s3:///bucket/key` fails).
+        use crate::parquet::parquet_support::prepare_object_store_with_configs;
+        let mut configs: HashMap<String, String> = HashMap::new();
+        configs.insert(
+            "fs.comet.s3Compliant.schemes".to_string(),
+            "blob".to_string(),
+        );
+        configs.insert(
+            "fs.s3a.aws.credentials.provider".to_string(),
+            "org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider".to_string(),
+        );
+        configs.insert(
+            "fs.s3a.endpoint.region".to_string(),
+            "us-east-1".to_string(),
+        );
+
+        for (input, expected_bucket, expected_path) in [
+            (
+                "blob://test_bucket/comet/spark-warehouse/part-00000.snappy.parquet",
+                "s3://test_bucket",
+                "/comet/spark-warehouse/part-00000.snappy.parquet",
+            ),
+            (
+                "blob:///mybucket/warehouse/data/part-0.snappy.parquet",
+                "s3://mybucket",
+                "warehouse/data/part-0.snappy.parquet",
+            ),
+        ] {
+            let (object_store_url, path) = prepare_object_store_with_configs(
+                Arc::new(RuntimeEnv::default()),
+                input.to_string(),
+                &configs,
+            )
+            .unwrap_or_else(|e| panic!("{input} should normalize to s3://: {e}"));
+            assert_eq!(
+                object_store_url,
+                ObjectStoreUrl::parse(expected_bucket).unwrap()
+            );
+            assert_eq!(path, Path::from(expected_path));
+        }
     }
 }

--- a/native/core/src/parquet/parquet_support.rs
+++ b/native/core/src/parquet/parquet_support.rs
@@ -553,16 +553,12 @@ pub(crate) fn prepare_object_store_with_configs(
     url: String,
     object_store_configs: &HashMap<String, String>,
 ) -> Result<(ObjectStoreUrl, Path), ExecutionError> {
-    let mut url = Url::parse(url.as_str())
-        .map_err(|e| ExecutionError::GeneralError(format!("Error parsing URL {url}: {e}")))?;
+    let url = super::objectstore::blob_alias::normalize_object_store_url(
+        url.as_str(),
+        object_store_configs,
+    )?;
     let is_hdfs_scheme = is_hdfs_scheme(&url, object_store_configs);
-    let mut scheme = url.scheme();
-    if !is_hdfs_scheme && scheme == "s3a" {
-        scheme = "s3";
-        url.set_scheme("s3").map_err(|_| {
-            ExecutionError::GeneralError("Could not convert scheme from s3a to s3".to_string())
-        })?;
-    }
+    let scheme = url.scheme();
     let url_key = format!(
         "{}://{}",
         scheme,
@@ -682,5 +678,72 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[cfg(not(feature = "hdfs-opendal"))]
+    #[test]
+    #[cfg_attr(miri, ignore)] // AWS credential providers and object_store call foreign functions
+    fn test_prepare_object_store_rewrites_blob_to_s3() {
+        // `blob` is a Comet-recognized synonym for `s3` -- the alias must be rewritten inside
+        // `prepare_object_store_with_configs`, otherwise ObjectStoreScheme::parse rejects the
+        // URL and the native scan fails at execution time (the JVM gate having already claimed
+        // the scan via `NativeBase.isObjectStoreSchemeSupported`). Regressing the rewrite would
+        // resurface `Unsupported filesystem schemes: blob` at execution rather than planning.
+        use crate::parquet::parquet_support::prepare_object_store_with_configs;
+        let mut configs: HashMap<String, String> = HashMap::new();
+        configs.insert(
+            "fs.s3a.aws.credentials.provider".to_string(),
+            "org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider".to_string(),
+        );
+        configs.insert(
+            "fs.s3a.endpoint.region".to_string(),
+            "us-east-1".to_string(),
+        );
+        let (object_store_url, path) = prepare_object_store_with_configs(
+            Arc::new(RuntimeEnv::default()),
+            "blob://test_bucket/comet/spark-warehouse/part-00000.snappy.parquet".to_string(),
+            &configs,
+        )
+        .expect("blob:// URL should be rewritten to s3:// and accepted");
+        assert_eq!(
+            object_store_url,
+            ObjectStoreUrl::parse("s3://test_bucket").unwrap()
+        );
+        assert_eq!(
+            path,
+            Path::from("/comet/spark-warehouse/part-00000.snappy.parquet")
+        );
+    }
+
+    #[cfg(not(feature = "hdfs-opendal"))]
+    #[test]
+    #[cfg_attr(miri, ignore)] // AWS credential providers and object_store call foreign functions
+    fn test_prepare_object_store_promotes_first_path_segment_when_blob_url_has_empty_authority() {
+        // Some deployments emit `blob:///bucket/key` (three slashes, empty authority) rather than
+        // the canonical `blob://bucket/key`. `ObjectStoreScheme::parse` in object_store 0.13
+        // requires a Some(host), so a naive rewrite to `s3:///bucket/key` fails at execution
+        // with `Generic URL error: Unable to recognise URL`. `prepare_object_store_with_configs`
+        // must lift the first path segment into the host to match S3's canonical shape.
+        use crate::parquet::parquet_support::prepare_object_store_with_configs;
+        let mut configs: HashMap<String, String> = HashMap::new();
+        configs.insert(
+            "fs.s3a.aws.credentials.provider".to_string(),
+            "org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider".to_string(),
+        );
+        configs.insert(
+            "fs.s3a.endpoint.region".to_string(),
+            "us-east-1".to_string(),
+        );
+        let (object_store_url, path) = prepare_object_store_with_configs(
+            Arc::new(RuntimeEnv::default()),
+            "blob:///mybucket/warehouse/data/part-0.snappy.parquet".to_string(),
+            &configs,
+        )
+        .expect("blob:///bucket/... should be normalized to s3://bucket/...");
+        assert_eq!(
+            object_store_url,
+            ObjectStoreUrl::parse("s3://mybucket").unwrap()
+        );
+        assert_eq!(path, Path::from("warehouse/data/part-0.snappy.parquet"));
     }
 }

--- a/native/core/src/parquet/parquet_support.rs
+++ b/native/core/src/parquet/parquet_support.rs
@@ -49,6 +49,7 @@ use std::{fmt::Debug, hash::Hash, sync::Arc};
 use url::Url;
 
 use super::objectstore;
+use super::objectstore::s3_blob_fs_support::normalize_object_store_url;
 
 // This file originates from cast.rs. While developing native scan support and implementing
 // SparkSchemaAdapter we observed that Spark's type conversion logic on Parquet reads does not
@@ -469,14 +470,21 @@ fn value_field(entries_field: &FieldRef) -> Option<FieldRef> {
     }
 }
 
+/// True if `scheme` appears in a Comet comma-separated scheme-list config, compared trimmed and
+/// case-insensitively. Shared by every such config (`fs.comet.libhdfs.schemes`,
+/// `fs.comet.s3Compliant.schemes`) so native parses them exactly like the JVM's
+/// `NativeConfig.parseSchemeSet`, which feeds the planner's fallback gate.
+pub(crate) fn scheme_in_list(list: &str, scheme: &str) -> bool {
+    list.split(',')
+        .any(|s| s.trim().eq_ignore_ascii_case(scheme))
+}
+
 pub fn is_hdfs_scheme(url: &Url, object_store_configs: &HashMap<String, String>) -> bool {
     const COMET_LIBHDFS_SCHEMES_KEY: &str = "fs.comet.libhdfs.schemes";
     let scheme = url.scheme();
-    if let Some(libhdfs_schemes) = object_store_configs.get(COMET_LIBHDFS_SCHEMES_KEY) {
-        use itertools::Itertools;
-        libhdfs_schemes.split(",").contains(scheme)
-    } else {
-        scheme == "hdfs"
+    match object_store_configs.get(COMET_LIBHDFS_SCHEMES_KEY) {
+        Some(libhdfs_schemes) => scheme_in_list(libhdfs_schemes, scheme),
+        None => scheme == "hdfs",
     }
 }
 
@@ -598,10 +606,7 @@ pub(crate) fn prepare_object_store_with_configs(
     url: String,
     object_store_configs: &HashMap<String, String>,
 ) -> Result<(ObjectStoreUrl, Path), ExecutionError> {
-    let url = super::objectstore::s3_blob_fs_support::normalize_object_store_url(
-        url.as_str(),
-        object_store_configs,
-    )?;
+    let url = normalize_object_store_url(url.as_str(), object_store_configs)?;
     let is_hdfs_scheme = is_hdfs_scheme(&url, object_store_configs);
     let scheme = url.scheme();
     let url_key = format!(

--- a/spark/src/main/java/org/apache/comet/NativeBase.java
+++ b/spark/src/main/java/org/apache/comet/NativeBase.java
@@ -318,13 +318,17 @@ public abstract class NativeBase {
   public static native boolean isFeatureEnabled(String featureName);
 
   /**
-   * Check whether Comet's native object_store layer recognizes the given URL's scheme (i.e. the
-   * scan would be natively readable rather than failing at execution with "Unable to recognise
-   * URL"). This is the authoritative answer from object_store's own scheme parser, so the JVM
-   * planner never has to hardcode (and drift from) the set of supported schemes.
+   * Check whether Comet's native object_store layer can open the given URL (i.e. the scan would be
+   * natively readable rather than failing at execution with "Unable to recognise URL"). This is
+   * the authoritative answer from object_store's own parser, so the JVM planner never has to
+   * hardcode (and drift from) the set of supported schemes.
    *
-   * @param url a fully-qualified URL whose scheme should be checked (e.g. "s3://bucket/path")
-   * @return true if object_store can construct a store for this scheme, false otherwise
+   * <p>The parser validates the path as well as the scheme, so a recognized scheme carrying a key
+   * object_store forbids (e.g. a directory name containing a newline) also returns false. Callers
+   * that want a path-independent answer must pass a synthetic scheme-only URL.
+   *
+   * @param url a fully-qualified URL to check (e.g. "s3://bucket/path")
+   * @return true if object_store can construct both a store and an object key for this URL
    */
   public static native boolean isObjectStoreSchemeSupported(String url);
 }

--- a/spark/src/main/java/org/apache/comet/NativeBase.java
+++ b/spark/src/main/java/org/apache/comet/NativeBase.java
@@ -319,9 +319,9 @@ public abstract class NativeBase {
 
   /**
    * Check whether Comet's native object_store layer can open the given URL (i.e. the scan would be
-   * natively readable rather than failing at execution with "Unable to recognise URL"). This is
-   * the authoritative answer from object_store's own parser, so the JVM planner never has to
-   * hardcode (and drift from) the set of supported schemes.
+   * natively readable rather than failing at execution with "Unable to recognise URL"). This is the
+   * authoritative answer from object_store's own parser, so the JVM planner never has to hardcode
+   * (and drift from) the set of supported schemes.
    *
    * <p>The parser validates the path as well as the scheme, so a recognized scheme carrying a key
    * object_store forbids (e.g. a directory name containing a newline) also returns false. Callers

--- a/spark/src/main/java/org/apache/comet/parquet/CometFileKeyUnwrapper.java
+++ b/spark/src/main/java/org/apache/comet/parquet/CometFileKeyUnwrapper.java
@@ -103,21 +103,27 @@ public class CometFileKeyUnwrapper {
 
   /**
    * Normalizes S3 URI schemes to a canonical form. S3 can be accessed via multiple schemes (s3://,
-   * s3a://, s3n://) that refer to the same logical filesystem. This method ensures consistent cache
-   * lookups regardless of which scheme is used.
+   * s3a://, s3n://, blob://) that refer to the same logical filesystem. This method ensures
+   * consistent cache lookups regardless of which scheme is used. The put and get sides must agree,
+   * because the JVM store side is called with the user-facing scheme (e.g. blob://) while the
+   * native side JNIs back with the scheme after `prepare_object_store_with_configs` has already
+   * rewritten aliases to s3://.
    *
    * @param filePath The file path that may contain an S3 URI
    * @return The file path with normalized S3 scheme (s3a://)
    */
   private String normalizeS3Scheme(final String filePath) {
-    // Normalize s3:// and s3n:// to s3a:// for consistent cache lookups
-    // This handles the case where ObjectStoreUrl uses s3:// but Spark uses s3a://
+    // Normalize s3://, s3n://, and blob:// to s3a:// for consistent cache lookups
+    // This handles the case where ObjectStoreUrl uses s3:// but Spark uses s3a:// or blob://
     String s3Prefix = "s3://";
     String s3nPrefix = "s3n://";
+    String blobPrefix = "blob://";
     if (filePath.startsWith(s3Prefix)) {
       return "s3a://" + filePath.substring(s3Prefix.length());
     } else if (filePath.startsWith(s3nPrefix)) {
       return "s3a://" + filePath.substring(s3nPrefix.length());
+    } else if (filePath.startsWith(blobPrefix)) {
+      return "s3a://" + filePath.substring(blobPrefix.length());
     }
     return filePath;
   }

--- a/spark/src/main/java/org/apache/comet/parquet/CometFileKeyUnwrapper.java
+++ b/spark/src/main/java/org/apache/comet/parquet/CometFileKeyUnwrapper.java
@@ -34,6 +34,8 @@ import org.apache.parquet.crypto.DecryptionPropertiesFactory;
 import org.apache.parquet.crypto.FileDecryptionProperties;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 
+import org.apache.comet.CometConf;
+
 // spotless:off
 /*
  * Architecture Overview:
@@ -99,10 +101,9 @@ import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 public class CometFileKeyUnwrapper {
 
   // Hadoop config key listing the user-opted-in S3-compliant alias schemes (e.g. blob, minio),
-  // comma-separated and case-insensitive. Same key NativeConfig and CometScanRule read. Resolved
-  // from the Hadoop conf on the put side, so it must be set at session-creation time (see
-  // CometConf.COMET_S3_COMPLIANT_SCHEMES).
-  private static final String S3_COMPLIANT_SCHEMES_KEY = "fs.comet.s3Compliant.schemes";
+  // comma-separated and case-insensitive. Resolved from the Hadoop conf on the put side, so it must
+  // be set at session-creation time.
+  private static final String S3_COMPLIANT_SCHEMES_KEY = CometConf.COMET_S3_COMPLIANT_SCHEMES_KEY();
 
   // Schemes object_store always treats as aliases of s3://, independent of config. The native side
   // rewrites every alias (these plus the configured ones below) to s3:// before it JNIs getKey

--- a/spark/src/main/java/org/apache/comet/parquet/CometFileKeyUnwrapper.java
+++ b/spark/src/main/java/org/apache/comet/parquet/CometFileKeyUnwrapper.java
@@ -19,8 +19,14 @@
 
 package org.apache.comet.parquet;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.crypto.DecryptionKeyRetriever;
@@ -92,6 +98,26 @@ import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
  */
 public class CometFileKeyUnwrapper {
 
+  // Hadoop config key listing the user-opted-in S3-compliant alias schemes (e.g. blob, minio),
+  // comma-separated and case-insensitive. Same key NativeConfig and CometScanRule read. Resolved
+  // from the Hadoop conf on the put side, so it must be set at session-creation time (see
+  // CometConf.COMET_S3_COMPLIANT_SCHEMES).
+  private static final String S3_COMPLIANT_SCHEMES_KEY = "fs.comet.s3Compliant.schemes";
+
+  // Schemes object_store always treats as aliases of s3://, independent of config. The native side
+  // rewrites every alias (these plus the configured ones below) to s3:// before it JNIs getKey
+  // back, so the get side always sees one of these; the configured aliases matter on the put side,
+  // called with the user-facing scheme (e.g. blob://). All fold to one canonical cache key.
+  private static final Set<String> BASE_S3_ALIAS_SCHEMES =
+      Collections.unmodifiableSet(new HashSet<>(Arrays.asList("s3", "s3n", "s3a")));
+
+  // User-opted-in S3-compliant alias schemes from S3_COMPLIANT_SCHEMES_KEY, resolved from the
+  // Hadoop conf on the put side and cached so the get side folds the same aliases to one cache key.
+  // volatile because getKey may be invoked from a native callback thread after the put side (on the
+  // setup thread) populated it. Empty until the first storeDecryptionKeyRetriever, which precedes
+  // any getKey.
+  private volatile Set<String> s3CompliantSchemes = Collections.emptySet();
+
   // Each file path gets a unique DecryptionKeyRetriever
   private final ConcurrentHashMap<String, DecryptionKeyRetriever> retrieverCache =
       new ConcurrentHashMap<>();
@@ -102,24 +128,73 @@ public class CometFileKeyUnwrapper {
   private Configuration conf = null;
 
   /**
-   * Normalizes S3 URI schemes to a canonical form. S3 can be accessed via multiple schemes (s3://,
-   * s3a://, s3n://) that refer to the same logical filesystem. This method ensures consistent cache
-   * lookups regardless of which scheme is used.
+   * Normalizes S3 and S3-compliant alias URI schemes to a canonical {@code s3a://<bucket>/<key>}
+   * form so cache lookups agree regardless of the scheme used. S3 can be addressed via {@code
+   * s3://}, {@code s3a://}, {@code s3n://}, and any scheme the user opted into via {@code
+   * fs.comet.s3Compliant.schemes} (e.g. {@code blob://}). The put and get sides must agree, because
+   * the put side is called with the user-facing scheme (e.g. blob://) while the native side JNIs
+   * back with the scheme after {@code prepare_object_store_with_configs} has already rewritten
+   * aliases to s3://.
    *
-   * @param filePath The file path that may contain an S3 URI
-   * @return The file path with normalized S3 scheme (s3a://)
+   * <p>The native rewrite also promotes the first path segment into the authority for the
+   * single-slash {@code blob:/bucket/key} (Java opaque form) and triple-slash {@code
+   * blob:///bucket/key} (empty authority) shapes, so the get side reconstructs {@code
+   * s3://bucket/key}. This method applies the same promotion, otherwise a {@code blob:/...} or
+   * {@code blob:///...} input listed by Spark would be cached under a key that never matches the
+   * get side's {@code s3a://bucket/key}.
+   *
+   * @param filePath The file path that may contain an S3 or alias URI
+   * @return The file path with a normalized {@code s3a://} scheme and bucket in the authority
    */
   private String normalizeS3Scheme(final String filePath) {
-    // Normalize s3:// and s3n:// to s3a:// for consistent cache lookups
-    // This handles the case where ObjectStoreUrl uses s3:// but Spark uses s3a://
-    String s3Prefix = "s3://";
-    String s3nPrefix = "s3n://";
-    if (filePath.startsWith(s3Prefix)) {
-      return "s3a://" + filePath.substring(s3Prefix.length());
-    } else if (filePath.startsWith(s3nPrefix)) {
-      return "s3a://" + filePath.substring(s3nPrefix.length());
+    return normalizeS3Scheme(filePath, s3CompliantSchemes);
+  }
+
+  /**
+   * Scheme-normalization core, parameterized by the opted-in alias schemes so it can be unit-tested
+   * without a live Hadoop conf. Folds {@code s3}/{@code s3n}/{@code s3a} (always) and any {@code
+   * s3CompliantSchemes} entry (case-insensitive) to canonical {@code s3a://<bucket>/<key>}; every
+   * other scheme is returned unchanged.
+   */
+  static String normalizeS3Scheme(final String filePath, final Set<String> s3CompliantSchemes) {
+    final int schemeEnd = filePath.indexOf(':');
+    if (schemeEnd <= 0) {
+      // Bare path with no scheme -- nothing to canonicalize.
+      return filePath;
     }
-    return filePath;
+    final String scheme = filePath.substring(0, schemeEnd).toLowerCase(Locale.ROOT);
+    if (!isS3AliasScheme(scheme, s3CompliantSchemes)) {
+      return filePath;
+    }
+    // Strip the scheme and every leading slash, re-join under s3a:// to promote the first path
+    // segment into the authority for the single-/triple-slash forms (matches the native
+    // rewrite_alias_to_s3 behavior).
+    return "s3a://" + StringUtils.stripStart(filePath.substring(schemeEnd + 1), "/");
+  }
+
+  private static boolean isS3AliasScheme(
+      final String scheme, final Set<String> s3CompliantSchemes) {
+    return BASE_S3_ALIAS_SCHEMES.contains(scheme) || s3CompliantSchemes.contains(scheme);
+  }
+
+  /**
+   * Parses a comma-separated, case-insensitive scheme list (the value of {@code
+   * fs.comet.s3Compliant.schemes}) into a trimmed, lowercased set. Mirrors {@code
+   * NativeConfig.parseSchemeSet} so the JVM and native sides agree on which schemes are aliases. A
+   * null or blank value yields an empty set.
+   */
+  private static Set<String> parseSchemeSet(final String raw) {
+    if (raw == null) {
+      return Collections.emptySet();
+    }
+    final Set<String> out = new HashSet<>();
+    for (String s : raw.split(",")) {
+      final String trimmed = s.trim().toLowerCase(Locale.ROOT);
+      if (!trimmed.isEmpty()) {
+        out.add(trimmed);
+      }
+    }
+    return out;
   }
 
   /**
@@ -129,16 +204,19 @@ public class CometFileKeyUnwrapper {
    * @param hadoopConf The Hadoop Configuration to use for this file path
    */
   public void storeDecryptionKeyRetriever(final String filePath, final Configuration hadoopConf) {
-    final String normalizedPath = normalizeS3Scheme(filePath);
     // Use DecryptionPropertiesFactory.loadFactory to get the factory and then call
     // getFileDecryptionProperties
     if (factory == null) {
       factory = DecryptionPropertiesFactory.loadFactory(hadoopConf);
       conf = hadoopConf;
+      // Resolve the opted-in alias schemes once, before the first normalizeS3Scheme below, so both
+      // the put side here and the later getKey side fold the same aliases to one cache key.
+      s3CompliantSchemes = parseSchemeSet(hadoopConf.get(S3_COMPLIANT_SCHEMES_KEY));
     } else {
       // Check the assumption that all files have the same hadoopConf and thus same Factory
       assert (conf == hadoopConf);
     }
+    final String normalizedPath = normalizeS3Scheme(filePath);
     Path path = new Path(filePath);
     FileDecryptionProperties decryptionProperties =
         factory.getFileDecryptionProperties(hadoopConf, path);

--- a/spark/src/main/java/org/apache/comet/parquet/CometFileKeyUnwrapper.java
+++ b/spark/src/main/java/org/apache/comet/parquet/CometFileKeyUnwrapper.java
@@ -20,7 +20,6 @@
 package org.apache.comet.parquet;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,7 +32,7 @@ import org.apache.parquet.crypto.DecryptionPropertiesFactory;
 import org.apache.parquet.crypto.FileDecryptionProperties;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 
-import org.apache.comet.CometConf;
+import org.apache.comet.objectstore.NativeConfig;
 
 // spotless:off
 /*
@@ -99,17 +98,12 @@ import org.apache.comet.CometConf;
  */
 public class CometFileKeyUnwrapper {
 
-  // Hadoop config key listing the user-opted-in S3-compliant alias schemes (e.g. blob, minio),
-  // comma-separated and case-insensitive. Resolved from the Hadoop conf on the put side, so it must
-  // be set at session-creation time.
-  private static final String S3_COMPLIANT_SCHEMES_KEY = CometConf.COMET_S3_COMPLIANT_SCHEMES_KEY();
-
   // Schemes object_store always treats as aliases of s3://, independent of config. The native side
   // rewrites every alias (these plus the configured ones below) to s3:// before it JNIs getKey
   // back, so the get side always sees one of these.
   private static final Set<String> BASE_S3_ALIAS_SCHEMES = Set.of("s3", "s3n", "s3a");
 
-  // User-opted-in S3-compliant alias schemes from S3_COMPLIANT_SCHEMES_KEY, resolved from the
+  // User-opted-in S3-compliant alias schemes from `fs.comet.s3Compliant.schemes`, resolved from the
   // Hadoop conf on the put side and cached so the get side folds the same aliases to one cache key.
   // volatile because getKey may be invoked from a native callback thread after the put side (on the
   // setup thread) populated it. Empty until the first storeDecryptionKeyRetriever, which precedes
@@ -125,34 +119,27 @@ public class CometFileKeyUnwrapper {
   // Cache the hadoopConf just to assert the assumption above.
   private Configuration conf = null;
 
-  /**
-   * Normalizes S3 and S3-compliant alias URI schemes to a canonical {@code s3a://<bucket>/<key>}
-   * form so cache lookups agree regardless of the scheme used. S3 can be addressed via {@code
-   * s3://}, {@code s3a://}, {@code s3n://}, and any scheme the user opted into via {@code
-   * fs.comet.s3Compliant.schemes} (e.g. {@code blob://}). The put and get sides must agree, because
-   * the put side is called with the user-facing scheme (e.g. blob://) while the native side JNIs
-   * back with the scheme after {@code prepare_object_store_with_configs} has already rewritten
-   * aliases to s3://.
-   *
-   * <p>The native rewrite also promotes the first path segment into the authority for the
-   * single-slash {@code blob:/bucket/key} (Java opaque form) and triple-slash {@code
-   * blob:///bucket/key} (empty authority) shapes, so the get side reconstructs {@code
-   * s3://bucket/key}. This method applies the same promotion, otherwise a {@code blob:/...} or
-   * {@code blob:///...} input listed by Spark would be cached under a key that never matches the
-   * get side's {@code s3a://bucket/key}.
-   *
-   * @param filePath The file path that may contain an S3 or alias URI
-   * @return The file path with a normalized {@code s3a://} scheme and bucket in the authority
-   */
   private String normalizeS3Scheme(final String filePath) {
     return normalizeS3Scheme(filePath, s3CompliantSchemes);
   }
 
   /**
-   * Scheme-normalization core, parameterized by the opted-in alias schemes so it can be unit-tested
-   * without a live Hadoop conf. Folds {@code s3}/{@code s3n}/{@code s3a} (always) and any {@code
-   * s3CompliantSchemes} entry (case-insensitive) to canonical {@code s3a://<bucket>/<key>}; every
-   * other scheme is returned unchanged.
+   * Normalizes S3 and S3-compliant alias URI schemes to a canonical {@code s3a://<bucket>/<key>}
+   * form so cache lookups agree regardless of the scheme used. Folds {@code s3}/{@code s3n}/{@code
+   * s3a} (always) and any {@code s3CompliantSchemes} entry (case-insensitive); every other scheme
+   * is returned unchanged. The put and get sides must agree, because the put side is called with
+   * the user-facing scheme (e.g. blob://) while the native side JNIs back with the scheme after
+   * {@code prepare_object_store_with_configs} has already rewritten aliases to s3://.
+   *
+   * <p>That native rewrite also promotes the first path segment into the authority for the
+   * single-slash {@code blob:/bucket/key} (Java opaque form) and triple-slash {@code
+   * blob:///bucket/key} (empty authority) shapes, so the get side reconstructs {@code
+   * s3://bucket/key}. Stripping every leading slash here applies the same promotion; otherwise a
+   * {@code blob:/...} input listed by Spark would be cached under a key that never matches the get
+   * side's {@code s3a://bucket/key}.
+   *
+   * <p>The alias set is a parameter rather than the field so this can be unit-tested without a live
+   * Hadoop conf.
    */
   static String normalizeS3Scheme(final String filePath, final Set<String> s3CompliantSchemes) {
     final int schemeEnd = filePath.indexOf(':');
@@ -164,23 +151,7 @@ public class CometFileKeyUnwrapper {
     if (!BASE_S3_ALIAS_SCHEMES.contains(scheme) && !s3CompliantSchemes.contains(scheme)) {
       return filePath;
     }
-    // Strip the scheme and every leading slash, re-join under s3a:// to promote the first path
-    // segment into the authority for the single-/triple-slash forms (matches the native
-    // rewrite_alias_to_s3 behavior).
     return "s3a://" + StringUtils.stripStart(filePath.substring(schemeEnd + 1), "/");
-  }
-
-  /**
-   * Reads the opted-in alias schemes from {@code fs.comet.s3Compliant.schemes} as a lowercased set.
-   * Hadoop's own comma-splitting is reused so the value parses exactly as {@code
-   * NativeConfig.parseSchemeSet} does on the Scala side.
-   */
-  private static Set<String> readS3CompliantSchemes(final Configuration hadoopConf) {
-    final Set<String> schemes = new HashSet<>();
-    for (String s : hadoopConf.getTrimmedStringCollection(S3_COMPLIANT_SCHEMES_KEY)) {
-      schemes.add(s.toLowerCase(Locale.ROOT));
-    }
-    return schemes;
   }
 
   /**
@@ -197,7 +168,9 @@ public class CometFileKeyUnwrapper {
       conf = hadoopConf;
       // Resolve the opted-in alias schemes once, before the first normalizeS3Scheme below, so both
       // the put side here and the later getKey side fold the same aliases to one cache key.
-      s3CompliantSchemes = readS3CompliantSchemes(hadoopConf);
+      // Delegated to NativeConfig so this parses `fs.comet.s3Compliant.schemes` exactly as the
+      // planner gate does; a second parser here could desync the two.
+      s3CompliantSchemes = NativeConfig.resolveS3CompliantSchemesAsJava(hadoopConf);
     } else {
       // Check the assumption that all files have the same hadoopConf and thus same Factory
       assert (conf == hadoopConf);

--- a/spark/src/main/java/org/apache/comet/parquet/CometFileKeyUnwrapper.java
+++ b/spark/src/main/java/org/apache/comet/parquet/CometFileKeyUnwrapper.java
@@ -19,7 +19,6 @@
 
 package org.apache.comet.parquet;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
@@ -107,10 +106,8 @@ public class CometFileKeyUnwrapper {
 
   // Schemes object_store always treats as aliases of s3://, independent of config. The native side
   // rewrites every alias (these plus the configured ones below) to s3:// before it JNIs getKey
-  // back, so the get side always sees one of these; the configured aliases matter on the put side,
-  // called with the user-facing scheme (e.g. blob://). All fold to one canonical cache key.
-  private static final Set<String> BASE_S3_ALIAS_SCHEMES =
-      Collections.unmodifiableSet(new HashSet<>(Arrays.asList("s3", "s3n", "s3a")));
+  // back, so the get side always sees one of these.
+  private static final Set<String> BASE_S3_ALIAS_SCHEMES = Set.of("s3", "s3n", "s3a");
 
   // User-opted-in S3-compliant alias schemes from S3_COMPLIANT_SCHEMES_KEY, resolved from the
   // Hadoop conf on the put side and cached so the get side folds the same aliases to one cache key.
@@ -164,7 +161,7 @@ public class CometFileKeyUnwrapper {
       return filePath;
     }
     final String scheme = filePath.substring(0, schemeEnd).toLowerCase(Locale.ROOT);
-    if (!isS3AliasScheme(scheme, s3CompliantSchemes)) {
+    if (!BASE_S3_ALIAS_SCHEMES.contains(scheme) && !s3CompliantSchemes.contains(scheme)) {
       return filePath;
     }
     // Strip the scheme and every leading slash, re-join under s3a:// to promote the first path
@@ -173,29 +170,17 @@ public class CometFileKeyUnwrapper {
     return "s3a://" + StringUtils.stripStart(filePath.substring(schemeEnd + 1), "/");
   }
 
-  private static boolean isS3AliasScheme(
-      final String scheme, final Set<String> s3CompliantSchemes) {
-    return BASE_S3_ALIAS_SCHEMES.contains(scheme) || s3CompliantSchemes.contains(scheme);
-  }
-
   /**
-   * Parses a comma-separated, case-insensitive scheme list (the value of {@code
-   * fs.comet.s3Compliant.schemes}) into a trimmed, lowercased set. Mirrors {@code
-   * NativeConfig.parseSchemeSet} so the JVM and native sides agree on which schemes are aliases. A
-   * null or blank value yields an empty set.
+   * Reads the opted-in alias schemes from {@code fs.comet.s3Compliant.schemes} as a lowercased set.
+   * Hadoop's own comma-splitting is reused so the value parses exactly as {@code
+   * NativeConfig.parseSchemeSet} does on the Scala side.
    */
-  private static Set<String> parseSchemeSet(final String raw) {
-    if (raw == null) {
-      return Collections.emptySet();
+  private static Set<String> readS3CompliantSchemes(final Configuration hadoopConf) {
+    final Set<String> schemes = new HashSet<>();
+    for (String s : hadoopConf.getTrimmedStringCollection(S3_COMPLIANT_SCHEMES_KEY)) {
+      schemes.add(s.toLowerCase(Locale.ROOT));
     }
-    final Set<String> out = new HashSet<>();
-    for (String s : raw.split(",")) {
-      final String trimmed = s.trim().toLowerCase(Locale.ROOT);
-      if (!trimmed.isEmpty()) {
-        out.add(trimmed);
-      }
-    }
-    return out;
+    return schemes;
   }
 
   /**
@@ -212,7 +197,7 @@ public class CometFileKeyUnwrapper {
       conf = hadoopConf;
       // Resolve the opted-in alias schemes once, before the first normalizeS3Scheme below, so both
       // the put side here and the later getKey side fold the same aliases to one cache key.
-      s3CompliantSchemes = parseSchemeSet(hadoopConf.get(S3_COMPLIANT_SCHEMES_KEY));
+      s3CompliantSchemes = readS3CompliantSchemes(hadoopConf);
     } else {
       // Check the assumption that all files have the same hadoopConf and thus same Factory
       assert (conf == hadoopConf);

--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -948,10 +948,8 @@ object CometConf extends ShimCometConf {
         "Defines filesystem schemes (e.g., blob, minio, r2) that Comet treats as S3-compliant, " +
           "separated by commas. Such schemes reuse the `fs.s3a.*` credential surface and accept " +
           "vendor-style `fs.<scheme>.<authority>.*` keys. Empty by default, so no alias scheme " +
-          "is claimed unless opted in. Read from the Hadoop configuration, so it must be set at " +
-          "session-creation time via `--conf spark.hadoop.fs.comet.s3Compliant.schemes=...`, " +
-          "SparkConf, or core-site.xml. Setting it with `spark.conf.set` after the session has " +
-          "started has no effect.")
+          "is claimed unless opted in. Read from the Hadoop configuration, so it must be set " +
+          "before the SparkSession is created.")
       .stringConf
       .createOptional
 

--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -939,6 +939,22 @@ object CometConf extends ShimCometConf {
       .stringConf
       .createOptional
 
+  val COMET_S3_COMPLIANT_SCHEMES_KEY = "fs.comet.s3Compliant.schemes"
+
+  val COMET_S3_COMPLIANT_SCHEMES: OptionalConfigEntry[String] =
+    conf(s"spark.hadoop.$COMET_S3_COMPLIANT_SCHEMES_KEY")
+      .category(CATEGORY_SCAN)
+      .doc(
+        "Defines filesystem schemes (e.g., blob, minio, r2) that Comet treats as S3-compliant, " +
+          "separated by commas. Such schemes reuse the `fs.s3a.*` credential surface and accept " +
+          "vendor-style `fs.<scheme>.<authority>.*` keys. Empty by default, so no alias scheme " +
+          "is claimed unless opted in. Read from the Hadoop configuration, so it must be set at " +
+          "session-creation time via `--conf spark.hadoop.fs.comet.s3Compliant.schemes=...`, " +
+          "SparkConf, or core-site.xml. Setting it with `spark.conf.set` after the session has " +
+          "started has no effect.")
+      .stringConf
+      .createOptional
+
   // Used on native side. Check spark_config.rs how the config is used
   val COMET_MAX_TEMP_DIRECTORY_SIZE: ConfigEntry[Long] =
     conf("spark.comet.maxTempDirectorySize")

--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -941,6 +941,10 @@ object CometConf extends ShimCometConf {
 
   val COMET_S3_COMPLIANT_SCHEMES_KEY = "fs.comet.s3Compliant.schemes"
 
+  // Declared so the value appears in the generated config reference and can be set via
+  // `spark.hadoop.*`, but never read through this entry: `NativeConfig.resolveS3CompliantSchemes`
+  // reads the Hadoop key below instead, so `core-site.xml` is honored too. Same shape as
+  // COMET_LIBHDFS_SCHEMES.
   val COMET_S3_COMPLIANT_SCHEMES: OptionalConfigEntry[String] =
     conf(s"spark.hadoop.$COMET_S3_COMPLIANT_SCHEMES_KEY")
       .category(CATEGORY_SCAN)

--- a/spark/src/main/scala/org/apache/comet/iceberg/IcebergReflection.scala
+++ b/spark/src/main/scala/org/apache/comet/iceberg/IcebergReflection.scala
@@ -1969,18 +1969,22 @@ object CometIcebergNativeScanMetadata extends Logging {
    *   Path to the table metadata file (already extracted)
    * @param catalogProperties
    *   Catalog properties for FileIO (already extracted)
+   * @param tasks
+   *   The scan's FileScanTasks (already extracted). Passed in rather than re-read via
+   *   [[IcebergReflection.getTasks]], which for a staged scan rebuilds a flattened list of every
+   *   task on each call.
    * @return
    *   Some(metadata) if all reflection succeeds, None to trigger fallback
    */
   def extract(
       scan: Any,
       metadataLocation: String,
-      catalogProperties: Map[String, String]): Option[CometIcebergNativeScanMetadata] = {
+      catalogProperties: Map[String, String],
+      tasks: java.util.List[_]): Option[CometIcebergNativeScanMetadata] = {
     import org.apache.comet.iceberg.IcebergReflection._
 
     for {
       table <- getTable(scan)
-      tasks <- getTasks(scan)
       scanSchema <- getExpectedSchema(scan)
       tableSchema <- getSchema(table)
     } yield {

--- a/spark/src/main/scala/org/apache/comet/objectstore/NativeConfig.scala
+++ b/spark/src/main/scala/org/apache/comet/objectstore/NativeConfig.scala
@@ -21,10 +21,10 @@ package org.apache.comet.objectstore
 
 import java.net.URI
 import java.util.Locale
-import java.util.regex.Pattern
 
 import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.conf.Configuration
+import org.apache.spark.sql.comet.util.Utils
 
 import org.apache.comet.CometConf.{COMET_LIBHDFS_SCHEMES_KEY, COMET_S3_COMPLIANT_SCHEMES_KEY}
 
@@ -64,7 +64,7 @@ object NativeConfig {
   // CometScanRule's scheme gate so the JVM admit-decision and native rewrite parse identically.
   private[comet] def parseSchemeSet(raw: String): Set[String] =
     Option(raw)
-      .map(_.split(",").iterator.map(_.trim.toLowerCase(Locale.ROOT)).filter(_.nonEmpty).toSet)
+      .map(Utils.stringToSeq(_).map(_.toLowerCase(Locale.ROOT)).toSet)
       .getOrElse(Set.empty)
 
   // Opt-in S3-compliant alias schemes from the Hadoop config `fs.comet.s3Compliant.schemes`
@@ -73,13 +73,6 @@ object NativeConfig {
   // (CometScanRule) and the Iceberg write path's data-bucket resolution.
   private[comet] def resolveS3CompliantSchemes(hadoopConf: Configuration): Set[String] =
     parseSchemeSet(hadoopConf.get(COMET_S3_COMPLIANT_SCHEMES_KEY))
-
-  // True when the user pinned path-style at this bucket scope. Suppresses the synthesized soft
-  // default so an explicit per-bucket setting (including `false`, the escape hatch) survives. A
-  // global `fs.s3a.path.style.access` is intentionally ignored: it may target other s3a workloads
-  // or be an ambient cluster default. Per-bucket synth wins over global in native anyway.
-  private def userSetPathStyle(hadoopConf: Configuration, bucket: Option[String]): Boolean =
-    bucket.exists(b => hadoopConf.get(s"fs.s3a.bucket.$b.path.style.access") != null)
 
   /**
    * The S3 bucket a URI addresses: its authority, or the first path segment for the authorityless
@@ -110,58 +103,44 @@ object NativeConfig {
     scheme == "s3" || scheme == "s3a" || scheme == "s3n" || s3CompliantSchemes.contains(scheme)
 
   /**
-   * The distinct S3 buckets addressed by the S3-family URIs in `uris` -- `s3`/`s3a`/`s3n` and any
-   * opted-in `s3CompliantSchemes` alias -- resolved via [[bucketForUri]], which drops
-   * non-S3-family URIs (`file`, `hdfs`, `gs`, `oss`, ...) since their authority is not an S3
-   * bucket and they do not share the `fs.s3a.*` per-bucket surface. Used to detect a scan whose
-   * files span multiple buckets that a single native object store, keyed on one bucket, cannot
-   * serve.
-   */
-  private[comet] def s3FamilyBuckets(
-      uris: Seq[URI],
-      s3CompliantSchemes: Set[String]): Set[String] =
-    uris.iterator.flatMap(bucketForUri(_, s3CompliantSchemes)).toSet
-
-  /**
-   * Translate vendor-style `fs.<scheme>.<authority>.<property>` keys into the `fs.s3a.*` shape
-   * object_store's AmazonS3Builder reads, for a configured S3-compliant `scheme`. Recognized
-   * properties are `vendorPropertyToS3aSuffix`; unknown ones are dropped.
+   * Translate the vendor-style `fs.<scheme>.<authority>.<property>` keys collected by
+   * `extractObjectStoreOptions` into the `fs.s3a.*` shape object_store's AmazonS3Builder reads.
+   * Recognized properties are `vendorPropertyToS3aSuffix`; unknown ones are dropped.
    *
    * Keys land at the per-bucket `fs.s3a.bucket.<bucket>.*` scope (for the `default` authority the
    * bucket is `defaultBucket`, promoted from the URL path) -- the scope native `get_config`
-   * checks first. The authority is matched greedily so dotted bucket names survive.
+   * checks first. The authority is taken greedily (split at the LAST dot) so dotted bucket names
+   * survive.
    *
    * An `endpoint` also synthesizes `path.style.access=true` as a soft default, suppressed by an
-   * explicit per-bucket setting or vendor `pathStyleAccess`. Applied AFTER the plain `fs.s3a.*`
-   * pass so real vendor keys override conflicting `fs.s3a.*` (the 403-misdirect note below).
+   * explicit vendor `pathStyleAccess` or by a per-bucket `fs.s3a.*` setting the caller already
+   * copied into `s3aOptions` (including `false`, the escape hatch). A GLOBAL
+   * `fs.s3a.path.style.access` is deliberately not consulted: it may target other s3a workloads,
+   * and per-bucket wins over global natively anyway.
    *
-   * `confEntries` is the caller's one-time snapshot of the Hadoop config (see
-   * `extractObjectStoreOptions`); `hadoopConf` is still used for `${...}` substitution and
-   * targeted per-bucket lookups.
+   * `vendorEntries` are `(authority.property, substituted value)` pairs, i.e. the key with its
+   * `fs.<scheme>.` prefix already stripped.
    */
   private def translateVendorKeys(
-      confEntries: Seq[(String, String)],
-      hadoopConf: Configuration,
-      scheme: String,
+      vendorEntries: Seq[(String, String)],
+      s3aOptions: collection.Map[String, String],
       defaultBucket: Option[String]): Map[String, String] = {
-    // `fs.<scheme>.<authority>.<property>`; scheme is regex-quoted (may contain `.`/`+`/`-`).
-    val vendorKeyPattern = ("^fs\\." + Pattern.quote(scheme) + "\\.(.+)\\.([^.]+)$").r
     val out = scala.collection.mutable.Map[String, String]()
 
+    val matched = vendorEntries.flatMap { case (authorityAndProperty, value) =>
+      val dot = authorityAndProperty.lastIndexOf('.')
+      if (dot <= 0) None
+      else {
+        vendorPropertyToS3aSuffix
+          .get(authorityAndProperty.substring(dot + 1))
+          .map(suffix => (authorityAndProperty.substring(0, dot), suffix, value))
+      }
+    }
     // Apply `default`-authority keys BEFORE explicit ones. A `default` key (promoted to the
     // URL-path bucket) and an explicit `fs.<scheme>.<bucket>.*` can resolve to the same
     // `fs.s3a.bucket.<bucket>.*` scope, and the explicit spelling must win -- which it does only
     // when written last. Otherwise the winner is whichever config entry is yielded last (hash
     // order), so the same config could pick either endpoint from one run to the next.
-    val matched = confEntries.flatMap { case (key, value) =>
-      key match {
-        case vendorKeyPattern(authority, property) =>
-          vendorPropertyToS3aSuffix
-            .get(property)
-            .map(suffix => (authority, suffix, substitutedValue(hadoopConf, key, value)))
-        case _ => None
-      }
-    }
     val (defaults, explicit) = matched.partition(_._1 == vendorDefaultAuthority)
 
     (defaults ++ explicit).foreach { case (authority, suffix, value) =>
@@ -169,7 +148,9 @@ object NativeConfig {
         if (authority == vendorDefaultAuthority) defaultBucket else Some(authority)
       val scope = bucket.map(b => s"fs.s3a.bucket.$b").getOrElse("fs.s3a")
       out(s"$scope.$suffix") = value
-      if (suffix == "endpoint" && !userSetPathStyle(hadoopConf, bucket)) {
+      val userPinnedPathStyle =
+        bucket.exists(b => s3aOptions.contains(s"fs.s3a.bucket.$b.path.style.access"))
+      if (suffix == "endpoint" && !userPinnedPathStyle) {
         out.getOrElseUpdate(s"$scope.path.style.access", "true")
       }
     }
@@ -214,22 +195,26 @@ object NativeConfig {
       return options.toMap
     }
 
-    // Materialize the Hadoop config once: `iterator()` rebuilds a full copy of the property map on
-    // every call, so we reuse this snapshot for the prefix pass and the vendor translation below.
-    val entries = hadoopConf.iterator().asScala.map(e => e.getKey -> e.getValue).toVector
+    // A configured S3-compliant alias also contributes vendor keys, but those must be applied
+    // AFTER the whole fs.s3a.* pass (so real vendor values win a conflict). Collect them during
+    // the single walk of the config below rather than making a second pass: `iterator()` rebuilds
+    // a full copy of the property map on every call.
+    val vendorPrefix = if (s3CompliantSchemes.contains(scheme)) s"fs.$scheme." else null
+    val vendorEntries = scala.collection.mutable.ArrayBuffer[(String, String)]()
 
-    // Extract all configurations that match the object store prefixes
-    entries.foreach { case (key, value) =>
+    hadoopConf.iterator().asScala.foreach { entry =>
+      val key = entry.getKey
       if (prefixes.get.exists(prefix => key.startsWith(prefix))) {
-        options(key) = substitutedValue(hadoopConf, key, value)
+        options(key) = substitutedValue(hadoopConf, key, entry.getValue)
+      } else if (vendorPrefix != null && key.startsWith(vendorPrefix)) {
+        vendorEntries +=
+          key.substring(vendorPrefix.length) -> substitutedValue(hadoopConf, key, entry.getValue)
       }
     }
 
-    // Configured S3-compliant scheme: translate vendor keys AFTER the fs.s3a.* pass so real vendor
-    // values override conflicting fs.s3a.*. Pass the resolved bucket so `fs.<scheme>.default.*`
-    // lands at that bucket's scope.
-    if (s3CompliantSchemes.contains(scheme)) {
-      translateVendorKeys(entries, hadoopConf, scheme, bucketForUri(uri, s3CompliantSchemes))
+    // Pass the resolved bucket so `fs.<scheme>.default.*` lands at that bucket's scope.
+    if (vendorEntries.nonEmpty) {
+      translateVendorKeys(vendorEntries.toSeq, options, bucketForUri(uri, s3CompliantSchemes))
         .foreach { case (k, v) => options(k) = v }
     }
 

--- a/spark/src/main/scala/org/apache/comet/objectstore/NativeConfig.scala
+++ b/spark/src/main/scala/org/apache/comet/objectstore/NativeConfig.scala
@@ -69,8 +69,8 @@ object NativeConfig {
 
   // Opt-in S3-compliant alias schemes from the Hadoop config `fs.comet.s3Compliant.schemes`
   // (comma-separated, trimmed, lowercased, empty/missing => none). The native gate no longer
-  // claims them, so the opt-in is resolved wherever the Hadoop config is available. Shared by the
-  // scan (CometScanRule) and write (CometIcebergNativeWrite) paths so both admit the same set.
+  // claims them, so the opt-in is resolved wherever the Hadoop config is available: the scan gate
+  // (CometScanRule) and the Iceberg write path's data-bucket resolution.
   private[comet] def resolveS3CompliantSchemes(hadoopConf: Configuration): Set[String] =
     parseSchemeSet(hadoopConf.get(COMET_S3_COMPLIANT_SCHEMES_KEY))
 
@@ -83,46 +83,44 @@ object NativeConfig {
 
   /**
    * The S3 bucket a URI addresses: its authority, or the first path segment for the authorityless
-   * `blob:///bucket/key` form (matching the native rewrite that promotes it into the host). The
-   * path-segment fallback fires only for S3-family schemes (`s3`, `s3a`, `s3n`, and the opted-in
-   * `s3CompliantSchemes`). For any other scheme an absent authority means no bucket, so a local
-   * Hadoop-catalog `file:///tmp/warehouse/...` returns None rather than the surprising `tmp`.
-   * Returns None when neither source applies.
+   * `blob:///bucket/key` form (matching the native rewrite that promotes it into the host).
+   * Returns None for a non-S3-family scheme, so a local Hadoop-catalog
+   * `file:///tmp/warehouse/...` or a `gs://` location yields no bucket rather than a surprising
+   * `tmp`: only `s3`/`s3a`/`s3n` and the opted-in `s3CompliantSchemes` share the `fs.s3a.*`
+   * per-bucket surface. Callers therefore need no scheme check of their own.
    */
-  def bucketForUri(uri: URI, s3CompliantSchemes: Set[String]): Option[String] = {
-    Option(uri.getAuthority)
-      .map(_.trim)
-      .filter(_.nonEmpty)
-      .orElse {
-        val scheme = Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)).getOrElse("")
-        if (isS3FamilyScheme(scheme, s3CompliantSchemes)) {
+  private[comet] def bucketForUri(uri: URI, s3CompliantSchemes: Set[String]): Option[String] = {
+    val scheme = Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)).getOrElse("")
+    if (!isS3FamilyScheme(scheme, s3CompliantSchemes)) {
+      None
+    } else {
+      Option(uri.getAuthority)
+        .map(_.trim)
+        .filter(_.nonEmpty)
+        .orElse(
           Option(uri.getPath)
             .map(_.stripPrefix("/"))
             .map(_.takeWhile(_ != '/'))
-            .filter(_.nonEmpty)
-        } else {
-          None
-        }
-      }
+            .filter(_.nonEmpty))
+    }
   }
 
   // s3/s3a/s3n and any opted-in alias share the authorityless path-promotion semantics above.
-  private[comet] def isS3FamilyScheme(scheme: String, s3CompliantSchemes: Set[String]): Boolean =
+  private def isS3FamilyScheme(scheme: String, s3CompliantSchemes: Set[String]): Boolean =
     scheme == "s3" || scheme == "s3a" || scheme == "s3n" || s3CompliantSchemes.contains(scheme)
 
   /**
    * The distinct S3 buckets addressed by the S3-family URIs in `uris` -- `s3`/`s3a`/`s3n` and any
-   * opted-in `s3CompliantSchemes` alias -- resolved via [[bucketForUri]]. Non-S3-family URIs
-   * (`file`, `hdfs`, `gs`, `oss`, ...) are ignored: their authority is not an S3 bucket and they
-   * do not share the `fs.s3a.*` per-bucket surface. Used to detect a scan whose files span
-   * multiple buckets that a single native object store, keyed on one bucket, cannot serve.
+   * opted-in `s3CompliantSchemes` alias -- resolved via [[bucketForUri]], which drops
+   * non-S3-family URIs (`file`, `hdfs`, `gs`, `oss`, ...) since their authority is not an S3
+   * bucket and they do not share the `fs.s3a.*` per-bucket surface. Used to detect a scan whose
+   * files span multiple buckets that a single native object store, keyed on one bucket, cannot
+   * serve.
    */
-  def s3FamilyBuckets(uris: Seq[URI], s3CompliantSchemes: Set[String]): Set[String] =
-    uris.iterator.flatMap { uri =>
-      val scheme = Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)).getOrElse("")
-      if (isS3FamilyScheme(scheme, s3CompliantSchemes)) bucketForUri(uri, s3CompliantSchemes)
-      else None
-    }.toSet
+  private[comet] def s3FamilyBuckets(
+      uris: Seq[URI],
+      s3CompliantSchemes: Set[String]): Set[String] =
+    uris.iterator.flatMap(bucketForUri(_, s3CompliantSchemes)).toSet
 
   /**
    * Translate vendor-style `fs.<scheme>.<authority>.<property>` keys into the `fs.s3a.*` shape

--- a/spark/src/main/scala/org/apache/comet/objectstore/NativeConfig.scala
+++ b/spark/src/main/scala/org/apache/comet/objectstore/NativeConfig.scala
@@ -30,9 +30,11 @@ import org.apache.comet.CometConf.COMET_LIBHDFS_SCHEMES_KEY
 object NativeConfig {
 
   private val objectStoreConfigPrefixes = Map(
-    // Amazon S3 configurations
+    // Amazon S3 configurations. `blob` is a Comet-recognized synonym for `s3` and shares the
+    // same Hadoop `fs.s3a.*` credential surface (see `prepare_object_store_with_configs`).
     "s3" -> Seq("fs.s3a."),
     "s3a" -> Seq("fs.s3a."),
+    "blob" -> Seq("fs.s3a."),
     // Google Cloud Storage configurations
     "gs" -> Seq("fs.gs."),
     // Azure Blob Storage configurations (can use both prefixes)
@@ -42,6 +44,55 @@ object NativeConfig {
     "abfs" -> Seq("fs.azure.", "fs.abfs."),
     "abfss" -> Seq("fs.azure.", "fs.abfss.", "fs.abfs."))
 
+  private val blobKeyPattern = "^fs\\.blob\\.([^.]+)\\.(.+)$".r
+
+  // Some blob:// filesystem implementations fall back to the literal string "default" as the
+  // authority when the URI has none. For `blob:///bucket/key`, the filesystem therefore looks
+  // up `fs.blob.default.*`, while the actual S3 bucket comes from the URL path. Translate
+  // `fs.blob.default.*` to the GLOBAL `fs.s3a.*` key (not the per-bucket
+  // `fs.s3a.bucket.default.*`) so the credentials/endpoint apply to whichever bucket the URL
+  // path resolves to, matching those implementations' semantics.
+  private val blobDefaultAuthority = "default"
+
+  /**
+   * Translates vendor-style `fs.blob.<authority>.<property>` keys into the `fs.s3a.*` shape that
+   * object_store's AmazonS3Builder reads. Some blob:// connectors use per-authority keys and
+   * never set a region -- an endpoint alone is enough for the AWS SDK v1 client they build -- and
+   * their endpoints are typically path-style against non-AWS services, so an `endpoint` key also
+   * enables `path.style.access` on the same scope.
+   *
+   * `fs.blob.<authority>.*` is the authoritative source for `blob://` URLs, so callers should
+   * apply these translations AFTER a plain `fs.s3a.*` pass so blob-supplied values override any
+   * unrelated `fs.s3a.*` the user set for a different workload (see 403 misdirect in the class
+   * docstring).
+   */
+  private def translateBlobKeys(hadoopConf: Configuration): Map[String, String] = {
+    import scala.jdk.CollectionConverters._
+    val out = scala.collection.mutable.Map[String, String]()
+    hadoopConf.iterator().asScala.foreach { entry =>
+      entry.getKey match {
+        case blobKeyPattern(authority, property) =>
+          val s3aSuffix = property match {
+            case "endpoint" => "endpoint"
+            case "awsAccessKeyId" => "access.key"
+            case "awsSecretAccessKey" => "secret.key"
+            case _ => null
+          }
+          if (s3aSuffix != null) {
+            val scope =
+              if (authority == blobDefaultAuthority) "fs.s3a"
+              else s"fs.s3a.bucket.$authority"
+            out(s"$scope.$s3aSuffix") = entry.getValue
+            if (s3aSuffix == "endpoint") {
+              out.getOrElseUpdate(s"$scope.path.style.access", "true")
+            }
+          }
+        case _ =>
+      }
+    }
+    out.toMap
+  }
+
   /**
    * Extract object store configurations from Hadoop configuration for native DataFusion usage.
    * This includes S3, GCS, Azure and other cloud storage configurations.
@@ -50,6 +101,21 @@ object NativeConfig {
    * global configurations (e.g., fs.s3a.access.key) and per-bucket configurations (e.g.,
    * fs.s3a.bucket.{bucket-name}.access.key). The native code will prioritize per-bucket
    * configurations over global ones when both are present.
+   *
+   * For `blob://` URIs it also translates vendor-style `fs.blob.<authority>.endpoint`,
+   * `fs.blob.<authority>.awsAccessKeyId`, and `fs.blob.<authority>.awsSecretAccessKey` into the
+   * equivalent `fs.s3a.bucket.<authority>.endpoint`, `access.key`, and `secret.key`. Because
+   * those blob:// backends usually talk path-style to non-AWS endpoints and never set a region,
+   * the translation also enables `fs.s3a.bucket.<authority>.path.style.access=true` when a blob
+   * endpoint is present.
+   *
+   * `fs.blob.<authority>.*` is the authoritative source for `blob://` URLs: the user may have
+   * `fs.s3a.*` keys targeting a completely different s3a-scheme workload in the same Spark
+   * session, and leaking those into blob-scheme connections silently redirects credentials to the
+   * wrong service (produces a 403 "The access key Id you provided does not exist in our
+   * records"). For `blob://` URIs, blob translations therefore OVERRIDE any conflicting
+   * `fs.s3a.*` values the user also set. If you actually want to override a blob endpoint, change
+   * the `fs.blob.<authority>.endpoint` value itself.
    *
    * The configurations are passed to the native code which uses object_store's parse_url_opts for
    * consistent and standardized cloud storage support across all providers.
@@ -75,11 +141,15 @@ object NativeConfig {
     // Extract all configurations that match the object store prefixes
     hadoopConf.iterator().asScala.foreach { entry =>
       val key = entry.getKey
-      val value = entry.getValue
-      // Check if key starts with any of the prefixes for this scheme
       if (prefixes.get.exists(prefix => key.startsWith(prefix))) {
-        options(key) = value
+        options(key) = entry.getValue
       }
+    }
+
+    // For blob:// URIs, apply vendor-key translation AFTER the fs.s3a.* pass so blob values
+    // override any unrelated fs.s3a.* the user set for a different workload.
+    if (scheme == "blob") {
+      translateBlobKeys(hadoopConf).foreach { case (k, v) => options(k) = v }
     }
 
     options.toMap

--- a/spark/src/main/scala/org/apache/comet/objectstore/NativeConfig.scala
+++ b/spark/src/main/scala/org/apache/comet/objectstore/NativeConfig.scala
@@ -21,16 +21,18 @@ package org.apache.comet.objectstore
 
 import java.net.URI
 import java.util.Locale
+import java.util.regex.Pattern
 
 import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.conf.Configuration
 
-import org.apache.comet.CometConf.COMET_LIBHDFS_SCHEMES_KEY
+import org.apache.comet.CometConf.{COMET_LIBHDFS_SCHEMES_KEY, COMET_S3_COMPLIANT_SCHEMES_KEY}
 
 object NativeConfig {
 
   private val objectStoreConfigPrefixes = Map(
-    // Amazon S3 configurations
+    // Amazon S3. Schemes listed in `COMET_S3_COMPLIANT_SCHEMES_KEY` reuse this same `fs.s3a.*`
+    // surface, resolved per-URI in `extractObjectStoreOptions`.
     "s3" -> Seq("fs.s3a."),
     "s3a" -> Seq("fs.s3a."),
     // Google Cloud Storage configurations
@@ -42,17 +44,151 @@ object NativeConfig {
     "abfs" -> Seq("fs.azure.", "fs.abfs."),
     "abfss" -> Seq("fs.azure.", "fs.abfss.", "fs.abfs."))
 
+  // Some alias filesystems report the literal authority "default" when the URI has none (e.g.
+  // `scheme:///bucket/key`); the real bucket is then promoted from the URL path. Keys under this
+  // authority map to the per-bucket `fs.s3a.bucket.<resolved-bucket>.*` scope, NOT global
+  // `fs.s3a.*`, because native `get_config` checks per-bucket before global.
+  private val vendorDefaultAuthority = "default"
+
+  // Recognized vendor properties -> `fs.s3a` suffix. Mirrors CometIcebergNativeScan's target set.
+  // Unknown properties are dropped.
+  private val vendorPropertyToS3aSuffix = Map(
+    "awsAccessKeyId" -> "access.key",
+    "awsSecretAccessKey" -> "secret.key",
+    "awsSessionToken" -> "session.token",
+    "endpoint" -> "endpoint",
+    "region" -> "endpoint.region",
+    "pathStyleAccess" -> "path.style.access")
+
+  // Comma-separated scheme list -> trimmed, lowercased set (case-insensitive). Shared with
+  // CometScanRule's scheme gate so the JVM admit-decision and native rewrite parse identically.
+  private[comet] def parseSchemeSet(raw: String): Set[String] =
+    Option(raw)
+      .map(_.split(",").iterator.map(_.trim.toLowerCase(Locale.ROOT)).filter(_.nonEmpty).toSet)
+      .getOrElse(Set.empty)
+
+  // Opt-in S3-compliant alias schemes from the Hadoop config `fs.comet.s3Compliant.schemes`
+  // (comma-separated, trimmed, lowercased, empty/missing => none). The native gate no longer
+  // claims them, so the opt-in is resolved wherever the Hadoop config is available. Shared by the
+  // scan (CometScanRule) and write (CometIcebergNativeWrite) paths so both admit the same set.
+  private[comet] def resolveS3CompliantSchemes(hadoopConf: Configuration): Set[String] =
+    parseSchemeSet(hadoopConf.get(COMET_S3_COMPLIANT_SCHEMES_KEY))
+
+  // True when the user pinned path-style at this bucket scope. Suppresses the synthesized soft
+  // default so an explicit per-bucket setting (including `false`, the escape hatch) survives. A
+  // global `fs.s3a.path.style.access` is intentionally ignored: it may target other s3a workloads
+  // or be an ambient cluster default. Per-bucket synth wins over global in native anyway.
+  private def userSetPathStyle(hadoopConf: Configuration, bucket: Option[String]): Boolean =
+    bucket.exists(b => hadoopConf.get(s"fs.s3a.bucket.$b.path.style.access") != null)
+
   /**
-   * Extract object store configurations from Hadoop configuration for native DataFusion usage.
-   * This includes S3, GCS, Azure and other cloud storage configurations.
+   * The S3 bucket a URI addresses: its authority, or the first path segment for the authorityless
+   * `blob:///bucket/key` form (matching the native rewrite that promotes it into the host). The
+   * path-segment fallback fires only for S3-family schemes (`s3`, `s3a`, `s3n`, and the opted-in
+   * `s3CompliantSchemes`). For any other scheme an absent authority means no bucket, so a local
+   * Hadoop-catalog `file:///tmp/warehouse/...` returns None rather than the surprising `tmp`.
+   * Returns None when neither source applies.
+   */
+  def bucketForUri(uri: URI, s3CompliantSchemes: Set[String]): Option[String] = {
+    Option(uri.getAuthority)
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .orElse {
+        val scheme = Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)).getOrElse("")
+        if (isS3FamilyScheme(scheme, s3CompliantSchemes)) {
+          Option(uri.getPath)
+            .map(_.stripPrefix("/"))
+            .map(_.takeWhile(_ != '/'))
+            .filter(_.nonEmpty)
+        } else {
+          None
+        }
+      }
+  }
+
+  // s3/s3a/s3n and any opted-in alias share the authorityless path-promotion semantics above.
+  private[comet] def isS3FamilyScheme(scheme: String, s3CompliantSchemes: Set[String]): Boolean =
+    scheme == "s3" || scheme == "s3a" || scheme == "s3n" || s3CompliantSchemes.contains(scheme)
+
+  /**
+   * The distinct S3 buckets addressed by the S3-family URIs in `uris` -- `s3`/`s3a`/`s3n` and any
+   * opted-in `s3CompliantSchemes` alias -- resolved via [[bucketForUri]]. Non-S3-family URIs
+   * (`file`, `hdfs`, `gs`, `oss`, ...) are ignored: their authority is not an S3 bucket and they
+   * do not share the `fs.s3a.*` per-bucket surface. Used to detect a scan whose files span
+   * multiple buckets that a single native object store, keyed on one bucket, cannot serve.
+   */
+  def s3FamilyBuckets(uris: Seq[URI], s3CompliantSchemes: Set[String]): Set[String] =
+    uris.iterator.flatMap { uri =>
+      val scheme = Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)).getOrElse("")
+      if (isS3FamilyScheme(scheme, s3CompliantSchemes)) bucketForUri(uri, s3CompliantSchemes)
+      else None
+    }.toSet
+
+  /**
+   * Translate vendor-style `fs.<scheme>.<authority>.<property>` keys into the `fs.s3a.*` shape
+   * object_store's AmazonS3Builder reads, for a configured S3-compliant `scheme`. Recognized
+   * properties are `vendorPropertyToS3aSuffix`; unknown ones are dropped.
    *
-   * This method extracts all configurations with supported prefixes, automatically capturing both
-   * global configurations (e.g., fs.s3a.access.key) and per-bucket configurations (e.g.,
-   * fs.s3a.bucket.{bucket-name}.access.key). The native code will prioritize per-bucket
-   * configurations over global ones when both are present.
+   * Keys land at the per-bucket `fs.s3a.bucket.<bucket>.*` scope (for the `default` authority the
+   * bucket is `defaultBucket`, promoted from the URL path) -- the scope native `get_config`
+   * checks first. The authority is matched greedily so dotted bucket names survive.
    *
-   * The configurations are passed to the native code which uses object_store's parse_url_opts for
-   * consistent and standardized cloud storage support across all providers.
+   * An `endpoint` also synthesizes `path.style.access=true` as a soft default, suppressed by an
+   * explicit per-bucket setting or vendor `pathStyleAccess`. Applied AFTER the plain `fs.s3a.*`
+   * pass so real vendor keys override conflicting `fs.s3a.*` (the 403-misdirect note below).
+   *
+   * `confEntries` is the caller's one-time snapshot of the Hadoop config (see
+   * `extractObjectStoreOptions`); `hadoopConf` is still used for `${...}` substitution and
+   * targeted per-bucket lookups.
+   */
+  private def translateVendorKeys(
+      confEntries: Seq[(String, String)],
+      hadoopConf: Configuration,
+      scheme: String,
+      defaultBucket: Option[String]): Map[String, String] = {
+    // `fs.<scheme>.<authority>.<property>`; scheme is regex-quoted (may contain `.`/`+`/`-`).
+    val vendorKeyPattern = ("^fs\\." + Pattern.quote(scheme) + "\\.(.+)\\.([^.]+)$").r
+    val out = scala.collection.mutable.Map[String, String]()
+
+    // Apply `default`-authority keys BEFORE explicit ones. A `default` key (promoted to the
+    // URL-path bucket) and an explicit `fs.<scheme>.<bucket>.*` can resolve to the same
+    // `fs.s3a.bucket.<bucket>.*` scope, and the explicit spelling must win -- which it does only
+    // when written last. Otherwise the winner is whichever config entry is yielded last (hash
+    // order), so the same config could pick either endpoint from one run to the next.
+    val matched = confEntries.flatMap { case (key, value) =>
+      key match {
+        case vendorKeyPattern(authority, property) =>
+          vendorPropertyToS3aSuffix
+            .get(property)
+            .map(suffix => (authority, suffix, substitutedValue(hadoopConf, key, value)))
+        case _ => None
+      }
+    }
+    val (defaults, explicit) = matched.partition(_._1 == vendorDefaultAuthority)
+
+    (defaults ++ explicit).foreach { case (authority, suffix, value) =>
+      val bucket =
+        if (authority == vendorDefaultAuthority) defaultBucket else Some(authority)
+      val scope = bucket.map(b => s"fs.s3a.bucket.$b").getOrElse("fs.s3a")
+      out(s"$scope.$suffix") = value
+      if (suffix == "endpoint" && !userSetPathStyle(hadoopConf, bucket)) {
+        out.getOrElseUpdate(s"$scope.path.style.access", "true")
+      }
+    }
+    out.toMap
+  }
+
+  /**
+   * Extract object store configs (S3, GCS, Azure, ...) from the Hadoop configuration for native
+   * DataFusion. Captures global and per-bucket keys; native code prefers per-bucket.
+   *
+   * A scheme listed in `COMET_S3_COMPLIANT_SCHEMES_KEY` reuses the `fs.s3a.*` surface, and its
+   * vendor `fs.<scheme>.<authority>.*` keys are translated to `fs.s3a.*` (see
+   * `translateVendorKeys`) AFTER the `fs.s3a.*` pass, so real vendor values override conflicting
+   * `fs.s3a.*` that would otherwise misdirect credentials to a 403. Empty by default: no alias
+   * scheme unless opted in.
+   *
+   * The result feeds object_store's parse_url_opts natively.
    */
   def extractObjectStoreOptions(hadoopConf: Configuration, uri: URI): Map[String, String] = {
     val scheme = Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)).getOrElse("file")
@@ -60,25 +196,43 @@ object NativeConfig {
     import scala.jdk.CollectionConverters._
     val options = scala.collection.mutable.Map[String, String]()
 
-    // The schemes will use libhdfs
+    // Scheme lists consumed on the native side ride along in the options map (both empty by
+    // default). Copy through when set.
     val libhdfsSchemes = hadoopConf.get(COMET_LIBHDFS_SCHEMES_KEY)
     if (StringUtils.isNotBlank(libhdfsSchemes)) {
       options(COMET_LIBHDFS_SCHEMES_KEY) = libhdfsSchemes
     }
+    val s3CompliantRaw = hadoopConf.get(COMET_S3_COMPLIANT_SCHEMES_KEY)
+    if (StringUtils.isNotBlank(s3CompliantRaw)) {
+      options(COMET_S3_COMPLIANT_SCHEMES_KEY) = s3CompliantRaw
+    }
+    val s3CompliantSchemes = parseSchemeSet(s3CompliantRaw)
 
-    // Get prefixes for this scheme, return early if none found
-    val prefixes = objectStoreConfigPrefixes.get(scheme)
+    // Prefixes for this scheme; a configured S3-compliant alias reuses the fs.s3a.* surface.
+    val prefixes = objectStoreConfigPrefixes.get(scheme).orElse {
+      if (s3CompliantSchemes.contains(scheme)) objectStoreConfigPrefixes.get("s3a") else None
+    }
     if (prefixes.isEmpty) {
       return options.toMap
     }
 
+    // Materialize the Hadoop config once: `iterator()` rebuilds a full copy of the property map on
+    // every call, so we reuse this snapshot for the prefix pass and the vendor translation below.
+    val entries = hadoopConf.iterator().asScala.map(e => e.getKey -> e.getValue).toVector
+
     // Extract all configurations that match the object store prefixes
-    hadoopConf.iterator().asScala.foreach { entry =>
-      val key = entry.getKey
-      // Check if key starts with any of the prefixes for this scheme
+    entries.foreach { case (key, value) =>
       if (prefixes.get.exists(prefix => key.startsWith(prefix))) {
-        options(key) = substitutedValue(hadoopConf, key, entry.getValue)
+        options(key) = substitutedValue(hadoopConf, key, value)
       }
+    }
+
+    // Configured S3-compliant scheme: translate vendor keys AFTER the fs.s3a.* pass so real vendor
+    // values override conflicting fs.s3a.*. Pass the resolved bucket so `fs.<scheme>.default.*`
+    // lands at that bucket's scope.
+    if (s3CompliantSchemes.contains(scheme)) {
+      translateVendorKeys(entries, hadoopConf, scheme, bucketForUri(uri, s3CompliantSchemes))
+        .foreach { case (k, v) => options(k) = v }
     }
 
     options.toMap

--- a/spark/src/main/scala/org/apache/comet/objectstore/NativeConfig.scala
+++ b/spark/src/main/scala/org/apache/comet/objectstore/NativeConfig.scala
@@ -50,15 +50,33 @@ object NativeConfig {
   // `fs.s3a.*`, because native `get_config` checks per-bucket before global.
   private val vendorDefaultAuthority = "default"
 
-  // Recognized vendor properties -> `fs.s3a` suffix. Mirrors CometIcebergNativeScan's target set.
-  // Unknown properties are dropped.
-  private val vendorPropertyToS3aSuffix = Map(
-    "awsAccessKeyId" -> "access.key",
-    "awsSecretAccessKey" -> "secret.key",
-    "awsSessionToken" -> "session.token",
-    "endpoint" -> "endpoint",
-    "region" -> "endpoint.region",
-    "pathStyleAccess" -> "path.style.access")
+  /**
+   * The S3 settings Comet plumbs, in the three spellings it has to speak: the vendor-style
+   * camelCase property (`fs.<alias>.<authority>.<vendorName>`), the Hadoop S3A suffix
+   * (`fs.s3a.<s3aSuffix>`), and the iceberg-rust catalog key. The camelCase spellings are the
+   * ones vendor-branded S3A forks expose; they are not a Hadoop or AWS standard. Single source of
+   * truth so adding a setting is one edit rather than one per direction; the user-facing table in
+   * `docs/source/user-guide/latest/datasources.md` mirrors the first two columns.
+   */
+  private val s3Properties: Seq[(String, String, String)] = Seq(
+    ("awsAccessKeyId", "access.key", "s3.access-key-id"),
+    ("awsSecretAccessKey", "secret.key", "s3.secret-access-key"),
+    ("awsSessionToken", "session.token", "s3.session-token"),
+    ("endpoint", "endpoint", "s3.endpoint"),
+    ("region", "endpoint.region", "s3.region"),
+    ("pathStyleAccess", "path.style.access", "s3.path-style-access"))
+
+  // Vendor property -> `fs.s3a` suffix. Unknown properties are dropped.
+  private val vendorPropertyToS3aSuffix: Map[String, String] =
+    s3Properties.map { case (vendor, s3aSuffix, _) => vendor -> s3aSuffix }.toMap
+
+  /** Maps a Hadoop `fs.s3a.*` property suffix to its GLOBAL iceberg-rust `s3.*` key. */
+  private[comet] val s3aSuffixToIcebergGlobalKey: Map[String, String] =
+    s3Properties.map { case (_, s3aSuffix, icebergKey) => s3aSuffix -> icebergKey }.toMap
+
+  /** A URI's scheme, lowercased; None when it has none. */
+  private[comet] def lowerScheme(uri: URI): Option[String] =
+    Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT))
 
   // Comma-separated scheme list -> trimmed, lowercased set (case-insensitive). Shared with
   // CometScanRule's scheme gate so the JVM admit-decision and native rewrite parse identically.
@@ -75,6 +93,16 @@ object NativeConfig {
     parseSchemeSet(hadoopConf.get(COMET_S3_COMPLIANT_SCHEMES_KEY))
 
   /**
+   * Java-callable view of [[resolveS3CompliantSchemes]], so `CometFileKeyUnwrapper` folds exactly
+   * the schemes this object admits instead of parsing the config a second time. Public (not
+   * `private[comet]`) so Scala emits the static forwarder the Java caller uses.
+   */
+  def resolveS3CompliantSchemesAsJava(hadoopConf: Configuration): java.util.Set[String] = {
+    import scala.jdk.CollectionConverters._
+    resolveS3CompliantSchemes(hadoopConf).asJava
+  }
+
+  /**
    * The S3 bucket a URI addresses: its authority, or the first path segment for the authorityless
    * `blob:///bucket/key` form (matching the native rewrite that promotes it into the host).
    * Returns None for a non-S3-family scheme, so a local Hadoop-catalog
@@ -83,8 +111,7 @@ object NativeConfig {
    * per-bucket surface. Callers therefore need no scheme check of their own.
    */
   private[comet] def bucketForUri(uri: URI, s3CompliantSchemes: Set[String]): Option[String] = {
-    val scheme = Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)).getOrElse("")
-    if (!isS3FamilyScheme(scheme, s3CompliantSchemes)) {
+    if (!lowerScheme(uri).exists(isS3FamilyScheme(_, s3CompliantSchemes))) {
       None
     } else {
       Option(uri.getAuthority)
@@ -176,7 +203,7 @@ object NativeConfig {
     val options = scala.collection.mutable.Map[String, String]()
 
     // Scheme lists consumed on the native side ride along in the options map (both empty by
-    // default). Copy through when set.
+    // default).
     val libhdfsSchemes = hadoopConf.get(COMET_LIBHDFS_SCHEMES_KEY)
     if (StringUtils.isNotBlank(libhdfsSchemes)) {
       options(COMET_LIBHDFS_SCHEMES_KEY) = libhdfsSchemes
@@ -199,14 +226,16 @@ object NativeConfig {
     // AFTER the whole fs.s3a.* pass (so real vendor values win a conflict). Collect them during
     // the single walk of the config below rather than making a second pass: `iterator()` rebuilds
     // a full copy of the property map on every call.
-    val vendorPrefix = if (s3CompliantSchemes.contains(scheme)) s"fs.$scheme." else null
+    // Empty when the scheme is not an opted-in alias, so the guard below costs one `nonEmpty`
+    // rather than an Option allocation per Hadoop property.
+    val vendorPrefix = if (s3CompliantSchemes.contains(scheme)) s"fs.$scheme." else ""
     val vendorEntries = scala.collection.mutable.ArrayBuffer[(String, String)]()
 
     hadoopConf.iterator().asScala.foreach { entry =>
       val key = entry.getKey
       if (prefixes.get.exists(prefix => key.startsWith(prefix))) {
         options(key) = substitutedValue(hadoopConf, key, entry.getValue)
-      } else if (vendorPrefix != null && key.startsWith(vendorPrefix)) {
+      } else if (vendorPrefix.nonEmpty && key.startsWith(vendorPrefix)) {
         vendorEntries +=
           key.substring(vendorPrefix.length) -> substitutedValue(hadoopConf, key, entry.getValue)
       }

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -1223,8 +1223,8 @@ object CometScanRule extends Logging {
    * S3-compliant aliases like `blob` are opt-in via `fs.comet.s3Compliant.schemes` (see
    * `isIcebergReadableScheme`), not hardcoded, since the native planner opens them via S3. The
    * write path keeps its own list (`CometIcebergNativeWrite.SupportedStorageSchemes`), which
-   * differs deliberately: it excludes `oss` (fails closed, see `storage_factory_for`) and includes
-   * `memory`.
+   * differs deliberately: it excludes `oss` (fails closed, see `storage_factory_for`) and
+   * includes `memory`.
    */
   private val icebergReadableSchemes: Set[String] =
     Set("file", "s3", "s3a", "gs", "oss")

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -591,9 +591,9 @@ case class CometScanRule(session: SparkSession)
         val allSupportedFilesystems = if (taskValidation.unsupportedSchemes.isEmpty) {
           true
         } else {
-          fallbackReasons += "Iceberg scan contains files with unsupported filesystem " +
-            s"schemes: ${taskValidation.unsupportedSchemes.mkString(", ")}. " +
-            "Comet only supports: file, s3, s3a, gs, gcs, oss, abfss, abfs, wasbs, wasb"
+          fallbackReasons += "Iceberg scan contains files with filesystem schemes not " +
+            "recognized by Comet's native object_store: " +
+            s"${taskValidation.unsupportedSchemes.toSeq.sorted.mkString(", ")}"
           false
         }
 
@@ -976,6 +976,26 @@ object CometScanRule extends Logging {
     org.apache.spark.sql.catalyst.trees.TreeNodeTag[Unit]("comet.skipCometScan")
 
   /**
+   * Schemes readable by iceberg-rust's OpenDAL storage factory that `ObjectStoreScheme::parse`
+   * does NOT recognize, so `isNativelyReadableScheme` alone under-admits for iceberg scans.
+   * Mirror of the extra `match` arms in
+   * `native/core/src/execution/operators/iceberg_scan.rs::storage_factory_for` -- add here what
+   * you add there. Currently Aliyun OSS via `OpenDalStorageFactory::Oss`.
+   */
+  private val icebergExtraSchemes: Set[String] = Set("oss")
+
+  /**
+   * Scheme gate for the Iceberg scan path. Accepts anything the Parquet scan gate accepts, plus
+   * schemes iceberg-rust reads via OpenDAL that object_store's parser doesn't recognize.
+   */
+  private[rules] def isIcebergReadableScheme(uri: URI): Boolean = {
+    if (isNativelyReadableScheme(uri)) return true
+    Option(uri.getScheme)
+      .map(_.toLowerCase(Locale.ROOT))
+      .exists(icebergExtraSchemes.contains)
+  }
+
+  /**
    * Single-pass validation of Iceberg FileScanTasks.
    *
    * Consolidates file format, filesystem scheme, residual transform, and delete file checks into
@@ -999,9 +1019,6 @@ object CometScanRule extends Logging {
     val deletesMethod = IcebergReflection.getMethod(fileScanTaskClass, "deletes")
     val termMethod = IcebergReflection.getMethod(unboundPredicateClass, "term")
 
-    val supportedSchemes =
-      Set("file", "s3", "s3a", "gs", "gcs", "oss", "abfss", "abfs", "wasbs", "wasb")
-
     var allParquet = true
     val unsupportedSchemes = mutable.Set[String]()
     var nonIdentityTransform: Option[String] = None
@@ -1016,12 +1033,14 @@ object CometScanRule extends Logging {
         allParquet = false
       }
 
-      // Filesystem scheme check for data file
+      // Filesystem scheme check for data file. Delegated to the native gate
+      // (`isNativelyReadableScheme` -> `NativeBase.isObjectStoreSchemeSupported`) so the iceberg
+      // and Parquet-scan paths share a single source of truth.
       try {
         val filePath = pathMethod.invoke(dataFile).toString
         val uri = new URI(filePath)
         val scheme = uri.getScheme
-        if (scheme != null && !supportedSchemes.contains(scheme)) {
+        if (scheme != null && !isIcebergReadableScheme(uri)) {
           unsupportedSchemes += scheme
         }
       } catch {
@@ -1059,7 +1078,7 @@ object CometScanRule extends Logging {
                 try {
                   val deleteUri = new URI(deletePath)
                   val deleteScheme = deleteUri.getScheme
-                  if (deleteScheme != null && !supportedSchemes.contains(deleteScheme)) {
+                  if (deleteScheme != null && !isIcebergReadableScheme(deleteUri)) {
                     unsupportedSchemes += deleteScheme
                   }
                 } catch {

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -258,17 +258,21 @@ case class CometScanRule(session: SparkSession)
     // Spark even though native can read it -- a silent regression for HDFS users in the default
     // configuration. So default to `Set("hdfs")` to stay in lockstep with the native default.
     val libhdfsSchemes: Set[String] = COMET_LIBHDFS_SCHEMES.get() match {
-      case Some(s) =>
-        s.split(",").map(_.trim.toLowerCase(Locale.ROOT)).filter(_.nonEmpty).toSet
+      case Some(s) => NativeConfig.parseSchemeSet(s)
       case None => Set("hdfs")
     }
-    val unsupportedFsSchemes = r.location.rootPaths
-      .map(_.toUri)
+    // Opt-in S3-compliant alias schemes (e.g. `blob`) from `fs.comet.s3Compliant.schemes`. The
+    // native object_store gate no longer claims aliases, so admit them here where the Hadoop
+    // config is available. Resolved once, not per root path.
+    val s3CompliantSchemes = NativeConfig.resolveS3CompliantSchemes(hadoopConf)
+    val rootUris = r.location.rootPaths.map(_.toUri)
+    val unsupportedFsSchemes = rootUris
       .filter { uri =>
         val sch = uri.getScheme
         sch != null && {
           val sl = sch.toLowerCase(Locale.ROOT)
-          !libhdfsSchemes.contains(sl) && !CometScanRule.isNativelyReadableScheme(uri)
+          !libhdfsSchemes.contains(sl) &&
+          !CometScanRule.isNativelyReadableScheme(uri, s3CompliantSchemes)
         }
       }
       .map(_.getScheme.toLowerCase(Locale.ROOT))
@@ -277,6 +281,40 @@ case class CometScanRule(session: SparkSession)
       withFallbackReason(
         scanExec,
         s"Unsupported filesystem schemes: ${unsupportedFsSchemes.mkString(", ")}")
+      return None
+    }
+    // Native planning registers ONE object store per FilePartition (keyed on the first file's
+    // bucket) and strips the authority from every file's object key, so a partition whose files
+    // span multiple buckets silently reads every key from the first file's bucket. Spark's
+    // FilePartition bin-packing can co-locate files from different root paths (hence buckets) in
+    // one partition, so decline when this scan's opt-in alias paths span more than one bucket. The
+    // same single-store limitation pre-exists for plain s3:// and is out of scope here; this guards
+    // only the alias reads CometScanRule newly admits.
+    val mixedAliasBuckets = CometScanRule.mixedAliasScanBuckets(rootUris, s3CompliantSchemes)
+    if (mixedAliasBuckets.nonEmpty) {
+      withFallbackReason(
+        scanExec,
+        "Native Parquet scan reads S3-compliant alias paths across multiple buckets " +
+          s"(${mixedAliasBuckets.toSeq.sorted.mkString(", ")}); Comet registers one object store " +
+          "per file partition and would read every file from the first file's bucket")
+      return None
+    }
+    // A scheme object_store recognizes can still carry a path it rejects (e.g. a directory whose
+    // name contains a newline -> `%0A` in the URI). `isNativelyReadableScheme`'s cache stays
+    // path-independent; here we probe the real path so native execution can't hard-fail with
+    // `Generic URL error` on a location Spark reads fine. Only object_store-native schemes are
+    // probed: aliases (normalized to s3:// natively) and libhdfs schemes route elsewhere.
+    val objectStoreRejectedPath = rootUris.find { uri =>
+      Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)).exists { sl =>
+        !libhdfsSchemes.contains(sl) && !s3CompliantSchemes.contains(sl) &&
+        !CometScanRule.objectStoreAcceptsPath(uri)
+      }
+    }
+    if (objectStoreRejectedPath.nonEmpty) {
+      withFallbackReason(
+        scanExec,
+        s"Native Parquet scan cannot open path '${objectStoreRejectedPath.get}': object_store " +
+          "rejects it (e.g. an unsupported character in the path)")
       return None
     }
     // Disabling the vectorized reader opts into parquet-mr's permissive behavior
@@ -444,6 +482,46 @@ case class CometScanRule(session: SparkSession)
             s"${scanExec.scan.getClass.getSimpleName}: Schema not supported"
         }
 
+        // Build the Hadoop conf once for this scan and reuse it below (metadata extraction, the
+        // file-scheme gate) rather than rebuilding a Configuration per read. Also resolve the
+        // opt-in S3-compliant alias schemes (e.g. `blob`) from `fs.comet.s3Compliant.schemes` once,
+        // shared by per-bucket resolution and the file-scheme gate and its fallback message.
+        val hadoopConf = session.sessionState.newHadoopConf()
+        val s3CompliantSchemes = NativeConfig.resolveS3CompliantSchemes(hadoopConf)
+
+        // Validate the FileScanTasks up front: the data/delete file buckets it resolves decide
+        // which bucket's per-bucket S3 settings the single native FileIO consumes (see
+        // catalogProperties below), so this must run before we build them. Sourcing tasks directly
+        // mirrors what `extract` does internally (both call the same cached `tasks()` accessor).
+        val taskValidation =
+          try {
+            IcebergReflection.getTasks(scanExec.scan) match {
+              case Some(tasks) =>
+                CometScanRule.validateIcebergFileScanTasks(tasks, s3CompliantSchemes)
+              case None =>
+                fallbackReasons += "Iceberg reflection failure: Could not extract FileScanTasks"
+                return withFallbackReasons(scanExec, fallbackReasons.toSet)
+            }
+          } catch {
+            case e: Exception =>
+              fallbackReasons += "Iceberg reflection failure: Could not validate " +
+                s"FileScanTasks: ${e.getMessage}"
+              return withFallbackReasons(scanExec, fallbackReasons.toSet)
+          }
+
+        // The native FileIO reads DATA and DELETE files; the metadata JSON was already read
+        // JVM-side during planning. Its single global S3 config therefore targets the data bucket,
+        // NOT the metadata bucket. When data/delete files span multiple S3 buckets, one FileIO
+        // cannot carry each bucket's per-bucket endpoint/credentials, so fall back.
+        if (taskValidation.dataFileBuckets.size > 1) {
+          fallbackReasons += "Iceberg scan reads data/delete files across multiple S3 buckets " +
+            s"(${taskValidation.dataFileBuckets.toSeq.sorted.mkString(", ")}); Comet's native " +
+            "reader uses a single object-store configuration per scan and cannot apply " +
+            "per-bucket S3 settings to each"
+          return withFallbackReasons(scanExec, fallbackReasons.toSet)
+        }
+        val icebergDataBucket: Option[String] = taskValidation.dataFileBuckets.headOption
+
         // Extract all Iceberg metadata once using reflection.
         // If any required reflection fails, this returns None, and we fall back to Spark.
         // First get metadataLocation and catalogProperties which are needed by the factory.
@@ -455,9 +533,6 @@ case class CometScanRule(session: SparkSession)
 
         val metadataOpt = metadataLocationOpt.flatMap { metadataLocation =>
           try {
-            val session = org.apache.spark.sql.SparkSession.active
-            val hadoopConf = session.sessionState.newHadoopConf()
-
             // For REST catalogs, the metadata file may not exist on disk since metadata
             // is fetched via HTTP. Check if file exists; if not, use table location instead.
             val metadataUri = new java.net.URI(metadataLocation)
@@ -489,8 +564,16 @@ case class CometScanRule(session: SparkSession)
 
             val hadoopS3Options = NativeConfig.extractObjectStoreOptions(hadoopConf, effectiveUri)
 
+            // Promote the DATA bucket's per-bucket `fs.s3a.bucket.<b>.*` settings to global (what
+            // the native FileIO reads), NOT the metadata bucket's: the FileIO opens data/delete
+            // files, and Iceberg allows a data location (`write.data.path`) in a different bucket
+            // than the metadata. `icebergDataBucket` is the single bucket those files resolve to
+            // (multi-bucket already fell back above); None for a local/GCS/OSS table needs no
+            // promotion.
             val hadoopDerivedProperties =
-              CometIcebergNativeScan.hadoopToIcebergS3Properties(hadoopS3Options)
+              CometIcebergNativeScan.hadoopToIcebergS3Properties(
+                hadoopS3Options,
+                icebergDataBucket)
 
             // Forward the full FileIO property bag (including credentials.uri, OAuth tokens,
             // tenant-id, etc.) so a CometS3CredentialProvider can see everything LoadTableResponse
@@ -501,7 +584,16 @@ case class CometScanRule(session: SparkSession)
               .flatMap(IcebergReflection.getFileIOProperties)
               .getOrElse(Map.empty)
 
-            val catalogProperties = hadoopDerivedProperties ++ fileIOProperties
+            // Iceberg reads the alias opt-in from catalog_properties (IcebergScanCommon has no
+            // object_store_options), and hadoopToIcebergS3Properties drops non-fs.s3a keys, so
+            // re-add it. load_file_io narrows catalog_properties to storage-prefix keys before
+            // iceberg-rust's FileIO, so the alias key never reaches FileIO -- but it is still
+            // handed, unfiltered, to CometS3CredentialBridge, so a custom credential provider sees
+            // it. That is intended: the provider gets the full property bag.
+            val catalogProperties = hadoopDerivedProperties ++ fileIOProperties ++
+              hadoopS3Options
+                .get(COMET_S3_COMPLIANT_SCHEMES_KEY)
+                .map(COMET_S3_COMPLIANT_SCHEMES_KEY -> _)
 
             val result = CometIcebergNativeScanMetadata
               .extract(scanExec.scan, effectiveLocation, catalogProperties)
@@ -523,6 +615,24 @@ case class CometScanRule(session: SparkSession)
             fallbackReasons += "Failed to extract Iceberg metadata via reflection"
             return withFallbackReasons(scanExec, fallbackReasons.toSet)
         }
+
+        // Gate the metadata location's scheme. It is the string storage_factory_for /
+        // load_file_io dispatch on, yet unlike the data- and delete-file paths (gated in
+        // validateIcebergFileScanTasks) it otherwise reaches native unchecked: an unsupported
+        // scheme would be claimed by the planner, then die at execution with `Unsupported
+        // storage scheme`. metadata.metadataLocation is the effectiveLocation extract() was
+        // handed, already parsed above. Schemeless local-catalog paths pass.
+        val metadataUri = new java.net.URI(metadata.metadataLocation)
+        val metadataSchemeSupported =
+          if (CometScanRule.isIcebergReadableScheme(metadataUri, s3CompliantSchemes)) {
+            true
+          } else {
+            fallbackReasons += "Iceberg metadata location uses filesystem scheme " +
+              s"'${metadataUri.getScheme}', which Comet's native Iceberg reader cannot open " +
+              "(object_store may recognize it but iceberg-rust's storage factory cannot build " +
+              s"it). ${CometScanRule.icebergSupportedSchemesMessage(s3CompliantSchemes)}"
+            false
+          }
 
         // Now perform all validation using the pre-extracted metadata
         // Check if table uses a FileIO implementation compatible with iceberg-rust.
@@ -654,25 +764,34 @@ case class CometScanRule(session: SparkSession)
               false
           }
 
-        // Single-pass validation of all FileScanTasks
-        val taskValidation =
-          try {
-            CometScanRule.validateIcebergFileScanTasks(metadata.tasks)
-          } catch {
-            case e: Exception =>
-              fallbackReasons += "Iceberg reflection failure: Could not validate " +
-                s"FileScanTasks: ${e.getMessage}"
-              return withFallbackReasons(scanExec, fallbackReasons.toSet)
-          }
-
-        // Check if all files are Parquet format and use supported filesystem schemes
+        // Check if all files are Parquet format and use supported filesystem schemes. The Iceberg
+        // gate is a narrower allowlist than the Parquet native gate: object_store recognizes
+        // schemes iceberg-rust cannot build, so those are rejected here and we tell the user which
+        // schemes ARE supported. (FileScanTask validation ran once, up front; see taskValidation.)
         val allSupportedFilesystems = if (taskValidation.unsupportedSchemes.isEmpty) {
           true
         } else {
-          fallbackReasons += "Iceberg scan contains files with unsupported filesystem " +
-            s"schemes: ${taskValidation.unsupportedSchemes.mkString(", ")}. " +
-            "Comet only supports: file, s3, s3a, gs, gcs, oss, abfss, abfs, wasbs, wasb"
+          fallbackReasons += "Iceberg scan contains files with filesystem schemes not supported " +
+            "by Comet's native Iceberg reader (object_store recognizes them but iceberg-rust's " +
+            "storage factory cannot build them): " +
+            s"${taskValidation.unsupportedSchemes.toSeq.sorted.mkString(", ")}. " +
+            CometScanRule.icebergSupportedSchemesMessage(s3CompliantSchemes)
           false
+        }
+
+        // iceberg-rust opens data/delete files by their raw recorded location. Its S3/GCS/OSS
+        // backends derive the bucket from the URL host and do NOT promote it from the key, so a
+        // hostless non-alias location fails at execution with a missing-bucket error. Opt-in
+        // S3-compliant aliases are exempt: the native reader promotes the bucket from the first
+        // path segment at the open boundary, so a hostless `blob:///bucket/key.parquet` is openable
+        // (see isIcebergOpenableLocation). Decline only the still-unopenable scans here.
+        val allLocationsOpenable = taskValidation.hostlessLocation match {
+          case Some(loc) =>
+            fallbackReasons += "Iceberg scan references a data/delete file location without a " +
+              s"URL host ('$loc'); Comet's native Iceberg reader opens files by their raw " +
+              "location and cannot promote a bucket from the path"
+            false
+          case None => true
         }
 
         if (!taskValidation.allParquet) {
@@ -916,8 +1035,8 @@ case class CometScanRule(session: SparkSession)
 
         if (schemaSupported && fileIOCompatible && formatVersionSupported &&
           defaultValuesSupported && schemaTypesSupported && encryptionKeyLengthSupported &&
-          taskValidation.allParquet && allSupportedFilesystems && partitionTypesSupported &&
-          unifiedPartitionTypeSupported &&
+          taskValidation.allParquet && allSupportedFilesystems && allLocationsOpenable &&
+          metadataSchemeSupported && partitionTypesSupported && unifiedPartitionTypeSupported &&
           complexTypePredicatesSupported && transformFunctionsSupported &&
           deleteFileTypesSupported && dppSubqueriesSupported) {
           CometBatchScanExec(
@@ -1018,31 +1137,82 @@ case class CometScanTypeChecker() extends DataTypeSupport with CometTypeShim {
 
 object CometScanRule extends Logging {
 
-  // Per-scheme memo of `NativeBase.isObjectStoreSchemeSupported`. The answer depends only on the
-  // URL scheme, so we cache by scheme and never re-cross the JNI boundary for a repeated scheme.
+  // Memo of `NativeBase.isObjectStoreSchemeSupported`, keyed by (scheme, has-authority) because
+  // object_store's parser keys on that pair (host-based stores need a host, file/memory need
+  // none). Caching by scheme alone lets an authorityless URL poison the whole scheme's answer.
   private val schemeSupportCache =
-    new ConcurrentHashMap[String, JBoolean]()
+    new ConcurrentHashMap[(String, Boolean), JBoolean]()
 
   /**
-   * True when Comet's native object_store layer recognizes this URI's scheme (so the scan is
-   * natively readable). Delegates to the native layer -- the source of truth -- instead of a
-   * hardcoded scheme list. On any failure to consult native (e.g. the library isn't loaded on
-   * this JVM, or predates this method) we assume the scheme IS supported: the scheme gate is an
-   * early-fallback optimization, and a build without a working native library can't run Comet's
-   * native scan anyway, so declining here would only over-restrict.
+   * True when Comet's native Parquet scan can read this URI's scheme: object_store recognizes it
+   * (asked of the native layer, the source of truth) OR it is an opt-in S3-compliant alias. If
+   * native can't be consulted (library not loaded), assume supported -- the gate is only an
+   * early-fallback optimization and such a build can't run the native scan anyway.
    */
-  private[rules] def isNativelyReadableScheme(uri: URI): Boolean = {
+  private[rules] def isNativelyReadableScheme(
+      uri: URI,
+      s3CompliantSchemes: Set[String]): Boolean = {
     val scheme = uri.getScheme
     if (scheme == null) return true
+    val lower = scheme.toLowerCase(Locale.ROOT)
+    if (s3CompliantSchemes.contains(lower)) return true
+    val hasAuthority = uri.getRawAuthority != null
     schemeSupportCache
       .computeIfAbsent(
-        scheme.toLowerCase(Locale.ROOT),
-        _ =>
-          try JBoolean.valueOf(NativeBase.isObjectStoreSchemeSupported(uri.toString))
-          catch {
-            case _: Throwable => JBoolean.TRUE
-          })
+        (lower, hasAuthority),
+        _ => {
+          // Probe a scheme(+fixed dummy host) URL, never the caller's authority/path: object_store
+          // keys on (scheme, host-presence) so we cache/probe by that pair. A fixed host stops an
+          // authorityless URL poisoning the authority-bearing form; dropping the real path avoids a
+          // spurious `false` from chars object_store rejects in a `Path` (e.g. Iceberg's `p=%0A`).
+          val probe = if (hasAuthority) s"$lower://comet-probe-host/" else s"$lower:///"
+          JBoolean.valueOf(probeObjectStore(probe))
+        })
       .booleanValue()
+  }
+
+  /**
+   * Ask the native object_store parser whether it can build `url` (scheme +
+   * `Path::from_url_path`). On any native error (e.g. the library isn't loaded), assume yes: the
+   * scheme/path gates are only early-fallback optimizations, and such a build can't run the
+   * native scan anyway. Single source of truth for that assume-supported-on-failure policy,
+   * shared by the cached scheme probe in [[isNativelyReadableScheme]] and the uncached real-path
+   * probe in [[objectStoreAcceptsPath]].
+   */
+  private def probeObjectStore(url: String): Boolean =
+    try NativeBase.isObjectStoreSchemeSupported(url)
+    catch { case _: Throwable => true }
+
+  /**
+   * True when object_store can actually open THIS exact path, not just recognize its scheme.
+   * `ObjectStoreScheme::parse` ends in `Path::from_url_path`, which rejects characters
+   * object_store forbids in a key (e.g. a directory name containing a newline, `%0A` in the URI).
+   * The scheme cache in [[isNativelyReadableScheme]] stays path-independent; this uncached,
+   * per-path probe catches a valid-scheme path native execution would otherwise hard-fail on,
+   * letting the scan fall back cleanly. Meaningful only for object_store-native schemes (callers
+   * skip aliases, which native normalizes to `s3://`, and libhdfs schemes).
+   */
+  private[rules] def objectStoreAcceptsPath(uri: URI): Boolean =
+    probeObjectStore(uri.toString)
+
+  /**
+   * The distinct buckets a mixed-bucket S3-compliant-alias scan would (wrongly) read from a
+   * single object store, or empty when the scan is safe. Non-empty means the Parquet gate must
+   * fall back: native planning registers one object store per FilePartition (keyed on the first
+   * file's bucket) and strips the authority from every file's object key, so files in a second
+   * bucket are read from the first. Scoped to scans that actually use an opt-in alias -- the same
+   * single-store limitation pre-exists for plain `s3://` and is intentionally left untouched
+   * here.
+   */
+  private[rules] def mixedAliasScanBuckets(
+      uris: Seq[URI],
+      s3CompliantSchemes: Set[String]): Set[String] = {
+    val hasAliasPath = uris.exists { uri =>
+      Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)).exists(s3CompliantSchemes.contains)
+    }
+    if (!hasAliasPath) return Set.empty
+    val buckets = NativeConfig.s3FamilyBuckets(uris, s3CompliantSchemes)
+    if (buckets.size > 1) buckets else Set.empty
   }
 
   /**
@@ -1055,12 +1225,80 @@ object CometScanRule extends Logging {
     org.apache.spark.sql.catalyst.trees.TreeNodeTag[Unit]("comet.skipCometScan")
 
   /**
+   * Schemes Comet's native Iceberg scan can actually open, mirroring the match arms in
+   * `native/core/src/execution/operators/iceberg_scan.rs::storage_factory_for`. Deliberately NOT
+   * delegated to `isNativelyReadableScheme`: object_store recognizes schemes (http/https, azure,
+   * memory) that iceberg-rust's OpenDAL storage factory cannot build, and admitting them here
+   * turns a clean JVM fallback into a native runtime "Unsupported storage scheme" error. Add here
+   * what you add to `storage_factory_for` (currently Aliyun `oss` and GCS `gs`). S3-compliant
+   * aliases like `blob` are opt-in via `fs.comet.s3Compliant.schemes` (see
+   * `isIcebergReadableScheme`), not hardcoded, since the native planner opens them via S3.
+   */
+  private val icebergReadableSchemes: Set[String] =
+    Set("file", "s3", "s3a", "gs", "oss")
+
+  /**
+   * "Supported schemes: ..." suffix shared by the Iceberg scheme-fallback messages. Lists the
+   * built-in Iceberg-readable allowlist plus the opt-in S3-compliant aliases.
+   */
+  private[rules] def icebergSupportedSchemesMessage(s3CompliantSchemes: Set[String]): String = {
+    val schemes = (icebergReadableSchemes ++ s3CompliantSchemes).toSeq.sorted.mkString(", ")
+    s"Supported schemes: $schemes"
+  }
+
+  /**
+   * Scheme gate for the Iceberg scan path: admit schemes iceberg-rust's storage factory can build
+   * (`icebergReadableSchemes`) or opt-in S3-compliant aliases (`fs.comet.s3Compliant.schemes`),
+   * plus schemeless local paths (which route to its LocalFs backend).
+   */
+  private[rules] def isIcebergReadableScheme(
+      uri: URI,
+      s3CompliantSchemes: Set[String]): Boolean = {
+    val scheme = uri.getScheme
+    if (scheme == null) return true
+    val lower = scheme.toLowerCase(Locale.ROOT)
+    icebergReadableSchemes.contains(lower) || s3CompliantSchemes.contains(lower)
+  }
+
+  /**
+   * True when iceberg-rust can actually open this exact data/delete file location, not just
+   * recognize its scheme. iceberg-rust opens files by their raw recorded location, and every
+   * backend except LocalFs derives the bucket from the URL host and does NOT promote it from the
+   * key. So a hostless `s3`/`s3a`/`gs`/`oss` location fails with a missing-bucket error and is
+   * not openable. `file` and schemeless paths route to LocalFs and need no host.
+   *
+   * The one exception is an opt-in S3-compliant alias (`fs.comet.s3Compliant.schemes`, e.g.
+   * `blob`): Comet's native reader wraps the S3 backend with `BlobHostPromotingS3Storage` (see
+   * `native/core/.../s3_blob_fs_support.rs`), which promotes the first path segment into the host
+   * at the open boundary. So a hostless alias location like `blob:///bucket/key.parquet` IS
+   * openable, as long as it carries a promotable bucket segment. The promotion is open-only and
+   * never touches the raw string iceberg-rust matches deletes against, so it is delete-safe.
+   */
+  private[rules] def isIcebergOpenableLocation(
+      uri: URI,
+      s3CompliantSchemes: Set[String]): Boolean = {
+    if (!isIcebergReadableScheme(uri, s3CompliantSchemes)) return false
+    Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)) match {
+      case None | Some("file") => true
+      case Some(_) if uri.getRawAuthority != null => true
+      // Hostless: only an opt-in S3-compliant alias can be opened, by promoting the bucket from the
+      // first path segment natively. Other schemes still need a host.
+      case Some(scheme) if s3CompliantSchemes.contains(scheme) =>
+        NativeConfig.bucketForUri(uri, s3CompliantSchemes).isDefined
+      case Some(_) => false
+    }
+  }
+
+  /**
    * Single-pass validation of Iceberg FileScanTasks.
    *
-   * Consolidates file format, filesystem scheme, residual transform, and delete file checks into
-   * one iteration for better performance with large tables.
+   * Consolidates file format, filesystem scheme, per-location openability (host presence),
+   * data-bucket collection, residual transform, and delete file checks into one iteration for
+   * better performance with large tables.
    */
-  def validateIcebergFileScanTasks(tasks: java.util.List[_]): IcebergTaskValidationResult = {
+  def validateIcebergFileScanTasks(
+      tasks: java.util.List[_],
+      s3CompliantSchemes: Set[String]): IcebergTaskValidationResult = {
     val contentScanTaskClass =
       IcebergReflection.loadClass(IcebergReflection.ClassNames.CONTENT_SCAN_TASK)
     val contentFileClass =
@@ -1078,13 +1316,37 @@ object CometScanRule extends Logging {
     val deletesMethod = IcebergReflection.getMethod(fileScanTaskClass, "deletes")
     val termMethod = IcebergReflection.getMethod(unboundPredicateClass, "term")
 
-    val supportedSchemes =
-      Set("file", "s3", "s3a", "gs", "gcs", "oss", "abfss", "abfs", "wasbs", "wasb")
-
     var allParquet = true
     val unsupportedSchemes = mutable.Set[String]()
     var nonIdentityTransform: Option[String] = None
     val deleteFiles = new java.util.ArrayList[Any]()
+    // Buckets the native FileIO must read (data + delete files), for the single-config check in
+    // CometScanRule; only S3-family locations contribute (see NativeConfig.s3FamilyBuckets).
+    val dataFileBuckets = mutable.Set[String]()
+    // First data/delete location with a readable scheme but no URL host (see
+    // isIcebergOpenableLocation); non-empty => decline. One example suffices for the message.
+    var hostlessLocation: Option[String] = None
+
+    // Classify one data/delete file location. Uses `isIcebergReadableScheme`, a separate allowlist
+    // intentionally narrower than the Parquet native gate: object_store recognizes schemes
+    // iceberg-rust's OpenDAL storage factory cannot build (http/https/abfs/abfss/wasb/wasbs/
+    // memory), so admitting them here would turn a clean JVM fallback into a native runtime error.
+    def inspectLocation(rawPath: String): Unit = {
+      val uri =
+        try new URI(rawPath)
+        catch { case _: java.net.URISyntaxException => return }
+      Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)) match {
+        case None => // schemeless local path -> iceberg-rust LocalFs, no host needed
+        case Some(scheme) if !isIcebergReadableScheme(uri, s3CompliantSchemes) =>
+          unsupportedSchemes += scheme
+        case Some(_) if !isIcebergOpenableLocation(uri, s3CompliantSchemes) =>
+          if (hostlessLocation.isEmpty) hostlessLocation = Some(rawPath)
+        case Some(scheme) =>
+          if (NativeConfig.isS3FamilyScheme(scheme, s3CompliantSchemes)) {
+            NativeConfig.bucketForUri(uri, s3CompliantSchemes).foreach(dataFileBuckets += _)
+          }
+      }
+    }
 
     tasks.asScala.foreach { task =>
       val dataFile = fileMethod.invoke(task)
@@ -1095,17 +1357,7 @@ object CometScanRule extends Logging {
         allParquet = false
       }
 
-      // Filesystem scheme check for data file
-      try {
-        val filePath = pathMethod.invoke(dataFile).toString
-        val uri = new URI(filePath)
-        val scheme = uri.getScheme
-        if (scheme != null && !supportedSchemes.contains(scheme)) {
-          unsupportedSchemes += scheme
-        }
-      } catch {
-        case _: java.net.URISyntaxException => // ignore
-      }
+      inspectLocation(pathMethod.invoke(dataFile).toString)
 
       // Residual transform check (short-circuit if already found unsupported)
       if (nonIdentityTransform.isEmpty && fileScanTaskClass.isInstance(task)) {
@@ -1134,16 +1386,7 @@ object CometScanRule extends Logging {
 
           deletes.asScala.foreach { deleteFile =>
             IcebergReflection.extractFileLocation(contentFileClass, deleteFile).foreach {
-              deletePath =>
-                try {
-                  val deleteUri = new URI(deletePath)
-                  val deleteScheme = deleteUri.getScheme
-                  if (deleteScheme != null && !supportedSchemes.contains(deleteScheme)) {
-                    unsupportedSchemes += deleteScheme
-                  }
-                } catch {
-                  case _: java.net.URISyntaxException => // ignore
-                }
+              deletePath => inspectLocation(deletePath)
             }
           }
         } catch {
@@ -1156,7 +1399,9 @@ object CometScanRule extends Logging {
       allParquet,
       unsupportedSchemes.toSet,
       nonIdentityTransform,
-      deleteFiles)
+      deleteFiles,
+      dataFileBuckets.toSet,
+      hostlessLocation)
   }
 }
 
@@ -1167,4 +1412,6 @@ case class IcebergTaskValidationResult(
     allParquet: Boolean,
     unsupportedSchemes: Set[String],
     nonIdentityTransform: Option[String],
-    deleteFiles: java.util.List[_])
+    deleteFiles: java.util.List[_],
+    dataFileBuckets: Set[String],
+    hostlessLocation: Option[String])

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -261,17 +261,21 @@ case class CometScanRule(session: SparkSession)
       case Some(s) => NativeConfig.parseSchemeSet(s)
       case None => Set("hdfs")
     }
-    // Opt-in S3-compliant alias schemes (e.g. `blob`) from `fs.comet.s3Compliant.schemes`. The
-    // native object_store gate no longer claims aliases, so admit them here where the Hadoop
-    // config is available. Resolved once, not per root path.
+    // Opt-in S3-compliant alias schemes (e.g. `blob`) from `fs.comet.s3Compliant.schemes`. Read
+    // from the Hadoop config rather than SQLConf (unlike COMET_LIBHDFS_SCHEMES above) so
+    // `core-site.xml` is honored. The native object_store gate no longer claims aliases, so admit
+    // them here where the Hadoop config is available.
     val s3CompliantSchemes = NativeConfig.resolveS3CompliantSchemes(hadoopConf)
-    val rootUris = r.location.rootPaths.map(_.toUri)
-    val unsupportedFsSchemes = rootUris.iterator.flatMap { uri =>
-      Option(uri.getScheme)
-        .map(_.toLowerCase(Locale.ROOT))
-        .filter(sl =>
-          !libhdfsSchemes.contains(sl) &&
-            !CometScanRule.isNativelyReadableScheme(uri, s3CompliantSchemes))
+
+    // Classify each root path once; see RootPathInfo.
+    val roots = CometScanRule.classifyRootPaths(
+      r.location.rootPaths.map(_.toUri),
+      libhdfsSchemes,
+      s3CompliantSchemes)
+
+    val unsupportedFsSchemes = roots.iterator.flatMap { root =>
+      root.scheme.filter(_ =>
+        !root.isLibhdfs && !CometScanRule.isNativelyReadableScheme(root.uri, s3CompliantSchemes))
     }.toSet
     if (unsupportedFsSchemes.nonEmpty) {
       withFallbackReason(
@@ -279,37 +283,32 @@ case class CometScanRule(session: SparkSession)
         s"Unsupported filesystem schemes: ${unsupportedFsSchemes.mkString(", ")}")
       return None
     }
-    // Native planning registers ONE object store per FilePartition (keyed on the first file's
-    // bucket) and strips the authority from every file's object key, so a partition whose files
-    // span multiple buckets silently reads every key from the first file's bucket. Spark's
-    // FilePartition bin-packing can co-locate files from different root paths (hence buckets) in
-    // one partition, so decline when this scan's opt-in alias paths span more than one bucket. The
-    // same single-store limitation pre-exists for plain s3:// and is out of scope here; this guards
-    // only the alias reads CometScanRule newly admits.
-    val mixedAliasBuckets = CometScanRule.mixedAliasScanBuckets(rootUris, s3CompliantSchemes)
-    if (mixedAliasBuckets.nonEmpty) {
+    // More than one bucket cannot be served by the single object store native planning registers
+    // per FilePartition; see aliasScanBuckets. Scoped to alias scans: plain multi-bucket `s3://`
+    // has the same flaw today and silently declining it would newly fall back scans that work by
+    // luck, so that widening is left as a separate decision. Note the sibling Iceberg guard
+    // (dataFileBuckets, below) is NOT so scoped -- it declines multi-bucket `s3a://` too.
+    val scanBuckets = CometScanRule.aliasScanBuckets(roots)
+    if (scanBuckets.size > 1) {
       withFallbackReason(
         scanExec,
         "Native Parquet scan reads S3-compliant alias paths across multiple buckets " +
-          s"(${mixedAliasBuckets.toSeq.sorted.mkString(", ")}); Comet registers one object store " +
+          s"(${scanBuckets.toSeq.sorted.mkString(", ")}); Comet registers one object store " +
           "per file partition and would read every file from the first file's bucket")
       return None
     }
     // A scheme object_store recognizes can still carry a path it rejects (e.g. a directory whose
-    // name contains a newline -> `%0A` in the URI). `isNativelyReadableScheme`'s cache stays
-    // path-independent; here we probe the real path so native execution can't hard-fail with
-    // `Generic URL error` on a location Spark reads fine. Only object_store-native schemes are
-    // probed: aliases (normalized to s3:// natively) and libhdfs schemes route elsewhere.
-    val objectStoreRejectedPath = rootUris.find { uri =>
-      Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)).exists { sl =>
-        !libhdfsSchemes.contains(sl) && !s3CompliantSchemes.contains(sl) &&
-        !CometScanRule.objectStoreAcceptsPath(uri)
-      }
-    }
-    if (objectStoreRejectedPath.nonEmpty) {
+    // name contains a newline -> `%0A` in the URI), which native execution would hard-fail on.
+    // Only object_store-native schemes are probed: aliases (normalized to s3:// natively) and
+    // libhdfs schemes route elsewhere. Root paths only -- a rejected character deeper in the tree
+    // still fails at execution.
+    val rejectedPath = roots.find(root =>
+      root.scheme.isDefined && !root.isLibhdfs && !root.isAlias &&
+        !CometScanRule.objectStoreAcceptsPath(root.uri))
+    if (rejectedPath.nonEmpty) {
       withFallbackReason(
         scanExec,
-        s"Native Parquet scan cannot open path '${objectStoreRejectedPath.get}': object_store " +
+        s"Native Parquet scan cannot open path '${rejectedPath.get.uri}': object_store " +
           "rejects it (e.g. an unsupported character in the path)")
       return None
     }
@@ -478,10 +477,8 @@ case class CometScanRule(session: SparkSession)
             s"${scanExec.scan.getClass.getSimpleName}: Schema not supported"
         }
 
-        // Build the Hadoop conf once for this scan and reuse it below (metadata extraction, the
-        // file-scheme gate) rather than rebuilding a Configuration per read. Also resolve the
-        // opt-in S3-compliant alias schemes (e.g. `blob`) from `fs.comet.s3Compliant.schemes` once,
-        // shared by per-bucket resolution and the file-scheme gate and its fallback message.
+        // Built once and reused below (metadata extraction, the file-scheme gate) rather than
+        // rebuilding a Configuration per read.
         val hadoopConf = session.sessionState.newHadoopConf()
         val s3CompliantSchemes = NativeConfig.resolveS3CompliantSchemes(hadoopConf)
 
@@ -760,10 +757,8 @@ case class CometScanRule(session: SparkSession)
               false
           }
 
-        // Check if all files are Parquet format and use supported filesystem schemes. The Iceberg
-        // gate is a narrower allowlist than the Parquet native gate: object_store recognizes
-        // schemes iceberg-rust cannot build, so those are rejected here and we tell the user which
-        // schemes ARE supported. (FileScanTask validation ran once, up front; see taskValidation.)
+        // Check if all files are Parquet format and use supported filesystem schemes.
+        // (FileScanTask validation ran once, up front; see taskValidation.)
         val allSupportedFilesystems = if (taskValidation.unsupportedSchemes.isEmpty) {
           true
         } else {
@@ -775,12 +770,7 @@ case class CometScanRule(session: SparkSession)
           false
         }
 
-        // iceberg-rust opens data/delete files by their raw recorded location. Its S3/GCS/OSS
-        // backends derive the bucket from the URL host and do NOT promote it from the key, so a
-        // hostless non-alias location fails at execution with a missing-bucket error. Opt-in
-        // S3-compliant aliases are exempt: the native reader promotes the bucket from the first
-        // path segment at the open boundary, so a hostless `blob:///bucket/key.parquet` is openable
-        // (see hasOpenableAuthority). Decline only the still-unopenable scans here.
+        // Hostless non-alias locations are unopenable; see hasOpenableAuthority.
         val allLocationsOpenable = taskValidation.hostlessLocation match {
           case Some(loc) =>
             fallbackReasons += "Iceberg scan references a data/delete file location without a " +
@@ -1162,46 +1152,57 @@ object CometScanRule extends Logging {
   }
 
   /**
-   * Ask the native object_store parser whether it can build `url` (scheme +
-   * `Path::from_url_path`). On any native error (e.g. the library isn't loaded), assume yes: the
-   * scheme/path gates are only early-fallback optimizations, and such a build can't run the
-   * native scan anyway. Single source of truth for that assume-supported-on-failure policy,
-   * shared by the cached scheme probe in [[isNativelyReadableScheme]] and the uncached real-path
-   * probe in [[objectStoreAcceptsPath]].
+   * A scan root path with the classification the V1 scheme gates share, computed once so the
+   * gates cannot disagree about which schemes each of them exempts.
+   */
+  private[rules] case class RootPathInfo(
+      uri: URI,
+      scheme: Option[String],
+      isLibhdfs: Boolean,
+      isAlias: Boolean,
+      bucket: Option[String])
+
+  private[rules] def classifyRootPaths(
+      uris: Seq[URI],
+      libhdfsSchemes: Set[String],
+      s3CompliantSchemes: Set[String]): Seq[RootPathInfo] =
+    uris.map { uri =>
+      val scheme = NativeConfig.lowerScheme(uri)
+      RootPathInfo(
+        uri,
+        scheme,
+        isLibhdfs = scheme.exists(libhdfsSchemes.contains),
+        isAlias = scheme.exists(s3CompliantSchemes.contains),
+        bucket = NativeConfig.bucketForUri(uri, s3CompliantSchemes))
+    }
+
+  /**
+   * The distinct buckets this scan's root paths address, or empty when none of them uses an
+   * opt-in S3-compliant alias. More than one bucket means the Parquet gate must fall back: native
+   * planning registers one object store per FilePartition (keyed on the first file's bucket) and
+   * strips the authority from every file's object key, so files in a second bucket are read from
+   * the first. Spark's FilePartition bin-packing can co-locate files from different root paths.
+   */
+  private[rules] def aliasScanBuckets(roots: Seq[RootPathInfo]): Set[String] =
+    if (!roots.exists(_.isAlias)) Set.empty else roots.flatMap(_.bucket).toSet
+
+  /**
+   * Ask the native object_store parser whether it can build `url`: both the scheme and, via
+   * `Path::from_url_path`, the key. On any native error (e.g. the library isn't loaded), assume
+   * yes -- these gates are only early-fallback optimizations, and such a build can't run the
+   * native scan anyway.
+   *
+   * Callers pass either a synthetic scheme-only probe (cached, see [[isNativelyReadableScheme]])
+   * or a real path (uncached), because `Path::from_url_path` rejects characters object_store
+   * forbids in a key, e.g. a directory name containing a newline (`%0A` in the URI).
    */
   private def probeObjectStore(url: String): Boolean =
     try NativeBase.isObjectStoreSchemeSupported(url)
     catch { case _: Throwable => true }
 
-  /**
-   * True when object_store can open THIS exact path, not just recognize its scheme.
-   * `Path::from_url_path` rejects characters object_store forbids in a key (e.g. a directory name
-   * containing a newline, `%0A` in the URI), which native execution would hard-fail on. Probed
-   * per path and uncached, unlike the path-independent scheme cache above.
-   */
+  /** [[probeObjectStore]] against a URI's real path, not just its scheme. Uncached. */
   private[rules] def objectStoreAcceptsPath(uri: URI): Boolean =
     probeObjectStore(uri.toString)
-
-  /**
-   * The distinct buckets a mixed-bucket S3-compliant-alias scan would (wrongly) read from a
-   * single object store, or empty when the scan is safe. Non-empty means the Parquet gate must
-   * fall back: native planning registers one object store per FilePartition (keyed on the first
-   * file's bucket) and strips the authority from every file's object key, so files in a second
-   * bucket are read from the first. Scoped to scans that actually use an opt-in alias -- the same
-   * single-store limitation pre-exists for plain `s3://` and is intentionally left untouched
-   * here.
-   */
-  private[rules] def mixedAliasScanBuckets(
-      uris: Seq[URI],
-      s3CompliantSchemes: Set[String]): Set[String] = {
-    if (s3CompliantSchemes.isEmpty) return Set.empty
-    val hasAliasPath = uris.exists { uri =>
-      Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)).exists(s3CompliantSchemes.contains)
-    }
-    if (!hasAliasPath) return Set.empty
-    val buckets = uris.iterator.flatMap(NativeConfig.bucketForUri(_, s3CompliantSchemes)).toSet
-    if (buckets.size > 1) buckets else Set.empty
-  }
 
   /**
    * Tag set on a scan (`FileSourceScanExec` or `BatchScanExec`) that should be left as a plain
@@ -1220,7 +1221,10 @@ object CometScanRule extends Logging {
    * here turns a clean JVM fallback into a native runtime "Unsupported storage scheme" error. Add
    * here what you add to `storage_factory_for` (currently Aliyun `oss` and GCS `gs`).
    * S3-compliant aliases like `blob` are opt-in via `fs.comet.s3Compliant.schemes` (see
-   * `isIcebergReadableScheme`), not hardcoded, since the native planner opens them via S3.
+   * `isIcebergReadableScheme`), not hardcoded, since the native planner opens them via S3. The
+   * write path keeps its own list (`CometIcebergNativeWrite.SupportedStorageSchemes`), which
+   * differs deliberately: it excludes `oss` (fails closed, see `storage_factory_for`) and includes
+   * `memory`.
    */
   private val icebergReadableSchemes: Set[String] =
     Set("file", "s3", "s3a", "gs", "oss")
@@ -1256,25 +1260,18 @@ object CometScanRule extends Logging {
    * missing-bucket error and is not openable. `file` and schemeless paths route to LocalFs and
    * need no host.
    *
-   * The one exception is an opt-in S3-compliant alias (`fs.comet.s3Compliant.schemes`, e.g.
-   * `blob`): Comet's native reader wraps the S3 backend with `BlobHostPromotingS3Storage` (see
-   * `native/core/.../s3_blob_fs_support.rs`), which promotes the first path segment into the host
-   * at the open boundary. So a hostless alias location like `blob:///bucket/key.parquet` IS
-   * openable, as long as it carries a promotable bucket segment. The promotion is open-only and
-   * never touches the raw string iceberg-rust matches deletes against, so it is delete-safe.
-   *
-   * `scheme` is the caller's already-lowercased URI scheme (null when there is none), so this
-   * does not re-derive it per data and delete file.
+   * The one exception is an opt-in S3-compliant alias, which the native reader opens by promoting
+   * the bucket from the first path segment (`s3_blob_fs_support.rs`), so a hostless
+   * `blob:///bucket/key.parquet` IS openable when it carries a promotable bucket segment.
    */
-  private[rules] def hasOpenableAuthority(
-      uri: URI,
-      scheme: String,
-      s3CompliantSchemes: Set[String]): Boolean =
-    scheme == null || scheme == "file" || uri.getRawAuthority != null ||
-      // Hostless: only an opt-in S3-compliant alias can be opened, by promoting the bucket from
-      // the first path segment natively. Other schemes still need a host.
-      (s3CompliantSchemes.contains(scheme) &&
-        NativeConfig.bucketForUri(uri, s3CompliantSchemes).isDefined)
+  private[rules] def hasOpenableAuthority(uri: URI, s3CompliantSchemes: Set[String]): Boolean = {
+    val scheme = NativeConfig.lowerScheme(uri)
+    scheme.isEmpty || scheme.contains("file") || uri.getRawAuthority != null ||
+    // Hostless: only an opt-in alias is openable, by promoting the bucket from the first path
+    // segment natively. Other schemes still need a host.
+    (scheme.exists(s3CompliantSchemes.contains) &&
+      NativeConfig.bucketForUri(uri, s3CompliantSchemes).isDefined)
+  }
 
   /**
    * Single-pass validation of Iceberg FileScanTasks.
@@ -1314,11 +1311,12 @@ object CometScanRule extends Logging {
     // hasOpenableAuthority); non-empty => decline. One example suffices for the message.
     var hostlessLocation: Option[String] = None
 
-    // Classify one data/delete file location against `icebergReadableSchemes`, a separate
-    // allowlist intentionally narrower than the Parquet native gate: object_store recognizes
-    // schemes iceberg-rust's OpenDAL storage factory cannot build (http/https/abfs/abfss/wasb/
-    // wasbs/memory), so admitting them here would turn a clean JVM fallback into a native runtime
-    // error. The scheme is lowercased once and threaded down; this runs per data and delete file.
+    // Union of the two admitted scheme sets, built once so the per-file loop does one lookup.
+    val openableSchemes = icebergReadableSchemes ++ s3CompliantSchemes
+
+    // Classify one data/delete file location; see `icebergReadableSchemes` for why that allowlist
+    // is narrower than the Parquet native gate. Runs per data and delete file, so the scheme and
+    // the bucket are each derived once and threaded down.
     def inspectLocation(rawPath: String): Unit = {
       val uri =
         try new URI(rawPath)
@@ -1327,12 +1325,12 @@ object CometScanRule extends Logging {
       val scheme = uri.getScheme
       if (scheme == null) return
       val lower = scheme.toLowerCase(Locale.ROOT)
-      if (!icebergReadableSchemes.contains(lower) && !s3CompliantSchemes.contains(lower)) {
+      if (!openableSchemes.contains(lower)) {
         unsupportedSchemes += lower
-      } else if (!hasOpenableAuthority(uri, lower, s3CompliantSchemes)) {
+      } else if (!hasOpenableAuthority(uri, s3CompliantSchemes)) {
         if (hostlessLocation.isEmpty) hostlessLocation = Some(rawPath)
       } else {
-        // bucketForUri ignores non-S3-family URIs, so no scheme re-check is needed here.
+        // bucketForUri yields None for non-S3-family URIs, so no scheme re-check is needed here.
         NativeConfig.bucketForUri(uri, s3CompliantSchemes).foreach(dataFileBuckets += _)
       }
     }

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -266,17 +266,13 @@ case class CometScanRule(session: SparkSession)
     // config is available. Resolved once, not per root path.
     val s3CompliantSchemes = NativeConfig.resolveS3CompliantSchemes(hadoopConf)
     val rootUris = r.location.rootPaths.map(_.toUri)
-    val unsupportedFsSchemes = rootUris
-      .filter { uri =>
-        val sch = uri.getScheme
-        sch != null && {
-          val sl = sch.toLowerCase(Locale.ROOT)
+    val unsupportedFsSchemes = rootUris.iterator.flatMap { uri =>
+      Option(uri.getScheme)
+        .map(_.toLowerCase(Locale.ROOT))
+        .filter(sl =>
           !libhdfsSchemes.contains(sl) &&
-          !CometScanRule.isNativelyReadableScheme(uri, s3CompliantSchemes)
-        }
-      }
-      .map(_.getScheme.toLowerCase(Locale.ROOT))
-      .toSet
+            !CometScanRule.isNativelyReadableScheme(uri, s3CompliantSchemes))
+    }.toSet
     if (unsupportedFsSchemes.nonEmpty) {
       withFallbackReason(
         scanExec,
@@ -491,13 +487,13 @@ case class CometScanRule(session: SparkSession)
 
         // Validate the FileScanTasks up front: the data/delete file buckets it resolves decide
         // which bucket's per-bucket S3 settings the single native FileIO consumes (see
-        // catalogProperties below), so this must run before we build them. Sourcing tasks directly
-        // mirrors what `extract` does internally (both call the same cached `tasks()` accessor).
-        val taskValidation =
+        // catalogProperties below), so this must run before we build them. The task list is
+        // handed to `extract` below so the reflective accessor runs once per scan.
+        val (icebergTasks, taskValidation) =
           try {
             IcebergReflection.getTasks(scanExec.scan) match {
               case Some(tasks) =>
-                CometScanRule.validateIcebergFileScanTasks(tasks, s3CompliantSchemes)
+                (tasks, CometScanRule.validateIcebergFileScanTasks(tasks, s3CompliantSchemes))
               case None =>
                 fallbackReasons += "Iceberg reflection failure: Could not extract FileScanTasks"
                 return withFallbackReasons(scanExec, fallbackReasons.toSet)
@@ -596,7 +592,7 @@ case class CometScanRule(session: SparkSession)
                 .map(COMET_S3_COMPLIANT_SCHEMES_KEY -> _)
 
             val result = CometIcebergNativeScanMetadata
-              .extract(scanExec.scan, effectiveLocation, catalogProperties)
+              .extract(scanExec.scan, effectiveLocation, catalogProperties, icebergTasks)
 
             result
           } catch {
@@ -784,7 +780,7 @@ case class CometScanRule(session: SparkSession)
         // hostless non-alias location fails at execution with a missing-bucket error. Opt-in
         // S3-compliant aliases are exempt: the native reader promotes the bucket from the first
         // path segment at the open boundary, so a hostless `blob:///bucket/key.parquet` is openable
-        // (see isIcebergOpenableLocation). Decline only the still-unopenable scans here.
+        // (see hasOpenableAuthority). Decline only the still-unopenable scans here.
         val allLocationsOpenable = taskValidation.hostlessLocation match {
           case Some(loc) =>
             fallbackReasons += "Iceberg scan references a data/delete file location without a " +
@@ -1137,11 +1133,10 @@ case class CometScanTypeChecker() extends DataTypeSupport with CometTypeShim {
 
 object CometScanRule extends Logging {
 
-  // Memo of `NativeBase.isObjectStoreSchemeSupported`, keyed by (scheme, has-authority) because
-  // object_store's parser keys on that pair (host-based stores need a host, file/memory need
-  // none). Caching by scheme alone lets an authorityless URL poison the whole scheme's answer.
-  private val schemeSupportCache =
-    new ConcurrentHashMap[(String, Boolean), JBoolean]()
+  // Memo of `NativeBase.isObjectStoreSchemeSupported`, keyed by the probe URL rather than the
+  // scheme: object_store's parser keys on (scheme, host-presence), so an authorityless URL would
+  // otherwise poison the authority-bearing form of the same scheme.
+  private val schemeSupportCache = new ConcurrentHashMap[String, JBoolean]()
 
   /**
    * True when Comet's native Parquet scan can read this URI's scheme: object_store recognizes it
@@ -1156,18 +1151,13 @@ object CometScanRule extends Logging {
     if (scheme == null) return true
     val lower = scheme.toLowerCase(Locale.ROOT)
     if (s3CompliantSchemes.contains(lower)) return true
-    val hasAuthority = uri.getRawAuthority != null
+    // Probe a scheme(+fixed dummy host) URL, never the caller's authority/path: the fixed host
+    // keeps the two host-presence answers apart, and dropping the real path avoids a spurious
+    // `false` from chars object_store rejects in a `Path` (e.g. Iceberg's `p=%0A`).
+    val probe =
+      if (uri.getRawAuthority != null) s"$lower://comet-probe-host/" else s"$lower:///"
     schemeSupportCache
-      .computeIfAbsent(
-        (lower, hasAuthority),
-        _ => {
-          // Probe a scheme(+fixed dummy host) URL, never the caller's authority/path: object_store
-          // keys on (scheme, host-presence) so we cache/probe by that pair. A fixed host stops an
-          // authorityless URL poisoning the authority-bearing form; dropping the real path avoids a
-          // spurious `false` from chars object_store rejects in a `Path` (e.g. Iceberg's `p=%0A`).
-          val probe = if (hasAuthority) s"$lower://comet-probe-host/" else s"$lower:///"
-          JBoolean.valueOf(probeObjectStore(probe))
-        })
+      .computeIfAbsent(probe, p => JBoolean.valueOf(probeObjectStore(p)))
       .booleanValue()
   }
 
@@ -1184,13 +1174,10 @@ object CometScanRule extends Logging {
     catch { case _: Throwable => true }
 
   /**
-   * True when object_store can actually open THIS exact path, not just recognize its scheme.
-   * `ObjectStoreScheme::parse` ends in `Path::from_url_path`, which rejects characters
-   * object_store forbids in a key (e.g. a directory name containing a newline, `%0A` in the URI).
-   * The scheme cache in [[isNativelyReadableScheme]] stays path-independent; this uncached,
-   * per-path probe catches a valid-scheme path native execution would otherwise hard-fail on,
-   * letting the scan fall back cleanly. Meaningful only for object_store-native schemes (callers
-   * skip aliases, which native normalizes to `s3://`, and libhdfs schemes).
+   * True when object_store can open THIS exact path, not just recognize its scheme.
+   * `Path::from_url_path` rejects characters object_store forbids in a key (e.g. a directory name
+   * containing a newline, `%0A` in the URI), which native execution would hard-fail on. Probed
+   * per path and uncached, unlike the path-independent scheme cache above.
    */
   private[rules] def objectStoreAcceptsPath(uri: URI): Boolean =
     probeObjectStore(uri.toString)
@@ -1207,11 +1194,12 @@ object CometScanRule extends Logging {
   private[rules] def mixedAliasScanBuckets(
       uris: Seq[URI],
       s3CompliantSchemes: Set[String]): Set[String] = {
+    if (s3CompliantSchemes.isEmpty) return Set.empty
     val hasAliasPath = uris.exists { uri =>
       Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)).exists(s3CompliantSchemes.contains)
     }
     if (!hasAliasPath) return Set.empty
-    val buckets = NativeConfig.s3FamilyBuckets(uris, s3CompliantSchemes)
+    val buckets = uris.iterator.flatMap(NativeConfig.bucketForUri(_, s3CompliantSchemes)).toSet
     if (buckets.size > 1) buckets else Set.empty
   }
 
@@ -1261,11 +1249,12 @@ object CometScanRule extends Logging {
   }
 
   /**
-   * True when iceberg-rust can actually open this exact data/delete file location, not just
-   * recognize its scheme. iceberg-rust opens files by their raw recorded location, and every
-   * backend except LocalFs derives the bucket from the URL host and does NOT promote it from the
-   * key. So a hostless `s3`/`s3a`/`gs`/`oss` location fails with a missing-bucket error and is
-   * not openable. `file` and schemeless paths route to LocalFs and need no host.
+   * True when iceberg-rust can actually open a data/delete file location whose scheme is already
+   * known Iceberg-readable, not just recognize that scheme. iceberg-rust opens files by their raw
+   * recorded location, and every backend except LocalFs derives the bucket from the URL host and
+   * does NOT promote it from the key. So a hostless `s3`/`s3a`/`gs`/`oss` location fails with a
+   * missing-bucket error and is not openable. `file` and schemeless paths route to LocalFs and
+   * need no host.
    *
    * The one exception is an opt-in S3-compliant alias (`fs.comet.s3Compliant.schemes`, e.g.
    * `blob`): Comet's native reader wraps the S3 backend with `BlobHostPromotingS3Storage` (see
@@ -1273,29 +1262,19 @@ object CometScanRule extends Logging {
    * at the open boundary. So a hostless alias location like `blob:///bucket/key.parquet` IS
    * openable, as long as it carries a promotable bucket segment. The promotion is open-only and
    * never touches the raw string iceberg-rust matches deletes against, so it is delete-safe.
+   *
+   * `scheme` is the caller's already-lowercased URI scheme (null when there is none), so this
+   * does not re-derive it per data and delete file.
    */
-  private[rules] def isIcebergOpenableLocation(
+  private[rules] def hasOpenableAuthority(
       uri: URI,
+      scheme: String,
       s3CompliantSchemes: Set[String]): Boolean =
-    isIcebergReadableScheme(uri, s3CompliantSchemes) && hasOpenableAuthority(
-      uri,
-      s3CompliantSchemes)
-
-  /**
-   * The authority half of [[isIcebergOpenableLocation]], split out for callers that have already
-   * established the scheme is Iceberg-readable (`inspectLocation`, which runs per data and delete
-   * file) so they do not re-derive the scheme and re-check the allowlist.
-   */
-  private def hasOpenableAuthority(uri: URI, s3CompliantSchemes: Set[String]): Boolean =
-    Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)) match {
-      case None | Some("file") => true
-      case Some(_) if uri.getRawAuthority != null => true
-      // Hostless: only an opt-in S3-compliant alias can be opened, by promoting the bucket from the
-      // first path segment natively. Other schemes still need a host.
-      case Some(scheme) if s3CompliantSchemes.contains(scheme) =>
-        NativeConfig.bucketForUri(uri, s3CompliantSchemes).isDefined
-      case Some(_) => false
-    }
+    scheme == null || scheme == "file" || uri.getRawAuthority != null ||
+      // Hostless: only an opt-in S3-compliant alias can be opened, by promoting the bucket from
+      // the first path segment natively. Other schemes still need a host.
+      (s3CompliantSchemes.contains(scheme) &&
+        NativeConfig.bucketForUri(uri, s3CompliantSchemes).isDefined)
 
   /**
    * Single-pass validation of Iceberg FileScanTasks.
@@ -1329,29 +1308,32 @@ object CometScanRule extends Logging {
     var nonIdentityTransform: Option[String] = None
     val deleteFiles = new java.util.ArrayList[Any]()
     // Buckets the native FileIO must read (data + delete files), for the single-config check in
-    // CometScanRule; only S3-family locations contribute (see NativeConfig.s3FamilyBuckets).
+    // CometScanRule; only S3-family locations contribute (see NativeConfig.bucketForUri).
     val dataFileBuckets = mutable.Set[String]()
     // First data/delete location with a readable scheme but no URL host (see
-    // isIcebergOpenableLocation); non-empty => decline. One example suffices for the message.
+    // hasOpenableAuthority); non-empty => decline. One example suffices for the message.
     var hostlessLocation: Option[String] = None
 
-    // Classify one data/delete file location. Uses `isIcebergReadableScheme`, a separate allowlist
-    // intentionally narrower than the Parquet native gate: object_store recognizes schemes
-    // iceberg-rust's OpenDAL storage factory cannot build (http/https/abfs/abfss/wasb/wasbs/
-    // memory), so admitting them here would turn a clean JVM fallback into a native runtime error.
+    // Classify one data/delete file location against `icebergReadableSchemes`, a separate
+    // allowlist intentionally narrower than the Parquet native gate: object_store recognizes
+    // schemes iceberg-rust's OpenDAL storage factory cannot build (http/https/abfs/abfss/wasb/
+    // wasbs/memory), so admitting them here would turn a clean JVM fallback into a native runtime
+    // error. The scheme is lowercased once and threaded down; this runs per data and delete file.
     def inspectLocation(rawPath: String): Unit = {
       val uri =
         try new URI(rawPath)
         catch { case _: java.net.URISyntaxException => return }
-      Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)) match {
-        case None => // schemeless local path -> iceberg-rust LocalFs, no host needed
-        case Some(scheme) if !isIcebergReadableScheme(uri, s3CompliantSchemes) =>
-          unsupportedSchemes += scheme
-        case Some(_) if !hasOpenableAuthority(uri, s3CompliantSchemes) =>
-          if (hostlessLocation.isEmpty) hostlessLocation = Some(rawPath)
-        case Some(_) =>
-          // bucketForUri ignores non-S3-family URIs, so no scheme re-check is needed here.
-          NativeConfig.bucketForUri(uri, s3CompliantSchemes).foreach(dataFileBuckets += _)
+      // A schemeless local path routes to iceberg-rust's LocalFs and needs no host.
+      val scheme = uri.getScheme
+      if (scheme == null) return
+      val lower = scheme.toLowerCase(Locale.ROOT)
+      if (!icebergReadableSchemes.contains(lower) && !s3CompliantSchemes.contains(lower)) {
+        unsupportedSchemes += lower
+      } else if (!hasOpenableAuthority(uri, lower, s3CompliantSchemes)) {
+        if (hostlessLocation.isEmpty) hostlessLocation = Some(rawPath)
+      } else {
+        // bucketForUri ignores non-S3-family URIs, so no scheme re-check is needed here.
+        NativeConfig.bucketForUri(uri, s3CompliantSchemes).foreach(dataFileBuckets += _)
       }
     }
 

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -1226,12 +1226,12 @@ object CometScanRule extends Logging {
 
   /**
    * Schemes Comet's native Iceberg scan can actually open, mirroring the match arms in
-   * `native/core/src/execution/operators/iceberg_scan.rs::storage_factory_for`. Deliberately NOT
-   * delegated to `isNativelyReadableScheme`: object_store recognizes schemes (http/https, azure,
-   * memory) that iceberg-rust's OpenDAL storage factory cannot build, and admitting them here
-   * turns a clean JVM fallback into a native runtime "Unsupported storage scheme" error. Add here
-   * what you add to `storage_factory_for` (currently Aliyun `oss` and GCS `gs`). S3-compliant
-   * aliases like `blob` are opt-in via `fs.comet.s3Compliant.schemes` (see
+   * `native/core/src/execution/operators/iceberg_common.rs::storage_factory_for`. Deliberately
+   * NOT delegated to `isNativelyReadableScheme`: object_store recognizes schemes (http/https,
+   * azure, memory) that iceberg-rust's OpenDAL storage factory cannot build, and admitting them
+   * here turns a clean JVM fallback into a native runtime "Unsupported storage scheme" error. Add
+   * here what you add to `storage_factory_for` (currently Aliyun `oss` and GCS `gs`).
+   * S3-compliant aliases like `blob` are opt-in via `fs.comet.s3Compliant.schemes` (see
    * `isIcebergReadableScheme`), not hardcoded, since the native planner opens them via S3.
    */
   private val icebergReadableSchemes: Set[String] =
@@ -1276,8 +1276,17 @@ object CometScanRule extends Logging {
    */
   private[rules] def isIcebergOpenableLocation(
       uri: URI,
-      s3CompliantSchemes: Set[String]): Boolean = {
-    if (!isIcebergReadableScheme(uri, s3CompliantSchemes)) return false
+      s3CompliantSchemes: Set[String]): Boolean =
+    isIcebergReadableScheme(uri, s3CompliantSchemes) && hasOpenableAuthority(
+      uri,
+      s3CompliantSchemes)
+
+  /**
+   * The authority half of [[isIcebergOpenableLocation]], split out for callers that have already
+   * established the scheme is Iceberg-readable (`inspectLocation`, which runs per data and delete
+   * file) so they do not re-derive the scheme and re-check the allowlist.
+   */
+  private def hasOpenableAuthority(uri: URI, s3CompliantSchemes: Set[String]): Boolean =
     Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)) match {
       case None | Some("file") => true
       case Some(_) if uri.getRawAuthority != null => true
@@ -1287,7 +1296,6 @@ object CometScanRule extends Logging {
         NativeConfig.bucketForUri(uri, s3CompliantSchemes).isDefined
       case Some(_) => false
     }
-  }
 
   /**
    * Single-pass validation of Iceberg FileScanTasks.
@@ -1339,12 +1347,11 @@ object CometScanRule extends Logging {
         case None => // schemeless local path -> iceberg-rust LocalFs, no host needed
         case Some(scheme) if !isIcebergReadableScheme(uri, s3CompliantSchemes) =>
           unsupportedSchemes += scheme
-        case Some(_) if !isIcebergOpenableLocation(uri, s3CompliantSchemes) =>
+        case Some(_) if !hasOpenableAuthority(uri, s3CompliantSchemes) =>
           if (hostlessLocation.isEmpty) hostlessLocation = Some(rawPath)
-        case Some(scheme) =>
-          if (NativeConfig.isS3FamilyScheme(scheme, s3CompliantSchemes)) {
-            NativeConfig.bucketForUri(uri, s3CompliantSchemes).foreach(dataFileBuckets += _)
-          }
+        case Some(_) =>
+          // bucketForUri ignores non-S3-family URIs, so no scheme re-check is needed here.
+          NativeConfig.bucketForUri(uri, s3CompliantSchemes).foreach(dataFileBuckets += _)
       }
     }
 

--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
@@ -42,6 +42,7 @@ import com.google.protobuf.ByteString
 
 import org.apache.comet.{CometConf, ConfigEntry}
 import org.apache.comet.iceberg.{CometIcebergNativeScanMetadata, IcebergReflection}
+import org.apache.comet.objectstore.NativeConfig
 import org.apache.comet.serde.{CometOperatorSerde, OperatorOuterClass}
 import org.apache.comet.serde.OperatorOuterClass.{Operator, SparkStructField}
 import org.apache.comet.serde.QueryPlanSerde.serializeDataType
@@ -567,59 +568,46 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
    *
    * Iceberg-rust's FileIO expects Iceberg-format keys (e.g., s3.access-key-id), not Hadoop keys
    * (e.g., fs.s3a.access.key). This function converts Hadoop keys extracted from Spark's
-   * configuration to the format expected by iceberg-rust.
+   * configuration to the format expected by iceberg-rust. The key mapping itself lives in
+   * `NativeConfig.s3aSuffixToIcebergGlobalKey`, shared with the vendor-key translation.
    *
    * @param targetBucket
    *   the bucket whose Hadoop per-bucket `fs.s3a.bucket.<b>.*` settings are promoted to global
-   *   `s3.*`. Required with no default: the pinned iceberg-rust S3 parser reads ONLY global
-   *   `s3.*`, so the caller must decide, and a `= None` default would silently restore the old
-   *   lossy behavior for a future caller that forgets to pass it. Both call sites pass the DATA
-   *   bucket, which Iceberg allows to differ from the metadata bucket.
+   *   `s3.*`. Required with no default: the pinned iceberg-rust S3 parser reads ONLY global `s3.*`
+   *   (never `s3.bucket.*`), so the caller must decide, and a `= None` default would silently
+   *   restore the old lossy behavior for a future caller that forgets to pass it. Both call sites
+   *   pass the DATA bucket, which Iceberg allows to differ from the metadata bucket. TODO: drop
+   *   the promotion once iceberg-rust is unpinned to a release whose S3 parser reads
+   *   `s3.bucket.*`.
    */
   def hadoopToIcebergS3Properties(
       hadoopProps: Map[String, String],
       targetBucket: Option[String]): Map[String, String] = {
-    val base = hadoopProps.flatMap { case (key, value) =>
-      key match {
-        // Hadoop global S3A keys -> global iceberg s3.*. This arm also catches
-        // `fs.s3a.bucket.<b>.*` (its `bucket.<b>.<prop>` suffix matches no case, so it maps to
-        // None): the pinned iceberg-rust parser reads only global s3.*, and the scan's own bucket
-        // is promoted to global by `targetBucketGlobals` below, so no `s3.bucket.*` emission is
-        // needed. Single source of truth for the mapping is `hadoopS3aSuffixToIcebergGlobalKey`.
-        case k if k.startsWith("fs.s3a.") =>
-          hadoopS3aSuffixToIcebergGlobalKey(k.stripPrefix("fs.s3a.")).map(_ -> value)
+    val targetPrefix = targetBucket.map(bucket => s"fs.s3a.bucket.$bucket.")
+    val global = Map.newBuilder[String, String]
+    // Promoted target-bucket keys must win over their global namesakes, so they are collected
+    // separately and merged last. Prefix-matched (not split) so dotted bucket names survive.
+    val promoted = Map.newBuilder[String, String]
 
-        // Pass through any keys that are already in Iceberg format
-        case k if k.startsWith("s3.") => Some(key -> value)
-
-        // Ignore all other keys
-        case _ => None
+    hadoopProps.foreach { case (key, value) =>
+      // Per-bucket keys for OTHER buckets fall through every branch and are dropped: the pinned
+      // parser would ignore an `s3.bucket.*` emission anyway.
+      targetPrefix match {
+        case Some(prefix) if key.startsWith(prefix) =>
+          NativeConfig.s3aSuffixToIcebergGlobalKey
+            .get(key.stripPrefix(prefix))
+            .foreach(promoted += _ -> value)
+        case _ if key.startsWith("fs.s3a.") =>
+          NativeConfig.s3aSuffixToIcebergGlobalKey
+            .get(key.stripPrefix("fs.s3a."))
+            .foreach(global += _ -> value)
+        // Keys already in Iceberg format pass through.
+        case _ if key.startsWith("s3.") => global += key -> value
+        case _ => // not an object-store key
       }
     }
 
-    // Promote the target bucket's per-bucket settings so its endpoint / credentials / path-style
-    // / region actually reach FileIO. Matched by prefix (not split) so dotted bucket names
-    // survive, and merged last so they override any global value.
-    val targetBucketGlobals = targetBucket.toSeq.flatMap { bucket =>
-      val prefix = s"fs.s3a.bucket.$bucket."
-      hadoopProps.collect {
-        case (key, value) if key.startsWith(prefix) =>
-          hadoopS3aSuffixToIcebergGlobalKey(key.stripPrefix(prefix)).map(_ -> value)
-      }.flatten
-    }
-
-    base ++ targetBucketGlobals
-  }
-
-  /** Maps a Hadoop `fs.s3a.*` property suffix to its GLOBAL iceberg-rust `s3.*` key. */
-  private def hadoopS3aSuffixToIcebergGlobalKey(suffix: String): Option[String] = suffix match {
-    case "access.key" => Some("s3.access-key-id")
-    case "secret.key" => Some("s3.secret-access-key")
-    case "session.token" => Some("s3.session-token")
-    case "endpoint" => Some("s3.endpoint")
-    case "path.style.access" => Some("s3.path-style-access")
-    case "endpoint.region" => Some("s3.region")
-    case _ => None
+    global.result() ++ promoted.result()
   }
 
   /**

--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
@@ -568,13 +568,14 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
    * Iceberg-rust's FileIO expects Iceberg-format keys (e.g., s3.access-key-id), not Hadoop keys
    * (e.g., fs.s3a.access.key). This function converts Hadoop keys extracted from Spark's
    * configuration to the format expected by iceberg-rust.
+   *
+   * @param targetBucket
+   *   the bucket whose Hadoop per-bucket `fs.s3a.bucket.<b>.*` settings are promoted to global
+   *   `s3.*`. Required with no default: the pinned iceberg-rust S3 parser reads ONLY global
+   *   `s3.*`, so the caller must decide, and a `= None` default would silently restore the old
+   *   lossy behavior for a future caller that forgets to pass it. Both call sites pass the DATA
+   *   bucket, which Iceberg allows to differ from the metadata bucket.
    */
-  // `targetBucket` is intentionally required (no default): the pinned iceberg-rust S3 parser reads
-  // ONLY global `s3.*`, so the caller must decide which bucket's per-bucket keys get promoted.
-  // A `= None` default would silently restore the old lossy behavior (no promotion) for any future
-  // caller that forgets to pass it. Both call sites (the CometScanRule scan path and the
-  // CometIcebergNativeWrite write path) pass the DATA bucket -- the bucket the native FileIO opens
-  // data/delete files from, which Iceberg allows to differ from the metadata bucket.
   def hadoopToIcebergS3Properties(
       hadoopProps: Map[String, String],
       targetBucket: Option[String]): Map[String, String] = {
@@ -596,21 +597,15 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
       }
     }
 
-    // The pinned iceberg-rust S3 parser reads ONLY global `s3.*` keys, never `s3.bucket.*`. Promote
-    // the TARGET bucket's Hadoop per-bucket settings to global `s3.*` so its endpoint / credentials
-    // / path-style / region actually reach FileIO. Matched by prefix (not split) so dotted bucket
-    // names survive, and merged last so they override any global value.
-    val targetBucketGlobals: Map[String, String] = targetBucket match {
-      case Some(bucket) =>
-        val prefix = s"fs.s3a.bucket.$bucket."
-        hadoopProps.flatMap { case (key, value) =>
-          if (key.startsWith(prefix)) {
-            hadoopS3aSuffixToIcebergGlobalKey(key.stripPrefix(prefix)).map(_ -> value)
-          } else {
-            None
-          }
-        }
-      case None => Map.empty
+    // Promote the target bucket's per-bucket settings so its endpoint / credentials / path-style
+    // / region actually reach FileIO. Matched by prefix (not split) so dotted bucket names
+    // survive, and merged last so they override any global value.
+    val targetBucketGlobals = targetBucket.toSeq.flatMap { bucket =>
+      val prefix = s"fs.s3a.bucket.$bucket."
+      hadoopProps.collect {
+        case (key, value) if key.startsWith(prefix) =>
+          hadoopS3aSuffixToIcebergGlobalKey(key.stripPrefix(prefix)).map(_ -> value)
+      }.flatten
     }
 
     base ++ targetBucketGlobals

--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
@@ -573,11 +573,11 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
    *
    * @param targetBucket
    *   the bucket whose Hadoop per-bucket `fs.s3a.bucket.<b>.*` settings are promoted to global
-   *   `s3.*`. Required with no default: the pinned iceberg-rust S3 parser reads ONLY global `s3.*`
-   *   (never `s3.bucket.*`), so the caller must decide, and a `= None` default would silently
-   *   restore the old lossy behavior for a future caller that forgets to pass it. Both call sites
-   *   pass the DATA bucket, which Iceberg allows to differ from the metadata bucket. TODO: drop
-   *   the promotion once iceberg-rust is unpinned to a release whose S3 parser reads
+   *   `s3.*`. Required with no default: the pinned iceberg-rust S3 parser reads ONLY global
+   *   `s3.*` (never `s3.bucket.*`), so the caller must decide, and a `= None` default would
+   *   silently restore the old lossy behavior for a future caller that forgets to pass it. Both
+   *   call sites pass the DATA bucket, which Iceberg allows to differ from the metadata bucket.
+   *   TODO: drop the promotion once iceberg-rust is unpinned to a release whose S3 parser reads
    *   `s3.bucket.*`.
    */
   def hadoopToIcebergS3Properties(

--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
@@ -569,36 +569,24 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
    * (e.g., fs.s3a.access.key). This function converts Hadoop keys extracted from Spark's
    * configuration to the format expected by iceberg-rust.
    */
-  def hadoopToIcebergS3Properties(hadoopProps: Map[String, String]): Map[String, String] = {
-    hadoopProps.flatMap { case (key, value) =>
+  // `targetBucket` is intentionally required (no default): the pinned iceberg-rust S3 parser reads
+  // ONLY global `s3.*`, so the caller must decide which bucket's per-bucket keys get promoted.
+  // A `= None` default would silently restore the old lossy behavior (no promotion) for any future
+  // caller that forgets to pass it. Both call sites (the CometScanRule scan path and the
+  // CometIcebergNativeWrite write path) pass the DATA bucket -- the bucket the native FileIO opens
+  // data/delete files from, which Iceberg allows to differ from the metadata bucket.
+  def hadoopToIcebergS3Properties(
+      hadoopProps: Map[String, String],
+      targetBucket: Option[String]): Map[String, String] = {
+    val base = hadoopProps.flatMap { case (key, value) =>
       key match {
-        // Global S3A configuration keys
-        case "fs.s3a.access.key" => Some("s3.access-key-id" -> value)
-        case "fs.s3a.secret.key" => Some("s3.secret-access-key" -> value)
-        case "fs.s3a.session.token" => Some("s3.session-token" -> value)
-        case "fs.s3a.endpoint" => Some("s3.endpoint" -> value)
-        case "fs.s3a.path.style.access" => Some("s3.path-style-access" -> value)
-        case "fs.s3a.endpoint.region" => Some("s3.region" -> value)
-
-        // Per-bucket configuration keys (e.g., fs.s3a.bucket.mybucket.access.key)
-        // Extract bucket name and property, then transform to s3.* format
-        case k if k.startsWith("fs.s3a.bucket.") =>
-          val parts = k.stripPrefix("fs.s3a.bucket.").split("\\.", 2)
-          if (parts.length == 2) {
-            val bucket = parts(0)
-            val property = parts(1)
-            property match {
-              case "access.key" => Some(s"s3.bucket.$bucket.access-key-id" -> value)
-              case "secret.key" => Some(s"s3.bucket.$bucket.secret-access-key" -> value)
-              case "session.token" => Some(s"s3.bucket.$bucket.session.token" -> value)
-              case "endpoint" => Some(s"s3.bucket.$bucket.endpoint" -> value)
-              case "path.style.access" => Some(s"s3.bucket.$bucket.path-style-access" -> value)
-              case "endpoint.region" => Some(s"s3.bucket.$bucket.region" -> value)
-              case _ => None
-            }
-          } else {
-            None
-          }
+        // Hadoop global S3A keys -> global iceberg s3.*. This arm also catches
+        // `fs.s3a.bucket.<b>.*` (its `bucket.<b>.<prop>` suffix matches no case, so it maps to
+        // None): the pinned iceberg-rust parser reads only global s3.*, and the scan's own bucket
+        // is promoted to global by `targetBucketGlobals` below, so no `s3.bucket.*` emission is
+        // needed. Single source of truth for the mapping is `hadoopS3aSuffixToIcebergGlobalKey`.
+        case k if k.startsWith("fs.s3a.") =>
+          hadoopS3aSuffixToIcebergGlobalKey(k.stripPrefix("fs.s3a.")).map(_ -> value)
 
         // Pass through any keys that are already in Iceberg format
         case k if k.startsWith("s3.") => Some(key -> value)
@@ -607,6 +595,36 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
         case _ => None
       }
     }
+
+    // The pinned iceberg-rust S3 parser reads ONLY global `s3.*` keys, never `s3.bucket.*`. Promote
+    // the TARGET bucket's Hadoop per-bucket settings to global `s3.*` so its endpoint / credentials
+    // / path-style / region actually reach FileIO. Matched by prefix (not split) so dotted bucket
+    // names survive, and merged last so they override any global value.
+    val targetBucketGlobals: Map[String, String] = targetBucket match {
+      case Some(bucket) =>
+        val prefix = s"fs.s3a.bucket.$bucket."
+        hadoopProps.flatMap { case (key, value) =>
+          if (key.startsWith(prefix)) {
+            hadoopS3aSuffixToIcebergGlobalKey(key.stripPrefix(prefix)).map(_ -> value)
+          } else {
+            None
+          }
+        }
+      case None => Map.empty
+    }
+
+    base ++ targetBucketGlobals
+  }
+
+  /** Maps a Hadoop `fs.s3a.*` property suffix to its GLOBAL iceberg-rust `s3.*` key. */
+  private def hadoopS3aSuffixToIcebergGlobalKey(suffix: String): Option[String] = suffix match {
+    case "access.key" => Some("s3.access-key-id")
+    case "secret.key" => Some("s3.secret-access-key")
+    case "session.token" => Some("s3.session-token")
+    case "endpoint" => Some("s3.endpoint")
+    case "path.style.access" => Some("s3.path-style-access")
+    case "endpoint.region" => Some("s3.region")
+    case _ => None
   }
 
   /**

--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeWrite.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeWrite.scala
@@ -641,8 +641,13 @@ object CometIcebergNativeWrite extends CometOperatorSerde[IcebergWriteExec] {
     // Promote the data bucket's per-bucket `fs.s3a.bucket.<b>.*` settings to global, mirroring the
     // scan path: iceberg-rust's pinned S3 parser reads only global `s3.*`. Only an S3-family data
     // location yields a bucket (None for a local/GCS/OSS write, which needs no promotion).
-    val s3CompliantSchemes = NativeConfig.resolveS3CompliantSchemes(writeHadoopConf)
-    val dataBucket = NativeConfig.bucketForUri(dataUri, s3CompliantSchemes)
+    //
+    // No opt-in S3-compliant aliases here: `requireSupportedStorageScheme` already declined any
+    // data location outside `SupportedStorageSchemes`, so an alias scheme never reaches this
+    // point. Alias support is scan-only. Enabling it would also mean forwarding
+    // `fs.comet.s3Compliant.schemes` into `catalogProperties`, as the scan does, since
+    // `storage_factory_for` reads the opt-in from there.
+    val dataBucket = NativeConfig.bucketForUri(dataUri, Set.empty)
     val hadoopDerivedProperties = CometIcebergNativeScan.hadoopToIcebergS3Properties(
       NativeConfig.extractObjectStoreOptions(writeHadoopConf, dataUri),
       dataBucket)

--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeWrite.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeWrite.scala
@@ -636,10 +636,16 @@ object CometIcebergNativeWrite extends CometOperatorSerde[IcebergWriteExec] {
     // (`CometScanRule`): extract the object-store options for the data location from the
     // session Hadoop configuration, translate them to the s3.* keys iceberg-rust consumes, and
     // let FileIO/vended properties win on conflict.
+    val writeHadoopConf = op.session.sessionState.newHadoopConf()
+    val dataUri = new java.net.URI(dataLocation)
+    // Promote the data bucket's per-bucket `fs.s3a.bucket.<b>.*` settings to global, mirroring the
+    // scan path: iceberg-rust's pinned S3 parser reads only global `s3.*`. Only an S3-family data
+    // location yields a bucket (None for a local/GCS/OSS write, which needs no promotion).
+    val s3CompliantSchemes = NativeConfig.resolveS3CompliantSchemes(writeHadoopConf)
+    val dataBucket = NativeConfig.s3FamilyBuckets(Seq(dataUri), s3CompliantSchemes).headOption
     val hadoopDerivedProperties = CometIcebergNativeScan.hadoopToIcebergS3Properties(
-      NativeConfig.extractObjectStoreOptions(
-        op.session.sessionState.newHadoopConf(),
-        new java.net.URI(dataLocation)))
+      NativeConfig.extractObjectStoreOptions(writeHadoopConf, dataUri),
+      dataBucket)
     val catalogProperties = hadoopDerivedProperties ++ fileIOProperties
 
     val common = IcebergWriteProtoTranslation.buildCommon(

--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeWrite.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeWrite.scala
@@ -642,7 +642,7 @@ object CometIcebergNativeWrite extends CometOperatorSerde[IcebergWriteExec] {
     // scan path: iceberg-rust's pinned S3 parser reads only global `s3.*`. Only an S3-family data
     // location yields a bucket (None for a local/GCS/OSS write, which needs no promotion).
     val s3CompliantSchemes = NativeConfig.resolveS3CompliantSchemes(writeHadoopConf)
-    val dataBucket = NativeConfig.s3FamilyBuckets(Seq(dataUri), s3CompliantSchemes).headOption
+    val dataBucket = NativeConfig.bucketForUri(dataUri, s3CompliantSchemes)
     val hadoopDerivedProperties = CometIcebergNativeScan.hadoopToIcebergS3Properties(
       NativeConfig.extractObjectStoreOptions(writeHadoopConf, dataUri),
       dataBucket)

--- a/spark/src/test/java/org/apache/comet/hadoop/fs/BlobSchemeFileSystem.java
+++ b/spark/src/test/java/org/apache/comet/hadoop/fs/BlobSchemeFileSystem.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.hadoop.fs;
+
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+
+/**
+ * An {@link S3AFileSystem} that reports the {@code blob} scheme, so a test can read/write a {@code
+ * blob://} path against MinIO without a real vendor connector. Bind via {@code
+ * spark.hadoop.fs.blob.impl}; S3A derives the bucket from the URI host and reads the same {@code
+ * fs.s3a.*} surface, so no extra config is needed beyond what the s3a suites set.
+ *
+ * <p>Overriding {@link #getScheme()} mirrors {@link FakeHdfsSchemeFileSystem}. {@code
+ * S3AFileSystem#checkPath} compares against the initialize-time URI (scheme {@code blob}), not
+ * {@code getScheme()}, so a {@code blob://} path is accepted.
+ */
+public class BlobSchemeFileSystem extends S3AFileSystem {
+
+  @Override
+  public String getScheme() {
+    return "blob";
+  }
+}

--- a/spark/src/test/java/org/apache/comet/parquet/TestCometFileKeyUnwrapper.java
+++ b/spark/src/test/java/org/apache/comet/parquet/TestCometFileKeyUnwrapper.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.parquet;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Regression guard for {@link CometFileKeyUnwrapper#normalizeS3Scheme(String, Set)}. The put side
+ * is called with the user-facing URI (e.g. {@code blob://...}), while the native side JNIs back
+ * with the URI after Comet has rewritten it to {@code s3://} in {@code
+ * prepare_object_store_with_configs}. Both sides must normalize to the SAME canonical form ({@code
+ * s3a://}) or encrypted Parquet reads over alias-scheme tables fail with {@code Failed to find
+ * DecryptionKeyRetriever}. The alias set is not hardcoded: it comes from {@code
+ * fs.comet.s3Compliant.schemes}, so a scheme is only folded when the user opted it in.
+ */
+public class TestCometFileKeyUnwrapper {
+
+  private static final Set<String> NONE = Collections.emptySet();
+  private static final Set<String> BLOB = Collections.singleton("blob");
+  private static final Set<String> BLOB_MINIO = new HashSet<>(asList("blob", "minio"));
+
+  private static String norm(String filePath, Set<String> schemes) {
+    return CometFileKeyUnwrapper.normalizeS3Scheme(filePath, schemes);
+  }
+
+  @Test
+  public void baseS3AliasesNormalizeWithoutConfig() {
+    // s3/s3a/s3n are always folded, independent of fs.comet.s3Compliant.schemes.
+    String suffix = "bucket/foo/part-0.parquet";
+    String canonical = "s3a://" + suffix;
+    assertEquals(canonical, norm("s3://" + suffix, NONE));
+    assertEquals(canonical, norm("s3a://" + suffix, NONE));
+    assertEquals(canonical, norm("s3n://" + suffix, NONE));
+  }
+
+  @Test
+  public void configuredAliasesNormalizeToS3a() {
+    // blob and minio fold ONLY when listed in fs.comet.s3Compliant.schemes. This is the case that
+    // used to fail: a hardcoded {s3,s3n,s3a,blob} list dropped minio, so an encrypted minio:// read
+    // cached under minio://... on the put side but looked up s3a://... on the get side.
+    String suffix = "bucket/foo/part-0.parquet";
+    String canonical = "s3a://" + suffix;
+    assertEquals(canonical, norm("blob://" + suffix, BLOB_MINIO));
+    assertEquals(canonical, norm("minio://" + suffix, BLOB_MINIO));
+  }
+
+  @Test
+  public void unconfiguredAliasPassesThrough() {
+    // An alias not opted in is left untouched. Here blob is configured but minio is not.
+    String minio = "minio://bucket/foo/part-0.parquet";
+    assertEquals(minio, norm(minio, BLOB));
+    // With no schemes configured at all, even blob passes through.
+    String blob = "blob://bucket/foo/part-0.parquet";
+    assertEquals(blob, norm(blob, NONE));
+  }
+
+  @Test
+  public void aliasSingleAndTripleSlashPromoteBucketToAuthority() {
+    // Java's URI.toString() collapses blob:///bucket/key to the single-slash blob:/bucket/key, and
+    // some deployments emit the triple-slash form directly. The native rewrite promotes the first
+    // path segment into the authority, so the get side reconstructs s3://bucket/key. The put side
+    // must canonicalize both forms the same way, otherwise the stored cache key never matches the
+    // get side's s3a://bucket/key and reads fail with "Failed to find DecryptionKeyRetriever".
+    String canonical = "s3a://bucket/foo/part-0.parquet";
+    assertEquals(canonical, norm("blob:/bucket/foo/part-0.parquet", BLOB));
+    assertEquals(canonical, norm("blob:///bucket/foo/part-0.parquet", BLOB));
+    // The two-slash form and the s3:// the native side calls back with must land on the same key.
+    assertEquals(canonical, norm("blob://bucket/foo/part-0.parquet", BLOB));
+    assertEquals(canonical, norm("s3://bucket/foo/part-0.parquet", BLOB));
+  }
+
+  @Test
+  public void nonS3SchemesPassThrough() {
+    String hdfs = "hdfs://nn/warehouse/part-0.parquet";
+    assertEquals(hdfs, norm(hdfs, BLOB));
+    String file = "file:///tmp/part-0.parquet";
+    assertEquals(file, norm(file, BLOB));
+  }
+}

--- a/spark/src/test/java/org/apache/comet/parquet/TestCometFileKeyUnwrapper.java
+++ b/spark/src/test/java/org/apache/comet/parquet/TestCometFileKeyUnwrapper.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.parquet;
+
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Regression guard for {@link CometFileKeyUnwrapper#normalizeS3Scheme}. The put side is called with
+ * the user-facing URI (e.g. {@code blob://...}), while the native side JNIs back with the URI after
+ * Comet has rewritten it to {@code s3://} in {@code prepare_object_store_with_configs}. Both sides
+ * must normalize to the SAME canonical form ({@code s3a://}) or encrypted Parquet reads over {@code
+ * blob://} tables fail with {@code Failed to find DecryptionKeyRetriever}.
+ */
+public class TestCometFileKeyUnwrapper {
+
+  private static String normalize(String filePath) throws Exception {
+    Method m = CometFileKeyUnwrapper.class.getDeclaredMethod("normalizeS3Scheme", String.class);
+    m.setAccessible(true);
+    return (String) m.invoke(new CometFileKeyUnwrapper(), filePath);
+  }
+
+  @Test
+  public void allS3AliasesNormalizeToS3a() throws Exception {
+    String suffix = "bucket/foo/part-0.parquet";
+    String canonical = "s3a://" + suffix;
+    assertEquals(canonical, normalize("s3://" + suffix));
+    assertEquals(canonical, normalize("s3a://" + suffix));
+    assertEquals(canonical, normalize("s3n://" + suffix));
+    assertEquals(canonical, normalize("blob://" + suffix));
+  }
+
+  @Test
+  public void nonS3SchemesPassThrough() throws Exception {
+    assertEquals(
+        "hdfs://nn/warehouse/part-0.parquet", normalize("hdfs://nn/warehouse/part-0.parquet"));
+    assertEquals("file:///tmp/part-0.parquet", normalize("file:///tmp/part-0.parquet"));
+  }
+}

--- a/spark/src/test/java/org/apache/comet/parquet/TestCometFileKeyUnwrapper.java
+++ b/spark/src/test/java/org/apache/comet/parquet/TestCometFileKeyUnwrapper.java
@@ -69,10 +69,16 @@ public class TestCometFileKeyUnwrapper {
   }
 
   @Test
-  public void unconfiguredAliasPassesThrough() {
-    // An alias not opted in is left untouched. Here blob is configured but minio is not.
-    String minio = "minio://bucket/foo/part-0.parquet";
-    assertEquals(minio, norm(minio, BLOB));
+  public void unlistedSchemesPassThrough() {
+    // A scheme not in the opted-in set is left untouched, whether it is a plausible alias (minio,
+    // blob) or a non-S3 filesystem. Here blob is configured but minio is not.
+    for (String p :
+        asList(
+            "minio://bucket/foo/part-0.parquet",
+            "hdfs://nn/warehouse/part-0.parquet",
+            "file:///tmp/part-0.parquet")) {
+      assertEquals(p, norm(p, BLOB));
+    }
     // With no schemes configured at all, even blob passes through.
     String blob = "blob://bucket/foo/part-0.parquet";
     assertEquals(blob, norm(blob, NONE));
@@ -88,13 +94,5 @@ public class TestCometFileKeyUnwrapper {
     String canonical = "s3a://bucket/foo/part-0.parquet";
     assertEquals(canonical, norm("blob:/bucket/foo/part-0.parquet", BLOB));
     assertEquals(canonical, norm("blob:///bucket/foo/part-0.parquet", BLOB));
-  }
-
-  @Test
-  public void nonS3SchemesPassThrough() {
-    String hdfs = "hdfs://nn/warehouse/part-0.parquet";
-    assertEquals(hdfs, norm(hdfs, BLOB));
-    String file = "file:///tmp/part-0.parquet";
-    assertEquals(file, norm(file, BLOB));
   }
 }

--- a/spark/src/test/java/org/apache/comet/parquet/TestCometFileKeyUnwrapper.java
+++ b/spark/src/test/java/org/apache/comet/parquet/TestCometFileKeyUnwrapper.java
@@ -88,9 +88,6 @@ public class TestCometFileKeyUnwrapper {
     String canonical = "s3a://bucket/foo/part-0.parquet";
     assertEquals(canonical, norm("blob:/bucket/foo/part-0.parquet", BLOB));
     assertEquals(canonical, norm("blob:///bucket/foo/part-0.parquet", BLOB));
-    // The two-slash form and the s3:// the native side calls back with must land on the same key.
-    assertEquals(canonical, norm("blob://bucket/foo/part-0.parquet", BLOB));
-    assertEquals(canonical, norm("s3://bucket/foo/part-0.parquet", BLOB));
   }
 
   @Test

--- a/spark/src/test/scala/org/apache/comet/CometS3TestBase.scala
+++ b/spark/src/test/scala/org/apache/comet/CometS3TestBase.scala
@@ -93,6 +93,20 @@ trait CometS3TestBase extends CometTestBase {
     conf.set(s"spark.sql.catalog.$catalogName.s3.path-style-access", "true")
   }
 
+  /**
+   * Wire the `blob://` opt-in S3-compliant alias for `bucket`: register the alias scheme and bind
+   * it to an S3A-derived FileSystem so Spark reads/writes blob://<bucket>/... against the same
+   * MinIO. The vendor-style per-authority keys are translated to fs.s3a.bucket.<bucket>.* for the
+   * native read by NativeConfig.translateVendorKeys, and an endpoint also defaults path-style on.
+   */
+  protected def applyBlobSchemeProps(conf: SparkConf, bucket: String): Unit = {
+    conf.set("spark.hadoop.fs.comet.s3Compliant.schemes", "blob")
+    conf.set("spark.hadoop.fs.blob.impl", "org.apache.comet.hadoop.fs.BlobSchemeFileSystem")
+    conf.set(s"spark.hadoop.fs.blob.$bucket.endpoint", minioContainer.getS3URL)
+    conf.set(s"spark.hadoop.fs.blob.$bucket.awsAccessKeyId", userName)
+    conf.set(s"spark.hadoop.fs.blob.$bucket.awsSecretAccessKey", password)
+  }
+
   protected def createBucketIfNotExists(bucketName: String): Unit = {
     val credentials = AwsBasicCredentials.create(userName, password)
     val s3Client = S3Client

--- a/spark/src/test/scala/org/apache/comet/CometS3TestBase.scala
+++ b/spark/src/test/scala/org/apache/comet/CometS3TestBase.scala
@@ -28,6 +28,8 @@ import org.testcontainers.utility.DockerImageName
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.comet.{CometNativeScanExec, CometScanExec}
+import org.apache.spark.sql.execution.SparkPlan
 
 import org.apache.comet.CometSparkSessionExtensions.isSpark42Plus
 
@@ -105,6 +107,12 @@ trait CometS3TestBase extends CometTestBase {
     conf.set(s"spark.hadoop.fs.blob.$bucket.endpoint", minioContainer.getS3URL)
     conf.set(s"spark.hadoop.fs.blob.$bucket.awsAccessKeyId", userName)
     conf.set(s"spark.hadoop.fs.blob.$bucket.awsSecretAccessKey", password)
+  }
+
+  /** The Comet Parquet scans in `plan`, native or JVM-side. */
+  protected def cometScans(plan: SparkPlan): Seq[SparkPlan] = collect(plan) {
+    case p: CometScanExec => p
+    case p: CometNativeScanExec => p
   }
 
   protected def createBucketIfNotExists(bucketName: String): Unit = {

--- a/spark/src/test/scala/org/apache/comet/CometS3TestBase.scala
+++ b/spark/src/test/scala/org/apache/comet/CometS3TestBase.scala
@@ -100,7 +100,7 @@ trait CometS3TestBase extends CometTestBase {
    * native read by NativeConfig.translateVendorKeys, and an endpoint also defaults path-style on.
    */
   protected def applyBlobSchemeProps(conf: SparkConf, bucket: String): Unit = {
-    conf.set("spark.hadoop.fs.comet.s3Compliant.schemes", "blob")
+    conf.set(CometConf.COMET_S3_COMPLIANT_SCHEMES.key, "blob")
     conf.set("spark.hadoop.fs.blob.impl", "org.apache.comet.hadoop.fs.BlobSchemeFileSystem")
     conf.set(s"spark.hadoop.fs.blob.$bucket.endpoint", minioContainer.getS3URL)
     conf.set(s"spark.hadoop.fs.blob.$bucket.awsAccessKeyId", userName)

--- a/spark/src/test/scala/org/apache/comet/IcebergReadFromS3Suite.scala
+++ b/spark/src/test/scala/org/apache/comet/IcebergReadFromS3Suite.scala
@@ -37,6 +37,16 @@ class IcebergReadFromS3Suite extends CometS3TestBase with RESTCatalogHelper {
     conf.set("spark.sql.catalog.s3_catalog.warehouse", s"s3a://$testBucketName/warehouse")
     applyS3CatalogProps(conf, "s3_catalog")
 
+    // blob:// variant: opt into the `blob` alias (shared setup in CometS3TestBase). Exercises the
+    // delete-matching invariant: the Iceberg path rewrites nothing, so metadata, delete, and data
+    // file paths all stay raw blob:// and iceberg-rust's exact-string delete match lines up.
+    applyBlobSchemeProps(conf, testBucketName)
+
+    conf.set("spark.sql.catalog.blob_catalog", "org.apache.iceberg.spark.SparkCatalog")
+    conf.set("spark.sql.catalog.blob_catalog.type", "hadoop")
+    conf.set("spark.sql.catalog.blob_catalog.warehouse", s"blob://$testBucketName/warehouse-blob")
+    applyS3CatalogProps(conf, "blob_catalog")
+
     conf.set(CometConf.COMET_ENABLED.key, "true")
     conf.set(CometConf.COMET_EXEC_ENABLED.key, "true")
     conf.set(CometConf.COMET_ICEBERG_NATIVE_ENABLED.key, "true")
@@ -220,6 +230,38 @@ class IcebergReadFromS3Suite extends CometS3TestBase with RESTCatalogHelper {
     checkIcebergNativeScan("SELECT * FROM s3_catalog.db.mor_delete_test ORDER BY id")
 
     spark.sql("DROP TABLE s3_catalog.db.mor_delete_test")
+  }
+
+  test("blob:// MOR table with deletes applies positional deletes over blob paths") {
+    assume(icebergAvailable, "Iceberg not available in classpath")
+
+    // Same shape as the s3a MOR test under a blob:// warehouse. Data files and the delete file's
+    // stored `file_path` both carry blob://, and the Iceberg path rewrites neither, so the raw
+    // data_file_path and the delete file's raw recorded location match by exact string compare. A
+    // scheme rewrite on either side would desync the two and silently leak deleted rows.
+    spark.sql("""
+      CREATE TABLE blob_catalog.db.mor_delete_blob (
+        id INT,
+        name STRING,
+        value DOUBLE
+      ) USING iceberg
+      TBLPROPERTIES (
+        'write.delete.mode' = 'merge-on-read',
+        'write.merge.mode' = 'merge-on-read'
+      )
+    """)
+
+    spark.sql("""
+      INSERT INTO blob_catalog.db.mor_delete_blob VALUES
+      (1, 'Alice', 10.5), (2, 'Bob', 20.3), (3, 'Charlie', 30.7),
+      (4, 'Diana', 15.2), (5, 'Eve', 25.8)
+    """)
+
+    spark.sql("DELETE FROM blob_catalog.db.mor_delete_blob WHERE id IN (2, 4)")
+
+    checkIcebergNativeScan("SELECT * FROM blob_catalog.db.mor_delete_blob ORDER BY id")
+
+    spark.sql("DROP TABLE blob_catalog.db.mor_delete_blob")
   }
 
   test("REST catalog credential vending rejects wrong credentials") {

--- a/spark/src/test/scala/org/apache/comet/IcebergReadFromS3Suite.scala
+++ b/spark/src/test/scala/org/apache/comet/IcebergReadFromS3Suite.scala
@@ -204,64 +204,39 @@ class IcebergReadFromS3Suite extends CometS3TestBase with RESTCatalogHelper {
     }
   }
 
-  test("MOR table with deletes in S3") {
-    assume(icebergAvailable, "Iceberg not available in classpath")
+  // The blob:// case additionally exercises the delete-matching invariant: data files and the
+  // delete file's stored `file_path` both carry blob://, and the Iceberg path rewrites neither, so
+  // the raw data_file_path and the delete file's raw recorded location match by exact string
+  // compare. A scheme rewrite on either side would desync the two and silently leak deleted rows.
+  Seq("s3_catalog" -> "mor_delete_test", "blob_catalog" -> "mor_delete_blob").foreach {
+    case (catalog, table) =>
+      test(s"MOR table with deletes in $catalog") {
+        assume(icebergAvailable, "Iceberg not available in classpath")
 
-    spark.sql("""
-      CREATE TABLE s3_catalog.db.mor_delete_test (
-        id INT,
-        name STRING,
-        value DOUBLE
-      ) USING iceberg
-      TBLPROPERTIES (
-        'write.delete.mode' = 'merge-on-read',
-        'write.merge.mode' = 'merge-on-read'
-      )
-    """)
+        spark.sql(s"""
+          CREATE TABLE $catalog.db.$table (
+            id INT,
+            name STRING,
+            value DOUBLE
+          ) USING iceberg
+          TBLPROPERTIES (
+            'write.delete.mode' = 'merge-on-read',
+            'write.merge.mode' = 'merge-on-read'
+          )
+        """)
 
-    spark.sql("""
-      INSERT INTO s3_catalog.db.mor_delete_test VALUES
-      (1, 'Alice', 10.5), (2, 'Bob', 20.3), (3, 'Charlie', 30.7),
-      (4, 'Diana', 15.2), (5, 'Eve', 25.8)
-    """)
+        spark.sql(s"""
+          INSERT INTO $catalog.db.$table VALUES
+          (1, 'Alice', 10.5), (2, 'Bob', 20.3), (3, 'Charlie', 30.7),
+          (4, 'Diana', 15.2), (5, 'Eve', 25.8)
+        """)
 
-    spark.sql("DELETE FROM s3_catalog.db.mor_delete_test WHERE id IN (2, 4)")
+        spark.sql(s"DELETE FROM $catalog.db.$table WHERE id IN (2, 4)")
 
-    checkIcebergNativeScan("SELECT * FROM s3_catalog.db.mor_delete_test ORDER BY id")
+        checkIcebergNativeScan(s"SELECT * FROM $catalog.db.$table ORDER BY id")
 
-    spark.sql("DROP TABLE s3_catalog.db.mor_delete_test")
-  }
-
-  test("blob:// MOR table with deletes applies positional deletes over blob paths") {
-    assume(icebergAvailable, "Iceberg not available in classpath")
-
-    // Same shape as the s3a MOR test under a blob:// warehouse. Data files and the delete file's
-    // stored `file_path` both carry blob://, and the Iceberg path rewrites neither, so the raw
-    // data_file_path and the delete file's raw recorded location match by exact string compare. A
-    // scheme rewrite on either side would desync the two and silently leak deleted rows.
-    spark.sql("""
-      CREATE TABLE blob_catalog.db.mor_delete_blob (
-        id INT,
-        name STRING,
-        value DOUBLE
-      ) USING iceberg
-      TBLPROPERTIES (
-        'write.delete.mode' = 'merge-on-read',
-        'write.merge.mode' = 'merge-on-read'
-      )
-    """)
-
-    spark.sql("""
-      INSERT INTO blob_catalog.db.mor_delete_blob VALUES
-      (1, 'Alice', 10.5), (2, 'Bob', 20.3), (3, 'Charlie', 30.7),
-      (4, 'Diana', 15.2), (5, 'Eve', 25.8)
-    """)
-
-    spark.sql("DELETE FROM blob_catalog.db.mor_delete_blob WHERE id IN (2, 4)")
-
-    checkIcebergNativeScan("SELECT * FROM blob_catalog.db.mor_delete_blob ORDER BY id")
-
-    spark.sql("DROP TABLE blob_catalog.db.mor_delete_blob")
+        spark.sql(s"DROP TABLE $catalog.db.$table")
+      }
   }
 
   test("REST catalog credential vending rejects wrong credentials") {

--- a/spark/src/test/scala/org/apache/comet/cloud/s3/CometS3CredentialBridgeSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/cloud/s3/CometS3CredentialBridgeSuite.scala
@@ -21,7 +21,7 @@ package org.apache.comet.cloud.s3
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SaveMode
-import org.apache.spark.sql.comet.{CometIcebergNativeScanExec, CometNativeScanExec, CometScanExec}
+import org.apache.spark.sql.comet.CometIcebergNativeScanExec
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.{col, sum}
@@ -61,13 +61,10 @@ class CometS3CredentialBridgeSuite
     MinioCometS3CredentialProvider.installCredentials(userName, password)
   }
 
-  private def assertHasCometParquetScan(plan: SparkPlan): Unit = {
-    val scans = collect(plan) {
-      case p: CometScanExec => p
-      case p: CometNativeScanExec => p
-    }
-    assert(scans.nonEmpty, s"Expected at least one Comet Parquet scan in plan:\n$plan")
-  }
+  private def assertHasCometParquetScan(plan: SparkPlan): Unit =
+    assert(
+      cometScans(plan).nonEmpty,
+      s"Expected at least one Comet Parquet scan in plan:\n$plan")
 
   private def assertHasCometIcebergScan(plan: SparkPlan): Unit = {
     val scans = collect(plan) { case p: CometIcebergNativeScanExec => p }

--- a/spark/src/test/scala/org/apache/comet/cloud/s3/CometS3CredentialBridgeSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/cloud/s3/CometS3CredentialBridgeSuite.scala
@@ -62,9 +62,7 @@ class CometS3CredentialBridgeSuite
   }
 
   private def assertHasCometParquetScan(plan: SparkPlan): Unit =
-    assert(
-      cometScans(plan).nonEmpty,
-      s"Expected at least one Comet Parquet scan in plan:\n$plan")
+    assert(cometScans(plan).nonEmpty, s"Expected at least one Comet Parquet scan in plan:\n$plan")
 
   private def assertHasCometIcebergScan(plan: SparkPlan): Unit = {
     val scans = collect(plan) { case p: CometIcebergNativeScanExec => p }

--- a/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
@@ -44,7 +44,10 @@ class NativeConfigSuite extends AnyFunSuite with Matchers {
     hadoopConf.set("fs.azure.account.key.testaccount.blob.core.windows.net", "azure-key")
 
     // Should extract s3 options
-    Seq("s3a://test-bucket/test-object", "s3://test-bucket/test-object").foreach { path =>
+    Seq(
+      "s3a://test-bucket/test-object",
+      "s3://test-bucket/test-object",
+      "blob://test-bucket/test-object").foreach { path =>
       val options = NativeConfig.extractObjectStoreOptions(hadoopConf, new URI(path))
       assert(options("fs.s3a.access.key") == "s3-access-key")
       assert(options("fs.s3a.secret.key") == "s3-secret-key")
@@ -107,5 +110,96 @@ class NativeConfigSuite extends AnyFunSuite with Matchers {
           "org.apache.hadoop.fs.azurebfs.oauth2.WorkloadIdentityTokenProvider",
         s"oauth provider type should be forwarded for $path")
     }
+  }
+
+  test("extractObjectStoreOptions - blob:// forwards vendor fs.blob.<authority>.* keys as s3a") {
+    // Some blob:// connectors use per-authority Hadoop keys and never set a region: the AWS
+    // SDK v1 client they build is happy with just an endpoint. Comet's native S3 path goes
+    // through object_store's AmazonS3Builder, which reads `fs.s3a.bucket.<bucket>.<suffix>`.
+    // When a user routes a bucket via `blob://` with an existing S3-compliant storage config,
+    // Comet must translate those keys automatically or the read fails with `Failed to resolve
+    // region: Bucket not found` (the AWS auto-detect HEAD).
+    val hadoopConf = new Configuration()
+    hadoopConf.set("fs.blob.mybucket.endpoint", "https://s3-compat.example.internal")
+    hadoopConf.set("fs.blob.mybucket.awsAccessKeyId", "AKIA-blob")
+    hadoopConf.set("fs.blob.mybucket.awsSecretAccessKey", "secret-blob")
+    // A different authority to make sure translation is per-authority.
+    hadoopConf.set("fs.blob.other.endpoint", "https://other.example.internal")
+
+    val opts = NativeConfig.extractObjectStoreOptions(
+      hadoopConf,
+      new URI("blob://mybucket/dataset/part-0.parquet"))
+
+    assert(opts("fs.s3a.bucket.mybucket.endpoint") == "https://s3-compat.example.internal")
+    assert(opts("fs.s3a.bucket.mybucket.access.key") == "AKIA-blob")
+    assert(opts("fs.s3a.bucket.mybucket.secret.key") == "secret-blob")
+    // Path-style is a common requirement of these S3-compatible services and must be
+    // propagated so signing targets the endpoint's path form rather than
+    // <bucket>.<endpoint-host>.
+    assert(opts("fs.s3a.bucket.mybucket.path.style.access") == "true")
+    // Per-authority translation must also apply to the second bucket seen in the same config.
+    assert(opts("fs.s3a.bucket.other.endpoint") == "https://other.example.internal")
+    // No region is set by the vendor connector; Comet must not synthesize one -- object_store's
+    // builder will default it, and non-AWS services typically accept any region in the SigV4
+    // credential.
+    assert(!opts.contains("fs.s3a.bucket.mybucket.endpoint.region"))
+  }
+
+  test("extractObjectStoreOptions - blob:// endpoint wins over conflicting fs.s3a.*") {
+    // For a blob:// URL, `fs.blob.<authority>.*` is the authoritative namespace. A user's
+    // `fs.s3a.*` in the same Spark session usually targets an unrelated s3a-scheme workload;
+    // leaking that endpoint into the blob connection silently sends credentials to the wrong
+    // service and produces a misleading 403 "access key Id you provided does not exist".
+    val hadoopConf = new Configuration()
+    hadoopConf.set("fs.blob.default.endpoint", "s3-compat.example.com")
+    hadoopConf.set("fs.blob.default.awsAccessKeyId", "AKIA-blob")
+    hadoopConf.set("fs.blob.default.awsSecretAccessKey", "secret-blob")
+    // Unrelated s3a-scheme endpoint the user also configured -- must NOT influence blob://.
+    hadoopConf.set("fs.s3a.endpoint", "other-s3.example.com")
+    hadoopConf.set("fs.s3a.endpoint.region", "other-region")
+
+    val opts = NativeConfig.extractObjectStoreOptions(
+      hadoopConf,
+      new URI("blob:///mybucket/dataset/part-0.parquet"))
+    assert(opts("fs.s3a.endpoint") == "s3-compat.example.com")
+    assert(opts("fs.s3a.access.key") == "AKIA-blob")
+    assert(opts("fs.s3a.secret.key") == "secret-blob")
+    assert(opts("fs.s3a.path.style.access") == "true")
+  }
+
+  test("extractObjectStoreOptions - blob translation does not fire for s3:// / s3a://") {
+    // The fs.blob.* namespace is scoped to blob:// URIs; do not surface it on plain s3/s3a URIs.
+    val hadoopConf = new Configuration()
+    hadoopConf.set("fs.blob.mybucket.endpoint", "https://s3-compat.example.internal")
+    val opts = NativeConfig.extractObjectStoreOptions(hadoopConf, new URI("s3a://mybucket/x"))
+    assert(!opts.contains("fs.s3a.bucket.mybucket.endpoint"))
+  }
+
+  test("extractObjectStoreOptions - blob:// maps fs.blob.default.* to global fs.s3a.*") {
+    // Some blob:// filesystem implementations fall back to authority=\"default\" whenever the
+    // URI has none. The actual S3 bucket in that case comes from the URL path, so per-bucket
+    // fs.s3a.bucket.default.* would never match at runtime. Translate to global fs.s3a.* so the
+    // credentials/endpoint apply to whichever bucket the URL path resolves to.
+    val hadoopConf = new Configuration()
+    hadoopConf.set("fs.blob.default.endpoint", "https://s3-compat.example.internal")
+    hadoopConf.set("fs.blob.default.awsAccessKeyId", "AKIA-default")
+    hadoopConf.set("fs.blob.default.awsSecretAccessKey", "secret-default")
+
+    // `blob:///mybucket/...` -- URL authority is empty, bucket is in the path.
+    val opts = NativeConfig.extractObjectStoreOptions(
+      hadoopConf,
+      new URI("blob:///mybucket/dataset/part-0.parquet"))
+
+    // GLOBAL keys, not per-bucket.
+    assert(opts("fs.s3a.endpoint") == "https://s3-compat.example.internal")
+    assert(opts("fs.s3a.access.key") == "AKIA-default")
+    assert(opts("fs.s3a.secret.key") == "secret-default")
+    // Vendor backends typically use path-style; propagate globally so the real-bucket request
+    // signs path-style even though the user did not set fs.s3a.path.style.access explicitly.
+    assert(opts("fs.s3a.path.style.access") == "true")
+    // Must NOT surface as fs.s3a.bucket.default.* -- that key would never match the real bucket
+    // and the auto-region HEAD to AWS would still fire.
+    assert(!opts.contains("fs.s3a.bucket.default.endpoint"))
+    assert(!opts.contains("fs.s3a.bucket.default.access.key"))
   }
 }

--- a/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
@@ -137,7 +137,8 @@ class NativeConfigSuite extends AnyFunSuite with Matchers {
     assert(options("fs.s3a.secret.key") == "${fs.s3a.access.key}")
   }
 
-  test("extractObjectStoreOptions - alias forwards vendor fs.<scheme>.<authority>.* keys as s3a") {
+  test(
+    "extractObjectStoreOptions - alias forwards vendor fs.<scheme>.<authority>.* keys as s3a") {
     // Alias connectors use per-authority keys (just an endpoint, no region). object_store's
     // AmazonS3Builder reads fs.s3a.bucket.<b>.<suffix>, so Comet must translate fs.<scheme>.<b>.*
     // or the read fails ("Failed to resolve region: Bucket not found"). The scheme is not

--- a/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
@@ -26,6 +26,8 @@ import org.scalatest.matchers.should.Matchers
 
 import org.apache.hadoop.conf.Configuration
 
+import org.apache.comet.CometConf.COMET_S3_COMPLIANT_SCHEMES_KEY
+
 class NativeConfigSuite extends AnyFunSuite with Matchers {
 
   test("extractObjectStoreOptions - multiple cloud provider configurations") {
@@ -72,11 +74,8 @@ class NativeConfigSuite extends AnyFunSuite with Matchers {
   }
 
   test("extractObjectStoreOptions - ABFS forwards Hadoop fs.azure.* auth keys") {
-    // Hadoop ABFS authentication (account keys, OAuth client credentials, Workload
-    // Identity / MSI token providers, SAS tokens) all live under fs.azure.*, not
-    // fs.abfs.*. Earlier versions of NativeConfig only forwarded fs.abfs.* for abfs[s]
-    // schemes, which silently dropped every real credential. Verify the abfs[s] prefix
-    // list now includes fs.azure.*.
+    // ABFS auth (account keys, OAuth, MSI/Workload Identity, SAS) lives under fs.azure.*, not
+    // fs.abfs.*. Verify abfs[s] forwards fs.azure.* (earlier versions dropped these credentials).
     val hadoopConf = new Configuration()
     hadoopConf.set("fs.azure.account.auth.type.myacct.dfs.core.windows.net", "OAuth")
     hadoopConf.set(
@@ -136,5 +135,249 @@ class NativeConfigSuite extends AnyFunSuite with Matchers {
       NativeConfig.extractObjectStoreOptions(hadoopConf, new URI("s3a://test-bucket/test-object"))
     assert(options("fs.s3a.access.key") == "${fs.s3a.secret.key}")
     assert(options("fs.s3a.secret.key") == "${fs.s3a.access.key}")
+  }
+
+  test("extractObjectStoreOptions - blob:// forwards vendor fs.blob.<authority>.* keys as s3a") {
+    // blob:// connectors use per-authority keys (just an endpoint, no region). object_store's
+    // AmazonS3Builder reads fs.s3a.bucket.<b>.<suffix>, so Comet must translate fs.blob.<b>.* or
+    // the read fails ("Failed to resolve region: Bucket not found").
+    val hadoopConf = new Configuration()
+    hadoopConf.set(COMET_S3_COMPLIANT_SCHEMES_KEY, "blob")
+    hadoopConf.set("fs.blob.mybucket.endpoint", "https://s3-compat.example.internal")
+    hadoopConf.set("fs.blob.mybucket.awsAccessKeyId", "AKIA-blob")
+    hadoopConf.set("fs.blob.mybucket.awsSecretAccessKey", "secret-blob")
+    // A different authority to make sure translation is per-authority.
+    hadoopConf.set("fs.blob.other.endpoint", "https://other.example.internal")
+
+    val opts = NativeConfig.extractObjectStoreOptions(
+      hadoopConf,
+      new URI("blob://mybucket/dataset/part-0.parquet"))
+
+    assert(opts("fs.s3a.bucket.mybucket.endpoint") == "https://s3-compat.example.internal")
+    assert(opts("fs.s3a.bucket.mybucket.access.key") == "AKIA-blob")
+    assert(opts("fs.s3a.bucket.mybucket.secret.key") == "secret-blob")
+    // Path-style is required by most S3-compatible services (signing targets the path form).
+    assert(opts("fs.s3a.bucket.mybucket.path.style.access") == "true")
+    // Per-authority translation must also apply to the second bucket seen in the same config.
+    assert(opts("fs.s3a.bucket.other.endpoint") == "https://other.example.internal")
+    // No region set by the vendor; Comet must not synthesize one (object_store defaults it).
+    assert(!opts.contains("fs.s3a.bucket.mybucket.endpoint.region"))
+  }
+
+  test(
+    "extractObjectStoreOptions - blob:// default authority lands at the resolved bucket scope") {
+    // For `blob:///mybucket/...` the blob FS reports authority "default"; the real bucket is the
+    // first path segment. `fs.blob.default.*` must land at `fs.s3a.bucket.mybucket.*`: overriding a
+    // stale per-bucket key there, and never clobbering an unrelated global `fs.s3a.*`.
+    val hadoopConf = new Configuration()
+    hadoopConf.set(COMET_S3_COMPLIANT_SCHEMES_KEY, "blob")
+    hadoopConf.set("fs.blob.default.endpoint", "s3-compat.example.com")
+    hadoopConf.set("fs.blob.default.awsAccessKeyId", "AKIA-blob")
+    hadoopConf.set("fs.blob.default.awsSecretAccessKey", "secret-blob")
+    // A stale per-bucket key for the SAME bucket the URL resolves to -- the default must win it.
+    hadoopConf.set("fs.s3a.bucket.mybucket.endpoint", "https://stale.example.internal")
+    // An unrelated global s3a endpoint -- must be preserved, proving the default never leaks there.
+    hadoopConf.set("fs.s3a.endpoint", "other-s3.example.com")
+
+    val opts = NativeConfig.extractObjectStoreOptions(
+      hadoopConf,
+      new URI("blob:///mybucket/dataset/part-0.parquet"))
+    assert(opts("fs.s3a.bucket.mybucket.endpoint") == "s3-compat.example.com")
+    assert(opts("fs.s3a.bucket.mybucket.access.key") == "AKIA-blob")
+    assert(opts("fs.s3a.bucket.mybucket.secret.key") == "secret-blob")
+    assert(opts("fs.s3a.bucket.mybucket.path.style.access") == "true")
+    // The unrelated global endpoint is intact: the default landed at bucket scope, not global.
+    assert(opts("fs.s3a.endpoint") == "other-s3.example.com")
+  }
+
+  test("extractObjectStoreOptions - blob translation does not fire for s3:// / s3a://") {
+    // The fs.blob.* namespace is scoped to blob:// URIs; do not surface it on plain s3/s3a URIs.
+    val hadoopConf = new Configuration()
+    hadoopConf.set(COMET_S3_COMPLIANT_SCHEMES_KEY, "blob")
+    hadoopConf.set("fs.blob.mybucket.endpoint", "https://s3-compat.example.internal")
+    val opts = NativeConfig.extractObjectStoreOptions(hadoopConf, new URI("s3a://mybucket/x"))
+    assert(!opts.contains("fs.s3a.bucket.mybucket.endpoint"))
+  }
+
+  test("extractObjectStoreOptions - explicit blob authority beats default authority") {
+    // `fs.blob.default.*` (promoted to the URL bucket) and an explicit `fs.blob.mybucket.*` both
+    // resolve to `fs.s3a.bucket.mybucket.*`. The explicit authority must win the conflict
+    // deterministically, independent of Hadoop config iteration order. Regression guard for the
+    // default-before-explicit ordering in translateVendorKeys.
+    val hadoopConf = new Configuration()
+    hadoopConf.set(COMET_S3_COMPLIANT_SCHEMES_KEY, "blob")
+    hadoopConf.set("fs.blob.default.endpoint", "https://default.example.internal")
+    hadoopConf.set("fs.blob.default.awsAccessKeyId", "AKIA-default")
+    hadoopConf.set("fs.blob.mybucket.endpoint", "https://explicit.example.internal")
+
+    val opts = NativeConfig.extractObjectStoreOptions(
+      hadoopConf,
+      new URI("blob://mybucket/data/part-0.parquet"))
+    // Explicit authority wins the conflicting endpoint...
+    assert(opts("fs.s3a.bucket.mybucket.endpoint") == "https://explicit.example.internal")
+    // ...and the default authority's non-conflicting key still lands at the same bucket scope.
+    assert(opts("fs.s3a.bucket.mybucket.access.key") == "AKIA-default")
+  }
+
+  test("extractObjectStoreOptions - blob:// preserves dotted bucket authorities") {
+    // Bucket names may contain dots (`my.bucket`); the authority group must keep the full name.
+    val hadoopConf = new Configuration()
+    hadoopConf.set(COMET_S3_COMPLIANT_SCHEMES_KEY, "blob")
+    hadoopConf.set("fs.blob.my.bucket.endpoint", "https://s3-compat.example.internal")
+    hadoopConf.set("fs.blob.my.bucket.awsAccessKeyId", "AKIA-dotted")
+    hadoopConf.set("fs.blob.my.bucket.awsSecretAccessKey", "secret-dotted")
+
+    val opts = NativeConfig.extractObjectStoreOptions(
+      hadoopConf,
+      new URI("blob://my.bucket/dataset/part-0.parquet"))
+
+    assert(opts("fs.s3a.bucket.my.bucket.endpoint") == "https://s3-compat.example.internal")
+    assert(opts("fs.s3a.bucket.my.bucket.access.key") == "AKIA-dotted")
+    assert(opts("fs.s3a.bucket.my.bucket.secret.key") == "secret-dotted")
+    assert(opts("fs.s3a.bucket.my.bucket.path.style.access") == "true")
+  }
+
+  test("extractObjectStoreOptions - S3-compliant schemes are opt-in (empty by default)") {
+    // With no `fs.comet.s3Compliant.schemes`, blob is not claimed, so nothing is extracted.
+    val hadoopConf = new Configuration()
+    hadoopConf.set("fs.s3a.access.key", "s3-access-key")
+    hadoopConf.set("fs.blob.mybucket.endpoint", "https://s3-compat.example.internal")
+
+    val opts = NativeConfig.extractObjectStoreOptions(
+      hadoopConf,
+      new URI("blob://mybucket/dataset/part-0.parquet"))
+    assert(opts.isEmpty, "blob must not be treated as S3-compliant unless opted in")
+  }
+
+  test("extractObjectStoreOptions - configured blob scheme reuses fs.s3a.* and copies the key") {
+    val hadoopConf = new Configuration()
+    hadoopConf.set(COMET_S3_COMPLIANT_SCHEMES_KEY, "blob")
+    hadoopConf.set("fs.s3a.access.key", "s3-access-key")
+    hadoopConf.set("fs.s3a.secret.key", "s3-secret-key")
+
+    val opts = NativeConfig.extractObjectStoreOptions(
+      hadoopConf,
+      new URI("blob://test-bucket/test-object"))
+    assert(opts("fs.s3a.access.key") == "s3-access-key")
+    assert(opts("fs.s3a.secret.key") == "s3-secret-key")
+    // The configured scheme list is forwarded to the native side.
+    assert(opts(COMET_S3_COMPLIANT_SCHEMES_KEY) == "blob")
+  }
+
+  test("extractObjectStoreOptions - non-blob configured scheme translates fs.<scheme>.* keys") {
+    // A configured alias uses its own vendor namespace (fs.minio.<auth>.*), case-insensitive list.
+    val hadoopConf = new Configuration()
+    hadoopConf.set(COMET_S3_COMPLIANT_SCHEMES_KEY, "MinIO, r2")
+    hadoopConf.set("fs.minio.mybucket.endpoint", "https://minio.example.internal")
+    hadoopConf.set("fs.minio.mybucket.awsAccessKeyId", "AKIA-minio")
+    hadoopConf.set("fs.minio.mybucket.awsSecretAccessKey", "secret-minio")
+
+    val opts = NativeConfig.extractObjectStoreOptions(
+      hadoopConf,
+      new URI("minio://mybucket/dataset/part-0.parquet"))
+    assert(opts("fs.s3a.bucket.mybucket.endpoint") == "https://minio.example.internal")
+    assert(opts("fs.s3a.bucket.mybucket.access.key") == "AKIA-minio")
+    assert(opts("fs.s3a.bucket.mybucket.secret.key") == "secret-minio")
+    assert(opts("fs.s3a.bucket.mybucket.path.style.access") == "true")
+  }
+
+  test("extractObjectStoreOptions - explicit per-bucket path.style.access=false is preserved") {
+    // The synthesized path-style is a soft default: an explicit per-bucket false wins (the hatch).
+    val hadoopConf = new Configuration()
+    hadoopConf.set(COMET_S3_COMPLIANT_SCHEMES_KEY, "blob")
+    hadoopConf.set("fs.blob.mybucket.endpoint", "https://s3-compat.example.internal")
+    hadoopConf.set("fs.s3a.bucket.mybucket.path.style.access", "false")
+
+    val opts = NativeConfig.extractObjectStoreOptions(
+      hadoopConf,
+      new URI("blob://mybucket/dataset/part-0.parquet"))
+    assert(opts("fs.s3a.bucket.mybucket.endpoint") == "https://s3-compat.example.internal")
+    assert(opts("fs.s3a.bucket.mybucket.path.style.access") == "false")
+  }
+
+  test(
+    "extractObjectStoreOptions - global path.style.access does not suppress per-bucket synth") {
+    // A global fs.s3a.path.style.access must NOT suppress the per-bucket synth: it may be ambient
+    // or for other workloads, and per-bucket wins natively. Only a per-bucket setting is the hatch.
+    val hadoopConf = new Configuration()
+    hadoopConf.set(COMET_S3_COMPLIANT_SCHEMES_KEY, "blob")
+    hadoopConf.set("fs.blob.mybucket.endpoint", "https://s3-compat.example.internal")
+    hadoopConf.set("fs.s3a.path.style.access", "false")
+
+    val opts = NativeConfig.extractObjectStoreOptions(
+      hadoopConf,
+      new URI("blob://mybucket/dataset/part-0.parquet"))
+    assert(opts("fs.s3a.bucket.mybucket.path.style.access") == "true")
+    assert(opts("fs.s3a.path.style.access") == "false")
+  }
+
+  test("extractObjectStoreOptions - vendor session token, region, path-style translate") {
+    val hadoopConf = new Configuration()
+    hadoopConf.set(COMET_S3_COMPLIANT_SCHEMES_KEY, "blob")
+    hadoopConf.set("fs.blob.mybucket.endpoint", "https://s3-compat.example.internal")
+    hadoopConf.set("fs.blob.mybucket.awsSessionToken", "session-token-xyz")
+    hadoopConf.set("fs.blob.mybucket.region", "us-west-2")
+    // An explicit vendor path-style must win over the synthesized endpoint default.
+    hadoopConf.set("fs.blob.mybucket.pathStyleAccess", "false")
+
+    val opts = NativeConfig.extractObjectStoreOptions(
+      hadoopConf,
+      new URI("blob://mybucket/dataset/part-0.parquet"))
+    assert(opts("fs.s3a.bucket.mybucket.session.token") == "session-token-xyz")
+    assert(opts("fs.s3a.bucket.mybucket.endpoint.region") == "us-west-2")
+    assert(opts("fs.s3a.bucket.mybucket.path.style.access") == "false")
+  }
+
+  test("extractObjectStoreOptions - vendor key overrides conflicting same-scope fs.s3a.*") {
+    // Real vendor keys override a same-scope fs.s3a.* value (the 403-misdirect guard).
+    val hadoopConf = new Configuration()
+    hadoopConf.set(COMET_S3_COMPLIANT_SCHEMES_KEY, "blob")
+    hadoopConf.set("fs.s3a.bucket.mybucket.endpoint", "https://stale.example.internal")
+    hadoopConf.set("fs.blob.mybucket.endpoint", "https://vendor.example.internal")
+
+    val opts = NativeConfig.extractObjectStoreOptions(
+      hadoopConf,
+      new URI("blob://mybucket/dataset/part-0.parquet"))
+    assert(opts("fs.s3a.bucket.mybucket.endpoint") == "https://vendor.example.internal")
+  }
+
+  test("bucketForUri - authority is the bucket for s3/s3a and configured aliases") {
+    NativeConfig.bucketForUri(new URI("s3://mybucket/key"), Set.empty) shouldBe Some("mybucket")
+    NativeConfig.bucketForUri(new URI("s3a://mybucket/key"), Set.empty) shouldBe Some("mybucket")
+    // blob is only S3-family when opted in; its authority is still the bucket.
+    NativeConfig.bucketForUri(new URI("blob://mybucket/key"), Set("blob")) shouldBe Some(
+      "mybucket")
+  }
+
+  test("bucketForUri - authorityless alias promotes the first path segment") {
+    // `blob:///mybucket/...` reports authority "default"; the real bucket is the first path segment
+    // (matching the native rewrite), but only when the scheme is an opted-in S3-compliant alias.
+    NativeConfig.bucketForUri(new URI("blob:///mybucket/key"), Set("blob")) shouldBe
+      Some("mybucket")
+    // Not opted in -> not S3-family -> no path promotion.
+    NativeConfig.bucketForUri(new URI("blob:///mybucket/key"), Set.empty) shouldBe None
+  }
+
+  test(
+    "bucketForUri - non-S3 scheme with no authority returns None, not the first path segment") {
+    // Regression guard: a local Hadoop-catalog metadata path must NOT resolve to bucket `tmp`.
+    NativeConfig.bucketForUri(
+      new URI("file:///tmp/warehouse/db/t/metadata/v1.metadata.json"),
+      Set("blob")) shouldBe None
+    NativeConfig.bucketForUri(new URI("gs:///tmp/object"), Set("blob")) shouldBe None
+  }
+
+  test("s3FamilyBuckets - collects distinct buckets from S3-family URIs only") {
+    val uris = Seq(
+      new URI("s3://bucket-a/x"),
+      new URI("s3a://bucket-a/y"), // same bucket, different scheme
+      new URI("blob://bucket-b/z"), // alias, counts only when opted in
+      new URI("file:///tmp/local"), // not S3-family -> ignored
+      new URI("gs://gcs-bucket/g")
+    ) // not S3-family -> ignored (no fs.s3a.* per-bucket surface)
+    NativeConfig.s3FamilyBuckets(uris, Set("blob")) shouldBe Set("bucket-a", "bucket-b")
+    // Without the opt-in, blob is not S3-family, so its bucket drops out.
+    NativeConfig.s3FamilyBuckets(uris, Set.empty) shouldBe Set("bucket-a")
+    NativeConfig.s3FamilyBuckets(Seq.empty, Set("blob")) shouldBe Set.empty
   }
 }

--- a/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
@@ -328,19 +328,6 @@ class NativeConfigSuite extends AnyFunSuite with Matchers {
     assert(opts("fs.s3a.bucket.mybucket.path.style.access") == "false")
   }
 
-  test("extractObjectStoreOptions - vendor key overrides conflicting same-scope fs.s3a.*") {
-    // Real vendor keys override a same-scope fs.s3a.* value (the 403-misdirect guard).
-    val hadoopConf = new Configuration()
-    hadoopConf.set(COMET_S3_COMPLIANT_SCHEMES_KEY, "blob")
-    hadoopConf.set("fs.s3a.bucket.mybucket.endpoint", "https://stale.example.internal")
-    hadoopConf.set("fs.blob.mybucket.endpoint", "https://vendor.example.internal")
-
-    val opts = NativeConfig.extractObjectStoreOptions(
-      hadoopConf,
-      new URI("blob://mybucket/dataset/part-0.parquet"))
-    assert(opts("fs.s3a.bucket.mybucket.endpoint") == "https://vendor.example.internal")
-  }
-
   test("bucketForUri - authority is the bucket for s3/s3a and configured aliases") {
     NativeConfig.bucketForUri(new URI("s3://mybucket/key"), Set.empty) shouldBe Some("mybucket")
     NativeConfig.bucketForUri(new URI("s3a://mybucket/key"), Set.empty) shouldBe Some("mybucket")
@@ -367,17 +354,14 @@ class NativeConfigSuite extends AnyFunSuite with Matchers {
     NativeConfig.bucketForUri(new URI("gs:///tmp/object"), Set("blob")) shouldBe None
   }
 
-  test("s3FamilyBuckets - collects distinct buckets from S3-family URIs only") {
-    val uris = Seq(
-      new URI("s3://bucket-a/x"),
-      new URI("s3a://bucket-a/y"), // same bucket, different scheme
-      new URI("blob://bucket-b/z"), // alias, counts only when opted in
-      new URI("file:///tmp/local"), // not S3-family -> ignored
-      new URI("gs://gcs-bucket/g")
-    ) // not S3-family -> ignored (no fs.s3a.* per-bucket surface)
-    NativeConfig.s3FamilyBuckets(uris, Set("blob")) shouldBe Set("bucket-a", "bucket-b")
-    // Without the opt-in, blob is not S3-family, so its bucket drops out.
-    NativeConfig.s3FamilyBuckets(uris, Set.empty) shouldBe Set("bucket-a")
-    NativeConfig.s3FamilyBuckets(Seq.empty, Set("blob")) shouldBe Set.empty
+  test("resolveS3CompliantSchemes - comma list is trimmed and lowercased, empty means none") {
+    val conf = new Configuration(false)
+    assert(
+      NativeConfig.resolveS3CompliantSchemes(conf).isEmpty,
+      "missing config must yield no aliases (opt-in default)")
+    conf.set(COMET_S3_COMPLIANT_SCHEMES_KEY, " Blob , MINIO ,, r2 ")
+    assert(
+      NativeConfig.resolveS3CompliantSchemes(conf) == Set("blob", "minio", "r2"),
+      "schemes must be split on commas, trimmed, lowercased, with blanks dropped")
   }
 }

--- a/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/objectstore/NativeConfigSuite.scala
@@ -137,31 +137,36 @@ class NativeConfigSuite extends AnyFunSuite with Matchers {
     assert(options("fs.s3a.secret.key") == "${fs.s3a.access.key}")
   }
 
-  test("extractObjectStoreOptions - blob:// forwards vendor fs.blob.<authority>.* keys as s3a") {
-    // blob:// connectors use per-authority keys (just an endpoint, no region). object_store's
-    // AmazonS3Builder reads fs.s3a.bucket.<b>.<suffix>, so Comet must translate fs.blob.<b>.* or
-    // the read fails ("Failed to resolve region: Bucket not found").
-    val hadoopConf = new Configuration()
-    hadoopConf.set(COMET_S3_COMPLIANT_SCHEMES_KEY, "blob")
-    hadoopConf.set("fs.blob.mybucket.endpoint", "https://s3-compat.example.internal")
-    hadoopConf.set("fs.blob.mybucket.awsAccessKeyId", "AKIA-blob")
-    hadoopConf.set("fs.blob.mybucket.awsSecretAccessKey", "secret-blob")
-    // A different authority to make sure translation is per-authority.
-    hadoopConf.set("fs.blob.other.endpoint", "https://other.example.internal")
+  test("extractObjectStoreOptions - alias forwards vendor fs.<scheme>.<authority>.* keys as s3a") {
+    // Alias connectors use per-authority keys (just an endpoint, no region). object_store's
+    // AmazonS3Builder reads fs.s3a.bucket.<b>.<suffix>, so Comet must translate fs.<scheme>.<b>.*
+    // or the read fails ("Failed to resolve region: Bucket not found"). The scheme is not
+    // hardcoded, and the configured list is case-insensitive.
+    for ((schemeList, scheme) <- Seq("blob" -> "blob", "MinIO, r2" -> "minio")) {
+      val hadoopConf = new Configuration()
+      hadoopConf.set(COMET_S3_COMPLIANT_SCHEMES_KEY, schemeList)
+      hadoopConf.set(s"fs.$scheme.mybucket.endpoint", "https://s3-compat.example.internal")
+      hadoopConf.set(s"fs.$scheme.mybucket.awsAccessKeyId", "AKIA-alias")
+      hadoopConf.set(s"fs.$scheme.mybucket.awsSecretAccessKey", "secret-alias")
+      // A different authority to make sure translation is per-authority.
+      hadoopConf.set(s"fs.$scheme.other.endpoint", "https://other.example.internal")
 
-    val opts = NativeConfig.extractObjectStoreOptions(
-      hadoopConf,
-      new URI("blob://mybucket/dataset/part-0.parquet"))
+      val opts = NativeConfig.extractObjectStoreOptions(
+        hadoopConf,
+        new URI(s"$scheme://mybucket/dataset/part-0.parquet"))
 
-    assert(opts("fs.s3a.bucket.mybucket.endpoint") == "https://s3-compat.example.internal")
-    assert(opts("fs.s3a.bucket.mybucket.access.key") == "AKIA-blob")
-    assert(opts("fs.s3a.bucket.mybucket.secret.key") == "secret-blob")
-    // Path-style is required by most S3-compatible services (signing targets the path form).
-    assert(opts("fs.s3a.bucket.mybucket.path.style.access") == "true")
-    // Per-authority translation must also apply to the second bucket seen in the same config.
-    assert(opts("fs.s3a.bucket.other.endpoint") == "https://other.example.internal")
-    // No region set by the vendor; Comet must not synthesize one (object_store defaults it).
-    assert(!opts.contains("fs.s3a.bucket.mybucket.endpoint.region"))
+      withClue(s"scheme=$scheme list=$schemeList: ") {
+        assert(opts("fs.s3a.bucket.mybucket.endpoint") == "https://s3-compat.example.internal")
+        assert(opts("fs.s3a.bucket.mybucket.access.key") == "AKIA-alias")
+        assert(opts("fs.s3a.bucket.mybucket.secret.key") == "secret-alias")
+        // Path-style is required by most S3-compatible services (signing targets the path form).
+        assert(opts("fs.s3a.bucket.mybucket.path.style.access") == "true")
+        // Per-authority translation must also apply to the second bucket in the same config.
+        assert(opts("fs.s3a.bucket.other.endpoint") == "https://other.example.internal")
+        // No region set by the vendor; Comet must not synthesize one (object_store defaults it).
+        assert(!opts.contains("fs.s3a.bucket.mybucket.endpoint.region"))
+      }
+    }
   }
 
   test(
@@ -264,51 +269,28 @@ class NativeConfigSuite extends AnyFunSuite with Matchers {
     assert(opts(COMET_S3_COMPLIANT_SCHEMES_KEY) == "blob")
   }
 
-  test("extractObjectStoreOptions - non-blob configured scheme translates fs.<scheme>.* keys") {
-    // A configured alias uses its own vendor namespace (fs.minio.<auth>.*), case-insensitive list.
-    val hadoopConf = new Configuration()
-    hadoopConf.set(COMET_S3_COMPLIANT_SCHEMES_KEY, "MinIO, r2")
-    hadoopConf.set("fs.minio.mybucket.endpoint", "https://minio.example.internal")
-    hadoopConf.set("fs.minio.mybucket.awsAccessKeyId", "AKIA-minio")
-    hadoopConf.set("fs.minio.mybucket.awsSecretAccessKey", "secret-minio")
-
-    val opts = NativeConfig.extractObjectStoreOptions(
-      hadoopConf,
-      new URI("minio://mybucket/dataset/part-0.parquet"))
-    assert(opts("fs.s3a.bucket.mybucket.endpoint") == "https://minio.example.internal")
-    assert(opts("fs.s3a.bucket.mybucket.access.key") == "AKIA-minio")
-    assert(opts("fs.s3a.bucket.mybucket.secret.key") == "secret-minio")
-    assert(opts("fs.s3a.bucket.mybucket.path.style.access") == "true")
-  }
-
-  test("extractObjectStoreOptions - explicit per-bucket path.style.access=false is preserved") {
-    // The synthesized path-style is a soft default: an explicit per-bucket false wins (the hatch).
+  test("extractObjectStoreOptions - endpoint path-style synth: only per-bucket suppresses it") {
+    // The synthesized path-style is a soft default: an explicit PER-BUCKET setting wins (the
+    // escape hatch), but a GLOBAL one must not suppress it -- the global may be ambient or for
+    // other s3a workloads, and per-bucket wins natively anyway.
     val hadoopConf = new Configuration()
     hadoopConf.set(COMET_S3_COMPLIANT_SCHEMES_KEY, "blob")
-    hadoopConf.set("fs.blob.mybucket.endpoint", "https://s3-compat.example.internal")
-    hadoopConf.set("fs.s3a.bucket.mybucket.path.style.access", "false")
-
-    val opts = NativeConfig.extractObjectStoreOptions(
-      hadoopConf,
-      new URI("blob://mybucket/dataset/part-0.parquet"))
-    assert(opts("fs.s3a.bucket.mybucket.endpoint") == "https://s3-compat.example.internal")
-    assert(opts("fs.s3a.bucket.mybucket.path.style.access") == "false")
-  }
-
-  test(
-    "extractObjectStoreOptions - global path.style.access does not suppress per-bucket synth") {
-    // A global fs.s3a.path.style.access must NOT suppress the per-bucket synth: it may be ambient
-    // or for other workloads, and per-bucket wins natively. Only a per-bucket setting is the hatch.
-    val hadoopConf = new Configuration()
-    hadoopConf.set(COMET_S3_COMPLIANT_SCHEMES_KEY, "blob")
-    hadoopConf.set("fs.blob.mybucket.endpoint", "https://s3-compat.example.internal")
+    hadoopConf.set("fs.blob.pinned.endpoint", "https://pinned.example.internal")
+    hadoopConf.set("fs.s3a.bucket.pinned.path.style.access", "false")
+    hadoopConf.set("fs.blob.synth.endpoint", "https://synth.example.internal")
     hadoopConf.set("fs.s3a.path.style.access", "false")
 
-    val opts = NativeConfig.extractObjectStoreOptions(
+    val pinned = NativeConfig.extractObjectStoreOptions(
       hadoopConf,
-      new URI("blob://mybucket/dataset/part-0.parquet"))
-    assert(opts("fs.s3a.bucket.mybucket.path.style.access") == "true")
-    assert(opts("fs.s3a.path.style.access") == "false")
+      new URI("blob://pinned/dataset/part-0.parquet"))
+    assert(pinned("fs.s3a.bucket.pinned.endpoint") == "https://pinned.example.internal")
+    assert(pinned("fs.s3a.bucket.pinned.path.style.access") == "false")
+
+    val synth = NativeConfig.extractObjectStoreOptions(
+      hadoopConf,
+      new URI("blob://synth/dataset/part-0.parquet"))
+    assert(synth("fs.s3a.bucket.synth.path.style.access") == "true")
+    assert(synth("fs.s3a.path.style.access") == "false")
   }
 
   test("extractObjectStoreOptions - vendor session token, region, path-style translate") {
@@ -328,30 +310,27 @@ class NativeConfigSuite extends AnyFunSuite with Matchers {
     assert(opts("fs.s3a.bucket.mybucket.path.style.access") == "false")
   }
 
-  test("bucketForUri - authority is the bucket for s3/s3a and configured aliases") {
-    NativeConfig.bucketForUri(new URI("s3://mybucket/key"), Set.empty) shouldBe Some("mybucket")
-    NativeConfig.bucketForUri(new URI("s3a://mybucket/key"), Set.empty) shouldBe Some("mybucket")
-    // blob is only S3-family when opted in; its authority is still the bucket.
-    NativeConfig.bucketForUri(new URI("blob://mybucket/key"), Set("blob")) shouldBe Some(
-      "mybucket")
-  }
+  test("bucketForUri - authority, alias path promotion, and non-S3 schemes") {
+    // `blob:///mybucket/...` reports authority "default"; the real bucket is the first path
+    // segment (matching the native rewrite), but path promotion applies ONLY to S3-family
+    // schemes. Non-S3 schemes must yield None rather than a surprising first-segment bucket --
+    // a local Hadoop-catalog metadata path must not resolve to bucket `tmp`.
+    val cases = Seq(
+      ("s3://mybucket/key", Set.empty[String], Some("mybucket")),
+      ("s3a://mybucket/key", Set.empty[String], Some("mybucket")),
+      // blob is only S3-family when opted in; its authority is still the bucket.
+      ("blob://mybucket/key", Set("blob"), Some("mybucket")),
+      ("blob:///mybucket/key", Set("blob"), Some("mybucket")),
+      // Not opted in -> not S3-family -> no path promotion.
+      ("blob:///mybucket/key", Set.empty[String], None),
+      ("file:///tmp/warehouse/db/t/metadata/v1.metadata.json", Set("blob"), None),
+      ("gs:///tmp/object", Set("blob"), None))
 
-  test("bucketForUri - authorityless alias promotes the first path segment") {
-    // `blob:///mybucket/...` reports authority "default"; the real bucket is the first path segment
-    // (matching the native rewrite), but only when the scheme is an opted-in S3-compliant alias.
-    NativeConfig.bucketForUri(new URI("blob:///mybucket/key"), Set("blob")) shouldBe
-      Some("mybucket")
-    // Not opted in -> not S3-family -> no path promotion.
-    NativeConfig.bucketForUri(new URI("blob:///mybucket/key"), Set.empty) shouldBe None
-  }
-
-  test(
-    "bucketForUri - non-S3 scheme with no authority returns None, not the first path segment") {
-    // Regression guard: a local Hadoop-catalog metadata path must NOT resolve to bucket `tmp`.
-    NativeConfig.bucketForUri(
-      new URI("file:///tmp/warehouse/db/t/metadata/v1.metadata.json"),
-      Set("blob")) shouldBe None
-    NativeConfig.bucketForUri(new URI("gs:///tmp/object"), Set("blob")) shouldBe None
+    for ((uri, schemes, expected) <- cases) {
+      withClue(s"$uri with aliases $schemes: ") {
+        NativeConfig.bucketForUri(new URI(uri), schemes) shouldBe expected
+      }
+    }
   }
 
   test("resolveS3CompliantSchemes - comma list is trimmed and lowercased, empty means none") {

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadFromS3Suite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadFromS3Suite.scala
@@ -27,7 +27,6 @@ import org.apache.parquet.crypto.keytools.{KeyToolkit, PropertiesDrivenCryptoFac
 import org.apache.parquet.crypto.keytools.mocks.InMemoryKMS
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, SaveMode}
-import org.apache.spark.sql.comet.{CometNativeScanExec, CometScanExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.{col, expr, max, sum}
 
@@ -67,21 +66,54 @@ class ParquetReadFromS3Suite extends CometS3TestBase with AdaptiveSparkPlanHelpe
     df.write.format("parquet").partitionBy("val").mode(SaveMode.Overwrite).save(filePath)
   }
 
-  private def assertCometScan(df: DataFrame): Unit = {
-    val scans = collect(df.queryExecution.executedPlan) {
-      case p: CometScanExec => p
-      case p: CometNativeScanExec => p
+  private def assertCometScan(df: DataFrame): Unit =
+    assert(cometScans(df.queryExecution.executedPlan).size == 1)
+
+  // Both schemes address the same MinIO. `blob` is the opt-in S3-compliant alias: the native scan
+  // reads it through object_store after rewriting blob:// -> s3://, with path-style defaulted on by
+  // the blob endpoint (MinIO requires it). assertCometScan confirms the alias is claimed natively.
+  private val readSchemes = Seq("s3a", "blob")
+
+  readSchemes.foreach { scheme =>
+    test(s"read parquet file from MinIO over $scheme://") {
+      val testFilePath = s"$scheme://$testBucketName/data/$scheme-test-file.parquet"
+      writeTestParquetFile(testFilePath)
+
+      val df = spark.read.format("parquet").load(testFilePath).agg(sum(col("id")))
+      assertCometScan(df)
+      assert(df.first().getLong(0) == 499500)
     }
-    assert(scans.size == 1)
-  }
 
-  test("read parquet file from MinIO") {
-    val testFilePath = s"s3a://$testBucketName/data/test-file.parquet"
-    writeTestParquetFile(testFilePath)
+    test(s"write and read encrypted parquet from S3 over $scheme://") {
+      import testImplicits._
 
-    val df = spark.read.format("parquet").load(testFilePath).agg(sum(col("id")))
-    assertCometScan(df)
-    assert(df.first().getLong(0) == 499500)
+      // Encryption cache-key agreement end to end. The put side caches the key retriever under the
+      // user-facing URI; the native side calls back with the rewritten s3:// URI. Both must
+      // canonicalize to the same key (CometFileKeyUnwrapper.normalizeS3Scheme) or the read fails.
+      withSQLConf(
+        DecryptionPropertiesFactory.CRYPTO_FACTORY_CLASS_PROPERTY_NAME -> cryptoFactoryClass,
+        KeyToolkit.KMS_CLIENT_CLASS_PROPERTY_NAME ->
+          "org.apache.parquet.crypto.keytools.mocks.InMemoryKMS",
+        InMemoryKMS.KEY_LIST_PROPERTY_NAME ->
+          s"footerKey: ${footerKey}, key1: ${key1}, key2: ${key2}") {
+
+        val inputDF = spark
+          .range(0, 1000)
+          .map(i => (i, i.toString, i.toFloat))
+          .repartition(5)
+          .toDF("a", "b", "c")
+
+        val testFilePath = s"$scheme://$testBucketName/data/encrypted-$scheme-test.parquet"
+        inputDF.write
+          .option(PropertiesDrivenCryptoFactory.COLUMN_KEYS_PROPERTY_NAME, "key1: a, b; key2: c")
+          .option(PropertiesDrivenCryptoFactory.FOOTER_KEY_PROPERTY_NAME, "footerKey")
+          .parquet(testFilePath)
+
+        val df = spark.read.parquet(testFilePath).agg(sum(col("a")))
+        assertCometScan(df)
+        assert(df.first().getLong(0) == 499500)
+      }
+    }
   }
 
   test("read partitioned parquet file from MinIO") {
@@ -104,83 +136,12 @@ class ParquetReadFromS3Suite extends CometS3TestBase with AdaptiveSparkPlanHelpe
     assert(df.first().getLong(0) == 499500)
   }
 
-  test("write and read encrypted parquet from S3") {
-    import testImplicits._
-
-    withSQLConf(
-      DecryptionPropertiesFactory.CRYPTO_FACTORY_CLASS_PROPERTY_NAME -> cryptoFactoryClass,
-      KeyToolkit.KMS_CLIENT_CLASS_PROPERTY_NAME ->
-        "org.apache.parquet.crypto.keytools.mocks.InMemoryKMS",
-      InMemoryKMS.KEY_LIST_PROPERTY_NAME ->
-        s"footerKey: ${footerKey}, key1: ${key1}, key2: ${key2}") {
-
-      val inputDF = spark
-        .range(0, 1000)
-        .map(i => (i, i.toString, i.toFloat))
-        .repartition(5)
-        .toDF("a", "b", "c")
-
-      val testFilePath = s"s3a://$testBucketName/data/encrypted-test.parquet"
-      inputDF.write
-        .option(PropertiesDrivenCryptoFactory.COLUMN_KEYS_PROPERTY_NAME, "key1: a, b; key2: c")
-        .option(PropertiesDrivenCryptoFactory.FOOTER_KEY_PROPERTY_NAME, "footerKey")
-        .parquet(testFilePath)
-
-      val df = spark.read.parquet(testFilePath).agg(sum(col("a")))
-      assertCometScan(df)
-      assert(df.first().getLong(0) == 499500)
-    }
-  }
-
-  test("read parquet file from MinIO over blob://") {
-    // Plain read over the opt-in blob:// alias: the native scan reads through object_store after
-    // rewriting blob:// -> s3://. path-style (defaulted on by the blob endpoint) is required for
-    // MinIO. assertCometScan confirms the alias was claimed natively.
-    val testFilePath = s"blob://$testBucketName/data/blob-test-file.parquet"
-    writeTestParquetFile(testFilePath)
-
-    val df = spark.read.format("parquet").load(testFilePath).agg(sum(col("id")))
-    assertCometScan(df)
-    assert(df.first().getLong(0) == 499500)
-  }
-
-  test("write and read encrypted parquet from S3 over blob://") {
-    import testImplicits._
-
-    // Encryption cache-key agreement over blob paths, end to end. The put side caches the key
-    // retriever under the blob:// URI. The native side calls back with the rewritten s3:// URI.
-    // Both must canonicalize to the same key (CometFileKeyUnwrapper.normalizeS3Scheme) or it fails.
-    withSQLConf(
-      DecryptionPropertiesFactory.CRYPTO_FACTORY_CLASS_PROPERTY_NAME -> cryptoFactoryClass,
-      KeyToolkit.KMS_CLIENT_CLASS_PROPERTY_NAME ->
-        "org.apache.parquet.crypto.keytools.mocks.InMemoryKMS",
-      InMemoryKMS.KEY_LIST_PROPERTY_NAME ->
-        s"footerKey: ${footerKey}, key1: ${key1}, key2: ${key2}") {
-
-      val inputDF = spark
-        .range(0, 1000)
-        .map(i => (i, i.toString, i.toFloat))
-        .repartition(5)
-        .toDF("a", "b", "c")
-
-      val testFilePath = s"blob://$testBucketName/data/encrypted-blob-test.parquet"
-      inputDF.write
-        .option(PropertiesDrivenCryptoFactory.COLUMN_KEYS_PROPERTY_NAME, "key1: a, b; key2: c")
-        .option(PropertiesDrivenCryptoFactory.FOOTER_KEY_PROPERTY_NAME, "footerKey")
-        .parquet(testFilePath)
-
-      val df = spark.read.parquet(testFilePath).agg(sum(col("a")))
-      assertCometScan(df)
-      assert(df.first().getLong(0) == 499500)
-    }
-  }
-
   test("mixed-bucket blob:// scan falls back and returns correct results") {
     // Native planning registers ONE object store per FilePartition (keyed on the first file's
     // bucket) and strips the authority from every file's object key, so a scan spanning two blob
     // buckets would read every file from the first bucket -- returning [111, 111] instead of
-    // [111, 222]. CometScanRule must decline it so Spark reads both buckets correctly. Regression
-    // for the P1 in sunchao's 2026-09-02 review. Same key in each bucket makes the misread visible.
+    // [111, 222]. CometScanRule must decline it so Spark reads both buckets correctly. Same key in
+    // each bucket makes the misread visible.
     createBucketIfNotExists(secondBucketName)
     val key = "multibucket/same-key.parquet"
     val firstPath = s"blob://$testBucketName/$key"
@@ -189,12 +150,8 @@ class ParquetReadFromS3Suite extends CometS3TestBase with AdaptiveSparkPlanHelpe
     spark.range(222, 223).toDF("id").write.mode(SaveMode.Overwrite).parquet(secondPath)
 
     val df = spark.read.parquet(firstPath, secondPath)
-    val nativeScans = collect(df.queryExecution.executedPlan) {
-      case p: CometNativeScanExec => p
-      case p: CometScanExec => p
-    }
     assert(
-      nativeScans.isEmpty,
+      cometScans(df.queryExecution.executedPlan).isEmpty,
       "mixed-bucket alias scan must fall back to Spark, but Comet claimed it:\n" +
         df.queryExecution.executedPlan)
     assert(

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadFromS3Suite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadFromS3Suite.scala
@@ -25,6 +25,7 @@ import java.util.Base64
 import org.apache.parquet.crypto.DecryptionPropertiesFactory
 import org.apache.parquet.crypto.keytools.{KeyToolkit, PropertiesDrivenCryptoFactory}
 import org.apache.parquet.crypto.keytools.mocks.InMemoryKMS
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.apache.spark.sql.comet.{CometNativeScanExec, CometScanExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
@@ -35,6 +36,17 @@ import org.apache.comet.CometS3TestBase
 class ParquetReadFromS3Suite extends CometS3TestBase with AdaptiveSparkPlanHelper {
 
   override protected val testBucketName = "test-bucket"
+  // Second bucket for the mixed-bucket regression below. BlobSchemeFileSystem is an S3AFileSystem
+  // reading the global fs.s3a.* surface, so this bucket needs no extra per-bucket config.
+  private val secondBucketName = "test-bucket-2"
+
+  override protected def sparkConf: SparkConf = {
+    val conf = super.sparkConf
+    // Opt into the `blob` alias (shared setup in CometS3TestBase). The blob:// tests below exercise
+    // the alias->s3 rewrite, path-style defaulting, and native claiming.
+    applyBlobSchemeProps(conf, testBucketName)
+    conf
+  }
 
   // Encryption keys for testing parquet encryption
   private val encoder = Base64.getEncoder
@@ -118,5 +130,75 @@ class ParquetReadFromS3Suite extends CometS3TestBase with AdaptiveSparkPlanHelpe
       assertCometScan(df)
       assert(df.first().getLong(0) == 499500)
     }
+  }
+
+  test("read parquet file from MinIO over blob://") {
+    // Plain read over the opt-in blob:// alias: the native scan reads through object_store after
+    // rewriting blob:// -> s3://. path-style (defaulted on by the blob endpoint) is required for
+    // MinIO. assertCometScan confirms the alias was claimed natively.
+    val testFilePath = s"blob://$testBucketName/data/blob-test-file.parquet"
+    writeTestParquetFile(testFilePath)
+
+    val df = spark.read.format("parquet").load(testFilePath).agg(sum(col("id")))
+    assertCometScan(df)
+    assert(df.first().getLong(0) == 499500)
+  }
+
+  test("write and read encrypted parquet from S3 over blob://") {
+    import testImplicits._
+
+    // Encryption cache-key agreement over blob paths, end to end. The put side caches the key
+    // retriever under the blob:// URI. The native side calls back with the rewritten s3:// URI.
+    // Both must canonicalize to the same key (CometFileKeyUnwrapper.normalizeS3Scheme) or it fails.
+    withSQLConf(
+      DecryptionPropertiesFactory.CRYPTO_FACTORY_CLASS_PROPERTY_NAME -> cryptoFactoryClass,
+      KeyToolkit.KMS_CLIENT_CLASS_PROPERTY_NAME ->
+        "org.apache.parquet.crypto.keytools.mocks.InMemoryKMS",
+      InMemoryKMS.KEY_LIST_PROPERTY_NAME ->
+        s"footerKey: ${footerKey}, key1: ${key1}, key2: ${key2}") {
+
+      val inputDF = spark
+        .range(0, 1000)
+        .map(i => (i, i.toString, i.toFloat))
+        .repartition(5)
+        .toDF("a", "b", "c")
+
+      val testFilePath = s"blob://$testBucketName/data/encrypted-blob-test.parquet"
+      inputDF.write
+        .option(PropertiesDrivenCryptoFactory.COLUMN_KEYS_PROPERTY_NAME, "key1: a, b; key2: c")
+        .option(PropertiesDrivenCryptoFactory.FOOTER_KEY_PROPERTY_NAME, "footerKey")
+        .parquet(testFilePath)
+
+      val df = spark.read.parquet(testFilePath).agg(sum(col("a")))
+      assertCometScan(df)
+      assert(df.first().getLong(0) == 499500)
+    }
+  }
+
+  test("mixed-bucket blob:// scan falls back and returns correct results") {
+    // Native planning registers ONE object store per FilePartition (keyed on the first file's
+    // bucket) and strips the authority from every file's object key, so a scan spanning two blob
+    // buckets would read every file from the first bucket -- returning [111, 111] instead of
+    // [111, 222]. CometScanRule must decline it so Spark reads both buckets correctly. Regression
+    // for the P1 in sunchao's 2026-09-02 review. Same key in each bucket makes the misread visible.
+    createBucketIfNotExists(secondBucketName)
+    val key = "multibucket/same-key.parquet"
+    val firstPath = s"blob://$testBucketName/$key"
+    val secondPath = s"blob://$secondBucketName/$key"
+    spark.range(111, 112).toDF("id").write.mode(SaveMode.Overwrite).parquet(firstPath)
+    spark.range(222, 223).toDF("id").write.mode(SaveMode.Overwrite).parquet(secondPath)
+
+    val df = spark.read.parquet(firstPath, secondPath)
+    val nativeScans = collect(df.queryExecution.executedPlan) {
+      case p: CometNativeScanExec => p
+      case p: CometScanExec => p
+    }
+    assert(
+      nativeScans.isEmpty,
+      "mixed-bucket alias scan must fall back to Spark, but Comet claimed it:\n" +
+        df.queryExecution.executedPlan)
+    assert(
+      df.collect().map(_.getLong(0)).toSet == Set(111L, 222L),
+      "both buckets must be read; a single registered object store would read one bucket twice")
   }
 }

--- a/spark/src/test/scala/org/apache/comet/rules/CometScanSchemeFallbackSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/CometScanSchemeFallbackSuite.scala
@@ -20,6 +20,7 @@
 package org.apache.comet.rules
 
 import java.io.File
+import java.net.URI
 import java.nio.file.Files
 import java.util.UUID
 
@@ -98,6 +99,41 @@ class CometScanSchemeFallbackSuite extends CometTestBase {
         sparkScans.size == 1,
         s"expected the scan to remain a Spark FileSourceScanExec:\n$transformed")
     }
+  }
+
+  test("blob:// is a Comet-recognized synonym for s3://") {
+    // `blob` is not in object_store::ObjectStoreScheme, so the native JNI must special-case it
+    // (native/core/src/lib.rs) for `isNativelyReadableScheme` to return true. Without that
+    // disjunct, `CometScanRule.transformV1Scan` emits `Unsupported filesystem schemes: blob`
+    // and falls back to Spark -- the exact regression this suite guards against. Both the
+    // Parquet-scan and Iceberg-scan gates delegate to `isNativelyReadableScheme`, so this one
+    // assertion covers both.
+    assert(
+      CometScanRule.isNativelyReadableScheme(new URI("blob://bucket/key.parquet")),
+      "blob:// must be recognized natively; native JNI or the s3-alias rewrite has regressed")
+  }
+
+  test("iceberg gate: oss:// admitted (regression guard for #<future>)") {
+    // Aliyun OSS is readable by iceberg-rust via `OpenDalStorageFactory::Oss`
+    // (native/core/src/execution/operators/iceberg_scan.rs::storage_factory_for), but
+    // `object_store::ObjectStoreScheme::parse` does NOT recognize it. If the iceberg gate
+    // delegates to only `isNativelyReadableScheme`, `oss` would fall back to Spark even though
+    // native can read it. `isIcebergReadableScheme` supplements the JNI check with schemes
+    // iceberg-rust supports on top of object_store; keep the two in lockstep with the arms in
+    // `storage_factory_for`.
+    assert(
+      CometScanRule.isIcebergReadableScheme(new URI("oss://bucket/key.parquet")),
+      "oss:// must remain iceberg-readable; icebergExtraSchemes has regressed")
+  }
+
+  test("iceberg gate: wasbs:// rejected (correctness tightening)") {
+    // The pre-delegation hardcoded set falsely admitted wasbs/wasb/gcs, none of which
+    // `storage_factory_for` in native/core/src/execution/operators/iceberg_scan.rs actually
+    // handles at runtime. Delegating to the native gate closes that false positive so scans
+    // fall back to Spark up-front instead of failing later during native setup.
+    assert(
+      !CometScanRule.isIcebergReadableScheme(new URI("wasbs://container@acct/key.parquet")),
+      "wasbs:// must not be iceberg-readable; native storage_factory_for has no wasbs arm")
   }
 
   test("native scan claims hdfs:// when libhdfs.schemes is unset (native-default lockstep)") {

--- a/spark/src/test/scala/org/apache/comet/rules/CometScanSchemeFallbackSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/CometScanSchemeFallbackSuite.scala
@@ -20,10 +20,12 @@
 package org.apache.comet.rules
 
 import java.io.File
+import java.net.URI
 import java.nio.file.Files
 import java.util.UUID
 
 import org.apache.commons.io.FileUtils
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{CometTestBase, SaveMode}
 import org.apache.spark.sql.comet.CometScanExec
@@ -31,17 +33,17 @@ import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 
 import org.apache.comet.CometConf
 import org.apache.comet.hadoop.fs.{FakeHDFSFileSystem, FakeHdfsSchemeFileSystem}
+import org.apache.comet.objectstore.NativeConfig
 
 /**
- * Comet's native readers go through object_store, which only understands a fixed set of URL
- * schemes. A custom Hadoop FileSystem scheme that object_store can't parse (here `fake://`) must
- * NOT be claimed by the native scan -- it would fail at execution with "Unable to recognise URL".
- * `CometScanRule` must decline it so Spark's Hadoop-FS-aware reader handles the scan.
- *
- * Unlike `ParquetReadFromFakeHadoopFsSuite`, this suite does NOT route the `fake` scheme through
- * libhdfs (`spark.hadoop.fs.comet.libhdfs.schemes`), so it exercises the decline path. The test
- * applies the rule directly to the physical plan and asserts fallback -- no query execution, so
- * it doesn't depend on the native reader actually attempting (and failing on) the scheme.
+ * Comet's native readers go through object_store, which understands a fixed set of URL schemes. A
+ * custom Hadoop FileSystem scheme object_store can't parse (`fake://`) must NOT be claimed -- it
+ * would fail at execution with "Unable to recognise URL". This suite applies `CometScanRule` to
+ * the physical plan and asserts fallback (no execution), and unit-tests the two scheme gates
+ * directly: `isNativelyReadableScheme` (Parquet) and `isIcebergReadableScheme` (Iceberg).
+ * S3-compliant alias schemes like `blob` are opt-in via `fs.comet.s3Compliant.schemes`, and the
+ * native probe is cached by (scheme, has-authority) so an authorityless URL can't poison the
+ * authority-bearing form.
  */
 class CometScanSchemeFallbackSuite extends CometTestBase {
 
@@ -73,10 +75,8 @@ class CometScanSchemeFallbackSuite extends CometTestBase {
     val path = s"${FakeHDFSFileSystem.PREFIX}${fakeRootDir.getAbsolutePath}/data"
     spark.range(0, 10).toDF("id").write.format("parquet").mode(SaveMode.Overwrite).save(path)
 
-    // Obtain a clean Spark physical plan (Comet disabled) with the FileSourceScanExec, then apply
-    // CometScanRule directly. No execution -- we only check whether the rule claims the scan.
-    // Capture via a var inside the block: `SQLTestUtils.withSQLConf` returns Unit on Spark 3.5
-    // but a value on Spark 4.x, so we can't return the plan out of it cross-version.
+    // Clean Spark plan (Comet disabled), then apply CometScanRule directly -- no execution, we
+    // only check whether the rule claims the scan. (var capture: withSQLConf returns Unit on 3.5.)
     var sparkPlan: SparkPlan = null
     withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
       sparkPlan = spark.read.parquet(path).queryExecution.executedPlan
@@ -100,12 +100,149 @@ class CometScanSchemeFallbackSuite extends CometTestBase {
     }
   }
 
+  test("both gates: a configured s3-compliant scheme (minio) is admitted") {
+    // Neither object_store-native nor in the Iceberg allowlist: declined absent config, admitted
+    // on both paths once opted in. A `blob` alias behaves identically on the parquet gate (opt-in,
+    // not object_store-native); its Iceberg-gate coverage is below and its end-to-end parquet
+    // coverage is in ParquetReadFromS3Suite.
+    val uri = new URI("minio://bucket/key.parquet")
+    assert(!CometScanRule.isNativelyReadableScheme(uri, Set.empty))
+    assert(!CometScanRule.isIcebergReadableScheme(uri, Set.empty))
+    assert(CometScanRule.isNativelyReadableScheme(uri, Set("minio")))
+    assert(CometScanRule.isIcebergReadableScheme(uri, Set("minio")))
+  }
+
+  test("parquet gate: authorityless URI first does not poison the authority-bearing form") {
+    // ObjectStoreScheme::parse keys on (scheme, host-presence): `gs:///` (no host) is unrecognized,
+    // `gs://bucket/` is. The cache uses the same pair, so probing the authorityless form first must
+    // NOT poison the whole scheme (the old single-scheme key did).
+    CometScanRule.isNativelyReadableScheme(new URI("gs:///key.parquet"), Set.empty)
+    assert(
+      CometScanRule.isNativelyReadableScheme(new URI("gs://bucket/key.parquet"), Set.empty),
+      "gs://bucket/... must be admitted even after an authorityless gs:// URI was probed first")
+  }
+
+  test("iceberg gate: builtin allowlist admitted, unbuildable schemes rejected, blob opt-in") {
+    // The Iceberg gate is an explicit allowlist mirroring `storage_factory_for`'s arms (keep in
+    // lockstep). Narrower than the Parquet gate: object_store recognizes http/abfs/wasb but
+    // iceberg-rust can't build them, so reject up-front rather than fail during native setup.
+    Seq(
+      "file:///tmp/key.parquet",
+      "s3://bucket/key.parquet",
+      "s3a://bucket/key.parquet",
+      "gs://bucket/key.parquet",
+      "oss://bucket/key.parquet").foreach { u =>
+      assert(
+        CometScanRule.isIcebergReadableScheme(new URI(u), Set.empty),
+        s"$u must be iceberg-readable; icebergReadableSchemes has regressed")
+    }
+    Seq(
+      "http://bucket.example.com/key.parquet",
+      "https://bucket.example.com/key.parquet",
+      "abfs://container@acct/key.parquet",
+      "abfss://container@acct/key.parquet",
+      "wasb://container@acct/key.parquet",
+      "wasbs://container@acct/key.parquet").foreach { u =>
+      assert(
+        !CometScanRule.isIcebergReadableScheme(new URI(u), Set.empty),
+        s"$u must not be iceberg-readable; storage_factory_for has no matching arm")
+    }
+    // `blob` was removed from the hardcoded allowlist; it is opt-in via config on this path too.
+    val blob = new URI("blob://bucket/key.parquet")
+    assert(
+      !CometScanRule.isIcebergReadableScheme(blob, Set.empty),
+      "blob:// must NOT be iceberg-readable without opt-in config")
+    assert(
+      CometScanRule.isIcebergReadableScheme(blob, Set("blob")),
+      "blob:// must be iceberg-readable once configured as an s3-compliant scheme")
+  }
+
+  test("parquet gate: mixed-bucket alias scan is declined (single object store per partition)") {
+    // Native planning registers one object store per FilePartition and strips the authority from
+    // every file's object key, so files in a second bucket would be read from the first. A scan
+    // whose opt-in alias paths span multiple buckets must fall back. [P1 / sunchao 2026-09-02]
+    val schemes = Set("blob")
+    val twoBuckets =
+      Seq(new URI("blob://bucket-a/k.parquet"), new URI("blob://bucket-b/k.parquet"))
+    assert(
+      CometScanRule.mixedAliasScanBuckets(twoBuckets, schemes) == Set("bucket-a", "bucket-b"),
+      "two alias buckets must be reported so the Parquet gate falls back")
+    // An alias bucket mixed with a plain-s3 bucket is still two object stores -> declined.
+    val aliasPlusS3 =
+      Seq(new URI("blob://bucket-a/k.parquet"), new URI("s3://bucket-b/k.parquet"))
+    assert(
+      CometScanRule.mixedAliasScanBuckets(aliasPlusS3, schemes) == Set("bucket-a", "bucket-b"))
+    // Safe scans report nothing: one alias bucket, or the same bucket via two paths.
+    val oneBucket = Seq(new URI("blob://bucket-a/x.parquet"))
+    assert(CometScanRule.mixedAliasScanBuckets(oneBucket, schemes).isEmpty)
+    val sameBucket =
+      Seq(new URI("blob://bucket-a/x.parquet"), new URI("blob://bucket-a/y.parquet"))
+    assert(CometScanRule.mixedAliasScanBuckets(sameBucket, schemes).isEmpty)
+    // No alias path present: plain multi-bucket s3:// is a pre-existing limitation, out of scope.
+    val plainS3 = Seq(new URI("s3://bucket-a/k.parquet"), new URI("s3://bucket-b/k.parquet"))
+    assert(CometScanRule.mixedAliasScanBuckets(plainS3, schemes).isEmpty)
+  }
+
+  test("parquet gate: object_store rejects an actual path with an illegal character") {
+    // The scheme cache is path-independent, but a valid `file` scheme can carry a path object_store
+    // rejects: a directory name with a newline surfaces as `%0A` and `Path::from_url_path` fails.
+    // Native execution would hard-error, so the real path is probed separately. [P2 / 2026-09-02]
+    assert(
+      CometScanRule.objectStoreAcceptsPath(new URI("file:///tmp/warehouse/data")),
+      "an ordinary local path must be accepted by object_store")
+    assert(
+      !CometScanRule.objectStoreAcceptsPath(new URI("file:///tmp/dir%0A/data")),
+      "a directory name containing a newline (%0A) must be rejected so the scan falls back")
+  }
+
+  test("iceberg gate: hostless alias promotes bucket from path; other hostless schemes decline") {
+    // iceberg-rust opens files by their raw location. Host-bearing locations always work. Hostless
+    // ones work ONLY for opt-in S3-compliant aliases, which the native reader opens by promoting
+    // the bucket from the first path segment (BlobHostPromotingS3Storage). [bucket promotion]
+    val schemes = Set("blob")
+    // Host-bearing: openable regardless of scheme family; `file`/schemeless need no host.
+    assert(CometScanRule.isIcebergOpenableLocation(new URI("s3://bucket/k.parquet"), schemes))
+    assert(CometScanRule.isIcebergOpenableLocation(new URI("blob://bucket/k.parquet"), schemes))
+    assert(CometScanRule.isIcebergOpenableLocation(new URI("file:///tmp/k.parquet"), schemes))
+    assert(CometScanRule.isIcebergOpenableLocation(new URI("/tmp/k.parquet"), schemes))
+    // Hostless alias: NOW openable -- the bucket is promoted from the first path segment.
+    assert(
+      CometScanRule.isIcebergOpenableLocation(new URI("blob:///bucket/k.parquet"), schemes),
+      "hostless blob:/// must be openable: native promotes the first path segment to the bucket")
+    assert(
+      CometScanRule.isIcebergOpenableLocation(new URI("blob:/bucket/k.parquet"), schemes),
+      "the opaque single-slash blob:/ form promotes the same way")
+    // Hostless alias with no promotable bucket segment: declined (nothing to promote).
+    assert(
+      !CometScanRule.isIcebergOpenableLocation(new URI("blob:///"), schemes),
+      "a hostless alias URL with no bucket segment cannot be promoted")
+    // Hostless non-alias: still declined; s3/s3a/gs/oss have no bucket-from-path promotion.
+    assert(
+      !CometScanRule.isIcebergOpenableLocation(new URI("s3:///bucket/k.parquet"), schemes),
+      "authorityless s3:/// has no host and no alias promotion")
+    // blob not opted in: not a readable scheme at all, so not openable.
+    assert(
+      !CometScanRule.isIcebergOpenableLocation(new URI("blob:///bucket/k.parquet"), Set.empty),
+      "without opt-in, blob is not iceberg-readable, so not openable")
+    // An unreadable scheme is never openable regardless of authority.
+    assert(!CometScanRule.isIcebergOpenableLocation(new URI("http://h/k.parquet"), schemes))
+  }
+
+  test("resolveS3CompliantSchemes: comma list is trimmed and lowercased, empty means none") {
+    val conf = new Configuration(false)
+    assert(
+      NativeConfig.resolveS3CompliantSchemes(conf).isEmpty,
+      "missing config must yield no aliases (opt-in default)")
+    conf.set(CometConf.COMET_S3_COMPLIANT_SCHEMES_KEY, " Blob , MINIO ,, r2 ")
+    assert(
+      NativeConfig.resolveS3CompliantSchemes(conf) == Set("blob", "minio", "r2"),
+      "schemes must be split on commas, trimmed, lowercased, with blanks dropped")
+  }
+
   test("native scan claims hdfs:// when libhdfs.schemes is unset (native-default lockstep)") {
-    // Native's `is_hdfs_scheme` treats `hdfs` as readable when `fs.comet.libhdfs.schemes` is unset,
-    // and `create_hdfs_object_store` is in the default build. The JVM gate must agree: with the
-    // config unset, an `hdfs://` scan must be CLAIMED by Comet, not declined to Spark. Guards the
-    // `case None => Set("hdfs")` default in CometScanRule against the silent-fallback regression
-    // Andy flagged in #4525.
+    // Native `is_hdfs_scheme` treats `hdfs` as readable when `fs.comet.libhdfs.schemes` is unset,
+    // so the JVM gate must agree and CLAIM `hdfs://`. Guards the `case None => Set("hdfs")` default
+    // against the silent-fallback regression from #4525.
     val path = s"${FakeHdfsSchemeFileSystem.PREFIX}${fakeRootDir.getAbsolutePath}/hdfs-data"
     spark.range(0, 10).toDF("id").write.format("parquet").mode(SaveMode.Overwrite).save(path)
 

--- a/spark/src/test/scala/org/apache/comet/rules/CometScanSchemeFallbackSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/CometScanSchemeFallbackSuite.scala
@@ -22,10 +22,9 @@ package org.apache.comet.rules
 import java.io.File
 import java.net.URI
 import java.nio.file.Files
-import java.util.UUID
+import java.util.{Locale, UUID}
 
 import org.apache.commons.io.FileUtils
-import org.apache.hadoop.conf.Configuration
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{CometTestBase, SaveMode}
 import org.apache.spark.sql.comet.CometScanExec
@@ -33,7 +32,6 @@ import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 
 import org.apache.comet.CometConf
 import org.apache.comet.hadoop.fs.{FakeHDFSFileSystem, FakeHdfsSchemeFileSystem}
-import org.apache.comet.objectstore.NativeConfig
 
 /**
  * Comet's native readers go through object_store, which understands a fixed set of URL schemes. A
@@ -42,8 +40,8 @@ import org.apache.comet.objectstore.NativeConfig
  * the physical plan and asserts fallback (no execution), and unit-tests the two scheme gates
  * directly: `isNativelyReadableScheme` (Parquet) and `isIcebergReadableScheme` (Iceberg).
  * S3-compliant alias schemes like `blob` are opt-in via `fs.comet.s3Compliant.schemes`, and the
- * native probe is cached by (scheme, has-authority) so an authorityless URL can't poison the
- * authority-bearing form.
+ * native probe is cached per probe URL so an authorityless URL can't poison the authority-bearing
+ * form of the same scheme.
  */
 class CometScanSchemeFallbackSuite extends CometTestBase {
 
@@ -114,8 +112,8 @@ class CometScanSchemeFallbackSuite extends CometTestBase {
 
   test("parquet gate: authorityless URI first does not poison the authority-bearing form") {
     // ObjectStoreScheme::parse keys on (scheme, host-presence): `gs:///` (no host) is unrecognized,
-    // `gs://bucket/` is. The cache uses the same pair, so probing the authorityless form first must
-    // NOT poison the whole scheme (the old single-scheme key did).
+    // `gs://bucket/` is. The cache is keyed on the probe URL, so probing the authorityless form
+    // first must NOT poison the whole scheme (the old single-scheme key did).
     CometScanRule.isNativelyReadableScheme(new URI("gs:///key.parquet"), Set.empty)
     assert(
       CometScanRule.isNativelyReadableScheme(new URI("gs://bucket/key.parquet"), Set.empty),
@@ -199,44 +197,38 @@ class CometScanSchemeFallbackSuite extends CometTestBase {
     // iceberg-rust opens files by their raw location. Host-bearing locations always work. Hostless
     // ones work ONLY for opt-in S3-compliant aliases, which the native reader opens by promoting
     // the bucket from the first path segment (BlobHostPromotingS3Storage). [bucket promotion]
+    // `hasOpenableAuthority` is the predicate `validateIcebergFileScanTasks` applies per data and
+    // delete file, once its scheme has cleared `isIcebergReadableScheme` (covered above).
     val schemes = Set("blob")
+    def openable(location: String, s3Compliant: Set[String] = schemes): Boolean = {
+      val uri = new URI(location)
+      val scheme = Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)).orNull
+      CometScanRule.hasOpenableAuthority(uri, scheme, s3Compliant)
+    }
     // Host-bearing: openable regardless of scheme family; `file`/schemeless need no host.
-    assert(CometScanRule.isIcebergOpenableLocation(new URI("s3://bucket/k.parquet"), schemes))
-    assert(CometScanRule.isIcebergOpenableLocation(new URI("blob://bucket/k.parquet"), schemes))
-    assert(CometScanRule.isIcebergOpenableLocation(new URI("file:///tmp/k.parquet"), schemes))
-    assert(CometScanRule.isIcebergOpenableLocation(new URI("/tmp/k.parquet"), schemes))
-    // Hostless alias: NOW openable -- the bucket is promoted from the first path segment.
+    assert(openable("s3://bucket/k.parquet"))
+    assert(openable("blob://bucket/k.parquet"))
+    assert(openable("file:///tmp/k.parquet"))
+    assert(openable("/tmp/k.parquet"))
+    // Hostless alias: openable -- the bucket is promoted from the first path segment.
     assert(
-      CometScanRule.isIcebergOpenableLocation(new URI("blob:///bucket/k.parquet"), schemes),
+      openable("blob:///bucket/k.parquet"),
       "hostless blob:/// must be openable: native promotes the first path segment to the bucket")
     assert(
-      CometScanRule.isIcebergOpenableLocation(new URI("blob:/bucket/k.parquet"), schemes),
+      openable("blob:/bucket/k.parquet"),
       "the opaque single-slash blob:/ form promotes the same way")
     // Hostless alias with no promotable bucket segment: declined (nothing to promote).
     assert(
-      !CometScanRule.isIcebergOpenableLocation(new URI("blob:///"), schemes),
+      !openable("blob:///"),
       "a hostless alias URL with no bucket segment cannot be promoted")
     // Hostless non-alias: still declined; s3/s3a/gs/oss have no bucket-from-path promotion.
     assert(
-      !CometScanRule.isIcebergOpenableLocation(new URI("s3:///bucket/k.parquet"), schemes),
+      !openable("s3:///bucket/k.parquet"),
       "authorityless s3:/// has no host and no alias promotion")
-    // blob not opted in: not a readable scheme at all, so not openable.
+    // blob not opted in: no promotion, so the hostless form is not openable either.
     assert(
-      !CometScanRule.isIcebergOpenableLocation(new URI("blob:///bucket/k.parquet"), Set.empty),
-      "without opt-in, blob is not iceberg-readable, so not openable")
-    // An unreadable scheme is never openable regardless of authority.
-    assert(!CometScanRule.isIcebergOpenableLocation(new URI("http://h/k.parquet"), schemes))
-  }
-
-  test("resolveS3CompliantSchemes: comma list is trimmed and lowercased, empty means none") {
-    val conf = new Configuration(false)
-    assert(
-      NativeConfig.resolveS3CompliantSchemes(conf).isEmpty,
-      "missing config must yield no aliases (opt-in default)")
-    conf.set(CometConf.COMET_S3_COMPLIANT_SCHEMES_KEY, " Blob , MINIO ,, r2 ")
-    assert(
-      NativeConfig.resolveS3CompliantSchemes(conf) == Set("blob", "minio", "r2"),
-      "schemes must be split on commas, trimmed, lowercased, with blanks dropped")
+      !openable("blob:///bucket/k.parquet", Set.empty),
+      "without opt-in, blob gets no bucket promotion, so a hostless blob location is unopenable")
   }
 
   test("native scan claims hdfs:// when libhdfs.schemes is unset (native-default lockstep)") {

--- a/spark/src/test/scala/org/apache/comet/rules/CometScanSchemeFallbackSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/CometScanSchemeFallbackSuite.scala
@@ -22,7 +22,7 @@ package org.apache.comet.rules
 import java.io.File
 import java.net.URI
 import java.nio.file.Files
-import java.util.{Locale, UUID}
+import java.util.UUID
 
 import org.apache.commons.io.FileUtils
 import org.apache.spark.SparkConf
@@ -120,7 +120,7 @@ class CometScanSchemeFallbackSuite extends CometTestBase {
       "gs://bucket/... must be admitted even after an authorityless gs:// URI was probed first")
   }
 
-  test("iceberg gate: builtin allowlist admitted, unbuildable schemes rejected, blob opt-in") {
+  test("iceberg gate: builtin allowlist admitted, unbuildable schemes rejected") {
     // The Iceberg gate is an explicit allowlist mirroring `storage_factory_for`'s arms (keep in
     // lockstep). Narrower than the Parquet gate: object_store recognizes http/abfs/wasb but
     // iceberg-rust can't build them, so reject up-front rather than fail during native setup.
@@ -145,46 +145,37 @@ class CometScanSchemeFallbackSuite extends CometTestBase {
         !CometScanRule.isIcebergReadableScheme(new URI(u), Set.empty),
         s"$u must not be iceberg-readable; storage_factory_for has no matching arm")
     }
-    // `blob` was removed from the hardcoded allowlist; it is opt-in via config on this path too.
-    val blob = new URI("blob://bucket/key.parquet")
-    assert(
-      !CometScanRule.isIcebergReadableScheme(blob, Set.empty),
-      "blob:// must NOT be iceberg-readable without opt-in config")
-    assert(
-      CometScanRule.isIcebergReadableScheme(blob, Set("blob")),
-      "blob:// must be iceberg-readable once configured as an s3-compliant scheme")
   }
 
   test("parquet gate: mixed-bucket alias scan is declined (single object store per partition)") {
     // Native planning registers one object store per FilePartition and strips the authority from
     // every file's object key, so files in a second bucket would be read from the first. A scan
-    // whose opt-in alias paths span multiple buckets must fall back. [P1 / sunchao 2026-09-02]
+    // whose opt-in alias paths span multiple buckets must fall back.
     val schemes = Set("blob")
-    val twoBuckets =
-      Seq(new URI("blob://bucket-a/k.parquet"), new URI("blob://bucket-b/k.parquet"))
+    def buckets(locations: String*): Set[String] =
+      CometScanRule.aliasScanBuckets(
+        CometScanRule.classifyRootPaths(locations.map(new URI(_)), Set.empty, schemes))
+
     assert(
-      CometScanRule.mixedAliasScanBuckets(twoBuckets, schemes) == Set("bucket-a", "bucket-b"),
+      buckets("blob://bucket-a/k.parquet", "blob://bucket-b/k.parquet") ==
+        Set("bucket-a", "bucket-b"),
       "two alias buckets must be reported so the Parquet gate falls back")
     // An alias bucket mixed with a plain-s3 bucket is still two object stores -> declined.
-    val aliasPlusS3 =
-      Seq(new URI("blob://bucket-a/k.parquet"), new URI("s3://bucket-b/k.parquet"))
     assert(
-      CometScanRule.mixedAliasScanBuckets(aliasPlusS3, schemes) == Set("bucket-a", "bucket-b"))
-    // Safe scans report nothing: one alias bucket, or the same bucket via two paths.
-    val oneBucket = Seq(new URI("blob://bucket-a/x.parquet"))
-    assert(CometScanRule.mixedAliasScanBuckets(oneBucket, schemes).isEmpty)
-    val sameBucket =
-      Seq(new URI("blob://bucket-a/x.parquet"), new URI("blob://bucket-a/y.parquet"))
-    assert(CometScanRule.mixedAliasScanBuckets(sameBucket, schemes).isEmpty)
+      buckets("blob://bucket-a/k.parquet", "s3://bucket-b/k.parquet") ==
+        Set("bucket-a", "bucket-b"))
+    // Safe scans report at most one bucket: one alias path, or the same bucket via two paths.
+    assert(buckets("blob://bucket-a/x.parquet") == Set("bucket-a"))
+    assert(
+      buckets("blob://bucket-a/x.parquet", "blob://bucket-a/y.parquet") == Set("bucket-a"))
     // No alias path present: plain multi-bucket s3:// is a pre-existing limitation, out of scope.
-    val plainS3 = Seq(new URI("s3://bucket-a/k.parquet"), new URI("s3://bucket-b/k.parquet"))
-    assert(CometScanRule.mixedAliasScanBuckets(plainS3, schemes).isEmpty)
+    assert(buckets("s3://bucket-a/k.parquet", "s3://bucket-b/k.parquet").isEmpty)
   }
 
   test("parquet gate: object_store rejects an actual path with an illegal character") {
     // The scheme cache is path-independent, but a valid `file` scheme can carry a path object_store
     // rejects: a directory name with a newline surfaces as `%0A` and `Path::from_url_path` fails.
-    // Native execution would hard-error, so the real path is probed separately. [P2 / 2026-09-02]
+    // Native execution would hard-error, so the real path is probed separately.
     assert(
       CometScanRule.objectStoreAcceptsPath(new URI("file:///tmp/warehouse/data")),
       "an ordinary local path must be accepted by object_store")
@@ -196,15 +187,12 @@ class CometScanSchemeFallbackSuite extends CometTestBase {
   test("iceberg gate: hostless alias promotes bucket from path; other hostless schemes decline") {
     // iceberg-rust opens files by their raw location. Host-bearing locations always work. Hostless
     // ones work ONLY for opt-in S3-compliant aliases, which the native reader opens by promoting
-    // the bucket from the first path segment (BlobHostPromotingS3Storage). [bucket promotion]
+    // the bucket from the first path segment (BlobHostPromotingS3Storage).
     // `hasOpenableAuthority` is the predicate `validateIcebergFileScanTasks` applies per data and
     // delete file, once its scheme has cleared `isIcebergReadableScheme` (covered above).
     val schemes = Set("blob")
-    def openable(location: String, s3Compliant: Set[String] = schemes): Boolean = {
-      val uri = new URI(location)
-      val scheme = Option(uri.getScheme).map(_.toLowerCase(Locale.ROOT)).orNull
-      CometScanRule.hasOpenableAuthority(uri, scheme, s3Compliant)
-    }
+    def openable(location: String, s3Compliant: Set[String] = schemes): Boolean =
+      CometScanRule.hasOpenableAuthority(new URI(location), s3Compliant)
     // Host-bearing: openable regardless of scheme family; `file`/schemeless need no host.
     assert(openable("s3://bucket/k.parquet"))
     assert(openable("blob://bucket/k.parquet"))

--- a/spark/src/test/scala/org/apache/comet/rules/CometScanSchemeFallbackSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/CometScanSchemeFallbackSuite.scala
@@ -166,8 +166,7 @@ class CometScanSchemeFallbackSuite extends CometTestBase {
         Set("bucket-a", "bucket-b"))
     // Safe scans report at most one bucket: one alias path, or the same bucket via two paths.
     assert(buckets("blob://bucket-a/x.parquet") == Set("bucket-a"))
-    assert(
-      buckets("blob://bucket-a/x.parquet", "blob://bucket-a/y.parquet") == Set("bucket-a"))
+    assert(buckets("blob://bucket-a/x.parquet", "blob://bucket-a/y.parquet") == Set("bucket-a"))
     // No alias path present: plain multi-bucket s3:// is a pre-existing limitation, out of scope.
     assert(buckets("s3://bucket-a/k.parquet", "s3://bucket-b/k.parquet").isEmpty)
   }

--- a/spark/src/test/scala/org/apache/comet/serde/operator/CometIcebergNativeScanSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/serde/operator/CometIcebergNativeScanSuite.scala
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.serde.operator
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Unit tests for [[CometIcebergNativeScan.hadoopToIcebergS3Properties]]. The pinned iceberg-rust
+ * S3 parser reads ONLY global `s3.*` keys (never `s3.bucket.*`), so the function drops per-bucket
+ * keys and promotes just the TARGET bucket's keys to global `s3.*`. Pure-function assertions, so
+ * a lightweight `AnyFunSuite` (no Spark session) suffices.
+ */
+class CometIcebergNativeScanSuite extends AnyFunSuite with Matchers {
+
+  private def translate(
+      props: Map[String, String],
+      targetBucket: Option[String]): Map[String, String] =
+    CometIcebergNativeScan.hadoopToIcebergS3Properties(props, targetBucket)
+
+  test("full fs.s3a.* suffix mapping to global s3.* keys") {
+    // Every suffix handled by hadoopS3aSuffixToIcebergGlobalKey, verified end to end. Mappings are
+    // per-key independent (no cross-key interaction), so this table-driven case also covers the
+    // "several global fs.s3a.* keys at once" scenario.
+    val cases = Seq(
+      "access.key" -> "s3.access-key-id",
+      "secret.key" -> "s3.secret-access-key",
+      "session.token" -> "s3.session-token",
+      "endpoint" -> "s3.endpoint",
+      "path.style.access" -> "s3.path-style-access",
+      "endpoint.region" -> "s3.region")
+
+    cases.foreach { case (hadoopSuffix, icebergKey) =>
+      val out = translate(Map(s"fs.s3a.$hadoopSuffix" -> "v"), None)
+      out should contain(icebergKey -> "v")
+      // The Hadoop key itself is never passed through untranslated.
+      out.keys should not contain s"fs.s3a.$hadoopSuffix"
+    }
+  }
+
+  test("target bucket per-bucket keys are promoted to global s3.*") {
+    val props = Map(
+      "fs.s3a.bucket.target.access.key" -> "AKIA-target",
+      "fs.s3a.bucket.target.secret.key" -> "secret-target",
+      "fs.s3a.bucket.target.session.token" -> "token-target",
+      "fs.s3a.bucket.target.endpoint" -> "https://target.example.com",
+      "fs.s3a.bucket.target.path.style.access" -> "true",
+      "fs.s3a.bucket.target.endpoint.region" -> "eu-central-1")
+
+    val out = translate(props, Some("target"))
+
+    out("s3.access-key-id") shouldBe "AKIA-target"
+    out("s3.secret-access-key") shouldBe "secret-target"
+    out("s3.session-token") shouldBe "token-target"
+    out("s3.endpoint") shouldBe "https://target.example.com"
+    out("s3.path-style-access") shouldBe "true"
+    out("s3.region") shouldBe "eu-central-1"
+
+    // Per-bucket keys are never emitted in s3.bucket.* form (the pinned parser ignores those).
+    out.keys.foreach(k => k should not startWith "s3.bucket.")
+  }
+
+  test("non-target bucket per-bucket keys are dropped entirely") {
+    val props = Map(
+      "fs.s3a.bucket.other.access.key" -> "AKIA-other",
+      "fs.s3a.bucket.other.endpoint" -> "https://other.example.com",
+      "fs.s3a.bucket.other.path.style.access" -> "true")
+
+    val out = translate(props, Some("target"))
+
+    // A non-target bucket contributes nothing (not promoted, not emitted as s3.bucket.*).
+    out shouldBe empty
+  }
+
+  test("target bucket keys coexist with a different non-target bucket") {
+    val props = Map(
+      "fs.s3a.bucket.target.endpoint" -> "https://target.example.com",
+      "fs.s3a.bucket.target.access.key" -> "AKIA-target",
+      "fs.s3a.bucket.other.endpoint" -> "https://other.example.com",
+      "fs.s3a.bucket.other.access.key" -> "AKIA-other")
+
+    val out = translate(props, Some("target"))
+
+    out("s3.endpoint") shouldBe "https://target.example.com"
+    out("s3.access-key-id") shouldBe "AKIA-target"
+    // The non-target bucket's values must not leak into the global keys.
+    out.values.toSet should not contain "https://other.example.com"
+    out.values.toSet should not contain "AKIA-other"
+  }
+
+  test("target bucket per-bucket value overrides a conflicting global value") {
+    // targetBucketGlobals is merged last, so the per-bucket endpoint wins over the global one.
+    val props = Map(
+      "fs.s3a.endpoint" -> "https://global.example.com",
+      "fs.s3a.access.key" -> "AKIA-global",
+      "fs.s3a.bucket.target.endpoint" -> "https://target.example.com")
+
+    val out = translate(props, Some("target"))
+
+    out("s3.endpoint") shouldBe "https://target.example.com"
+    // A global key with no per-bucket override survives.
+    out("s3.access-key-id") shouldBe "AKIA-global"
+  }
+
+  test("dotted target bucket names survive (prefix match, not split)") {
+    val props = Map(
+      "fs.s3a.bucket.my.bucket.name.endpoint" -> "https://dotted.example.com",
+      "fs.s3a.bucket.my.bucket.name.access.key" -> "AKIA-dotted",
+      "fs.s3a.bucket.my.bucket.name.secret.key" -> "secret-dotted")
+
+    val out = translate(props, Some("my.bucket.name"))
+
+    out("s3.endpoint") shouldBe "https://dotted.example.com"
+    out("s3.access-key-id") shouldBe "AKIA-dotted"
+    out("s3.secret-access-key") shouldBe "secret-dotted"
+  }
+
+  test("keys already in iceberg s3.* form pass through unchanged") {
+    val props = Map(
+      "s3.endpoint" -> "https://passthrough.example.com",
+      "s3.access-key-id" -> "AKIA-passthrough")
+
+    val out = translate(props, None)
+
+    out("s3.endpoint") shouldBe "https://passthrough.example.com"
+    out("s3.access-key-id") shouldBe "AKIA-passthrough"
+  }
+
+  test("unrelated keys are ignored") {
+    val props = Map(
+      "fs.gs.project.id" -> "gcp-project",
+      "fs.azure.account.key.acct.blob.core.windows.net" -> "azure-key",
+      "spark.sql.shuffle.partitions" -> "200")
+
+    translate(props, Some("target")) shouldBe empty
+  }
+
+  test("no target bucket means no per-bucket promotion") {
+    // Required-parameter contract: with None, per-bucket keys drop, only global keys survive.
+    val props = Map(
+      "fs.s3a.bucket.some.endpoint" -> "https://some.example.com",
+      "fs.s3a.endpoint" -> "https://global.example.com")
+
+    val out = translate(props, None)
+
+    out("s3.endpoint") shouldBe "https://global.example.com"
+    out.values.toSet should not contain "https://some.example.com"
+  }
+}

--- a/spark/src/test/scala/org/apache/comet/serde/operator/CometIcebergNativeScanSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/serde/operator/CometIcebergNativeScanSuite.scala
@@ -35,19 +35,19 @@ class CometIcebergNativeScanSuite extends AnyFunSuite with Matchers {
       targetBucket: Option[String]): Map[String, String] =
     CometIcebergNativeScan.hadoopToIcebergS3Properties(props, targetBucket)
 
-  test("full fs.s3a.* suffix mapping to global s3.* keys") {
-    // Every suffix handled by hadoopS3aSuffixToIcebergGlobalKey, verified end to end. Mappings are
-    // per-key independent (no cross-key interaction), so this table-driven case also covers the
-    // "several global fs.s3a.* keys at once" scenario.
-    val cases = Seq(
-      "access.key" -> "s3.access-key-id",
-      "secret.key" -> "s3.secret-access-key",
-      "session.token" -> "s3.session-token",
-      "endpoint" -> "s3.endpoint",
-      "path.style.access" -> "s3.path-style-access",
-      "endpoint.region" -> "s3.region")
+  /** Every `fs.s3a.*` suffix the translator maps, paired with its global iceberg `s3.*` key. */
+  private val suffixToIcebergKey = Seq(
+    "access.key" -> "s3.access-key-id",
+    "secret.key" -> "s3.secret-access-key",
+    "session.token" -> "s3.session-token",
+    "endpoint" -> "s3.endpoint",
+    "path.style.access" -> "s3.path-style-access",
+    "endpoint.region" -> "s3.region")
 
-    cases.foreach { case (hadoopSuffix, icebergKey) =>
+  test("full fs.s3a.* suffix mapping to global s3.* keys") {
+    // Mappings are per-key independent (no cross-key interaction), so this table-driven case also
+    // covers the "several global fs.s3a.* keys at once" scenario.
+    suffixToIcebergKey.foreach { case (hadoopSuffix, icebergKey) =>
       val out = translate(Map(s"fs.s3a.$hadoopSuffix" -> "v"), None)
       out should contain(icebergKey -> "v")
       // The Hadoop key itself is never passed through untranslated.
@@ -56,23 +56,15 @@ class CometIcebergNativeScanSuite extends AnyFunSuite with Matchers {
   }
 
   test("target bucket per-bucket keys are promoted to global s3.*") {
-    val props = Map(
-      "fs.s3a.bucket.target.access.key" -> "AKIA-target",
-      "fs.s3a.bucket.target.secret.key" -> "secret-target",
-      "fs.s3a.bucket.target.session.token" -> "token-target",
-      "fs.s3a.bucket.target.endpoint" -> "https://target.example.com",
-      "fs.s3a.bucket.target.path.style.access" -> "true",
-      "fs.s3a.bucket.target.endpoint.region" -> "eu-central-1")
+    val props = suffixToIcebergKey.map { case (suffix, _) =>
+      s"fs.s3a.bucket.target.$suffix" -> s"value-$suffix"
+    }.toMap
 
     val out = translate(props, Some("target"))
 
-    out("s3.access-key-id") shouldBe "AKIA-target"
-    out("s3.secret-access-key") shouldBe "secret-target"
-    out("s3.session-token") shouldBe "token-target"
-    out("s3.endpoint") shouldBe "https://target.example.com"
-    out("s3.path-style-access") shouldBe "true"
-    out("s3.region") shouldBe "eu-central-1"
-
+    suffixToIcebergKey.foreach { case (suffix, icebergKey) =>
+      out(icebergKey) shouldBe s"value-$suffix"
+    }
     // Per-bucket keys are never emitted in s3.bucket.* form (the pinned parser ignores those).
     out.keys.foreach(k => k should not startWith "s3.bucket.")
   }
@@ -121,24 +113,17 @@ class CometIcebergNativeScanSuite extends AnyFunSuite with Matchers {
     out("s3.secret-access-key") shouldBe "secret-dotted"
   }
 
-  test("keys already in iceberg s3.* form pass through unchanged") {
+  test("keys already in iceberg s3.* form pass through; unrelated keys are ignored") {
     val props = Map(
       "s3.endpoint" -> "https://passthrough.example.com",
-      "s3.access-key-id" -> "AKIA-passthrough")
-
-    val out = translate(props, None)
-
-    out("s3.endpoint") shouldBe "https://passthrough.example.com"
-    out("s3.access-key-id") shouldBe "AKIA-passthrough"
-  }
-
-  test("unrelated keys are ignored") {
-    val props = Map(
+      "s3.access-key-id" -> "AKIA-passthrough",
       "fs.gs.project.id" -> "gcp-project",
       "fs.azure.account.key.acct.blob.core.windows.net" -> "azure-key",
       "spark.sql.shuffle.partitions" -> "200")
 
-    translate(props, Some("target")) shouldBe empty
+    translate(props, Some("target")) shouldBe Map(
+      "s3.endpoint" -> "https://passthrough.example.com",
+      "s3.access-key-id" -> "AKIA-passthrough")
   }
 
   test("no target bucket means no per-bucket promotion") {

--- a/spark/src/test/scala/org/apache/comet/serde/operator/CometIcebergNativeScanSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/serde/operator/CometIcebergNativeScanSuite.scala
@@ -77,18 +77,6 @@ class CometIcebergNativeScanSuite extends AnyFunSuite with Matchers {
     out.keys.foreach(k => k should not startWith "s3.bucket.")
   }
 
-  test("non-target bucket per-bucket keys are dropped entirely") {
-    val props = Map(
-      "fs.s3a.bucket.other.access.key" -> "AKIA-other",
-      "fs.s3a.bucket.other.endpoint" -> "https://other.example.com",
-      "fs.s3a.bucket.other.path.style.access" -> "true")
-
-    val out = translate(props, Some("target"))
-
-    // A non-target bucket contributes nothing (not promoted, not emitted as s3.bucket.*).
-    out shouldBe empty
-  }
-
   test("target bucket keys coexist with a different non-target bucket") {
     val props = Map(
       "fs.s3a.bucket.target.endpoint" -> "https://target.example.com",
@@ -100,9 +88,10 @@ class CometIcebergNativeScanSuite extends AnyFunSuite with Matchers {
 
     out("s3.endpoint") shouldBe "https://target.example.com"
     out("s3.access-key-id") shouldBe "AKIA-target"
-    // The non-target bucket's values must not leak into the global keys.
+    // The non-target bucket contributes nothing: not promoted, not leaked into the global keys.
     out.values.toSet should not contain "https://other.example.com"
     out.values.toSet should not contain "AKIA-other"
+    out.keys.size shouldBe 2
   }
 
   test("target bucket per-bucket value overrides a conflicting global value") {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5313

## Rationale for this change

Some environments front an S3-compatible service (MinIO, Ceph RGW, Cloudflare R2,
Wasabi, and similar) with a vendor-branded Hadoop filesystem client that registers
its own URL scheme, for example `blob://`, instead of `s3://` or `s3a://`. Today
Comet does not recognize these schemes, so the native Parquet and Iceberg scans
fall back to Spark. This PR lets Comet treat such schemes as aliases for `s3://`
and read them directly, without the caller rewriting URLs.

## What changes are included in this PR?

- New opt-in config `fs.comet.s3Compliant.schemes` (Hadoop key, set via
  `spark.hadoop.*`/SparkConf/core-site.xml at session start). It is a
  comma-separated, case-insensitive list of schemes to treat as S3 aliases. Empty
  by default, so no alias is claimed unless opted in. Short names like `blob` are
  not unique to S3, so the empty default avoids misrouting (for example Azure Blob).
- Native Parquet scan: `normalize_object_store_url` rewrites alias schemes and
  `s3a` to `s3://bucket/key` so the existing `scheme == "s3"` dispatch fires.
- Native Iceberg scan: routes alias schemes to the S3 backend by scheme instead of
  rewriting the URL, preserving the raw `file_path` bytes that iceberg-rust uses for
  exact-match delete-file resolution.
- Vendor-style per-authority Hadoop keys `fs.<scheme>.<authority>.<property>` are
  translated to the `fs.s3a.*` surface (access/secret/session, endpoint, region,
  path-style). Path-style access defaults to enabled when an endpoint is set.
- `CometScanRule` gates alias schemes for both Parquet and Iceberg and emits clear
  fallback messages listing the supported schemes.
- `CometFileKeyUnwrapper` canonicalizes alias schemes so the put and get sides
  agree on one cache key for Parquet encryption key unwrapping.
- Docs: new S3-compliant filesystem scheme section in the datasources user guide.

## How are these changes tested?

- Rust unit tests in `native/core/src/parquet/objectstore/s3_blob_fs_support.rs`
  for URL normalization and alias-scheme detection.
- Scala/Java suites: `NativeConfigSuite`, `CometScanSchemeFallbackSuite`,
  `TestCometFileKeyUnwrapper`, and `CometIcebergNativeScanSuite`.
- End-to-end `blob://` reads against MinIO in `ParquetReadFromS3Suite` and
  `IcebergReadFromS3Suite`, using a `BlobSchemeFileSystem` test shim over
  `S3AFileSystem`
