### PR TITLE
fix: use current shuffle config in aggregate test

### DIFF
--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -315,7 +315,7 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
         withParquetTable(data, "tbl") {
           withSQLConf(
             disabledHalf.key -> "false",
-            CometConf.COMET_EXEC_SHUFFLE_ENABLED.key -> "true",
+            CometConf.COMET_SHUFFLE_ENABLED.key -> "true",
             CometConf.COMET_SHUFFLE_MODE.key -> "jvm") {
             val df = sql("SELECT _2, sort_array(collect_list(_1)), count(*) FROM tbl GROUP BY _2")
             checkSparkAnswer(df)


### PR DESCRIPTION
## Which issue does this PR close?

Follow-up to #5055.

## Rationale for this change

PR #5055 added an aggregate test using the removed `COMET_EXEC_SHUFFLE_ENABLED` constant. Current `main` therefore fails the Spark 3.4 Scalafix build while compiling test sources.

## What changes are included in this PR?

Use the current `COMET_SHUFFLE_ENABLED` config entry, matching the rest of `CometAggregateSuite` and `CometConf`.

## How are these changes tested?

The previously failing command now completes successfully:

```shell
./mvnw -B package -DskipTests scalafix:scalafix -Dscalafix.mode=CHECK -Psemanticdb -Pspark-3.4 -Pscala-2.12
```
