### PR TITLE
feat: Add trail mode config for Comet evaluation without native execution

### DIFF
--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -668,6 +668,14 @@ object CometConf extends ShimCometConf {
       .booleanConf
       .createWithDefault(false)
 
+  val COMET_TRIAL_ENABLED: ConfigEntry[Boolean] =
+    conf("spark.comet.trial.enabled")
+      .category(CATEGORY_EXEC_EXPLAIN)
+      .doc("Analyze each query as if Comet were enabled and emit a coverage report, but do " +
+        "not actually offload execution to native.")
+      .booleanConf
+      .createWithDefault(false)
+
   val COMET_EXPLAIN_CODEGEN_ENABLED: ConfigEntry[Boolean] =
     conf("spark.comet.explain.codegen.enabled")
       .withAlternative("spark.comet.explainCodegen.enabled")

--- a/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
@@ -49,7 +49,7 @@ import org.apache.spark.sql.execution.window.WindowExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
-import org.apache.comet.{CometConf, CometExplainInfo, ExtendedExplainInfo}
+import org.apache.comet.{CometConf, CometCoverageStats, CometExplainInfo, ExtendedExplainInfo}
 import org.apache.comet.CometConf.{COMET_SPARK_TO_ARROW_ENABLED, COMET_SPARK_TO_ARROW_SUPPORTED_OPERATOR_LIST}
 import org.apache.comet.CometSparkSessionExtensions._
 import org.apache.comet.rules.CometExecRule.allExecs
@@ -614,6 +614,20 @@ case class CometExecRule(session: SparkSession)
               s"(set ${CometConf.COMET_EXPLAIN_FALLBACK_ENABLED.key}=false " +
               "to disable this logging):\n" +
               s"${info.generateExtendedInfo(newPlan)}")
+        }
+      }
+
+      // Trial mode: log how much of this query Comet would accelerate (measured from the
+      // fully-converted plan), then execute on Spark by reverting the native scans that
+      // CometScanRule produced, so nothing is actually offloaded to native. The rest of the
+      // native conversion only exists in `newPlan`, which we discard here.
+      if (CometConf.COMET_TRIAL_ENABLED.get()) {
+        logWarning(
+          s"[Comet trial] ${CometCoverageStats.forPlan(newPlan)}\n" +
+            new ExtendedExplainInfo().generateExtendedInfo(newPlan))
+        return plan.transformUp {
+          case s: CometScanExec => s.wrapped
+          case s: CometBatchScanExec => s.wrapped.copy(runtimeFilters = s.runtimeFilters)
         }
       }
 

--- a/spark/src/test/scala/org/apache/comet/rules/CometExecRuleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/CometExecRuleSuite.scala
@@ -797,4 +797,36 @@ class CometExecRuleSuite extends CometTestBase {
     }
   }
 
+  test("trial mode analyzes the plan but executes entirely on Spark") {
+    withParquetTable((0 until 100).map(i => (i, i % 5)), "tbl") {
+      val query = "SELECT _2, count(*) FROM tbl GROUP BY _2"
+      withSQLConf(
+        CometConf.COMET_ENABLED.key -> "true",
+        CometConf.COMET_EXEC_ENABLED.key -> "true",
+        CometConf.COMET_TRIAL_ENABLED.key -> "true") {
+        val df = sql(query)
+        // Results are identical to vanilla Spark.
+        checkSparkAnswer(df)
+        // Nothing is offloaded: the executed plan contains no Comet operators.
+        val cometNodes = stripAQEPlan(df.queryExecution.executedPlan).collect {
+          case p: CometPlan => p
+        }
+        assert(
+          cometNodes.isEmpty,
+          s"trial mode must not offload, but found Comet operators: $cometNodes")
+      }
+
+      // Sanity check: with trial mode off, the same query is accelerated by Comet.
+      withSQLConf(
+        CometConf.COMET_ENABLED.key -> "true",
+        CometConf.COMET_EXEC_ENABLED.key -> "true",
+        CometConf.COMET_TRIAL_ENABLED.key -> "false") {
+        val cometNodes = stripAQEPlan(sql(query).queryExecution.executedPlan).collect {
+          case p: CometPlan => p
+        }
+        assert(cometNodes.nonEmpty, "expected Comet operators when trial mode is disabled")
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/datafusion-comet/issues/5335

## Rationale for this change

One of the feedbacks / growing patterns we observe in the industry is to evaluate comet to see how many operators are supported without actually executing anything in the native side. This should help the data engineering teams to better evaluate thair plans and potentially make changes to make use of full native execution. `spark.comet.trial.enabled"` unlocks that config. All the plans are annotated `Comet[Trail]` to let users know (through the driver logs) that comet is only printing the plan while the execution is still native 

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
1. Added a new config to enable trail mode which prints out the plan with comet trail annotations while still running things on JVM

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?

Unit tests to grep the plans and make sure no operators are native when the trail mode is enabled

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
