### PR TITLE
fix: support empty struct types

### DIFF
--- a/native/spark-expr/src/array_funcs/get_array_struct_fields.rs
+++ b/native/spark-expr/src/array_funcs/get_array_struct_fields.rs
@@ -71,11 +71,26 @@ impl GetArrayStructFields {
             ))),
         }
     }
+
+    /// The field describing the extracted list's element, used by both `data_type` and `evaluate`
+    /// so the declared output type always matches the array `evaluate` produces. A row whose
+    /// parent struct element is null yields a null in the extracted child even when that child
+    /// field is declared non-nullable, so the element field must be nullable whenever the parent
+    /// struct element can be null.
+    fn output_field(&self, input_schema: &Schema) -> DataFusionResult<FieldRef> {
+        let list_field = self.list_field(input_schema)?;
+        let struct_field = self.child_field(input_schema)?;
+        if list_field.is_nullable() && !struct_field.is_nullable() {
+            Ok(Arc::new(struct_field.as_ref().clone().with_nullable(true)))
+        } else {
+            Ok(struct_field)
+        }
+    }
 }
 
 impl PhysicalExpr for GetArrayStructFields {
     fn data_type(&self, input_schema: &Schema) -> DataFusionResult<DataType> {
-        let struct_field = self.child_field(input_schema)?;
+        let struct_field = self.output_field(input_schema)?;
         match self.child.data_type(input_schema)? {
             DataType::List(_) => Ok(DataType::List(struct_field)),
             DataType::LargeList(_) => Ok(DataType::LargeList(struct_field)),
@@ -91,18 +106,19 @@ impl PhysicalExpr for GetArrayStructFields {
     }
 
     fn evaluate(&self, batch: &RecordBatch) -> DataFusionResult<ColumnarValue> {
+        let output_field = self.output_field(&batch.schema())?;
         let child_value = self.child.evaluate(batch)?.into_array(batch.num_rows())?;
 
         match child_value.data_type() {
             DataType::List(_) => {
                 let list_array = as_list_array(&child_value)?;
 
-                get_array_struct_fields(list_array, self.ordinal)
+                get_array_struct_fields(list_array, self.ordinal, output_field)
             }
             DataType::LargeList(_) => {
                 let list_array = as_large_list_array(&child_value)?;
 
-                get_array_struct_fields(list_array, self.ordinal)
+                get_array_struct_fields(list_array, self.ordinal, output_field)
             }
             data_type => Err(DataFusionError::Internal(format!(
                 "Unexpected child type for ListExtract: {data_type:?}"
@@ -135,6 +151,7 @@ impl PhysicalExpr for GetArrayStructFields {
 fn get_array_struct_fields<O: OffsetSizeTrait>(
     list_array: &GenericListArray<O>,
     ordinal: usize,
+    output_field: FieldRef,
 ) -> DataFusionResult<ColumnarValue> {
     let values = list_array
         .values()
@@ -142,7 +159,6 @@ fn get_array_struct_fields<O: OffsetSizeTrait>(
         .downcast_ref::<StructArray>()
         .expect("A StructType is expected");
 
-    let field = Arc::clone(&values.fields()[ordinal]);
     // Get struct column by ordinal
     let extracted_column = values.column(ordinal);
 
@@ -164,6 +180,17 @@ fn get_array_struct_fields<O: OffsetSizeTrait>(
         )
     };
 
+    // `output_field` is the same field `data_type()` declares for the extracted list's element,
+    // already widened to nullable when the parent struct element is nullable. Guard the remaining
+    // case where the parent's runtime null buffer is narrower than its declared nullability (a
+    // low-level reader can under-report), which merges a null into `data` under a field that the
+    // schema still called non-nullable; GenericListArray's constructor would then reject it.
+    let field = if data.null_count() > 0 && !output_field.is_nullable() {
+        Arc::new(output_field.as_ref().clone().with_nullable(true))
+    } else {
+        output_field
+    };
+
     let array = GenericListArray::new(
         field,
         list_array.offsets().clone(),
@@ -172,6 +199,120 @@ fn get_array_struct_fields<O: OffsetSizeTrait>(
     );
 
     Ok(ColumnarValue::Array(Arc::new(array)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int32Array, ListArray};
+    use arrow::buffer::OffsetBuffer;
+    use arrow::datatypes::{Field, Fields};
+    use datafusion::physical_expr::expressions::Column;
+
+    /// A list of `struct<e: struct<>>` whose element `e` is declared non-nullable, but where the
+    /// parent struct's null bitmap marks row 0 null (mirrors `array_repeat(n, 1).e` for a
+    /// nullable `n`). Returns `(input_schema, batch, expr)` for the extraction of ordinal 0.
+    fn nested_empty_struct_setup() -> (Schema, RecordBatch, GetArrayStructFields) {
+        let e_field = Arc::new(Field::new("e", DataType::Struct(Fields::empty()), false));
+        let e_array = StructArray::new_empty_fields(2, None);
+        let n_fields = Fields::from(vec![e_field]);
+        let n_values = StructArray::new(
+            n_fields.clone(),
+            vec![Arc::new(e_array)],
+            Some(NullBuffer::from(vec![false, true])),
+        );
+
+        // The list element (`n`) is nullable while its `e` field is not.
+        let elem_field = Arc::new(Field::new("item", DataType::Struct(n_fields), true));
+        let offsets = OffsetBuffer::new(vec![0, 1, 2].into());
+        let list_array = ListArray::new(
+            Arc::clone(&elem_field),
+            offsets,
+            Arc::new(n_values),
+            Some(NullBuffer::from(vec![true, true])),
+        );
+
+        let schema = Schema::new(vec![Field::new("arr", DataType::List(elem_field), true)]);
+        let batch =
+            RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(list_array)]).unwrap();
+        let expr = GetArrayStructFields::new(Arc::new(Column::new("arr", 0)), 0);
+        (schema, batch, expr)
+    }
+
+    #[test]
+    fn extracts_a_non_nullable_field_when_its_parent_struct_is_null() {
+        let (_schema, batch, expr) = nested_empty_struct_setup();
+
+        let extracted = expr
+            .evaluate(&batch)
+            .expect("must not panic")
+            .into_array(2)
+            .expect("must produce an array");
+        let extracted_list = extracted
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("result is a ListArray");
+
+        let e_values = extracted_list
+            .values()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("extracted values are a StructArray");
+        assert!(e_values.is_null(0), "row 0's parent `n` was NULL");
+        assert!(!e_values.is_null(1), "row 1's parent `n` was Row(Row())");
+    }
+
+    #[test]
+    fn declared_data_type_matches_the_array_evaluate_produces() {
+        // The reviewer's blocker: `data_type()` must advertise the same element-field nullability
+        // that `evaluate()` produces, otherwise a projection re-wrapping the output in a batch
+        // built from `data_type()` fails Arrow's field-vs-data validation.
+        let (schema, batch, expr) = nested_empty_struct_setup();
+
+        let declared = expr.data_type(&schema).expect("data_type");
+        let output = expr.evaluate(&batch).unwrap().into_array(2).unwrap();
+
+        assert_eq!(
+            &declared,
+            output.data_type(),
+            "declared output type must equal the produced array's type"
+        );
+        // And the produced array must satisfy a batch built from the declared type.
+        let out_schema = Schema::new(vec![Field::new("out", declared, true)]);
+        RecordBatch::try_new(Arc::new(out_schema), vec![output])
+            .expect("produced array must validate against the declared output schema");
+    }
+
+    #[test]
+    fn non_nullable_parent_and_child_keeps_the_field_non_nullable() {
+        // Control: when neither the list element nor the extracted field is nullable, the output
+        // stays non-nullable (no over-widening from the blocker fix).
+        let inner = Arc::new(Field::new("v", DataType::Int32, false));
+        let s_fields = Fields::from(vec![inner]);
+        let s_values = StructArray::new(
+            s_fields.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2]))],
+            None,
+        );
+        let elem_field = Arc::new(Field::new("item", DataType::Struct(s_fields), false));
+        let list_array = ListArray::new(
+            Arc::clone(&elem_field),
+            OffsetBuffer::new(vec![0, 1, 2].into()),
+            Arc::new(s_values),
+            None,
+        );
+        let schema = Schema::new(vec![Field::new("arr", DataType::List(elem_field), false)]);
+        let batch =
+            RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(list_array)]).unwrap();
+        let expr = GetArrayStructFields::new(Arc::new(Column::new("arr", 0)), 0);
+
+        match expr.data_type(&schema).unwrap() {
+            DataType::List(f) => assert!(!f.is_nullable(), "field must not be widened"),
+            other => panic!("expected List, got {other:?}"),
+        }
+        let output = expr.evaluate(&batch).unwrap().into_array(2).unwrap();
+        assert_eq!(&expr.data_type(&schema).unwrap(), output.data_type());
+    }
 }
 
 impl Display for GetArrayStructFields {

--- a/native/spark-expr/src/json_funcs/from_json.rs
+++ b/native/spark-expr/src/json_funcs/from_json.rs
@@ -124,6 +124,17 @@ impl PhysicalExpr for FromJson {
     }
 }
 
+/// Whether `s` is blank per Spark's own definition (SPARK-19543): Spark's `JacksonParser`
+/// treats input as blank when the underlying Jackson `JsonParser` finds no first token, which
+/// happens when only JSON whitespace precedes EOF. RFC 8259 defines JSON whitespace as exactly
+/// space, tab, CR, and LF -- a narrower set than Rust's Unicode-aware `str::trim()` (which also
+/// trims e.g. NBSP, U+2028) and than ASCII "control or space" (which also trims e.g. NUL, BEL,
+/// vertical tab -- not JSON whitespace, so Jackson would fail to tokenize them and PERMISSIVE
+/// mode would produce a non-null struct, not NULL).
+fn is_blank(s: &str) -> bool {
+    s.trim_matches([' ', '\t', '\n', '\r']).is_empty()
+}
+
 /// Parse JSON string array into struct array
 fn json_string_to_struct(arr: &Arc<dyn Array>, schema: &DataType) -> Result<ArrayRef> {
     use arrow::array::StringArray;
@@ -150,7 +161,7 @@ fn json_string_to_struct(arr: &Arc<dyn Array>, schema: &DataType) -> Result<Arra
         } else {
             let json_str = string_array.value(row_idx);
 
-            if json_str.trim().is_empty() {
+            if is_blank(json_str) {
                 // Blank input (empty or whitespace only) is NULL, not a struct with null
                 // fields (SPARK-19543) -- distinct from a non-blank string that fails to
                 // parse, which PERMISSIVE mode below turns into a struct with null fields.

--- a/native/spark-expr/src/json_funcs/from_json.rs
+++ b/native/spark-expr/src/json_funcs/from_json.rs
@@ -397,7 +397,14 @@ fn finish_builder(builder: FieldBuilder) -> Result<ArrayRef> {
                 .map(finish_builder)
                 .collect::<Result<Vec<_>>>()?;
             let null_buf = arrow::buffer::NullBuffer::from(null_buffer);
-            Arc::new(StructArray::new(fields, nested_arrays, Some(null_buf)))
+            // `StructArray::new` derives its row count from the first child array; a zero-field
+            // schema (e.g. a `struct<>`-typed field nested inside a larger schema) has no child
+            // arrays to derive it from, so the count is supplied explicitly here instead.
+            if fields.is_empty() {
+                Arc::new(StructArray::new_empty_fields(null_buf.len(), Some(null_buf)))
+            } else {
+                Arc::new(StructArray::new(fields, nested_arrays, Some(null_buf)))
+            }
         }
     })
 }

--- a/native/spark-expr/src/json_funcs/from_json.rs
+++ b/native/spark-expr/src/json_funcs/from_json.rs
@@ -124,6 +124,17 @@ impl PhysicalExpr for FromJson {
     }
 }
 
+/// Whether `s` is blank per Spark's own definition (SPARK-19543): Spark's `JacksonParser`
+/// treats input as blank when the underlying Jackson `JsonParser` finds no first token, which
+/// happens when only JSON whitespace precedes EOF. RFC 8259 defines JSON whitespace as exactly
+/// space, tab, CR, and LF -- a narrower set than Rust's Unicode-aware `str::trim()` (which also
+/// trims e.g. NBSP, U+2028) and than ASCII "control or space" (which also trims e.g. NUL, BEL,
+/// vertical tab -- not JSON whitespace, so Jackson would fail to tokenize them and PERMISSIVE
+/// mode would produce a non-null struct, not NULL).
+fn is_blank(s: &str) -> bool {
+    s.trim_matches([' ', '\t', '\n', '\r']).is_empty()
+}
+
 /// Parse JSON string array into struct array
 fn json_string_to_struct(arr: &Arc<dyn Array>, schema: &DataType) -> Result<ArrayRef> {
     use arrow::array::StringArray;
@@ -150,26 +161,34 @@ fn json_string_to_struct(arr: &Arc<dyn Array>, schema: &DataType) -> Result<Arra
         } else {
             let json_str = string_array.value(row_idx);
 
-            // Parse JSON (PERMISSIVE mode: return null fields on error)
-            match serde_json::from_str::<serde_json::Value>(json_str) {
-                Ok(json_value) => {
-                    if let serde_json::Value::Object(obj) = json_value {
-                        // Struct is not null, extract each field
-                        *struct_null = true;
-                        for (field, builder) in fields.iter().zip(field_builders.iter_mut()) {
-                            let field_value = obj.get(field.name());
-                            append_field_value(builder, field, field_value)?;
+            if is_blank(json_str) {
+                // Blank input (empty or whitespace only) is NULL, not a struct with null
+                // fields (SPARK-19543) -- distinct from a non-blank string that fails to
+                // parse, which PERMISSIVE mode below turns into a struct with null fields.
+                *struct_null = false;
+                append_null_to_all_builders(&mut field_builders);
+            } else {
+                // Parse JSON (PERMISSIVE mode: return null fields on error)
+                match serde_json::from_str::<serde_json::Value>(json_str) {
+                    Ok(json_value) => {
+                        if let serde_json::Value::Object(obj) = json_value {
+                            // Struct is not null, extract each field
+                            *struct_null = true;
+                            for (field, builder) in fields.iter().zip(field_builders.iter_mut()) {
+                                let field_value = obj.get(field.name());
+                                append_field_value(builder, field, field_value)?;
+                            }
+                        } else {
+                            // Not an object -> struct with null fields
+                            *struct_null = true;
+                            append_null_to_all_builders(&mut field_builders);
                         }
-                    } else {
-                        // Not an object -> struct with null fields
+                    }
+                    Err(_) => {
+                        // Parse error -> struct with null fields (PERMISSIVE mode)
                         *struct_null = true;
                         append_null_to_all_builders(&mut field_builders);
                     }
-                }
-                Err(_) => {
-                    // Parse error -> struct with null fields (PERMISSIVE mode)
-                    *struct_null = true;
-                    append_null_to_all_builders(&mut field_builders);
                 }
             }
         }
@@ -180,11 +199,15 @@ fn json_string_to_struct(arr: &Arc<dyn Array>, schema: &DataType) -> Result<Arra
         .map(finish_builder)
         .collect::<Result<Vec<_>>>()?;
     let null_buffer = NullBuffer::from(struct_nulls);
-    Ok(Arc::new(StructArray::new(
-        fields.clone(),
-        arrays,
-        Some(null_buffer),
-    )))
+    // `StructArray::new` derives its length from the first child array, so it panics when
+    // `fields` is empty (a legitimate zero-field target schema, e.g. `from_json(_, 'struct<>')`).
+    // `new_empty_fields` takes the length explicitly instead.
+    let struct_array: ArrayRef = if fields.is_empty() {
+        Arc::new(StructArray::new_empty_fields(num_rows, Some(null_buffer)))
+    } else {
+        Arc::new(StructArray::new(fields.clone(), arrays, Some(null_buffer)))
+    };
+    Ok(struct_array)
 }
 
 /// Builder enum for different data types
@@ -393,7 +416,17 @@ fn finish_builder(builder: FieldBuilder) -> Result<ArrayRef> {
                 .map(finish_builder)
                 .collect::<Result<Vec<_>>>()?;
             let null_buf = arrow::buffer::NullBuffer::from(null_buffer);
-            Arc::new(StructArray::new(fields, nested_arrays, Some(null_buf)))
+            // `StructArray::new` derives its row count from the first child array; a zero-field
+            // schema (e.g. a `struct<>`-typed field nested inside a larger schema) has no child
+            // arrays to derive it from, so the count is supplied explicitly here instead.
+            if fields.is_empty() {
+                Arc::new(StructArray::new_empty_fields(
+                    null_buf.len(),
+                    Some(null_buf),
+                ))
+            } else {
+                Arc::new(StructArray::new(fields, nested_arrays, Some(null_buf)))
+            }
         }
     })
 }

--- a/native/spark-expr/src/json_funcs/from_json.rs
+++ b/native/spark-expr/src/json_funcs/from_json.rs
@@ -180,11 +180,15 @@ fn json_string_to_struct(arr: &Arc<dyn Array>, schema: &DataType) -> Result<Arra
         .map(finish_builder)
         .collect::<Result<Vec<_>>>()?;
     let null_buffer = NullBuffer::from(struct_nulls);
-    Ok(Arc::new(StructArray::new(
-        fields.clone(),
-        arrays,
-        Some(null_buffer),
-    )))
+    // `StructArray::new` derives its length from the first child array, so it panics when
+    // `fields` is empty (a legitimate zero-field target schema, e.g. `from_json(_, 'struct<>')`).
+    // `new_empty_fields` takes the length explicitly instead.
+    let struct_array: ArrayRef = if fields.is_empty() {
+        Arc::new(StructArray::new_empty_fields(num_rows, Some(null_buffer)))
+    } else {
+        Arc::new(StructArray::new(fields.clone(), arrays, Some(null_buffer)))
+    };
+    Ok(struct_array)
 }
 
 /// Builder enum for different data types

--- a/native/spark-expr/src/json_funcs/from_json.rs
+++ b/native/spark-expr/src/json_funcs/from_json.rs
@@ -150,26 +150,34 @@ fn json_string_to_struct(arr: &Arc<dyn Array>, schema: &DataType) -> Result<Arra
         } else {
             let json_str = string_array.value(row_idx);
 
-            // Parse JSON (PERMISSIVE mode: return null fields on error)
-            match serde_json::from_str::<serde_json::Value>(json_str) {
-                Ok(json_value) => {
-                    if let serde_json::Value::Object(obj) = json_value {
-                        // Struct is not null, extract each field
-                        *struct_null = true;
-                        for (field, builder) in fields.iter().zip(field_builders.iter_mut()) {
-                            let field_value = obj.get(field.name());
-                            append_field_value(builder, field, field_value)?;
+            if json_str.trim().is_empty() {
+                // Blank input (empty or whitespace only) is NULL, not a struct with null
+                // fields (SPARK-19543) -- distinct from a non-blank string that fails to
+                // parse, which PERMISSIVE mode below turns into a struct with null fields.
+                *struct_null = false;
+                append_null_to_all_builders(&mut field_builders);
+            } else {
+                // Parse JSON (PERMISSIVE mode: return null fields on error)
+                match serde_json::from_str::<serde_json::Value>(json_str) {
+                    Ok(json_value) => {
+                        if let serde_json::Value::Object(obj) = json_value {
+                            // Struct is not null, extract each field
+                            *struct_null = true;
+                            for (field, builder) in fields.iter().zip(field_builders.iter_mut()) {
+                                let field_value = obj.get(field.name());
+                                append_field_value(builder, field, field_value)?;
+                            }
+                        } else {
+                            // Not an object -> struct with null fields
+                            *struct_null = true;
+                            append_null_to_all_builders(&mut field_builders);
                         }
-                    } else {
-                        // Not an object -> struct with null fields
+                    }
+                    Err(_) => {
+                        // Parse error -> struct with null fields (PERMISSIVE mode)
                         *struct_null = true;
                         append_null_to_all_builders(&mut field_builders);
                     }
-                }
-                Err(_) => {
-                    // Parse error -> struct with null fields (PERMISSIVE mode)
-                    *struct_null = true;
-                    append_null_to_all_builders(&mut field_builders);
                 }
             }
         }
@@ -401,7 +409,10 @@ fn finish_builder(builder: FieldBuilder) -> Result<ArrayRef> {
             // schema (e.g. a `struct<>`-typed field nested inside a larger schema) has no child
             // arrays to derive it from, so the count is supplied explicitly here instead.
             if fields.is_empty() {
-                Arc::new(StructArray::new_empty_fields(null_buf.len(), Some(null_buf)))
+                Arc::new(StructArray::new_empty_fields(
+                    null_buf.len(),
+                    Some(null_buf),
+                ))
             } else {
                 Arc::new(StructArray::new(fields, nested_arrays, Some(null_buf)))
             }

--- a/spark/src/main/scala/org/apache/comet/DataTypeSupport.scala
+++ b/spark/src/main/scala/org/apache/comet/DataTypeSupport.scala
@@ -54,8 +54,9 @@ trait DataTypeSupport {
           CalendarIntervalType =>
         true
       case StructType(fields) =>
-        fields.nonEmpty && fields.forall(f =>
-          isTypeSupported(f.dataType, f.name, fallbackReasons))
+        // A struct's `fields` can be empty -- e.g. Iceberg's `_partition` metadata column is
+        // exactly that on an unpartitioned table. It's still a value Comet can represent.
+        fields.forall(f => isTypeSupported(f.dataType, f.name, fallbackReasons))
       case ArrayType(elementType, _) =>
         isTypeSupported(elementType, ARRAY_ELEMENT, fallbackReasons)
       case MapType(keyType, valueType, _) =>

--- a/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
@@ -1071,7 +1071,8 @@ case class CometExecRule(session: SparkSession)
     if (groupingExpressions.isEmpty && aggregateExpressions.isEmpty) return false
 
     if (groupingExpressions.exists(e =>
-        SupportLevel.containsType(e.dataType, classOf[MapType]))) {
+        SupportLevel.containsType(e.dataType, classOf[MapType]) ||
+          SupportLevel.containsEmptyStruct(e.dataType))) {
       return false
     }
 

--- a/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
@@ -1073,7 +1073,8 @@ case class CometExecRule(session: SparkSession)
     if (groupingExpressions.isEmpty && aggregateExpressions.isEmpty) return false
 
     if (groupingExpressions.exists(e =>
-        SupportLevel.containsType(e.dataType, classOf[MapType]))) {
+        SupportLevel.containsType(e.dataType, classOf[MapType]) ||
+          SupportLevel.containsEmptyStruct(e.dataType))) {
       return false
     }
 

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -539,7 +539,9 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
     case dt if isTimeType(dt) =>
       true
     case s: StructType if allowComplex =>
-      s.fields.nonEmpty && s.fields.map(_.dataType).forall(supportedDataType(_, allowComplex))
+      // A struct's `fields` can be empty -- e.g. Iceberg's `_partition` metadata column is
+      // exactly that on an unpartitioned table. It's still a value Comet can represent.
+      s.fields.map(_.dataType).forall(supportedDataType(_, allowComplex))
     case a: ArrayType if allowComplex =>
       supportedDataType(a.elementType, allowComplex)
     case m: MapType if allowComplex =>

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -132,11 +132,11 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
       classOf[Expm1] -> CometScalarFunction("expm1"),
       classOf[Factorial] -> CometScalarFunction("factorial"),
       classOf[Floor] -> CometFloor,
-      classOf[Greatest] -> CometScalarFunction("greatest"),
+      classOf[Greatest] -> CometGreatest,
       classOf[Hex] -> CometHex,
       classOf[IntegralDivide] -> CometIntegralDivide,
       classOf[IsNaN] -> CometIsNaN,
-      classOf[Least] -> CometScalarFunction("least"),
+      classOf[Least] -> CometLeast,
       classOf[Log] -> CometLog,
       classOf[Log2] -> CometLog2,
       classOf[Log10] -> CometLog10,
@@ -539,7 +539,9 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
     case dt if isTimeType(dt) =>
       true
     case s: StructType if allowComplex =>
-      s.fields.nonEmpty && s.fields.map(_.dataType).forall(supportedDataType(_, allowComplex))
+      // A struct's `fields` can be empty -- e.g. Iceberg's `_partition` metadata column is
+      // exactly that on an unpartitioned table. It's still a value Comet can represent.
+      s.fields.map(_.dataType).forall(supportedDataType(_, allowComplex))
     case a: ArrayType if allowComplex =>
       supportedDataType(a.elementType, allowComplex)
     case m: MapType if allowComplex =>

--- a/spark/src/main/scala/org/apache/comet/serde/SupportLevel.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/SupportLevel.scala
@@ -84,6 +84,43 @@ object SupportLevel {
   }
 
   /**
+   * Whether `dt` is, or contains (recursively, through struct/array/map), a zero-field struct.
+   * Several DataFusion 54.1 code paths that reconstruct a struct -- `ScalarValue::compact`
+   * (backing the `FirstValue`/`LastValue`/`DistinctArrayAggAccumulator` accumulators),
+   * `GroupValuesRows::emit`'s dictionary-encoding step, and the cast applied to a window
+   * function's typed default value -- assume at least one child array (or a non-empty field-name
+   * overlap) to work from, and panic or error for a zero-field struct. Callers that would
+   * otherwise reach one of those paths decline such schemas instead; see
+   * https://github.com/apache/datafusion-comet/pull/5414.
+   */
+  def containsEmptyStruct(dt: DataType): Boolean = dt match {
+    case StructType(fields) if fields.isEmpty => true
+    case StructType(fields) => fields.exists(f => containsEmptyStruct(f.dataType))
+    case ArrayType(elementType, _) => containsEmptyStruct(elementType)
+    case MapType(keyType, valueType, _) =>
+      containsEmptyStruct(keyType) || containsEmptyStruct(valueType)
+    case _ => false
+  }
+
+  /**
+   * Fallback reason for a `map_extract` lookup (Spark `GetMapValue` / `element_at(map, key)`)
+   * whose map key type contains a zero-field struct. DataFusion's `map_extract` coercion rewrites
+   * the lookup key to the map's exact Arrow key type, and Comet's planner then inserts a
+   * `CastExpr` for any Arrow-level difference -- including a struct/list field *name* that
+   * Spark's `DataType` cannot express. Casting a zero-field struct fails with "no field name
+   * overlap", so such lookups stay on Spark. See
+   * https://github.com/apache/datafusion-comet/pull/5414.
+   */
+  def emptyStructMapKeyReason(mapType: DataType): Option[String] = mapType match {
+    case MapType(keyType, _, _) if containsEmptyStruct(keyType) =>
+      Some(
+        "map lookup with an empty struct in the key type is not supported (DataFusion's " +
+          "map_extract coerces the lookup key to the map's exact key type, which casts a " +
+          "zero-field struct and errors)")
+    case _ => None
+  }
+
+  /**
    * Gate for [[CometConf.COMET_EXEC_STRICT_FLOATING_POINT]]: returns the standard incompatibility
    * reason when strict mode is enabled and `dt` contains a float or double (at any nesting
    * level), and `None` otherwise. Callers wrap the reason with `Incompatible` or pass it to

--- a/spark/src/main/scala/org/apache/comet/serde/SupportLevel.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/SupportLevel.scala
@@ -84,6 +84,25 @@ object SupportLevel {
   }
 
   /**
+   * Whether `dt` is, or contains (recursively, through struct/array/map), a zero-field struct.
+   * Several DataFusion 54.1 code paths that reconstruct a struct -- `ScalarValue::compact`
+   * (backing the `FirstValue`/`LastValue`/`DistinctArrayAggAccumulator` accumulators),
+   * `GroupValuesRows::emit`'s dictionary-encoding step, and the cast applied to a window
+   * function's typed default value -- assume at least one child array (or a non-empty field-name
+   * overlap) to work from, and panic or error for a zero-field struct. Callers that would
+   * otherwise reach one of those paths decline such schemas instead; see
+   * https://github.com/apache/datafusion-comet/pull/5414.
+   */
+  def containsEmptyStruct(dt: DataType): Boolean = dt match {
+    case StructType(fields) if fields.isEmpty => true
+    case StructType(fields) => fields.exists(f => containsEmptyStruct(f.dataType))
+    case ArrayType(elementType, _) => containsEmptyStruct(elementType)
+    case MapType(keyType, valueType, _) =>
+      containsEmptyStruct(keyType) || containsEmptyStruct(valueType)
+    case _ => false
+  }
+
+  /**
    * Gate for [[CometConf.COMET_EXEC_STRICT_FLOATING_POINT]]: returns the standard incompatibility
    * reason when strict mode is enabled and `dt` contains a float or double (at any nesting
    * level), and `None` otherwise. Callers wrap the reason with `Incompatible` or pass it to

--- a/spark/src/main/scala/org/apache/comet/serde/aggregates.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/aggregates.scala
@@ -843,12 +843,20 @@ object CometCollectSet extends CometAggregateExpressionSerde[CollectSet] {
       " `spark.comet.expression.CollectSet.allowIncompatible=true` is set.")
 
   override def getSupportLevel(expr: CollectSet): SupportLevel = {
-    // The native path always drops null inputs. Spark 4.2 added an `ignoreNulls` field to
-    // CollectSet that `RESPECT NULLS` sets to false, preserving nulls in the result; Comet
-    // cannot match that, so fall back. This branch is only reachable on Spark 4.2+: on 3.4
-    // through 4.1 the field does not exist, `RESPECT NULLS`/`IGNORE NULLS` are rejected at
-    // analysis time, and CometCollectShim.ignoreNulls hardcodes true, making this a no-op.
-    if (!CometCollectShim.ignoreNulls(expr)) {
+    // DataFusion's DistinctArrayAggAccumulator (backing SparkCollectSet) calls
+    // ScalarValue::compacted() per non-null input, hitting the same zero-field
+    // StructArray::new panic as First/Last -- see SupportLevel.containsEmptyStruct.
+    if (SupportLevel.containsEmptyStruct(expr.dataType)) {
+      Unsupported(
+        Some(
+          "collect_set on a schema containing an empty struct is not supported " +
+            "(DataFusion's ScalarValue::compacted panics on zero-field structs)"))
+      // The native path always drops null inputs. Spark 4.2 added an `ignoreNulls` field to
+      // CollectSet that `RESPECT NULLS` sets to false, preserving nulls in the result; Comet
+      // cannot match that, so fall back. This branch is only reachable on Spark 4.2+: on 3.4
+      // through 4.1 the field does not exist, `RESPECT NULLS`/`IGNORE NULLS` are rejected at
+      // analysis time, and CometCollectShim.ignoreNulls hardcodes true, making this a no-op.
+    } else if (!CometCollectShim.ignoreNulls(expr)) {
       Unsupported(Some("collect_set with RESPECT NULLS (ignoreNulls = false) is not supported"))
     } else {
       SupportLevel
@@ -1036,26 +1044,9 @@ object AggSerde {
     }
   }
 
-  /**
-   * Whether `dt` is, or contains (recursively, through struct/array/map), a zero-field struct.
-   * DataFusion's `ScalarValue::compact` -- used by the `FirstValue`/`LastValue` accumulators that
-   * back Comet's `First`/`Last` -- calls `StructArray::new` unconditionally when reconstructing a
-   * struct, which panics for a zero-field struct (no child array to derive its row count from).
-   * `First`/`Last` decline such schemas until that's fixed upstream; see
-   * https://github.com/apache/datafusion-comet/pull/5414.
-   */
-  def containsEmptyStruct(dt: DataType): Boolean = dt match {
-    case StructType(fields) if fields.isEmpty => true
-    case StructType(fields) => fields.exists(f => containsEmptyStruct(f.dataType))
-    case ArrayType(elementType, _) => containsEmptyStruct(elementType)
-    case MapType(keyType, valueType, _) =>
-      containsEmptyStruct(keyType) || containsEmptyStruct(valueType)
-    case _ => false
-  }
-
   /** Shared support level for `First` / `Last`, which can't accept an empty struct. */
   def firstLastSupportLevel(dt: DataType): SupportLevel = {
-    if (containsEmptyStruct(dt)) {
+    if (SupportLevel.containsEmptyStruct(dt)) {
       Unsupported(
         Some(
           "FIRST/LAST on a schema containing an empty struct is not supported " +

--- a/spark/src/main/scala/org/apache/comet/serde/aggregates.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/aggregates.scala
@@ -240,6 +240,9 @@ object CometFirst extends CometAggregateExpressionSerde[First] {
   override def getCompatibleNotes(): Seq[String] = Seq(
     "This function is not deterministic. Results may not match Spark.")
 
+  override def getSupportLevel(expr: First): SupportLevel =
+    AggSerde.firstLastSupportLevel(expr.dataType)
+
   override def convert(
       aggExpr: AggregateExpression,
       first: First,
@@ -274,6 +277,9 @@ object CometLast extends CometAggregateExpressionSerde[Last] {
 
   override def getCompatibleNotes(): Seq[String] = Seq(
     "This function is not deterministic. Results may not match Spark.")
+
+  override def getSupportLevel(expr: Last): SupportLevel =
+    AggSerde.firstLastSupportLevel(expr.dataType)
 
   override def convert(
       aggExpr: AggregateExpression,
@@ -1027,6 +1033,35 @@ object AggSerde {
     dt match {
       case ByteType | ShortType | IntegerType | LongType => true
       case _ => false
+    }
+  }
+
+  /**
+   * Whether `dt` is, or contains (recursively, through struct/array/map), a zero-field struct.
+   * DataFusion's `ScalarValue::compact` -- used by the `FirstValue`/`LastValue` accumulators that
+   * back Comet's `First`/`Last` -- calls `StructArray::new` unconditionally when reconstructing a
+   * struct, which panics for a zero-field struct (no child array to derive its row count from).
+   * `First`/`Last` decline such schemas until that's fixed upstream; see
+   * https://github.com/apache/datafusion-comet/pull/5414.
+   */
+  def containsEmptyStruct(dt: DataType): Boolean = dt match {
+    case StructType(fields) if fields.isEmpty => true
+    case StructType(fields) => fields.exists(f => containsEmptyStruct(f.dataType))
+    case ArrayType(elementType, _) => containsEmptyStruct(elementType)
+    case MapType(keyType, valueType, _) =>
+      containsEmptyStruct(keyType) || containsEmptyStruct(valueType)
+    case _ => false
+  }
+
+  /** Shared support level for `First` / `Last`, which can't accept an empty struct. */
+  def firstLastSupportLevel(dt: DataType): SupportLevel = {
+    if (containsEmptyStruct(dt)) {
+      Unsupported(
+        Some(
+          "FIRST/LAST on a schema containing an empty struct is not supported " +
+            "(DataFusion's ScalarValue::compact panics on zero-field structs)"))
+    } else {
+      Compatible()
     }
   }
 

--- a/spark/src/main/scala/org/apache/comet/serde/aggregates.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/aggregates.scala
@@ -240,6 +240,9 @@ object CometFirst extends CometAggregateExpressionSerde[First] {
   override def getCompatibleNotes(): Seq[String] = Seq(
     "This function is not deterministic. Results may not match Spark.")
 
+  override def getSupportLevel(expr: First): SupportLevel =
+    AggSerde.firstLastSupportLevel(expr.dataType)
+
   override def convert(
       aggExpr: AggregateExpression,
       first: First,
@@ -274,6 +277,9 @@ object CometLast extends CometAggregateExpressionSerde[Last] {
 
   override def getCompatibleNotes(): Seq[String] = Seq(
     "This function is not deterministic. Results may not match Spark.")
+
+  override def getSupportLevel(expr: Last): SupportLevel =
+    AggSerde.firstLastSupportLevel(expr.dataType)
 
   override def convert(
       aggExpr: AggregateExpression,
@@ -837,12 +843,20 @@ object CometCollectSet extends CometAggregateExpressionSerde[CollectSet] {
       " `spark.comet.expression.CollectSet.allowIncompatible=true` is set.")
 
   override def getSupportLevel(expr: CollectSet): SupportLevel = {
-    // The native path always drops null inputs. Spark 4.2 added an `ignoreNulls` field to
-    // CollectSet that `RESPECT NULLS` sets to false, preserving nulls in the result; Comet
-    // cannot match that, so fall back. This branch is only reachable on Spark 4.2+: on 3.4
-    // through 4.1 the field does not exist, `RESPECT NULLS`/`IGNORE NULLS` are rejected at
-    // analysis time, and CometCollectShim.ignoreNulls hardcodes true, making this a no-op.
-    if (!CometCollectShim.ignoreNulls(expr)) {
+    // DataFusion's DistinctArrayAggAccumulator (backing SparkCollectSet) calls
+    // ScalarValue::compacted() per non-null input, hitting the same zero-field
+    // StructArray::new panic as First/Last -- see SupportLevel.containsEmptyStruct.
+    if (SupportLevel.containsEmptyStruct(expr.dataType)) {
+      Unsupported(
+        Some(
+          "collect_set on a schema containing an empty struct is not supported " +
+            "(DataFusion's ScalarValue::compacted panics on zero-field structs)"))
+      // The native path always drops null inputs. Spark 4.2 added an `ignoreNulls` field to
+      // CollectSet that `RESPECT NULLS` sets to false, preserving nulls in the result; Comet
+      // cannot match that, so fall back. This branch is only reachable on Spark 4.2+: on 3.4
+      // through 4.1 the field does not exist, `RESPECT NULLS`/`IGNORE NULLS` are rejected at
+      // analysis time, and CometCollectShim.ignoreNulls hardcodes true, making this a no-op.
+    } else if (!CometCollectShim.ignoreNulls(expr)) {
       Unsupported(Some("collect_set with RESPECT NULLS (ignoreNulls = false) is not supported"))
     } else {
       SupportLevel
@@ -887,13 +901,22 @@ object CometCollectSet extends CometAggregateExpressionSerde[CollectSet] {
 object CometCollectList extends CometAggregateExpressionSerde[CollectList] {
 
   override def getSupportLevel(expr: CollectList): SupportLevel = {
-    // The native path delegates to SparkCollectList, which always drops null inputs. Spark 4.2
-    // added an `ignoreNulls` field to CollectList that `RESPECT NULLS` sets to false, preserving
-    // nulls in the result; Comet cannot match that, so fall back. This branch is only reachable
-    // on Spark 4.2+: on 3.4 through 4.1 the field does not exist, `RESPECT NULLS`/`IGNORE NULLS`
-    // are rejected at analysis time, and CometCollectShim.ignoreNulls hardcodes true, making this
-    // a no-op.
-    if (!CometCollectShim.ignoreNulls(expr)) {
+    // planner.rs's coerce_collect_child_nullability casts the child to an all-nullable variant
+    // of its type whenever any nested field is non-nullable (e.g. a named_struct argument), so
+    // that the accumulator's always-nullable output matches the declared schema. DataFusion casts
+    // a struct field-by-field even when only a sibling field's nullability changed, and casting a
+    // zero-field struct to itself still fails -- see SupportLevel.containsEmptyStruct.
+    if (SupportLevel.containsEmptyStruct(expr.dataType)) {
+      Unsupported(
+        Some(
+          "collect_list on a schema containing an empty struct is not supported " +
+            "(DataFusion errors casting a zero-field struct to itself)"))
+      // The native path always drops null inputs. Spark 4.2 added an `ignoreNulls` field to
+      // CollectList that `RESPECT NULLS` sets to false, preserving nulls in the result; Comet
+      // cannot match that, so fall back. This branch is only reachable on Spark 4.2+: on 3.4
+      // through 4.1 the field does not exist, `RESPECT NULLS`/`IGNORE NULLS` are rejected at
+      // analysis time, and CometCollectShim.ignoreNulls hardcodes true, making this a no-op.
+    } else if (!CometCollectShim.ignoreNulls(expr)) {
       Unsupported(Some("collect_list with RESPECT NULLS (ignoreNulls = false) is not supported"))
     } else {
       Compatible()
@@ -1027,6 +1050,18 @@ object AggSerde {
     dt match {
       case ByteType | ShortType | IntegerType | LongType => true
       case _ => false
+    }
+  }
+
+  /** Shared support level for `First` / `Last`, which can't accept an empty struct. */
+  def firstLastSupportLevel(dt: DataType): SupportLevel = {
+    if (SupportLevel.containsEmptyStruct(dt)) {
+      Unsupported(
+        Some(
+          "FIRST/LAST on a schema containing an empty struct is not supported " +
+            "(DataFusion's ScalarValue::compact panics on zero-field structs)"))
+    } else {
+      Compatible()
     }
   }
 

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -216,6 +216,17 @@ object CometArrayIntersect
 }
 
 object CometArrayMax extends CometExpressionSerde[ArrayMax] {
+  override def getSupportLevel(expr: ArrayMax): SupportLevel = {
+    // DataFusion's `ScalarValue::partial_cmp_struct` flattens a struct into its leaf columns to
+    // find the extreme element; a zero-field struct contributes no columns, so a NULL element
+    // and a non-null empty-struct element compare equal instead of ordering NULL out.
+    if (SupportLevel.containsEmptyStruct(expr.dataType)) {
+      Unsupported(Some("array_max on a schema containing an empty struct is not supported"))
+    } else {
+      Compatible()
+    }
+  }
+
   override def convert(
       expr: ArrayMax,
       inputs: Seq[Attribute],
@@ -229,6 +240,15 @@ object CometArrayMax extends CometExpressionSerde[ArrayMax] {
 }
 
 object CometArrayMin extends CometExpressionSerde[ArrayMin] {
+  override def getSupportLevel(expr: ArrayMin): SupportLevel = {
+    // Same DataFusion comparator issue as CometArrayMax above.
+    if (SupportLevel.containsEmptyStruct(expr.dataType)) {
+      Unsupported(Some("array_min on a schema containing an empty struct is not supported"))
+    } else {
+      Compatible()
+    }
+  }
+
   override def convert(
       expr: ArrayMin,
       inputs: Seq[Attribute],
@@ -482,6 +502,23 @@ object CometCreateArray extends CometExpressionSerde[CreateArray] {
     //
     // TODO: remove this decline once apache/datafusion#22366 lands; the upstream fix widens the
     // element type via nullability-OR-merge and casts each child before MutableArrayData.
+    // DataFusion's `make_array` coerces its arguments to one common type, and Comet's planner
+    // then inserts a `CastExpr` for any argument whose type differs from that common type --
+    // including when the only difference is an Arrow list/struct field *name* that Spark's
+    // `ArrayType` cannot represent (e.g. `array(array_repeat(n, 1).e, array_repeat(n.e, 1))`,
+    // whose elements are `list<e: struct<>>` vs `list<item: struct<>>`). Casting a zero-field
+    // struct fails with "no field name overlap", and `normalizeContainerNullability` below
+    // cannot see the name difference, so keep any multi-argument `CreateArray` whose element
+    // type contains an empty struct on Spark. See `SupportLevel.containsEmptyStruct`.
+    if (children.size > 1 && SupportLevel.containsEmptyStruct(expr.dataType)) {
+      withFallbackReason(
+        expr,
+        "CreateArray with more than one argument and an empty struct in the element type is " +
+          "not supported (DataFusion's make_array coerces its arguments to a common type, " +
+          "which casts a zero-field struct and errors)")
+      return None
+    }
+
     val normalizedTypes = children.map(c => normalizeContainerNullability(c.dataType))
     if (normalizedTypes.distinct.size > 1) {
       withFallbackReason(
@@ -593,7 +630,13 @@ object CometElementAt extends CometExpressionSerde[ElementAt] {
   override def getSupportLevel(expr: ElementAt): SupportLevel = {
     expr.left.dataType match {
       case _: ArrayType => Compatible()
-      case _: MapType => Compatible()
+      case mapType: MapType =>
+        // element_at(map, key) lowers to the same native map_extract as GetMapValue and hits the
+        // same zero-field-struct key-coercion cast -- see SupportLevel.emptyStructMapKeyReason.
+        SupportLevel
+          .emptyStructMapKeyReason(mapType)
+          .map(r => Unsupported(Some(r)))
+          .getOrElse(Compatible())
       case _ => Unsupported(Some("Input must be an array or map"))
     }
   }

--- a/spark/src/main/scala/org/apache/comet/serde/conditional.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/conditional.scala
@@ -21,9 +21,9 @@ package org.apache.comet.serde
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, CaseWhen, Coalesce, Expression, If, IsNotNull}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, CaseWhen, Coalesce, Expression, Greatest, If, IsNotNull, Least}
 
-import org.apache.comet.serde.QueryPlanSerde.exprToProtoInternal
+import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, scalarFunctionExprToProto}
 
 object CometIf extends CometExpressionSerde[If] {
   override def convert(
@@ -87,6 +87,46 @@ object CometCaseWhen extends CometExpressionSerde[CaseWhen] {
     }
   }
 }
+
+/**
+ * `Greatest` / `Least` serialize as plain DataFusion scalar functions, and their arguments only
+ * have to share a datatype up to nullability (Spark's `TypeCoercion.haveSameType` ignores
+ * `nullable` / `containsNull` / `valueContainsNull`). DataFusion's `greatest`/`least` coerce
+ * every argument to one common type; Comet's planner then inserts a `CastExpr` for any argument
+ * whose Arrow type differs from that common type -- differing nested nullability, but also a
+ * struct/list field *name* that Spark's `DataType` cannot express (e.g. `greatest(array_repeat(n,
+ * 1).e, array_repeat(n.e, 1))`, whose elements are `list<e: struct<>>` vs `list<item:
+ * struct<>>`). Casting a zero-field struct errors, so decline any multi-argument call whose
+ * argument types contain an empty struct; a single argument is never coerced against anything.
+ * See `SupportLevel.containsEmptyStruct` and
+ * https://github.com/apache/datafusion-comet/pull/5414.
+ */
+abstract class CometLeastGreatest[T <: Expression](name: String) extends CometExpressionSerde[T] {
+  override def getSupportLevel(expr: T): SupportLevel = {
+    val types = expr.children.map(_.dataType)
+    if (expr.children.size > 1 && types.exists(SupportLevel.containsEmptyStruct)) {
+      Unsupported(
+        Some(
+          s"$name over more than one operand whose type contains an empty struct is not " +
+            "supported (DataFusion coerces the arguments to a common type, which casts a " +
+            "zero-field struct and errors)"))
+    } else {
+      Compatible()
+    }
+  }
+
+  override def convert(
+      expr: T,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] = {
+    val childExpr = expr.children.map(exprToProtoInternal(_, inputs, binding))
+    scalarFunctionExprToProto(name, childExpr: _*)
+  }
+}
+
+object CometGreatest extends CometLeastGreatest[Greatest]("greatest")
+
+object CometLeast extends CometLeastGreatest[Least]("least")
 
 object CometCoalesce extends CometExpressionSerde[Coalesce] {
   override def convert(

--- a/spark/src/main/scala/org/apache/comet/serde/literals.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/literals.scala
@@ -24,13 +24,12 @@ import java.lang
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Literal}
 import org.apache.spark.sql.catalyst.util.ArrayData
-import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteType, DateType, DayTimeIntervalType, Decimal, DecimalType, DoubleType, FloatType, IntegerType, LongType, NullType, ShortType, StringType, TimestampNTZType, TimestampType}
+import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteType, DataType, DateType, DayTimeIntervalType, Decimal, DecimalType, DoubleType, FloatType, IntegerType, LongType, MapType, NullType, ShortType, StringType, StructType, TimestampNTZType, TimestampType}
 import org.apache.spark.unsafe.types.UTF8String
 
 import com.google.protobuf.ByteString
 
 import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
-import org.apache.comet.DataTypeSupport.isComplexType
 import org.apache.comet.serde.{CometExpressionSerde, Compatible, ExprOuterClass, LiteralOuterClass, SupportLevel, Unsupported}
 import org.apache.comet.serde.QueryPlanSerde.{isTimeType, serializeDataType, supportedDataType}
 import org.apache.comet.serde.Types.ListLiteral
@@ -40,6 +39,20 @@ object CometLiteral extends CometExpressionSerde[Literal] with Logging {
   override def getUnsupportedReasons(): Seq[String] = Seq(
     "Not all data types are supported for literal values")
 
+  /**
+   * Whether `makeListLiteral` can serialize an array literal whose (possibly nested) element type
+   * is `dt`. It has an explicit case per primitive type and recurses through `ArrayType`, but no
+   * case for `StructType` or `MapType` at all -- passing one through throws a `MatchError` at
+   * plan time. Checking this recursively (rather than only one level of nesting, as the caller
+   * below used to) keeps e.g. `array<array<struct<...>>>` -- empty struct or not -- off the
+   * literal path until `makeListLiteral` can actually encode it.
+   */
+  private def isListLiteralElementSupported(dt: DataType): Boolean = dt match {
+    case a: ArrayType => isListLiteralElementSupported(a.elementType)
+    case _: StructType | _: MapType => false
+    case _ => true
+  }
+
   override def getSupportLevel(expr: Literal): SupportLevel = {
 
     if (supportedDataType(
@@ -48,12 +61,8 @@ object CometLiteral extends CometExpressionSerde[Literal] with Logging {
 
           // Nested literal support for native reader
           // can be tracked https://github.com/apache/datafusion-comet/issues/1937
-          (expr.dataType
-            .isInstanceOf[ArrayType] && (!isComplexType(
-            expr.dataType.asInstanceOf[ArrayType].elementType) || expr.dataType
-            .asInstanceOf[ArrayType]
-            .elementType
-            .isInstanceOf[ArrayType])))) {
+          (expr.dataType.isInstanceOf[ArrayType] &&
+            isListLiteralElementSupported(expr.dataType.asInstanceOf[ArrayType].elementType)))) {
       Compatible(None)
     } else {
       expr.dataType match {

--- a/spark/src/main/scala/org/apache/comet/serde/maps.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/maps.scala
@@ -64,6 +64,12 @@ object CometMapValues extends CometExpressionSerde[MapValues] {
 
 object CometMapExtract extends CometExpressionSerde[GetMapValue] {
 
+  override def getSupportLevel(expr: GetMapValue): SupportLevel =
+    SupportLevel
+      .emptyStructMapKeyReason(expr.child.dataType)
+      .map(r => Unsupported(Some(r)))
+      .getOrElse(Compatible())
+
   override def convert(
       expr: GetMapValue,
       inputs: Seq[Attribute],

--- a/spark/src/main/scala/org/apache/comet/serde/operator/CometSink.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/operator/CometSink.scala
@@ -46,7 +46,9 @@ abstract class CometSink[T <: SparkPlan] extends CometOperatorSerde[T] {
   protected final def supportedSinkDataType(dt: DataType): Boolean = dt match {
     case _: YearMonthIntervalType | _: DayTimeIntervalType => true
     case StructType(fields) =>
-      fields.nonEmpty && fields.forall(f => supportedSinkDataType(f.dataType))
+      // A struct's `fields` can be empty -- e.g. Iceberg's `_partition` metadata column is
+      // exactly that on an unpartitioned table. It's still a value the sink can serialize.
+      fields.forall(f => supportedSinkDataType(f.dataType))
     case ArrayType(elementType, _) => supportedSinkDataType(elementType)
     case MapType(keyType, valueType, _) =>
       supportedSinkDataType(keyType) && supportedSinkDataType(valueType)

--- a/spark/src/main/scala/org/apache/comet/serde/predicates.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/predicates.scala
@@ -294,8 +294,17 @@ object CometInSet extends CometExpressionSerde[InSet] with CodegenDispatchFallba
 trait CollationAwareBinaryPredicate[T <: BinaryExpression]
     extends CometExpressionSerde[T]
     with CodegenDispatchFallback {
-  override def getSupportLevel(expr: T): SupportLevel =
-    ComparisonUtils.collationSupportLevel(expr.prettyName, expr.left, expr.right)
+  override def getSupportLevel(expr: T): SupportLevel = {
+    val collation = ComparisonUtils.collationSupportLevel(expr.prettyName, expr.left, expr.right)
+    if (collation.isInstanceOf[Unsupported]) {
+      collation
+    } else {
+      ComparisonUtils.nestedEmptyStructMismatchSupportLevel(
+        expr.prettyName,
+        expr.left,
+        expr.right)
+    }
+  }
 
   override def getUnsupportedReasons(): Seq[String] =
     Seq(ComparisonUtils.nonDefaultCollationDocReason)
@@ -329,6 +338,30 @@ object ComparisonUtils {
     } else {
       Compatible()
     }
+
+  // DataFusion's nested comparison kernel requires both operands to share an identical type,
+  // including nested field nullability, so `planner.rs`'s `reconcile_nested_comparison_types`
+  // casts whichever operand doesn't already match a merged nullability-union type. DataFusion
+  // casts a struct field-by-field even when only a sibling field's nullability differs, and
+  // casting a zero-field struct to itself still fails -- see SupportLevel.containsEmptyStruct.
+  // Operands with identical types (the common case) never reach that cast, so only a genuine
+  // mismatch is guarded here.
+  def nestedEmptyStructMismatchSupportLevel(
+      exprName: String,
+      left: Expression,
+      right: Expression): SupportLevel = {
+    val (lt, rt) = (left.dataType, right.dataType)
+    if (lt != rt && (SupportLevel.containsEmptyStruct(lt) || SupportLevel.containsEmptyStruct(
+        rt))) {
+      Unsupported(
+        Some(
+          s"$exprName on differently-typed operands containing an empty struct is not " +
+            "supported (DataFusion errors casting a zero-field struct to itself while " +
+            "reconciling the comparison types)"))
+    } else {
+      Compatible()
+    }
+  }
 
   // Spark's `In` / `InSet` return `false` for any operand against an empty list, except under the
   // legacy `null IN ()` behavior, where a `NULL` operand returns `NULL` (SPARK-44550). Comet's

--- a/spark/src/main/scala/org/apache/comet/serde/structs.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/structs.scala
@@ -250,7 +250,9 @@ object CometJsonToStructs extends CometCodegenDispatch[JsonToStructs] with Nativ
 
   private def isSupportedSchema(dt: DataType): Boolean = dt match {
     case StructType(fields) =>
-      fields.nonEmpty && fields.forall(f => isSupportedSchema(f.dataType))
+      // A struct's `fields` can be empty -- e.g. `from_json(col, 'struct<>')`'s target schema.
+      // With no fields to check, this holds vacuously.
+      fields.forall(f => isSupportedSchema(f.dataType))
     case DataTypes.IntegerType | DataTypes.LongType | DataTypes.FloatType | DataTypes.DoubleType |
         DataTypes.BooleanType | DataTypes.StringType =>
       true

--- a/spark/src/main/scala/org/apache/comet/serde/structs.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/structs.scala
@@ -233,10 +233,15 @@ object CometJsonToStructs extends CometCodegenDispatch[JsonToStructs] with Nativ
       }
     }
 
-    // Convert child expression and schema to protobuf
+    // Convert child expression and schema to protobuf. Serialize `expr.dataType`, not
+    // `expr.schema`: Spark's `JsonToStructs` evaluates against `schema.asNullable` (its
+    // `dataType`), so every field of the result is nullable regardless of how the user wrote the
+    // schema. A parse miss (including a missing field under a `struct<>` target) yields a NULL,
+    // and serializing the user's non-nullable field here would put that NULL under a
+    // non-nullable Arrow field. See SPARK JsonToStructs.nullableSchema.
     for {
       childProto <- exprToProtoInternal(expr.child, inputs, binding)
-      schemaProto <- serializeDataType(expr.schema)
+      schemaProto <- serializeDataType(expr.dataType)
     } yield {
       val fromJson = ExprOuterClass.FromJson
         .newBuilder()
@@ -250,7 +255,9 @@ object CometJsonToStructs extends CometCodegenDispatch[JsonToStructs] with Nativ
 
   private def isSupportedSchema(dt: DataType): Boolean = dt match {
     case StructType(fields) =>
-      fields.nonEmpty && fields.forall(f => isSupportedSchema(f.dataType))
+      // A struct's `fields` can be empty -- e.g. `from_json(col, 'struct<>')`'s target schema.
+      // With no fields to check, this holds vacuously.
+      fields.forall(f => isSupportedSchema(f.dataType))
     case DataTypes.IntegerType | DataTypes.LongType | DataTypes.FloatType | DataTypes.DoubleType |
         DataTypes.BooleanType | DataTypes.StringType =>
       true

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometWindowExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometWindowExec.scala
@@ -34,7 +34,7 @@ import com.google.common.base.Objects
 
 import org.apache.comet.{CometConf, ConfigEntry}
 import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
-import org.apache.comet.serde.{AggSerde, CometOperatorSerde, LiteralOuterClass, OperatorOuterClass}
+import org.apache.comet.serde.{AggSerde, CometOperatorSerde, LiteralOuterClass, OperatorOuterClass, SupportLevel}
 import org.apache.comet.serde.OperatorOuterClass.Operator
 import org.apache.comet.serde.QueryPlanSerde.{aggExprToProto, exprToProto, scalarFunctionExprToProto, serializeDataType}
 
@@ -261,6 +261,16 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
           // https://github.com/apache/datafusion-comet/issues/4268
           withFallbackReason(windowExpr, "Lag default value must be a literal")
           (None, None, false)
+        case lag: Lag if SupportLevel.containsEmptyStruct(lag.default.dataType) =>
+          // An omitted or plain-NULL default is untyped (`NullType`) and unaffected. Only an
+          // explicitly typed default -- e.g. `CAST(NULL AS ARRAY<STRUCT<>>)` -- carries the
+          // empty struct into DataFusion's cast of the default to the input type, which errors
+          // on a zero-field struct even when source and target agree ("no field name overlap")
+          // -- see SupportLevel.containsEmptyStruct.
+          withFallbackReason(
+            windowExpr,
+            "LAG with an empty-struct-typed default value is not supported")
+          (None, None, false)
         case lag: Lag =>
           val inputExpr = exprToProto(lag.input, output)
           val offsetExpr = exprToProto(lag.inputOffset, output)
@@ -270,6 +280,12 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
         case lead: Lead if !lead.default.isInstanceOf[Literal] =>
           // https://github.com/apache/datafusion-comet/issues/4268
           withFallbackReason(windowExpr, "Lead default value must be a literal")
+          (None, None, false)
+        case lead: Lead if SupportLevel.containsEmptyStruct(lead.default.dataType) =>
+          // Same DataFusion cast issue as the LAG case above.
+          withFallbackReason(
+            windowExpr,
+            "LEAD with an empty-struct-typed default value is not supported")
           (None, None, false)
         case lead: Lead =>
           val inputExpr = exprToProto(lead.input, output)

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometWindowExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometWindowExec.scala
@@ -34,7 +34,7 @@ import com.google.common.base.Objects
 
 import org.apache.comet.{CometConf, ConfigEntry}
 import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
-import org.apache.comet.serde.{AggSerde, CometOperatorSerde, LiteralOuterClass, OperatorOuterClass}
+import org.apache.comet.serde.{AggSerde, CometOperatorSerde, LiteralOuterClass, OperatorOuterClass, SupportLevel}
 import org.apache.comet.serde.OperatorOuterClass.Operator
 import org.apache.comet.serde.QueryPlanSerde.{aggExprToProto, exprToProto, scalarFunctionExprToProto, serializeDataType}
 
@@ -261,6 +261,16 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
           // https://github.com/apache/datafusion-comet/issues/4268
           withFallbackReason(windowExpr, "Lag default value must be a literal")
           (None, None, false)
+        case lag: Lag if SupportLevel.containsEmptyStruct(lag.default.dataType) =>
+          // An omitted or plain-NULL default is untyped (`NullType`) and unaffected. Only an
+          // explicitly typed default -- e.g. `CAST(NULL AS ARRAY<STRUCT<>>)` -- carries the
+          // empty struct into DataFusion's cast of the default to the input type, which errors
+          // on a zero-field struct even when source and target agree ("no field name overlap")
+          // -- see SupportLevel.containsEmptyStruct.
+          withFallbackReason(
+            windowExpr,
+            "LAG with an empty-struct-typed default value is not supported")
+          (None, None, false)
         case lag: Lag =>
           val inputExpr = exprToProto(lag.input, output)
           val offsetExpr = exprToProto(lag.inputOffset, output)
@@ -270,6 +280,12 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
         case lead: Lead if !lead.default.isInstanceOf[Literal] =>
           // https://github.com/apache/datafusion-comet/issues/4268
           withFallbackReason(windowExpr, "Lead default value must be a literal")
+          (None, None, false)
+        case lead: Lead if SupportLevel.containsEmptyStruct(lead.default.dataType) =>
+          // Same DataFusion cast issue as the LAG case above.
+          withFallbackReason(
+            windowExpr,
+            "LEAD with an empty-struct-typed default value is not supported")
           (None, None, false)
         case lead: Lead =>
           val inputExpr = exprToProto(lead.input, output)
@@ -351,6 +367,22 @@ object CometWindowExec extends CometOperatorSerde[WindowExec] {
           }
         case _ =>
       }
+    }
+
+    // DataFusion's `ScalarValue::partial_cmp_struct` flattens a struct into its leaf columns to
+    // compare RANGE peers; a zero-field struct contributes no columns, so a NULL struct and a
+    // non-null empty struct compare equal instead of ordering NULL first. That misgroups RANGE
+    // peers for any RANGE frame on such an ORDER BY key, not just the explicit-offset ones
+    // checked below (whose bounds are UNBOUNDED/CURRENT ROW and so skip that check entirely).
+    f match {
+      case SpecifiedWindowFrame(RangeFrame, _, _)
+          if windowExpr.windowSpec.orderSpec.exists(o =>
+            SupportLevel.containsEmptyStruct(o.dataType)) =>
+        withFallbackReason(
+          windowExpr,
+          "RANGE frame ordering on a schema containing an empty struct is not supported")
+        return None
+      case _ =>
     }
 
     // Comet's native window planner ships RANGE frame offsets as

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -419,7 +419,10 @@ object CometShuffleExchangeExec
       case dt if isTimeType(dt) =>
         true
       case StructType(fields) =>
-        fields.nonEmpty && fields.forall(f => supportedSerializableDataType(f.dataType))
+        // A struct's `fields` can be empty -- e.g. Iceberg's `_partition` metadata column is
+        // exactly that on an unpartitioned table. Arrow represents it as zero child arrays plus
+        // its own validity bitmap, which native shuffle serializes like any other struct.
+        fields.forall(f => supportedSerializableDataType(f.dataType))
       case ArrayType(elementType, _) =>
         supportedSerializableDataType(elementType)
       case MapType(keyType, valueType, _) =>
@@ -544,10 +547,12 @@ object CometShuffleExchangeExec
       case dt if isTimeType(dt) =>
         true
       case StructType(fields) =>
-        fields.nonEmpty && fields.forall(f => supportedSerializableDataType(f.dataType)) &&
+        // A struct's `fields` can be empty -- e.g. Iceberg's `_partition` metadata column is
+        // exactly that on an unpartitioned table. The distinct-name check below holds
+        // vacuously when there are no fields to compare.
+        fields.forall(f => supportedSerializableDataType(f.dataType)) &&
         // Java Arrow stream reader cannot work on duplicate field name
-        fields.map(f => f.name).distinct.length == fields.length &&
-        fields.nonEmpty
+        fields.map(f => f.name).distinct.length == fields.length
       case ArrayType(elementType, _) =>
         supportedSerializableDataType(elementType)
       case MapType(keyType, valueType, _) =>

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -424,7 +424,10 @@ object CometShuffleExchangeExec
       case dt if isTimeType(dt) =>
         true
       case StructType(fields) =>
-        fields.nonEmpty && fields.forall(f => supportedSerializableDataType(f.dataType))
+        // A struct's `fields` can be empty -- e.g. Iceberg's `_partition` metadata column is
+        // exactly that on an unpartitioned table. Arrow represents it as zero child arrays plus
+        // its own validity bitmap, which native shuffle serializes like any other struct.
+        fields.forall(f => supportedSerializableDataType(f.dataType))
       case ArrayType(elementType, _) =>
         supportedSerializableDataType(elementType)
       case MapType(keyType, valueType, _) =>
@@ -549,10 +552,12 @@ object CometShuffleExchangeExec
       case dt if isTimeType(dt) =>
         true
       case StructType(fields) =>
-        fields.nonEmpty && fields.forall(f => supportedSerializableDataType(f.dataType)) &&
+        // A struct's `fields` can be empty -- e.g. Iceberg's `_partition` metadata column is
+        // exactly that on an unpartitioned table. The distinct-name check below holds
+        // vacuously when there are no fields to compare.
+        fields.forall(f => supportedSerializableDataType(f.dataType)) &&
         // Java Arrow stream reader cannot work on duplicate field name
-        fields.map(f => f.name).distinct.length == fields.length &&
-        fields.nonEmpty
+        fields.map(f => f.name).distinct.length == fields.length
       case ArrayType(elementType, _) =>
         supportedSerializableDataType(elementType)
       case MapType(keyType, valueType, _) =>

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -1689,6 +1689,16 @@ trait CometBaseAggregate {
       return None
     }
 
+    if (groupingExpressions.exists(expr => SupportLevel.containsEmptyStruct(expr.dataType))) {
+      // DataFusion's `GroupValuesRows::emit` dictionary-encodes struct-typed group keys via
+      // `StructArray::try_new`, which errors for a zero-field struct -- see
+      // SupportLevel.containsEmptyStruct.
+      withFallbackReason(
+        aggregate,
+        "Grouping on a schema containing an empty struct is not supported")
+      return None
+    }
+
     if (groupingExpressions.exists(expr => isStringCollationType(expr.dataType))) {
       // Collation-aware grouping requires collation-aware hashing/equality; Comet only
       // compares raw bytes, which would put rows that compare equal under the collation

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -1693,6 +1693,16 @@ trait CometBaseAggregate {
       return None
     }
 
+    if (groupingExpressions.exists(expr => SupportLevel.containsEmptyStruct(expr.dataType))) {
+      // DataFusion's `GroupValuesRows::emit` dictionary-encodes struct-typed group keys via
+      // `StructArray::try_new`, which errors for a zero-field struct -- see
+      // SupportLevel.containsEmptyStruct.
+      withFallbackReason(
+        aggregate,
+        "Grouping on a schema containing an empty struct is not supported")
+      return None
+    }
+
     if (groupingExpressions.exists(expr => isStringCollationType(expr.dataType))) {
       // Collation-aware grouping requires collation-aware hashing/equality; Comet only
       // compares raw bytes, which would put rows that compare equal under the collation

--- a/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
@@ -890,6 +890,21 @@ class CometArrayExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelp
     }
   }
 
+  test("array literal of empty struct falls back instead of crashing planning") {
+    // `array(array(struct()))` constant-folds to a literal whose (doubly-nested) array element
+    // type is an empty struct. `makeListLiteral` has no case for StructType at all (empty or
+    // not) -- letting this reach the literal path throws a bare `scala.MatchError` at plan
+    // time rather than a graceful fallback. See CometLiteral.isListLiteralElementSupported.
+    withTempDir { dir =>
+      val path = new Path(dir.toURI.toString, "test.parquet")
+      spark.range(10).write.parquet(path.toString)
+      withTempView("t1") {
+        spark.read.parquet(path.toString).createOrReplaceTempView("t1")
+        checkSparkAnswer(sql("SELECT id, array(array(struct())) FROM t1"))
+      }
+    }
+  }
+
   test("array_reverse") {
     withTempDir { dir =>
       val path = new Path(dir.toURI.toString, "test.parquet")

--- a/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
@@ -19,16 +19,17 @@
 
 package org.apache.comet
 
+import scala.jdk.CollectionConverters._
 import scala.util.Random
 
 import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.{CometTestBase, Row}
 import org.apache.spark.sql.catalyst.expressions.{ArrayAppend, ArrayExcept, ArrayInsert, ArrayIntersect, ArrayJoin, ArrayRepeat}
 import org.apache.spark.sql.catalyst.expressions.{ArrayContains, ArrayRemove}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.ArrayType
+import org.apache.spark.sql.types.{ArrayType, IntegerType, StructField, StructType}
 
 import org.apache.comet.CometSparkSessionExtensions.{isSpark35Plus, isSpark40Plus}
 import org.apache.comet.DataTypeSupport.isComplexType
@@ -887,6 +888,73 @@ class CometArrayExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelp
           }
         }
       }
+    }
+  }
+
+  test("array literal of empty struct falls back instead of crashing planning") {
+    // `array(array(struct()))` constant-folds to a literal whose (doubly-nested) array element
+    // type is an empty struct. `makeListLiteral` has no case for StructType at all (empty or
+    // not) -- letting this reach the literal path throws a bare `scala.MatchError` at plan
+    // time rather than a graceful fallback. See CometLiteral.isListLiteralElementSupported.
+    withTempDir { dir =>
+      val path = new Path(dir.toURI.toString, "test.parquet")
+      spark.range(10).write.parquet(path.toString)
+      withTempView("t1") {
+        spark.read.parquet(path.toString).createOrReplaceTempView("t1")
+        checkSparkAnswerAndFallbackReason(
+          "SELECT id, array(array(struct())) FROM t1",
+          "Unsupported data type array<array<struct")
+      }
+    }
+  }
+
+  test("array of empty-struct elements from differently-named list fields falls back") {
+    // `array_repeat(n, 1).e` and `array_repeat(n.e, 1)` are both `array<struct<>>` to Spark, but
+    // their Arrow element fields are named differently (`e` vs `item`). DataFusion's `make_array`
+    // coercion casts one to the other, and casting a zero-field struct errors ("no field name
+    // overlap"). CometCreateArray cannot see the name difference, so it must fall back.
+    withSQLConf(
+      CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true",
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        "org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation") {
+      val schema = StructType(
+        Seq(
+          StructField("id", IntegerType),
+          StructField("n", StructType(Seq(StructField("e", StructType(Nil)))))))
+      val data = Seq(Row(1, Row(Row())), Row(2, Row(null)), Row(3, null)).asJava
+      val df = spark.createDataFrame(data, schema)
+      df.createOrReplaceTempView("empty_struct_create_array")
+
+      checkSparkAnswerAndFallbackReason(
+        "SELECT array(array_repeat(n, 1).e, array_repeat(n.e, 1)) FROM empty_struct_create_array",
+        "an empty struct in the element type is not supported")
+    }
+  }
+
+  test("array_max/array_min decline an empty-struct element type") {
+    // DataFusion's `ScalarValue::partial_cmp_struct` flattens a struct into its leaf columns to
+    // find the extreme element; a zero-field struct contributes no columns, so a NULL element
+    // and a non-null empty-struct element compare equal instead of ordering NULL out.
+    withSQLConf(
+      CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true",
+      // Otherwise Catalyst's ConvertToLocalRelation rule evaluates this deterministic,
+      // aggregate-free projection directly over the LocalRelation's rows at plan time,
+      // producing a plan with no ArrayMax expression left to convert (or reject).
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        "org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation") {
+      val elemType = StructType(Seq(StructField("marker", StructType(Nil))))
+      val schema =
+        StructType(Seq(StructField("id", IntegerType), StructField("a", ArrayType(elemType))))
+      val data = Seq(Row(1, Array(Row(null), Row(Row())))).asJava
+      val df = spark.createDataFrame(data, schema)
+      df.createOrReplaceTempView("empty_struct_array_extrema")
+
+      checkSparkAnswerAndFallbackReason(
+        "SELECT array_max(a) FROM empty_struct_array_extrema",
+        "array_max on a schema containing an empty struct is not supported")
+      checkSparkAnswerAndFallbackReason(
+        "SELECT array_min(a) FROM empty_struct_array_extrema",
+        "array_min on a schema containing an empty struct is not supported")
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -44,6 +44,100 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   val DIVIDE_BY_ZERO_EXCEPTION_MSG =
     """Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead"""
 
+  test("struct comparison declines mismatched-nullability operands containing an empty struct") {
+    // planner.rs's reconcile_nested_comparison_types casts whichever comparison operand doesn't
+    // already match the nullability-union of both operand types; a named_struct literal argument
+    // infers a non-nullable field, so comparing it against a schema-nullable column of the same
+    // shape casts one side. DataFusion casts a struct field-by-field even when only that one
+    // field's nullability differs, and casting a zero-field struct to itself still fails -- see
+    // SupportLevel.containsEmptyStruct.
+    withSQLConf(
+      CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true",
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        "org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation") {
+      val schema =
+        StructType(Seq(StructField("outer", StructType(Seq(StructField("e", StructType(Nil)))))))
+      val data =
+        java.util.List.of[Row](Row(Row(Row())), Row(Row(null)), Row(null))
+      val df = spark.createDataFrame(data, schema)
+      df.createOrReplaceTempView("empty_struct_cmp")
+
+      checkSparkAnswerAndFallbackReason(
+        "SELECT outer <=> named_struct('e', struct()) FROM empty_struct_cmp",
+        "on differently-typed operands containing an empty struct is not supported")
+    }
+  }
+
+  test("greatest/least decline multi-arg empty-struct operands (nested nullability mismatch)") {
+    // Spark's `TypeCoercion.haveSameType` lets `greatest`/`least` take two structs that match
+    // only up to nullability. DataFusion's `greatest`/`least` coerce every argument to one
+    // common type, and reconciling the nullability difference inserts a struct cast that errors
+    // on the zero-field child -- see SupportLevel.containsEmptyStruct.
+    withSQLConf(
+      CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true",
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        "org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation") {
+      val empty = StructType(Nil)
+      val leftType = StructType(
+        Seq(
+          StructField("marker", empty, nullable = true),
+          StructField("value", IntegerType, nullable = false)))
+      val rightType = StructType(
+        Seq(
+          StructField("marker", empty, nullable = true),
+          StructField("value", IntegerType, nullable = true)))
+      val schema = StructType(
+        Seq(
+          StructField("a", leftType, nullable = false),
+          StructField("b", rightType, nullable = false)))
+      val data = java.util.List.of[Row](Row(Row(Row(), 1), Row(Row(), 2)))
+      val df = spark.createDataFrame(data, schema)
+      df.createOrReplaceTempView("empty_struct_least_greatest")
+
+      for (fn <- Seq("greatest", "least")) {
+        checkSparkAnswerAndFallbackReason(
+          s"SELECT $fn(a, b) FROM empty_struct_least_greatest",
+          "whose type contains an empty struct is not supported")
+      }
+    }
+  }
+
+  test("greatest/least decline empty-struct operands with only an Arrow field-name mismatch") {
+    // `array_repeat(n, 1).e` and `array_repeat(n.e, 1)` are both `array<struct<>>` to Spark, so
+    // no unifying Catalyst cast, but their Arrow element fields are named differently (`e` vs
+    // `item`). DataFusion's greatest/least coercion casts one to the other, and casting a
+    // zero-field struct errors -- the guard keys on `containsEmptyStruct` + arg count, not on a
+    // Spark-visible type difference.
+    withSQLConf(
+      CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true",
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        "org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation") {
+      val schema = StructType(
+        Seq(
+          StructField("id", IntegerType),
+          StructField("n", StructType(Seq(StructField("e", StructType(Nil)))))))
+      val data = java.util.List.of[Row](Row(1, Row(Row())), Row(2, Row(null)), Row(3, null))
+      val df = spark.createDataFrame(data, schema)
+      df.createOrReplaceTempView("empty_struct_lg_names")
+
+      for (fn <- Seq("greatest", "least")) {
+        checkSparkAnswerAndFallbackReason(
+          s"SELECT $fn(array_repeat(n, 1).e, array_repeat(n.e, 1)) FROM empty_struct_lg_names",
+          "whose type contains an empty struct is not supported")
+      }
+    }
+  }
+
+  test("greatest/least with mismatched operand nullability but no empty struct stay native") {
+    // Control for the guard above: the guard keys on `containsEmptyStruct`, so an ordinary
+    // nullability mismatch (here one nullable and one non-nullable int argument) must not trip
+    // it -- `greatest`/`least` stay on the native path.
+    withParquetTable((0 until 10).map(i => (i, i + 1)), "least_greatest_control") {
+      checkSparkAnswerAndOperator(
+        "SELECT greatest(_1, _2, 5), least(_1, _2, 5) FROM least_greatest_control")
+    }
+  }
+
   // Temporary test to verify checkSparkAnswer failure output labels Comet/Spark correctly.
   ignore("check output labels on mismatch") {
     val cometDf = Seq((1, "apple"), (2, "banana"), (3, "cherry")).toDF("id", "fruit")

--- a/spark/src/test/scala/org/apache/comet/CometJsonExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometJsonExpressionSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.CometTestBase
 import org.apache.spark.sql.catalyst.expressions.{JsonToStructs, StructsToJson}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
 import org.apache.comet.serde.CometStructsToJson
 import org.apache.comet.testing.{DataGenOptions, ParquetGenerator, SchemaGenOptions}
@@ -162,6 +163,79 @@ class CometJsonExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelpe
         // Field access on null struct should return null
         checkSparkAnswerAndOperator(
           s"SELECT _1, from_json(_2, '$schema').a FROM tbl WHERE _1 = 2")
+      }
+    }
+  }
+
+  test("from_json - empty struct schema") {
+    // A zero-field target schema is a legitimate value: no fields to parse into, but a real
+    // (possibly null) struct row per input, same as any other from_json result. Blank input
+    // (empty or whitespace only) is NULL per Spark's own contract (SPARK-19543), distinct from
+    // non-blank malformed input, which PERMISSIVE mode turns into a non-null struct.
+    Seq(true, false).foreach { dictionaryEnabled =>
+      withParquetTable(
+        Seq(
+          (1, "{}"), // valid JSON object
+          (2, ""), // blank input -> NULL
+          (3, "   "), // JSON-whitespace-only input (spaces) -> NULL
+          (4, "not json"), // malformed, non-blank -> non-null struct
+          (5, null), // SQL NULL input -> NULL
+          // Spark's blank check is Jackson's tokenizer finding no first token, which skips
+          // only JSON whitespace (RFC 8259: space/tab/CR/LF). Neither of the next two chars
+          // qualifies, so both must fail to tokenize -> non-null struct, not NULL.
+          (6, "\u00A0"), // non-breaking space -> not JSON whitespace, non-null struct
+          (7, "\u000B") // vertical tab -> ASCII control, not JSON whitespace, non-null struct
+        ),
+        "tbl",
+        withDictionary = dictionaryEnabled) {
+
+        checkSparkAnswerAndOperator("SELECT _1, from_json(_2, 'struct<>') FROM tbl ORDER BY _1")
+        checkSparkAnswerAndOperator(
+          "SELECT _1, from_json(_2, 'struct<>') IS NULL FROM tbl ORDER BY _1")
+      }
+    }
+  }
+
+  test("from_json - nested empty struct schema") {
+    // The zero-field struct can also appear nested inside a non-empty outer struct, which
+    // builds the result through a different code path (the nested-field builder, not the
+    // top-level one) -- both need to construct the Arrow array correctly.
+    Seq(true, false).foreach { dictionaryEnabled =>
+      withParquetTable(
+        (0 until 20).map(i => (i, """{"outer":{}}""")),
+        "tbl",
+        withDictionary = dictionaryEnabled) {
+
+        checkSparkAnswerAndOperator("SELECT from_json(_2, 'outer struct<>') FROM tbl")
+        checkSparkAnswerAndOperator("SELECT from_json(_2, 'outer struct<>').outer FROM tbl")
+      }
+    }
+  }
+
+  test("from_json - non-nullable schema field still yields NULL for missing/null values") {
+    // Spark's JsonToStructs evaluates against `schema.asNullable` (its `dataType`), so a
+    // missing or explicitly-null field comes back NULL even when the supplied schema declared
+    // it non-nullable. Comet must serialize that nullable contract, not the user's schema, or
+    // the native result puts a NULL under a non-nullable Arrow field.
+    val schema = StructType(
+      Seq(
+        StructField("a", IntegerType, nullable = false),
+        StructField("e", StructType(Nil), nullable = false)))
+    Seq(true, false).foreach { dictionaryEnabled =>
+      withParquetTable(
+        Seq(
+          (1, """{"a":1}"""), // "e" missing -> NULL
+          (2, """{"a":null}"""), // "a" explicitly null
+          (3, "{}"), // both missing
+          (4, "not json")
+        ), // malformed, non-blank -> non-null struct, null fields
+        "tbl",
+        withDictionary = dictionaryEnabled) {
+        val df = spark
+          .sql("SELECT _1, _2 FROM tbl ORDER BY _1")
+          .select(col("_1"), from_json(col("_2"), schema).as("j"))
+        checkSparkAnswerAndOperator(df.select(col("_1"), col("j.a"), col("j.e")))
+        checkSparkAnswerAndOperator(df.select(col("_1"), col("j").isNull))
       }
     }
   }

--- a/spark/src/test/scala/org/apache/comet/CometJsonExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometJsonExpressionSuite.scala
@@ -167,8 +167,8 @@ class CometJsonExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelpe
   }
 
   test("from_json - empty struct schema") {
-    // A zero-field target schema is a legitimate, trivially-serializable value, not a reason to
-    // fall back to the codegen dispatcher (matches the other empty-struct fixes in this diff).
+    // A zero-field target schema is a legitimate value: no fields to parse into, but a real
+    // (possibly null) struct row per input, same as any other from_json result.
     Seq(true, false).foreach { dictionaryEnabled =>
       withParquetTable(
         (0 until 20).map(i => (i, "{}")),
@@ -177,6 +177,22 @@ class CometJsonExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelpe
 
         checkSparkAnswerAndOperator("SELECT from_json(_2, 'struct<>') FROM tbl")
         checkSparkAnswerAndOperator("SELECT from_json(_2, 'struct<>') IS NULL FROM tbl")
+      }
+    }
+  }
+
+  test("from_json - nested empty struct schema") {
+    // The zero-field struct can also appear nested inside a non-empty outer struct, which
+    // builds the result through a different code path (the nested-field builder, not the
+    // top-level one) -- both need to construct the Arrow array correctly.
+    Seq(true, false).foreach { dictionaryEnabled =>
+      withParquetTable(
+        (0 until 20).map(i => (i, """{"outer":{}}""")),
+        "tbl",
+        withDictionary = dictionaryEnabled) {
+
+        checkSparkAnswerAndOperator("SELECT from_json(_2, 'outer struct<>') FROM tbl")
+        checkSparkAnswerAndOperator("SELECT from_json(_2, 'outer struct<>').outer FROM tbl")
       }
     }
   }

--- a/spark/src/test/scala/org/apache/comet/CometJsonExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometJsonExpressionSuite.scala
@@ -166,6 +166,21 @@ class CometJsonExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelpe
     }
   }
 
+  test("from_json - empty struct schema") {
+    // A zero-field target schema is a legitimate, trivially-serializable value, not a reason to
+    // fall back to the codegen dispatcher (matches the other empty-struct fixes in this diff).
+    Seq(true, false).foreach { dictionaryEnabled =>
+      withParquetTable(
+        (0 until 20).map(i => (i, "{}")),
+        "tbl",
+        withDictionary = dictionaryEnabled) {
+
+        checkSparkAnswerAndOperator("SELECT from_json(_2, 'struct<>') FROM tbl")
+        checkSparkAnswerAndOperator("SELECT from_json(_2, 'struct<>') IS NULL FROM tbl")
+      }
+    }
+  }
+
   test("from_json - nested struct") {
     Seq(true, false).foreach { dictionaryEnabled =>
       withParquetTable(

--- a/spark/src/test/scala/org/apache/comet/CometJsonExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometJsonExpressionSuite.scala
@@ -176,9 +176,14 @@ class CometJsonExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelpe
         Seq(
           (1, "{}"), // valid JSON object
           (2, ""), // blank input -> NULL
-          (3, "   "), // whitespace-only input -> NULL
+          (3, "   "), // JSON-whitespace-only input (spaces) -> NULL
           (4, "not json"), // malformed, non-blank -> non-null struct
-          (5, null) // SQL NULL input -> NULL
+          (5, null), // SQL NULL input -> NULL
+          // Spark's blank check is Jackson's tokenizer finding no first token, which skips
+          // only JSON whitespace (RFC 8259: space/tab/CR/LF). Neither of the next two chars
+          // qualifies, so both must fail to tokenize -> non-null struct, not NULL.
+          (6, "\u00A0"), // non-breaking space -> not JSON whitespace, non-null struct
+          (7, "\u000B") // vertical tab -> ASCII control, not JSON whitespace, non-null struct
         ),
         "tbl",
         withDictionary = dictionaryEnabled) {

--- a/spark/src/test/scala/org/apache/comet/CometJsonExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometJsonExpressionSuite.scala
@@ -168,15 +168,24 @@ class CometJsonExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelpe
 
   test("from_json - empty struct schema") {
     // A zero-field target schema is a legitimate value: no fields to parse into, but a real
-    // (possibly null) struct row per input, same as any other from_json result.
+    // (possibly null) struct row per input, same as any other from_json result. Blank input
+    // (empty or whitespace only) is NULL per Spark's own contract (SPARK-19543), distinct from
+    // non-blank malformed input, which PERMISSIVE mode turns into a non-null struct.
     Seq(true, false).foreach { dictionaryEnabled =>
       withParquetTable(
-        (0 until 20).map(i => (i, "{}")),
+        Seq(
+          (1, "{}"), // valid JSON object
+          (2, ""), // blank input -> NULL
+          (3, "   "), // whitespace-only input -> NULL
+          (4, "not json"), // malformed, non-blank -> non-null struct
+          (5, null) // SQL NULL input -> NULL
+        ),
         "tbl",
         withDictionary = dictionaryEnabled) {
 
-        checkSparkAnswerAndOperator("SELECT from_json(_2, 'struct<>') FROM tbl")
-        checkSparkAnswerAndOperator("SELECT from_json(_2, 'struct<>') IS NULL FROM tbl")
+        checkSparkAnswerAndOperator("SELECT _1, from_json(_2, 'struct<>') FROM tbl ORDER BY _1")
+        checkSparkAnswerAndOperator(
+          "SELECT _1, from_json(_2, 'struct<>') IS NULL FROM tbl ORDER BY _1")
       }
     }
   }

--- a/spark/src/test/scala/org/apache/comet/CometMapExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometMapExpressionSuite.scala
@@ -22,10 +22,10 @@ package org.apache.comet
 import scala.util.Random
 
 import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.{CometTestBase, Row}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.BinaryType
+import org.apache.spark.sql.types.{BinaryType, IntegerType, MapType, StructField, StructType}
 
 import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
 import org.apache.comet.testing.{DataGenOptions, ParquetGenerator, SchemaGenOptions}
@@ -269,6 +269,31 @@ class CometMapExpressionSuite extends CometTestBase {
       import testImplicits._
       val df = Seq(Map(1 -> 100, 2 -> 200)).toDF("m")
       checkSparkAnswerAndOperator(df.selectExpr("map_entries(m)"))
+    }
+  }
+
+  test("map lookup with an empty-struct key type falls back to Spark") {
+    // DataFusion's `map_extract` coercion rewrites the lookup key to the map's exact Arrow key
+    // type; Comet's planner then casts the key literal, and casting the zero-field `e` child
+    // errors ("no field name overlap"). Both `m[key]` (GetMapValue) and `element_at(m, key)`
+    // lower to `map_extract` -- see SupportLevel.emptyStructMapKeyReason.
+    withSQLConf(
+      CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true",
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        "org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation") {
+      import scala.jdk.CollectionConverters._
+      val keyType = StructType(Seq(StructField("e", StructType(Nil))))
+      val schema = StructType(Seq(StructField("m", MapType(keyType, IntegerType))))
+      val data = java.util.List.of[Row](Row(Map(Row(Row()) -> 10)))
+      val df = spark.createDataFrame(data, schema)
+      df.createOrReplaceTempView("empty_struct_map")
+
+      checkSparkAnswerAndFallbackReason(
+        "SELECT m[named_struct('e', struct())] FROM empty_struct_map",
+        "empty struct in the key type is not supported")
+      checkSparkAnswerAndFallbackReason(
+        "SELECT element_at(m, named_struct('e', struct())) FROM empty_struct_map",
+        "empty struct in the key type is not supported")
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -107,6 +107,44 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("collect_set declines an empty-struct input") {
+    // DataFusion's DistinctArrayAggAccumulator (backing SparkCollectSet) calls
+    // ScalarValue::compacted() per non-null input, hitting the same zero-field
+    // StructArray::new panic as First/Last -- see SupportLevel.containsEmptyStruct.
+    withSQLConf(CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true") {
+      import scala.jdk.CollectionConverters._
+
+      import org.apache.spark.sql.functions.collect_set
+      val schema = StructType(
+        Seq(StructField("id", DataTypes.IntegerType), StructField("marker", StructType(Nil))))
+      val data = (0 until 3).map(i => Row(i, Row())).asJava
+      val df = spark.createDataFrame(data, schema)
+      checkSparkAnswer(df.agg(collect_set(col("marker"))))
+    }
+  }
+
+  test("grouping on an empty struct falls back to Spark") {
+    // DataFusion's `GroupValuesRows::emit` dictionary-encodes struct-typed group keys via
+    // `StructArray::try_new`, which errors for a zero-field struct -- see
+    // SupportLevel.containsEmptyStruct.
+    withSQLConf(CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true") {
+      import scala.jdk.CollectionConverters._
+
+      val schema = StructType(
+        Seq(StructField("id", DataTypes.IntegerType), StructField("marker", StructType(Nil))))
+      val data = (0 until 3).map(i => Row(i, Row())).asJava
+      val df = spark.createDataFrame(data, schema)
+      df.createOrReplaceTempView("empty_struct_group")
+
+      checkSparkAnswerAndFallbackReason(
+        "SELECT marker, COUNT(id) FROM empty_struct_group GROUP BY marker",
+        "Grouping on a schema containing an empty struct is not supported")
+      checkSparkAnswerAndFallbackReason(
+        "SELECT DISTINCT marker FROM empty_struct_group",
+        "Grouping on a schema containing an empty struct is not supported")
+    }
+  }
+
   test("min/max floating point with negative zero") {
     val r = new Random(42)
     val schema = StructType(

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -216,6 +216,69 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("collect_set declines an empty-struct input") {
+    // DataFusion's DistinctArrayAggAccumulator (backing SparkCollectSet) calls
+    // ScalarValue::compacted() per non-null input, hitting the same zero-field
+    // StructArray::new panic as First/Last -- see SupportLevel.containsEmptyStruct.
+    withSQLConf(CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true") {
+      import scala.jdk.CollectionConverters._
+
+      import org.apache.spark.sql.functions.collect_set
+      val schema = StructType(
+        Seq(StructField("id", DataTypes.IntegerType), StructField("marker", StructType(Nil))))
+      val data = (0 until 3).map(i => Row(i, Row())).asJava
+      val df = spark.createDataFrame(data, schema)
+      checkSparkAnswerAndFallbackReason(
+        df.agg(collect_set(col("marker"))),
+        "collect_set on a schema containing an empty struct is not supported")
+    }
+  }
+
+  test("collect_list declines an empty-struct input") {
+    // planner.rs's coerce_collect_child_nullability casts the aggregated value to an all-nullable
+    // variant of its type whenever a nested field is non-nullable (named_struct's literal `n`
+    // field is non-nullable here), and DataFusion errors casting a zero-field struct to itself
+    // even when only a sibling field's nullability changed -- see SupportLevel.containsEmptyStruct.
+    // The plain integer grouping key does not trip the separate grouping-key guard, so this must
+    // be caught by CometCollectList's own support-level check.
+    withSQLConf(CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true") {
+      import scala.jdk.CollectionConverters._
+
+      val schema = StructType(
+        Seq(StructField("g", DataTypes.IntegerType), StructField("marker", StructType(Nil))))
+      val data = (0 until 3).map(i => Row(i % 2, Row())).asJava
+      val df = spark.createDataFrame(data, schema)
+      df.createOrReplaceTempView("empty_struct_collect_list")
+
+      checkSparkAnswerAndFallbackReason(
+        "SELECT g, collect_list(named_struct('marker', marker, 'n', 1)) " +
+          "FROM empty_struct_collect_list GROUP BY g",
+        "collect_list on a schema containing an empty struct is not supported")
+    }
+  }
+
+  test("grouping on an empty struct falls back to Spark") {
+    // DataFusion's `GroupValuesRows::emit` dictionary-encodes struct-typed group keys via
+    // `StructArray::try_new`, which errors for a zero-field struct -- see
+    // SupportLevel.containsEmptyStruct.
+    withSQLConf(CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true") {
+      import scala.jdk.CollectionConverters._
+
+      val schema = StructType(
+        Seq(StructField("id", DataTypes.IntegerType), StructField("marker", StructType(Nil))))
+      val data = (0 until 3).map(i => Row(i, Row())).asJava
+      val df = spark.createDataFrame(data, schema)
+      df.createOrReplaceTempView("empty_struct_group")
+
+      checkSparkAnswerAndFallbackReason(
+        "SELECT marker, COUNT(id) FROM empty_struct_group GROUP BY marker",
+        "Grouping on a schema containing an empty struct is not supported")
+      checkSparkAnswerAndFallbackReason(
+        "SELECT DISTINCT marker FROM empty_struct_group",
+        "Grouping on a schema containing an empty struct is not supported")
+    }
+  }
+
   test("min/max floating point with negative zero") {
     val r = new Random(42)
     val schema = StructType(

--- a/spark/src/test/scala/org/apache/comet/exec/CometColumnarShuffleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometColumnarShuffleSuite.scala
@@ -21,6 +21,7 @@ package org.apache.comet.exec
 
 import java.nio.file.{Files, Paths}
 
+import scala.jdk.CollectionConverters._
 import scala.reflect.runtime.universe._
 
 import org.scalactic.source.Position
@@ -138,6 +139,35 @@ abstract class CometColumnarShuffleSuite extends CometTestBase with AdaptiveSpar
           }
         }
       }
+    }
+  }
+
+  test("columnar shuffle on empty struct") {
+    // A struct with zero fields is a legitimate Arrow value (e.g. Iceberg's `_partition`
+    // metadata column on an unpartitioned table), not a reason to fall back to Spark. The
+    // shuffle's input must itself be Comet-native for this to exercise the real path -- a bare
+    // `LocalRelation` needs COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED to get a native upstream.
+    // For a zero-field struct the parent validity bitmap is the ONLY per-row payload, so the
+    // fixture must mix NULL against `{}` (and, nested, a NULL parent against `{e: {}}` /
+    // `{e: NULL}`) to actually exercise it across the shuffle's serialize/deserialize boundary.
+    withSQLConf(CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true") {
+      val schema = StructType(
+        Seq(
+          StructField("id", IntegerType),
+          StructField("marker", StructType(Nil)),
+          StructField("nested", StructType(Seq(StructField("e", StructType(Nil)))))))
+      val data = (0 until 50).map { i =>
+        val marker = if (i % 2 == 0) Row() else null
+        val nested = i % 3 match {
+          case 0 => Row(Row())
+          case 1 => Row(null)
+          case _ => null
+        }
+        Row(i, marker, nested)
+      }.asJava
+      val df = spark.createDataFrame(data, schema)
+      val shuffled = df.repartition(10, $"id")
+      checkShuffleAnswer(shuffled, 1)
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/exec/CometColumnarShuffleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometColumnarShuffleSuite.scala
@@ -21,6 +21,7 @@ package org.apache.comet.exec
 
 import java.nio.file.{Files, Paths}
 
+import scala.jdk.CollectionConverters._
 import scala.reflect.runtime.universe._
 
 import org.scalactic.source.Position
@@ -138,6 +139,21 @@ abstract class CometColumnarShuffleSuite extends CometTestBase with AdaptiveSpar
           }
         }
       }
+    }
+  }
+
+  test("columnar shuffle on empty struct") {
+    // A struct with zero fields is a legitimate Arrow value (e.g. Iceberg's `_partition`
+    // metadata column on an unpartitioned table), not a reason to fall back to Spark. The
+    // shuffle's input must itself be Comet-native for this to exercise the real path -- a bare
+    // `LocalRelation` needs COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED to get a native upstream.
+    withSQLConf(CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true") {
+      val schema =
+        StructType(Seq(StructField("id", IntegerType), StructField("marker", StructType(Nil))))
+      val data = (0 until 50).map(i => Row(i, Row())).asJava
+      val df = spark.createDataFrame(data, schema)
+      val shuffled = df.repartition(10, $"id")
+      checkShuffleAnswer(shuffled, 1)
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/exec/CometNativeShuffleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometNativeShuffleSuite.scala
@@ -20,6 +20,7 @@
 package org.apache.comet.exec
 
 import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters._
 import scala.util.Random
 
 import org.scalactic.source.Position
@@ -31,6 +32,7 @@ import org.apache.spark.sql.{CometTestBase, DataFrame, Dataset, Row}
 import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.{col, count, sum}
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
 import org.apache.comet.CometConf
 
@@ -105,6 +107,21 @@ class CometNativeShuffleSuite extends CometTestBase with AdaptiveSparkPlanHelper
           }
         }
       }
+    }
+  }
+
+  test("native shuffle on empty struct") {
+    // A struct with zero fields is a legitimate Arrow value (e.g. Iceberg's `_partition`
+    // metadata column on an unpartitioned table), not a reason to fall back to Spark. The
+    // shuffle's input must itself be Comet-native for this to exercise the real path -- a bare
+    // `LocalRelation` needs COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED to get a native upstream.
+    withSQLConf(CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true") {
+      val schema =
+        StructType(Seq(StructField("id", IntegerType), StructField("marker", StructType(Nil))))
+      val data = (0 until 50).map(i => Row(i, Row())).asJava
+      val df = spark.createDataFrame(data, schema)
+      val shuffled = df.repartition(10, $"id")
+      checkShuffleAnswer(shuffled, 1, checkNativeOperators = true)
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/exec/CometNativeShuffleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometNativeShuffleSuite.scala
@@ -24,6 +24,7 @@ import java.nio.{ByteBuffer, ByteOrder}
 
 import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters._
 import scala.util.Random
 
 import org.scalactic.source.Position
@@ -40,7 +41,7 @@ import org.apache.spark.sql.comet.execution.arrow.CometArrowStream
 import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.{col, count, sum}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 
 import org.apache.comet.{CometConf, CometExecIterator, CometShuffleBlockIterator, Native}
@@ -391,6 +392,35 @@ class CometNativeShuffleSuite extends CometTestBase with AdaptiveSparkPlanHelper
           }
         }
       }
+    }
+  }
+
+  test("native shuffle on empty struct") {
+    // A struct with zero fields is a legitimate Arrow value (e.g. Iceberg's `_partition`
+    // metadata column on an unpartitioned table), not a reason to fall back to Spark. The
+    // shuffle's input must itself be Comet-native for this to exercise the real path -- a bare
+    // `LocalRelation` needs COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED to get a native upstream.
+    // For a zero-field struct the parent validity bitmap is the ONLY per-row payload, so the
+    // fixture must mix NULL against `{}` (and, nested, a NULL parent against `{e: {}}` /
+    // `{e: NULL}`) to actually exercise it across the shuffle's serialize/deserialize boundary.
+    withSQLConf(CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true") {
+      val schema = StructType(
+        Seq(
+          StructField("id", IntegerType),
+          StructField("marker", StructType(Nil)),
+          StructField("nested", StructType(Seq(StructField("e", StructType(Nil)))))))
+      val data = (0 until 50).map { i =>
+        val marker = if (i % 2 == 0) Row() else null
+        val nested = i % 3 match {
+          case 0 => Row(Row())
+          case 1 => Row(null)
+          case _ => null
+        }
+        Row(i, marker, nested)
+      }.asJava
+      val df = spark.createDataFrame(data, schema)
+      val shuffled = df.repartition(10, $"id")
+      checkShuffleAnswer(shuffled, 1, checkNativeOperators = true)
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/exec/CometWindowExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometWindowExecSuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.execution.window.{WindowExec => SparkWindowExec}
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions.{count, lead, sum}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{DecimalType, IntegerType, StructField, StructType}
+import org.apache.spark.sql.types.{ArrayType, DecimalType, IntegerType, StructField, StructType}
 
 import org.apache.comet.CometConf
 import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
@@ -929,7 +929,7 @@ class CometWindowExecSuite extends CometTestBase {
   test("window: FIRST_VALUE/LAST_VALUE decline an empty-struct input") {
     // DataFusion's ScalarValue::compact panics reconstructing a zero-field StructArray, so
     // CometFirst/CometLast must decline this schema and let the window run on Spark instead
-    // of letting CometWindowExec crash -- see AggSerde.containsEmptyStruct.
+    // of letting CometWindowExec crash -- see SupportLevel.containsEmptyStruct.
     val schema =
       StructType(Seq(StructField("id", IntegerType), StructField("marker", StructType(Nil))))
     val data = (0 until 3).map(i => Row(i, Row())).asJava
@@ -942,6 +942,32 @@ class CometWindowExecSuite extends CometTestBase {
     // needs no equivalent guard -- pinned here so a future regression would be caught.
     checkSparkAnswer(
       sql("SELECT nth_value(marker, 1) OVER (ORDER BY id) FROM empty_struct_window"))
+  }
+
+  test("window: LAG/LEAD decline a typed-NULL empty-struct-array default") {
+    // DataFusion casts the literal default to the input type when building the window expr,
+    // and its cast errors on a zero-field struct even when source and target agree ("no field
+    // name overlap") -- see SupportLevel.containsEmptyStruct.
+    val schema = StructType(
+      Seq(StructField("id", IntegerType), StructField("arr", ArrayType(StructType(Nil)))))
+    val data = (0 until 3).map(i => Row(i, Array(Row()))).asJava
+    spark.createDataFrame(data, schema).createOrReplaceTempView("empty_struct_array_window")
+
+    checkSparkAnswer(sql("""
+      SELECT lag(arr, 1, CAST(NULL AS ARRAY<STRUCT<>>)) OVER (ORDER BY id)
+      FROM empty_struct_array_window
+      """))
+    checkSparkAnswer(sql("""
+      SELECT lead(arr, 1, CAST(NULL AS ARRAY<STRUCT<>>)) OVER (ORDER BY id)
+      FROM empty_struct_array_window
+      """))
+
+    // The omitted-default and plain-NULL-literal forms don't go through the typed-NULL cast
+    // that panics -- they should stay native, not fall back with the rest of this schema.
+    checkSparkAnswerAndOperator(
+      sql("SELECT lag(arr, 1) OVER (ORDER BY id) FROM empty_struct_array_window"))
+    checkSparkAnswerAndOperator(
+      sql("SELECT lag(arr, 1, NULL) OVER (ORDER BY id) FROM empty_struct_array_window"))
   }
 
   test("window: LAST_VALUE with ROWS frame") {

--- a/spark/src/test/scala/org/apache/comet/exec/CometWindowExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometWindowExecSuite.scala
@@ -19,6 +19,7 @@
 
 package org.apache.comet.exec
 
+import scala.jdk.CollectionConverters._
 import scala.util.Random
 
 import org.scalactic.source.Position
@@ -33,7 +34,7 @@ import org.apache.spark.sql.execution.window.{WindowExec => SparkWindowExec}
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions.{count, lead, sum}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.DecimalType
+import org.apache.spark.sql.types.{DecimalType, IntegerType, StructField, StructType}
 
 import org.apache.comet.CometConf
 import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
@@ -923,6 +924,24 @@ class CometWindowExecSuite extends CometTestBase {
       """)
       checkSparkAnswerAndOperator(df)
     }
+  }
+
+  test("window: FIRST_VALUE/LAST_VALUE decline an empty-struct input") {
+    // DataFusion's ScalarValue::compact panics reconstructing a zero-field StructArray, so
+    // CometFirst/CometLast must decline this schema and let the window run on Spark instead
+    // of letting CometWindowExec crash -- see AggSerde.containsEmptyStruct.
+    val schema =
+      StructType(Seq(StructField("id", IntegerType), StructField("marker", StructType(Nil))))
+    val data = (0 until 3).map(i => Row(i, Row())).asJava
+    spark.createDataFrame(data, schema).createOrReplaceTempView("empty_struct_window")
+
+    checkSparkAnswer(sql("SELECT first_value(marker) OVER () FROM empty_struct_window"))
+    checkSparkAnswer(sql("SELECT last_value(marker) OVER () FROM empty_struct_window"))
+    // NTH_VALUE goes through a different DataFusion code path (a built-in window function,
+    // not an AggregateExpression accumulator) and doesn't hit ScalarValue::compact, so it
+    // needs no equivalent guard -- pinned here so a future regression would be caught.
+    checkSparkAnswer(
+      sql("SELECT nth_value(marker, 1) OVER (ORDER BY id) FROM empty_struct_window"))
   }
 
   test("window: LAST_VALUE with ROWS frame") {

--- a/spark/src/test/scala/org/apache/comet/exec/CometWindowExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometWindowExecSuite.scala
@@ -19,6 +19,7 @@
 
 package org.apache.comet.exec
 
+import scala.jdk.CollectionConverters._
 import scala.util.Random
 
 import org.scalactic.source.Position
@@ -33,7 +34,7 @@ import org.apache.spark.sql.execution.window.{WindowExec => SparkWindowExec}
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions.{count, lead, sum}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.DecimalType
+import org.apache.spark.sql.types.{ArrayType, DecimalType, IntegerType, StructField, StructType}
 
 import org.apache.comet.CometConf
 import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
@@ -923,6 +924,75 @@ class CometWindowExecSuite extends CometTestBase {
       """)
       checkSparkAnswerAndOperator(df)
     }
+  }
+
+  test("window: FIRST_VALUE/LAST_VALUE decline an empty-struct input") {
+    // DataFusion's ScalarValue::compact panics reconstructing a zero-field StructArray, so
+    // CometFirst/CometLast must decline this schema and let the window run on Spark instead
+    // of letting CometWindowExec crash -- see SupportLevel.containsEmptyStruct.
+    val schema =
+      StructType(Seq(StructField("id", IntegerType), StructField("marker", StructType(Nil))))
+    val data = (0 until 3).map(i => Row(i, Row())).asJava
+    spark.createDataFrame(data, schema).createOrReplaceTempView("empty_struct_window")
+
+    checkSparkAnswerAndFallbackReason(
+      "SELECT first_value(marker) OVER () FROM empty_struct_window",
+      "FIRST/LAST on a schema containing an empty struct is not supported")
+    checkSparkAnswerAndFallbackReason(
+      "SELECT last_value(marker) OVER () FROM empty_struct_window",
+      "FIRST/LAST on a schema containing an empty struct is not supported")
+    // NTH_VALUE goes through a different DataFusion code path (a built-in window function,
+    // not an AggregateExpression accumulator) and doesn't hit ScalarValue::compact, so it
+    // needs no equivalent guard -- pinned here so a future regression would be caught.
+    checkSparkAnswer(
+      sql("SELECT nth_value(marker, 1) OVER (ORDER BY id) FROM empty_struct_window"))
+  }
+
+  test("window: LAG/LEAD decline a typed-NULL empty-struct-array default") {
+    // DataFusion casts the literal default to the input type when building the window expr,
+    // and its cast errors on a zero-field struct even when source and target agree ("no field
+    // name overlap") -- see SupportLevel.containsEmptyStruct.
+    val schema = StructType(
+      Seq(StructField("id", IntegerType), StructField("arr", ArrayType(StructType(Nil)))))
+    val data = (0 until 3).map(i => Row(i, Array(Row()))).asJava
+    spark.createDataFrame(data, schema).createOrReplaceTempView("empty_struct_array_window")
+
+    checkSparkAnswerAndFallbackReason(
+      """
+      SELECT lag(arr, 1, CAST(NULL AS ARRAY<STRUCT<>>)) OVER (ORDER BY id)
+      FROM empty_struct_array_window
+      """,
+      "LAG with an empty-struct-typed default value is not supported")
+    checkSparkAnswerAndFallbackReason(
+      """
+      SELECT lead(arr, 1, CAST(NULL AS ARRAY<STRUCT<>>)) OVER (ORDER BY id)
+      FROM empty_struct_array_window
+      """,
+      "LEAD with an empty-struct-typed default value is not supported")
+
+    // The omitted-default and plain-NULL-literal forms don't go through the typed-NULL cast
+    // that panics -- they should stay native, not fall back with the rest of this schema.
+    checkSparkAnswerAndOperator(
+      sql("SELECT lag(arr, 1) OVER (ORDER BY id) FROM empty_struct_array_window"))
+    checkSparkAnswerAndOperator(
+      sql("SELECT lag(arr, 1, NULL) OVER (ORDER BY id) FROM empty_struct_array_window"))
+  }
+
+  test("window: RANGE frame declines an empty-struct ORDER BY key") {
+    // DataFusion's `ScalarValue::partial_cmp_struct` flattens a struct into its leaf columns to
+    // compare RANGE peers; a zero-field struct contributes no columns, so a NULL struct and a
+    // non-null empty struct compare equal instead of ordering NULL first -- misgrouping peers.
+    val schema = StructType(
+      Seq(
+        StructField("s", StructType(Seq(StructField("e", StructType(Nil))))),
+        StructField("k", IntegerType)))
+    val data = Seq(Row(Row(null), 1), Row(Row(Row()), 1), Row(Row(null), 2)).asJava
+    spark.createDataFrame(data, schema).createOrReplaceTempView("empty_struct_range_window")
+
+    checkSparkAnswerAndFallbackReason(
+      "SELECT COUNT(*) OVER (ORDER BY s, k RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) " +
+        "FROM empty_struct_range_window",
+      "RANGE frame ordering on a schema containing an empty struct is not supported")
   }
 
   test("window: LAST_VALUE with ROWS frame") {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5413.

## Rationale for this change

Six copies of the same guard reject a zero-field `StructType`, treating it the same
as a genuinely unsupported type. It's a legitimate Arrow value. Iceberg's `_partition`
metadata column is exactly this shape on an unpartitioned table, so any plan carrying
it silently fell back to Spark at the first shuffle/sink/scan boundary.

## What changes are included in this PR?

Removed the empty-struct exclusion from all six checks: native shuffle, columnar
shuffle, `CometSink`, `QueryPlanSerde.supportedDataType`, `DataTypeSupport`, and
`from_json`'s target-schema check. The last one alone wasn't safe to fix Scala-side --
it uncovered a real native panic in `from_json.rs` (`StructArray::new` can't derive row
count with zero child arrays), fixed by branching to `StructArray::new_empty_fields`.

## How are these changes tested?

Added new tests to test the fix.