### PR TITLE
perf: make CometShuffleBenchmark completable and fast

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometShuffleBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometShuffleBenchmark.scala
@@ -21,6 +21,7 @@ package org.apache.spark.sql.benchmark
 
 import java.text.SimpleDateFormat
 
+import scala.concurrent.duration._
 import scala.util.Random
 
 import org.apache.spark.SparkConf
@@ -41,6 +42,38 @@ import org.apache.comet.testing.{DataGenOptions, FuzzDataGenerator, SchemaGenOpt
  */
 // spotless:on
 object CometShuffleBenchmark extends CometBenchmarkBase {
+
+  /**
+   * Types covered by the shuffle groups. A representative spread of fixed-width, variable-width,
+   * and decimal encodings; the shuffle paths do not branch per numeric width, so covering every
+   * integer and float size multiplies runtime without distinguishing implementations.
+   */
+  private val benchmarkTypes: Seq[DataType] =
+    Seq(IntegerType, LongType, DoubleType, StringType, DecimalType(10, 0))
+
+  /**
+   * High partition count for the groups that measure both a low and a high fan-out. This must
+   * stay above Spark's `spark.shuffle.sort.bypassMergeThreshold` (200). Below that threshold the
+   * write path switches to `CometBypassMergeSortShuffleWriter`, which holds a page per partition
+   * from a JVM-wide pool, so a lower value both raises the shuffle memory requirement several
+   * fold and hides the JVM shuffle's degradation at high fan-out.
+   */
+  private val manyPartitions = 201
+
+  /**
+   * Spark's `Benchmark` defaults spend two seconds warming up and two seconds measuring every
+   * case. At the row counts used here a single iteration takes tens of milliseconds, so those
+   * floors, not the work, set the suite's runtime. Shorter budgets with a slightly higher
+   * iteration minimum keep the comparison stable while cutting the floor by 4x.
+   */
+  private def microBenchmark(name: String, valuesPerIteration: Long): Benchmark =
+    new Benchmark(
+      name,
+      valuesPerIteration,
+      minNumIters = 5,
+      warmupTime = 500.millis,
+      minTime = 500.millis,
+      output = output)
 
   override def getSparkSession: SparkSession = {
     val conf = new SparkConf()
@@ -74,10 +107,7 @@ object CometShuffleBenchmark extends CometBenchmarkBase {
 
   def shuffleArrayBenchmark(values: Int, dataType: DataType, partitionNum: Int): Unit = {
     val benchmark =
-      new Benchmark(
-        s"SQL ${dataType.sql} shuffle on array ($partitionNum Partition)",
-        values,
-        output = output)
+      microBenchmark(s"SQL ${dataType.sql} shuffle on array ($partitionNum Partition)", values)
 
     withTempPath { dir =>
       withTempTable("parquetV1Table") {
@@ -125,10 +155,7 @@ object CometShuffleBenchmark extends CometBenchmarkBase {
 
   def shuffleStructBenchmark(values: Int, dataType: DataType, partitionNum: Int): Unit = {
     val benchmark =
-      new Benchmark(
-        s"SQL ${dataType.sql} shuffle on struct ($partitionNum Partition)",
-        values,
-        output = output)
+      microBenchmark(s"SQL ${dataType.sql} shuffle on struct ($partitionNum Partition)", values)
 
     withTempPath { dir =>
       withTempTable("parquetV1Table") {
@@ -183,16 +210,16 @@ object CometShuffleBenchmark extends CometBenchmarkBase {
 
   def shuffleDictionaryBenchmark(values: Int, dataType: DataType, partitionNum: Int): Unit = {
     val benchmark =
-      new Benchmark(
-        s"SQL ${dataType.sql} Dictionary Shuffle($partitionNum Partition)",
-        values,
-        output = output)
+      microBenchmark(s"SQL ${dataType.sql} Dictionary Shuffle($partitionNum Partition)", values)
 
     withTempPath { dir =>
       withTempTable("parquetV1Table") {
+        // Build the repeated value as a string and cast to the target type. ANSI mode, the
+        // default on Spark 4.x, rejects a direct INT to BINARY cast.
         prepareTable(
           dir,
-          spark.sql(s"SELECT REPEAT(CAST(1 AS ${dataType.sql}), 100) AS c1 FROM $tbl"))
+          spark.sql(
+            s"SELECT CAST(REPEAT(CAST(1 AS STRING), 100) AS ${dataType.sql}) AS c1 FROM $tbl"))
 
         benchmark.addCase("SQL Parquet - Spark") { _ =>
           spark
@@ -260,92 +287,15 @@ object CometShuffleBenchmark extends CometBenchmarkBase {
     }
   }
 
-  def shuffleBenchmark(
-      values: Int,
-      dataType: DataType,
-      random: Boolean,
-      partitionNum: Int): Unit = {
-    val randomTitle = if (random) {
-      "With Random"
-    } else {
-      ""
-    }
-    val benchmark =
-      new Benchmark(
-        s"SQL Single ${dataType.sql} Shuffle($partitionNum Partition) $randomTitle",
-        values,
-        output = output)
-
-    withTempPath { dir =>
-      withTempTable("parquetV1Table") {
-        if (random) {
-          prepareTable(
-            dir,
-            spark.sql(
-              s"SELECT CAST(CAST(RAND(1) * 100 AS INTEGER) AS ${dataType.sql}) AS c1 FROM $tbl"))
-        } else {
-          prepareTable(dir, spark.sql(s"SELECT CAST(1 AS ${dataType.sql}) AS c1 FROM $tbl"))
-        }
-
-        benchmark.addCase("SQL Parquet - Spark") { _ =>
-          spark
-            .sql("select c1 from parquetV1Table")
-            .repartition(partitionNum, Column("c1"))
-            .noop()
-        }
-
-        benchmark.addCase("SQL Parquet - Comet (Spark Shuffle)") { _ =>
-          withSQLConf(
-            CometConf.COMET_ENABLED.key -> "true",
-            CometConf.COMET_EXEC_ENABLED.key -> "true",
-            CometConf.COMET_SHUFFLE_ENABLED.key -> "false") {
-            spark
-              .sql("select c1 from parquetV1Table")
-              .repartition(partitionNum, Column("c1"))
-              .noop()
-          }
-        }
-
-        benchmark.addCase("SQL Parquet - Comet (Comet JVM Shuffle)") { _ =>
-          withSQLConf(
-            CometConf.COMET_ENABLED.key -> "true",
-            CometConf.COMET_EXEC_ENABLED.key -> "true",
-            CometConf.COMET_SHUFFLE_ENABLED.key -> "true",
-            CometConf.COMET_SHUFFLE_MODE.key -> "jvm") {
-            spark
-              .sql("select c1 from parquetV1Table")
-              .repartition(partitionNum, Column("c1"))
-              .noop()
-          }
-        }
-
-        benchmark.addCase("SQL Parquet - Comet (Comet Shuffle)") { _ =>
-          withSQLConf(
-            CometConf.COMET_ENABLED.key -> "true",
-            CometConf.COMET_EXEC_ENABLED.key -> "true",
-            CometConf.COMET_SHUFFLE_ENABLED.key -> "true") {
-            spark
-              .sql("select c1 from parquetV1Table")
-              .repartition(partitionNum, Column("c1"))
-              .noop()
-          }
-        }
-
-        benchmark.run()
-      }
-    }
-  }
-
   def shuffleWideBenchmark(
       values: Int,
       dataType: DataType,
       width: Int,
       partitionNum: Int): Unit = {
     val benchmark =
-      new Benchmark(
+      microBenchmark(
         s"SQL Wide ($width cols) ${dataType.sql} Shuffle($partitionNum Partition)",
-        values,
-        output = output)
+        values)
 
     val projection = (1 to width)
       .map(i => s"CAST(CAST(RAND(1) * 100 AS INTEGER) AS ${dataType.sql}) AS c$i")
@@ -412,10 +362,9 @@ object CometShuffleBenchmark extends CometBenchmarkBase {
       width: Int,
       partitionNum: Int): Unit = {
     val benchmark =
-      new Benchmark(
+      microBenchmark(
         s"SQL Wide ($width cols) ${dataType.sql} Range Partition Shuffle($partitionNum Partition)",
-        values,
-        output = output)
+        values)
 
     val projection = (1 to width)
       .map(i => s"CAST(CAST(RAND(1) * 100 AS INTEGER) AS ${dataType.sql}) AS c$i")
@@ -482,7 +431,7 @@ object CometShuffleBenchmark extends CometBenchmarkBase {
       numRows: Int,
       partitionNum: Int): Unit = {
     val benchmark =
-      new Benchmark(s"Shuffle with nested schema ($name)", numRows, output = output)
+      microBenchmark(s"Shuffle with nested schema ($name)", numRows)
     val df = spark.read.parquet(filename)
     withTempTable("deeplyNestedTable") {
       df.createOrReplaceTempView("deeplyNestedTable")
@@ -534,7 +483,7 @@ object CometShuffleBenchmark extends CometBenchmarkBase {
       val filename =
         createDeeplyNestedParquetFile(numRows, maxDepth)
       try {
-        for (partitionNum <- Seq(5, 201)) {
+        for (partitionNum <- Seq(5, manyPartitions)) {
           val name = s"maxDepth=$maxDepth, partitionNum=$partitionNum"
           shuffleDeeplyNestedBenchmark(name, filename, numRows, partitionNum)
         }
@@ -544,236 +493,82 @@ object CometShuffleBenchmark extends CometBenchmarkBase {
     }
 
     runBenchmarkWithTable("Shuffle on array", 1024 * 1024 * 1) { v =>
-      Seq(
-        BooleanType,
-        ByteType,
-        ShortType,
-        IntegerType,
-        LongType,
-        FloatType,
-        DoubleType,
-        StringType,
-        DecimalType(10, 0)).foreach { dataType =>
-        Seq(5, 201).foreach { partitionNum =>
+      benchmarkTypes.foreach { dataType =>
+        Seq(5, manyPartitions).foreach { partitionNum =>
           shuffleArrayBenchmark(v, dataType, partitionNum)
         }
       }
     }
 
-    runBenchmarkWithTable("Shuffle on struct", 1024 * 1024 * 100) { v =>
-      Seq(
-        BooleanType,
-        ByteType,
-        ShortType,
-        IntegerType,
-        LongType,
-        FloatType,
-        DoubleType,
-        StringType,
-        DecimalType(10, 0)).foreach { dataType =>
-        Seq(5, 201).foreach { partitionNum =>
+    runBenchmarkWithTable("Shuffle on struct", 1024 * 1024 * 1) { v =>
+      benchmarkTypes.foreach { dataType =>
+        Seq(5, manyPartitions).foreach { partitionNum =>
           shuffleStructBenchmark(v, dataType, partitionNum)
         }
       }
     }
 
-    runBenchmarkWithTable("Dictionary Shuffle", 1024 * 1024 * 100) { v =>
+    runBenchmarkWithTable("Dictionary Shuffle", 1024 * 1024 * 1) { v =>
       Seq(BinaryType, StringType).foreach { dataType =>
-        Seq(5, 201).foreach { partitionNum =>
+        Seq(5, manyPartitions).foreach { partitionNum =>
           shuffleDictionaryBenchmark(v, dataType, partitionNum)
         }
       }
     }
 
-    runBenchmarkWithTable("Shuffle", 1024 * 1024 * 10) { v =>
-      Seq(
-        BooleanType,
-        ByteType,
-        ShortType,
-        IntegerType,
-        LongType,
-        FloatType,
-        DoubleType,
-        StringType,
-        DecimalType(10, 0))
-        .foreach { dataType =>
-          shuffleBenchmark(v, dataType, false, 5)
-        }
-    }
-
-    runBenchmarkWithTable("Shuffle", 1024 * 1024 * 10) { v =>
-      Seq(
-        BooleanType,
-        ByteType,
-        ShortType,
-        IntegerType,
-        LongType,
-        FloatType,
-        DoubleType,
-        StringType,
-        DecimalType(10, 0))
-        .foreach { dataType =>
-          shuffleBenchmark(v, dataType, false, 201)
-        }
-    }
-
-    runBenchmarkWithTable("Shuffle with random values", 1024 * 1024 * 10) { v =>
-      Seq(
-        BooleanType,
-        ByteType,
-        ShortType,
-        IntegerType,
-        LongType,
-        FloatType,
-        DoubleType,
-        StringType,
-        DecimalType(10, 0))
-        .foreach { dataType =>
-          shuffleBenchmark(v, dataType, true, 5)
-        }
-    }
-
-    runBenchmarkWithTable("Shuffle with random values", 1024 * 1024 * 10) { v =>
-      Seq(
-        BooleanType,
-        ByteType,
-        ShortType,
-        IntegerType,
-        LongType,
-        FloatType,
-        DoubleType,
-        StringType,
-        DecimalType(10, 0))
-        .foreach { dataType =>
-          shuffleBenchmark(v, dataType, true, 201)
-        }
-    }
-
-    runBenchmarkWithTable("Wide Shuffle (10 cols)", 1024 * 1024 * 10) { v =>
-      Seq(
-        BooleanType,
-        ByteType,
-        ShortType,
-        IntegerType,
-        LongType,
-        FloatType,
-        DoubleType,
-        StringType,
-        DecimalType(10, 0))
+    runBenchmarkWithTable("Wide Shuffle (10 cols)", 1024 * 1024 * 1) { v =>
+      benchmarkTypes
         .foreach { dataType =>
           shuffleWideBenchmark(v, dataType, 10, 5)
         }
     }
 
-    runBenchmarkWithTable("Wide Shuffle (20 cols)", 1024 * 1024 * 10) { v =>
-      Seq(
-        BooleanType,
-        ByteType,
-        ShortType,
-        IntegerType,
-        LongType,
-        FloatType,
-        DoubleType,
-        StringType,
-        DecimalType(10, 0))
+    runBenchmarkWithTable("Wide Shuffle (20 cols)", 1024 * 1024 * 1) { v =>
+      benchmarkTypes
         .foreach { dataType =>
           shuffleWideBenchmark(v, dataType, 20, 5)
         }
     }
 
-    runBenchmarkWithTable("Wide Shuffle (10 cols)", 1024 * 1024 * 10) { v =>
-      Seq(
-        BooleanType,
-        ByteType,
-        ShortType,
-        IntegerType,
-        LongType,
-        FloatType,
-        DoubleType,
-        StringType,
-        DecimalType(10, 0))
+    runBenchmarkWithTable("Wide Shuffle (10 cols)", 1024 * 1024 * 1) { v =>
+      benchmarkTypes
         .foreach { dataType =>
-          shuffleWideBenchmark(v, dataType, 10, 201)
+          shuffleWideBenchmark(v, dataType, 10, manyPartitions)
         }
     }
 
-    runBenchmarkWithTable("Wide Shuffle (20 cols)", 1024 * 1024 * 10) { v =>
-      Seq(
-        BooleanType,
-        ByteType,
-        ShortType,
-        IntegerType,
-        LongType,
-        FloatType,
-        DoubleType,
-        StringType,
-        DecimalType(10, 0))
+    runBenchmarkWithTable("Wide Shuffle (20 cols)", 1024 * 1024 * 1) { v =>
+      benchmarkTypes
         .foreach { dataType =>
-          shuffleWideBenchmark(v, dataType, 20, 201)
+          shuffleWideBenchmark(v, dataType, 20, manyPartitions)
         }
     }
 
-    runBenchmarkWithTable("Wide Range Partition Shuffle (10 cols)", 1024 * 1024 * 10) { v =>
-      Seq(
-        BooleanType,
-        ByteType,
-        ShortType,
-        IntegerType,
-        LongType,
-        FloatType,
-        DoubleType,
-        StringType,
-        DecimalType(10, 0))
+    runBenchmarkWithTable("Wide Range Partition Shuffle (10 cols)", 1024 * 1024 * 1) { v =>
+      benchmarkTypes
         .foreach { dataType =>
           shuffleRangePartitionBenchmark(v, dataType, 10, 5)
         }
     }
 
-    runBenchmarkWithTable("Wide Range Partition Shuffle (20 cols)", 1024 * 1024 * 10) { v =>
-      Seq(
-        BooleanType,
-        ByteType,
-        ShortType,
-        IntegerType,
-        LongType,
-        FloatType,
-        DoubleType,
-        StringType,
-        DecimalType(10, 0))
+    runBenchmarkWithTable("Wide Range Partition Shuffle (20 cols)", 1024 * 1024 * 1) { v =>
+      benchmarkTypes
         .foreach { dataType =>
           shuffleRangePartitionBenchmark(v, dataType, 20, 5)
         }
     }
 
-    runBenchmarkWithTable("Wide Range Partition Shuffle (10 cols)", 1024 * 1024 * 10) { v =>
-      Seq(
-        BooleanType,
-        ByteType,
-        ShortType,
-        IntegerType,
-        LongType,
-        FloatType,
-        DoubleType,
-        StringType,
-        DecimalType(10, 0))
+    runBenchmarkWithTable("Wide Range Partition Shuffle (10 cols)", 1024 * 1024 * 1) { v =>
+      benchmarkTypes
         .foreach { dataType =>
-          shuffleRangePartitionBenchmark(v, dataType, 10, 201)
+          shuffleRangePartitionBenchmark(v, dataType, 10, manyPartitions)
         }
     }
 
-    runBenchmarkWithTable("Wide Range Partition Shuffle (20 cols)", 1024 * 1024 * 10) { v =>
-      Seq(
-        BooleanType,
-        ByteType,
-        ShortType,
-        IntegerType,
-        LongType,
-        FloatType,
-        DoubleType,
-        StringType,
-        DecimalType(10, 0))
+    runBenchmarkWithTable("Wide Range Partition Shuffle (20 cols)", 1024 * 1024 * 1) { v =>
+      benchmarkTypes
         .foreach { dataType =>
-          shuffleRangePartitionBenchmark(v, dataType, 20, 201)
+          shuffleRangePartitionBenchmark(v, dataType, 20, manyPartitions)
         }
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?

Part of https://github.com/apache/datafusion-comet/issues/5373. Addresses the shuffle suite timeout raised in review of https://github.com/apache/datafusion-comet/pull/5380.

## Rationale for this change

`CometShuffleBenchmark` never finishes. In the baseline run recorded in `benchmarks/results/micro/RUN-INFO.md` it hit the runner's one hour timeout partway through the struct group, so the shuffle family has no published results and the truncated artifact was dropped from #5380.

Raising the timeout does not fix it. Two independent defects prevent the suite from completing at all, and separately the suite is far slower than a microbenchmark should be.

Two blockers:

1. The struct and dictionary groups ran at `1024 * 1024 * 100` rows while the equivalent array group ran at `1024 * 1024 * 1`. Both select a constant (`CAST(1 AS <type>)`), so every row is identical and repartitioning on that column routes everything to a single partition. The extra rows bought no coverage, only runtime: each struct case measured about 25s per implementation, putting that one group well past half an hour.

2. `shuffleDictionaryBenchmark` built its data with `REPEAT(CAST(1 AS BINARY), 100)`. ANSI mode, the default on Spark 4.x, rejects an INT to BINARY cast:

```
[DATATYPE_MISMATCH.CAST_WITH_CONF_SUGGESTION] Cannot resolve "CAST(1 AS BINARY)" due to data type
mismatch: cannot cast "INT" to "BINARY" with ANSI mode on.
```

This fails on the group's first case regardless of row count or timeout. The recorded run never reached it because it timed out during struct, so the timeout was masking a hard failure.

On runtime, the dominant cost was not the work. Spark's `Benchmark` spends two seconds warming up and two seconds measuring every case, and the minimum measured duration across 576 runs was exactly 2000ms, so those floors set the suite's runtime rather than the shuffles themselves.

## What changes are included in this PR?

Correctness:

- Build the dictionary group's value as a string and cast to the target type, so `BINARY` works under ANSI.

Runtime, measured locally from 54m48s to 8m10s:

- Use 500ms warmup and measurement budgets with a higher iteration minimum, via a `microBenchmark` helper.
- Drop all groups to `1024 * 1024 * 1` rows.
- Cover five representative types instead of nine, hoisted into a shared `benchmarkTypes`. The shuffle paths do not branch per numeric width, so the extra integer and float widths multiplied runtime without distinguishing implementations.
- Remove the single column `Shuffle` and `Shuffle with random values` groups and the now unused `shuffleBenchmark`. A single column table is not representative of real shuffles, and the wide 10 and 20 column groups already cover the same paths with realistic row widths.

Partition counts are unchanged, and the high value is now documented as load bearing: it must stay above Spark's `spark.shuffle.sort.bypassMergeThreshold`. Below that threshold the write path switches to `CometBypassMergeSortShuffleWriter`, which holds a page per partition from a JVM wide pool. Lowering it to 50 raised the required shuffle memory from 8GB to roughly 16GB, which does not fit the m7i.2xlarge used for baselines, and it also hid the JVM shuffle's degradation at high fan-out.

## How are these changes tested?

Ran the suite locally on Spark 4.1 and compared against the previous configuration.

- Completes in 8m10s, down from 54m48s, with all 15 groups present in the results file for the first time.
- Relative Spark versus Comet ratios are preserved where they matter. The wide groups at the high partition count still show Comet JVM shuffle at 0.5X to 0.7X, retaining the high fan-out degradation signal. Array, struct and dictionary ratios are unchanged within noise against the previous run.
- Measurement noise: stdev as a fraction of best time is p50 6.8%, p90 13.8%.

Verifying the reduced row counts required working around a separate pre-existing issue: `getSparkSession` sets `spark.executor.memoryOverhead`, which is Spark's overhead rather than Comet's, so the JVM shuffle pool stays at its default and the first nested case fails with `UNABLE_TO_ACQUIRE_MEMORY` on a many core machine. Runs here passed `-Dspark.comet.memoryOverhead=8g`. That is left for a follow up along with the redundant per case table writes.
