### PR TITLE
fix: use Spark type names in ANSI abs overflow errors

### DIFF
--- a/native/spark-expr/src/math_funcs/abs.rs
+++ b/native/spark-expr/src/math_funcs/abs.rs
@@ -38,6 +38,7 @@ macro_rules! legacy_compute_op {
     }};
 }
 
+/// `$FROM_TYPE` is the Spark SQL type name carried in the `ArithmeticOverflow` payload.
 macro_rules! ansi_compute_op {
     ($ARRAY:expr, $FUNC:ident, $TYPE:ident, $RESULT:ident, $NATIVE:ident, $FROM_TYPE:expr) => {{
         let n = $ARRAY.as_any().downcast_ref::<$TYPE>();
@@ -95,7 +96,7 @@ pub fn abs(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
                     let result = legacy_compute_op!(array, wrapping_abs, Int8Array, Int8Array);
                     Ok(ColumnarValue::Array(Arc::new(result?)))
                 } else {
-                    ansi_compute_op!(array, abs, Int8Array, Int8Type, i8, "Int8")
+                    ansi_compute_op!(array, abs, Int8Array, Int8Type, i8, "byte")
                 }
             }
             DataType::Int16 => {
@@ -103,7 +104,7 @@ pub fn abs(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
                     let result = legacy_compute_op!(array, wrapping_abs, Int16Array, Int16Array);
                     Ok(ColumnarValue::Array(Arc::new(result?)))
                 } else {
-                    ansi_compute_op!(array, abs, Int16Array, Int16Type, i16, "Int16")
+                    ansi_compute_op!(array, abs, Int16Array, Int16Type, i16, "short")
                 }
             }
             DataType::Int32 => {
@@ -111,7 +112,7 @@ pub fn abs(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
                     let result = legacy_compute_op!(array, wrapping_abs, Int32Array, Int32Array);
                     Ok(ColumnarValue::Array(Arc::new(result?)))
                 } else {
-                    ansi_compute_op!(array, abs, Int32Array, Int32Type, i32, "Int32")
+                    ansi_compute_op!(array, abs, Int32Array, Int32Type, i32, "integer")
                 }
             }
             DataType::Int64 => {
@@ -119,7 +120,7 @@ pub fn abs(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
                     let result = legacy_compute_op!(array, wrapping_abs, Int64Array, Int64Array);
                     Ok(ColumnarValue::Array(Arc::new(result?)))
                 } else {
-                    ansi_compute_op!(array, abs, Int64Array, Int64Type, i64, "Int64")
+                    ansi_compute_op!(array, abs, Int64Array, Int64Type, i64, "long")
                 }
             }
             DataType::Float32 => {
@@ -207,7 +208,7 @@ pub fn abs(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
                             // return the original value
                             Ok(ColumnarValue::Scalar(ScalarValue::Int8(Some(*v))))
                         } else {
-                            Err(arithmetic_overflow_error("Int8").into())
+                            Err(arithmetic_overflow_error("byte").into())
                         }
                     }
                 },
@@ -221,7 +222,7 @@ pub fn abs(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
                             // return the original value
                             Ok(ColumnarValue::Scalar(ScalarValue::Int16(Some(*v))))
                         } else {
-                            Err(arithmetic_overflow_error("Int16").into())
+                            Err(arithmetic_overflow_error("short").into())
                         }
                     }
                 },
@@ -235,7 +236,7 @@ pub fn abs(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
                             // return the original value
                             Ok(ColumnarValue::Scalar(ScalarValue::Int32(Some(*v))))
                         } else {
-                            Err(arithmetic_overflow_error("Int32").into())
+                            Err(arithmetic_overflow_error("integer").into())
                         }
                     }
                 },
@@ -249,7 +250,7 @@ pub fn abs(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
                             // return the original value
                             Ok(ColumnarValue::Scalar(ScalarValue::Int64(Some(*v))))
                         } else {
-                            Err(arithmetic_overflow_error("Int64").into())
+                            Err(arithmetic_overflow_error("long").into())
                         }
                     }
                 },
@@ -312,6 +313,7 @@ pub fn abs(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::SparkError;
     use datafusion::common::cast::{
         as_decimal128_array, as_decimal256_array, as_float32_array, as_float64_array,
         as_int16_array, as_int32_array, as_int64_array, as_int8_array, as_uint64_array,
@@ -320,6 +322,87 @@ mod tests {
     fn with_fail_on_error<F: Fn(bool) -> Result<()>>(test_fn: F) {
         for fail_on_error in [true, false] {
             test_fn(fail_on_error).expect("test should pass on error successfully");
+        }
+    }
+
+    fn assert_spark_overflow(err: DataFusionError, expected_from_type: &str) {
+        if let DataFusionError::External(ref e) = err {
+            if let Some(SparkError::ArithmeticOverflow { from_type }) =
+                e.downcast_ref::<SparkError>()
+            {
+                assert_eq!(from_type, expected_from_type);
+                return;
+            }
+        }
+        panic!(
+            "Expected SparkError::ArithmeticOverflow {{ from_type: {expected_from_type:?} }}, got: {err:?}"
+        );
+    }
+
+    fn abs_ansi(value: ColumnarValue) -> Result<ColumnarValue> {
+        abs(&[
+            value,
+            ColumnarValue::Scalar(ScalarValue::Boolean(Some(true))),
+        ])
+    }
+
+    /// `abs(MIN)` under ANSI must name the Spark type, so the shims render `"long overflow"`
+    /// rather than `"Int64 overflow"`.
+    #[test]
+    fn test_ansi_abs_min_uses_spark_type_names() {
+        let arrays: Vec<(ArrayRef, &str)> = vec![
+            (Arc::new(Int8Array::from(vec![i8::MIN])), "byte"),
+            (Arc::new(Int16Array::from(vec![i16::MIN])), "short"),
+            (Arc::new(Int32Array::from(vec![i32::MIN])), "integer"),
+            (Arc::new(Int64Array::from(vec![i64::MIN])), "long"),
+        ];
+        for (array, from_type) in arrays {
+            assert_spark_overflow(
+                abs_ansi(ColumnarValue::Array(array)).unwrap_err(),
+                from_type,
+            );
+        }
+
+        for (scalar, from_type) in [
+            (ScalarValue::Int8(Some(i8::MIN)), "byte"),
+            (ScalarValue::Int16(Some(i16::MIN)), "short"),
+            (ScalarValue::Int32(Some(i32::MIN)), "integer"),
+            (ScalarValue::Int64(Some(i64::MIN)), "long"),
+        ] {
+            assert_spark_overflow(
+                abs_ansi(ColumnarValue::Scalar(scalar)).unwrap_err(),
+                from_type,
+            );
+        }
+    }
+
+    /// The nearest valid input to each overflow boundary still succeeds, so the guard above is
+    /// not over-broad.
+    #[test]
+    fn test_ansi_abs_just_inside_boundary_succeeds() {
+        for (scalar, expected) in [
+            (
+                ScalarValue::Int8(Some(i8::MIN + 1)),
+                ScalarValue::Int8(Some(i8::MAX)),
+            ),
+            (
+                ScalarValue::Int16(Some(i16::MIN + 1)),
+                ScalarValue::Int16(Some(i16::MAX)),
+            ),
+            (
+                ScalarValue::Int32(Some(i32::MIN + 1)),
+                ScalarValue::Int32(Some(i32::MAX)),
+            ),
+            (
+                ScalarValue::Int64(Some(i64::MIN + 1)),
+                ScalarValue::Int64(Some(i64::MAX)),
+            ),
+        ] {
+            let ColumnarValue::Scalar(result) = abs_ansi(ColumnarValue::Scalar(scalar)).unwrap()
+            else {
+                panic!("expected scalar result")
+            };
+            assert_eq!(result, expected);
         }
     }
 

--- a/spark/src/test/resources/sql-tests/expressions/math/abs_ansi_spark42.sql
+++ b/spark/src/test/resources/sql-tests/expressions/math/abs_ansi_spark42.sql
@@ -18,10 +18,11 @@
 -- ANSI mode abs function tests
 -- Tests that abs throws exceptions for overflow on minimum integer values
 
--- Spark 4.2 drops the type name from the abs overflow message and reports a bare
--- "[ARITHMETIC_OVERFLOW] overflow.", so the int and long patterns below cannot hold there.
--- abs_ansi_spark42.sql covers 4.2 and later with the loose pattern.
--- MaxSparkVersion: 4.1
+-- Spark 4.2 reports a bare "[ARITHMETIC_OVERFLOW] overflow." for abs, with no type name, so every
+-- pattern here is the loose "overflow". abs_ansi.sql covers 4.1 and earlier, where int and long
+-- carry the type name and are asserted exactly. Comet still emits the Spark type names on every
+-- version, which the Rust tests in abs.rs assert directly.
+-- MinSparkVersion: 4.2
 
 -- Config: spark.sql.ansi.enabled=true
 
@@ -58,11 +59,11 @@ INSERT INTO ansi_test_abs_byte VALUES (-128)
 -- ============================================================================
 
 -- abs(-2147483648) cannot be represented as int (since INT_MAX = 2147483647)
-query expect_error(integer overflow)
+query expect_error(overflow)
 SELECT abs(v) FROM ansi_test_abs_int
 
 -- literal
-query expect_error(integer overflow)
+query expect_error(overflow)
 SELECT abs(-2147483648)
 
 -- ============================================================================
@@ -70,21 +71,17 @@ SELECT abs(-2147483648)
 -- ============================================================================
 
 -- abs(-9223372036854775808) cannot be represented as long
-query expect_error(long overflow)
+query expect_error(overflow)
 SELECT abs(v) FROM ansi_test_abs_long
 
 -- literal
-query expect_error(long overflow)
+query expect_error(overflow)
 SELECT abs(-9223372036854775808L)
 
 -- ============================================================================
 -- abs(SHORT_MIN) overflow
 -- ============================================================================
 
--- Byte and short stay on the loose `overflow` pattern. Spark 4.x reports
--- "byte overflow" / "short overflow", but 3.4 and 3.5 raise
--- _LEGACY_ERROR_TEMP_2043 ("- <sqlValue> caused overflow.") instead, and
--- expect_error asserts the pattern against Spark's message as well as Comet's.
 -- abs(-32768) cannot be represented as short
 query expect_error(overflow)
 SELECT abs(v) FROM ansi_test_abs_short


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5356.

## Rationale for this change

Under ANSI mode, `abs` on an integer minimum raises `ARITHMETIC_OVERFLOW`. Comet's
Spark error shim turns the native `fromType` field into Spark's arithmetic-overflow
message by passing `fromType + " overflow"` to
`QueryExecutionErrors.arithmeticOverflowError`. `native/spark-expr/src/math_funcs/abs.rs`
was passing Arrow-style type names as `fromType`, hard-coded at each arm, so Comet
reported `Int64 overflow` where Spark reports `long overflow`, and `Int32 overflow`
where Spark reports `integer overflow`.

```sql
SET spark.sql.ansi.enabled=true;
SELECT abs(v) FROM t;   -- v BIGINT, single row -9223372036854775808
```

Spark: `[ARITHMETIC_OVERFLOW] long overflow.`
Comet before this PR: same error class, `Int64 overflow`.

The message determines the user-visible Spark exception message.

## What changes are included in this PR?

The eight `from_type` strings in `abs.rs`, four on the array path through `ansi_compute_op!` and
four on the scalar path, now carry Spark's name instead of Arrow's:

| Arrow | was | now |
| --- | --- | --- |
| `Int8` | `"Int8"` | `"byte"` |
| `Int16` | `"Int16"` | `"short"` |
| `Int32` | `"Int32"` | `"integer"` |
| `Int64` | `"Int64"` | `"long"` |

The mapping is not uniform across the supported Spark versions. Spark's `Abs` negates
through `MathUtils.negateExact`. For int and long that surfaces the JDK
`ArithmeticException` text, which is `integer overflow` and `long overflow` on 3.4, 3.5
and 4.x alike. Byte and short match 4.x only: 3.4 and 3.5 route those two widths to
`QueryExecutionErrors.unaryMinusCauseOverflowError`, raising
`_LEGACY_ERROR_TEMP_2043` (`- <sqlValue> caused overflow.`), a different error class,
so no single string can satisfy every version. 4.0 sends all four widths through
`MathUtils.negateExact`. I originally reproduced this against 3.4.3, 3.5.8, 4.0.2 and
4.1.2 jars; the same code paths remain in the currently supported 3.5.9 and 4.1.3
sources.

`Decimal128` and `Decimal256` are deliberately left alone. Those guards fire only at `i128::MIN` and
`i256::MIN`, which no Spark decimal reaches at its maximum precision of 38, and decimal overflow
goes through a different Spark error class. That belongs in its own change.

## How are these changes tested?

**`abs_ansi.sql`.** The fixture already ran `abs(v)` over a column of each width at its minimum, but
every assertion was `expect_error(overflow)`, which `"Int64 overflow"` satisfies exactly as happily
as `"long overflow"`. It could not fail on this bug. The int and long cases now assert the full
message, `expect_error(integer overflow)` and `expect_error(long overflow)`.

Byte and short stay on the loose pattern, and the fixture says why in a comment: `ExpectError`
asserts the pattern against Spark's message as well as Comet's, and on 3.4 and 3.5 Spark genuinely
words those two differently.

`ExpectError` runs Spark and Comet separately and requires both errors to contain the
pattern. It does not by itself prove native coverage. Native reachability for the INT
column case is established by the negative control below: reverting only the production
change while keeping the strengthened fixture makes the Comet run fail on
`integer overflow`, while Spark is unchanged.

Negative control at the Spark level, production reverted and the fixture kept:
`org.apache.comet.CometSqlFileTestSuite` on Spark 3.5 / Scala 2.12 goes from **444 run, 444
succeeded** to **444 run, 443 succeeded, 1 failed**, the failure being
`expressions/math/abs_ansi.sql:57`, `SELECT abs(v) FROM ansi_test_abs_int`, `does not contain
'integer overflow'`. Spark is identical between the two runs, so that failure is the Comet side of
the assertion.

**Rust.** The ANSI branches had no error assertions at all, so this adds two tests:

- `test_ansi_abs_min_uses_spark_type_names` downcasts to `SparkError::ArithmeticOverflow` and
  asserts `from_type` for all four widths on both the array and the scalar path. Asserting the
  variant and the field rather than a substring of the rendered string.
- `test_ansi_abs_just_inside_boundary_succeeds` checks `MIN + 1` for each width still returns `MAX`,
  so the guard is not over-broad.

Negative control on the unpatched production code with these tests kept: **18 passed, 1 failed**,
the failure being `assertion left == right failed, left: "Int8", right: "byte"`. Note it stops at
the first case in the table, so what is proven red on `main` is the byte case in Rust and the int
case at the Spark level.

Also run on this branch: the full `datafusion-comet-spark-expr` lib suite, `cargo fmt --all --
--check`, and `cargo clippy -p datafusion-comet-spark-expr --all-targets -- -D warnings`.

## Note for reviewers

TINYINT and SMALLINT have no Spark-level regression test here, only the Rust one, for the version
reason above. If you would rather see them covered, the fixture would need to gate the assertion on
the Spark version, which felt like more machinery than the case is worth.
