### PR TITLE
test: make expression benchmark harness fair and reproducible

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
@@ -29,7 +29,7 @@ import org.apache.parquet.crypto.keytools.mocks.InMemoryKMS
 import org.apache.spark.SparkConf
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, Literal}
 import org.apache.spark.sql.catalyst.optimizer.ConstantFolding
 import org.apache.spark.sql.comet.CometPlanChecker
 import org.apache.spark.sql.comet.util.Utils
@@ -157,6 +157,16 @@ trait CometBenchmarkBase
             |likely removed by the optimizer.
             |Spark plan:""".stripMargin + "\n" + plan.treeString)
       }
+      val rowInvariant = rowInvariantProjections(plan)
+      if (rowInvariant.nonEmpty) {
+        warn(
+          benchmark,
+          s"""WARNING: these projections reference no input column, so their value is the same
+             |for every row: ${rowInvariant.mkString(", ")}
+             |An engine may evaluate them once per batch and broadcast the result rather than
+             |per row, so the two arms are not necessarily doing comparable work. Benchmark the
+             |expression over a column instead.""".stripMargin)
+      }
     }
 
     // Check that the plan is fully Comet native before running the benchmark. Unlike the check
@@ -207,16 +217,35 @@ trait CometBenchmarkBase
    * aggregates and filters are never reported as trivial even when they project bare attributes.
    */
   private def isTrivialPlan(plan: SparkPlan): Boolean = !plan.exists {
-    case p: ProjectExec =>
-      p.projectList.exists {
-        case _: AttributeReference | _: Literal => false
-        case Alias(_: AttributeReference | _: Literal, _) => false
-        case _ => true
-      }
+    case p: ProjectExec => p.projectList.exists(expr => !isTrivialExpr(expr))
     case _: ColumnarToRowExec | _: WholeStageCodegenExec | _: InputAdapter | _: LeafExecNode =>
       false
     case _ => true
   }
+
+  /** A projection that copies a column or emits a constant, doing no per-row work. */
+  private def isTrivialExpr(expr: Expression): Boolean = expr match {
+    case _: AttributeReference | _: Literal => true
+    case Alias(_: AttributeReference | _: Literal, _) => true
+    case _ => false
+  }
+
+  /**
+   * Projections whose value is the same for every row, because they reference no input column.
+   *
+   * An engine is free to evaluate these once per batch and broadcast the result, and engines
+   * differ on whether they do. Comet's native `space` takes a `ColumnarValue::Scalar` and builds
+   * one string per batch, while Spark's `StringSpace` calls `UTF8String.blankString` per row. The
+   * two plans look identical, so nothing else here can tell them apart.
+   *
+   * Nondeterministic expressions are excluded: `rand()` also references no column but genuinely
+   * evaluates per row.
+   */
+  private def rowInvariantProjections(plan: SparkPlan): Seq[Expression] =
+    plan
+      .collect { case p: ProjectExec => p }
+      .flatMap(_.projectList)
+      .filter(expr => expr.references.isEmpty && expr.deterministic && !isTrivialExpr(expr))
 
   /**
    * Writes a warning to the benchmark results file as well as the console. `Benchmark.out` tees

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
@@ -23,15 +23,15 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import java.util.Base64
 
-import scala.util.Random
-
 import org.apache.parquet.crypto.DecryptionPropertiesFactory
 import org.apache.parquet.crypto.keytools.{KeyToolkit, PropertiesDrivenCryptoFactory}
 import org.apache.parquet.crypto.keytools.mocks.InMemoryKMS
 import org.apache.spark.SparkConf
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, Literal}
 import org.apache.spark.sql.comet.CometPlanChecker
+import org.apache.spark.sql.execution.{ColumnarToRowExec, InputAdapter, LeafExecNode, ProjectExec, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
 import org.apache.spark.sql.internal.SQLConf
@@ -97,9 +97,13 @@ trait CometBenchmarkBase
       useDictionary: Boolean = false)(f: Int => Any): Unit = {
     withTempTable(tbl) {
       import spark.implicits._
+      // Derive the values from the row id with a pure function rather than a random number
+      // generator, so that results are comparable across runs. Seeding a driver-side `Random`
+      // would not work here: the closure runs per row on the executor.
       spark
         .range(values)
-        .map(_ => if (useDictionary) Random.nextLong() % 5 else Random.nextLong())
+        .map(i =>
+          if (useDictionary) CometBenchmarkBase.mix64(i) % 5 else CometBenchmarkBase.mix64(i))
         .createOrReplaceTempView(tbl)
       runBenchmark(benchmarkName)(f(values))
     }
@@ -125,48 +129,119 @@ trait CometBenchmarkBase
       extraCometConfigs: Map[String, String] = Map.empty): Unit = {
     val benchmark = new Benchmark(name, cardinality, output = output)
 
+    // Constant folding is excluded so that expressions over literal arguments are still evaluated
+    // per row. It must be excluded for both arms: if only Comet excludes it, Spark folds the
+    // expression away and does no per-row work, and the comparison is meaningless.
+    val sharedConfigs = Map(
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        excludedRulesWith("org.apache.spark.sql.catalyst.optimizer.ConstantFolding"))
+
+    val sparkConfigs = sharedConfigs ++ Map(CometConf.COMET_ENABLED.key -> "false")
+
+    val cometConfigs = sharedConfigs ++ Map(
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ENABLED.key -> "true") ++ extraCometConfigs
+
+    // Check that the benchmarked expression survives optimization into the Spark baseline plan.
+    withSQLConf(sparkConfigs.toSeq: _*) {
+      val df = spark.sql(query)
+      df.noop()
+      val plan = stripAQEPlan(df.queryExecution.executedPlan)
+      if (isTrivialPlan(plan)) {
+        emitWarning(
+          Seq(
+            "WARNING: the Spark baseline plan does no work beyond scanning and projecting",
+            "columns, so this case is not measuring an expression. The expression was most",
+            "likely removed by the optimizer.",
+            "Spark plan:",
+            plan.treeString))
+      }
+    }
+
+    // Check that the plan is fully Comet native before running the benchmark
+    withSQLConf(cometConfigs.toSeq: _*) {
+      val df = spark.sql(query)
+      df.noop()
+      val plan = stripAQEPlan(df.queryExecution.executedPlan)
+      findFirstNonCometOperator(plan).foreach { op =>
+        emitWarning(
+          Seq(
+            "WARNING: the Comet plan is NOT fully Comet native, so the Comet case below is",
+            "partly or wholly measuring Spark.",
+            s"First non-Comet operator: ${op.nodeName}",
+            "Comet plan:",
+            plan.treeString))
+      }
+    }
+
     benchmark.addCase("Spark") { _ =>
-      withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
+      withSQLConf(sparkConfigs.toSeq: _*) {
         spark.sql(query).noop()
       }
     }
 
-    val cometExecConfigs = Map(
-      CometConf.COMET_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_ENABLED.key -> "true",
-      "spark.sql.optimizer.excludedRules" ->
-        "org.apache.spark.sql.catalyst.optimizer.ConstantFolding") ++ extraCometConfigs
-
-    // Check that the plan is fully Comet native before running the benchmark
-    withSQLConf(cometExecConfigs.toSeq: _*) {
-      val df = spark.sql(query)
-      df.noop()
-      val plan = stripAQEPlan(df.queryExecution.executedPlan)
-      findFirstNonCometOperator(plan) match {
-        case Some(op) =>
-          // scalastyle:off println
-          println()
-          println("=" * 80)
-          println("WARNING: Benchmark plan is NOT fully Comet native!")
-          println(s"First non-Comet operator: ${op.nodeName}")
-          println("=" * 80)
-          println("Query plan:")
-          println(plan.treeString)
-          println("=" * 80)
-          println()
-        // scalastyle:on println
-        case None =>
-        // All operators are Comet native, no warning needed
-      }
-    }
-
     benchmark.addCase("Comet") { _ =>
-      withSQLConf(cometExecConfigs.toSeq: _*) {
+      withSQLConf(cometConfigs.toSeq: _*) {
         spark.sql(query).noop()
       }
     }
 
     benchmark.run()
+  }
+
+  /**
+   * Returns the value of `spark.sql.optimizer.excludedRules` with `rules` appended, so that
+   * benchmark-specific exclusions do not clobber exclusions already configured by the caller.
+   */
+  private def excludedRulesWith(rules: String*): String =
+    (spark.conf
+      .get(SQLConf.OPTIMIZER_EXCLUDED_RULES.key, "")
+      .split(",")
+      .map(_.trim)
+      .filter(_.nonEmpty) ++ rules).distinct.mkString(",")
+
+  /**
+   * Returns true if the plan does nothing but scan and emit columns, which means the benchmarked
+   * expression was removed by the optimizer and the case measures nothing.
+   *
+   * Any node other than a scan, projection or row conversion counts as real work, so joins,
+   * aggregates and filters are never reported as trivial even when they project bare attributes.
+   */
+  private def isTrivialPlan(plan: SparkPlan): Boolean = {
+    val doesWork = plan.exists {
+      case _: ProjectExec | _: ColumnarToRowExec | _: WholeStageCodegenExec | _: InputAdapter =>
+        false
+      case _: LeafExecNode => false
+      case _ => true
+    }
+    if (doesWork) {
+      return false
+    }
+    plan.collect { case p: ProjectExec => p }.forall {
+      _.projectList.map(unwrapAlias).forall {
+        case _: AttributeReference | _: Literal => true
+        case _ => false
+      }
+    }
+  }
+
+  private def unwrapAlias(expr: Expression): Expression = expr match {
+    case a: Alias => a.child
+    case other => other
+  }
+
+  /**
+   * Writes a warning to the benchmark results file as well as the console. `println` alone
+   * reaches only the console, so a reader of a results file, or of a results table pasted into a
+   * PR, cannot tell that a case did not measure what its label claims.
+   */
+  private def emitWarning(lines: Seq[String]): Unit = {
+    val border = "=" * 80
+    val text = (Seq("", border) ++ lines ++ Seq(border, "")).mkString("\n")
+    output.foreach(_.write(text.getBytes(StandardCharsets.UTF_8)))
+    // scalastyle:off println
+    println(text)
+    // scalastyle:on println
   }
 
   protected def addParquetScanCases(
@@ -289,5 +364,21 @@ trait CometBenchmarkBase
       .range(values)
       .map(_ % div)
       .select((($"value" - 500) / 100.0) cast decimal as Symbol("dec"))
+  }
+}
+
+object CometBenchmarkBase {
+
+  /**
+   * SplitMix64 finalizer, used to turn a row id into a well distributed pseudo-random value.
+   *
+   * This lives in the companion object rather than the trait because referencing a trait method
+   * from a Dataset closure captures `this`, which is not serializable.
+   */
+  def mix64(value: Long): Long = {
+    var z = value + 0x9e3779b97f4a7c15L
+    z = (z ^ (z >>> 30)) * 0xbf58476d1ce4e5b9L
+    z = (z ^ (z >>> 27)) * 0x94d049bb133111ebL
+    z ^ (z >>> 31)
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
@@ -29,8 +29,10 @@ import org.apache.parquet.crypto.keytools.mocks.InMemoryKMS
 import org.apache.spark.SparkConf
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Literal}
+import org.apache.spark.sql.catalyst.optimizer.ConstantFolding
 import org.apache.spark.sql.comet.CometPlanChecker
+import org.apache.spark.sql.comet.util.Utils
 import org.apache.spark.sql.execution.{ColumnarToRowExec, InputAdapter, LeafExecNode, ProjectExec, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
@@ -132,56 +134,56 @@ trait CometBenchmarkBase
     // Constant folding is excluded so that expressions over literal arguments are still evaluated
     // per row. It must be excluded for both arms: if only Comet excludes it, Spark folds the
     // expression away and does no per-row work, and the comparison is meaningless.
-    val sharedConfigs = Map(
-      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-        excludedRulesWith("org.apache.spark.sql.catalyst.optimizer.ConstantFolding"))
+    val noConstantFolding =
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> excludedRulesWith(ConstantFolding.ruleName)
 
-    val sparkConfigs = sharedConfigs ++ Map(CometConf.COMET_ENABLED.key -> "false")
+    val sparkConfigs = Seq(noConstantFolding, CometConf.COMET_ENABLED.key -> "false")
 
-    val cometConfigs = sharedConfigs ++ Map(
+    val cometConfigs = Seq(
+      noConstantFolding,
       CometConf.COMET_ENABLED.key -> "true",
       CometConf.COMET_EXEC_ENABLED.key -> "true") ++ extraCometConfigs
 
     // Check that the benchmarked expression survives optimization into the Spark baseline plan.
-    withSQLConf(sparkConfigs.toSeq: _*) {
-      val df = spark.sql(query)
-      df.noop()
-      val plan = stripAQEPlan(df.queryExecution.executedPlan)
+    // The query is not executed: before execution `stripAQEPlan` yields the initial physical
+    // plan, which already carries the projections this check inspects.
+    withSQLConf(sparkConfigs: _*) {
+      val plan = stripAQEPlan(spark.sql(query).queryExecution.executedPlan)
       if (isTrivialPlan(plan)) {
-        emitWarning(
-          Seq(
-            "WARNING: the Spark baseline plan does no work beyond scanning and projecting",
-            "columns, so this case is not measuring an expression. The expression was most",
-            "likely removed by the optimizer.",
-            "Spark plan:",
-            plan.treeString))
+        warn(
+          benchmark,
+          """WARNING: the Spark baseline plan does no work beyond scanning and projecting
+            |columns, so this case is not measuring an expression. The expression was most
+            |likely removed by the optimizer.
+            |Spark plan:""".stripMargin + "\n" + plan.treeString)
       }
     }
 
-    // Check that the plan is fully Comet native before running the benchmark
-    withSQLConf(cometConfigs.toSeq: _*) {
+    // Check that the plan is fully Comet native before running the benchmark. Unlike the check
+    // above this one does execute the query, because AQE can re-plan a join after the first
+    // stage completes and the Comet operators are what we are checking for.
+    withSQLConf(cometConfigs: _*) {
       val df = spark.sql(query)
       df.noop()
       val plan = stripAQEPlan(df.queryExecution.executedPlan)
       findFirstNonCometOperator(plan).foreach { op =>
-        emitWarning(
-          Seq(
-            "WARNING: the Comet plan is NOT fully Comet native, so the Comet case below is",
-            "partly or wholly measuring Spark.",
-            s"First non-Comet operator: ${op.nodeName}",
-            "Comet plan:",
-            plan.treeString))
+        warn(
+          benchmark,
+          s"""WARNING: the Comet plan is NOT fully Comet native, so the Comet case below is
+             |partly or wholly measuring Spark.
+             |First non-Comet operator: ${op.nodeName}
+             |Comet plan:""".stripMargin + "\n" + plan.treeString)
       }
     }
 
     benchmark.addCase("Spark") { _ =>
-      withSQLConf(sparkConfigs.toSeq: _*) {
+      withSQLConf(sparkConfigs: _*) {
         spark.sql(query).noop()
       }
     }
 
     benchmark.addCase("Comet") { _ =>
-      withSQLConf(cometConfigs.toSeq: _*) {
+      withSQLConf(cometConfigs: _*) {
         spark.sql(query).noop()
       }
     }
@@ -190,15 +192,12 @@ trait CometBenchmarkBase
   }
 
   /**
-   * Returns the value of `spark.sql.optimizer.excludedRules` with `rules` appended, so that
+   * Returns the value of `spark.sql.optimizer.excludedRules` with `rule` appended, so that
    * benchmark-specific exclusions do not clobber exclusions already configured by the caller.
    */
-  private def excludedRulesWith(rules: String*): String =
-    (spark.conf
-      .get(SQLConf.OPTIMIZER_EXCLUDED_RULES.key, "")
-      .split(",")
-      .map(_.trim)
-      .filter(_.nonEmpty) ++ rules).distinct.mkString(",")
+  private def excludedRulesWith(rule: String): String =
+    (Utils.stringToSeq(spark.conf.get(SQLConf.OPTIMIZER_EXCLUDED_RULES.key, "")) :+ rule).distinct
+      .mkString(",")
 
   /**
    * Returns true if the plan does nothing but scan and emit columns, which means the benchmarked
@@ -207,41 +206,26 @@ trait CometBenchmarkBase
    * Any node other than a scan, projection or row conversion counts as real work, so joins,
    * aggregates and filters are never reported as trivial even when they project bare attributes.
    */
-  private def isTrivialPlan(plan: SparkPlan): Boolean = {
-    val doesWork = plan.exists {
-      case _: ProjectExec | _: ColumnarToRowExec | _: WholeStageCodegenExec | _: InputAdapter =>
-        false
-      case _: LeafExecNode => false
-      case _ => true
-    }
-    if (doesWork) {
-      return false
-    }
-    plan.collect { case p: ProjectExec => p }.forall {
-      _.projectList.map(unwrapAlias).forall {
-        case _: AttributeReference | _: Literal => true
-        case _ => false
+  private def isTrivialPlan(plan: SparkPlan): Boolean = !plan.exists {
+    case p: ProjectExec =>
+      p.projectList.exists {
+        case _: AttributeReference | _: Literal => false
+        case Alias(_: AttributeReference | _: Literal, _) => false
+        case _ => true
       }
-    }
-  }
-
-  private def unwrapAlias(expr: Expression): Expression = expr match {
-    case a: Alias => a.child
-    case other => other
+    case _: ColumnarToRowExec | _: WholeStageCodegenExec | _: InputAdapter | _: LeafExecNode =>
+      false
+    case _ => true
   }
 
   /**
-   * Writes a warning to the benchmark results file as well as the console. `println` alone
-   * reaches only the console, so a reader of a results file, or of a results table pasted into a
-   * PR, cannot tell that a case did not measure what its label claims.
+   * Writes a warning to the benchmark results file as well as the console. `Benchmark.out` tees
+   * the two, and writing through it keeps the warning ordered against the results table that
+   * `Benchmark.run` writes to the same stream.
    */
-  private def emitWarning(lines: Seq[String]): Unit = {
+  private def warn(benchmark: Benchmark, message: String): Unit = {
     val border = "=" * 80
-    val text = (Seq("", border) ++ lines ++ Seq(border, "")).mkString("\n")
-    output.foreach(_.write(text.getBytes(StandardCharsets.UTF_8)))
-    // scalastyle:off println
-    println(text)
-    // scalastyle:on println
+    benchmark.out.println(s"\n$border\n$message\n$border")
   }
 
   protected def addParquetScanCases(

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometStringExpressionBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometStringExpressionBenchmark.scala
@@ -75,7 +75,11 @@ object CometStringExpressionBenchmark extends CometBenchmarkBase {
     StringExprConfig("rlike", "select c1 rlike '[0-9]+' from parquetV1Table"),
     StringExprConfig("rpad", "select rpad(c1, 150, 'x') from parquetV1Table"),
     StringExprConfig("rtrim", "select rtrim(c1) from parquetV1Table"),
-    StringExprConfig("space", "select space(2) from parquetV1Table"),
+    // `space` takes its length from a column rather than a literal. Given a literal, Comet's
+    // native `space` receives a `ColumnarValue::Scalar`, builds one string per batch and lets
+    // DataFusion broadcast it, while Spark's `StringSpace` calls `UTF8String.blankString` once
+    // per row. The plans look symmetric but the work is not.
+    StringExprConfig("space", "select space(c2) from parquetV1Table"),
     StringExprConfig("startswith", "select startswith(c1, '1') from parquetV1Table"),
     StringExprConfig("substring", "select substring(c1, 1, 100) from parquetV1Table"),
     StringExprConfig("translate", "select translate(c1, '123456', 'aBcDeF') from parquetV1Table"),
@@ -86,9 +90,14 @@ object CometStringExpressionBenchmark extends CometBenchmarkBase {
     runBenchmarkWithTable("String expressions", 1024) { v =>
       withTempPath { dir =>
         withTempTable("parquetV1Table") {
+          // c2 gives expressions that take a length or a count something to vary over per row.
+          // `pmod` keeps it non-negative, so `space(c2)` builds a string on every row rather
+          // than returning empty for the negative half of the input.
           prepareTable(
             dir,
-            spark.sql(s"SELECT REPEAT(CAST(value AS STRING), 10) AS c1 FROM $tbl"))
+            spark.sql(
+              s"SELECT REPEAT(CAST(value AS STRING), 10) AS c1," +
+                s" CAST(PMOD(value, 200) AS INT) AS c2 FROM $tbl"))
 
           val extraConfigs = Map(
             CometConf.getExprAllowIncompatConfigKey("Upper") -> "true",

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometStringExpressionBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometStringExpressionBenchmark.scala
@@ -96,7 +96,7 @@ object CometStringExpressionBenchmark extends CometBenchmarkBase {
           prepareTable(
             dir,
             spark.sql(
-              s"SELECT REPEAT(CAST(value AS STRING), 10) AS c1," +
+              "SELECT REPEAT(CAST(value AS STRING), 10) AS c1," +
                 s" CAST(PMOD(value, 200) AS INT) AS c2 FROM $tbl"))
 
           val extraConfigs = Map(


### PR DESCRIPTION
## Which issue does this PR close?

Part of #5363. This covers checklist items 3, 4, 8 and 9 of that epic; the epic stays open.

## Rationale for this change

`runExpressionBenchmark` in `CometBenchmarkBase` backs 27 benchmark suites. Four defects make its output untrustworthy, and they are worth fixing before the larger harness rework in #5363 so that later results can be compared against something sound.

**Constant folding was excluded for the Comet arm only.** `cometExecConfigs` set `spark.sql.optimizer.excludedRules` to `ConstantFolding`; the Spark case ran with folding enabled. For `select space(2) from parquetV1Table` in `CometStringExpressionBenchmark`, the Spark plan was:

```
*(1) Project [   AS space(2)#1366]
```

a folded literal doing no per-row work, while Comet evaluated `space(2)` for every row. That row reported a Comet regression that does not exist. The conf was also assigned rather than appended, clobbering any pre-existing exclusions.

**Nothing checked that the benchmarked expression survived optimization.** Rules that are not excluded, such as `SimplifyCasts` on a no-op cast, can remove the expression entirely and leave a case that measures only the scan.

**The not-fully-native warning went to `println`.** `Benchmark(output = output)` writes the results table to the `.txt`, but the warning only reached the console, so a reader of a results table cannot tell that a row labelled "Comet" actually ran on Spark.

**Table data came from an unseeded `scala.util.Random`,** so runs are not comparable. This is not only cosmetic: `CometStringExpressionBenchmark` derives `REPEAT(CAST(value AS STRING), 10)` from it, so `lpad(c1, 150, 'x')` is sometimes padding and sometimes truncating.

## What changes are included in this PR?

All changes are in `CometBenchmarkBase.scala`. No call sites change.

- `spark.sql.optimizer.excludedRules` is now built once and applied to both arms, appending to the existing value rather than overwriting it.
- A structural check warns when the Spark baseline plan does no work beyond scanning and projecting bare attributes or literals. Any other node counts as work, so the join and aggregate suites, which legitimately project bare attributes, are unaffected.
- Both that warning and the existing not-fully-native warning go through a helper that writes to `output` as well as the console, so they land in the results file directly above the affected table.
- The base table is generated from a SplitMix64 mix of the row id instead of `Random.nextLong()`. Seeding a driver-side `Random` would not have worked, since the closure runs per row on the executor. The helper lives in a companion object because referencing a trait method from a Dataset closure captures `this`, which is not serializable.

Two things reviewers may want to weigh in on:

- The checks warn rather than fail. Failing would block regenerating results for suites that currently fall back, which later items in #5363 address.
- The plan check runs the Spark arm once, untimed, before benchmarking. Previously only the Comet arm was pre-run. This costs an extra run per case but warms both arms symmetrically.

Results files are not regenerated here. The final item of #5363 regenerates them once, after the baseline-case and aggregate-sink work lands.

## How are these changes tested?

Benchmarks do not run in CI, so this was verified by running them locally. Compiles clean under the `spark-4.1`, `spark-3.5` and `spark-3.4` profiles.

- **Reproducibility.** `SELECT sum(hash(value)), count(*)` over the generated table returned `sum=-293787312920 count=65536` on three independent runs across JVM restarts.
- **The `space(2)` fix.** With folding excluded on both arms the Spark plan becomes `*(1) Project [space(2) AS space(2)#1367]`, evaluated per row, rather than the folded literal above.
- **Both warning paths.** Exercised with a temporary suite containing a bare-column projection and a case with `spark.comet.exec.project.enabled=false`. Both warnings appeared in the generated `.txt` above the correct table, with the offending plan. A control case using `abs(c1)` produced no warning. The temporary suite was removed.
- **No false positives.** `CometStringExpressionBenchmark` (31 expressions), `CometCastNumericToNumericBenchmark` and `CometPredicateExpressionBenchmark` were run in full. None produced a trivial-plan warning.

Running the suites with the warnings visible surfaced fallbacks that were previously console-only:

- `translate` in `CometStringExpressionBenchmark` falls back to a JVM `Project`.
- Eight `c_short` cases in `CometCastNumericToNumericBenchmark` do the same, for example `Project [cast(c_short#19 as int) AS c_short#528]`.

Those rows have been reporting Spark timings under a "Comet" label. I will file a separate issue rather than address them here.

Two corrections to the epic text that came out of this work, noted for whoever picks up the remaining items:

- #5363 refers throughout to "committed results files". `spark/benchmarks` is listed in `.gitignore`, so no Scala microbenchmark results are tracked in git; the only committed benchmark results are the TPC JSON files under `benchmarks/results/`. The `.txt` files are local artifacts pasted into PRs and issues by hand, which is where a console-only warning does its damage.
- The epic expects the plan assertion to catch the `In` predicate in `CometPredicateExpressionBenchmark`. It does not, and cannot: Spark retains `FilterExec` above the Parquet scan even when the filter is pushed down, so that plan contains real work. Confirmed by running the suite. Moving the `In` into the SELECT list remains a separate manual fix.
