### PR TITLE
feat: Sort-aware Iceberg reads in Comet via a per-partition streaming merge

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -315,6 +315,7 @@ jobs:
               org.apache.comet.CometIcebergEncryptionSuite
               org.apache.comet.CometIcebergRewriteActionSuite
               org.apache.comet.CometIcebergWriteActionSuite
+              org.apache.comet.CometIcebergSortMergeReadSuite
               org.apache.comet.CometIcebergWriteDetectionSuite
               org.apache.comet.iceberg.IcebergReflectionSuite
               org.apache.comet.csv.CometCsvNativeReadSuite

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -131,6 +131,7 @@ jobs:
               org.apache.comet.CometIcebergEncryptionSuite
               org.apache.comet.CometIcebergRewriteActionSuite
               org.apache.comet.CometIcebergWriteActionSuite
+              org.apache.comet.CometIcebergSortMergeReadSuite
               org.apache.comet.CometIcebergWriteDetectionSuite
               org.apache.comet.iceberg.IcebergReflectionSuite
               org.apache.comet.csv.CometCsvNativeReadSuite

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -109,9 +109,11 @@ use crate::execution::tracing::{
 
 use crate::execution::memory_pools::logging_pool::LoggingMemoryPool;
 use crate::execution::spark_config::{
-    SparkConfig, COMET_DEBUG_ENABLED, COMET_DEBUG_MEMORY, COMET_EXPLAIN_NATIVE_ENABLED,
+    IcebergSortMergeConfig, SparkConfig, COMET_DEBUG_ENABLED, COMET_DEBUG_MEMORY,
+    COMET_EXPLAIN_NATIVE_ENABLED, COMET_ICEBERG_SORT_MERGE_MAX_FILES_PER_PARTITION,
     COMET_MAX_TEMP_DIRECTORY_SIZE, COMET_PARQUET_ROW_FILTER_PUSHDOWN_ENABLED,
-    COMET_TRACING_ENABLED, SPARK_EXECUTOR_CORES,
+    COMET_TRACING_ENABLED, DEFAULT_ICEBERG_SORT_MERGE_MAX_FILES_PER_PARTITION,
+    SPARK_EXECUTOR_CORES,
 };
 use crate::parquet::encryption_support::{CometEncryptionFactory, ENCRYPTION_FACTORY_ID};
 use datafusion_comet_proto::spark_operator::operator::OpStruct;
@@ -613,6 +615,18 @@ fn prepare_datafusion_session_context(
             session_config = session_config.set_str(&df_key, value);
         }
     }
+
+    // Carry the Iceberg sort-merge max-files-per-partition setting to the physical planner as a
+    // session extension (it is a Comet scan config, not a DataFusion option). Above this many files
+    // in one partition the planner reads unordered and sorts with a spillable SortExec instead of a
+    // per-file k-way merge, to bound concurrently-open readers.
+    let iceberg_sort_merge_max_files = spark_config.get_usize(
+        COMET_ICEBERG_SORT_MERGE_MAX_FILES_PER_PARTITION,
+        DEFAULT_ICEBERG_SORT_MERGE_MAX_FILES_PER_PARTITION,
+    );
+    session_config = session_config.with_extension(Arc::new(IcebergSortMergeConfig {
+        max_files_per_partition: iceberg_sort_merge_max_files,
+    }));
 
     let runtime = rt_config.build()?;
 

--- a/native/core/src/execution/operators/iceberg_scan.rs
+++ b/native/core/src/execution/operators/iceberg_scan.rs
@@ -28,7 +28,7 @@ use arrow::datatypes::SchemaRef;
 use datafusion::common::{DataFusionError, Result as DFResult};
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::expressions::Column;
-use datafusion::physical_expr::{EquivalenceProperties, PhysicalExpr};
+use datafusion::physical_expr::{EquivalenceProperties, LexOrdering, PhysicalExpr};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::metrics::{
     BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
@@ -86,6 +86,24 @@ pub struct IcebergScanExec {
     tasks: Vec<FileScanTask>,
     /// Number of data files to read concurrently
     data_file_concurrency_limit: usize,
+    /// FileIO (and, for S3, the JVM credential bridge behind it) built once at plan time and shared
+    /// across partitions. FileIO is cheap to clone (Arc-backed), so each `execute` clones this
+    /// rather than rebuilding the storage factory + credential bridge. This matters in the ordered
+    /// path, where the scan is one partition per file and `execute` is called once per file.
+    file_io: FileIO,
+    /// Table sort order Iceberg reported, translated against `output_schema`. `Some` makes this a
+    /// multi-partition scan: one sorted stream per task, which a SortPreservingMergeExec above
+    /// merges back into one sorted partition. It is also advertised in `plan_properties`. `None`
+    /// keeps the old single-partition unordered read (all tasks streamed together).
+    ///
+    /// Concurrency note: in the ordered path each partition reads exactly one task, so
+    /// `data_file_concurrency_limit` no longer bounds cross-file concurrency; instead the wrapping
+    /// SortPreservingMergeExec drives one reader per file to merge them. That fan-out (files per
+    /// Spark partition) is intrinsic to a k-way merge of per-file sorted streams -- the files must
+    /// be read as separate streams to stay individually sorted -- and is the natural granularity
+    /// for a sorted Iceberg table. `data_file_concurrency_limit` still bounds delete-file stats and
+    /// the unordered path.
+    ordering: Option<LexOrdering>,
     /// Metrics
     metrics: ExecutionPlanMetricsSet,
 }
@@ -98,11 +116,30 @@ impl IcebergScanExec {
         catalog_name: String,
         tasks: Vec<FileScanTask>,
         data_file_concurrency_limit: usize,
+        ordering: Option<LexOrdering>,
     ) -> Result<Self, ExecutionError> {
         let output_schema = schema;
-        let plan_properties = Self::compute_properties(Arc::clone(&output_schema), 1);
+        // With an ordering, read each task as its own sorted stream on its own partition, so the
+        // SortPreservingMergeExec above can merge them. Without one, keep the single partition that
+        // reads every task. Comet only drives execute(0), so a multi-partition leaf with no merge
+        // above it would read only the first task.
+        let num_partitions = if ordering.is_some() {
+            tasks.len().max(1)
+        } else {
+            1
+        };
+        let plan_properties = Self::compute_properties(
+            Arc::clone(&output_schema),
+            num_partitions,
+            ordering.as_ref(),
+        );
 
         let metrics = ExecutionPlanMetricsSet::new();
+
+        // Build FileIO (and the S3 credential bridge) once here rather than per `execute`. In the
+        // ordered path `execute` is called once per file, so rebuilding it there would repeat the
+        // JNI/reflection credential-bridge construction for every file in the partition.
+        let file_io = Self::load_file_io(&catalog_properties, &metadata_location, &catalog_name)?;
 
         Ok(Self {
             metadata_location,
@@ -112,13 +149,26 @@ impl IcebergScanExec {
             catalog_name,
             tasks,
             data_file_concurrency_limit,
+            file_io,
+            ordering,
             metrics,
         })
     }
 
-    fn compute_properties(schema: SchemaRef, num_partitions: usize) -> Arc<PlanProperties> {
+    fn compute_properties(
+        schema: SchemaRef,
+        num_partitions: usize,
+        ordering: Option<&LexOrdering>,
+    ) -> Arc<PlanProperties> {
+        let eq_properties = match ordering {
+            Some(lex) => EquivalenceProperties::new_with_orderings(
+                Arc::clone(&schema),
+                std::iter::once(lex.iter().cloned()),
+            ),
+            None => EquivalenceProperties::new(Arc::clone(&schema)),
+        };
         Arc::new(PlanProperties::new(
-            EquivalenceProperties::new(schema),
+            eq_properties,
             Partitioning::UnknownPartitioning(num_partitions),
             EmissionType::Incremental,
             Boundedness::Bounded,
@@ -152,10 +202,18 @@ impl ExecutionPlan for IcebergScanExec {
 
     fn execute(
         &self,
-        _partition: usize,
+        partition: usize,
         context: Arc<TaskContext>,
     ) -> DFResult<SendableRecordBatchStream> {
-        self.execute_with_tasks(self.tasks.clone(), context)
+        // With a reported ordering this is a multi-partition operator: partition `i` reads only
+        // task `i` as its own sorted stream, and the SortPreservingMergeExec above merges them.
+        // Without one, the single partition reads every task together (legacy unordered path).
+        let tasks = if self.ordering.is_some() {
+            self.tasks.get(partition).cloned().into_iter().collect()
+        } else {
+            self.tasks.clone()
+        };
+        self.execute_with_tasks(tasks, context)
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
@@ -172,11 +230,7 @@ impl IcebergScanExec {
         context: Arc<TaskContext>,
     ) -> DFResult<SendableRecordBatchStream> {
         let output_schema = Arc::clone(&self.output_schema);
-        let file_io = Self::load_file_io(
-            &self.catalog_properties,
-            &self.metadata_location,
-            &self.catalog_name,
-        )?;
+        let file_io = self.file_io.clone();
         let batch_size = context.session_config().batch_size();
 
         let metrics = IcebergScanMetrics::new(&self.metrics);
@@ -640,6 +694,7 @@ mod tests {
     use iceberg_storage_opendal::OpenDalStorageFactory;
 
     use super::IcebergScanExec;
+    use datafusion::physical_plan::ExecutionPlan;
 
     fn fs_file_io() -> FileIO {
         FileIOBuilder::new(Arc::new(OpenDalStorageFactory::Fs)).build()
@@ -739,6 +794,59 @@ mod tests {
         IcebergScanExec::fill_delete_file_sizes(&mut tasks, &fs_file_io(), 4)
             .await
             .unwrap();
+    }
+
+    fn int_schema() -> arrow::datatypes::SchemaRef {
+        use arrow::datatypes::{DataType, Field, Schema};
+        Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]))
+    }
+
+    fn single_col_ordering() -> Option<datafusion::physical_expr::LexOrdering> {
+        use arrow::compute::SortOptions;
+        use datafusion::physical_expr::expressions::Column;
+        use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr};
+        LexOrdering::new(vec![PhysicalSortExpr {
+            expr: Arc::new(Column::new("a", 0)),
+            options: SortOptions::default(),
+        }])
+    }
+
+    // Builds a scan over three empty-delete tasks with the given reported ordering.
+    fn exec_with_ordering(
+        ordering: Option<datafusion::physical_expr::LexOrdering>,
+    ) -> IcebergScanExec {
+        use std::collections::HashMap;
+        let tasks = vec![
+            task_with_deletes(vec![]),
+            task_with_deletes(vec![]),
+            task_with_deletes(vec![]),
+        ];
+        IcebergScanExec::new(
+            "metadata.json".to_string(),
+            int_schema(),
+            HashMap::new(),
+            "cat".to_string(),
+            tasks,
+            1,
+            ordering,
+        )
+        .unwrap()
+    }
+
+    // A reported ordering turns the scan into a multi-partition operator (one partition per task)
+    // so a SortPreservingMergeExec above can k-way merge the per-file sorted streams.
+    #[test]
+    fn reported_ordering_makes_scan_multi_partition() {
+        let exec = exec_with_ordering(single_col_ordering());
+        assert_eq!(exec.properties().partitioning.partition_count(), 3);
+    }
+
+    // Without a reported ordering the scan stays single-partition (Comet drives only execute(0),
+    // which must read every task), preserving the legacy unordered behaviour.
+    #[test]
+    fn no_ordering_keeps_single_partition() {
+        let exec = exec_with_ordering(None);
+        assert_eq!(exec.properties().partitioning.partition_count(), 1);
     }
 
     fn from_hex(s: &str) -> Vec<u8> {

--- a/native/core/src/execution/operators/iceberg_scan.rs
+++ b/native/core/src/execution/operators/iceberg_scan.rs
@@ -213,7 +213,7 @@ impl ExecutionPlan for IcebergScanExec {
         } else {
             self.tasks.clone()
         };
-        self.execute_with_tasks(tasks, context)
+        self.execute_with_tasks(tasks, partition, context)
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
@@ -227,13 +227,14 @@ impl IcebergScanExec {
     fn execute_with_tasks(
         &self,
         tasks: Vec<FileScanTask>,
+        partition: usize,
         context: Arc<TaskContext>,
     ) -> DFResult<SendableRecordBatchStream> {
         let output_schema = Arc::clone(&self.output_schema);
         let file_io = self.file_io.clone();
         let batch_size = context.session_config().batch_size();
 
-        let metrics = IcebergScanMetrics::new(&self.metrics);
+        let metrics = IcebergScanMetrics::new(&self.metrics, partition);
         metrics.num_splits.add(tasks.len());
 
         // Fill delete-file sizes as the first step of the task stream so the stats run on the
@@ -479,11 +480,11 @@ struct IcebergScanMetrics {
 }
 
 impl IcebergScanMetrics {
-    fn new(metrics: &ExecutionPlanMetricsSet) -> Self {
+    fn new(metrics: &ExecutionPlanMetricsSet, partition: usize) -> Self {
         Self {
-            baseline: BaselineMetrics::new(metrics, 0),
-            num_splits: MetricBuilder::new(metrics).counter("num_splits", 0),
-            bytes_scanned: MetricBuilder::new(metrics).counter("bytes_scanned", 0),
+            baseline: BaselineMetrics::new(metrics, partition),
+            num_splits: MetricBuilder::new(metrics).counter("num_splits", partition),
+            bytes_scanned: MetricBuilder::new(metrics).counter("bytes_scanned", partition),
         }
     }
 }
@@ -847,6 +848,88 @@ mod tests {
     fn no_ordering_keeps_single_partition() {
         let exec = exec_with_ordering(None);
         assert_eq!(exec.properties().partitioning.partition_count(), 1);
+    }
+
+    // The ordered scan reads each file as its own sorted partition and relies on
+    // SortPreservingMergeExec to k-way merge them into one globally sorted stream. This feeds known
+    // sorted partitions (with duplicate keys across partitions, and both asc and desc) into that
+    // merge with the same kind of LexOrdering the planner builds, and checks the output is globally
+    // sorted and complete. It is deterministic coverage of the merge that does not depend on an
+    // ordering-reporting Iceberg build (which is why the end-to-end suite's merge assertions cancel
+    // on the published Iceberg used in CI).
+    async fn merge_ints(input: Vec<Vec<i32>>, descending: bool) -> Vec<i32> {
+        use arrow::array::Int32Array;
+        use arrow::array::RecordBatch;
+        use arrow::compute::SortOptions;
+        use arrow::datatypes::{DataType, Field, Schema};
+        use datafusion::datasource::memory::MemorySourceConfig;
+        use datafusion::physical_expr::expressions::Column;
+        use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr};
+        use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
+        use datafusion::prelude::SessionContext;
+        use futures::StreamExt;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let partitions: Vec<Vec<RecordBatch>> = input
+            .into_iter()
+            .map(|vals| {
+                vec![RecordBatch::try_new(
+                    Arc::clone(&schema),
+                    vec![Arc::new(Int32Array::from(vals))],
+                )
+                .unwrap()]
+            })
+            .collect();
+        let source =
+            MemorySourceConfig::try_new_exec(&partitions, Arc::clone(&schema), None).unwrap();
+
+        let ordering = LexOrdering::new(vec![PhysicalSortExpr {
+            expr: Arc::new(Column::new("id", 0)),
+            options: SortOptions {
+                descending,
+                nulls_first: false,
+            },
+        }])
+        .unwrap();
+        let spm = SortPreservingMergeExec::new(ordering, source);
+        assert_eq!(spm.properties().partitioning.partition_count(), 1);
+
+        let ctx = SessionContext::new();
+        let mut stream = spm.execute(0, ctx.task_ctx()).unwrap();
+        let mut got = Vec::new();
+        while let Some(batch) = stream.next().await {
+            let batch = batch.unwrap();
+            let col = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            (0..col.len()).for_each(|i| got.push(col.value(i)));
+        }
+        got
+    }
+
+    #[tokio::test]
+    async fn spm_merges_ascending_sorted_partitions() {
+        // Two individually-sorted partitions with duplicate keys across them.
+        let got = merge_ints(vec![vec![1, 3, 3, 5, 8], vec![2, 3, 6, 7]], false).await;
+        let mut expected = vec![1, 3, 3, 5, 8, 2, 3, 6, 7];
+        expected.sort_unstable();
+        assert_eq!(
+            got, expected,
+            "ascending merge must be globally sorted and complete"
+        );
+    }
+
+    #[tokio::test]
+    async fn spm_merges_descending_sorted_partitions() {
+        let got = merge_ints(vec![vec![8, 5, 3, 3, 1], vec![7, 6, 3, 2]], true).await;
+        let mut expected = vec![8, 5, 3, 3, 1, 7, 6, 3, 2];
+        expected.sort_unstable_by(|a, b| b.cmp(a));
+        assert_eq!(
+            got, expected,
+            "descending merge must be globally sorted and complete"
+        );
     }
 
     fn from_hex(s: &str) -> Vec<u8> {

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -85,6 +85,9 @@ use iceberg::expr::Bind;
 
 use crate::execution::operators::ExecutionError::GeneralError;
 use crate::execution::shuffle::{CometPartitioning, CompressionCodec};
+use crate::execution::spark_config::{
+    IcebergSortMergeConfig, DEFAULT_ICEBERG_SORT_MERGE_MAX_FILES_PER_PARTITION,
+};
 use crate::execution::spark_plan::SparkPlan;
 use crate::parquet::parquet_support::prepare_object_store_with_configs;
 use datafusion::common::scalar::ScalarStructBuilder;
@@ -376,6 +379,19 @@ impl PhysicalPlanner {
     /// Return session context of this planner.
     pub fn session_ctx(&self) -> &Arc<SessionContext> {
         &self.session_ctx
+    }
+
+    /// Max files in one Spark partition the native Iceberg scan will k-way merge. Above this, the
+    /// scan reads unordered and sorts with a spillable SortExec instead, to bound the number of
+    /// concurrently-open file readers. Carried on the session config as a type-keyed extension by
+    /// prepare_datafusion_session_context.
+    fn iceberg_sort_merge_max_files_per_partition(&self) -> usize {
+        self.session_ctx
+            .state()
+            .config()
+            .get_extension::<IcebergSortMergeConfig>()
+            .map(|c| c.max_files_per_partition)
+            .unwrap_or(DEFAULT_ICEBERG_SORT_MERGE_MAX_FILES_PER_PARTITION)
     }
 
     /// Return partition id of this planner.
@@ -1756,6 +1772,7 @@ impl PhysicalPlanner {
                 let metadata_location = common.metadata_location.clone();
                 let catalog_name = common.catalog_name.clone();
                 let tasks = parse_file_scan_tasks_from_common(common, &scan.file_scan_tasks)?;
+                let tasks_len = tasks.len();
                 let data_file_concurrency_limit = common.data_file_concurrency_limit as usize;
 
                 // Table sort order Iceberg reported. Empty unless sortMerge is on and the order
@@ -1772,6 +1789,18 @@ impl PhysicalPlanner {
                     LexOrdering::new(exprs)
                 };
 
+                // A per-file-stream k-way merge opens one reader per file at once. Above the
+                // configured limit we instead read the partition unordered (bounded by
+                // data_file_concurrency_limit) and sort with a spillable SortExec, which bounds both
+                // open readers and memory. Both paths still produce sorted output, so the ordering
+                // Spark eliminated its Sort on is honoured either way.
+                let use_merge = ordering.is_some()
+                    && tasks_len <= self.iceberg_sort_merge_max_files_per_partition();
+
+                // Only the merge path is multi-partition (one sorted stream per file). The sort
+                // fallback and the no-ordering path read a single unordered partition.
+                let scan_ordering = if use_merge { ordering.clone() } else { None };
+
                 let iceberg_scan: Arc<dyn ExecutionPlan> = Arc::new(IcebergScanExec::new(
                     metadata_location,
                     required_schema,
@@ -1779,15 +1808,13 @@ impl PhysicalPlanner {
                     catalog_name,
                     tasks,
                     data_file_concurrency_limit,
-                    ordering.clone(),
+                    scan_ordering,
                 )?);
 
-                // With an ordering, the scan is multi-partition (one sorted stream per file). Wrap
-                // it in a SortPreservingMergeExec so each Spark partition comes out sorted. Keep the
-                // scan as an additional native plan so its metrics (num_splits, bytes_scanned) still
-                // roll up. Without an ordering, the scan stays a single-partition leaf, unchanged.
+                // Metrics of the underlying scan roll up via additional_native_plans so num_splits /
+                // bytes_scanned still surface under the single Spark scan node.
                 let result_plan = match ordering {
-                    Some(lex) => {
+                    Some(lex) if use_merge => {
                         let spm: Arc<dyn ExecutionPlan> = Arc::new(
                             SortPreservingMergeExec::new(lex, Arc::clone(&iceberg_scan))
                                 .with_round_robin_repartition(false),
@@ -1795,6 +1822,17 @@ impl PhysicalPlanner {
                         SparkPlan::new_with_additional(
                             spark_plan.plan_id,
                             spm,
+                            vec![],
+                            vec![iceberg_scan],
+                        )
+                    }
+                    Some(lex) => {
+                        // Too many files to merge: single unordered read + spillable SortExec.
+                        let sort: Arc<dyn ExecutionPlan> =
+                            Arc::new(SortExec::new(lex, Arc::clone(&iceberg_scan)));
+                        SparkPlan::new_with_additional(
+                            spark_plan.plan_id,
+                            sort,
                             vec![],
                             vec![iceberg_scan],
                         )
@@ -5875,5 +5913,102 @@ mod tests {
                 .unwrap_or(true),
             "unified partition type should have no fields for an all-unknown-transform spec"
         );
+    }
+
+    /// Builds an IcebergScan Operator with `num_files` file-scan tasks and a reported identity
+    /// ordering on a single Int column, so create_plan takes the sort-merge path.
+    fn iceberg_scan_op_with_ordering(num_files: usize) -> Operator {
+        let schema_json = serde_json::to_string(
+            &iceberg::spec::Schema::builder()
+                .with_schema_id(0)
+                .with_fields(vec![iceberg::spec::NestedField::required(
+                    1,
+                    "id",
+                    iceberg::spec::Type::Primitive(iceberg::spec::PrimitiveType::Int),
+                )
+                .into()])
+                .build()
+                .expect("schema"),
+        )
+        .expect("serialize schema");
+
+        let int_type = spark_expression::DataType {
+            type_id: 3, // Int32
+            type_info: None,
+        };
+
+        let required_schema = vec![spark_operator::SparkStructField {
+            name: "id".to_string(),
+            data_type: Some(int_type.clone()),
+            nullable: false,
+            metadata: Default::default(),
+        }];
+
+        // id ASC NULLS FIRST, as Expr { SortOrder { child: Bound(0) } }.
+        let sort_child = Expr {
+            expr_struct: Some(Bound(spark_expression::BoundReference {
+                index: 0,
+                datatype: Some(int_type),
+            })),
+            query_context: None,
+            expr_id: None,
+        };
+        let sort_order = Expr {
+            expr_struct: Some(ExprStruct::SortOrder(Box::new(
+                spark_expression::SortOrder {
+                    child: Some(Box::new(sort_child)),
+                    direction: 0,     // Ascending
+                    null_ordering: 0, // NullsFirst
+                },
+            ))),
+            query_context: None,
+            expr_id: None,
+        };
+
+        let common = spark_operator::IcebergScanCommon {
+            schema_pool: vec![schema_json],
+            project_field_ids_pool: vec![spark_operator::ProjectFieldIdList { field_ids: vec![1] }],
+            required_schema,
+            table_sort_orders: vec![sort_order],
+            ..Default::default()
+        };
+
+        let task = spark_operator::IcebergFileScanTask {
+            data_file_path: "file:///tmp/data.parquet".to_string(),
+            file_size_in_bytes: 100,
+            schema_idx: 0,
+            project_field_ids_idx: 0,
+            ..Default::default()
+        };
+
+        Operator {
+            plan_id: 1,
+            sql_text_pool: vec![],
+            children: vec![],
+            op_struct: Some(OpStruct::IcebergScan(spark_operator::IcebergScan {
+                common: Some(common),
+                file_scan_tasks: vec![task; num_files],
+            })),
+        }
+    }
+
+    // At or below the max-files-per-partition limit (default 64), a reported ordering makes the
+    // scan multi-partition and the planner wraps it in a SortPreservingMergeExec.
+    #[test]
+    fn iceberg_scan_merges_when_files_within_limit() {
+        let op = iceberg_scan_op_with_ordering(4);
+        let planner = PhysicalPlanner::default();
+        let (_, _, plan) = planner.create_plan(&op, &mut vec![], 1).unwrap();
+        assert_eq!("SortPreservingMergeExec", plan.native_plan.name());
+    }
+
+    // Above the limit, merging would open too many readers at once, so the planner falls back to a
+    // single unordered read wrapped in a spillable SortExec (still sorted output).
+    #[test]
+    fn iceberg_scan_falls_back_to_sort_above_file_limit() {
+        let op = iceberg_scan_op_with_ordering(65);
+        let planner = PhysicalPlanner::default();
+        let (_, _, plan) = planner.create_plan(&op, &mut vec![], 1).unwrap();
+        assert_eq!("SortExec", plan.native_plan.name());
     }
 }

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -70,6 +70,7 @@ use datafusion::{
         limit::LocalLimitExec,
         projection::ProjectionExec,
         sorts::sort::SortExec,
+        sorts::sort_preserving_merge::SortPreservingMergeExec,
         ExecutionPlan,
     },
     prelude::SessionContext,
@@ -1757,24 +1758,51 @@ impl PhysicalPlanner {
                 let tasks = parse_file_scan_tasks_from_common(common, &scan.file_scan_tasks)?;
                 let data_file_concurrency_limit = common.data_file_concurrency_limit as usize;
 
-                let iceberg_scan = IcebergScanExec::new(
+                // Table sort order Iceberg reported. Empty unless sortMerge is on and the order
+                // passed the identity gate in CometIcebergNativeScan. The SortOrder children are
+                // bound references into required_schema, so build the LexOrdering against it.
+                let ordering: Option<LexOrdering> = if common.table_sort_orders.is_empty() {
+                    None
+                } else {
+                    let exprs = common
+                        .table_sort_orders
+                        .iter()
+                        .map(|expr| self.create_sort_expr(expr, Arc::clone(&required_schema)))
+                        .collect::<Result<Vec<PhysicalSortExpr>, ExecutionError>>()?;
+                    LexOrdering::new(exprs)
+                };
+
+                let iceberg_scan: Arc<dyn ExecutionPlan> = Arc::new(IcebergScanExec::new(
                     metadata_location,
                     required_schema,
                     catalog_properties,
                     catalog_name,
                     tasks,
                     data_file_concurrency_limit,
-                )?;
+                    ordering.clone(),
+                )?);
 
-                Ok((
-                    vec![],
-                    vec![],
-                    Arc::new(SparkPlan::new(
-                        spark_plan.plan_id,
-                        Arc::new(iceberg_scan),
-                        vec![],
-                    )),
-                ))
+                // With an ordering, the scan is multi-partition (one sorted stream per file). Wrap
+                // it in a SortPreservingMergeExec so each Spark partition comes out sorted. Keep the
+                // scan as an additional native plan so its metrics (num_splits, bytes_scanned) still
+                // roll up. Without an ordering, the scan stays a single-partition leaf, unchanged.
+                let result_plan = match ordering {
+                    Some(lex) => {
+                        let spm: Arc<dyn ExecutionPlan> = Arc::new(
+                            SortPreservingMergeExec::new(lex, Arc::clone(&iceberg_scan))
+                                .with_round_robin_repartition(false),
+                        );
+                        SparkPlan::new_with_additional(
+                            spark_plan.plan_id,
+                            spm,
+                            vec![],
+                            vec![iceberg_scan],
+                        )
+                    }
+                    None => SparkPlan::new(spark_plan.plan_id, iceberg_scan, vec![]),
+                };
+
+                Ok((vec![], vec![], Arc::new(result_plan)))
             }
             OpStruct::ShuffleWriter(writer) => {
                 assert_eq!(children.len(), 1);

--- a/native/core/src/execution/spark_config.rs
+++ b/native/core/src/execution/spark_config.rs
@@ -26,6 +26,21 @@ pub(crate) const COMET_PARQUET_ROW_FILTER_PUSHDOWN_ENABLED: &str =
     "spark.comet.parquet.rowFilterPushdown.enabled";
 pub(crate) const SPARK_EXECUTOR_CORES: &str = "spark.executor.cores";
 
+/// Above this many files in a single Spark partition, the native Iceberg scan does not attempt a
+/// per-file-stream k-way merge (which would open one reader per file at once); it reads the
+/// partition unordered and sorts with a spillable SortExec instead. Read from the config below and
+/// carried to the physical planner as an [`IcebergSortMergeConfig`] session extension.
+pub(crate) const COMET_ICEBERG_SORT_MERGE_MAX_FILES_PER_PARTITION: &str =
+    "spark.comet.scan.icebergNative.sortMerge.maxFilesPerPartition";
+pub(crate) const DEFAULT_ICEBERG_SORT_MERGE_MAX_FILES_PER_PARTITION: usize = 64;
+
+/// Comet planner settings carried on the DataFusion `SessionConfig` as a type-keyed extension, so
+/// the physical planner can read Comet scan configs that are not DataFusion options.
+#[derive(Debug)]
+pub(crate) struct IcebergSortMergeConfig {
+    pub max_files_per_partition: usize,
+}
+
 pub(crate) trait SparkConfig {
     fn get_bool(&self, name: &str) -> bool;
     fn get_u64(&self, name: &str, default_value: u64) -> u64;

--- a/native/proto/src/proto/operator.proto
+++ b/native/proto/src/proto/operator.proto
@@ -304,6 +304,12 @@ message IcebergScanCommon {
   // projections or filters, so PlanDataInjector keys planning data by
   // (metadata_location, scan_hash_code) rather than metadata_location alone.
   int32 scan_hash_code = 15;
+
+  // Table sort order Iceberg reported (SupportsReportOrdering), against required_schema. Each Expr
+  // wraps a SortOrder (child, direction, null_ordering). When set, the native scan reads each file
+  // as its own sorted stream and wraps the scan in a SortPreservingMergeExec, so each Spark
+  // partition comes out sorted. Empty means no reported order: read unordered, as before.
+  repeated spark.spark_expression.Expr table_sort_orders = 16;
 }
 
 message IcebergScan {

--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -133,18 +133,6 @@ object CometConf extends ShimCometConf {
       .booleanConf
       .createWithDefault(true)
 
-  val COMET_ICEBERG_REPORT_PARTITIONING_ENABLED: ConfigEntry[Boolean] =
-    conf("spark.comet.scan.icebergNative.reportPartitioning.enabled")
-      .category(CATEGORY_SCAN)
-      .doc("Whether the native Iceberg scan reports Iceberg's key-grouped partitioning (requires " +
-        "spark.sql.sources.v2.bucketing.enabled) so storage-partitioned joins avoid a shuffle, " +
-        "which is what lets a reported sort order eliminate a join's sort. Independent of " +
-        "sortMerge.enabled. Defaults to disabled: the AQE + push-down-partition-values path is " +
-        "not yet verified, so reporting is off until it is exercised. When disabled, " +
-        "partitioning is reported as unknown, as before.")
-      .booleanConf
-      .createWithDefault(false)
-
   val COMET_ICEBERG_WRITE_SPLIT_OPERATOR_ENABLED: ConfigEntry[Boolean] =
     conf("spark.comet.write.iceberg.splitOperator.enabled")
       .category(CATEGORY_TESTING)

--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -133,6 +133,18 @@ object CometConf extends ShimCometConf {
       .booleanConf
       .createWithDefault(true)
 
+  val COMET_ICEBERG_SORT_MERGE_MAX_FILES_PER_PARTITION: ConfigEntry[Int] =
+    conf("spark.comet.scan.icebergNative.sortMerge.maxFilesPerPartition")
+      .category(CATEGORY_SCAN)
+      .doc(
+        "The maximum number of files in a single partition that the native Iceberg scan will " +
+          "k-way merge to preserve sort order. A merge opens one reader per file at once, so " +
+          "above this many files the scan instead reads the partition unordered and sorts it " +
+          "with a spillable sort, bounding concurrently-open readers. Both paths produce sorted " +
+          "output; this only trades merge for a full sort on partitions with many files.")
+      .intConf
+      .createWithDefault(64)
+
   val COMET_ICEBERG_WRITE_SPLIT_OPERATOR_ENABLED: ConfigEntry[Boolean] =
     conf("spark.comet.write.iceberg.splitOperator.enabled")
       .category(CATEGORY_TESTING)

--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -121,6 +121,30 @@ object CometConf extends ShimCometConf {
       .booleanConf
       .createWithDefault(true)
 
+  val COMET_ICEBERG_SORT_MERGE_ENABLED: ConfigEntry[Boolean] =
+    conf("spark.comet.scan.icebergNative.sortMerge.enabled")
+      .category(CATEGORY_SCAN)
+      .doc("Whether the native Iceberg scan reports the table sort order and performs a " +
+        "per-partition streaming merge of already-sorted files. When enabled and Iceberg reports " +
+        "an ordering (requires Iceberg's spark.sql.iceberg.planning.preserve-data-ordering), " +
+        "each Spark partition reads its files as separate sorted streams merged into one sorted " +
+        "output, and the ordering is surfaced to Spark so redundant sorts are eliminated. When " +
+        "disabled, files are read unordered as before.")
+      .booleanConf
+      .createWithDefault(true)
+
+  val COMET_ICEBERG_REPORT_PARTITIONING_ENABLED: ConfigEntry[Boolean] =
+    conf("spark.comet.scan.icebergNative.reportPartitioning.enabled")
+      .category(CATEGORY_SCAN)
+      .doc("Whether the native Iceberg scan reports Iceberg's key-grouped partitioning (requires " +
+        "spark.sql.sources.v2.bucketing.enabled) so storage-partitioned joins avoid a shuffle, " +
+        "which is what lets a reported sort order eliminate a join's sort. Independent of " +
+        "sortMerge.enabled. Defaults to disabled: the AQE + push-down-partition-values path is " +
+        "not yet verified, so reporting is off until it is exercised. When disabled, " +
+        "partitioning is reported as unknown, as before.")
+      .booleanConf
+      .createWithDefault(false)
+
   val COMET_ICEBERG_WRITE_SPLIT_OPERATOR_ENABLED: ConfigEntry[Boolean] =
     conf("spark.comet.write.iceberg.splitOperator.enabled")
       .category(CATEGORY_TESTING)

--- a/spark/src/main/scala/org/apache/comet/iceberg/IcebergReflection.scala
+++ b/spark/src/main/scala/org/apache/comet/iceberg/IcebergReflection.scala
@@ -936,6 +936,32 @@ object IcebergReflection extends Logging {
   }
 
   /**
+   * Names of top-level columns whose Iceberg sort order can differ from Spark's comparison of the
+   * Spark type they map to, so a native k-way merge keyed on the Spark value could mis-order
+   * rows. Today that is UUID: Iceberg maps UUID to Spark StringType (see TypeToSparkType) but
+   * sorts by its own UUID comparator, not by the canonical string, so the file order and a string
+   * comparison can disagree. reportableOrdering refuses a sort key in this set. v1 only reports
+   * identity, top-level sort keys, so top-level columns are enough.
+   */
+  def orderingUnsafeColumns(schema: Any): Set[String] = {
+    import scala.jdk.CollectionConverters._
+    try {
+      val columns = getMethod(schema.getClass, "columns")
+        .invoke(schema)
+        .asInstanceOf[java.util.List[_]]
+      columns.asScala.flatMap { column =>
+        val name = getMethod(column.getClass, "name").invoke(column).asInstanceOf[String]
+        val typeStr = getMethod(column.getClass, "type").invoke(column).toString
+        if (typeStr == "uuid") Some(name) else None
+      }.toSet
+    } catch {
+      case e: Exception =>
+        logWarning(s"Failed to inspect schema for ordering-unsafe columns: ${e.getMessage}")
+        Set.empty[String]
+    }
+  }
+
+  /**
    * Validates partition column types for compatibility with iceberg-rust.
    *
    * iceberg-rust's Literal::try_from_json() has incomplete type support: - Binary/fixed types:

--- a/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala
@@ -835,12 +835,38 @@ case class CometScanRule(session: SparkSession)
           }
         }
 
+        // If Iceberg reports an ordering, EnsureRequirements may have already dropped the Sort
+        // above this scan (it decides that on the vanilla BatchScanExec, before Comet converts the
+        // scan). If the native scan cannot guarantee that ordering, reading unordered here would
+        // silently return wrong results, so stay on Spark -- its Iceberg reader produces the sorted
+        // output it promised. reportableOrdering is the same gate the native scan/serde use, so the
+        // decision here cannot diverge from what the native path would do.
+        val orderingHonored: Boolean = {
+          val reported = scanExec.ordering.getOrElse(Nil)
+          if (reported.isEmpty) {
+            true
+          } else {
+            val unsafe = IcebergReflection.orderingUnsafeColumns(metadata.tableSchema)
+            val honorable =
+              CometIcebergNativeScan.reportableOrdering(
+                scanExec.ordering,
+                scanExec.output,
+                unsafe)
+            if (honorable.isEmpty) {
+              fallbackReasons += "Iceberg reports a sort order the native scan cannot guarantee " +
+                "(sort-merge disabled, or a transform / unsafe-type sort key); staying on Spark " +
+                "so the reported ordering is preserved"
+            }
+            honorable.nonEmpty
+          }
+        }
+
         if (schemaSupported && fileIOCompatible && formatVersionSupported &&
           defaultValuesSupported && schemaTypesSupported && encryptionKeyLengthSupported &&
           taskValidation.allParquet && allSupportedFilesystems && partitionTypesSupported &&
           unifiedPartitionTypeSupported &&
           complexTypePredicatesSupported && transformFunctionsSupported &&
-          deleteFileTypesSupported && dppSubqueriesSupported) {
+          deleteFileTypesSupported && dppSubqueriesSupported && orderingHonored) {
           CometBatchScanExec(
             scanExec.clone().asInstanceOf[BatchScanExec],
             runtimeFilters = scanExec.runtimeFilters,

--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
@@ -877,15 +877,24 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
    *
    * We read scanExec.ordering (the raw reported order), not scanExec.outputOrdering. Spark blanks
    * outputOrdering when a partition holds more than one file -- the case this merge handles.
+   *
+   * `unsafeColumns` are top-level columns whose Iceberg sort order can differ from Spark's
+   * comparison of the mapped Spark type (today: UUID, which Iceberg maps to StringType but sorts
+   * by its own comparator -- see IcebergReflection.orderingUnsafeColumns). A sort key on such a
+   * column is refused, because the files are sorted by an order the native string merge would not
+   * reproduce. This cannot be detected from the Spark type alone (UUID looks like a plain
+   * string), so the caller passes the names in.
    */
   def reportableOrdering(
       ordering: Option[Seq[SortOrder]],
-      output: Seq[Attribute]): Seq[SortOrder] = {
+      output: Seq[Attribute],
+      unsafeColumns: Set[String] = Set.empty): Seq[SortOrder] = {
     if (!CometConf.COMET_ICEBERG_SORT_MERGE_ENABLED.get()) {
       Nil
     } else {
       ordering match {
-        case Some(orders) if orders.nonEmpty && orders.forall(isReportable(_, output)) =>
+        case Some(orders)
+            if orders.nonEmpty && orders.forall(isReportable(_, output, unsafeColumns)) =>
           orders
         case _ =>
           Nil
@@ -893,8 +902,18 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
     }
   }
 
-  private def isReportable(order: SortOrder, output: Seq[Attribute]): Boolean =
-    isIdentityProjected(order, output) && exprToProto(order, output).isDefined
+  private def isReportable(
+      order: SortOrder,
+      output: Seq[Attribute],
+      unsafeColumns: Set[String]): Boolean =
+    isIdentityProjected(order, output) && !isUnsafeColumn(order, unsafeColumns) &&
+      exprToProto(order, output).isDefined
+
+  private def isUnsafeColumn(order: SortOrder, unsafeColumns: Set[String]): Boolean =
+    order.child match {
+      case a: AttributeReference => unsafeColumns.contains(a.name)
+      case _ => false
+    }
 
   private def isIdentityProjected(order: SortOrder, output: Seq[Attribute]): Boolean =
     order.child match {
@@ -933,6 +952,7 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
   def serializePartitions(
       scanExec: BatchScanExec,
       output: Seq[Attribute],
+      reportedOrdering: Seq[SortOrder],
       metadata: CometIcebergNativeScanMetadata): (Array[Byte], Array[Array[Byte]]) = {
 
     val commonBuilder = OperatorOuterClass.IcebergScanCommon.newBuilder()
@@ -992,18 +1012,18 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
       commonBuilder.addRequiredSchema(field.build())
     }
 
-    // Report the table sort order so the native scan reads each file as its own sorted stream and
-    // wraps the scan in a SortPreservingMergeExec (see IcebergScanCommon.table_sort_orders).
-    // reportableOrdering uses the same gate as outputOrdering, and has already checked each order
-    // serializes via exprToProto. So the forall below always holds, and we never write an order to
-    // the proto that the scan does not also report to Spark. Bind against `output` so each
-    // SortOrder child becomes a BoundReference into required_schema.
-    val reportable = reportableOrdering(scanExec.ordering, output)
-    if (reportable.nonEmpty) {
-      val protoOrders = reportable.map(exprToProto(_, output))
-      if (protoOrders.forall(_.isDefined)) {
-        commonBuilder.addAllTableSortOrders(protoOrders.map(_.get).asJava)
-      }
+    // Serialize the ordering the exec already decided to report (reportedOrdering), so the gate is
+    // evaluated exactly once. Reporting an order to Spark but not merging natively would drop a
+    // Sort and return wrong results, so if any reported order fails to serialize we throw rather
+    // than silently write a partial/empty list. Bind against `output` so each SortOrder child
+    // becomes a BoundReference into required_schema.
+    if (reportedOrdering.nonEmpty) {
+      val protoOrders = reportedOrdering.map(exprToProto(_, output))
+      require(
+        protoOrders.forall(_.isDefined),
+        s"reported ordering $reportedOrdering could not be serialized to proto; refusing to " +
+          "report an ordering the native scan will not honour")
+      commonBuilder.addAllTableSortOrders(protoOrders.map(_.get).asJava)
     }
 
     // Load Iceberg classes once (avoid repeated class loading in loop)

--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometIcebergNativeScan.scala
@@ -44,7 +44,7 @@ import org.apache.comet.{CometConf, ConfigEntry}
 import org.apache.comet.iceberg.{CometIcebergNativeScanMetadata, IcebergReflection}
 import org.apache.comet.serde.{CometOperatorSerde, OperatorOuterClass}
 import org.apache.comet.serde.OperatorOuterClass.{Operator, SparkStructField}
-import org.apache.comet.serde.QueryPlanSerde.serializeDataType
+import org.apache.comet.serde.QueryPlanSerde.{exprToProto, serializeDataType}
 
 object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] with Logging {
 
@@ -860,6 +860,49 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
   }
 
   /**
+   * The part of an Iceberg-reported sort order that the native per-partition merge can honour, or
+   * Nil when the merge must stay off. Two callers use this one gate: the proto serialization
+   * (which turns on the native SortPreservingMergeExec) and
+   * CometIcebergNativeScanExec.outputOrdering (which tells Spark the scan is sorted). Sharing the
+   * gate means the two always agree.
+   *
+   * v1 accepts only identity sort fields on top-level columns that are in the projection. Each
+   * SortOrder child must be an AttributeReference in `output`, and must serialize to proto.
+   * Transform sort fields (bucket/truncate/...) are not AttributeReferences, so they fall through
+   * to Nil and we read unordered. Checking exprToProto here, not just in the proto path, keeps
+   * the two callers in step: outputOrdering never advertises an order the proto path would drop.
+   *
+   * We trust Iceberg on file-level sortedness. If it reports an ordering, SortOrderAnalyzer has
+   * already checked each file's sort_order_id matches the table order, so every file is sorted.
+   *
+   * We read scanExec.ordering (the raw reported order), not scanExec.outputOrdering. Spark blanks
+   * outputOrdering when a partition holds more than one file -- the case this merge handles.
+   */
+  def reportableOrdering(
+      ordering: Option[Seq[SortOrder]],
+      output: Seq[Attribute]): Seq[SortOrder] = {
+    if (!CometConf.COMET_ICEBERG_SORT_MERGE_ENABLED.get()) {
+      Nil
+    } else {
+      ordering match {
+        case Some(orders) if orders.nonEmpty && orders.forall(isReportable(_, output)) =>
+          orders
+        case _ =>
+          Nil
+      }
+    }
+  }
+
+  private def isReportable(order: SortOrder, output: Seq[Attribute]): Boolean =
+    isIdentityProjected(order, output) && exprToProto(order, output).isDefined
+
+  private def isIdentityProjected(order: SortOrder, output: Seq[Attribute]): Boolean =
+    order.child match {
+      case a: AttributeReference => output.exists(_.exprId == a.exprId)
+      case _ => false
+    }
+
+  /**
    * Serializes partitions from inputRDD at execution time.
    *
    * Called after doPrepare() has resolved DPP subqueries. Builds pools and per-partition data in
@@ -947,6 +990,20 @@ object CometIcebergNativeScan extends CometOperatorSerde[CometBatchScanExec] wit
         .setNullable(attr.nullable)
       serializeDataType(attr.dataType).foreach(field.setDataType)
       commonBuilder.addRequiredSchema(field.build())
+    }
+
+    // Report the table sort order so the native scan reads each file as its own sorted stream and
+    // wraps the scan in a SortPreservingMergeExec (see IcebergScanCommon.table_sort_orders).
+    // reportableOrdering uses the same gate as outputOrdering, and has already checked each order
+    // serializes via exprToProto. So the forall below always holds, and we never write an order to
+    // the proto that the scan does not also report to Spark. Bind against `output` so each
+    // SortOrder child becomes a BoundReference into required_schema.
+    val reportable = reportableOrdering(scanExec.ordering, output)
+    if (reportable.nonEmpty) {
+      val protoOrders = reportable.map(exprToProto(_, output))
+      if (protoOrders.forall(_.isDefined)) {
+        commonBuilder.addAllTableSortOrders(protoOrders.map(_.get).asJava)
+      }
     }
 
     // Load Iceberg classes once (avoid repeated class loading in loop)

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometIcebergNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometIcebergNativeScanExec.scala
@@ -34,8 +34,7 @@ import org.apache.spark.util.AccumulatorV2
 
 import com.google.common.base.Objects
 
-import org.apache.comet.CometConf
-import org.apache.comet.iceberg.CometIcebergNativeScanMetadata
+import org.apache.comet.iceberg.{CometIcebergNativeScanMetadata, IcebergReflection}
 import org.apache.comet.serde.OperatorOuterClass.Operator
 import org.apache.comet.serde.operator.CometIcebergNativeScan
 
@@ -109,6 +108,9 @@ case class CometIcebergNativeScanExec(
     CometIcebergNativeScan.serializePartitions(
       effectiveOriginalPlan,
       output,
+      // Pass the ordering the exec reports to Spark (outputOrdering) so the proto and the reported
+      // ordering come from a single evaluation of the gate, not two dynamic conf reads.
+      outputOrdering,
       nativeIcebergScanMetadata)
   }
 
@@ -120,30 +122,13 @@ case class CometIcebergNativeScanExec(
   // Only accessed during execution, not planning
   def numPartitions: Int = perPartitionData.length
 
-  // Report Iceberg's key-grouped partitioning (storage-partitioned join) instead of dropping it to
-  // UnknownPartitioning. This lets a sort-merge join over co-partitioned tables skip the shuffle.
-  // Without it the join shuffles, the shuffle re-orders the rows, and the sort we reported comes
-  // back. Delegating to originalPlan.outputPartitioning is safe because perPartitionData IS
-  // originalPlan.inputRDD.partitions (1:1, same order), so the partition count and values match
-  // Comet's execution partitions by Spark's own construction. We delegate rather than name
-  // KeyGroupedPartitioning so this compiles across Spark versions. Enabled by
-  // COMET_ICEBERG_REPORT_PARTITIONING_ENABLED plus V2 bucketing; otherwise, and on canonicalized
-  // instances, keep UnknownPartitioning. The delegating branch does not read numPartitions, so it
-  // avoids forcing DPP resolution and serialization; only the fallback does.
-  //
-  // NOTE: the flag defaults off because the AQE + pushPartValues path is only partially verified.
-  // There, EnsureRequirements would need to push commonPartitionValues into the leaf, but
-  // populateCommonPartitionInfo matches only BatchScanExec. Verify that before enabling this.
-  override lazy val outputPartitioning: Partitioning = {
-    if (originalPlan != null &&
-      CometConf.COMET_ICEBERG_REPORT_PARTITIONING_ENABLED.get() &&
-      originalPlan.keyGroupedPartitioning.isDefined &&
-      conf.v2BucketingEnabled) {
-      originalPlan.outputPartitioning
-    } else {
-      UnknownPartitioning(numPartitions)
-    }
-  }
+  // Spark's EnsureRequirements runs before Comet converts this scan, so it already eliminates a
+  // redundant shuffle based on the vanilla BatchScanExec's KeyGroupedPartitioning (storage-
+  // partitioned join) while the leaf is still a BatchScanExec. This node therefore does not need
+  // to re-report partitioning: UnknownPartitioning is enough, and it keeps the whole SPJ
+  // negotiation (including commonPartitionValues push-down under AQE) on BatchScanExec, which is
+  // the only node Spark can push into.
+  override lazy val outputPartitioning: Partitioning = UnknownPartitioning(numPartitions)
 
   // Report the Iceberg-reported ordering (gated to what the native per-partition merge honours) so
   // Spark elides redundant sorts above the scan. Uses the same reportableOrdering gate as the proto
@@ -154,7 +139,16 @@ case class CometIcebergNativeScanExec(
     if (originalPlan == null) {
       Nil
     } else {
-      CometIcebergNativeScan.reportableOrdering(originalPlan.ordering, output)
+      // Exclude sort keys whose Iceberg type orders differently from Spark's comparison of the
+      // mapped type (UUID maps to StringType but sorts by its own comparator). This is invisible
+      // at the Spark type level, so pass the column names down from the Iceberg schema.
+      val unsafeColumns =
+        if (nativeIcebergScanMetadata != null) {
+          IcebergReflection.orderingUnsafeColumns(nativeIcebergScanMetadata.tableSchema)
+        } else {
+          Set.empty[String]
+        }
+      CometIcebergNativeScan.reportableOrdering(originalPlan.ordering, output, unsafeColumns)
     }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometIcebergNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometIcebergNativeScanExec.scala
@@ -26,7 +26,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, SortOrder}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, UnknownPartitioning}
+import org.apache.spark.sql.catalyst.plans.physical.{KeyGroupedPartitioning, Partitioning, UnknownPartitioning}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -34,6 +34,7 @@ import org.apache.spark.util.AccumulatorV2
 
 import com.google.common.base.Objects
 
+import org.apache.comet.CometConf
 import org.apache.comet.iceberg.CometIcebergNativeScanMetadata
 import org.apache.comet.serde.OperatorOuterClass.Operator
 import org.apache.comet.serde.operator.CometIcebergNativeScan
@@ -119,9 +120,45 @@ case class CometIcebergNativeScanExec(
   // Only accessed during execution, not planning
   def numPartitions: Int = perPartitionData.length
 
-  override lazy val outputPartitioning: Partitioning = UnknownPartitioning(numPartitions)
+  // Report Iceberg's KeyGroupedPartitioning (storage-partitioned join) instead of dropping it to
+  // UnknownPartitioning. This lets a sort-merge join over co-partitioned tables skip the shuffle.
+  // Without it the join shuffles, the shuffle re-orders the rows, and the sort we
+  // reported comes back. Delegating to originalPlan.outputPartitioning is safe because
+  // perPartitionData IS originalPlan.inputRDD.partitions (1:1, same order), so the partition count
+  // and values match Comet's execution partitions by Spark's own construction. Enable if
+  // COMET_ICEBERG_REPORT_PARTITIONING_ENABLED, and V2 bucketing is enabled. Otherwise, and on
+  // canonicalized keep UnknownPartitioning. The KeyGroupedPartitioning branch does not read
+  // numPartitions, so it avoids forcing DPP resolution and serialization; only the fallback does.
+  //
+  // NOTE: the flag defaults off because the AQE + pushPartValues path is partially verified. There,
+  // EnsureRequirements would need to push commonPartitionValues into the leaf, but
+  // populateCommonPartitionInfo matches only BatchScanExec. We need to verify that before enabling
+  // this.
+  override lazy val outputPartitioning: Partitioning = {
+    if (originalPlan != null &&
+      CometConf.COMET_ICEBERG_REPORT_PARTITIONING_ENABLED.get() &&
+      originalPlan.keyGroupedPartitioning.isDefined &&
+      conf.v2BucketingEnabled) {
+      originalPlan.outputPartitioning match {
+        case kgp: KeyGroupedPartitioning => kgp
+        case _ => UnknownPartitioning(numPartitions)
+      }
+    } else {
+      UnknownPartitioning(numPartitions)
+    }
+  }
 
-  override lazy val outputOrdering: Seq[SortOrder] = Nil
+  // Report the Iceberg-reported ordering (gated to what the native per-partition merge honours) so
+  // Spark elides redundant sorts above the scan. Uses the same reportableOrdering gate as the proto
+  // serialization, so the advertised ordering always matches what the native merge actually
+  // produces. Nil on canonicalized instances (originalPlan nulled) -- they are never executed and
+  // their ordering is irrelevant to equality.
+  override lazy val outputOrdering: Seq[SortOrder] =
+    if (originalPlan == null) {
+      Nil
+    } else {
+      CometIcebergNativeScan.reportableOrdering(originalPlan.ordering, output)
+    }
 
   /**
    * Maps Iceberg V2 custom metric types to standard Spark metric types for better UI formatting.

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometIcebergNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometIcebergNativeScanExec.scala
@@ -26,7 +26,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, SortOrder}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.catalyst.plans.physical.{KeyGroupedPartitioning, Partitioning, UnknownPartitioning}
+import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, UnknownPartitioning}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -120,29 +120,26 @@ case class CometIcebergNativeScanExec(
   // Only accessed during execution, not planning
   def numPartitions: Int = perPartitionData.length
 
-  // Report Iceberg's KeyGroupedPartitioning (storage-partitioned join) instead of dropping it to
+  // Report Iceberg's key-grouped partitioning (storage-partitioned join) instead of dropping it to
   // UnknownPartitioning. This lets a sort-merge join over co-partitioned tables skip the shuffle.
-  // Without it the join shuffles, the shuffle re-orders the rows, and the sort we
-  // reported comes back. Delegating to originalPlan.outputPartitioning is safe because
-  // perPartitionData IS originalPlan.inputRDD.partitions (1:1, same order), so the partition count
-  // and values match Comet's execution partitions by Spark's own construction. Enable if
-  // COMET_ICEBERG_REPORT_PARTITIONING_ENABLED, and V2 bucketing is enabled. Otherwise, and on
-  // canonicalized keep UnknownPartitioning. The KeyGroupedPartitioning branch does not read
-  // numPartitions, so it avoids forcing DPP resolution and serialization; only the fallback does.
+  // Without it the join shuffles, the shuffle re-orders the rows, and the sort we reported comes
+  // back. Delegating to originalPlan.outputPartitioning is safe because perPartitionData IS
+  // originalPlan.inputRDD.partitions (1:1, same order), so the partition count and values match
+  // Comet's execution partitions by Spark's own construction. We delegate rather than name
+  // KeyGroupedPartitioning so this compiles across Spark versions. Enabled by
+  // COMET_ICEBERG_REPORT_PARTITIONING_ENABLED plus V2 bucketing; otherwise, and on canonicalized
+  // instances, keep UnknownPartitioning. The delegating branch does not read numPartitions, so it
+  // avoids forcing DPP resolution and serialization; only the fallback does.
   //
-  // NOTE: the flag defaults off because the AQE + pushPartValues path is partially verified. There,
-  // EnsureRequirements would need to push commonPartitionValues into the leaf, but
-  // populateCommonPartitionInfo matches only BatchScanExec. We need to verify that before enabling
-  // this.
+  // NOTE: the flag defaults off because the AQE + pushPartValues path is only partially verified.
+  // There, EnsureRequirements would need to push commonPartitionValues into the leaf, but
+  // populateCommonPartitionInfo matches only BatchScanExec. Verify that before enabling this.
   override lazy val outputPartitioning: Partitioning = {
     if (originalPlan != null &&
       CometConf.COMET_ICEBERG_REPORT_PARTITIONING_ENABLED.get() &&
       originalPlan.keyGroupedPartitioning.isDefined &&
       conf.v2BucketingEnabled) {
-      originalPlan.outputPartitioning match {
-        case kgp: KeyGroupedPartitioning => kgp
-        case _ => UnknownPartitioning(numPartitions)
-      }
+      originalPlan.outputPartitioning
     } else {
       UnknownPartitioning(numPartitions)
     }

--- a/spark/src/test/scala/org/apache/comet/CometIcebergSortMergeReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergSortMergeReadSuite.scala
@@ -1,0 +1,634 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.catalyst.expressions.{Add, Ascending, AttributeReference, Literal, SortOrder}
+import org.apache.spark.sql.catalyst.plans.physical.KeyGroupedPartitioning
+import org.apache.spark.sql.comet.{CometIcebergNativeScanExec, CometSortExec}
+import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
+import org.apache.spark.sql.execution.{SortExec, SparkPlan}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+import org.apache.spark.sql.types.IntegerType
+
+import org.apache.comet.serde.operator.CometIcebergNativeScan
+
+/**
+ * Tests for the sort-aware native Iceberg scan (branch `stream-merge`): the scan reports the
+ * Iceberg table sort order to Spark and does a per-partition streaming k-way merge of the
+ * already-sorted files, so Catalyst can drop the Sort and (with storage-partitioned join) the
+ * Exchange that a sort-merge join / grouped aggregate / window would otherwise need.
+ *
+ * The suite has two parts:
+ *   - Unit tests of the [[CometIcebergNativeScan.reportableOrdering]] gate (no SparkSession
+ *     required) -- the single decision shared by the proto serialization (which turns on the
+ *     native SortPreservingMergeExec) and CometIcebergNativeScanExec.outputOrdering (which tells
+ *     Spark the scan is sorted).
+ *   - End-to-end tests over real Iceberg tables that exercise every Spark 4.0 mechanism which
+ *     exploits already-sorted input to avoid a Sort or a shuffle (all keyed off
+ *     `SortOrder.orderingSatisfies`, prefix semantics): `SupportsReportOrdering` ->
+ *     `BatchScanExec.outputOrdering` and `EnsureRequirements` eliding the required-child Sort;
+ *     `EliminateSorts` / `RemoveRedundantSorts`; `SortMergeJoinExec.requiredChildOrdering` +
+ *     storage-partitioned join (`KeyGroupedPartitioning`,
+ *     `spark.sql.sources.v2.bucketing.enabled`); `ReplaceHashWithSortAgg` / `SortAggregateExec`;
+ *     `WindowExec`; `TakeOrderedAndProjectExec`.
+ *
+ * Two invariants determine the end-to-end assertions:
+ *   1. Correctness is checked unconditionally via `checkSparkAnswer` (Comet vs vanilla Spark).
+ *      This is the primary guarantee: any k-way-merge defect (dropped, duplicated or mis-ordered
+ *      rows, or an outputOrdering/outputPartitioning that does not match the rows the native
+ *      operator actually produces) shows up as a result mismatch. It holds on any Iceberg build.
+ *      2. The strict "no Sort / no Exchange" plan assertions are the *target* of this feature.
+ *      They only hold where the Iceberg build actually reports the ordering
+ *      (`SupportsReportOrdering`, today an Iceberg fork feature -- the published/upstream Iceberg
+ *      used in CI does not report it) and where the native scan reports `KeyGroupedPartitioning`.
+ *      Each such test therefore runs the correctness check first, then `assume`s the reporting is
+ *      active before asserting the plan shape, so it enforces the contract on a reporting build
+ *      and is skipped (not failed) elsewhere. `sort = 0` is asserted only for *operator-required*
+ *      orderings (SMJ / aggregate / window), never for a global `ORDER BY`, which Spark keeps
+ *      regardless (the per-partition merge is not a global order).
+ *
+ * These cannot be SQL-file fixtures: setting an Iceberg sort order needs the Iceberg Java API
+ * (the Comet test session registers no Iceberg SQL extensions, so `WRITE ORDERED BY` will not
+ * parse), and the plan-shape assertions need access to the executed SparkPlan.
+ *
+ * Each test gets its own catalog name and temp warehouse (the Hadoop `SparkCatalog` instance is
+ * cached per catalog name, so a shared name would bind every test to the first warehouse), and
+ * its tables are dropped in a `finally` so a failing test cannot leak a table into a later one.
+ */
+class CometIcebergSortMergeReadSuite
+    extends CometTestBase
+    with CometIcebergTestBase
+    with AdaptiveSparkPlanHelper {
+
+  // ---------------------------------------------------------------------------------------------
+  // Unit tests of the reportableOrdering gate (merged from the former CometIcebergSortMergeSuite).
+  // v1 identity-scope gate as a pure function, independent of a live SparkSession or an Iceberg
+  // build that reports ordering. The flag defaults to enabled, so no SQLConf override is needed.
+  // ---------------------------------------------------------------------------------------------
+
+  private val gateA = AttributeReference("a", IntegerType)()
+  private val gateB = AttributeReference("b", IntegerType)()
+
+  test("gate: identity ordering on projected columns is reportable") {
+    val ordering = Seq(SortOrder(gateA, Ascending))
+    assert(
+      CometIcebergNativeScan.reportableOrdering(Some(ordering), Seq(gateA, gateB)) === ordering)
+  }
+
+  test("gate: ordering on a column outside the projection falls back") {
+    val ordering = Seq(SortOrder(gateA, Ascending))
+    assert(CometIcebergNativeScan.reportableOrdering(Some(ordering), Seq(gateB)).isEmpty)
+  }
+
+  test("gate: a transform (non-AttributeReference) sort child falls back") {
+    val ordering = Seq(SortOrder(Add(gateA, Literal(1)), Ascending))
+    assert(CometIcebergNativeScan.reportableOrdering(Some(ordering), Seq(gateA)).isEmpty)
+  }
+
+  test("gate: if any sort field is unreportable, the whole ordering falls back") {
+    val ordering = Seq(SortOrder(gateA, Ascending), SortOrder(Add(gateB, Literal(1)), Ascending))
+    assert(CometIcebergNativeScan.reportableOrdering(Some(ordering), Seq(gateA, gateB)).isEmpty)
+  }
+
+  test("gate: absent or empty ordering falls back") {
+    assert(CometIcebergNativeScan.reportableOrdering(None, Seq(gateA)).isEmpty)
+    assert(CometIcebergNativeScan.reportableOrdering(Some(Seq.empty), Seq(gateA)).isEmpty)
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // End-to-end fixtures.
+  // ---------------------------------------------------------------------------------------------
+
+  private val catalogCounter = new AtomicInteger(0)
+
+  // preserve-data-ordering makes Iceberg report the table sort order; adaptive off keeps the
+  // executed plan stable for the sort/shuffle counts below.
+  private val orderedReadConf: Seq[(String, String)] = Seq(
+    "spark.sql.iceberg.planning.preserve-data-ordering" -> "true",
+    "spark.sql.adaptive.enabled" -> "false")
+
+  // Storage-partitioned join config. preserve-data-grouping + v2 bucketing let Iceberg report
+  // KeyGroupedPartitioning; reportPartitioning surfaces it from the Comet leaf (default off, so it
+  // must be set here); the join knobs force a sort-merge join over co-partitioned inputs so the
+  // Exchange can be eliminated. This is the non-AQE path (adaptive off), the verified one.
+  private val spjConf: Seq[(String, String)] = Seq(
+    "spark.sql.iceberg.planning.preserve-data-ordering" -> "true",
+    "spark.sql.iceberg.planning.preserve-data-grouping" -> "true",
+    "spark.sql.sources.v2.bucketing.enabled" -> "true",
+    "spark.sql.sources.v2.bucketing.pushPartValues.enabled" -> "true",
+    "spark.sql.requireAllClusterKeysForCoPartition" -> "false",
+    "spark.sql.autoBroadcastJoinThreshold" -> "-1",
+    "spark.sql.join.preferSortMergeJoin" -> "true",
+    "spark.sql.adaptive.enabled" -> "false",
+    CometConf.COMET_ICEBERG_REPORT_PARTITIONING_ENABLED.key -> "true")
+
+  /**
+   * Runs `f` against a fresh, uniquely-named Hadoop catalog backed by a fresh temp warehouse,
+   * then drops the named tables (IF EXISTS) in a `finally` -- so tables are cleaned up even when
+   * the test body fails, and no two tests can collide on a table name. `f` receives the catalog
+   * name; tables live under the `db` namespace, e.g. `$cat.db.$table`.
+   */
+  private def withSortedTables(extraConf: Seq[(String, String)])(tables: String*)(
+      f: String => Unit): Unit = {
+    assume(icebergAvailable, "Iceberg not available in classpath")
+    withTempIcebergDir { warehouseDir =>
+      val cat = s"sort_cat_${catalogCounter.incrementAndGet()}"
+      val cometConf = Seq(
+        s"spark.sql.catalog.$cat" -> "org.apache.iceberg.spark.SparkCatalog",
+        s"spark.sql.catalog.$cat.type" -> "hadoop",
+        s"spark.sql.catalog.$cat.warehouse" -> warehouseDir.getAbsolutePath,
+        CometConf.COMET_ENABLED.key -> "true",
+        CometConf.COMET_EXEC_ENABLED.key -> "true",
+        CometConf.COMET_ICEBERG_NATIVE_ENABLED.key -> "true")
+      withSQLConf((cometConf ++ extraConf): _*) {
+        try f(cat)
+        finally tables.foreach(t => spark.sql(s"DROP TABLE IF EXISTS $cat.db.$t"))
+      }
+    }
+  }
+
+  /**
+   * Sets the table sort order via the Iceberg Java API. `cols` is (column, ascending); ascending
+   * uses Iceberg's default NULLS FIRST and descending its default NULLS LAST, matching the ORDER
+   * BY null-ordering the tests use.
+   */
+  private def replaceSortOrder(
+      cat: String,
+      namespace: String,
+      table: String,
+      cols: (String, Boolean)*): Unit = {
+    val catalog = spark.sessionState.catalogManager
+      .catalog(cat)
+      .asInstanceOf[org.apache.iceberg.spark.SparkCatalog]
+    val ident =
+      org.apache.spark.sql.connector.catalog.Identifier.of(Array(namespace), table)
+    val icebergTable = catalog
+      .loadTable(ident)
+      .asInstanceOf[org.apache.iceberg.spark.source.SparkTable]
+      .table()
+    var sortOrder = icebergTable.replaceSortOrder()
+    cols.foreach { case (c, asc) =>
+      sortOrder = if (asc) sortOrder.asc(c) else sortOrder.desc(c)
+    }
+    sortOrder.commit()
+  }
+
+  /**
+   * Each string becomes a separate INSERT, hence a separate data file, so merging is required.
+   */
+  private def insertBatches(cat: String, table: String, batches: String*): Unit =
+    batches.foreach(values => spark.sql(s"INSERT INTO $cat.db.$table VALUES $values"))
+
+  private def nativeScans(plan: SparkPlan): Seq[CometIcebergNativeScanExec] =
+    collect(stripAQEPlan(plan)) { case s: CometIcebergNativeScanExec => s }
+
+  private def countSorts(plan: SparkPlan): Int =
+    collect(stripAQEPlan(plan)) {
+      case s: SortExec => s
+      case s: CometSortExec => s
+    }.size
+
+  private def countShuffles(plan: SparkPlan): Int =
+    collect(stripAQEPlan(plan)) {
+      case e: ShuffleExchangeExec => e
+      case e: CometShuffleExchangeExec => e
+    }.size
+
+  /** True once every native scan in the plan advertises the reported ordering. */
+  private def orderingReported(plan: SparkPlan): Boolean = {
+    val scans = nativeScans(plan)
+    scans.nonEmpty && scans.forall(_.outputOrdering.nonEmpty)
+  }
+
+  /** True once every native scan reports KeyGroupedPartitioning (storage-partitioned join). */
+  private def partitioningReported(plan: SparkPlan): Boolean = {
+    val scans = nativeScans(plan)
+    scans.nonEmpty && scans.forall(_.outputPartitioning.isInstanceOf[KeyGroupedPartitioning])
+  }
+
+  // NOTE ON CANCELED TESTS: the two helpers below CANCEL the test (ScalaTest `assume`, reported as
+  // "!!! CANCELED !!!", not a failure) when the Iceberg build on the classpath does not implement
+  // the DSv2 `SupportsReportOrdering` API. Published/upstream Iceberg (the runtime used in CI and
+  // the default mvn profiles) does not report a sort order, so `outputOrdering` comes back empty
+  // and there is no eliminated Sort to assert on. These tests therefore show as canceled there --
+  // that is expected, NOT a regression. The preceding `checkSparkAnswer` has already validated
+  // correctness; only the sort/shuffle-elimination plan assertion is skipped. Run against an
+  // ordering-reporting (fork) Iceberg build to exercise those assertions.
+
+  /** Cancels the test (see note above) unless the scan reported an ordering. */
+  private def assumeOrderingReported(plan: SparkPlan): Unit =
+    assume(
+      orderingReported(plan),
+      "current Iceberg build does not implement SupportsReportOrdering (no ordering reported); " +
+        "sort-elimination assertion skipped")
+
+  /**
+   * Cancels the test (see note above) unless the scan reported both ordering and partitioning.
+   */
+  private def assumeOrderingAndPartitioningReported(plan: SparkPlan): Unit =
+    assume(
+      orderingReported(plan) && partitioningReported(plan),
+      "current Iceberg build does not report ordering (SupportsReportOrdering) and/or " +
+        "KeyGroupedPartitioning; sort/shuffle-elimination assertion skipped")
+
+  // The reporting mechanism: SupportsReportOrdering -> CometIcebergNativeScanExec.outputOrdering
+
+  test("native scan reports the table sort order for a multi-file sorted table") {
+    withSortedTables(orderedReadConf)("t") { cat =>
+      spark.sql(s"CREATE TABLE $cat.db.t (id INT, data STRING) USING iceberg")
+      replaceSortOrder(cat, "db", "t", "id" -> true)
+      insertBatches(cat, "t", "(1,'a'),(3,'c')", "(2,'b'),(4,'d')")
+
+      val (_, plan) = checkSparkAnswer(s"SELECT id, data FROM $cat.db.t ORDER BY id")
+      assume(nativeScans(plan).nonEmpty, "query did not use the native Iceberg scan")
+      assumeOrderingReported(plan)
+      assert(
+        nativeScans(plan).head.outputOrdering.head.child.references.exists(_.name == "id"),
+        s"expected the scan to report an ordering on id:\n$plan")
+    }
+  }
+
+  test("native scan reports no ordering when the sort-merge flag is disabled") {
+    withSortedTables(
+      orderedReadConf ++ Seq(CometConf.COMET_ICEBERG_SORT_MERGE_ENABLED.key -> "false"))("t") {
+      cat =>
+        spark.sql(s"CREATE TABLE $cat.db.t (id INT, data STRING) USING iceberg")
+        replaceSortOrder(cat, "db", "t", "id" -> true)
+        insertBatches(cat, "t", "(1,'a'),(3,'c')", "(2,'b'),(4,'d')")
+
+        // Correctness must hold with the feature off, and no ordering may be advertised.
+        val (_, plan) = checkSparkAnswer(s"SELECT id, data FROM $cat.db.t ORDER BY id")
+        nativeScans(plan).foreach { scan =>
+          assert(
+            scan.outputOrdering.isEmpty,
+            s"no ordering must be reported when the flag is off:\n$plan")
+        }
+    }
+  }
+
+  // K-way merge correctness (EnsureRequirements / EliminateSorts consume the reported ordering;
+  // ORDER BY keeps the comparison order-sensitive so a merge defect is caught directly).
+
+  test("merges multiple sorted files into one globally-ordered stream") {
+    withSortedTables(orderedReadConf)("t") { cat =>
+      spark.sql(s"CREATE TABLE $cat.db.t (id INT, data STRING) USING iceberg")
+      replaceSortOrder(cat, "db", "t", "id" -> true)
+      insertBatches(
+        cat,
+        "t",
+        "(1,'a'),(2,'b')",
+        "(3,'c'),(4,'d')",
+        "(5,'e'),(6,'f')",
+        "(7,'g'),(8,'h')")
+
+      val (_, plan) = checkSparkAnswer(s"SELECT id, data FROM $cat.db.t ORDER BY id")
+      assert(nativeScans(plan).length == 1, s"expected exactly one native scan:\n$plan")
+    }
+  }
+
+  test("merge interleaves duplicate sort-key values across files") {
+    withSortedTables(orderedReadConf)("t") { cat =>
+      spark.sql(s"CREATE TABLE $cat.db.t (id INT, data STRING) USING iceberg")
+      replaceSortOrder(cat, "db", "t", "id" -> true)
+      // The same id appears in several files; the merge must keep every row, not drop or mis-order.
+      insertBatches(cat, "t", "(1,'a'),(2,'b')", "(1,'c'),(2,'d')", "(1,'e'),(3,'f')")
+
+      checkSparkAnswer(s"SELECT id, data FROM $cat.db.t ORDER BY id, data")
+    }
+  }
+
+  test("merge honours NULLS FIRST on an ascending sort key") {
+    withSortedTables(spjConf)("t") { cat =>
+      spark.sql(
+        s"CREATE TABLE $cat.db.t (c1 INT, c2 STRING, c3 STRING) USING iceberg " +
+          "PARTITIONED BY (c3)")
+      replaceSortOrder(cat, "db", "t", "c1" -> true) // ASC -> Iceberg default NULLS FIRST
+      insertBatches(
+        cat,
+        "t",
+        "(null,'x','P1'),(3,'c','P1')",
+        "(null,'y','P1'),(1,'a','P1'),(2,'b','P1')")
+
+      checkSparkAnswer(
+        s"SELECT c1, c2 FROM $cat.db.t WHERE c3 = 'P1' ORDER BY c1 ASC NULLS FIRST, c2")
+    }
+  }
+
+  test("merge honours NULLS LAST on a descending sort key") {
+    withSortedTables(spjConf)("t") { cat =>
+      spark.sql(
+        s"CREATE TABLE $cat.db.t (c1 INT, c2 STRING, c3 STRING) USING iceberg " +
+          "PARTITIONED BY (c3)")
+      replaceSortOrder(cat, "db", "t", "c1" -> false) // DESC -> Iceberg default NULLS LAST
+      insertBatches(
+        cat,
+        "t",
+        "(null,'x','P1'),(1,'a','P1')",
+        "(null,'y','P1'),(3,'c','P1'),(2,'b','P1')")
+
+      checkSparkAnswer(
+        s"SELECT c1, c2 FROM $cat.db.t WHERE c3 = 'P1' ORDER BY c1 DESC NULLS LAST, c2")
+    }
+  }
+
+  test("merge on a descending sort order") {
+    withSortedTables(orderedReadConf)("t") { cat =>
+      spark.sql(s"CREATE TABLE $cat.db.t (id INT, data STRING) USING iceberg")
+      replaceSortOrder(cat, "db", "t", "id" -> false)
+      insertBatches(cat, "t", "(10,'j'),(9,'i')", "(8,'h'),(7,'g')", "(6,'f'),(4,'d')")
+
+      checkSparkAnswer(s"SELECT id FROM $cat.db.t ORDER BY id DESC")
+    }
+  }
+
+  test("merge on a multi-column sort order") {
+    withSortedTables(orderedReadConf)("t") { cat =>
+      spark.sql(s"CREATE TABLE $cat.db.t (c1 INT, c2 STRING, c3 STRING) USING iceberg")
+      replaceSortOrder(cat, "db", "t", "c3" -> true, "c1" -> true)
+      insertBatches(
+        cat,
+        "t",
+        "(1,'a','A'),(3,'c','A')",
+        "(2,'b','A'),(1,'a','B')",
+        "(2,'b','B'),(3,'c','B')")
+
+      checkSparkAnswer(s"SELECT c3, c1, c2 FROM $cat.db.t ORDER BY c3, c1")
+    }
+  }
+
+  test("single file needs no merge") {
+    withSortedTables(orderedReadConf)("t") { cat =>
+      spark.sql(s"CREATE TABLE $cat.db.t (id INT, data STRING) USING iceberg")
+      replaceSortOrder(cat, "db", "t", "id" -> true)
+      insertBatches(cat, "t", "(1,'a'),(2,'b')")
+
+      checkSparkAnswer(s"SELECT id, data FROM $cat.db.t ORDER BY id")
+    }
+  }
+
+  test("partitioned table with several files per partition") {
+    withSortedTables(spjConf)("t") { cat =>
+      spark.sql(
+        s"CREATE TABLE $cat.db.t (c1 INT, c2 STRING, c3 STRING) USING iceberg " +
+          "PARTITIONED BY (c3)")
+      replaceSortOrder(cat, "db", "t", "c1" -> true)
+      insertBatches(
+        cat,
+        "t",
+        "(1,'a','P1'),(3,'c','P1')",
+        "(2,'b','P1'),(4,'d','P1')",
+        "(5,'e','P2'),(7,'g','P2')",
+        "(6,'f','P2'),(8,'h','P2')")
+
+      checkSparkAnswer(s"SELECT c1, c2 FROM $cat.db.t WHERE c3 = 'P1' ORDER BY c1")
+      checkSparkAnswer(s"SELECT c1, c2 FROM $cat.db.t WHERE c3 = 'P2' ORDER BY c1")
+    }
+  }
+
+  test("sort key absent from the projection: falls back to an unordered read but stays correct") {
+    withSortedTables(spjConf)("t") { cat =>
+      spark.sql(
+        s"CREATE TABLE $cat.db.t (c1 INT, c2 STRING, c3 STRING) USING iceberg " +
+          "PARTITIONED BY (c3)")
+      replaceSortOrder(cat, "db", "t", "c1" -> true) // c1 is the sort key
+      insertBatches(cat, "t", "(1,'a','P1'),(3,'c','P1')", "(2,'b','P1'),(4,'d','P1')")
+
+      // c1 is NOT selected -> reportableOrdering returns Nil (the identity-projected gate fails),
+      // so no ordering is reported. Result must still be correct.
+      val (_, plan) = checkSparkAnswer(s"SELECT c2 FROM $cat.db.t WHERE c3 = 'P1'")
+      nativeScans(plan).foreach { scan =>
+        assert(
+          scan.outputOrdering.isEmpty,
+          s"ordering must not be reported when the sort key is not projected:\n$plan")
+      }
+    }
+  }
+
+  test("results are identical with the sort-merge feature on and off") {
+    withSortedTables(orderedReadConf)("t") { cat =>
+      spark.sql(s"CREATE TABLE $cat.db.t (id INT, data STRING) USING iceberg")
+      replaceSortOrder(cat, "db", "t", "id" -> true)
+      insertBatches(cat, "t", "(1,'a'),(3,'c')", "(2,'b'),(4,'d')", "(5,'e'),(6,'f')")
+      val query = s"SELECT id, data FROM $cat.db.t ORDER BY id"
+
+      val enabled = spark.sql(query).collect().toSeq
+      val disabled = withSQLConf(CometConf.COMET_ICEBERG_SORT_MERGE_ENABLED.key -> "false") {
+        spark.sql(query).collect().toSeq
+      }
+      assert(enabled == disabled, "reporting the ordering must not change the result")
+    }
+  }
+
+  // Sort-merge join: sorted + storage-partitioned inputs let EnsureRequirements drop both the
+  // required-child Sort AND the Exchange. Target: zero of each (assume-gated on the reporting).
+
+  test("sort-merge join over co-partitioned sorted tables drops the sort and the shuffle") {
+    withSortedTables(spjConf)("a", "b") { cat =>
+      Seq("a", "b").foreach { t =>
+        spark.sql(
+          s"CREATE TABLE $cat.db.$t (c1 INT, c2 STRING, c3 STRING) USING iceberg " +
+            "PARTITIONED BY (bucket(4, c1))")
+        replaceSortOrder(cat, "db", t, "c1" -> true)
+        insertBatches(
+          cat,
+          t,
+          s"(1,'${t}1','X'),(2,'${t}2','X')",
+          s"(3,'${t}3','X'),(4,'${t}4','X')")
+      }
+
+      val query =
+        s"SELECT t1.c1, t1.c2, t2.c2 FROM $cat.db.a t1 JOIN $cat.db.b t2 ON t1.c1 = t2.c1"
+      val (_, plan) = checkSparkAnswer(query)
+
+      assumeOrderingAndPartitioningReported(plan)
+      assert(countShuffles(plan) == 0, s"storage-partitioned join must not shuffle:\n$plan")
+      assert(countSorts(plan) == 0, s"reported ordering must eliminate the join sort:\n$plan")
+    }
+  }
+
+  test("storage-partitioned join on the bucket key drops the shuffle") {
+    withSortedTables(spjConf)("a", "b") { cat =>
+      // No sort order set: this isolates the SPJ shuffle-elimination (KeyGroupedPartitioning),
+      // independent of the ordering path. A join sort may remain; the Exchange must not.
+      Seq("a", "b").foreach { t =>
+        spark.sql(
+          s"CREATE TABLE $cat.db.$t (c1 INT, c2 STRING, c3 STRING) USING iceberg " +
+            "PARTITIONED BY (bucket(4, c1))")
+        insertBatches(
+          cat,
+          t,
+          s"(1,'${t}1','X'),(2,'${t}2','X')",
+          s"(3,'${t}3','X'),(4,'${t}4','X')")
+      }
+
+      val query =
+        s"SELECT t1.c1, t1.c2, t2.c2 FROM $cat.db.a t1 JOIN $cat.db.b t2 ON t1.c1 = t2.c1"
+      val (_, plan) = checkSparkAnswer(query)
+
+      assume(
+        partitioningReported(plan),
+        "native scan does not report KeyGroupedPartitioning; skipping plan assertion")
+      assert(countShuffles(plan) == 0, s"storage-partitioned join must not shuffle:\n$plan")
+    }
+  }
+
+  // AQE runtime partition-value pushdown -- the one join case we are not yet sure about, gated
+  // HARD so it stays red until the path is verified. Under AQE Spark computes the exact common set
+  // of partition values once both sides materialize and pushes it into the scan
+  // (EnsureRequirements.populateCommonPartitionInfo, which matches only `case scan: BatchScanExec`,
+  // not Comet's native leaf). Both sides sort their partitions by value and Spark pads each with
+  // the merged set, so the same list index means the same key on both sides; if the native leaf is
+  // not padded, its index i points at a different key than Spark's spec expects and the SMJ zips
+  // mismatched groups -> mis-paired / dropped / wrongly null-padded rows.
+  //
+  // No sort order is set: the risk is purely about KeyGroupedPartitioning value alignment (grouping
+  // is upstream Iceberg, unlike ordering), so this does not need an ordering-reporting build. The
+  // two tables carry offset partition-value sets (a: c1 in 1..4, b: 3..6) so the merged/padded set
+  // differs from each side's own list -- exactly the case where a skipped pad shifts the indices.
+  //
+  // The asserts are hard, not `assume`d: correctness (Comet vs vanilla Spark) must hold, both sides
+  // must stay native (a fallback to Spark's BatchScanExec, which handles the pushdown itself, would
+  // let correctness pass vacuously), and the join must not shuffle (a shuffle re-partitions
+  // correctly and would mask the pushdown entirely). Only Iceberg is a precondition.
+
+  /** a: c1 in 1..4, b: c1 in 3..6, both bucketed the same way -- offset partition-value sets. */
+  private def createAqePartitionedPair(cat: String): Unit = {
+    Seq("a", "b").foreach { t =>
+      spark.sql(
+        s"CREATE TABLE $cat.db.$t (c1 INT, c2 STRING) USING iceberg " +
+          "PARTITIONED BY (bucket(8, c1))")
+    }
+    insertBatches(cat, "a", "(1,'a1'),(2,'a2')", "(3,'a3'),(4,'a4')")
+    insertBatches(cat, "b", "(3,'b3'),(4,'b4')", "(5,'b5'),(6,'b6')")
+  }
+
+  private val aqeSpjConf: Seq[(String, String)] =
+    spjConf.filterNot(_._1 == "spark.sql.adaptive.enabled") :+
+      ("spark.sql.adaptive.enabled" -> "true")
+
+  private def assertNativeSpj(plan: SparkPlan): Unit = {
+    assert(
+      nativeScans(plan).length == 2,
+      s"both join sides must stay on the native Iceberg scan (no fallback):\n$plan")
+    assert(
+      partitioningReported(plan),
+      s"native scan must report KeyGroupedPartitioning under AQE pushdown:\n$plan")
+    assert(countShuffles(plan) == 0, s"storage-partitioned join must not shuffle:\n$plan")
+  }
+
+  // Left outer is the sensitive case: every left row must appear, so if the leaf's partition
+  // indices are shifted relative to Spark's padded spec, a left row whose key exists on the right
+  // gets a wrong NULL (or a match against the wrong group) -- caught by checkSparkAnswer. An inner
+  // join would only drop the same unmatched rows on both sides and can pass despite misalignment.
+  test("AQE storage-partitioned left outer join with runtime partition pushdown is correct") {
+    withSortedTables(aqeSpjConf)("a", "b") { cat =>
+      createAqePartitionedPair(cat)
+      val query =
+        s"SELECT t1.c1, t1.c2, t2.c2 FROM $cat.db.a t1 LEFT OUTER JOIN $cat.db.b t2 " +
+          "ON t1.c1 = t2.c1"
+      val (_, plan) = checkSparkAnswer(query)
+      assertNativeSpj(plan)
+    }
+  }
+
+  test("AQE storage-partitioned inner join with runtime partition pushdown is correct") {
+    val innerConf = aqeSpjConf :+
+      ("spark.sql.sources.v2.bucketing.partiallyClusteredDistribution.enabled" -> "true")
+    withSortedTables(innerConf)("a", "b") { cat =>
+      createAqePartitionedPair(cat)
+      val query =
+        s"SELECT t1.c1, t1.c2, t2.c2 FROM $cat.db.a t1 JOIN $cat.db.b t2 ON t1.c1 = t2.c1"
+      val (_, plan) = checkSparkAnswer(query)
+      assertNativeSpj(plan)
+    }
+  }
+
+  // Grouped aggregate / distinct: ReplaceHashWithSortAgg + a satisfied ClusteredDistribution.
+
+  test("group-by on the sort key drops the sort and the shuffle") {
+    withSortedTables(spjConf)("t") { cat =>
+      spark.sql(
+        s"CREATE TABLE $cat.db.t (c1 INT, c2 STRING, c3 STRING) USING iceberg " +
+          "PARTITIONED BY (bucket(4, c1))")
+      replaceSortOrder(cat, "db", "t", "c1" -> true)
+      insertBatches(cat, "t", "(1,'a','X'),(2,'b','X')", "(1,'c','X'),(3,'d','X')")
+
+      // No trailing ORDER BY: checkSparkAnswer compares order-insensitively, so sort = 0 is a
+      // legitimate target (a grouped aggregate over sorted + clustered input needs neither).
+      val query = s"SELECT c1, COUNT(*) FROM $cat.db.t GROUP BY c1"
+      val (_, plan) = checkSparkAnswer(query)
+
+      assumeOrderingAndPartitioningReported(plan)
+      assert(countShuffles(plan) == 0, s"grouped aggregate must not shuffle:\n$plan")
+      assert(countSorts(plan) == 0, s"grouped aggregate over sorted input must not sort:\n$plan")
+    }
+  }
+
+  test("distinct on the sort key is correct") {
+    withSortedTables(spjConf)("t") { cat =>
+      spark.sql(
+        s"CREATE TABLE $cat.db.t (c1 INT, c2 STRING, c3 STRING) USING iceberg " +
+          "PARTITIONED BY (bucket(4, c1))")
+      replaceSortOrder(cat, "db", "t", "c1" -> true)
+      insertBatches(cat, "t", "(1,'a','X'),(2,'b','X')", "(1,'c','X'),(3,'d','X')")
+
+      checkSparkAnswer(s"SELECT DISTINCT c1 FROM $cat.db.t ORDER BY c1")
+    }
+  }
+
+  // Window: WindowExec.requiredChildOrdering (partitionSpec ++ orderSpec) + ClusteredDistribution.
+
+  test("window partitioned + ordered on the sort keys drops the sort and the shuffle") {
+    withSortedTables(spjConf)("t") { cat =>
+      spark.sql(
+        s"CREATE TABLE $cat.db.t (c1 INT, c2 STRING, c3 STRING) USING iceberg " +
+          "PARTITIONED BY (bucket(4, c1))")
+      replaceSortOrder(cat, "db", "t", "c1" -> true, "c2" -> true)
+      insertBatches(cat, "t", "(1,'a','X'),(2,'b','X')", "(1,'c','X'),(2,'d','X')")
+
+      val query =
+        s"SELECT c1, c2, ROW_NUMBER() OVER (PARTITION BY c1 ORDER BY c2) AS rn FROM $cat.db.t"
+      val (_, plan) = checkSparkAnswer(query)
+
+      assumeOrderingAndPartitioningReported(plan)
+      assert(countShuffles(plan) == 0, s"window over clustered input must not shuffle:\n$plan")
+      assert(countSorts(plan) == 0, s"window over sorted input must not sort:\n$plan")
+    }
+  }
+
+  // Limit: TakeOrderedAndProjectExec degenerates to a cheap take when the child is already sorted.
+
+  test("order-by-limit over a sorted table is correct") {
+    withSortedTables(orderedReadConf)("t") { cat =>
+      spark.sql(s"CREATE TABLE $cat.db.t (id INT, data STRING) USING iceberg")
+      replaceSortOrder(cat, "db", "t", "id" -> true)
+      insertBatches(cat, "t", "(1,'a'),(3,'c')", "(2,'b'),(4,'d')", "(5,'e'),(6,'f')")
+
+      // TakeOrderedAndProject is planned for ORDER BY ... LIMIT and, when the child is already
+      // reported sorted, degenerates to a cheap bounded take instead of a full top-N heap.
+      // Correctness (including the LIMIT cut over the merged order) is the guarantee here.
+      checkSparkAnswer(s"SELECT id, data FROM $cat.db.t ORDER BY id LIMIT 3")
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/comet/CometIcebergSortMergeReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergSortMergeReadSuite.scala
@@ -397,6 +397,24 @@ class CometIcebergSortMergeReadSuite
     }
   }
 
+  test("many small files in one partition merge correctly") {
+    // Raise the per-partition file limit so the k-way merge (not the sort fallback) runs with many
+    // files -- the shape this feature targets, where the merge opens one reader per file at once.
+    // On an ordering-reporting Iceberg build this exercises a ~70-way SortPreservingMerge; on the
+    // published Iceberg (no reported ordering) it is a plain read. checkSparkAnswer guards
+    // correctness; asserting on memory-pool usage / peak concurrent readers is a TODO for #5343.
+    val conf =
+      orderedReadConf :+ (CometConf.COMET_ICEBERG_SORT_MERGE_MAX_FILES_PER_PARTITION.key -> "1000")
+    withSortedTables(conf)("t") { cat =>
+      spark.sql(s"CREATE TABLE $cat.db.t (id INT, data STRING) USING iceberg")
+      replaceSortOrder(cat, "db", "t", "id" -> true)
+      val rows = (1 to 70).map(i => s"($i,'v$i')")
+      insertBatches(cat, "t", rows: _*)
+
+      checkSparkAnswer(s"SELECT id, data FROM $cat.db.t ORDER BY id")
+    }
+  }
+
   test("many small files in one partition stay correct (exercises the sort fallback)") {
     withSortedTables(orderedReadConf)("t") { cat =>
       spark.sql(s"CREATE TABLE $cat.db.t (id INT, data STRING) USING iceberg")

--- a/spark/src/test/scala/org/apache/comet/CometIcebergSortMergeReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergSortMergeReadSuite.scala
@@ -115,6 +115,16 @@ class CometIcebergSortMergeReadSuite
     assert(CometIcebergNativeScan.reportableOrdering(Some(Seq.empty), Seq(gateA)).isEmpty)
   }
 
+  test("gate: a sort key on an ordering-unsafe column (e.g. UUID) falls back") {
+    // "a" stands in for a UUID column: Iceberg maps it to StringType but sorts by its own order,
+    // so it is unsafe to honour even though it looks like a plain string at the Spark level.
+    val ordering = Seq(SortOrder(gateA, Ascending))
+    assert(
+      CometIcebergNativeScan
+        .reportableOrdering(Some(ordering), Seq(gateA, gateB), Set("a"))
+        .isEmpty)
+  }
+
   // ---------------------------------------------------------------------------------------------
   // End-to-end fixtures.
   // ---------------------------------------------------------------------------------------------
@@ -128,9 +138,10 @@ class CometIcebergSortMergeReadSuite
     "spark.sql.adaptive.enabled" -> "false")
 
   // Storage-partitioned join config. preserve-data-grouping + v2 bucketing let Iceberg report
-  // KeyGroupedPartitioning; reportPartitioning surfaces it from the Comet leaf (default off, so it
-  // must be set here); the join knobs force a sort-merge join over co-partitioned inputs so the
-  // Exchange can be eliminated. This is the non-AQE path (adaptive off), the verified one.
+  // KeyGroupedPartitioning on the BatchScanExec, and the join knobs force a sort-merge join over
+  // co-partitioned inputs so the Exchange can be eliminated. Comet does not report partitioning
+  // itself; Spark's EnsureRequirements eliminates the shuffle on the BatchScanExec before Comet
+  // converts the scan. Adaptive off keeps the executed plan stable for the counts below.
   private val spjConf: Seq[(String, String)] = Seq(
     "spark.sql.iceberg.planning.preserve-data-ordering" -> "true",
     "spark.sql.iceberg.planning.preserve-data-grouping" -> "true",
@@ -139,8 +150,7 @@ class CometIcebergSortMergeReadSuite
     "spark.sql.requireAllClusterKeysForCoPartition" -> "false",
     "spark.sql.autoBroadcastJoinThreshold" -> "-1",
     "spark.sql.join.preferSortMergeJoin" -> "true",
-    "spark.sql.adaptive.enabled" -> "false",
-    CometConf.COMET_ICEBERG_REPORT_PARTITIONING_ENABLED.key -> "true")
+    "spark.sql.adaptive.enabled" -> "false")
 
   /**
    * Runs `f` against a fresh, uniquely-named Hadoop catalog backed by a fresh temp warehouse,
@@ -220,15 +230,7 @@ class CometIcebergSortMergeReadSuite
     scans.nonEmpty && scans.forall(_.outputOrdering.nonEmpty)
   }
 
-  /** True once every native scan reports KeyGroupedPartitioning (storage-partitioned join). */
-  private def partitioningReported(plan: SparkPlan): Boolean = {
-    val scans = nativeScans(plan)
-    scans.nonEmpty && scans.forall { s =>
-      s.outputPartitioning.getClass.getSimpleName == "KeyGroupedPartitioning"
-    }
-  }
-
-  // NOTE ON CANCELED TESTS: the two helpers below CANCEL the test (ScalaTest `assume`, reported as
+  // NOTE ON CANCELED TESTS: the helper below CANCELS the test (ScalaTest `assume`, reported as
   // "!!! CANCELED !!!", not a failure) when the Iceberg build on the classpath does not implement
   // the DSv2 `SupportsReportOrdering` API. Published/upstream Iceberg (the runtime used in CI and
   // the default mvn profiles) does not report a sort order, so `outputOrdering` comes back empty
@@ -243,15 +245,6 @@ class CometIcebergSortMergeReadSuite
       orderingReported(plan),
       "current Iceberg build does not implement SupportsReportOrdering (no ordering reported); " +
         "sort-elimination assertion skipped")
-
-  /**
-   * Cancels the test (see note above) unless the scan reported both ordering and partitioning.
-   */
-  private def assumeOrderingAndPartitioningReported(plan: SparkPlan): Unit =
-    assume(
-      orderingReported(plan) && partitioningReported(plan),
-      "current Iceberg build does not report ordering (SupportsReportOrdering) and/or " +
-        "KeyGroupedPartitioning; sort/shuffle-elimination assertion skipped")
 
   // The reporting mechanism: SupportsReportOrdering -> CometIcebergNativeScanExec.outputOrdering
 
@@ -316,6 +309,22 @@ class CometIcebergSortMergeReadSuite
       insertBatches(cat, "t", "(1,'a'),(2,'b')", "(1,'c'),(2,'d')", "(1,'e'),(3,'f')")
 
       checkSparkAnswer(s"SELECT id, data FROM $cat.db.t ORDER BY id, data")
+    }
+  }
+
+  test("merge applies merge-on-read deletes across a multi-file sorted partition") {
+    withSortedTables(orderedReadConf)("t") { cat =>
+      spark.sql(
+        s"CREATE TABLE $cat.db.t (id INT, data STRING) USING iceberg " +
+          "TBLPROPERTIES ('format-version'='2', 'write.delete.mode'='merge-on-read')")
+      replaceSortOrder(cat, "db", "t", "id" -> true)
+      // Several files so a merge is required; then delete rows from some of them. On a v2
+      // merge-on-read table DELETE writes delete files rather than rewriting the data files, so
+      // the scan must apply the deletes while merging the still-sorted files.
+      insertBatches(cat, "t", "(1,'a'),(4,'d')", "(2,'b'),(5,'e')", "(3,'c'),(6,'f')")
+      spark.sql(s"DELETE FROM $cat.db.t WHERE id IN (2, 5)")
+
+      checkSparkAnswer(s"SELECT id, data FROM $cat.db.t ORDER BY id")
     }
   }
 
@@ -465,8 +474,10 @@ class CometIcebergSortMergeReadSuite
         s"SELECT t1.c1, t1.c2, t2.c2 FROM $cat.db.a t1 JOIN $cat.db.b t2 ON t1.c1 = t2.c1"
       val (_, plan) = checkSparkAnswer(query)
 
-      assumeOrderingAndPartitioningReported(plan)
+      // Shuffle elimination needs only the grouping (upstream Iceberg), so assert it always.
       assert(countShuffles(plan) == 0, s"storage-partitioned join must not shuffle:\n$plan")
+      // Sort elimination needs the reported ordering (fork Iceberg today), so gate that one.
+      assumeOrderingReported(plan)
       assert(countSorts(plan) == 0, s"reported ordering must eliminate the join sort:\n$plan")
     }
   }
@@ -490,31 +501,26 @@ class CometIcebergSortMergeReadSuite
         s"SELECT t1.c1, t1.c2, t2.c2 FROM $cat.db.a t1 JOIN $cat.db.b t2 ON t1.c1 = t2.c1"
       val (_, plan) = checkSparkAnswer(query)
 
-      assume(
-        partitioningReported(plan),
-        "native scan does not report KeyGroupedPartitioning; skipping plan assertion")
+      // Comet no longer reports partitioning; EnsureRequirements eliminates the shuffle on the
+      // BatchScanExec before Comet converts the scan, so this holds on any Iceberg with grouping.
       assert(countShuffles(plan) == 0, s"storage-partitioned join must not shuffle:\n$plan")
     }
   }
 
-  // AQE runtime partition-value pushdown -- the one join case we are not yet sure about, gated
-  // HARD so it stays red until the path is verified. Under AQE Spark computes the exact common set
-  // of partition values once both sides materialize and pushes it into the scan
-  // (EnsureRequirements.populateCommonPartitionInfo, which matches only `case scan: BatchScanExec`,
-  // not Comet's native leaf). Both sides sort their partitions by value and Spark pads each with
-  // the merged set, so the same list index means the same key on both sides; if the native leaf is
-  // not padded, its index i points at a different key than Spark's spec expects and the SMJ zips
-  // mismatched groups -> mis-paired / dropped / wrongly null-padded rows.
-  //
-  // No sort order is set: the risk is purely about KeyGroupedPartitioning value alignment (grouping
-  // is upstream Iceberg, unlike ordering), so this does not need an ordering-reporting build. The
-  // two tables carry offset partition-value sets (a: c1 in 1..4, b: 3..6) so the merged/padded set
-  // differs from each side's own list -- exactly the case where a skipped pad shifts the indices.
+  // AQE runtime partition-value pushdown. Under AQE Spark computes the exact common set of
+  // partition values once both sides materialize and pushes it into the scan
+  // (EnsureRequirements.populateCommonPartitionInfo, which matches only `case scan: BatchScanExec`).
+  // Because Comet converts the scan AFTER EnsureRequirements, that push-down lands on the vanilla
+  // BatchScanExec, and Comet's execution partitions come from originalPlan.inputRDD -- already
+  // padded to the merged set. So the native leaf stays aligned with Spark's spec without Comet
+  // reporting any partitioning itself. Offset partition-value sets (a: c1 in 1..4, b: 3..6) make
+  // the merged/padded set differ from each side's own list, exactly where a misalignment would
+  // surface.
   //
   // The asserts are hard, not `assume`d: correctness (Comet vs vanilla Spark) must hold, both sides
-  // must stay native (a fallback to Spark's BatchScanExec, which handles the pushdown itself, would
-  // let correctness pass vacuously), and the join must not shuffle (a shuffle re-partitions
-  // correctly and would mask the pushdown entirely). Only Iceberg is a precondition.
+  // must stay native (a fallback to Spark's BatchScanExec would let correctness pass vacuously),
+  // and the join must not shuffle (a shuffle would re-partition correctly and mask the pushdown).
+  // Only Iceberg is a precondition (grouping is upstream, unlike ordering).
 
   /** a: c1 in 1..4, b: c1 in 3..6, both bucketed the same way -- offset partition-value sets. */
   private def createAqePartitionedPair(cat: String): Unit = {
@@ -535,9 +541,6 @@ class CometIcebergSortMergeReadSuite
     assert(
       nativeScans(plan).length == 2,
       s"both join sides must stay on the native Iceberg scan (no fallback):\n$plan")
-    assert(
-      partitioningReported(plan),
-      s"native scan must report KeyGroupedPartitioning under AQE pushdown:\n$plan")
     assert(countShuffles(plan) == 0, s"storage-partitioned join must not shuffle:\n$plan")
   }
 
@@ -583,8 +586,8 @@ class CometIcebergSortMergeReadSuite
       val query = s"SELECT c1, COUNT(*) FROM $cat.db.t GROUP BY c1"
       val (_, plan) = checkSparkAnswer(query)
 
-      assumeOrderingAndPartitioningReported(plan)
       assert(countShuffles(plan) == 0, s"grouped aggregate must not shuffle:\n$plan")
+      assumeOrderingReported(plan)
       assert(countSorts(plan) == 0, s"grouped aggregate over sorted input must not sort:\n$plan")
     }
   }
@@ -615,8 +618,8 @@ class CometIcebergSortMergeReadSuite
         s"SELECT c1, c2, ROW_NUMBER() OVER (PARTITION BY c1 ORDER BY c2) AS rn FROM $cat.db.t"
       val (_, plan) = checkSparkAnswer(query)
 
-      assumeOrderingAndPartitioningReported(plan)
       assert(countShuffles(plan) == 0, s"window over clustered input must not shuffle:\n$plan")
+      assumeOrderingReported(plan)
       assert(countSorts(plan) == 0, s"window over sorted input must not sort:\n$plan")
     }
   }

--- a/spark/src/test/scala/org/apache/comet/CometIcebergSortMergeReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergSortMergeReadSuite.scala
@@ -397,6 +397,24 @@ class CometIcebergSortMergeReadSuite
     }
   }
 
+  test("many small files in one partition stay correct (exercises the sort fallback)") {
+    withSortedTables(orderedReadConf)("t") { cat =>
+      spark.sql(s"CREATE TABLE $cat.db.t (id INT, data STRING) USING iceberg")
+      replaceSortOrder(cat, "db", "t", "id" -> true)
+      // 70 single-row inserts -> 70 files in one unpartitioned partition, above the default
+      // maxFilesPerPartition (64). On an ordering-reporting Iceberg build this drives the native
+      // fallback -- a single unordered read plus a spillable SortExec, not a 70-way merge -- which
+      // is the shape this feature actually targets (a sorted table with many small commits). On
+      // the published Iceberg (no reported ordering) it is a plain read. checkSparkAnswer guards
+      // correctness either way; asserting on memory-pool usage / peak concurrent readers is a
+      // TODO for #5343.
+      val rows = (1 to 70).map(i => s"($i,'v$i')")
+      insertBatches(cat, "t", rows: _*)
+
+      checkSparkAnswer(s"SELECT id, data FROM $cat.db.t ORDER BY id")
+    }
+  }
+
   test("partitioned table with several files per partition") {
     withSortedTables(spjConf)("t") { cat =>
       spark.sql(

--- a/spark/src/test/scala/org/apache/comet/CometIcebergSortMergeReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergSortMergeReadSuite.scala
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.spark.sql.CometTestBase
 import org.apache.spark.sql.catalyst.expressions.{Add, Ascending, AttributeReference, Literal, SortOrder}
-import org.apache.spark.sql.catalyst.plans.physical.KeyGroupedPartitioning
 import org.apache.spark.sql.comet.{CometIcebergNativeScanExec, CometSortExec}
 import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 import org.apache.spark.sql.execution.{SortExec, SparkPlan}
@@ -224,7 +223,9 @@ class CometIcebergSortMergeReadSuite
   /** True once every native scan reports KeyGroupedPartitioning (storage-partitioned join). */
   private def partitioningReported(plan: SparkPlan): Boolean = {
     val scans = nativeScans(plan)
-    scans.nonEmpty && scans.forall(_.outputPartitioning.isInstanceOf[KeyGroupedPartitioning])
+    scans.nonEmpty && scans.forall { s =>
+      s.outputPartitioning.getClass.getSimpleName == "KeyGroupedPartitioning"
+    }
   }
 
   // NOTE ON CANCELED TESTS: the two helpers below CANCEL the test (ScalaTest `assume`, reported as
@@ -433,8 +434,11 @@ class CometIcebergSortMergeReadSuite
       val query = s"SELECT id, data FROM $cat.db.t ORDER BY id"
 
       val enabled = spark.sql(query).collect().toSeq
-      val disabled = withSQLConf(CometConf.COMET_ICEBERG_SORT_MERGE_ENABLED.key -> "false") {
-        spark.sql(query).collect().toSeq
+      // withSQLConf returns the block value on Spark 4.x but Unit on 3.4/3.5, so capture the rows
+      // in a var rather than relying on its return value.
+      var disabled: Seq[org.apache.spark.sql.Row] = Seq.empty
+      withSQLConf(CometConf.COMET_ICEBERG_SORT_MERGE_ENABLED.key -> "false") {
+        disabled = spark.sql(query).collect().toSeq
       }
       assert(enabled == disabled, "reporting the ordering must not change the result")
     }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5337

## Rationale for this change

When Comet reads a sorted Iceberg table, the native scan throws away the ordering to get
parallelism. Spark then can't tell the data is already sorted and re-sorts on every read — in
joins, aggregates, windows, and order-by queries — even though the sort was done at write time.

This PR makes the native scan preserve and report that ordering so Spark can drop the redundant
sorts. It builds on Iceberg's `SupportsReportOrdering` (apache/iceberg#14948): when Iceberg reports
a sort order, Comet merges the sorted files per partition and tells Spark the result is sorted.

## What changes are included in this PR?

For each Spark partition, the scan reads every sorted file as its own stream and k-way-merges them
into one sorted stream with DataFusion's `SortPreservingMergeExec`.

Summary of changes:
- **Proto**: `IcebergScanCommon` carries the reported sort order (`table_sort_orders`) and the
  merge cap (`max_files_per_partition`) to the native side.
- **Scala (rule + serde + scan exec)**: report the sort order to Spark, gated to the safe v1 case —
  identity-transform sort fields on top-level columns that are in the projection. Anything else
  (a transform sort key, a UUID sort key whose Iceberg byte order differs from Spark's string order,
  or a schema that can't be read) reports nothing and stays on Spark, so the result is always
  correct. The gate is evaluated and bound to proto once at planning time, so a binding failure
  falls back cleanly instead of erroring at task start.
- **Native (Rust)**: `IcebergScanExec` becomes multi-partition when an ordering is present (one
  sorted stream per file), and the planner wraps it in `SortPreservingMergeExec`. Above
  `maxFilesPerPartition` files in a partition it instead reads unordered and wraps a spillable
  `SortExec`, which bounds concurrently-open readers. Both paths produce sorted output. No changes
  to iceberg-rust.

Config flags:
- `spark.comet.scan.icebergNative.sortMerge.enabled` (default **on**) — do the per-partition merge.
  When off, the scan stays native and still honours the reported order via a spillable sort instead
  of the k-way merge (equivalent to `maxFilesPerPartition = 0`). Only does anything when Iceberg's
  `spark.sql.iceberg.planning.preserve-data-ordering` is on (off by default).
- `spark.comet.scan.icebergNative.sortMerge.maxFilesPerPartition` (default **64**) — the most files
  in one partition Comet will k-way merge before falling back to the spillable sort.

Note: a global `ORDER BY` keeps its final sort — a per-partition merge isn't a cluster-wide order —
so that case is unchanged.

## How are these changes tested?

- **Native planner tests** in `planner.rs`: merge-vs-sort at the `maxFilesPerPartition` boundary, and
  that the cap is read from the proto (a low cap flips a 3-file scan to the sort path).
- **End-to-end suite** `CometIcebergSortMergeReadSuite` over real Iceberg tables (local Hadoop
  catalog, sort order set via the Iceberg Java API, one file per insert), plus unit tests of the
  reportability gate. Correctness (`checkSparkAnswer`) runs on any Iceberg build; the
  sort/shuffle-elimination assertions self-cancel on the published Iceberg that doesn't report an
  ordering.

Key edits: dropped the key-grouped-partitioning paragraph and the reportPartitioning.enabled flag (both gone with the outputPartitioning override), added maxFilesPerPartition and the enabled=false semantics, fixed the malformed Closes # link, and refreshed the tests section. Double-check #5337 is the right issue — the old body had a malformed link; I preserved the number.