### PR TITLE
test: add expression fallback-invariance suite

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -412,6 +412,7 @@ jobs:
               org.apache.comet.CometWidthBucketSuite
               org.apache.comet.CometUuidExpressionSuite
               org.apache.comet.serde.CometScalarFunctionSuite
+              org.apache.comet.CometFallbackInvarianceSuite
       fail-fast: false
     name: ${{ matrix.profile.name }} [${{ matrix.suite.name }}]
     runs-on: ubuntu-24.04

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -228,6 +228,7 @@ jobs:
               org.apache.comet.CometWidthBucketSuite
               org.apache.comet.CometUuidExpressionSuite
               org.apache.comet.serde.CometScalarFunctionSuite
+              org.apache.comet.CometFallbackInvarianceSuite
 
       fail-fast: false
     name: ${{ matrix.os }}/${{ matrix.profile.name }} [${{ matrix.suite.name }}]

--- a/spark/src/test/scala/org/apache/comet/CometFallbackInvarianceSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometFallbackInvarianceSuite.scala
@@ -53,17 +53,23 @@ import org.apache.spark.sql.internal.SQLConf
 class CometFallbackInvarianceSuite extends CometFuzzTestBase {
 
   /**
-   * Expressions Comet documents as not guaranteed to match Spark exactly. A divergence here is
-   * reported as EXCUSED: logged for the record, never counted as a pass.
+   * Whether a value divergence for `expr` is excusable under the configuration this suite is
+   * actually running with.
+   *
+   * Derived rather than listed. A static set of "incompatible" names goes stale silently and in
+   * the dangerous direction: it converts real failures into EXCUSED. `RLike` was the concrete
+   * case -- `CometRLike.getSupportLevel` returns `Compatible` on both branches, so the default
+   * path routes through Spark's own codegen and is required to match, yet a hardcoded exemption
+   * still waved opposite Boolean results through as green.
+   *
+   * Comet only evaluates an expression in a mode it documents as possibly-divergent when
+   * `spark.comet.expression.<Name>.allowIncompatible` is set. With it unset, the expression is
+   * either rated `Compatible` and must match, or rated `Incompatible` and never runs natively at
+   * all -- in both cases a divergence is a defect, not an exemption. Reading the live config is
+   * therefore the whole rule, and it self-updates as support levels change.
    */
-  private val incompatibleRated: Set[String] =
-    Set(
-      "DateFormatClass",
-      "FromUTCTimestamp",
-      "GetJsonObject",
-      "RLike",
-      "StringTranslate",
-      "TruncTimestamp")
+  private def divergenceExcusable(expr: String): Boolean =
+    CometConf.isExprAllowIncompat(expr)
 
   private sealed trait Outcome
   private case class Rows(rows: Seq[String]) extends Outcome
@@ -169,7 +175,7 @@ class CometFallbackInvarianceSuite extends CometFuzzTestBase {
             bump("pass")
           } else {
             val i = a.zip(b).indexWhere { case (x, y) => x != y }
-            if (incompatibleRated.contains(expr)) {
+            if (divergenceExcusable(expr)) {
               bump("excused")
               findings += s"EXCUSED [$label] $expr row=$i default=[${a(i)}] forced=[${b(i)}]"
             } else {

--- a/spark/src/test/scala/org/apache/comet/CometFallbackInvarianceSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometFallbackInvarianceSuite.scala
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet
+
+import scala.collection.mutable
+import scala.util.{Failure, Success, Try}
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.{ProjectExec, SparkPlan}
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Checks that forcing an expression from Comet's native path back to Spark does not change the
+ * outcome of a query.
+ *
+ * Comet exposes `spark.comet.expression.<Name>.enabled` for every registered expression, and
+ * `QueryPlanSerde` honours it as forced fallback. For any expression Comet rates compatible, that
+ * gives a free invariant: the outcome of a query -- its rows, or the error it raises -- must be
+ * identical whether the expression is evaluated natively or by Spark.
+ *
+ * Two properties of this suite are load-bearing:
+ *
+ *   1. "Outcome" is three-valued. A leg either produces rows or throws. A value on one leg and an
+ *      exception on the other is a failure with a named witness, not an error in the harness --
+ *      exception parity is where several historical divergences have lived.
+ *
+ * 2. Every comparison is gated on evidence that the config flip actually moved execution. A query
+ * whose executed plan proves nothing is reported SKIPPED-VACUOUS and never counted as a pass.
+ * Without that gate an invariance sweep silently overstates its own coverage.
+ *
+ * Queries deliberately avoid `ORDER BY`: a shuffle roots the executed plan at
+ * `AdaptiveSparkPlanExec`, whose `children` is empty, so plan inspection would read zero for
+ * everything and the gate above would be inoperative. Row order is canonicalised in the
+ * comparator instead.
+ */
+class CometFallbackInvarianceSuite extends CometFuzzTestBase {
+
+  /**
+   * Expressions Comet documents as not guaranteed to match Spark exactly. A divergence here is
+   * reported as EXCUSED: logged for the record, never counted as a pass.
+   */
+  private val incompatibleRated: Set[String] =
+    Set(
+      "DateFormatClass",
+      "FromUTCTimestamp",
+      "GetJsonObject",
+      "RLike",
+      "StringTranslate",
+      "TruncTimestamp")
+
+  private sealed trait Outcome
+  private case class Rows(rows: Seq[String]) extends Outcome
+  private case class Threw(errorClass: String) extends Outcome
+
+  /**
+   * What the executed plan proves about where the projection ran. Captured whether or not
+   * execution succeeded, so a leg that throws is still gated rather than waved through.
+   *
+   * `opaque` is the guard that matters: a plan showing neither a Comet operator nor a Spark
+   * `ProjectExec` proves nothing at all, and must never be read as "ran natively".
+   */
+  private case class Presence(cometOps: Int, cometProjects: Int, sparkProjects: Int) {
+    def opaque: Boolean = cometOps == 0 && sparkProjects == 0
+    def ranNatively: Boolean = sparkProjects == 0 && cometOps > 0
+    def fellBack: Boolean = sparkProjects > 0
+    override def toString: String =
+      s"cometOps=$cometOps cometProject=$cometProjects sparkProject=$sparkProjects"
+  }
+
+  private case class Leg(outcome: Outcome, presence: Presence)
+
+  private def presenceOf(plan: SparkPlan): Presence =
+    Presence(
+      cometOps = plan.collect {
+        case op if op.getClass.getSimpleName.startsWith("Comet") => true
+      }.length,
+      cometProjects = plan.collect {
+        case op if op.getClass.getSimpleName == "CometProjectExec" => true
+      }.length,
+      sparkProjects = plan.collect { case _: ProjectExec => true }.length)
+
+  private def errorClassOf(e: Throwable): String = {
+    var root: Throwable = e
+    while (root.getCause != null && root.getCause != root) root = root.getCause
+    val message = Option(root.getMessage).getOrElse("")
+    "\\[([A-Z_]+)\\]".r
+      .findFirstMatchIn(message)
+      .map(_.group(1))
+      .getOrElse(root.getClass.getSimpleName)
+  }
+
+  /** NaN, -0.0 and NULL are distinct tokens; row order is canonicalised by sorting. */
+  private def canon(rows: Seq[Row]): Seq[String] =
+    rows.map { row =>
+      (0 until row.length)
+        .map { i =>
+          val value = row.get(i)
+          if (value == null) "<NULL>"
+          else
+            value match {
+              case d: java.lang.Double if d.isNaN => "<NaN>"
+              case f: java.lang.Float if f.isNaN => "<NaN>"
+              case d: java.lang.Double if d == 0.0d && (1.0d / d) < 0 => "<NEGZERO>"
+              case f: java.lang.Float if f == 0.0f && (1.0f / f) < 0 => "<NEGZERO>"
+              case other => other.toString
+            }
+        }
+        .mkString("|")
+    }.sorted
+
+  private def runLeg(sql: String): Leg = {
+    val df = spark.sql(sql)
+    val collected = Try(df.collect())
+    // The executed plan is available whether or not collect() succeeded, so both legs are gated.
+    val presence = Try(presenceOf(df.queryExecution.executedPlan))
+      .getOrElse(Presence(0, 0, 0))
+    val outcome = collected match {
+      case Success(rows) => Rows(canon(rows.toSeq))
+      case Failure(e) => Threw(errorClassOf(e))
+    }
+    Leg(outcome, presence)
+  }
+
+  private def compare(
+      label: String,
+      expr: String,
+      base: Leg,
+      forced: Leg,
+      tally: mutable.Map[String, Int],
+      findings: mutable.ArrayBuffer[String]): Unit = {
+    def bump(key: String): Unit = tally(key) = tally.getOrElse(key, 0) + 1
+    def skip(why: String): Unit = {
+      bump("vacuous")
+      findings += s"SKIPPED-VACUOUS [$label] $expr $why " +
+        s"(default: ${base.presence}) (forced: ${forced.presence})"
+    }
+
+    if (base.presence.opaque || forced.presence.opaque) {
+      // Neither "ran natively" nor "fell back" can be established from this plan.
+      skip("bind-unprovable-opaque-plan")
+    } else if (!base.presence.ranNatively) {
+      skip("not-native-by-default")
+    } else if (!forced.presence.fellBack) {
+      skip("flip-did-not-force-fallback")
+    } else {
+      (base.outcome, forced.outcome) match {
+        case (Rows(a), Rows(b)) =>
+          if (a.length != b.length) {
+            bump("fail")
+            findings += s"FAIL-LEN [$label] $expr default=${a.length} forced=${b.length}"
+          } else if (a == b) {
+            bump("pass")
+          } else {
+            val i = a.zip(b).indexWhere { case (x, y) => x != y }
+            if (incompatibleRated.contains(expr)) {
+              bump("excused")
+              findings += s"EXCUSED [$label] $expr row=$i default=[${a(i)}] forced=[${b(i)}]"
+            } else {
+              bump("fail")
+              findings += s"FAIL-VALUE [$label] $expr row=$i default=[${a(i)}] forced=[${b(i)}]"
+            }
+          }
+        case (Rows(a), Threw(k)) =>
+          bump("fail")
+          findings += s"FAIL-OUTCOME [$label] $expr " +
+            s"default=VALUE(${a.headOption.getOrElse("<empty>")}) forced=THREW($k)"
+        case (Threw(k), Rows(b)) =>
+          bump("fail")
+          findings += s"FAIL-OUTCOME [$label] $expr default=THREW($k) " +
+            s"forced=VALUE(${b.headOption.getOrElse("<empty>")})"
+        case (Threw(k1), Threw(k2)) =>
+          if (k1 == k2) {
+            bump("pass")
+          } else {
+            bump("fail")
+            findings += s"FAIL-ERRCLASS [$label] $expr default=$k1 forced=$k2"
+          }
+      }
+    }
+  }
+
+  /**
+   * Runs the query with the expression forced to fall back to Spark. The leg is captured through
+   * a local rather than returned from `withSQLConf`, because on Spark 3.x that helper is declared
+   * to return `Unit`.
+   */
+  private def runLegForced(expr: String, sql: String): Leg = {
+    var leg: Option[Leg] = None
+    withSQLConf(CometConf.getExprEnabledConfigKey(expr) -> "false") {
+      leg = Some(runLeg(sql))
+    }
+    leg.get
+  }
+
+  private def sweep(
+      label: String,
+      cases: Seq[(String, String)],
+      tally: mutable.Map[String, Int],
+      findings: mutable.ArrayBuffer[String]): Unit =
+    cases.foreach { case (expr, sql) =>
+      val base = runLeg(sql)
+      val forced = runLegForced(expr, sql)
+      compare(label, expr, base, forced, tally, findings)
+    }
+
+  test("outcome is invariant under forced per-expression fallback") {
+    val tally = mutable.Map[String, Int]()
+    val findings = mutable.ArrayBuffer[String]()
+
+    // Value parity over the shared fuzz fixture, ANSI off.
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "false") {
+      val df = spark.read.parquet(filename)
+      df.createOrReplaceTempView("t1")
+      val schema = df.schema.fields
+      def firstOf(p: String => Boolean): Option[String] =
+        schema.find(field => p(field.dataType.typeName)).map(_.name)
+      val i = firstOf(t => t == "integer" || t == "long").getOrElse("c0")
+      val s = firstOf(_ == "string").getOrElse("c0")
+      val d = firstOf(_.startsWith("decimal")).getOrElse(i)
+      val f = firstOf(t => t == "double" || t == "float").getOrElse(i)
+
+      sweep(
+        "values",
+        Seq(
+          ("Add", s"SELECT $i + 1 AS r FROM t1"),
+          ("Subtract", s"SELECT $i - 1 AS r FROM t1"),
+          ("Multiply", s"SELECT $i * 2 AS r FROM t1"),
+          ("Divide", s"SELECT $d / 3 AS r FROM t1"),
+          ("Remainder", s"SELECT $i % 7 AS r FROM t1"),
+          ("Abs", s"SELECT abs($i) AS r FROM t1"),
+          ("Cast", s"SELECT CAST($i AS STRING) AS r FROM t1"),
+          ("Substring", s"SELECT substring($s, 1, 3) AS r FROM t1"),
+          ("Upper", s"SELECT upper($s) AS r FROM t1"),
+          ("Lower", s"SELECT lower($s) AS r FROM t1"),
+          ("Length", s"SELECT length($s) AS r FROM t1"),
+          ("Coalesce", s"SELECT coalesce($i, 0) AS r FROM t1"),
+          ("IsNull", s"SELECT $i IS NULL AS r FROM t1"),
+          ("EqualTo", s"SELECT $i = 1 AS r FROM t1"),
+          ("GreaterThan", s"SELECT $i > 0 AS r FROM t1"),
+          ("If", s"SELECT IF($i > 0, 1, 2) AS r FROM t1"),
+          ("CaseWhen", s"SELECT CASE WHEN $i > 0 THEN 1 ELSE 2 END AS r FROM t1"),
+          ("Sqrt", s"SELECT sqrt(abs($f)) AS r FROM t1"),
+          ("StringTranslate", s"SELECT translate($s, 'ab', 'xy') AS r FROM t1"),
+          ("RLike", s"SELECT $s RLIKE 'a' AS r FROM t1")),
+        tally,
+        findings)
+    }
+
+    // Error parity, ANSI on: expressions whose divergence shows up as a raised exception rather
+    // than a wrong value. ANSI is set explicitly so the section behaves the same on every profile.
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+      withTable("fallback_invariance_t") {
+        sql("CREATE TABLE fallback_invariance_t (s STRING, i INT) USING parquet")
+        sql("INSERT INTO fallback_invariance_t VALUES ('notadate', NULL), ('2024-01-01', 1)")
+        sweep(
+          "errors",
+          Seq(
+            (
+              "AddMonths",
+              "SELECT add_months(CAST(s AS DATE), i) AS r FROM fallback_invariance_t"),
+            (
+              "MonthsBetween",
+              "SELECT months_between(CAST(s AS DATE), CAST(s AS DATE)) AS r " +
+                "FROM fallback_invariance_t"),
+            ("Pmod", "SELECT pmod(i, CAST(s AS INT)) AS r FROM fallback_invariance_t"),
+            ("Conv", "SELECT conv(s, 16, 10) AS r FROM fallback_invariance_t"),
+            ("Cast", "SELECT CAST(s AS DATE) AS r FROM fallback_invariance_t")),
+          tally,
+          findings)
+      }
+    }
+
+    val summary =
+      s"pass=${tally.getOrElse("pass", 0)} fail=${tally.getOrElse("fail", 0)} " +
+        s"excused=${tally.getOrElse("excused", 0)} vacuous=${tally.getOrElse("vacuous", 0)}"
+    // scalastyle:off println
+    println(s"FALLBACK-INVARIANCE-RESULT $summary")
+    findings.foreach(finding => println(s"FALLBACK-INVARIANCE $finding"))
+    // scalastyle:on println
+
+    val failures = findings.filter(_.startsWith("FAIL"))
+    assert(
+      failures.isEmpty,
+      s"forced fallback changed the outcome of ${failures.length} quer" +
+        s"${if (failures.length == 1) "y" else "ies"} ($summary):\n" +
+        failures.mkString("\n"))
+  }
+}


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5328.

## Rationale for this change

For every expression Comet rates compatible, forcing it back to Spark with `spark.comet.expression.<Name>.enabled=false` must not change a query's outcome — neither its rows nor whether and what it throws. The invariant is free: the config already ships, and `QueryPlanSerde` already honours it for all 293 registered expressions.

It is not currently swept. Four tests exercise the lever, each on one hand-picked expression; all four check the answer, but none checks a range of expressions mechanically and none checks that the two legs raise the *same* error.

Replaying #5218's pre-fix logic shows the shape has teeth: the defect is invisible to `CometFuzzMathSuite` (30/30), `CometCodegenFuzzSuite` (28/28), `CometCodegenHOFSuite` (5/5) and `CometExecRuleSuite` (29/29), while this suite names it:

```
FAIL-OUTCOME [errors] AddMonths default=VALUE(2024-02-01) forced=THREW(CAST_INVALID_INPUT)
```

To be clear about what that is and isn't: `AddMonths` is in the corpus *because* #5218 named it, so this is a validation replay rather than an independent find, and `CometCodegenSuite` already guards that exact query end-to-end. The generic-detector misses are the load-bearing part, and the comparator is not specific to `add_months` — it flags this shape for any corpus expression.

## What changes are included in this PR?

One new suite, `CometFallbackInvarianceSuite`, extending `CometFuzzTestBase`. No product code.

- **Fixed query corpus** — 25 expressions over the existing seeded fuzz fixture, no new fixtures. A value-parity section with ANSI off, and an error-parity section with ANSI set explicitly on so it behaves identically on every Spark profile.
- **Bind gate, mandatory.** Before any comparison, the executed plan must prove the flip moved execution: default leg shows Comet operators and zero Spark `ProjectExec`; forced leg shows a Spark `ProjectExec`. A plan showing neither is `SKIPPED-VACUOUS` and reported — never a pass. Plan presence is captured whether or not `collect()` succeeded, so a leg that throws is gated too.
- **Three-valued outcome comparison** (`Rows` vs `Threw(errorClass)`): value-vs-throw is a failure, differing error classes are a failure, row-count mismatch is a failure. Error parity is where #5218 lives, so these comparator rules are load-bearing rather than incidental.
- **Verdicts** — compatible-rated divergence `FAIL` · value-vs-throw `FAIL` · differing error class `FAIL` · length mismatch `FAIL` · incompatible-rated divergence `EXCUSED`, logged but never certified · NaN / `-0.0` / NULL as distinct tokens · row order canonicalised by sorting.

## How are these changes tested?

The suite is the test. On a clean tree:

```
FALLBACK-INVARIANCE-RESULT pass=24 fail=0 excused=0 vacuous=1
FALLBACK-INVARIANCE SKIPPED-VACUOUS [values] StringTranslate not-native-by-default
```

24 pass, 0 fail, 1 skipped-vacuous per variant × 3 variants, ~10 s. The one skip is honest and expected: `StringTranslate` is incompatible-rated, so it already runs on Spark by default and there is no native leg to compare against. Verified under `spark-3.4`, `spark-3.5` and `spark-4.1`.

Validated by injected divergence twice: a deliberately broken `spark_decimal_div` as a positive control (also caught by `CometFuzzMathSuite`, as it should be), and the #5218 pre-fix replay. The probe run reports `pass=23 fail=1` — one delta from clean, and it is the witness quoted above.

**On the bind gate.** It earned its place three times over while this suite was being written. An early version reported 22 passes where the truth was 19 passes and 3 vacuous. A second pinned ANSI off and mapped throw-vs-value to a harness error, making it structurally blind to the very bug class it exists for. A third used `ORDER BY` for determinism, which introduces a shuffle and roots the executed plan at `AdaptiveSparkPlanExec` — whose `children` is empty, so plan inspection silently read zero for every query in that section and the gate stopped working entirely. Comet's own `spark.comet.expression.*` tests sidestep all of this by using simple queries with no shuffle; this suite now does the same, avoiding `ORDER BY` and canonicalising row order in the comparator instead.

**Scope, stated plainly.** 25 of 293 expressions. The suite owns one historical bug (#5218) and is not claimed to cover operator-level mixed execution, fallback-*decision* logic, or scan-metadata mismatches — #4813, #4051, #4789 and #2720 are different mechanisms and this invariant would not have caught any of them.

Provenance note: produced during an AI-assisted audit of Comet's verification machinery, human-verified at each gate; mutation experiments were run with positive controls and the tree restored clean afterward.
