### PR TITLE
docs: correct Spark 4.2 version and CI test status in installation guide

### DIFF
--- a/docs/source/contributor-guide/adding_a_new_spark_version.md
+++ b/docs/source/contributor-guide/adding_a_new_spark_version.md
@@ -62,7 +62,8 @@ existing profile (for example `spark-4.1`) and update the version
 properties:
 
 - `spark.version`: the full upstream version, including any qualifier
-  (for example `4.2.0-preview4`).
+  (for example `4.3.0` for a final release, or `4.3.0-preview1` while only a
+  preview has been published).
 - `spark.version.short`: the major.minor (for example `4.2`).
 - `parquet.version`, `slf4j.version`, `scala.version`,
   `scala.binary.version`, `java.version`: align with what the new Spark
@@ -317,7 +318,7 @@ issue keeps the diff small and makes regressions easy to bisect.
 The user guide currently uses two tiers, "Supported" and "Experimental".
 Comet uses "Experimental" to describe its confidence in its own
 integration with a Spark version, distinct from Spark's "preview" tag
-(which refers to upstream release qualifiers like `4.2.0-preview4`). The
+(which refers to upstream release qualifiers like `4.3.0-preview1`). The
 term is already established in `installation.md`, `operators.md`, and
 `datasources.md`, so keep using it rather than introducing a new label.
 

--- a/docs/source/user-guide/latest/compatibility/spark-versions.md
+++ b/docs/source/user-guide/latest/compatibility/spark-versions.md
@@ -91,9 +91,9 @@ Spark 4.1.3 is supported with Java 17/21 and Scala 2.13.
 
 ## Spark 4.2 (Experimental)
 
-Spark 4.2.0-preview4 is provided as experimental support with Java 17 and Scala 2.13.
+Spark 4.2.0 is provided as experimental support with Java 17 and Scala 2.13.
 
 ```{warning}
-Spark 4.2 support is experimental and targets a preview release of Spark. It is intended for early
-evaluation only and should not be used in production.
+Spark 4.2 support is experimental. Comet tests run in CI for this version, but the Spark SQL tests
+do not yet. It is intended for early evaluation only and should not be used in production.
 ```

--- a/docs/source/user-guide/latest/installation.md
+++ b/docs/source/user-guide/latest/installation.md
@@ -62,9 +62,9 @@ Note that we do not test the full matrix of supported Java and Scala versions in
 Experimental support is provided for the following versions of Apache Spark and is intended for development/testing
 use only and should not be used in production yet.
 
-| Spark Version  | Java Version | Scala Version | Comet Tests in CI | Spark SQL Tests in CI |
-| -------------- | ------------ | ------------- | ----------------- | --------------------- |
-| 4.2.0-preview4 | 17           | 2.13          | No                | No                    |
+| Spark Version | Java Version | Scala Version | Comet Tests in CI | Spark SQL Tests in CI |
+| ------------- | ------------ | ------------- | ----------------- | --------------------- |
+| 4.2.0         | 17           | 2.13          | Yes               | No                    |
 
 Note that Comet may not fully work with proprietary forks of Apache Spark such as the Spark versions offered by
 Cloud Service Providers.


### PR DESCRIPTION
## Which issue does this PR close?

N/A — docs correction spotted while reading the installation guide.

## Rationale for this change

The experimental-versions table in the installation guide has two stale claims about Spark 4.2:

1. It lists the version as `4.2.0-preview4`, but the `spark-4.2` Maven profile in `pom.xml` targets the `4.2.0` final release (`<spark.version>4.2.0</spark.version>`).
2. It says "Comet Tests in CI: No", but `.github/workflows/pr_build_linux.yml` has a `"Spark 4.2, JDK 17"` entry in the `linux-test` matrix, so Comet tests do run for 4.2.

## What changes are included in this PR?

- `installation.md`: experimental table row becomes `4.2.0` with "Comet Tests in CI: Yes".
- `compatibility/spark-versions.md`: drop the `-preview4` suffix and reword the warning, which claimed 4.2 support "targets a preview release of Spark".
- `adding_a_new_spark_version.md`: the two `4.2.0-preview4` examples cited a version Comet no longer targets; switched to a hypothetical future release so they keep illustrating the release-qualifier point.

Spark SQL tests still do not run for 4.2 — there is no `spark_4_2` job in `ci.yml` — so that column stays "No" and 4.2 remains in the experimental tier. Per the promotion criteria in `adding_a_new_spark_version.md`, promotion to "Supported" requires both CI columns to be "Yes", so this PR intentionally does not promote it.

## How are these changes tested?

Docs only. `npx prettier` reports no changes for all three files.