### PR TITLE
fix: report native shuffle write metrics accurately

### DIFF
--- a/docs/source/user-guide/latest/metrics.md
+++ b/docs/source/user-guide/latest/metrics.md
@@ -33,12 +33,21 @@ Comet operators report the following metrics in the Spark SQL UI.
 
 Comet adds some additional metrics:
 
-| Metric                          | Description                                                   |
-| ------------------------------- | ------------------------------------------------------------- |
-| `native shuffle time`           | Total time in native code excluding any child operators.      |
-| `repartition time`              | Time to repartition batches.                                  |
-| `memory pool time`              | Time interacting with memory pool.                            |
-| `encoding and compression time` | Time to encode batches in IPC format and compress using ZSTD. |
+| Metric                          | Description                                                                 |
+| ------------------------------- | --------------------------------------------------------------------------- |
+| `native shuffle time`           | Total time in native code excluding any child operators.                    |
+| `repartition time`              | Time to repartition batches.                                                |
+| `partition interleaving time`   | Time to interleave partitioned batches before writing them.                 |
+| `memory pool time`              | Time interacting with memory pool.                                          |
+| `encoding and compression time` | Time to encode batches in IPC format and compress using ZSTD.               |
+| `disk spilled bytes`            | Actual compressed bytes written to native shuffle spill files on disk.      |
+| `memory spilled bytes`          | Uncompressed Arrow backing-buffer and partition-index data before spilling. |
+
+Disk and memory spilled bytes measure different representations of the same native shuffle spill,
+so their values differ when compression is used. These values also appear in Spark's task metrics
+and Spark UI as `diskBytesSpilled` and `memoryBytesSpilled`, respectively. The memory value follows
+Spark's `memoryBytesSpilled` semantics and includes uncompressed in-memory Arrow backing-buffer and
+partition-index data rather than the compressed size of the spill file.
 
 ## Native Metrics
 
@@ -57,13 +66,17 @@ Here is a guide to some of the native metrics.
 
 ### ShuffleWriterExec
 
-| Metric            | Description                                                   |
-| ----------------- | ------------------------------------------------------------- |
-| `elapsed_compute` | Total time excluding any child operators.                     |
-| `repart_time`     | Time to repartition batches.                                  |
-| `ipc_time`        | Time to encode batches in IPC format and compress using ZSTD. |
-| `mempool_time`    | Time interacting with memory pool.                            |
-| `write_time`      | Time spent writing bytes to disk.                             |
+| Metric                 | Description                                                            |
+| ---------------------- | ---------------------------------------------------------------------- |
+| `elapsed_compute`      | Total time excluding any child operators.                              |
+| `repart_time`          | Time to repartition batches.                                           |
+| `interleave_time`      | Time to interleave partitioned batches before writing them.            |
+| `ipc_time`             | Time to encode batches in IPC format and compress using ZSTD.          |
+| `mempool_time`         | Time interacting with memory pool.                                     |
+| `write_time`           | Time spent writing bytes to disk.                                      |
+| `spill_count`          | Number of native shuffle spills.                                       |
+| `spilled_bytes`        | Actual compressed bytes written to native shuffle spill files on disk. |
+| `memory_spilled_bytes` | Uncompressed Arrow backing-buffer and partition-index memory spilled.  |
 
 ## Task-Level Input Metrics on Spark 4.1+
 

--- a/docs/source/user-guide/latest/metrics.md
+++ b/docs/source/user-guide/latest/metrics.md
@@ -40,14 +40,15 @@ Comet adds some additional metrics:
 | `partition interleaving time`   | Time to interleave partitioned batches before writing them.                 |
 | `memory pool time`              | Time interacting with memory pool.                                          |
 | `encoding and compression time` | Time to encode batches in IPC format and compress using ZSTD.               |
-| `disk spilled bytes`            | Actual compressed bytes written to native shuffle spill files on disk.      |
+| `disk spilled bytes`            | Actual bytes written to native shuffle spill files on disk.                 |
 | `memory spilled bytes`          | Uncompressed Arrow backing-buffer and partition-index data before spilling. |
 
-Disk and memory spilled bytes measure different representations of the same native shuffle spill,
-so their values differ when compression is used. These values also appear in Spark's task metrics
-and Spark UI as `diskBytesSpilled` and `memoryBytesSpilled`, respectively. The memory value follows
-Spark's `memoryBytesSpilled` semantics and includes uncompressed in-memory Arrow backing-buffer and
-partition-index data rather than the compressed size of the spill file.
+Disk and memory spilled bytes measure different representations of the same native shuffle spill.
+Disk spill bytes count the actual bytes written to disk: compressed when shuffle compression is
+enabled and uncompressed when `spark.shuffle.compress=false`. Memory spill bytes follow Spark's
+`memoryBytesSpilled` semantics and include uncompressed in-memory Arrow backing-buffer and
+partition-index data rather than their on-disk size. These values also appear in Spark's task
+metrics and Spark UI as `diskBytesSpilled` and `memoryBytesSpilled`, respectively.
 
 ## Native Metrics
 
@@ -66,17 +67,17 @@ Here is a guide to some of the native metrics.
 
 ### ShuffleWriterExec
 
-| Metric                 | Description                                                            |
-| ---------------------- | ---------------------------------------------------------------------- |
-| `elapsed_compute`      | Total time excluding any child operators.                              |
-| `repart_time`          | Time to repartition batches.                                           |
-| `interleave_time`      | Time to interleave partitioned batches before writing them.            |
-| `ipc_time`             | Time to encode batches in IPC format and compress using ZSTD.          |
-| `mempool_time`         | Time interacting with memory pool.                                     |
-| `write_time`           | Time spent writing bytes to disk.                                      |
-| `spill_count`          | Number of native shuffle spills.                                       |
-| `spilled_bytes`        | Actual compressed bytes written to native shuffle spill files on disk. |
-| `memory_spilled_bytes` | Uncompressed Arrow backing-buffer and partition-index memory spilled.  |
+| Metric                 | Description                                                           |
+| ---------------------- | --------------------------------------------------------------------- |
+| `elapsed_compute`      | Total time excluding any child operators.                             |
+| `repart_time`          | Time to repartition batches.                                          |
+| `interleave_time`      | Time to interleave partitioned batches before writing them.           |
+| `ipc_time`             | Time to encode batches in IPC format and compress using ZSTD.         |
+| `mempool_time`         | Time interacting with memory pool.                                    |
+| `write_time`           | Time spent writing bytes to disk.                                     |
+| `spill_count`          | Number of native shuffle spills.                                      |
+| `spilled_bytes`        | Actual bytes written to native shuffle spill files on disk.           |
+| `memory_spilled_bytes` | Uncompressed Arrow backing-buffer and partition-index memory spilled. |
 
 ## Task-Level Input Metrics on Spark 4.1+
 

--- a/native/shuffle/src/metrics.rs
+++ b/native/shuffle/src/metrics.rs
@@ -45,6 +45,9 @@ pub(crate) struct ShufflePartitionerMetrics {
     /// total spilled bytes during the execution of the operator
     pub(crate) spilled_bytes: Count,
 
+    /// Total in-memory bytes released by spills before compression.
+    pub(crate) memory_spilled_bytes: Count,
+
     /// The original size of spilled data. Different to `spilled_bytes` because of compression.
     pub(crate) data_size: Count,
 }
@@ -60,6 +63,8 @@ impl ShufflePartitionerMetrics {
             input_batches: MetricBuilder::new(metrics).counter("input_batches", partition),
             spill_count: MetricBuilder::new(metrics).spill_count(partition),
             spilled_bytes: MetricBuilder::new(metrics).spilled_bytes(partition),
+            memory_spilled_bytes: MetricBuilder::new(metrics)
+                .counter("memory_spilled_bytes", partition),
             data_size: MetricBuilder::new(metrics).counter("data_size", partition),
         }
     }

--- a/native/shuffle/src/partitioners/multi_partition.rs
+++ b/native/shuffle/src/partitioners/multi_partition.rs
@@ -457,15 +457,18 @@ impl<T: PartitionWriter> MultiPartitionShuffleRepartitioner<T> {
             mem_growth += after_size.saturating_sub(before_size);
         }
 
-        // `try_grow` is evaluated first so the reservation accounts for this batch either way.
+        // A rejected reservation does not include this batch's memory, even though the batch
+        // and its partition indices have already been buffered and must be counted as spilled.
+        let reservation_failed = self.reservation.try_grow(mem_growth).is_err();
         // Checking after buffering lets the writer overshoot the limit by at most one batch,
         // which is how the memory-pressure trigger already behaves.
-        if self.reservation.try_grow(mem_growth).is_err()
+        if reservation_failed
             || self
                 .max_buffer_bytes
                 .is_some_and(|limit| self.reservation.size() >= limit)
         {
-            self.spill()?;
+            let unreserved_bytes = if reservation_failed { mem_growth } else { 0 };
+            self.spill(unreserved_bytes)?;
         }
 
         Ok(())
@@ -501,7 +504,7 @@ impl<T: PartitionWriter> MultiPartitionShuffleRepartitioner<T> {
         PartitionedBatchesProducer::new(buffered_batches, indices, self.batch_size)
     }
 
-    pub(crate) fn spill(&mut self) -> datafusion::common::Result<()> {
+    pub(crate) fn spill(&mut self, unreserved_bytes: usize) -> datafusion::common::Result<()> {
         log::info!(
             "ShuffleRepartitioner spilling shuffle data of {} to disk while inserting ({} time(s) so far)",
             self.used(),
@@ -525,7 +528,8 @@ impl<T: PartitionWriter> MultiPartitionShuffleRepartitioner<T> {
                 )?;
             }
 
-            self.reservation.free();
+            let memory_spilled_bytes = self.reservation.free().saturating_add(unreserved_bytes);
+            self.metrics.memory_spilled_bytes.add(memory_spilled_bytes);
             self.pinned_buffers.clear();
             self.metrics.spill_count.add(1);
             Ok(())

--- a/native/shuffle/src/partitioners/multi_partition.rs
+++ b/native/shuffle/src/partitioners/multi_partition.rs
@@ -122,12 +122,21 @@ pub(crate) struct MultiPartitionShuffleRepartitioner<T: PartitionWriter> {
     /// allocation once rather than once per slice that references it. Cleared whenever the
     /// buffered batches drain (spill / shuffle_write). See `count_new_buffers`.
     pinned_buffers: HashSet<usize>,
+    /// Backing buffers already reported as spilled while slicing the current outer input batch.
+    /// The outer batch keeps these allocations alive across spills, so clear this set only when
+    /// that input batch finishes rather than whenever the repartitioner's buffers drain.
+    spill_accounted_input_buffers: HashSet<usize>,
+    /// Bytes in the currently buffered batches that were already counted by a previous spill of
+    /// the same outer input batch. Partition-index allocations are never included here.
+    repeated_spill_buffer_bytes: usize,
 }
 
 /// Sum of the capacities of the backing buffers reachable from `batch` whose start address is
 /// not already in `seen` (recursing through child data: dictionary values, list children, and so
 /// on). `seen` is kept across every buffered batch, so this returns the bytes a batch newly
-/// pins, which is the memory the shuffle writer holds resident by buffering it.
+/// pins, which is the memory the shuffle writer holds resident by buffering it. The second return
+/// value contains the subset of those bytes whose buffers were already reported spilled while
+/// processing the current outer input batch.
 ///
 /// Cheaper measures do not match resident memory for the batches this writer sees. A partial
 /// `HashAggregate` emits one group-values buffer sliced into batch_size chunks, and every
@@ -144,28 +153,53 @@ pub(crate) struct MultiPartitionShuffleRepartitioner<T: PartitionWriter> {
 ///
 /// Counting each distinct allocation once, keyed by start address, is the measure that tracks
 /// resident memory regardless of how arrays share or slice their buffers.
-fn count_new_buffers(batch: &RecordBatch, seen: &mut HashSet<usize>) -> usize {
-    fn visit(data: &ArrayData, seen: &mut HashSet<usize>, total: &mut usize) {
+fn count_new_buffers(
+    batch: &RecordBatch,
+    seen: &mut HashSet<usize>,
+    previously_spilled: Option<&HashSet<usize>>,
+) -> (usize, usize) {
+    fn visit(
+        data: &ArrayData,
+        seen: &mut HashSet<usize>,
+        previously_spilled: Option<&HashSet<usize>>,
+        total: &mut usize,
+        repeated: &mut usize,
+    ) {
         for buffer in data.buffers() {
-            if seen.insert(buffer.data_ptr().as_ptr() as usize) {
+            let address = buffer.data_ptr().as_ptr() as usize;
+            if seen.insert(address) {
                 *total += buffer.capacity();
+                if previously_spilled.is_some_and(|buffers| buffers.contains(&address)) {
+                    *repeated += buffer.capacity();
+                }
             }
         }
         if let Some(nulls) = data.nulls() {
             let inner = nulls.inner().inner();
-            if seen.insert(inner.data_ptr().as_ptr() as usize) {
+            let address = inner.data_ptr().as_ptr() as usize;
+            if seen.insert(address) {
                 *total += inner.capacity();
+                if previously_spilled.is_some_and(|buffers| buffers.contains(&address)) {
+                    *repeated += inner.capacity();
+                }
             }
         }
         for child in data.child_data() {
-            visit(child, seen, total);
+            visit(child, seen, previously_spilled, total, repeated);
         }
     }
     let mut total = 0;
+    let mut repeated = 0;
     for column in batch.columns() {
-        visit(&column.to_data(), seen, &mut total);
+        visit(
+            &column.to_data(),
+            seen,
+            previously_spilled,
+            &mut total,
+            &mut repeated,
+        );
     }
-    total
+    (total, repeated)
 }
 
 impl<T: PartitionWriter> MultiPartitionShuffleRepartitioner<T> {
@@ -219,6 +253,8 @@ impl<T: PartitionWriter> MultiPartitionShuffleRepartitioner<T> {
             max_buffer_bytes,
             tracing_enabled,
             pinned_buffers: HashSet::new(),
+            spill_accounted_input_buffers: HashSet::new(),
+            repeated_spill_buffer_bytes: 0,
         })
     }
 
@@ -426,7 +462,12 @@ impl<T: PartitionWriter> MultiPartitionShuffleRepartitioner<T> {
     ) -> datafusion::common::Result<()> {
         // Charge both the reservation and the data_size metric for the buffers this batch newly
         // pins; `count_new_buffers` dedups buffers shared across already-buffered batches.
-        let new_buffer_bytes = count_new_buffers(&input, &mut self.pinned_buffers);
+        let (new_buffer_bytes, repeated_buffer_bytes) = count_new_buffers(
+            &input,
+            &mut self.pinned_buffers,
+            Some(&self.spill_accounted_input_buffers),
+        );
+        self.repeated_spill_buffer_bytes += repeated_buffer_bytes;
         self.metrics.data_size.add(new_buffer_bytes);
         let mut mem_growth: usize = new_buffer_bytes;
         let buffered_partition_idx = self.buffered_batches.len() as u32;
@@ -468,6 +509,13 @@ impl<T: PartitionWriter> MultiPartitionShuffleRepartitioner<T> {
                 .is_some_and(|limit| self.reservation.size() >= limit)
         {
             let unreserved_bytes = if reservation_failed { mem_growth } else { 0 };
+            count_new_buffers(
+                self.buffered_batches
+                    .last()
+                    .expect("the current input batch was buffered before spilling"),
+                &mut self.spill_accounted_input_buffers,
+                None,
+            );
             self.spill(unreserved_bytes)?;
         }
 
@@ -528,9 +576,14 @@ impl<T: PartitionWriter> MultiPartitionShuffleRepartitioner<T> {
                 )?;
             }
 
-            let memory_spilled_bytes = self.reservation.free().saturating_add(unreserved_bytes);
+            let memory_spilled_bytes = self
+                .reservation
+                .free()
+                .saturating_add(unreserved_bytes)
+                .saturating_sub(self.repeated_spill_buffer_bytes);
             self.metrics.memory_spilled_bytes.add(memory_spilled_bytes);
             self.pinned_buffers.clear();
+            self.repeated_spill_buffer_bytes = 0;
             self.metrics.spill_count.add(1);
             Ok(())
         })
@@ -548,7 +601,8 @@ impl<T: PartitionWriter> ShufflePartitioner for MultiPartitionShuffleRepartition
     /// This function will slice input batch according to configured batch size and then
     /// shuffle rows into corresponding partition buffer.
     async fn insert_batch(&mut self, batch: RecordBatch) -> datafusion::common::Result<()> {
-        with_trace_async("shuffle_insert_batch", self.tracing_enabled, || async {
+        self.spill_accounted_input_buffers.clear();
+        let result = with_trace_async("shuffle_insert_batch", self.tracing_enabled, || async {
             let start_time = Instant::now();
             let mut start = 0;
             while start < batch.num_rows() {
@@ -564,7 +618,9 @@ impl<T: PartitionWriter> ShufflePartitioner for MultiPartitionShuffleRepartition
                 .add_duration(start_time.elapsed());
             Ok(())
         })
-        .await
+        .await;
+        self.spill_accounted_input_buffers.clear();
+        result
     }
 
     /// Writes buffered shuffled record batches into Arrow IPC bytes.

--- a/native/shuffle/src/shuffle_writer.rs
+++ b/native/shuffle/src/shuffle_writer.rs
@@ -504,6 +504,105 @@ mod test {
         );
     }
 
+    /// Spill every slice of one shared Arrow allocation and verify that memory accounting
+    /// includes that backing allocation once per outer input batch, plus each slice's indices.
+    async fn shared_buffer_memory_spilled_bytes(
+        max_buffer_bytes: Option<usize>,
+        memory_limit: usize,
+        input_batches: usize,
+    ) -> usize {
+        let num_rows = 16_384usize;
+        let batch_size = 1024usize;
+        let num_partitions = 2;
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+        let backing = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from_iter_values(0..num_rows as i64))],
+        )
+        .unwrap();
+        let buffer_bytes = backing.get_array_memory_size();
+
+        let runtime_env = create_runtime(memory_limit);
+        let metrics_set = ExecutionPlanMetricsSet::new();
+        let metrics = ShufflePartitionerMetrics::new(&metrics_set, 0);
+        let spill_count = metrics.spill_count.clone();
+        let memory_spilled_bytes = metrics.memory_spilled_bytes.clone();
+        let dir = tempfile::tempdir().unwrap();
+        let shuffle_block_writer =
+            ShuffleBlockWriter::try_new(schema.as_ref(), CompressionCodec::Lz4Frame).unwrap();
+        let local_partition_writer = LocalPartitionWriter::try_new(
+            dir.path().join("data.out").to_str().unwrap().to_string(),
+            dir.path().join("index.out").to_str().unwrap().to_string(),
+            shuffle_block_writer,
+            num_partitions,
+            batch_size,
+            1024 * 1024,
+            Arc::clone(&runtime_env),
+        )
+        .unwrap();
+        let mut repartitioner = MultiPartitionShuffleRepartitioner::try_new(
+            0,
+            local_partition_writer,
+            CometPartitioning::Hash(vec![Arc::new(Column::new("a", 0))], num_partitions),
+            metrics,
+            runtime_env,
+            batch_size,
+            false,
+            max_buffer_bytes,
+        )
+        .unwrap();
+
+        for _ in 0..input_batches {
+            repartitioner.insert_batch(backing.clone()).await.unwrap();
+        }
+        repartitioner.shuffle_write().unwrap();
+
+        let expected_spills = input_batches * num_rows / batch_size;
+        assert_eq!(
+            spill_count.value(),
+            expected_spills,
+            "each slice must spill to exercise shared-buffer accounting"
+        );
+
+        let spilled = memory_spilled_bytes.value();
+        let minimum_backing_bytes = input_batches * buffer_bytes;
+        assert!(
+            spilled > minimum_backing_bytes,
+            "partition-index allocations must remain in memory spill accounting: \
+             {spilled} bytes reported for {minimum_backing_bytes} backing bytes"
+        );
+        // Each row receives one (batch index, row index) entry. Allow twice the logical index
+        // size for Vec capacity rounding while still rejecting one full backing charge per slice.
+        let maximum_index_bytes = input_batches * num_rows * std::mem::size_of::<(u32, u32)>() * 2;
+        let maximum_spilled = minimum_backing_bytes + maximum_index_bytes;
+        assert!(
+            spilled <= maximum_spilled,
+            "shared backing buffers must be charged once per input batch: \
+             {spilled} bytes reported, expected at most {maximum_spilled}"
+        );
+
+        spilled
+    }
+
+    #[tokio::test]
+    #[cfg_attr(miri, ignore)] // miri can't call foreign function `ZSTD_createCCtx`
+    async fn max_buffer_spills_charge_shared_backing_once_per_input_batch() {
+        let one_batch = shared_buffer_memory_spilled_bytes(Some(8 * 1024), 512 * 1024, 1).await;
+        let two_batches = shared_buffer_memory_spilled_bytes(Some(8 * 1024), 512 * 1024, 2).await;
+        assert_eq!(
+            two_batches,
+            one_batch * 2,
+            "separate outer input batches must contribute cumulatively even when they clone \
+             the same Arrow backing allocation"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg_attr(miri, ignore)] // miri can't call foreign function `ZSTD_createCCtx`
+    async fn rejected_reservations_charge_shared_backing_once_per_input_batch() {
+        shared_buffer_memory_spilled_bytes(None, 1, 1).await;
+    }
+
     /// Buffer `num_batches` batches through a `MultiPartitionShuffleRepartitioner` and return its
     /// spill count, uncompressed in-memory spill size, and compressed on-disk spill size.
     async fn spill_metrics_with_max_buffer_bytes(

--- a/native/shuffle/src/shuffle_writer.rs
+++ b/native/shuffle/src/shuffle_writer.rs
@@ -428,7 +428,7 @@ mod test {
             assert!(!spill_writers[1].has_spill_file());
         }
 
-        repartitioner.spill().unwrap();
+        repartitioner.spill(0).unwrap();
 
         // after spill, there should be spill files
         {
@@ -504,21 +504,21 @@ mod test {
         );
     }
 
-    /// Buffer `num_batches` batches through a `MultiPartitionShuffleRepartitioner` configured
-    /// with `max_buffer_bytes`, against a memory pool large enough that `try_grow` never fails,
-    /// and return how many times it spilled.
-    async fn spill_count_with_max_buffer_bytes(
+    /// Buffer `num_batches` batches through a `MultiPartitionShuffleRepartitioner` and return its
+    /// spill count, uncompressed in-memory spill size, and compressed on-disk spill size.
+    async fn spill_metrics_with_max_buffer_bytes(
         max_buffer_bytes: Option<usize>,
         num_batches: usize,
-    ) -> usize {
+        memory_limit: usize,
+    ) -> (usize, usize, usize) {
         let batch = create_batch(1000);
         let num_partitions = 4;
-        // Far larger than anything these batches can reserve, so pool pressure never triggers
-        // a spill and any spill observed must come from the max_buffer_bytes limit.
-        let runtime_env = create_runtime(1024 * 1024 * 1024);
+        let runtime_env = create_runtime(memory_limit);
         let metrics_set = ExecutionPlanMetricsSet::new();
         let metrics = ShufflePartitionerMetrics::new(&metrics_set, 0);
         let spill_count = metrics.spill_count.clone();
+        let memory_spilled_bytes = metrics.memory_spilled_bytes.clone();
+        let spilled_bytes = metrics.spilled_bytes.clone();
         let dir = tempfile::tempdir().unwrap();
         let shuffle_block_writer =
             ShuffleBlockWriter::try_new(batch.schema().as_ref(), CompressionCodec::Lz4Frame)
@@ -550,7 +550,24 @@ mod test {
         }
         repartitioner.shuffle_write().unwrap();
 
-        spill_count.value()
+        let actual_spilled_bytes: usize = repartitioner
+            .partition_writer()
+            .get_spill_writers()
+            .iter()
+            .filter_map(|writer| writer.path())
+            .map(|path| usize::try_from(std::fs::metadata(path).unwrap().len()).unwrap())
+            .sum();
+        assert_eq!(
+            spilled_bytes.value(),
+            actual_spilled_bytes,
+            "reported disk spill bytes must match the complete compressed spill files"
+        );
+
+        (
+            spill_count.value(),
+            memory_spilled_bytes.value(),
+            spilled_bytes.value(),
+        )
     }
 
     #[tokio::test]
@@ -559,21 +576,51 @@ mod test {
         // A limit far below what 20 batches buffer must spill, even though the pool never
         // denies an allocation. The paired zero case pins that the spills come from the new
         // limit and not from the pre-existing memory-pressure trigger.
-        let spills = spill_count_with_max_buffer_bytes(Some(8 * 1024), 20).await;
+        let (spills, memory_spilled_bytes, spilled_bytes) =
+            spill_metrics_with_max_buffer_bytes(Some(8 * 1024), 20, 1024 * 1024 * 1024).await;
         assert!(
             spills > 0,
             "a max_buffer_bytes limit below the buffered size must trigger spilling, got {spills}"
+        );
+        assert!(
+            memory_spilled_bytes > spilled_bytes,
+            "in-memory spill bytes ({memory_spilled_bytes}) must exceed compressed disk spill bytes ({spilled_bytes})"
+        );
+        assert!(
+            spilled_bytes > 0,
+            "a forced spill must report the compressed bytes written to disk"
         );
     }
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)] // miri can't call foreign function `ZSTD_createCCtx`
     async fn max_buffer_bytes_none_leaves_spilling_to_memory_pressure() {
-        let spills = spill_count_with_max_buffer_bytes(None, 20).await;
+        let (spills, memory_spilled_bytes, spilled_bytes) =
+            spill_metrics_with_max_buffer_bytes(None, 20, 1024 * 1024 * 1024).await;
         assert_eq!(
             spills, 0,
             "an unset max_buffer_bytes disables the limit, and this pool never denies an allocation"
         );
+        assert_eq!(
+            memory_spilled_bytes, 0,
+            "no memory should be reported spilled"
+        );
+        assert_eq!(spilled_bytes, 0, "no disk bytes should be reported spilled");
+    }
+
+    #[tokio::test]
+    #[cfg_attr(miri, ignore)] // miri can't call foreign function `ZSTD_createCCtx`
+    async fn memory_pressure_spill_accounts_for_rejected_reservation() {
+        // A one-byte pool rejects the first batch's reservation. The batch is already resident,
+        // so its memory must still be counted even though MemoryReservation::free() returns zero.
+        let (spills, memory_spilled_bytes, spilled_bytes) =
+            spill_metrics_with_max_buffer_bytes(None, 1, 1).await;
+        assert!(spills > 0, "memory pressure must trigger a spill");
+        assert!(
+            memory_spilled_bytes > spilled_bytes,
+            "a rejected reservation must still count the buffered memory ({memory_spilled_bytes} vs {spilled_bytes} compressed bytes)"
+        );
+        assert!(spilled_bytes > 0, "the spill must write compressed data");
     }
 
     /// Run a shuffle end-to-end through `ShuffleWriterExec` with the given `max_buffer_bytes`

--- a/native/shuffle/src/writers/local/spill.rs
+++ b/native/shuffle/src/writers/local/spill.rs
@@ -66,18 +66,21 @@ impl SpillWriter {
                     self.write_buffer_size,
                     self.batch_size,
                 );
-                let mut bytes_written =
-                    buf_batch_writer.write(&batch?, &metrics.encode_time, &metrics.write_time)?;
+                let initial_position = buf_batch_writer.writer_stream_position()?;
+                buf_batch_writer.write(&batch?, &metrics.encode_time, &metrics.write_time)?;
                 for batch in iter.by_ref() {
                     let batch = batch?;
-                    bytes_written += buf_batch_writer.write(
-                        &batch,
-                        &metrics.encode_time,
-                        &metrics.write_time,
-                    )?;
+                    buf_batch_writer.write(&batch, &metrics.encode_time, &metrics.write_time)?;
                 }
                 buf_batch_writer.flush(&metrics.encode_time, &metrics.write_time)?;
-                bytes_written
+                let bytes_written = buf_batch_writer
+                    .writer_stream_position()?
+                    .saturating_sub(initial_position);
+                usize::try_from(bytes_written).map_err(|_| {
+                    DataFusionError::Execution(format!(
+                        "Spill file byte count exceeds platform capacity: {bytes_written}"
+                    ))
+                })?
             };
             metrics.spilled_bytes.add(total_bytes_written);
         }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
@@ -345,10 +345,12 @@ object CometMetricNode {
     Map(
       "elapsed_compute" -> SQLMetrics.createNanoTimingMetric(sc, "native shuffle writer time"),
       "repart_time" -> SQLMetrics.createNanoTimingMetric(sc, "repartition time"),
+      "interleave_time" -> SQLMetrics.createNanoTimingMetric(sc, "partition interleaving time"),
       "encode_time" -> SQLMetrics.createNanoTimingMetric(sc, "encoding and compression time"),
       "decode_time" -> SQLMetrics.createNanoTimingMetric(sc, "decoding and decompression time"),
       "spill_count" -> SQLMetrics.createMetric(sc, "number of spills"),
       "spilled_bytes" -> SQLMetrics.createSizeMetric(sc, "spilled bytes"),
+      "memory_spilled_bytes" -> SQLMetrics.createSizeMetric(sc, "memory spilled bytes"),
       "input_batches" -> SQLMetrics.createMetric(sc, "number of input batches"))
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
@@ -105,6 +105,31 @@ case class CometMetricNode(metrics: Map[String, SQLMetric], children: Seq[CometM
   }
 
   /**
+   * Reports this node's native shuffle spill metrics to Spark's task metrics, preserving the
+   * distinction between compressed disk bytes and uncompressed in-memory bytes.
+   *
+   * Must be registered on the task thread before [[org.apache.comet.CometExecIterator]] so its
+   * completion listener publishes final SQL metrics before this listener runs, including when the
+   * shuffle attempt fails.
+   */
+  def reportSpillMetrics(ctx: TaskContext): Unit = {
+    ctx.addTaskCompletionListener[Unit] { _ =>
+      metrics.get("spilled_bytes").foreach { metric =>
+        val spilledBytes = metric.value
+        if (spilledBytes > 0L) {
+          ctx.taskMetrics().incDiskBytesSpilled(spilledBytes)
+        }
+      }
+      metrics.get("memory_spilled_bytes").foreach { metric =>
+        val spilledBytes = metric.value
+        if (spilledBytes > 0L) {
+          ctx.taskMetrics().incMemoryBytesSpilled(spilledBytes)
+        }
+      }
+    }
+  }
+
+  /**
    * Gets a child node. Called from native.
    */
   def getChildNode(i: Int): CometMetricNode = {
@@ -349,7 +374,7 @@ object CometMetricNode {
       "encode_time" -> SQLMetrics.createNanoTimingMetric(sc, "encoding and compression time"),
       "decode_time" -> SQLMetrics.createNanoTimingMetric(sc, "decoding and decompression time"),
       "spill_count" -> SQLMetrics.createMetric(sc, "number of spills"),
-      "spilled_bytes" -> SQLMetrics.createSizeMetric(sc, "spilled bytes"),
+      "spilled_bytes" -> SQLMetrics.createSizeMetric(sc, "disk spilled bytes"),
       "memory_spilled_bytes" -> SQLMetrics.createSizeMetric(sc, "memory spilled bytes"),
       "input_batches" -> SQLMetrics.createMetric(sc, "number of input batches"))
   }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
@@ -106,7 +106,7 @@ case class CometMetricNode(metrics: Map[String, SQLMetric], children: Seq[CometM
 
   /**
    * Reports this node's native shuffle spill metrics to Spark's task metrics, preserving the
-   * distinction between compressed disk bytes and uncompressed in-memory bytes.
+   * distinction between on-disk bytes and uncompressed in-memory bytes.
    *
    * Must be registered on the task thread before [[org.apache.comet.CometExecIterator]] so its
    * completion listener publishes final SQL metrics before this listener runs, including when the

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
@@ -133,23 +133,7 @@ class CometNativeShuffleWriter[K, V](
       Option(context).foreach(nativeMetrics.reportScanInputMetrics)
     }
 
-    // Register before CometExecIterator so its later completion listener closes the native plan
-    // and publishes final SQL metrics before this listener runs. This also preserves spill metrics
-    // for failed shuffle attempts, which never reach the successful write/commit path below.
-    Option(context).foreach { taskCtx =>
-      taskCtx.addTaskCompletionListener[Unit] { _ =>
-        val diskBytesSpilled =
-          shuffleWriterSQLMetrics.get("spilled_bytes").map(_.value).getOrElse(0L)
-        if (diskBytesSpilled > 0) {
-          taskCtx.taskMetrics().incDiskBytesSpilled(diskBytesSpilled)
-        }
-        val memoryBytesSpilled =
-          shuffleWriterSQLMetrics.get("memory_spilled_bytes").map(_.value).getOrElse(0L)
-        if (memoryBytesSpilled > 0) {
-          taskCtx.taskMetrics().incMemoryBytesSpilled(memoryBytesSpilled)
-        }
-      }
-    }
+    Option(context).foreach(nativeMetrics.reportSpillMetrics)
 
     val cometIter = new CometExecIterator(
       CometExec.newIterId,

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
@@ -109,9 +109,11 @@ class CometNativeShuffleWriter[K, V](
       "elapsed_compute",
       "encode_time",
       "repart_time",
+      "interleave_time",
       "input_batches",
       "spill_count",
-      "spilled_bytes")
+      "spilled_bytes",
+      "memory_spilled_bytes")
     val metricsOutputRows = new SQLMetric("outputRows")
     val metricsWriteTime = new SQLMetric("writeTime")
     val shuffleWriterSQLMetrics = Map(
@@ -181,12 +183,16 @@ class CometNativeShuffleWriter[K, V](
     metricsReporter.incRecordsWritten(metricsOutputRows.value)
     metricsReporter.incWriteTime(metricsWriteTime.value)
 
-    // Report spill metrics to Spark's task metrics so they appear in
-    // Spark UI task summaries (not just SQL metrics)
-    val spilledBytes = shuffleWriterSQLMetrics.get("spilled_bytes").map(_.value).getOrElse(0L)
-    if (spilledBytes > 0) {
-      context.taskMetrics().incMemoryBytesSpilled(spilledBytes)
-      context.taskMetrics().incDiskBytesSpilled(spilledBytes)
+    // Report the compressed spill-file size and the released in-memory size independently so
+    // Spark UI task summaries preserve Spark's distinct disk and memory spill semantics.
+    val diskBytesSpilled = shuffleWriterSQLMetrics.get("spilled_bytes").map(_.value).getOrElse(0L)
+    if (diskBytesSpilled > 0) {
+      context.taskMetrics().incDiskBytesSpilled(diskBytesSpilled)
+    }
+    val memoryBytesSpilled =
+      shuffleWriterSQLMetrics.get("memory_spilled_bytes").map(_.value).getOrElse(0L)
+    if (memoryBytesSpilled > 0) {
+      context.taskMetrics().incMemoryBytesSpilled(memoryBytesSpilled)
     }
 
     // commit

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
@@ -133,6 +133,24 @@ class CometNativeShuffleWriter[K, V](
       Option(context).foreach(nativeMetrics.reportScanInputMetrics)
     }
 
+    // Register before CometExecIterator so its later completion listener closes the native plan
+    // and publishes final SQL metrics before this listener runs. This also preserves spill metrics
+    // for failed shuffle attempts, which never reach the successful write/commit path below.
+    Option(context).foreach { taskCtx =>
+      taskCtx.addTaskCompletionListener[Unit] { _ =>
+        val diskBytesSpilled =
+          shuffleWriterSQLMetrics.get("spilled_bytes").map(_.value).getOrElse(0L)
+        if (diskBytesSpilled > 0) {
+          taskCtx.taskMetrics().incDiskBytesSpilled(diskBytesSpilled)
+        }
+        val memoryBytesSpilled =
+          shuffleWriterSQLMetrics.get("memory_spilled_bytes").map(_.value).getOrElse(0L)
+        if (memoryBytesSpilled > 0) {
+          taskCtx.taskMetrics().incMemoryBytesSpilled(memoryBytesSpilled)
+        }
+      }
+    }
+
     val cometIter = new CometExecIterator(
       CometExec.newIterId,
       inputObjects,
@@ -182,18 +200,6 @@ class CometNativeShuffleWriter[K, V](
     metricsReporter.incBytesWritten(Files.size(tempDataFilePath))
     metricsReporter.incRecordsWritten(metricsOutputRows.value)
     metricsReporter.incWriteTime(metricsWriteTime.value)
-
-    // Report the compressed spill-file size and the released in-memory size independently so
-    // Spark UI task summaries preserve Spark's distinct disk and memory spill semantics.
-    val diskBytesSpilled = shuffleWriterSQLMetrics.get("spilled_bytes").map(_.value).getOrElse(0L)
-    if (diskBytesSpilled > 0) {
-      context.taskMetrics().incDiskBytesSpilled(diskBytesSpilled)
-    }
-    val memoryBytesSpilled =
-      shuffleWriterSQLMetrics.get("memory_spilled_bytes").map(_.value).getOrElse(0L)
-    if (memoryBytesSpilled > 0) {
-      context.taskMetrics().incMemoryBytesSpilled(memoryBytesSpilled)
-    }
 
     // commit
     shuffleBlockResolver.writeMetadataFileAndCommit(

--- a/spark/src/test/scala/org/apache/spark/sql/comet/CometTaskMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/CometTaskMetricsSuite.scala
@@ -128,6 +128,8 @@ class CometTaskMetricsSuite extends CometTestBase with AdaptiveSparkPlanHelper {
             native
         }.getOrElse(fail("Expected a native shuffle exchange"))
         val metrics = exchange.metrics
+        assert(metrics("spilled_bytes").name.contains("disk spilled bytes"))
+        assert(metrics("memory_spilled_bytes").name.contains("memory spilled bytes"))
         val sqlMemorySpilled = metrics("memory_spilled_bytes").value
         val sqlDiskSpilled = metrics("spilled_bytes").value
 
@@ -213,7 +215,6 @@ class CometTaskMetricsSuite extends CometTestBase with AdaptiveSparkPlanHelper {
             CometConf.COMET_SHUFFLE_COMPRESSION_CODEC.key -> "zstd",
             CometConf.COMET_SHUFFLE_NATIVE_MAX_BUFFER_BYTES.key -> "32k",
             CometConf.COMET_BATCH_SIZE.key -> "1024",
-            CometConf.COMET_SHUFFLE_JVM_BATCH_SIZE.key -> "1024",
             SQLConf.ANSI_ENABLED.key -> "true",
             SQLConf.SHUFFLE_PARTITIONS.key -> "4") {
             val shuffled = sql("SELECT _1, _1 / _2 AS quotient, _3 FROM failed_shuffle_tbl")

--- a/spark/src/test/scala/org/apache/spark/sql/comet/CometTaskMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/CometTaskMetricsSuite.scala
@@ -106,6 +106,58 @@ class CometTaskMetricsSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("native shuffle write reports separate memory and disk spill metrics") {
+    val expectedRecords = 20000L
+    val compressibleValue = "native-shuffle-spill-metrics-" * 8
+    withParquetTable((0 until expectedRecords.toInt).map(i => (i, compressibleValue)), "tbl") {
+      withSQLConf(
+        CometConf.COMET_SHUFFLE_MODE.key -> "native",
+        CometConf.COMET_SHUFFLE_COMPRESSION_CODEC.key -> "zstd",
+        CometConf.COMET_SHUFFLE_NATIVE_MAX_BUFFER_BYTES.key -> "32k",
+        SQLConf.SHUFFLE_PARTITIONS.key -> "4") {
+        val shuffled = sql("SELECT * FROM tbl").repartition(4, $"_1")
+        val store = spark.sparkContext.statusStore
+        spark.sparkContext.listenerBus.waitUntilEmpty()
+        val stagesBefore = store.stageList(null).map(_.stageId).toSet
+
+        assert(shuffled.collect().length == expectedRecords)
+        spark.sparkContext.listenerBus.waitUntilEmpty()
+
+        val exchange = collectFirst(shuffled.queryExecution.executedPlan) {
+          case native: CometShuffleExchangeExec if native.shuffleType == CometNativeShuffle =>
+            native
+        }.getOrElse(fail("Expected a native shuffle exchange"))
+        val metrics = exchange.metrics
+        val sqlMemorySpilled = metrics("memory_spilled_bytes").value
+        val sqlDiskSpilled = metrics("spilled_bytes").value
+
+        assert(metrics("shuffleRecordsWritten").value == expectedRecords)
+        assert(metrics("shuffleBytesWritten").value > 0L)
+        assert(metrics("shuffleWriteTime").value > 0L)
+        assert(metrics("interleave_time").value > 0L)
+        assert(metrics("spill_count").value > 0L)
+        assert(sqlDiskSpilled > 0L, "Compressed native shuffle spill bytes were not reported")
+        assert(
+          sqlMemorySpilled > sqlDiskSpilled,
+          s"Expected in-memory spill bytes ($sqlMemorySpilled) to exceed compressed " +
+            s"disk spill bytes ($sqlDiskSpilled)")
+
+        val shuffleWriteStages = store
+          .stageList(null)
+          .filterNot(stage => stagesBefore.contains(stage.stageId))
+          .filter(_.shuffleWriteRecords > 0L)
+
+        assert(shuffleWriteStages.nonEmpty, "No native shuffle write stage was recorded")
+        assert(shuffleWriteStages.map(_.shuffleWriteRecords).sum == expectedRecords)
+        assert(
+          shuffleWriteStages.map(_.shuffleWriteBytes).sum == metrics("shuffleBytesWritten").value)
+        assert(shuffleWriteStages.map(_.shuffleWriteTime).sum > 0L)
+        assert(shuffleWriteStages.map(_.memoryBytesSpilled).sum == sqlMemorySpilled)
+        assert(shuffleWriteStages.map(_.diskBytesSpilled).sum == sqlDiskSpilled)
+      }
+    }
+  }
+
   test("native shuffle reports task input metrics for its scan child") {
     // A native shuffle whose child subtree includes a CometNativeScanExec runs that scan inside
     // the writer's single plan, so the usual CometExecRDD.compute() input-metric bridge never

--- a/spark/src/test/scala/org/apache/spark/sql/comet/CometTaskMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/CometTaskMetricsSuite.scala
@@ -23,7 +23,7 @@ import java.io.File
 
 import scala.collection.mutable
 
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.{SparkConf, SparkContext, Success}
 import org.apache.spark.executor.ShuffleReadMetrics
 import org.apache.spark.executor.ShuffleWriteMetrics
 import org.apache.spark.scheduler.SparkListener
@@ -154,6 +154,111 @@ class CometTaskMetricsSuite extends CometTestBase with AdaptiveSparkPlanHelper {
         assert(shuffleWriteStages.map(_.shuffleWriteTime).sum > 0L)
         assert(shuffleWriteStages.map(_.memoryBytesSpilled).sum == sqlMemorySpilled)
         assert(shuffleWriteStages.map(_.diskBytesSpilled).sum == sqlDiskSpilled)
+      }
+    }
+  }
+
+  test("failed native shuffle attempts preserve memory and disk spill metrics") {
+    val failureRow = 8192
+    val compressibleValue = "native-shuffle-failed-spill-metrics-" * 8
+
+    withTempPath { path =>
+      spark
+        .createDataFrame((0 until failureRow + 1024).map { i =>
+          (i, if (i == failureRow) 0 else 1, compressibleValue)
+        })
+        .coalesce(1)
+        .write
+        .parquet(path.getAbsolutePath)
+
+      withParquetTable(path.getAbsolutePath, "failed_shuffle_tbl") {
+        val failedShuffleMetrics = mutable.ArrayBuffer.empty[(Long, Long)]
+        val targetStageIds = mutable.HashSet.empty[Int]
+        val jobGroupId = s"failed-native-shuffle-metrics-${java.util.UUID.randomUUID().toString}"
+
+        val listener = new SparkListener {
+          override def onJobStart(jobStart: SparkListenerJobStart): Unit = {
+            val isTargetJob = Option(jobStart.properties)
+              .flatMap(props => Option(props.getProperty(SparkContext.SPARK_JOB_GROUP_ID)))
+              .contains(jobGroupId)
+            if (isTargetJob) {
+              targetStageIds.synchronized {
+                targetStageIds ++= jobStart.stageInfos.map(_.stageId)
+              }
+            }
+          }
+
+          override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
+            val isTargetStage = targetStageIds.synchronized {
+              targetStageIds.contains(taskEnd.stageId)
+            }
+            if (isTargetStage && taskEnd.taskType.contains("ShuffleMapTask") &&
+              taskEnd.reason != Success) {
+              val taskMetrics = taskEnd.taskMetrics
+              failedShuffleMetrics.synchronized {
+                failedShuffleMetrics += ((
+                  taskMetrics.memoryBytesSpilled,
+                  taskMetrics.diskBytesSpilled))
+              }
+            }
+          }
+        }
+        spark.sparkContext.addSparkListener(listener)
+
+        try {
+          spark.sparkContext.listenerBus.waitUntilEmpty()
+
+          withSQLConf(
+            CometConf.COMET_SHUFFLE_MODE.key -> "native",
+            CometConf.COMET_SHUFFLE_COMPRESSION_CODEC.key -> "zstd",
+            CometConf.COMET_SHUFFLE_NATIVE_MAX_BUFFER_BYTES.key -> "32k",
+            CometConf.COMET_BATCH_SIZE.key -> "1024",
+            CometConf.COMET_SHUFFLE_JVM_BATCH_SIZE.key -> "1024",
+            SQLConf.ANSI_ENABLED.key -> "true",
+            SQLConf.SHUFFLE_PARTITIONS.key -> "4") {
+            val shuffled = sql("SELECT _1, _1 / _2 AS quotient, _3 FROM failed_shuffle_tbl")
+              .repartition(4, $"_1")
+            val exchange = collectFirst(shuffled.queryExecution.executedPlan) {
+              case native: CometShuffleExchangeExec if native.shuffleType == CometNativeShuffle =>
+                native
+            }.getOrElse(fail("Expected a native shuffle exchange"))
+            assert(
+              collect(exchange.child) { case project: CometProjectExec => project }.nonEmpty,
+              s"Expected the failing division to execute in a native project:\n${exchange.treeString}")
+
+            spark.sparkContext.setJobGroup(jobGroupId, "failed native shuffle spill metrics")
+            try {
+              val failure = intercept[Exception] {
+                shuffled.collect()
+              }
+              val messages = Iterator
+                .iterate(failure: Throwable)(_.getCause)
+                .takeWhile(_ != null)
+                .flatMap(error => Option(error.getMessage))
+                .toSeq
+              assert(
+                messages.exists(message =>
+                  message.contains("DIVIDE_BY_ZERO") || message.contains("Division by zero")),
+                s"Expected the late-row division failure, got:\n${messages.mkString("\n")}")
+            } finally {
+              spark.sparkContext.clearJobGroup()
+            }
+          }
+
+          spark.sparkContext.listenerBus.waitUntilEmpty()
+
+          val metrics = failedShuffleMetrics.synchronized {
+            failedShuffleMetrics.toSeq
+          }
+          assert(metrics.nonEmpty, "No failed native shuffle map attempt was recorded")
+          assert(
+            metrics.exists { case (memoryBytesSpilled, diskBytesSpilled) =>
+              memoryBytesSpilled > 0L && diskBytesSpilled > 0L
+            },
+            s"Failed shuffle attempts must preserve both memory and disk spill metrics: $metrics")
+        } finally {
+          spark.sparkContext.removeSparkListener(listener)
+        }
       }
     }
   }


### PR DESCRIPTION
## Why are the changes needed?

When a shuffle becomes too large to keep in memory, Spark spills intermediate data to local disk. Operators use the Spark UI to answer two different questions about that work: **how much memory was occupied by the data that spilled**, and **how much data was actually written to disk**. Spark intentionally exposes these as separate task metrics because the on-disk representation may be compressed and can be much smaller than the in-memory representation.

Comet's native shuffle writer did not preserve that distinction. It copied the same on-disk byte count into both `memoryBytesSpilled` and `diskBytesSpilled`. Worse, its disk counter considered only bytes returned by immediate writes, even though Arrow's batch coalescer can hold those bytes until `flush()`. In that common case, a real spill could appear as **zero memory spilled and zero disk spilled** in the Spark UI.

For example, suppose a task spills **256 MiB** of in-memory shuffle data and partition indices, which compress to **32 MiB** on disk. These numbers are illustrative:

| Situation | What actually happened | Spark UI before | Spark UI after |
| --- | --- | --- | --- |
| Compressed bytes are emitted during the write | 256 MiB in memory, 32 MiB on disk | Memory: **32 MiB**; disk: **32 MiB** | Memory: **256 MiB**; disk: **32 MiB** |
| Compressed bytes are emitted only when the writer flushes | 256 MiB in memory, 32 MiB on disk | Memory: **0**; disk: **0** | Memory: **256 MiB**; disk: **32 MiB** |
| The task spills successfully, then fails before the shuffle commit | 256 MiB in memory, 32 MiB on disk | Failed-task memory: **0**; disk: **0** | Failed-task memory: **256 MiB**; disk: **32 MiB** |

The failure case matters especially for debugging: a task that runs out of disk, encounters bad input, or fails after several spills should not look as though it never spilled at all.

Accurate in-memory accounting also has an Arrow-specific complication. One input batch can be split into many zero-copy slices that all reference the same underlying allocation. The regression test uses **16,384 `Int64` values**, backed by one **128 KiB** allocation, and processes them as **16 slices of 1,024 rows**. If every slice triggers a spill, simply summing each released memory reservation counts that same 128 KiB allocation 16 times: **2 MiB instead of 128 KiB**, before even including the real per-slice partition-index allocations. The underlying allocation remains owned by the original input batch throughout the operation, so it must be counted once for that batch, not once per slice.

Finally, native shuffle already measures the time spent interleaving rows into output partitions, but that work was not visible in the SQL exchange metrics. This made it harder to distinguish repartitioning overhead from encoding and compression overhead when investigating slow shuffle stages.

Part of #3996. This PR addresses **native shuffle write observability only**; shuffle reads and mixed native/JVM scan-input accounting remain outside its scope. Follow-up #5382 tracks spills from native child operators inlined beneath the shuffle writer.

## What changes were proposed in this PR?

The change gives native shuffle spill accounting two independent sources of truth and carries them consistently into both of Spark's observability surfaces.

For **disk usage**, the source of truth is the physical spill file itself. The native writer observes the file position before a spill and again after buffered Arrow data has been flushed. Their difference is the actual number of bytes written to disk, including data produced only during the final flush and data appended to an existing spill file. When shuffle compression is enabled, this is the compressed size; when `spark.shuffle.compress=false`, it is the uncompressed on-disk size.

For **memory usage**, the source of truth is the in-memory shuffle state being spilled: Arrow backing allocations plus the partition-index structures that organize its rows. The native writer records the memory released by the spill and also includes the current batch when the memory pool rejected its reservation after that batch had already been buffered. To avoid turning Arrow's zero-copy slicing into fictional memory growth, it remembers which backing allocations have already been counted for the lifetime of the original input batch. Separate input batches still contribute cumulatively, as Spark's spill metrics require.

Those two measurements are exposed separately in the SQL shuffle exchange and copied into their corresponding Spark task metrics only after the native execution plan has published its final values. The copy runs from a task-completion listener registered before the native iterator; Spark invokes completion listeners in reverse registration order, so native cleanup and final metric publication happen first. Because task-completion listeners also run when an attempt fails or is canceled, the same accounting remains available for the attempts that are most useful to diagnose.

The exchange also surfaces the native partition-interleaving timer, making the main stages of native shuffle work visible alongside the existing repartitioning, encoding, and spill metrics. Existing shuffle output semantics, compression behavior, and scan-input accounting are unchanged.

## How was this PR tested?

Focused Rust tests exercise both spill triggers: an explicit maximum buffer size and a memory-pool reservation failure. They compare reported disk spill bytes against the actual spill-file sizes, verify zero spill metrics when no spill occurs, and cover the shared-allocation example above. They also verify that separate outer input batches are counted cumulatively even when they reference the same Arrow backing buffer.

The Spark integration tests validate the complete native-to-Spark reporting path on both Spark 3.5 and Spark 4.0:

- A successful shuffle writes **20,000 rows** across four partitions with Zstandard compression and forced spills. The test verifies shuffle records, output bytes, write time, partition-interleaving time, separate memory/disk SQL metrics, and exact agreement between those SQL metrics and Spark's recorded stage/task metrics.
- A failing shuffle processes **8,192 valid rows** before a later row triggers an ANSI divide-by-zero inside a native projection. Earlier batches have already spilled, and the test verifies that the failed `ShuffleMapTask` still reports both memory and disk spill bytes.

```bash
cd native
cargo fmt --all -- --check
cargo clippy -p datafusion-comet-shuffle --lib -- -D warnings
cargo test -p datafusion-comet-shuffle --lib spill -- --nocapture
cargo test -p datafusion-comet-shuffle --lib shared_backing_once_per_input_batch -- --nocapture

cd ..
make core
./mvnw -Pspark-3.5 test -Dtest=none \
  '-Dsuites=org.apache.spark.sql.comet.CometTaskMetricsSuite memory and disk spill metrics'
./mvnw -Pspark-4.0 test -Dtest=none \
  '-Dsuites=org.apache.spark.sql.comet.CometTaskMetricsSuite memory and disk spill metrics'
```
