### PR TITLE
test: report expression cost against a scan-and-transfer baseline [WIP / experimental]

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -369,6 +369,7 @@ jobs:
               org.apache.spark.sql.comet.CometDecimalPromotionSuite
               org.apache.spark.sql.comet.CometScanWithPlanDataSuite
               org.apache.spark.sql.comet.util.UtilsSuite
+              org.apache.spark.sql.benchmark.BenchmarkTableSuite
               org.apache.comet.vector.NativeUtilSuite
               org.apache.comet.objectstore.NativeConfigSuite
               org.apache.spark.sql.CometToPrettyStringSuite

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -185,6 +185,7 @@ jobs:
               org.apache.spark.sql.comet.CometDecimalPromotionSuite
               org.apache.spark.sql.comet.CometScanWithPlanDataSuite
               org.apache.spark.sql.comet.util.UtilsSuite
+              org.apache.spark.sql.benchmark.BenchmarkTableSuite
               org.apache.comet.vector.NativeUtilSuite
               org.apache.comet.objectstore.NativeConfigSuite
               org.apache.spark.sql.CometToPrettyStringSuite

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/BenchmarkTable.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/BenchmarkTable.scala
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.benchmark
+
+import org.apache.spark.benchmark.Benchmark
+
+/**
+ * One measured arm of a benchmark, with the scan-plus-row-conversion floor it should be read
+ * against.
+ *
+ * @param name
+ *   the arm, e.g. "Spark" or "Comet"
+ * @param total
+ *   the whole query, including scan and result transfer
+ * @param baseline
+ *   the same scan projecting its raw columns, or None when no baseline could be derived
+ */
+case class BenchmarkRow(name: String, total: Benchmark.Result, baseline: Option[Benchmark.Result])
+
+/**
+ * Renders benchmark results as a table that separates expression cost from the scan and result
+ * transfer surrounding it.
+ *
+ * Spark's `Benchmark.run` cannot express this: it computes results from its own case list,
+ * accepts no precomputed `Result`, and has nowhere to put a derived column. This renderer
+ * consumes the `Result` values that `Benchmark.measure` returns, so measurement still uses
+ * Spark's warmup, iteration and stdev logic.
+ *
+ * `render` is pure, which is what makes the column rules testable without a `SparkSession`.
+ */
+object BenchmarkTable {
+
+  /**
+   * The cost attributable to the expression, or None when it cannot be told apart from
+   * measurement noise.
+   *
+   * A difference smaller than the combined standard deviations is not evidence of anything, and a
+   * negative difference means the baseline happened to run slower than the query it is a floor
+   * for. Both are reported as "below the measurement floor" rather than as a number, because a
+   * number invites a conclusion the data does not support.
+   */
+  def exprMs(row: BenchmarkRow): Option[Double] = row.baseline.flatMap { baseline =>
+    val diff = row.total.bestMs - baseline.bestMs
+    if (diff > row.total.stdevMs + baseline.stdevMs) Some(diff) else None
+  }
+
+  def render(
+      title: String,
+      cardinality: Long,
+      rows: Seq[BenchmarkRow],
+      baselineQuery: Option[String] = None): String = {
+    require(rows.nonEmpty, "a benchmark table needs at least one row")
+
+    val exprs = rows.map(exprMs)
+    // Ratios are only comparable when every arm has an expression cost. Otherwise fall back to the
+    // contaminated total, and say so in the header so nobody reads it as an expression ratio.
+    val onExpr = exprs.forall(_.isDefined)
+    val reference = if (onExpr) exprs.head.get else rows.head.total.bestMs
+    val relativeHeader = if (onExpr) "Relative(expr)" else "Relative(total)"
+
+    val nameWidth = math.max(40, rows.map(_.name.length).max)
+    val format = s"%-${nameWidth}s %12s %11s %14s %11s %16s"
+
+    val out = new StringBuilder
+    out.append(Benchmark.getJVMOSInfo()).append('\n')
+    out.append(Benchmark.getProcessorName()).append('\n')
+    baselineQuery.foreach(query => out.append(s"baseline: $query\n"))
+    out.append(
+      format.format(
+        s"$title ($cardinality rows):",
+        "Best(ms)",
+        "Stdev(ms)",
+        "Baseline(ms)",
+        "Expr(ms)",
+        relativeHeader))
+    out.append('\n')
+    out.append("-" * (nameWidth + 70)).append('\n')
+
+    rows.zip(exprs).foreach { case (row, expr) =>
+      // Every row's ratio must be over the same quantity as `reference`. Using a row's expression
+      // cost while the reference is a total would divide two different things.
+      val relative = if (onExpr) expr.get else row.total.bestMs
+      out.append(
+        format.format(
+          row.name,
+          "%.1f".format(row.total.bestMs),
+          "%.1f".format(row.total.stdevMs),
+          row.baseline.map(b => "%.1f".format(b.bestMs)).getOrElse("-"),
+          expr.map("%.1f".format(_)).getOrElse("-"),
+          "%.1fX".format(reference / relative)))
+      out.append('\n')
+    }
+
+    if (exprs.exists(_.isEmpty)) {
+      out.append(footnote(rows, exprs)).append('\n')
+    }
+    out.toString
+  }
+
+  private def footnote(rows: Seq[BenchmarkRow], exprs: Seq[Option[Double]]): String = {
+    val noBaseline = rows.zip(exprs).exists { case (row, _) => row.baseline.isEmpty }
+    val belowFloor = rows.zip(exprs).exists { case (row, expr) =>
+      row.baseline.isDefined && expr.isEmpty
+    }
+    val reasons = Seq(
+      if (noBaseline) Some("no single-table baseline could be derived for this query") else None,
+      if (belowFloor) Some("the expression cost is below the measurement floor")
+      else None).flatten
+    s"[-] ${reasons.mkString("; ")}"
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/BenchmarkTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/BenchmarkTableSuite.scala
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.benchmark
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.benchmark.Benchmark
+
+class BenchmarkTableSuite extends AnyFunSuite {
+
+  /** `Result(avgMs, bestRate, bestMs, stdevMs)`. Only bestMs and stdevMs are rendered. */
+  private def result(bestMs: Double, stdevMs: Double = 0.1): Benchmark.Result =
+    Benchmark.Result(bestMs, 0.0, bestMs, stdevMs)
+
+  private def row(name: String, bestMs: Double, baselineMs: Double, stdevMs: Double = 0.1) =
+    BenchmarkRow(name, result(bestMs, stdevMs), Some(result(baselineMs, stdevMs)))
+
+  /** The measured rows: everything after the rule, excluding the trailing footnote. */
+  private def dataLines(table: String): Seq[String] =
+    table.linesIterator.toSeq
+      .dropWhile(!_.startsWith("-"))
+      .drop(1)
+      .filter(line => line.trim.nonEmpty && !line.startsWith("[-]"))
+
+  private def assertClose(actual: Option[Double], expected: Double): Unit =
+    assert(
+      actual.exists(v => math.abs(v - expected) < 1e-9),
+      s"$actual was not close to $expected")
+
+  test("expression cost is the total minus the baseline") {
+    assertClose(BenchmarkTable.exprMs(row("Spark", bestMs = 9.0, baselineMs = 8.1)), 0.9)
+  }
+
+  test("relative is computed on expression cost when every arm has one") {
+    // Spark spends 4.0ms on the expression, Comet 2.0ms, so Comet is 2x on the expression even
+    // though the totals are only 1.2x apart.
+    val table = BenchmarkTable.render(
+      "space",
+      1000,
+      Seq(row("Spark", bestMs = 24.0, baselineMs = 20.0), row("Comet", bestMs = 20.0, 18.0)))
+
+    assert(table.contains("Relative(expr)"))
+    val Seq(spark, comet) = dataLines(table)
+    assert(spark.contains("4.0") && spark.endsWith("1.0X"))
+    assert(comet.contains("2.0") && comet.endsWith("2.0X"))
+  }
+
+  test("a missing baseline blanks the derived columns and falls back to relative on total") {
+    val table = BenchmarkTable.render(
+      "inner join",
+      1000,
+      Seq(BenchmarkRow("Spark", result(20.0), None), BenchmarkRow("Comet", result(10.0), None)))
+
+    assert(table.contains("Relative(total)"))
+    val Seq(spark, comet) = dataLines(table)
+    // Baseline and Expr blank; relative still reports the 2x on the total.
+    assert(spark.contains("-") && spark.endsWith("1.0X"))
+    assert(comet.endsWith("2.0X"))
+    assert(table.contains("no single-table baseline could be derived"))
+  }
+
+  test("when only one arm has an expression cost, every ratio is over the total") {
+    // Regression: an earlier version used the row's own expression cost when it had one, so a
+    // table headed Relative(total) divided one arm's total by the other arm's expression cost.
+    val table = BenchmarkTable.render(
+      "levenshtein",
+      1024,
+      Seq(
+        // Spark's 2.5ms difference is lost in a combined stdev of 2.6ms.
+        row("Spark", bestMs = 15.1, baselineMs = 12.6, stdevMs = 1.3),
+        row("Comet", bestMs = 35.4, baselineMs = 8.6, stdevMs = 0.9)))
+
+    assert(table.contains("Relative(total)"))
+    val Seq(spark, comet) = dataLines(table)
+    assert(spark.endsWith("1.0X"))
+    // 15.1 / 35.4 = 0.43, not 15.1 / 26.8 = 0.56.
+    assert(comet.endsWith("0.4X"), comet)
+  }
+
+  test("a negative expression cost is blanked rather than reported") {
+    // The baseline ran slower than the query it is a floor for, which is noise, not a negative cost.
+    assert(BenchmarkTable.exprMs(row("Spark", bestMs = 8.0, baselineMs = 9.0)).isEmpty)
+
+    val table = BenchmarkTable.render(
+      "length",
+      1000,
+      Seq(row("Spark", bestMs = 8.0, baselineMs = 9.0), row("Comet", bestMs = 7.0, 6.0)))
+    assert(table.contains("the expression cost is below the measurement floor"))
+    assert(table.contains("Relative(total)"))
+  }
+
+  test("an expression cost within combined stdev of zero is blanked") {
+    // diff of 0.5ms against stdevs summing to 0.6ms is not evidence of anything.
+    assert(
+      BenchmarkTable.exprMs(row("Spark", bestMs = 8.5, baselineMs = 8.0, stdevMs = 0.3)).isEmpty)
+    // The same 0.5ms diff is meaningful once the measurement is tighter.
+    assertClose(
+      BenchmarkTable.exprMs(row("Spark", bestMs = 8.5, baselineMs = 8.0, stdevMs = 0.1)),
+      0.5)
+  }
+
+  test("the baseline query is shown so a reader can audit what the floor measured") {
+    val table = BenchmarkTable.render(
+      "abs",
+      1000,
+      Seq(row("Spark", bestMs = 9.0, baselineMs = 8.0)),
+      baselineQuery = Some("SELECT c1 FROM parquetV1Table"))
+    assert(table.contains("baseline: SELECT c1 FROM parquetV1Table"))
+  }
+
+  test("the row count is carried in the title") {
+    val table =
+      BenchmarkTable.render("abs", 1024 * 1024, Seq(row("Spark", bestMs = 9.0, baselineMs = 8.0)))
+    assert(table.contains("abs (1048576 rows):"))
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
@@ -29,7 +29,7 @@ import org.apache.parquet.crypto.keytools.mocks.InMemoryKMS
 import org.apache.spark.SparkConf
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, Literal}
 import org.apache.spark.sql.catalyst.optimizer.ConstantFolding
 import org.apache.spark.sql.comet.CometPlanChecker
 import org.apache.spark.sql.comet.util.Utils
@@ -157,6 +157,16 @@ trait CometBenchmarkBase
             |likely removed by the optimizer.
             |Spark plan:""".stripMargin + "\n" + plan.treeString)
       }
+      val rowInvariant = rowInvariantProjections(plan)
+      if (rowInvariant.nonEmpty) {
+        warn(
+          benchmark,
+          s"""WARNING: these projections reference no input column, so their value is the same
+             |for every row: ${rowInvariant.mkString(", ")}
+             |An engine may evaluate them once per batch and broadcast the result rather than
+             |per row, so the two arms are not necessarily doing comparable work. Benchmark the
+             |expression over a column instead.""".stripMargin)
+      }
     }
 
     // Check that the plan is fully Comet native before running the benchmark. Unlike the check
@@ -207,16 +217,35 @@ trait CometBenchmarkBase
    * aggregates and filters are never reported as trivial even when they project bare attributes.
    */
   private def isTrivialPlan(plan: SparkPlan): Boolean = !plan.exists {
-    case p: ProjectExec =>
-      p.projectList.exists {
-        case _: AttributeReference | _: Literal => false
-        case Alias(_: AttributeReference | _: Literal, _) => false
-        case _ => true
-      }
+    case p: ProjectExec => p.projectList.exists(expr => !isTrivialExpr(expr))
     case _: ColumnarToRowExec | _: WholeStageCodegenExec | _: InputAdapter | _: LeafExecNode =>
       false
     case _ => true
   }
+
+  /** A projection that copies a column or emits a constant, doing no per-row work. */
+  private def isTrivialExpr(expr: Expression): Boolean = expr match {
+    case _: AttributeReference | _: Literal => true
+    case Alias(_: AttributeReference | _: Literal, _) => true
+    case _ => false
+  }
+
+  /**
+   * Projections whose value is the same for every row, because they reference no input column.
+   *
+   * An engine is free to evaluate these once per batch and broadcast the result, and engines
+   * differ on whether they do. Comet's native `space` takes a `ColumnarValue::Scalar` and builds
+   * one string per batch, while Spark's `StringSpace` calls `UTF8String.blankString` per row. The
+   * two plans look identical, so nothing else here can tell them apart.
+   *
+   * Nondeterministic expressions are excluded: `rand()` also references no column but genuinely
+   * evaluates per row.
+   */
+  private def rowInvariantProjections(plan: SparkPlan): Seq[Expression] =
+    plan
+      .collect { case p: ProjectExec => p }
+      .flatMap(_.projectList)
+      .filter(expr => expr.references.isEmpty && expr.deterministic && !isTrivialExpr(expr))
 
   /**
    * Writes a warning to the benchmark results file as well as the console. `Benchmark.out` tees

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
@@ -23,6 +23,8 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import java.util.Base64
 
+import scala.collection.mutable
+
 import org.apache.parquet.crypto.DecryptionPropertiesFactory
 import org.apache.parquet.crypto.keytools.{KeyToolkit, PropertiesDrivenCryptoFactory}
 import org.apache.parquet.crypto.keytools.mocks.InMemoryKMS
@@ -31,6 +33,7 @@ import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, Literal}
 import org.apache.spark.sql.catalyst.optimizer.ConstantFolding
+import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias
 import org.apache.spark.sql.comet.CometPlanChecker
 import org.apache.spark.sql.comet.util.Utils
 import org.apache.spark.sql.execution.{ColumnarToRowExec, InputAdapter, LeafExecNode, ProjectExec, SparkPlan, WholeStageCodegenExec}
@@ -144,11 +147,15 @@ trait CometBenchmarkBase
       CometConf.COMET_ENABLED.key -> "true",
       CometConf.COMET_EXEC_ENABLED.key -> "true") ++ extraCometConfigs
 
-    // Check that the benchmarked expression survives optimization into the Spark baseline plan.
-    // The query is not executed: before execution `stripAQEPlan` yields the initial physical
-    // plan, which already carries the projections this check inspects.
+    // Derive the scan-plus-row-conversion floor, and check that the benchmarked expression
+    // survives optimization into the Spark baseline plan. The query is not executed: before
+    // execution `stripAQEPlan` yields the initial physical plan, which already carries the
+    // projections this check inspects.
+    var baselineQuery: Option[String] = None
     withSQLConf(sparkConfigs: _*) {
-      val plan = stripAQEPlan(spark.sql(query).queryExecution.executedPlan)
+      val df = spark.sql(query)
+      baselineQuery = deriveBaselineQuery(df)
+      val plan = stripAQEPlan(df.queryExecution.executedPlan)
       if (isTrivialPlan(plan)) {
         warn(
           benchmark,
@@ -186,19 +193,66 @@ trait CometBenchmarkBase
       }
     }
 
-    benchmark.addCase("Spark") { _ =>
-      withSQLConf(sparkConfigs: _*) {
-        spark.sql(query).noop()
+    val rows = Seq("Spark" -> sparkConfigs, "Comet" -> cometConfigs).map { case (arm, configs) =>
+      val total = measure(benchmark, cardinality, configs)(spark.sql(query).noop())
+      val baseline = baselineQuery.map { baseline =>
+        baselineResults.getOrElseUpdate(
+          (baseline, configs),
+          measure(benchmark, cardinality, configs)(spark.sql(baseline).noop()))
       }
+      BenchmarkRow(arm, total, baseline)
     }
 
-    benchmark.addCase("Comet") { _ =>
-      withSQLConf(cometConfigs: _*) {
-        spark.sql(query).noop()
+    // `Benchmark.run` is deliberately not used: it renders from its own case list, so a cached
+    // baseline cannot appear as a row and there is nowhere to put a derived column.
+    benchmark.out.println(BenchmarkTable.render(name, cardinality, rows, baselineQuery))
+  }
+
+  /**
+   * The scan-plus-row-conversion floor is the same for every expression measured over the same
+   * columns of the same table, so it is measured once per (query, config) pair rather than once
+   * per benchmark. Without this, adding a baseline would roughly double total benchmark runtime.
+   */
+  private val baselineResults =
+    mutable.Map.empty[(String, Seq[(String, String)]), Benchmark.Result]
+
+  /**
+   * Runs `body` under `configs` and returns Spark's measurement of it, reusing `Benchmark`'s
+   * warmup, iteration and standard deviation logic.
+   */
+  private def measure(benchmark: Benchmark, cardinality: Long, configs: Seq[(String, String)])(
+      body: => Unit): Benchmark.Result = {
+    // `withSQLConf` returns Unit on Spark 3.5, so the result has to come back through a var.
+    var result: Benchmark.Result = null
+    withSQLConf(configs: _*) {
+      result = benchmark.measure(cardinality, 0) { timer =>
+        timer.startTiming()
+        body
+        timer.stopTiming()
       }
     }
+    result
+  }
 
-    benchmark.run()
+  /**
+   * The query measuring the floor for `df`: the same scan, projecting the columns it reads and
+   * doing no expression work. The optimized plan's leaf output is already column-pruned, so it is
+   * exactly what the real query scans.
+   *
+   * Defined only when the plan reads a single table. A join has two leaves and no single
+   * meaningful floor, so those benchmarks report totals instead.
+   */
+  private def deriveBaselineQuery(df: DataFrame): Option[String] = {
+    val leaves = df.queryExecution.optimizedPlan.collectLeaves
+    val aliases = df.queryExecution.analyzed.collect { case s: SubqueryAlias =>
+      s.identifier.name
+    }.distinct
+    val columns = leaves.headOption.map(_.output.map(name => s"`${name.name}`")).getOrElse(Nil)
+    if (leaves.size == 1 && aliases.size == 1 && columns.nonEmpty) {
+      Some(s"SELECT ${columns.mkString(", ")} FROM ${aliases.head}")
+    } else {
+      None
+    }
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
@@ -23,15 +23,15 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import java.util.Base64
 
-import scala.util.Random
-
 import org.apache.parquet.crypto.DecryptionPropertiesFactory
 import org.apache.parquet.crypto.keytools.{KeyToolkit, PropertiesDrivenCryptoFactory}
 import org.apache.parquet.crypto.keytools.mocks.InMemoryKMS
 import org.apache.spark.SparkConf
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, Literal}
 import org.apache.spark.sql.comet.CometPlanChecker
+import org.apache.spark.sql.execution.{ColumnarToRowExec, InputAdapter, LeafExecNode, ProjectExec, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
 import org.apache.spark.sql.internal.SQLConf
@@ -97,9 +97,13 @@ trait CometBenchmarkBase
       useDictionary: Boolean = false)(f: Int => Any): Unit = {
     withTempTable(tbl) {
       import spark.implicits._
+      // Derive the values from the row id with a pure function rather than a random number
+      // generator, so that results are comparable across runs. Seeding a driver-side `Random`
+      // would not work here: the closure runs per row on the executor.
       spark
         .range(values)
-        .map(_ => if (useDictionary) Random.nextLong() % 5 else Random.nextLong())
+        .map(i =>
+          if (useDictionary) CometBenchmarkBase.mix64(i) % 5 else CometBenchmarkBase.mix64(i))
         .createOrReplaceTempView(tbl)
       runBenchmark(benchmarkName)(f(values))
     }
@@ -125,48 +129,119 @@ trait CometBenchmarkBase
       extraCometConfigs: Map[String, String] = Map.empty): Unit = {
     val benchmark = new Benchmark(name, cardinality, output = output)
 
+    // Constant folding is excluded so that expressions over literal arguments are still evaluated
+    // per row. It must be excluded for both arms: if only Comet excludes it, Spark folds the
+    // expression away and does no per-row work, and the comparison is meaningless.
+    val sharedConfigs = Map(
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        excludedRulesWith("org.apache.spark.sql.catalyst.optimizer.ConstantFolding"))
+
+    val sparkConfigs = sharedConfigs ++ Map(CometConf.COMET_ENABLED.key -> "false")
+
+    val cometConfigs = sharedConfigs ++ Map(
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ENABLED.key -> "true") ++ extraCometConfigs
+
+    // Check that the benchmarked expression survives optimization into the Spark baseline plan.
+    withSQLConf(sparkConfigs.toSeq: _*) {
+      val df = spark.sql(query)
+      df.noop()
+      val plan = stripAQEPlan(df.queryExecution.executedPlan)
+      if (isTrivialPlan(plan)) {
+        emitWarning(
+          Seq(
+            "WARNING: the Spark baseline plan does no work beyond scanning and projecting",
+            "columns, so this case is not measuring an expression. The expression was most",
+            "likely removed by the optimizer.",
+            "Spark plan:",
+            plan.treeString))
+      }
+    }
+
+    // Check that the plan is fully Comet native before running the benchmark
+    withSQLConf(cometConfigs.toSeq: _*) {
+      val df = spark.sql(query)
+      df.noop()
+      val plan = stripAQEPlan(df.queryExecution.executedPlan)
+      findFirstNonCometOperator(plan).foreach { op =>
+        emitWarning(
+          Seq(
+            "WARNING: the Comet plan is NOT fully Comet native, so the Comet case below is",
+            "partly or wholly measuring Spark.",
+            s"First non-Comet operator: ${op.nodeName}",
+            "Comet plan:",
+            plan.treeString))
+      }
+    }
+
     benchmark.addCase("Spark") { _ =>
-      withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
+      withSQLConf(sparkConfigs.toSeq: _*) {
         spark.sql(query).noop()
       }
     }
 
-    val cometExecConfigs = Map(
-      CometConf.COMET_ENABLED.key -> "true",
-      CometConf.COMET_EXEC_ENABLED.key -> "true",
-      "spark.sql.optimizer.excludedRules" ->
-        "org.apache.spark.sql.catalyst.optimizer.ConstantFolding") ++ extraCometConfigs
-
-    // Check that the plan is fully Comet native before running the benchmark
-    withSQLConf(cometExecConfigs.toSeq: _*) {
-      val df = spark.sql(query)
-      df.noop()
-      val plan = stripAQEPlan(df.queryExecution.executedPlan)
-      findFirstNonCometOperator(plan) match {
-        case Some(op) =>
-          // scalastyle:off println
-          println()
-          println("=" * 80)
-          println("WARNING: Benchmark plan is NOT fully Comet native!")
-          println(s"First non-Comet operator: ${op.nodeName}")
-          println("=" * 80)
-          println("Query plan:")
-          println(plan.treeString)
-          println("=" * 80)
-          println()
-        // scalastyle:on println
-        case None =>
-        // All operators are Comet native, no warning needed
-      }
-    }
-
     benchmark.addCase("Comet") { _ =>
-      withSQLConf(cometExecConfigs.toSeq: _*) {
+      withSQLConf(cometConfigs.toSeq: _*) {
         spark.sql(query).noop()
       }
     }
 
     benchmark.run()
+  }
+
+  /**
+   * Returns the value of `spark.sql.optimizer.excludedRules` with `rules` appended, so that
+   * benchmark-specific exclusions do not clobber exclusions already configured by the caller.
+   */
+  private def excludedRulesWith(rules: String*): String =
+    (spark.conf
+      .get(SQLConf.OPTIMIZER_EXCLUDED_RULES.key, "")
+      .split(",")
+      .map(_.trim)
+      .filter(_.nonEmpty) ++ rules).distinct.mkString(",")
+
+  /**
+   * Returns true if the plan does nothing but scan and emit columns, which means the benchmarked
+   * expression was removed by the optimizer and the case measures nothing.
+   *
+   * Any node other than a scan, projection or row conversion counts as real work, so joins,
+   * aggregates and filters are never reported as trivial even when they project bare attributes.
+   */
+  private def isTrivialPlan(plan: SparkPlan): Boolean = {
+    val doesWork = plan.exists {
+      case _: ProjectExec | _: ColumnarToRowExec | _: WholeStageCodegenExec | _: InputAdapter =>
+        false
+      case _: LeafExecNode => false
+      case _ => true
+    }
+    if (doesWork) {
+      return false
+    }
+    plan.collect { case p: ProjectExec => p }.forall {
+      _.projectList.map(unwrapAlias).forall {
+        case _: AttributeReference | _: Literal => true
+        case _ => false
+      }
+    }
+  }
+
+  private def unwrapAlias(expr: Expression): Expression = expr match {
+    case a: Alias => a.child
+    case other => other
+  }
+
+  /**
+   * Writes a warning to the benchmark results file as well as the console. `println` alone
+   * reaches only the console, so a reader of a results file, or of a results table pasted into a
+   * PR, cannot tell that a case did not measure what its label claims.
+   */
+  private def emitWarning(lines: Seq[String]): Unit = {
+    val border = "=" * 80
+    val text = (Seq("", border) ++ lines ++ Seq(border, "")).mkString("\n")
+    output.foreach(_.write(text.getBytes(StandardCharsets.UTF_8)))
+    // scalastyle:off println
+    println(text)
+    // scalastyle:on println
   }
 
   protected def addParquetScanCases(
@@ -289,5 +364,21 @@ trait CometBenchmarkBase
       .range(values)
       .map(_ % div)
       .select((($"value" - 500) / 100.0) cast decimal as Symbol("dec"))
+  }
+}
+
+object CometBenchmarkBase {
+
+  /**
+   * SplitMix64 finalizer, used to turn a row id into a well distributed pseudo-random value.
+   *
+   * This lives in the companion object rather than the trait because referencing a trait method
+   * from a Dataset closure captures `this`, which is not serializable.
+   */
+  def mix64(value: Long): Long = {
+    var z = value + 0x9e3779b97f4a7c15L
+    z = (z ^ (z >>> 30)) * 0xbf58476d1ce4e5b9L
+    z = (z ^ (z >>> 27)) * 0x94d049bb133111ebL
+    z ^ (z >>> 31)
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometBenchmarkBase.scala
@@ -29,8 +29,10 @@ import org.apache.parquet.crypto.keytools.mocks.InMemoryKMS
 import org.apache.spark.SparkConf
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Literal}
+import org.apache.spark.sql.catalyst.optimizer.ConstantFolding
 import org.apache.spark.sql.comet.CometPlanChecker
+import org.apache.spark.sql.comet.util.Utils
 import org.apache.spark.sql.execution.{ColumnarToRowExec, InputAdapter, LeafExecNode, ProjectExec, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
@@ -132,56 +134,56 @@ trait CometBenchmarkBase
     // Constant folding is excluded so that expressions over literal arguments are still evaluated
     // per row. It must be excluded for both arms: if only Comet excludes it, Spark folds the
     // expression away and does no per-row work, and the comparison is meaningless.
-    val sharedConfigs = Map(
-      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-        excludedRulesWith("org.apache.spark.sql.catalyst.optimizer.ConstantFolding"))
+    val noConstantFolding =
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> excludedRulesWith(ConstantFolding.ruleName)
 
-    val sparkConfigs = sharedConfigs ++ Map(CometConf.COMET_ENABLED.key -> "false")
+    val sparkConfigs = Seq(noConstantFolding, CometConf.COMET_ENABLED.key -> "false")
 
-    val cometConfigs = sharedConfigs ++ Map(
+    val cometConfigs = Seq(
+      noConstantFolding,
       CometConf.COMET_ENABLED.key -> "true",
       CometConf.COMET_EXEC_ENABLED.key -> "true") ++ extraCometConfigs
 
     // Check that the benchmarked expression survives optimization into the Spark baseline plan.
-    withSQLConf(sparkConfigs.toSeq: _*) {
-      val df = spark.sql(query)
-      df.noop()
-      val plan = stripAQEPlan(df.queryExecution.executedPlan)
+    // The query is not executed: before execution `stripAQEPlan` yields the initial physical
+    // plan, which already carries the projections this check inspects.
+    withSQLConf(sparkConfigs: _*) {
+      val plan = stripAQEPlan(spark.sql(query).queryExecution.executedPlan)
       if (isTrivialPlan(plan)) {
-        emitWarning(
-          Seq(
-            "WARNING: the Spark baseline plan does no work beyond scanning and projecting",
-            "columns, so this case is not measuring an expression. The expression was most",
-            "likely removed by the optimizer.",
-            "Spark plan:",
-            plan.treeString))
+        warn(
+          benchmark,
+          """WARNING: the Spark baseline plan does no work beyond scanning and projecting
+            |columns, so this case is not measuring an expression. The expression was most
+            |likely removed by the optimizer.
+            |Spark plan:""".stripMargin + "\n" + plan.treeString)
       }
     }
 
-    // Check that the plan is fully Comet native before running the benchmark
-    withSQLConf(cometConfigs.toSeq: _*) {
+    // Check that the plan is fully Comet native before running the benchmark. Unlike the check
+    // above this one does execute the query, because AQE can re-plan a join after the first
+    // stage completes and the Comet operators are what we are checking for.
+    withSQLConf(cometConfigs: _*) {
       val df = spark.sql(query)
       df.noop()
       val plan = stripAQEPlan(df.queryExecution.executedPlan)
       findFirstNonCometOperator(plan).foreach { op =>
-        emitWarning(
-          Seq(
-            "WARNING: the Comet plan is NOT fully Comet native, so the Comet case below is",
-            "partly or wholly measuring Spark.",
-            s"First non-Comet operator: ${op.nodeName}",
-            "Comet plan:",
-            plan.treeString))
+        warn(
+          benchmark,
+          s"""WARNING: the Comet plan is NOT fully Comet native, so the Comet case below is
+             |partly or wholly measuring Spark.
+             |First non-Comet operator: ${op.nodeName}
+             |Comet plan:""".stripMargin + "\n" + plan.treeString)
       }
     }
 
     benchmark.addCase("Spark") { _ =>
-      withSQLConf(sparkConfigs.toSeq: _*) {
+      withSQLConf(sparkConfigs: _*) {
         spark.sql(query).noop()
       }
     }
 
     benchmark.addCase("Comet") { _ =>
-      withSQLConf(cometConfigs.toSeq: _*) {
+      withSQLConf(cometConfigs: _*) {
         spark.sql(query).noop()
       }
     }
@@ -190,15 +192,12 @@ trait CometBenchmarkBase
   }
 
   /**
-   * Returns the value of `spark.sql.optimizer.excludedRules` with `rules` appended, so that
+   * Returns the value of `spark.sql.optimizer.excludedRules` with `rule` appended, so that
    * benchmark-specific exclusions do not clobber exclusions already configured by the caller.
    */
-  private def excludedRulesWith(rules: String*): String =
-    (spark.conf
-      .get(SQLConf.OPTIMIZER_EXCLUDED_RULES.key, "")
-      .split(",")
-      .map(_.trim)
-      .filter(_.nonEmpty) ++ rules).distinct.mkString(",")
+  private def excludedRulesWith(rule: String): String =
+    (Utils.stringToSeq(spark.conf.get(SQLConf.OPTIMIZER_EXCLUDED_RULES.key, "")) :+ rule).distinct
+      .mkString(",")
 
   /**
    * Returns true if the plan does nothing but scan and emit columns, which means the benchmarked
@@ -207,41 +206,26 @@ trait CometBenchmarkBase
    * Any node other than a scan, projection or row conversion counts as real work, so joins,
    * aggregates and filters are never reported as trivial even when they project bare attributes.
    */
-  private def isTrivialPlan(plan: SparkPlan): Boolean = {
-    val doesWork = plan.exists {
-      case _: ProjectExec | _: ColumnarToRowExec | _: WholeStageCodegenExec | _: InputAdapter =>
-        false
-      case _: LeafExecNode => false
-      case _ => true
-    }
-    if (doesWork) {
-      return false
-    }
-    plan.collect { case p: ProjectExec => p }.forall {
-      _.projectList.map(unwrapAlias).forall {
-        case _: AttributeReference | _: Literal => true
-        case _ => false
+  private def isTrivialPlan(plan: SparkPlan): Boolean = !plan.exists {
+    case p: ProjectExec =>
+      p.projectList.exists {
+        case _: AttributeReference | _: Literal => false
+        case Alias(_: AttributeReference | _: Literal, _) => false
+        case _ => true
       }
-    }
-  }
-
-  private def unwrapAlias(expr: Expression): Expression = expr match {
-    case a: Alias => a.child
-    case other => other
+    case _: ColumnarToRowExec | _: WholeStageCodegenExec | _: InputAdapter | _: LeafExecNode =>
+      false
+    case _ => true
   }
 
   /**
-   * Writes a warning to the benchmark results file as well as the console. `println` alone
-   * reaches only the console, so a reader of a results file, or of a results table pasted into a
-   * PR, cannot tell that a case did not measure what its label claims.
+   * Writes a warning to the benchmark results file as well as the console. `Benchmark.out` tees
+   * the two, and writing through it keeps the warning ordered against the results table that
+   * `Benchmark.run` writes to the same stream.
    */
-  private def emitWarning(lines: Seq[String]): Unit = {
+  private def warn(benchmark: Benchmark, message: String): Unit = {
     val border = "=" * 80
-    val text = (Seq("", border) ++ lines ++ Seq(border, "")).mkString("\n")
-    output.foreach(_.write(text.getBytes(StandardCharsets.UTF_8)))
-    // scalastyle:off println
-    println(text)
-    // scalastyle:on println
+    benchmark.out.println(s"\n$border\n$message\n$border")
   }
 
   protected def addParquetScanCases(

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometStringExpressionBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometStringExpressionBenchmark.scala
@@ -75,7 +75,11 @@ object CometStringExpressionBenchmark extends CometBenchmarkBase {
     StringExprConfig("rlike", "select c1 rlike '[0-9]+' from parquetV1Table"),
     StringExprConfig("rpad", "select rpad(c1, 150, 'x') from parquetV1Table"),
     StringExprConfig("rtrim", "select rtrim(c1) from parquetV1Table"),
-    StringExprConfig("space", "select space(2) from parquetV1Table"),
+    // `space` takes its length from a column rather than a literal. Given a literal, Comet's
+    // native `space` receives a `ColumnarValue::Scalar`, builds one string per batch and lets
+    // DataFusion broadcast it, while Spark's `StringSpace` calls `UTF8String.blankString` once
+    // per row. The plans look symmetric but the work is not.
+    StringExprConfig("space", "select space(c2) from parquetV1Table"),
     StringExprConfig("startswith", "select startswith(c1, '1') from parquetV1Table"),
     StringExprConfig("substring", "select substring(c1, 1, 100) from parquetV1Table"),
     StringExprConfig("translate", "select translate(c1, '123456', 'aBcDeF') from parquetV1Table"),
@@ -86,9 +90,14 @@ object CometStringExpressionBenchmark extends CometBenchmarkBase {
     runBenchmarkWithTable("String expressions", 1024) { v =>
       withTempPath { dir =>
         withTempTable("parquetV1Table") {
+          // c2 gives expressions that take a length or a count something to vary over per row.
+          // `pmod` keeps it non-negative, so `space(c2)` builds a string on every row rather
+          // than returning empty for the negative half of the input.
           prepareTable(
             dir,
-            spark.sql(s"SELECT REPEAT(CAST(value AS STRING), 10) AS c1 FROM $tbl"))
+            spark.sql(
+              s"SELECT REPEAT(CAST(value AS STRING), 10) AS c1," +
+                s" CAST(PMOD(value, 200) AS INT) AS c2 FROM $tbl"))
 
           val extraConfigs = Map(
             CometConf.getExprAllowIncompatConfigKey("Upper") -> "true",


### PR DESCRIPTION
## Which issue does this PR close?

Part of #5363, covering checklist item 1. The epic stays open.

**Stacked on #5371.** That PR is the first two commits here; review and merge it first. This PR's own change is the third commit, `test: report expression cost against a scan-and-transfer baseline`.

## Rationale for this change

Every timed case in `runExpressionBenchmark` is `spark.sql("SELECT expr(c1) FROM t").noop()`, so the timed region contains a Parquet scan and a columnar-to-row conversion in addition to the expression. The two arms use different readers, Spark's vectorized reader against Comet's native scan, so the contamination does not cancel: the reported ratio converges on the *scan* ratio for any expression cheaper than the scan. Nothing in the results file told a reader how much of the number was floor.

## What changes are included in this PR?

**Measure the floor and subtract it.** For a single-table query the baseline is the optimized plan's leaf output, which is already column-pruned, projected straight back out. `SELECT abs(c1) FROM parquetV1Table` yields `SELECT c1 FROM parquetV1Table`: the same scan, the same columns, no expression work. The derived query is printed above each table so a reader can audit what the floor actually measured.

**Cache it.** The baseline is measured once per `(query, config)` pair. The 31 tables in `CometStringExpressionBenchmark` share one measurement per arm rather than adding 31, and the whole suite runs in about 4.5 minutes. Without caching, adding two cases per table would roughly double total benchmark runtime; `CometCastNumericToNumericBenchmark` alone would go from about 9 minutes to about 18.

**Report through our own renderer.** `Benchmark.addCase`/`Benchmark.run` renders from its own case list, accepts no precomputed `Result`, and has nowhere to put a derived column, so a cached baseline can never appear in its output. Measurement still uses Spark's warmup, iteration and standard deviation logic via the public `Benchmark.measure`; only the rendering is ours.

```
OpenJDK 64-Bit Server VM 17.0.17+10 on Mac OS X 26.3.1
Apple M3 Ultra
baseline: SELECT `c1` FROM parquetv1table
levenshtein_threshold (1024 rows):           Best(ms)   Stdev(ms)   Baseline(ms)    Expr(ms)  Relative(total)
--------------------------------------------------------------------------------------------------------------
Spark                                            10.4         1.3           12.8           -             1.0X
Comet                                             8.8         1.0            6.7         2.1             1.2X
[-] the expression cost is below the measurement floor
```

A difference smaller than the combined standard deviations, or a negative one, is reported as below the measurement floor rather than as a number, because a number invites a conclusion the data does not support. Queries reading more than one table, which is the 13 join cases, get no baseline and fall back to totals. The `Relative` header names which quantity the ratio is over, so a total ratio is never misread as an expression ratio.

`BenchmarkTable.render` is a pure function over Spark's `Result` case class, so it needs no `SparkSession`. That makes the column rules unit-testable, which matters here: nothing in this area was testable before, and #5371 could only be verified by running benchmarks and reading the output by hand.

Spark's `Avg`, `Rate(M/s)` and `Per Row(ns)` columns are dropped to make room. `Avg` is redundant with `Best` plus `Stdev`, and both rate columns are derivable from `Best` and the row count now carried in the title.

This diverges in output format from the 13 suites that call `new Benchmark` directly, such as `CometReadBenchmark` and the TPC suites. That seems right rather than unfortunate: the expression suites are precisely the ones the epic says report the wrong number, so they should report a different one.

## How are these changes tested?

New `BenchmarkTableSuite`, 8 tests, running in CI and registered in both `pr_build_linux.yml` and `pr_build_macos.yml`:

- expression cost is total minus baseline, with `Relative` computed on it
- a missing baseline blanks the derived columns and falls back to `Relative` on total
- when only one arm has an expression cost, every ratio is over the total
- a negative expression cost is blanked, with the footnote
- a difference within the combined standard deviations is blanked, and the same difference is reported once the measurement is tighter
- the baseline query and the row count appear in the output

The third of those is a regression test. The first live run reported `levenshtein` as `0.6X` under a `Relative(total)` header, which was Spark's *total* divided by Comet's *expression cost*. It now reads `0.4X`.

Compiles under the `spark-4.1`, `spark-3.5` and `spark-3.4` profiles.

End to end, `CometStringExpressionBenchmark` and `CometHashJoinBenchmark` were run in full. The baseline is measured once per arm, confirmed by all 31 string tables reporting an identical baseline rather than 31 separately measured values. The join suite blanks the derived columns and prints the no-baseline footnote.

One substantive finding falls straight out of this, confirming the third bullet of Problem 2 in the epic: at 1024 rows, **all 31 string expressions are below the measurement floor**, with a Spark baseline of 12.8ms against totals in the 10-16ms range, and Comet's total frequently under its own baseline. That suite has been reporting noise. The harness now says so in the results file instead of printing a ratio. Raising the cardinality is item 5 of the epic and is left to a later PR.
