### PR TITLE
feat: expose native aggregate spill and memory metrics

### DIFF
--- a/native/core/src/execution/metrics/utils.rs
+++ b/native/core/src/execution/metrics/utils.rs
@@ -124,3 +124,58 @@ fn insert_metric_value(metrics: &mut HashMap<String, i64>, value: &MetricValue) 
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::physical_plan::metrics::{
+        ExecutionPlanMetricsSet, MetricBuilder, MetricCategory, SpillMetrics,
+    };
+
+    fn metric_values(metrics: &ExecutionPlanMetricsSet) -> HashMap<String, i64> {
+        let mut values = HashMap::new();
+        metrics
+            .clone_inner()
+            .aggregate_by_name()
+            .iter()
+            .for_each(|metric| insert_metric_value(&mut values, metric.value()));
+        values
+    }
+
+    #[test]
+    fn preserves_absent_and_registered_aggregate_metrics() {
+        let aggregate_metric_names = [
+            "spill_count",
+            "spilled_bytes",
+            "spilled_rows",
+            "peak_mem_used",
+        ];
+
+        let absent = metric_values(&ExecutionPlanMetricsSet::new());
+        for name in aggregate_metric_names {
+            assert!(!absent.contains_key(name));
+        }
+
+        let metrics = ExecutionPlanMetricsSet::new();
+        let spill_metrics = SpillMetrics::new(&metrics, 0);
+        let peak_mem_used = MetricBuilder::new(&metrics)
+            .with_category(MetricCategory::Bytes)
+            .gauge("peak_mem_used", 0);
+
+        let registered_zero = metric_values(&metrics);
+        for name in aggregate_metric_names {
+            assert_eq!(registered_zero.get(name), Some(&0));
+        }
+
+        spill_metrics.spill_file_count.add(2);
+        spill_metrics.spilled_bytes.add(4096);
+        spill_metrics.spilled_rows.add(128);
+        peak_mem_used.set(8192);
+
+        let updated = metric_values(&metrics);
+        assert_eq!(updated.get("spill_count"), Some(&2));
+        assert_eq!(updated.get("spilled_bytes"), Some(&4096));
+        assert_eq!(updated.get("spilled_rows"), Some(&128));
+        assert_eq!(updated.get("peak_mem_used"), Some(&8192));
+    }
+}

--- a/native/core/src/execution/operators/projection.rs
+++ b/native/core/src/execution/operators/projection.rs
@@ -66,10 +66,19 @@ impl OperatorBuilder for ProjectionBuilder {
             Arc::clone(&child.native_plan),
         )?);
 
-        Ok((
-            scans,
-            shuffle_scans,
-            Arc::new(SparkPlan::new(spark_plan.plan_id, projection, vec![child])),
-        ))
+        let spark_plan = if child.plan_id == spark_plan.plan_id {
+            let mut additional_native_plans = vec![Arc::clone(&child.native_plan)];
+            additional_native_plans.extend(child.additional_native_plans.iter().cloned());
+            Arc::new(SparkPlan::new_with_additional(
+                spark_plan.plan_id,
+                projection,
+                child.children.clone(),
+                additional_native_plans,
+            ))
+        } else {
+            Arc::new(SparkPlan::new(spark_plan.plan_id, projection, vec![child]))
+        };
+
+        Ok((scans, shuffle_scans, spark_plan))
     }
 }

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -4905,6 +4905,47 @@ mod tests {
         assert_eq!("ScanExec", hash_join_exec.children[1].native_plan.name());
     }
 
+    #[test]
+    fn projection_rolls_up_same_plan_id_child_metrics() {
+        let op_scan = Operator {
+            plan_id: 1,
+            ..create_scan()
+        };
+        let hash_agg = Operator {
+            plan_id: 2,
+            sql_text_pool: vec![],
+            children: vec![op_scan],
+            op_struct: Some(OpStruct::HashAgg(spark_operator::HashAggregate {
+                grouping_exprs: vec![create_bound_reference(0)],
+                agg_exprs: vec![],
+                mode: spark_operator::AggregateMode::Partial as i32,
+                expr_modes: vec![],
+                initial_input_buffer_offset: 0,
+            })),
+        };
+        let projection = Operator {
+            plan_id: 2,
+            sql_text_pool: vec![],
+            children: vec![hash_agg],
+            op_struct: Some(OpStruct::Projection(spark_operator::Projection {
+                project_list: vec![create_bound_reference(0)],
+            })),
+        };
+
+        let planner = PhysicalPlanner::default();
+        let (_scans, _shuffle_scans, projection_exec) =
+            planner.create_plan(&projection, &mut vec![], 1).unwrap();
+
+        assert_eq!("ProjectionExec", projection_exec.native_plan.name());
+        assert_eq!(1, projection_exec.additional_native_plans.len());
+        assert_eq!(
+            "AggregateExec",
+            projection_exec.additional_native_plans[0].name()
+        );
+        assert_eq!(1, projection_exec.children.len());
+        assert_eq!("ScanExec", projection_exec.children[0].native_plan.name());
+    }
+
     fn create_bound_reference(index: i32) -> Expr {
         Expr {
             expr_struct: Some(Bound(spark_expression::BoundReference {

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
@@ -81,6 +81,21 @@ case class CometMetricNode(metrics: Map[String, SQLMetric], children: Seq[CometM
   }
 
   /**
+   * Range sampling executes aggregate inputs again for the actual shuffle, so exclude aggregate
+   * metrics during sampling to avoid counting their spills and memory usage twice.
+   */
+  private[comet] def withoutAggregateMetrics(plan: SparkPlan): CometMetricNode =
+    CometMetricNode(
+      if (plan.isInstanceOf[CometHashAggregateExec]) {
+        metrics -- CometMetricNode.aggregateMetricNames
+      } else {
+        metrics
+      },
+      children.zip(plan.children).map { case (child, childPlan) =>
+        child.withoutAggregateMetrics(childPlan)
+      })
+
+  /**
    * Reports aggregated scan input metrics (bytesRead, recordsRead) to Spark's task metrics.
    * Aggregates across all scan leaf nodes to handle plans with multiple scans (e.g., joins). Must
    * be called in a TaskCompletionListener after the iterator is fully consumed.
@@ -191,6 +206,9 @@ case class CometMetricNode(metrics: Map[String, SQLMetric], children: Seq[CometM
 }
 
 object CometMetricNode {
+
+  private val aggregateMetricNames =
+    Set("spill_count", "spilled_bytes", "spilled_rows", "peak_mem_used")
 
   /**
    * The baseline SQL metrics for DataFusion `BaselineMetrics`.

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
@@ -203,6 +203,14 @@ object CometMetricNode {
         "total time (in ms) spent in this operator"))
   }
 
+  def aggregateMetrics(sc: SparkContext): Map[String, SQLMetric] = {
+    Map(
+      "spill_count" -> SQLMetrics.createMetric(sc, "number of spills"),
+      "spilled_bytes" -> SQLMetrics.createSizeMetric(sc, "total spilled bytes"),
+      "spilled_rows" -> SQLMetrics.createMetric(sc, "number of spilled rows"),
+      "peak_mem_used" -> SQLMetrics.createSizeMetric(sc, "peak native aggregate memory"))
+  }
+
   /**
    * Base SQL Metrics for ScanExec and BatchScanExec These are needed for various Spark systems to
    * function properly, and are calculated on the general iterator created by the scan operator,

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -183,7 +183,11 @@ case class CometShuffleExchangeExec(
           // RangePartitioner needs real rows for sampling. Reuse the precomputed context so we
           // don't re-walk the SparkPlan tree or re-broadcast the encryption Hadoop conf.
           val samplingRDD: Option[RDD[ColumnarBatch]] = outputPartitioning match {
-            case _: RangePartitioning => Some(nativeChild.executeColumnarWithContext(ctx))
+            case _: RangePartitioning =>
+              Some(
+                nativeChild.executeColumnarWithContext(
+                  ctx,
+                  nativeChildMetricNode.withoutAggregateMetrics(nativeChild)))
             case _ => None
           }
           CometShuffleExchangeExec.prepareNativeShuffleDependency(

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -2099,6 +2099,15 @@ case class CometHashAggregateExec(
   override def hashCode(): Int =
     Objects.hashCode(output, groupingExpressions, aggregateExpressions, input, modes, child)
 
+  override lazy val metrics: Map[String, SQLMetric] = {
+    val baseline = CometMetricNode.baselineMetrics(sparkContext)
+    if (groupingExpressions.nonEmpty) {
+      baseline ++ CometMetricNode.aggregateMetrics(sparkContext)
+    } else {
+      baseline
+    }
+  }
+
   override protected def outputExpressions: Seq[NamedExpression] = resultExpressions
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -602,11 +602,15 @@ abstract class CometNativeExec extends CometExec {
    * shuffle path can sample (RangePartitioning) without re-walking the SparkPlan tree and
    * re-broadcasting the encryption Hadoop conf.
    */
-  private[comet] def executeColumnarWithContext(ctx: NativeExecContext): RDD[ColumnarBatch] = {
+  private[comet] def executeColumnarWithContext(ctx: NativeExecContext): RDD[ColumnarBatch] =
+    executeColumnarWithContext(ctx, CometMetricNode.fromCometPlan(this))
+
+  private[comet] def executeColumnarWithContext(
+      ctx: NativeExecContext,
+      nativeMetrics: CometMetricNode): RDD[ColumnarBatch] = {
     val serializedPlan = serializedPlanOpt.plan.getOrElse(
       throw new CometRuntimeException(
         s"CometNativeExec should not be executed directly without a serialized plan: $this"))
-    val nativeMetrics = CometMetricNode.fromCometPlan(this)
 
     new CometExecRDD(
       sparkContext,

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -19,15 +19,21 @@
 
 package org.apache.comet.exec
 
+import java.util.concurrent.atomic.AtomicLong
+
 import scala.util.Random
 
 import org.apache.hadoop.fs.Path
-import org.apache.spark.SparkConf
+import org.apache.spark.{CometListenerBusUtils, SparkConf}
+import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
 import org.apache.spark.sql.{CometTestBase, DataFrame, Row}
 import org.apache.spark.sql.catalyst.expressions.Cast
 import org.apache.spark.sql.catalyst.expressions.aggregate.{Final, Partial}
 import org.apache.spark.sql.catalyst.optimizer.EliminateSorts
+import org.apache.spark.sql.catalyst.plans.physical.RangePartitioning
 import org.apache.spark.sql.comet.CometHashAggregateExec
+import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
+import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions.{avg, col, count_distinct, sum}
 import org.apache.spark.sql.internal.SQLConf
@@ -86,6 +92,58 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
         globalAggregates.foreach { aggregate =>
           assert(aggregateMetricNames.intersect(aggregate.metrics.keySet).isEmpty)
         }
+      }
+    }
+  }
+
+  test("range sampling does not report grouped aggregate metrics") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.SHUFFLE_PARTITIONS.key -> "2",
+      CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+      withParquetTable((0 until 1024).map(i => (i % 64, i)), "tbl", false) {
+        val ranged =
+          sql("SELECT _1, SUM(_2) AS total FROM tbl GROUP BY _1").repartitionByRange(2, col("_1"))
+        val plan = stripAQEPlan(ranged.queryExecution.executedPlan)
+        val exchange = plan
+          .collectFirst {
+            case exchange: CometShuffleExchangeExec
+                if exchange.outputPartitioning.isInstanceOf[RangePartitioning] =>
+              exchange
+          }
+          .getOrElse(fail("Expected a native range shuffle"))
+        val aggregate = exchange.child
+          .collectFirst {
+            case aggregate: CometHashAggregateExec if aggregate.modes.contains(Final) => aggregate
+          }
+          .getOrElse(fail("Expected a final native aggregate under the range shuffle"))
+
+        val samplingInputBytes = new AtomicLong()
+        val samplingInputRecords = new AtomicLong()
+        val listener = new SparkListener {
+          override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
+            samplingInputBytes.addAndGet(taskEnd.taskMetrics.inputMetrics.bytesRead)
+            samplingInputRecords.addAndGet(taskEnd.taskMetrics.inputMetrics.recordsRead)
+          }
+        }
+
+        plan.resetMetrics()
+        CometListenerBusUtils.waitUntilEmpty(spark.sparkContext)
+        spark.sparkContext.addSparkListener(listener)
+        try {
+          SQLExecution.withNewExecutionId(ranged.queryExecution, Some("range sampling")) {
+            exchange.shuffleDependency
+          }
+          CometListenerBusUtils.waitUntilEmpty(spark.sparkContext)
+        } finally {
+          spark.sparkContext.removeSparkListener(listener)
+        }
+        assert(aggregate.metrics("peak_mem_used").value == 0L)
+        assert(samplingInputBytes.get() > 0L)
+        assert(samplingInputRecords.get() > 0L)
+
+        assert(ranged.collect().length == 64)
+        assert(aggregate.metrics("peak_mem_used").value > 0L)
       }
     }
   }

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{CometTestBase, DataFrame, Row}
 import org.apache.spark.sql.catalyst.expressions.Cast
+import org.apache.spark.sql.catalyst.expressions.aggregate.{Final, Partial}
 import org.apache.spark.sql.catalyst.optimizer.EliminateSorts
 import org.apache.spark.sql.comet.CometHashAggregateExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
@@ -47,6 +48,47 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   // ANSI-mode variants opt in to ANSI explicitly via withSQLConf.
   override protected def sparkConf: SparkConf =
     super.sparkConf.set(SQLConf.ANSI_ENABLED.key, "false")
+
+  test("grouped aggregate metrics are forwarded without fabricating global metrics") {
+    val aggregateMetricNames =
+      Set("spill_count", "spilled_bytes", "spilled_rows", "peak_mem_used")
+
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.SHUFFLE_PARTITIONS.key -> "2") {
+      withParquetTable((0 until 1024).map(i => (i % 64, i)), "tbl", false) {
+        val grouped = sql("SELECT _1, SUM(_2) FROM tbl GROUP BY _1")
+        assert(grouped.collect().length == 64)
+
+        val groupedAggregates = stripAQEPlan(grouped.queryExecution.executedPlan).collect {
+          case aggregate: CometHashAggregateExec => aggregate
+        }
+        assert(groupedAggregates.exists(_.modes.contains(Partial)))
+        assert(groupedAggregates.exists(_.modes.contains(Final)))
+        groupedAggregates.foreach { aggregate =>
+          assert(aggregateMetricNames.subsetOf(aggregate.metrics.keySet))
+          assert(aggregate.metrics("spill_count").metricType == "sum")
+          assert(aggregate.metrics("spilled_bytes").metricType == "size")
+          assert(aggregate.metrics("spilled_rows").metricType == "sum")
+          assert(aggregate.metrics("peak_mem_used").metricType == "size")
+          assert(
+            aggregate.metrics("peak_mem_used").value > 0L,
+            s"Expected peak aggregate memory for modes ${aggregate.modes}")
+        }
+
+        val global = sql("SELECT SUM(_2) FROM tbl")
+        assert(global.collect().length == 1)
+
+        val globalAggregates = stripAQEPlan(global.queryExecution.executedPlan).collect {
+          case aggregate: CometHashAggregateExec => aggregate
+        }
+        assert(globalAggregates.nonEmpty)
+        globalAggregates.foreach { aggregate =>
+          assert(aggregateMetricNames.intersect(aggregate.metrics.keySet).isEmpty)
+        }
+      }
+    }
+  }
 
   test("collect_list over struct with non-nullable fields") {
     // Building a struct from non-nullable columns yields non-nullable struct fields. The native


### PR DESCRIPTION
## Why are the changes needed?

Grouped aggregation can consume substantial memory: every distinct grouping key adds hash-table entries and aggregate state, and memory pressure can force intermediate results to spill to disk. Those spills often explain why a query becomes unexpectedly slow even though it still completes successfully.

For example, consider a query that aggregates a large table by a high-cardinality key:

```sql
SELECT customer_id, SUM(amount)
FROM orders
GROUP BY customer_id;
```

Comet can execute both the partial and final aggregates natively. DataFusion already records how much memory each grouped aggregate uses and whether it spills, but those measurements are not currently exposed on the corresponding Spark SQL operator. As a result, the Spark UI can show that an aggregate produced rows and spent time executing, while leaving the most important diagnostic question unanswered: was that time spent aggregating in memory, or repeatedly spilling intermediate state to disk?

For illustration, the operator currently looks roughly like this:

```text
CometHashAggregate
  number of output rows: 2,000,000
  time spent in this operator: 48 s
```

After this change, the same operator can also report:

```text
CometHashAggregate
  number of output rows: 2,000,000
  time spent in this operator: 48 s
  number of spills: 4
  total spilled bytes: 1.2 GiB
  number of spilled rows: 8,000,000
  peak native aggregate memory: 256 MiB
```

The values above are illustrative. Together, these metrics make native aggregation behavior visible through the same Spark SQL interfaces users already rely on when investigating expensive stages, skewed grouping keys, shuffle partitioning, and memory pressure. The spilled bytes represent temporary aggregate-state spills; they are not a substitute for shuffle-write or scan-input metrics.

## What changes were proposed in this PR?

This PR closes the observability gap by carrying DataFusion's existing grouped-aggregate measurements through Comet's existing native-to-Spark metric pipeline and exposing them on the corresponding `CometHashAggregateExec`. Spill counts and spilled-row counts are presented as count metrics, while spilled bytes and peak aggregate memory are presented as size metrics. Both partial and final grouped aggregates retain their own operator-level measurements. No new spill accounting, memory manager, or parallel metric collection framework is introduced.

The main implementation concern is preserving the meaning and ownership of those measurements as native execution is mapped back onto a Spark plan. A single Spark aggregate may be represented natively by an `AggregateExec` wrapped in a projection that shares the same Spark plan ID. In that case, the aggregate's existing metrics need to be associated with the enclosing Spark operator rather than lost under an extra native-plan level; existing child relationships and output-row accounting must remain intact.

The same care is needed for range-partitioned native shuffles. A plan such as:

```scala
orders
  .groupBy("customer_id")
  .sum("amount")
  .repartitionByRange(col("customer_id"))
```

may execute its input once to sample partition boundaries and again to produce the actual shuffle output. Reporting aggregate metrics from both passes would make a single logical aggregate appear to have used more memory or spilled more data than its material execution actually did. The sampling pass therefore suppresses only aggregate-specific metrics; scan input accounting and unrelated operator metrics continue to work normally. The real execution still reports the aggregate measurements.

Finally, the new metrics are exposed only where DataFusion actually provides the corresponding grouped-aggregation instrumentation. A global aggregate such as `SELECT SUM(amount) FROM orders` does not acquire fabricated spill or memory counters. This preserves the distinction between an observed value of zero, meaning that a supported metric was measured and no spill occurred, and an absent metric, meaning that the operator does not provide that measurement.

## How was this PR tested?

The Spark-side regression coverage executes a real native grouped aggregation and verifies that both partial and final aggregate operators expose correctly typed spill and memory metrics, including a nonzero measured native-memory value. It also runs a global aggregation and verifies that unsupported aggregate metrics remain absent rather than being fabricated as zeroes.

A separate native-shuffle regression exercises range partitioning through the actual sampling path. It verifies that sampling does not update grouped-aggregate metrics, that scan bytes and records are still reported during sampling, and that the subsequent real execution does publish the aggregate's memory usage. The latest focused run passed: **1 test, 0 failures**.

Native unit coverage verifies absent-versus-zero semantics, propagation of nonzero spill and memory values, and correct metric ownership when a projection and aggregate share a Spark plan ID. Spotless formatting checks also passed.
