### PR TITLE
test: deduplicate Throwable cause-chain traversal

### DIFF
--- a/spark/src/test/scala/org/apache/comet/CometRegExpJvmSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometRegExpJvmSuite.scala
@@ -305,7 +305,7 @@ class CometRegExpJvmSuite extends CometTestBase with AdaptiveSparkPlanHelper {
       val df =
         sql("SELECT regexp_replace(s, '(?<first>[a-zA-Z]+) (?<last>[a-zA-Z]+)', '$3 $1') FROM t")
       val e = intercept[Throwable](df.collect())
-      val chain = Iterator.iterate(e)(_.getCause).takeWhile(_ != null).toList
+      val chain = causeChain(e)
       val names = chain.map(_.getClass.getName)
       // The original Spark exception must survive: re-thrown unwrapped, not flattened into a
       // CometNativeException at the JNI boundary.

--- a/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
@@ -40,9 +40,6 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
   private val crossTimezones =
     Seq("UTC", "America/Los_Angeles", "Europe/London", "Asia/Tokyo")
 
-  private def causeChain(error: Throwable): Seq[Throwable] =
-    Iterator.iterate(error)(_.getCause).takeWhile(_ != null).toSeq
-
   private def deepestSparkThrowable(error: Throwable): SparkThrowable with Throwable =
     causeChain(error)
       .collect { case e: SparkThrowable with Throwable => e }

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -4200,11 +4200,7 @@ class CometExecSuite extends CometTestBase {
         }
         // Spark reports its own per-file read failures as FAILED_READ_FILE carrying the path.
         // Comet's native scan must do the same instead of leaking a raw CometNativeException.
-        val messages = Iterator
-          .iterate(e: Throwable)(_.getCause)
-          .takeWhile(_ != null)
-          .map(t => s"${t.getClass.getName}: ${t.getMessage}")
-          .toList
+        val messages = causeChain(e).map(t => s"${t.getClass.getName}: ${t.getMessage}")
         val chain = messages.mkString("\n  ")
         // `cannotReadFilesError` is the FAILED_READ_FILE path. Its message is version-stable
         // ("Encountered error while reading file ..."); only Spark 4.x prepends the
@@ -4239,11 +4235,7 @@ class CometExecSuite extends CometTestBase {
         val e = intercept[Throwable] {
           df.collect()
         }
-        val messages = Iterator
-          .iterate(e: Throwable)(_.getCause)
-          .takeWhile(_ != null)
-          .map(t => s"${t.getClass.getName}: ${t.getMessage}")
-          .toList
+        val messages = causeChain(e).map(t => s"${t.getClass.getName}: ${t.getMessage}")
         val chain = messages.mkString("\n  ")
         assert(
           messages.exists(m =>

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -1268,10 +1268,7 @@ abstract class ParquetReadSuite extends CometTestBase {
           }
           // Walk the cause chain: Comet's shim adds an extra SparkException
           // wrap on Spark 3.x compared to vanilla Spark.
-          val chain = Iterator
-            .iterate[Throwable](outer)(_.getCause)
-            .takeWhile(_ != null)
-            .toSeq
+          val chain = causeChain(outer)
           assert(
             chain.exists(_.isInstanceOf[
               org.apache.spark.sql.execution.datasources.SchemaColumnConvertNotSupportedException]),

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -115,6 +115,9 @@ abstract class CometTestBase
     }
   }
 
+  protected def causeChain(error: Throwable): Seq[Throwable] =
+    Iterator.iterate(error)(_.getCause).takeWhile(_ != null).toSeq
+
   protected def internalCheckSparkAnswer(
       df: => DataFrame,
       assertCometNative: Boolean,

--- a/spark/src/test/scala/org/apache/spark/sql/comet/CometTaskMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/CometTaskMetricsSuite.scala
@@ -232,11 +232,7 @@ class CometTaskMetricsSuite extends CometTestBase with AdaptiveSparkPlanHelper {
               val failure = intercept[Exception] {
                 shuffled.collect()
               }
-              val messages = Iterator
-                .iterate(failure: Throwable)(_.getCause)
-                .takeWhile(_ != null)
-                .flatMap(error => Option(error.getMessage))
-                .toSeq
+              val messages = causeChain(failure).flatMap(error => Option(error.getMessage))
               assert(
                 messages.exists(message =>
                   message.contains("DIVIDE_BY_ZERO") || message.contains("Division by zero")),


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5223.

## Rationale for this change

Several Comet test suites independently walk `Throwable` cause chains. Centralizing the common traversal keeps null termination and outer-to-inner ordering consistent while preserving suite-specific exception policies.

## What changes are included in this PR?

- Add a protected `causeChain` helper to `CometTestBase`.
- Migrate equivalent full-chain traversal in the temporal, regexp, Parquet, execution, and task-metrics suites.
- Leave bounded, root-only, one-level, and cycle-safe traversals unchanged.

## How are these changes tested?

- `./mvnw spotless:check`
- `make core`
- Spark 4.1 / Scala 2.13 focused run: 6 tests across 5 suites passed.
- Spark 3.4 / Scala 2.12 compatibility run: all changed test sources compiled and the focused `ParquetReadV1Suite` regression passed (1/1).