### PR TITLE
  feat: recognize SparkCopyOnWriteScan as a native Iceberg scan                                                                                                                     

### DIFF
--- a/spark/src/main/scala/org/apache/comet/iceberg/IcebergReflection.scala
+++ b/spark/src/main/scala/org/apache/comet/iceberg/IcebergReflection.scala
@@ -54,6 +54,7 @@ object IcebergReflection extends Logging {
     val UNBOUND_PREDICATE = "org.apache.iceberg.expressions.UnboundPredicate"
     val SPARK_BATCH_QUERY_SCAN = "org.apache.iceberg.spark.source.SparkBatchQueryScan"
     val SPARK_STAGED_SCAN = "org.apache.iceberg.spark.source.SparkStagedScan"
+    val SPARK_COPY_ON_WRITE_SCAN = "org.apache.iceberg.spark.source.SparkCopyOnWriteScan"
     val SPARK_SCHEMA_UTIL = "org.apache.iceberg.spark.SparkSchemaUtil"
     val TABLE = "org.apache.iceberg.Table"
     val PARTITIONING = "org.apache.iceberg.Partitioning"
@@ -71,7 +72,10 @@ object IcebergReflection extends Logging {
    * instances.
    */
   val ICEBERG_SCAN_CLASSES: Set[String] =
-    Set(ClassNames.SPARK_BATCH_QUERY_SCAN, ClassNames.SPARK_STAGED_SCAN)
+    Set(
+      ClassNames.SPARK_BATCH_QUERY_SCAN,
+      ClassNames.SPARK_STAGED_SCAN,
+      ClassNames.SPARK_COPY_ON_WRITE_SCAN)
 
   def isIcebergScanClass(name: String): Boolean = ICEBERG_SCAN_CLASSES.contains(name)
 


### PR DESCRIPTION
  ## Which issue does this PR close?                                                                                                                                                
                                                                                                                                                                                    
  Closes #5319.

## Rationale for this change

Iceberg's `MERGE`/`UPDATE`/`DELETE` target tables scan through `SparkCopyOnWriteScan`, which
extends the same `SparkPartitioningAwareScan` base as the already-supported `SparkBatchQueryScan`
but wasn't in Comet's recognized scan set, so it always fell back to Spark.

## What changes are included in this PR?

Add `SparkCopyOnWriteScan` to `IcebergReflection.ICEBERG_SCAN_CLASSES`.

## How are these changes tested?

verified manually against a real Iceberg REST catalog.