### PR TITLE
fix: canonicalize NaN in flat arrays_overlap float keys

### DIFF
--- a/native/spark-expr/src/array_funcs/arrays_overlap.rs
+++ b/native/spark-expr/src/array_funcs/arrays_overlap.rs
@@ -272,10 +272,9 @@ fn range_has_null(nulls: Option<&NullBuffer>, range: Range<usize>) -> bool {
     nulls.is_some_and(|n| n.null_count() > 0 && n.slice(range.start, range.len()).null_count() > 0)
 }
 
-/// Projects a native value onto a hashable key whose equality matches the Arrow compare kernels:
-/// the value itself for integral types, the bit pattern for floats. Arrow orders floats by total
-/// order rather than IEEE semantics (NaN equals NaN, and 0.0 does not equal -0.0), which is
-/// exactly bit equality.
+/// Projects a native value onto a Spark-compatible hashable key. Floating-point keys canonicalize
+/// every NaN representation while preserving the distinct bit patterns of positive and negative
+/// zero.
 trait OverlapKey: Copy {
     type Key: Hash + Eq + Copy;
 
@@ -299,7 +298,11 @@ impl OverlapKey for f32 {
     type Key = u32;
 
     fn overlap_key(self) -> u32 {
-        self.to_bits()
+        if self.is_nan() {
+            f32::NAN.to_bits()
+        } else {
+            self.to_bits()
+        }
     }
 }
 
@@ -307,7 +310,11 @@ impl OverlapKey for f64 {
     type Key = u64;
 
     fn overlap_key(self) -> u64 {
-        self.to_bits()
+        if self.is_nan() {
+            f64::NAN.to_bits()
+        } else {
+            self.to_bits()
+        }
     }
 }
 
@@ -551,6 +558,132 @@ mod tests {
         let result = result.as_any().downcast_ref::<BooleanArray>().unwrap();
         assert!(!result.value(0));
         assert!(result.is_valid(0));
+        Ok(())
+    }
+
+    #[test]
+    fn test_flat_float32_nan_payloads_and_signed_zero() -> Result<()> {
+        let positive_nan = f32::from_bits(0x7fc0_0001);
+        let negative_nan = f32::from_bits(0xffc0_0002);
+        let signaling_nan = f32::from_bits(0x7f80_0001);
+
+        let hash_nan_left = (1..=16)
+            .map(|value| Some(value as f32))
+            .chain([Some(positive_nan)])
+            .collect::<Vec<_>>();
+        let hash_nan_right = (17..=32)
+            .map(|value| Some(value as f32))
+            .chain([Some(negative_nan)])
+            .collect::<Vec<_>>();
+        let hash_zero_left = (1..=16)
+            .map(|value| Some(value as f32))
+            .chain([Some(0.0)])
+            .collect::<Vec<_>>();
+        let hash_zero_right = (17..=32)
+            .map(|value| Some(value as f32))
+            .chain([Some(-0.0)])
+            .collect::<Vec<_>>();
+
+        let left = ListArray::from_iter_primitive::<Float32Type, _, _>([
+            Some(vec![Some(positive_nan)]),
+            Some(vec![Some(negative_nan)]),
+            Some(vec![Some(signaling_nan)]),
+            Some(vec![Some(0.0)]),
+            Some(vec![Some(-0.0)]),
+            Some(vec![Some(positive_nan), None]),
+            Some(vec![Some(0.0), None]),
+            Some(hash_nan_left),
+            Some(hash_zero_left),
+        ]);
+        let right = ListArray::from_iter_primitive::<Float32Type, _, _>([
+            Some(vec![Some(f32::NAN)]),
+            Some(vec![Some(positive_nan)]),
+            Some(vec![Some(negative_nan)]),
+            Some(vec![Some(-0.0)]),
+            Some(vec![Some(0.0)]),
+            Some(vec![Some(negative_nan)]),
+            Some(vec![Some(-0.0)]),
+            Some(hash_nan_right),
+            Some(hash_zero_right),
+        ]);
+
+        let result = arrays_overlap_list::<i32>(&left, &right)?;
+        let result = result.as_any().downcast_ref::<BooleanArray>().unwrap();
+        let expected = BooleanArray::from(vec![
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(false),
+            Some(false),
+            Some(true),
+            None,
+            Some(true),
+            Some(false),
+        ]);
+        assert_eq!(result, &expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_flat_float64_nan_payloads_and_signed_zero() -> Result<()> {
+        let positive_nan = f64::from_bits(0x7ff8_0000_0000_0001);
+        let negative_nan = f64::from_bits(0xfff8_0000_0000_0002);
+        let signaling_nan = f64::from_bits(0x7ff0_0000_0000_0001);
+
+        let hash_nan_left = (1..=16)
+            .map(|value| Some(value as f64))
+            .chain([Some(positive_nan)])
+            .collect::<Vec<_>>();
+        let hash_nan_right = (17..=32)
+            .map(|value| Some(value as f64))
+            .chain([Some(negative_nan)])
+            .collect::<Vec<_>>();
+        let hash_zero_left = (1..=16)
+            .map(|value| Some(value as f64))
+            .chain([Some(0.0)])
+            .collect::<Vec<_>>();
+        let hash_zero_right = (17..=32)
+            .map(|value| Some(value as f64))
+            .chain([Some(-0.0)])
+            .collect::<Vec<_>>();
+
+        let left = ListArray::from_iter_primitive::<Float64Type, _, _>([
+            Some(vec![Some(positive_nan)]),
+            Some(vec![Some(negative_nan)]),
+            Some(vec![Some(signaling_nan)]),
+            Some(vec![Some(0.0)]),
+            Some(vec![Some(-0.0)]),
+            Some(vec![Some(positive_nan), None]),
+            Some(vec![Some(0.0), None]),
+            Some(hash_nan_left),
+            Some(hash_zero_left),
+        ]);
+        let right = ListArray::from_iter_primitive::<Float64Type, _, _>([
+            Some(vec![Some(f64::NAN)]),
+            Some(vec![Some(positive_nan)]),
+            Some(vec![Some(negative_nan)]),
+            Some(vec![Some(-0.0)]),
+            Some(vec![Some(0.0)]),
+            Some(vec![Some(negative_nan)]),
+            Some(vec![Some(-0.0)]),
+            Some(hash_nan_right),
+            Some(hash_zero_right),
+        ]);
+
+        let result = arrays_overlap_list::<i32>(&left, &right)?;
+        let result = result.as_any().downcast_ref::<BooleanArray>().unwrap();
+        let expected = BooleanArray::from(vec![
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(false),
+            Some(false),
+            Some(true),
+            None,
+            Some(true),
+            Some(false),
+        ]);
+        assert_eq!(result, &expected);
         Ok(())
     }
 

--- a/spark/src/test/resources/sql-tests/expressions/array/arrays_overlap.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/arrays_overlap.sql
@@ -122,6 +122,57 @@ INSERT INTO test_overlap_dbl VALUES (array(1.0, 2.0), array(2.0, 3.0)), (array(1
 query
 SELECT a, b, arrays_overlap(a, b) FROM test_overlap_dbl
 
+-- Flat FLOAT/DOUBLE NaNs must compare equal regardless of their sign or payload.
+-- Parquet canonicalizes NaNs, so negate a scanned column to produce a noncanonical
+-- NaN at execution time. String casts preserve the sign of the zero controls.
+statement
+CREATE TABLE test_overlap_floating_point(
+  id int, fl float, fr float, dl double, dr double
+) USING parquet
+
+statement
+INSERT INTO test_overlap_floating_point VALUES
+  (0, CAST('NaN' AS FLOAT), CAST('NaN' AS FLOAT), CAST('NaN' AS DOUBLE), CAST('NaN' AS DOUBLE)),
+  (1, CAST('0.0' AS FLOAT), CAST('-0.0' AS FLOAT), CAST('0.0' AS DOUBLE), CAST('-0.0' AS DOUBLE)),
+  (2, CAST('-0.0' AS FLOAT), CAST('0.0' AS FLOAT), CAST('-0.0' AS DOUBLE), CAST('0.0' AS DOUBLE)),
+  (3, CAST('0.0' AS FLOAT), CAST('0.0' AS FLOAT), CAST('0.0' AS DOUBLE), CAST('0.0' AS DOUBLE)),
+  (4, CAST('-0.0' AS FLOAT), CAST('-0.0' AS FLOAT), CAST('-0.0' AS DOUBLE), CAST('-0.0' AS DOUBLE)),
+  (5, CAST(1 AS FLOAT), CAST(2 AS FLOAT), CAST(1 AS DOUBLE), CAST(2 AS DOUBLE)),
+  (6, CAST('NaN' AS FLOAT), CAST(1 AS FLOAT), CAST('NaN' AS DOUBLE), CAST(1 AS DOUBLE)),
+  (7, CAST(1 AS FLOAT), CAST('NaN' AS FLOAT), CAST(1 AS DOUBLE), CAST('NaN' AS DOUBLE))
+
+-- Short arrays, reversed operands, and direct signed-zero controls. Spark 4.2+
+-- normalizes signed zeros before arrays_overlap (SPARK-54918); comparing with the
+-- running Spark version checks the appropriate behavior without fixed expectations.
+query
+SELECT id,
+  arrays_overlap(array(fl), array(-fr)) AS float_short,
+  arrays_overlap(array(dl), array(-dr)) AS double_short,
+  arrays_overlap(array(-fr), array(fl)) AS float_reversed,
+  arrays_overlap(array(-dr), array(dl)) AS double_reversed,
+  arrays_overlap(array(fl), array(fr)) AS float_direct,
+  arrays_overlap(array(dl), array(dr)) AS double_direct
+FROM test_overlap_floating_point
+
+-- Seventeen elements on each side exceed the native budget of 256 comparisons
+-- and exercise the hash-probe path, including signed-zero and nonmatching rows.
+query
+SELECT id,
+  arrays_overlap(array_repeat(fl, 17), array_repeat(-fr, 17)) AS float_long,
+  arrays_overlap(array_repeat(dl, 17), array_repeat(-dr, 17)) AS double_long,
+  arrays_overlap(array_repeat(-fr, 17), array_repeat(fl, 17)) AS float_long_reversed,
+  arrays_overlap(array_repeat(-dr, 17), array_repeat(dl, 17)) AS double_long_reversed
+FROM test_overlap_floating_point
+
+-- A definite NaN match wins over NULL; a nonmatch with NULL remains unknown.
+query
+SELECT id,
+  arrays_overlap(array(fl, CAST(NULL AS FLOAT)), array(-fr)),
+  arrays_overlap(array(dl, CAST(NULL AS DOUBLE)), array(-dr)),
+  arrays_overlap(array(-fr), array(fl, CAST(NULL AS FLOAT))),
+  arrays_overlap(array(-dr), array(dl, CAST(NULL AS DOUBLE)))
+FROM test_overlap_floating_point
+
 -- boolean arrays
 query
 SELECT arrays_overlap(array(true, false), array(false)) FROM test_overlap_dbl

--- a/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
@@ -560,6 +560,90 @@ class CometArrayExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelp
     }
   }
 
+  test("arrays_overlap - floating-point NaN payloads and signed zeros") {
+    val positiveFloatNaNBits = 0x7fc01234
+    val negativeFloatNaNBits = 0x7fc05678 | Int.MinValue
+    val positiveDoubleNaNBits = 0x7ff8000000001234L
+    val negativeDoubleNaNBits = 0x7ff8000000005678L | Long.MinValue
+
+    val positiveFloatNaN = java.lang.Float.intBitsToFloat(positiveFloatNaNBits)
+    val negativeFloatNaN = java.lang.Float.intBitsToFloat(negativeFloatNaNBits)
+    val positiveDoubleNaN = java.lang.Double.longBitsToDouble(positiveDoubleNaNBits)
+    val negativeDoubleNaN = java.lang.Double.longBitsToDouble(negativeDoubleNaNBits)
+
+    val data = Seq(
+      (0, positiveFloatNaN, negativeFloatNaN, positiveDoubleNaN, negativeDoubleNaN),
+      (1, negativeFloatNaN, positiveFloatNaN, negativeDoubleNaN, positiveDoubleNaN),
+      (2, Float.NaN, positiveFloatNaN, Double.NaN, positiveDoubleNaN),
+      (3, positiveFloatNaN, Float.NaN, positiveDoubleNaN, Double.NaN),
+      (4, 0.0f, -0.0f, 0.0d, -0.0d),
+      (5, -0.0f, 0.0f, -0.0d, 0.0d),
+      (6, 0.0f, 0.0f, 0.0d, 0.0d),
+      (7, -0.0f, -0.0f, -0.0d, -0.0d),
+      (8, 1.0f, 2.0f, 1.0d, 2.0d))
+
+    withParquetTable(data, "floating_point_overlap", withDictionary = false) {
+      // Parquet's floating-point writers canonicalize every NaN, including its sign and payload.
+      val firstRow = spark.table("floating_point_overlap").collect().find(_.getInt(0) == 0).get
+      val canonicalFloatNaNBits = java.lang.Float.floatToRawIntBits(Float.NaN)
+      val canonicalDoubleNaNBits = java.lang.Double.doubleToRawLongBits(Double.NaN)
+      assert(java.lang.Float.floatToRawIntBits(firstRow.getFloat(1)) == canonicalFloatNaNBits)
+      assert(java.lang.Float.floatToRawIntBits(firstRow.getFloat(2)) == canonicalFloatNaNBits)
+      assert(
+        java.lang.Double.doubleToRawLongBits(firstRow.getDouble(3)) == canonicalDoubleNaNBits)
+      assert(
+        java.lang.Double.doubleToRawLongBits(firstRow.getDouble(4)) == canonicalDoubleNaNBits)
+
+      // Runtime negation is therefore required to produce noncanonical NaNs after the scan.
+      val generatedNaNs = sql("SELECT -_3, -_5 FROM floating_point_overlap WHERE _1 = 0").head()
+      assert(
+        java.lang.Float.floatToRawIntBits(generatedNaNs.getFloat(0)) ==
+          (canonicalFloatNaNBits | Int.MinValue))
+      assert(
+        java.lang.Double.doubleToRawLongBits(generatedNaNs.getDouble(1)) ==
+          (canonicalDoubleNaNBits | Long.MinValue))
+
+      // Seventeen elements on each side exceed the native nested-scan budget of 256 comparisons.
+      def longArray(column: String): String = Seq.fill(17)(column).mkString("array(", ", ", ")")
+
+      val query = sql(s"""
+           |SELECT _1,
+           |  arrays_overlap(array(_2), array(-_3)) AS float_short,
+           |  arrays_overlap(array(_4), array(-_5)) AS double_short,
+           |  arrays_overlap(array(-_3), array(_2)) AS float_reversed,
+           |  arrays_overlap(array(-_5), array(_4)) AS double_reversed,
+           |  arrays_overlap(${longArray("_2")}, ${longArray("-_3")}) AS float_long,
+           |  arrays_overlap(${longArray("_4")}, ${longArray("-_5")}) AS double_long,
+           |  arrays_overlap(array(_2), array(_3)) AS float_direct,
+           |  arrays_overlap(array(_4), array(_5)) AS double_direct,
+           |  arrays_overlap(array(_2, CAST(NULL AS FLOAT)), array(-_3)) AS float_nullable,
+           |  arrays_overlap(array(_4, CAST(NULL AS DOUBLE)), array(-_5)) AS double_nullable
+           |FROM floating_point_overlap
+           |""".stripMargin)
+
+      checkSparkAnswerAndOperator(query)
+
+      val runtimeOverlappingRows = Set(0, 1, 2, 3, 4, 5)
+      val directOverlappingRows = Set(0, 1, 2, 3, 6, 7)
+      query.collect().foreach { row =>
+        val shouldOverlapAtRuntime = runtimeOverlappingRows.contains(row.getInt(0))
+        for (column <- 1 to 6) {
+          assert(row.getBoolean(column) == shouldOverlapAtRuntime)
+        }
+        for (column <- 7 to 8) {
+          assert(row.getBoolean(column) == directOverlappingRows.contains(row.getInt(0)))
+        }
+        for (column <- 9 to 10) {
+          if (shouldOverlapAtRuntime) {
+            assert(row.getBoolean(column))
+          } else {
+            assert(row.isNullAt(column))
+          }
+        }
+      }
+    }
+  }
+
   test("arrays_overlap - null handling behavior verification") {
     withSQLConf(
       "spark.sql.optimizer.excludedRules" -> "org.apache.spark.sql.catalyst.optimizer.ConstantFolding") {

--- a/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.ArrayType
 
-import org.apache.comet.CometSparkSessionExtensions.{isSpark35Plus, isSpark40Plus}
+import org.apache.comet.CometSparkSessionExtensions.{isSpark35Plus, isSpark40Plus, isSpark42Plus}
 import org.apache.comet.DataTypeSupport.isComplexType
 import org.apache.comet.serde.{CometArrayExcept, CometArrayRemove, CometArrayReverse, CometFlatten}
 import org.apache.comet.testing.{DataGenOptions, ParquetGenerator, SchemaGenOptions}
@@ -623,8 +623,11 @@ class CometArrayExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelp
 
       checkSparkAnswerAndOperator(query)
 
-      val runtimeOverlappingRows = Set(0, 1, 2, 3, 4, 5)
-      val directOverlappingRows = Set(0, 1, 2, 3, 6, 7)
+      // Spark 4.2+ normalizes signed zeros in arrays_overlap operands (SPARK-54918).
+      val runtimeOverlappingRows =
+        if (isSpark42Plus) Set(0, 1, 2, 3, 4, 5, 6, 7) else Set(0, 1, 2, 3, 4, 5)
+      val directOverlappingRows =
+        if (isSpark42Plus) Set(0, 1, 2, 3, 4, 5, 6, 7) else Set(0, 1, 2, 3, 6, 7)
       query.collect().foreach { row =>
         val shouldOverlapAtRuntime = runtimeOverlappingRows.contains(row.getInt(0))
         for (column <- 1 to 6) {

--- a/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.ArrayType
 
-import org.apache.comet.CometSparkSessionExtensions.{isSpark35Plus, isSpark40Plus, isSpark42Plus}
+import org.apache.comet.CometSparkSessionExtensions.{isSpark35Plus, isSpark40Plus}
 import org.apache.comet.DataTypeSupport.isComplexType
 import org.apache.comet.serde.{CometArrayExcept, CometArrayRemove, CometArrayReverse, CometFlatten}
 import org.apache.comet.testing.{DataGenOptions, ParquetGenerator, SchemaGenOptions}
@@ -560,90 +560,30 @@ class CometArrayExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelp
     }
   }
 
-  test("arrays_overlap - floating-point NaN payloads and signed zeros") {
-    val positiveFloatNaNBits = 0x7fc01234
-    val negativeFloatNaNBits = 0x7fc05678 | Int.MinValue
-    val positiveDoubleNaNBits = 0x7ff8000000001234L
-    val negativeDoubleNaNBits = 0x7ff8000000005678L | Long.MinValue
+  test("arrays_overlap - runtime NaN representations") {
+    val floatNaN = java.lang.Float.intBitsToFloat(0x7fc01234 | Int.MinValue)
+    val doubleNaN = java.lang.Double.longBitsToDouble(0x7ff8000000001234L | Long.MinValue)
 
-    val positiveFloatNaN = java.lang.Float.intBitsToFloat(positiveFloatNaNBits)
-    val negativeFloatNaN = java.lang.Float.intBitsToFloat(negativeFloatNaNBits)
-    val positiveDoubleNaN = java.lang.Double.longBitsToDouble(positiveDoubleNaNBits)
-    val negativeDoubleNaN = java.lang.Double.longBitsToDouble(negativeDoubleNaNBits)
-
-    val data = Seq(
-      (0, positiveFloatNaN, negativeFloatNaN, positiveDoubleNaN, negativeDoubleNaN),
-      (1, negativeFloatNaN, positiveFloatNaN, negativeDoubleNaN, positiveDoubleNaN),
-      (2, Float.NaN, positiveFloatNaN, Double.NaN, positiveDoubleNaN),
-      (3, positiveFloatNaN, Float.NaN, positiveDoubleNaN, Double.NaN),
-      (4, 0.0f, -0.0f, 0.0d, -0.0d),
-      (5, -0.0f, 0.0f, -0.0d, 0.0d),
-      (6, 0.0f, 0.0f, 0.0d, 0.0d),
-      (7, -0.0f, -0.0f, -0.0d, -0.0d),
-      (8, 1.0f, 2.0f, 1.0d, 2.0d))
-
-    withParquetTable(data, "floating_point_overlap", withDictionary = false) {
-      // Parquet's floating-point writers canonicalize every NaN, including its sign and payload.
-      val firstRow = spark.table("floating_point_overlap").collect().find(_.getInt(0) == 0).get
+    withParquetTable(
+      Seq((floatNaN, doubleNaN)),
+      "floating_point_overlap",
+      withDictionary = false) {
+      // The behavioral cases live in arrays_overlap.sql. SQL equality cannot distinguish NaN
+      // representations, so verify here that Parquet canonicalizes the inputs and that native
+      // runtime negation produces noncanonical NaNs after the scan.
+      val query = sql("SELECT _1, -_1, _2, -_2 FROM floating_point_overlap")
+      checkSparkAnswerAndOperator(query)
+      val row = query.head()
       val canonicalFloatNaNBits = java.lang.Float.floatToRawIntBits(Float.NaN)
       val canonicalDoubleNaNBits = java.lang.Double.doubleToRawLongBits(Double.NaN)
-      assert(java.lang.Float.floatToRawIntBits(firstRow.getFloat(1)) == canonicalFloatNaNBits)
-      assert(java.lang.Float.floatToRawIntBits(firstRow.getFloat(2)) == canonicalFloatNaNBits)
+      assert(java.lang.Float.floatToRawIntBits(row.getFloat(0)) == canonicalFloatNaNBits)
       assert(
-        java.lang.Double.doubleToRawLongBits(firstRow.getDouble(3)) == canonicalDoubleNaNBits)
-      assert(
-        java.lang.Double.doubleToRawLongBits(firstRow.getDouble(4)) == canonicalDoubleNaNBits)
-
-      // Runtime negation is therefore required to produce noncanonical NaNs after the scan.
-      val generatedNaNs = sql("SELECT -_3, -_5 FROM floating_point_overlap WHERE _1 = 0").head()
-      assert(
-        java.lang.Float.floatToRawIntBits(generatedNaNs.getFloat(0)) ==
+        java.lang.Float.floatToRawIntBits(row.getFloat(1)) ==
           (canonicalFloatNaNBits | Int.MinValue))
+      assert(java.lang.Double.doubleToRawLongBits(row.getDouble(2)) == canonicalDoubleNaNBits)
       assert(
-        java.lang.Double.doubleToRawLongBits(generatedNaNs.getDouble(1)) ==
+        java.lang.Double.doubleToRawLongBits(row.getDouble(3)) ==
           (canonicalDoubleNaNBits | Long.MinValue))
-
-      // Seventeen elements on each side exceed the native nested-scan budget of 256 comparisons.
-      def longArray(column: String): String = Seq.fill(17)(column).mkString("array(", ", ", ")")
-
-      val query = sql(s"""
-           |SELECT _1,
-           |  arrays_overlap(array(_2), array(-_3)) AS float_short,
-           |  arrays_overlap(array(_4), array(-_5)) AS double_short,
-           |  arrays_overlap(array(-_3), array(_2)) AS float_reversed,
-           |  arrays_overlap(array(-_5), array(_4)) AS double_reversed,
-           |  arrays_overlap(${longArray("_2")}, ${longArray("-_3")}) AS float_long,
-           |  arrays_overlap(${longArray("_4")}, ${longArray("-_5")}) AS double_long,
-           |  arrays_overlap(array(_2), array(_3)) AS float_direct,
-           |  arrays_overlap(array(_4), array(_5)) AS double_direct,
-           |  arrays_overlap(array(_2, CAST(NULL AS FLOAT)), array(-_3)) AS float_nullable,
-           |  arrays_overlap(array(_4, CAST(NULL AS DOUBLE)), array(-_5)) AS double_nullable
-           |FROM floating_point_overlap
-           |""".stripMargin)
-
-      checkSparkAnswerAndOperator(query)
-
-      // Spark 4.2+ normalizes signed zeros in arrays_overlap operands (SPARK-54918).
-      val runtimeOverlappingRows =
-        if (isSpark42Plus) Set(0, 1, 2, 3, 4, 5, 6, 7) else Set(0, 1, 2, 3, 4, 5)
-      val directOverlappingRows =
-        if (isSpark42Plus) Set(0, 1, 2, 3, 4, 5, 6, 7) else Set(0, 1, 2, 3, 6, 7)
-      query.collect().foreach { row =>
-        val shouldOverlapAtRuntime = runtimeOverlappingRows.contains(row.getInt(0))
-        for (column <- 1 to 6) {
-          assert(row.getBoolean(column) == shouldOverlapAtRuntime)
-        }
-        for (column <- 7 to 8) {
-          assert(row.getBoolean(column) == directOverlappingRows.contains(row.getInt(0)))
-        }
-        for (column <- 9 to 10) {
-          if (shouldOverlapAtRuntime) {
-            assert(row.getBoolean(column))
-          } else {
-            assert(row.isNullAt(column))
-          }
-        }
-      }
     }
   }
 


### PR DESCRIPTION
## Why are the changes needed?

`arrays_overlap` answers a simple question: do two arrays contain at least one common value? For floating-point arrays, Spark treats every representation of `NaN` as the same value, even when their underlying IEEE 754 sign bits or payloads differ. Comet's native implementation compared those raw bit patterns instead. As a result, enabling Comet could silently change the answer to an otherwise ordinary Spark SQL query.

Consider a Parquet table containing a `NaN`:

```sql
CREATE TABLE t_flat(x DOUBLE) USING parquet;
INSERT INTO t_flat VALUES (DOUBLE('NaN')), (0.0D), (1.0D);

SELECT x,
       arrays_overlap(array(x), array(-x)) AS overlap
FROM t_flat;
```

For the first row, `-x` is still a `NaN`, but negating it at execution time changes its sign bit. Spark correctly considers that value equal to the original `NaN`. On Spark 3.4–4.1, before this change, Comet incorrectly treated the two representations as different:

| Input `x` | Spark 3.4–4.1 | Comet before | Comet after |
| --- | --- | --- | --- |
| `NaN` | `true` | `false` | `true` |
| `+0.0` | `false` | `false` | `false` |
| `1.0` | `false` | `false` | `false` |

The `+0.0` row is also a compatibility control: `-x` becomes `-0.0`, and Spark 3.4–4.1 considers the two zeros different for flat arrays. Fixing `NaN` comparisons must not change that result.

Spark 4.2 and later intentionally behave differently. Under [SPARK-54918](https://github.com/apache/spark/blob/0e25e40348772702b621a8664482510c17e99812/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeFloatingNumbers.scala#L102-L113), Spark's optimizer normalizes both floating-point `arrays_overlap` operands before evaluation. Consequently, `+0.0` and `-0.0` overlap, and both Spark and Comet return `true`. The native comparison must still preserve distinct zero keys for earlier Spark versions; on Spark 4.2+, the operands have already been normalized before those keys are constructed.

On Spark 3.4–4.1, the mismatch also affects SQL null semantics. If the first array additionally contains `NULL`, Spark returns `true` because the two `NaN` values overlap, while the previous Comet implementation returns `NULL` because it misses that definite match:

```sql
SELECT arrays_overlap(
  array(x, CAST(NULL AS DOUBLE)),
  array(-x)
)
FROM t_flat
WHERE isnan(x);

-- Spark: true
-- Comet before: NULL
-- Comet after: true
```

Runtime negation in these examples is intentional. Parquet canonicalizes floating-point `NaN` values when writing them, so storing a negative or custom-payload `NaN` in the input file is not enough to reproduce the bug. A distinct representation must be produced after the scan.

The signed-zero boundary is therefore version-specific:

```sql
SELECT arrays_overlap(array(0.0D), array(-0.0D));

-- Spark 3.4–4.1 and Comet: false
-- Spark 4.2+ and Comet: true (operands are normalized first)
```

A general-purpose floating-point normalizer that also merges signed zero inside Comet's comparison key would fix the NaN mismatch but introduce a Spark 3.4–4.1 compatibility regression.

Closes #5270.

## What changes were proposed in this PR?

The change gives Comet's existing flat-array comparison the same floating-point equality contract as Spark. When Comet derives a comparison key for a `FLOAT` or `DOUBLE`, every `NaN` representation is mapped to one canonical key. All other values retain their original bit patterns. This preserves distinct signed zeros when Spark 3.4–4.1 passes them through unchanged, while respecting Spark 4.2's earlier normalization of the operands.

Applying the correction at the shared comparison-key boundary fixes both ways the existing implementation checks for overlap: direct comparisons for small arrays and hash-based lookups for larger arrays. The execution plan, fast-path structure, null propagation, and behavior for non-floating-point values are otherwise unchanged.

This PR intentionally does not change nested-array comparisons. Spark uses a different equality contract for nested values, and the separate nested signed-zero issue is addressed in #5235.

Mixed scalar/array argument broadcasting is another pre-existing issue, tracked separately in #5269. This change does not alter that argument-dispatch behavior.

## How was this PR tested?

The native Rust regressions construct positive, negative, and signaling `NaN` bit patterns directly for both floating-point widths. They verify NaN equivalence, distinct signed-zero keys, SQL null handling, and both sides of the small-array/hash-lookup threshold. All 23 focused `arrays_overlap` tests pass.

Most integration coverage now lives in the existing `expressions/array/arrays_overlap.sql` fixture, as requested in review. Its Parquet-backed queries generate noncanonical NaNs after the scan and exercise `FLOAT` and `DOUBLE`, reversed operands, nullable arrays, signed-zero controls, and arrays large enough to use hash lookup. The SQL-file harness compares Comet with the running Spark version and checks native execution, so it also covers Spark 4.2's different signed-zero behavior without duplicating version-specific expected results.

A small Scala test remains to inspect the actual floating-point bits. It confirms that Parquet canonicalizes stored NaNs and that native runtime negation produces noncanonical NaNs after the scan—something SQL equality alone cannot establish.

Both focused integration tests pass locally on Spark 3.5, Spark 4.0, and Spark 4.2. Maven Spotless checks also pass for all three profiles.

Native formatting, compilation, and focused tests, from `native/`:

```bash
cargo fmt --all -- --check
cargo build
cargo test -p datafusion-comet-spark-expr --lib \
  array_funcs::arrays_overlap::tests -- --nocapture
```

The focused Spark commands were run from the repository root with JDK 17 configured. Clean reactor builds were used when switching profiles:

```bash
./mvnw -B -ntp test -Pspark-3.5 -Dtest=none \
  '-Dsuites=org.apache.comet.CometSqlFileTestSuite expressions/array/arrays_overlap.sql' \
  -Dscalastyle.skip=true
./mvnw -B -ntp test -Pspark-3.5 -Dtest=none \
  '-Dsuites=org.apache.comet.CometArrayExpressionSuite runtime NaN representations' \
  -Dscalastyle.skip=true

./mvnw -B -ntp clean test -Pspark-4.0 -Dtest=none \
  '-Dsuites=org.apache.comet.CometSqlFileTestSuite expressions/array/arrays_overlap.sql' \
  -Dscalastyle.skip=true
./mvnw -B -ntp test -Pspark-4.0 -Dtest=none \
  '-Dsuites=org.apache.comet.CometArrayExpressionSuite runtime NaN representations' \
  -Dscalastyle.skip=true

./mvnw -B -ntp clean test -Pspark-4.2 -Dtest=none \
  '-Dsuites=org.apache.comet.CometSqlFileTestSuite expressions/array/arrays_overlap.sql' \
  -Dscalastyle.skip=true
./mvnw -B -ntp test -Pspark-4.2 -Dtest=none \
  '-Dsuites=org.apache.comet.CometArrayExpressionSuite runtime NaN representations' \
  -Dscalastyle.skip=true
```

