### PR TITLE
test: strengthen signed-zero SQL assertions

### DIFF
--- a/spark/src/test/resources/sql-tests/expressions/aggregate/percentile.sql
+++ b/spark/src/test/resources/sql-tests/expressions/aggregate/percentile.sql
@@ -105,6 +105,19 @@ INSERT INTO test_percentile_special VALUES
 query
 SELECT percentile(v, 0.0), percentile(v, 0.5), percentile(v, 0.8), percentile(v, 1.0) FROM test_percentile_special
 
+-- The exact median selects zero itself. Keep the signs in separate groups so
+-- equal-valued zeros cannot make the result depend on tie or partition order.
+statement
+CREATE TABLE test_percentile_signed_zero(g int, f float, d double) USING parquet
+
+statement
+INSERT INTO test_percentile_signed_zero VALUES
+  (1, -1.0, -1.0), (1, float('-0.0'), double('-0.0')), (1, 1.0, 1.0),
+  (2, -1.0, -1.0), (2, float('0.0'), double('0.0')), (2, 1.0, 1.0)
+
+query
+SELECT g, percentile(f, 0.5), percentile(d, 0.5) FROM test_percentile_signed_zero GROUP BY g ORDER BY g
+
 -- ============================================================
 -- Unsupported forms fall back to Spark cleanly
 -- ============================================================

--- a/spark/src/test/resources/sql-tests/expressions/array/array_intersect.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_intersect.sql
@@ -120,7 +120,9 @@ INSERT INTO test_intersect_long VALUES (array(9223372036854775807, 1, -922337203
 query
 SELECT a, b, array_intersect(a, b) FROM test_intersect_long
 
--- float arrays with NaN, Infinity, -Infinity
+-- Float arrays with NaN, Infinity, -Infinity, and signed-zero membership.
+-- Opposite-sign singletons distinguish membership from deduplication. Spark 4.2+
+-- normalizes their zeros, so compare with the running Spark version.
 statement
 CREATE TABLE test_intersect_float(a array<float>, b array<float>) USING parquet
 
@@ -133,12 +135,15 @@ INSERT INTO test_intersect_float VALUES
   (array(1.0, 2.0), array(float('NaN'))),
   (array(float('NaN'), NULL), array(float('NaN'), NULL)),
   (array(float('Infinity'), 1.0, float('-Infinity')), array(float('Infinity'), float('-Infinity'))),
-  (array(cast(0.0 as float), float('-0.0')), array(cast(0.0 as float)))
+  (array(cast(0.0 as float), float('-0.0')), array(cast(0.0 as float))),
+  (array(float('-0.0')), array(float('0.0'))),
+  (array(float('0.0')), array(float('-0.0'))),
+  (array(float('-0.0')), array(float('-0.0')))
 
 query
 SELECT a, b, array_intersect(a, b) FROM test_intersect_float
 
--- double arrays with NaN, Infinity, -Infinity
+-- Double arrays with NaN, Infinity, -Infinity, and signed-zero membership.
 statement
 CREATE TABLE test_intersect_dbl(a array<double>, b array<double>) USING parquet
 
@@ -152,6 +157,9 @@ INSERT INTO test_intersect_dbl VALUES
   (array(double('NaN'), NULL), array(double('NaN'), NULL)),
   (array(double('Infinity'), 1.0, double('-Infinity')), array(double('Infinity'), double('-Infinity'))),
   (array(0.0, double('-0.0')), array(0.0)),
+  (array(double('-0.0')), array(double('0.0'))),
+  (array(double('0.0')), array(double('-0.0'))),
+  (array(double('-0.0')), array(double('-0.0'))),
   (array(1.0, 2.0, NULL), array(1.0, NULL))
 
 query

--- a/spark/src/test/resources/sql-tests/expressions/array/arrays_zip.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/arrays_zip.sql
@@ -27,7 +27,19 @@ SELECT arrays_zip(array(1, 2, 3), array('a', 'b'));
 
 -- With floating points
 query
-SELECT arrays_zip(array(-.1234567E+2BD, CAST('-Infinity' AS DOUBLE), CAST('NaN' AS DOUBLE)), array(CAST('Infinity' AS FLOAT), float('-0.0'), -0.1234567f, CAST('NaN' AS FLOAT)));
+SELECT arrays_zip(array(-.1234567E+2BD, CAST('-Infinity' AS DOUBLE), CAST('NaN' AS DOUBLE)), array(CAST('Infinity' AS FLOAT), double('-0.0'), -0.1234567f, CAST('NaN' AS FLOAT)));
+
+-- Preserve both signs of zero in float and double array columns.
+statement
+CREATE TABLE test_arrays_zip_fp(f array<float>, d array<double>) USING parquet
+
+statement
+INSERT INTO test_arrays_zip_fp VALUES
+  (array(float('-0.0'), float('0.0')), array(double('0.0'), double('-0.0'))),
+  (array(float('0.0'), float('-0.0')), array(double('-0.0')))
+
+query
+SELECT arrays_zip(f, d) FROM test_arrays_zip_fp
 
 -- basic: two integer arrays of equal length
 query


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5402. This is a test-only follow-up to #5271 and #5393.

## Why are the changes needed?

#5393 corrected negative-zero literals so the test inputs really contain `-0.0`. That is necessary, but a test only protects signed-zero behavior if losing the sign would change its expected output. Some existing assertions still pass even when an implementation treats every zero as positive zero.

For example, consider `array_intersect` on floating-point arrays in Spark 3.4 through 4.1. The following is value notation, not SQL literal syntax:

| Input arrays | Spark result | Result if negative zeros are incorrectly replaced with positive zeros |
| --- | --- | --- |
| `[+0.0, -0.0]` and `[+0.0]` | `[+0.0]` | `[+0.0]` |
| `[-0.0]` and `[+0.0]` | `[]` | `[+0.0]` |

The first row is the existing test shape: both implementations return the same answer, so the assertion cannot detect the bug. The second row makes membership depend on the sign and therefore distinguishes the two behaviors. Spark 4.2 intentionally normalizes zeros for this operation, so its expected answer differs. The tests must follow the running Spark version rather than hard-code the older behavior.

The percentile fixture has a similar blind spot. Its inputs include both zero signs, but the requested probabilities `0`, `0.5`, `0.8`, and `1` return `[-Infinity, 0.5, +Infinity, NaN]`. None returns zero, so replacing the negative-zero input with positive zero would leave every assertion unchanged.

There is also a type-coverage change to repair: the literal correction in `arrays_zip` changed the second zipped field from `DOUBLE` to `FLOAT`. That retained a valid test, but no longer exercised the original double-precision shape.

## What changes were proposed in this PR?

The assertions are strengthened by choosing inputs whose observable results depend on correct signed-zero handling. For intersection, opposite-sign singletons make membership itself the check, while a same-sign negative-zero control also checks the sign of the returned element against Spark. Both operand orders and both floating-point widths are covered.

For percentile, the new cases select zero itself as an exact median. Each group contains only one zero sign:

| Values within a group | Expected median |
| --- | --- |
| `-1.0, -0.0, +1.0` | `-0.0` |
| `-1.0, +0.0, +1.0` | `+0.0` |

Separating the groups makes the result sensitive to a lost sign without depending on the order of equal mixed-sign zeros or on interpolation. The same idea is applied to `arrays_zip`: restore the original double-precision literal shape, then check preservation directly through Parquet-backed `FLOAT` and `DOUBLE` array columns containing both signs and unequal lengths.

All of these remain ordinary Comet SQL `query` assertions. They require Comet operator coverage and compare against Spark without a numeric tolerance, so a zero-sign difference fails the comparison. Using Spark as the oracle also accommodates the intentional intersection behavior change in Spark 4.2. No runtime implementation changes are included, and this PR does not claim a newly introduced production bug.

## How was this PR tested?

All **four directly changed SQL-file/configuration cases passed on each of Spark 3.4.3 and 4.1.3** with Comet and the unchanged native library built under JDK 17. A fresh Spark 3.4.3 replay during review confirmed the same results.

Separately, the affected SQL records passed **50 Spark-only query checks** across Spark 3.4.3, 3.5.9, 4.0.2, 4.1.3, and 4.2.0, including schema and raw sign-bit assertions. Additional checks on Spark 3.5.9 and 4.2.0 reordered and repartitioned the percentile inputs without changing the expected signed medians. These cross-version probes validate the fixtures and Spark expectations; they are not five-version Comet runtime tests.

The standalone replay exercised both `parquet.enable.dictionary` settings. Footer inspection showed that the tiny `arrays_zip` fixtures still used plain pages, so this is configuration coverage, not proof of dictionary-page coverage. Spotless and `git diff --check` passed. Local validation did not include the full test suite or a native Comet run on Spark 4.2.

<details>
<summary>Focused test commands</summary>

Each selector was run separately:

```sh
./mvnw test -Pspark-4.1 -Dtest=none -Dscalastyle.skip=true -Dsuites="org.apache.comet.CometSqlFileTestSuite arrays_zip"
./mvnw test -Pspark-4.1 -Dtest=none -Dscalastyle.skip=true -Dsuites="org.apache.comet.CometSqlFileTestSuite array_intersect"
./mvnw test -Pspark-4.1 -Dtest=none -Dscalastyle.skip=true -Dsuites="org.apache.comet.CometSqlFileTestSuite percentile"
```

Repeated with `-Pspark-3.4`, using a clean reactor build when switching profiles. Local runs used dependency-cache and native-library-directory overrides. These substring selectors also include neighboring fixtures; the count above includes only the changed fixtures and their configuration variants.

</details>
