### PR TITLE
chore: respect Cargo parallelism settings for native release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,18 +51,18 @@ format:
 
 # build native libs for amd64 architecture Linux/MacOS on a Linux/amd64 machine/container
 core-amd64-libs:
-	cd native && RUSTFLAGS="-Ctarget-cpu=x86-64-v3" cargo build -j 2 --release $(FEATURES_ARG)
+	cd native && RUSTFLAGS="-Ctarget-cpu=x86-64-v3" cargo build --release $(FEATURES_ARG)
 ifdef HAS_OSXCROSS
 	rustup target add x86_64-apple-darwin
-	cd native && cargo build -j 2 --target x86_64-apple-darwin --release $(FEATURES_ARG)
+	cd native && cargo build --target x86_64-apple-darwin --release $(FEATURES_ARG)
 endif
 
 # build native libs for arm64 architecture Linux/MacOS on a Linux/arm64 machine/container
 core-arm64-libs:
-	cd native && RUSTFLAGS="-Ctarget-cpu=neoverse-n1" cargo build -j 2 --release $(FEATURES_ARG)
+	cd native && RUSTFLAGS="-Ctarget-cpu=neoverse-n1" cargo build --release $(FEATURES_ARG)
 ifdef HAS_OSXCROSS
 	rustup target add aarch64-apple-darwin
-	cd native && cargo build -j 2 --target aarch64-apple-darwin --release $(FEATURES_ARG)
+	cd native && cargo build --target aarch64-apple-darwin --release $(FEATURES_ARG)
 endif
 
 core-amd64:

--- a/dev/release/build-release-comet.sh
+++ b/dev/release/build-release-comet.sh
@@ -140,6 +140,7 @@ docker run \
    --name comet-amd64-builder-container \
    --memory 24g \
    --cpus 6 \
+   --env "CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS:-2}" \
    -it \
    --platform linux/amd64 \
    $BUILDER_IMAGE_AMD64 "${REPO}" "${BRANCH}" amd64
@@ -156,6 +157,7 @@ docker run \
    --name comet-arm64-builder-container \
    --memory 24g \
    --cpus 6 \
+   --env "CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS:-2}" \
    -it \
    --platform linux/arm64 \
    $BUILDER_IMAGE_ARM64 "${REPO}" "${BRANCH}" arm64


### PR DESCRIPTION
## Which issue does this PR close?

No issue filed.

## Rationale for this change

The `core-amd64-libs` and `core-arm64-libs` targets hardcode `cargo build -j 2`, limiting compilation to two concurrent jobs regardless of available CPU resources.

This also overrides Cargo's standard `CARGO_BUILD_JOBS` environment variable and `build.jobs` configuration, preventing users from controlling parallelism through existing Cargo mechanisms.

Removing the hardcoded limit lets Cargo automatically determine the appropriate level of parallelism while preserving the ability to configure it explicitly:

```bash
CARGO_BUILD_JOBS=2 make core-amd64-libs
```

## What changes are included in this PR?

Remove `-j 2` from all four Cargo invocations in `core-amd64-libs` and `core-arm64-libs`, including optional macOS cross-compilation builds.

## How are these changes tested?

Verified the generated commands for both architectures:

```bash
make -n core-amd64-libs core-arm64-libs
make -n HAS_OSXCROSS=1 core-amd64-libs core-arm64-libs
```

Also verified that `CARGO_BUILD_JOBS=7` is passed through to all four Cargo invocations using mocked `cargo` and `rustup` binaries.
