### PR TITLE
fix: report native child spill metrics in shuffle tasks

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometMetricNode.scala
@@ -19,6 +19,8 @@
 
 package org.apache.spark.sql.comet
 
+import java.util.IdentityHashMap
+
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.{SparkContext, TaskContext}
@@ -59,6 +61,23 @@ case class CometMetricNode(metrics: Map[String, SQLMetric], children: Seq[CometM
   def leafNodes: Seq[CometMetricNode] = {
     if (children.isEmpty) Seq(this)
     else children.flatMap(_.leafNodes)
+  }
+
+  private[comet] def sumMetricValues(metricName: String): Long = {
+    val seenMetrics = new IdentityHashMap[SQLMetric, java.lang.Boolean]()
+
+    def sumFromNode(metricNode: CometMetricNode): Long = {
+      val nodeValue = metricNode.metrics.get(metricName).fold(0L) { metric =>
+        if (seenMetrics.put(metric, java.lang.Boolean.TRUE) == null) {
+          math.max(metric.value, 0L)
+        } else {
+          0L
+        }
+      }
+      nodeValue + metricNode.children.iterator.map(sumFromNode).sum
+    }
+
+    sumFromNode(this)
   }
 
   /**
@@ -105,8 +124,8 @@ case class CometMetricNode(metrics: Map[String, SQLMetric], children: Seq[CometM
   }
 
   /**
-   * Reports this node's native shuffle spill metrics to Spark's task metrics, preserving the
-   * distinction between on-disk bytes and uncompressed in-memory bytes.
+   * Reports this node's and its descendants' native shuffle spill metrics to Spark's task
+   * metrics, preserving the distinction between on-disk bytes and uncompressed in-memory bytes.
    *
    * Must be registered on the task thread before [[org.apache.comet.CometExecIterator]] so its
    * completion listener publishes final SQL metrics before this listener runs, including when the
@@ -114,17 +133,14 @@ case class CometMetricNode(metrics: Map[String, SQLMetric], children: Seq[CometM
    */
   def reportSpillMetrics(ctx: TaskContext): Unit = {
     ctx.addTaskCompletionListener[Unit] { _ =>
-      metrics.get("spilled_bytes").foreach { metric =>
-        val spilledBytes = metric.value
-        if (spilledBytes > 0L) {
-          ctx.taskMetrics().incDiskBytesSpilled(spilledBytes)
-        }
+      val diskBytesSpilled = sumMetricValues("spilled_bytes")
+      if (diskBytesSpilled > 0L) {
+        ctx.taskMetrics().incDiskBytesSpilled(diskBytesSpilled)
       }
-      metrics.get("memory_spilled_bytes").foreach { metric =>
-        val spilledBytes = metric.value
-        if (spilledBytes > 0L) {
-          ctx.taskMetrics().incMemoryBytesSpilled(spilledBytes)
-        }
+
+      val memoryBytesSpilled = sumMetricValues("memory_spilled_bytes")
+      if (memoryBytesSpilled > 0L) {
+        ctx.taskMetrics().incMemoryBytesSpilled(memoryBytesSpilled)
       }
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleInputRDD.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleInputRDD.scala
@@ -21,7 +21,7 @@ package org.apache.spark.sql.comet.execution.shuffle
 
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.comet.CometExecRDD
+import org.apache.spark.sql.comet.{CometExecRDD, CometMetricNode}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import org.apache.comet.CometShuffleBlockIterator
@@ -44,6 +44,8 @@ private[shuffle] class CometNativeShuffleInputRDD(
       sc,
       inputRDDs.map(rdd => new OneToOneDependency(rdd))) {
 
+  private[shuffle] var spillMetricNode: Option[CometMetricNode] = None
+
   override protected def getPartitions: Array[Partition] =
     (0 until numPartitionsParam).map { i =>
       // Resolve leaf-RDD partitions on the driver here (where their @transient fields are still
@@ -63,6 +65,7 @@ private[shuffle] class CometNativeShuffleInputRDD(
   override def compute(
       split: Partition,
       context: TaskContext): Iterator[Product2[Int, ColumnarBatch]] = {
+    spillMetricNode.foreach(_.reportSpillMetrics(context))
     val partition = split.asInstanceOf[CometNativeShuffleInputPartition]
     val (inputObjects, shuffleBlockIters) =
       CometExecRDD.resolveInputObjects(

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleInputRDD.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleInputRDD.scala
@@ -39,12 +39,11 @@ private[shuffle] class CometNativeShuffleInputRDD(
     var inputRDDs: Seq[RDD[_]],
     numPartitionsParam: Int,
     shuffleScanIndices: Set[Int],
+    spillMetricNode: CometMetricNode,
     @transient perPartitionByKey: Map[String, Array[Array[Byte]]] = Map.empty)
     extends RDD[Product2[Int, ColumnarBatch]](
       sc,
       inputRDDs.map(rdd => new OneToOneDependency(rdd))) {
-
-  private[shuffle] var spillMetricNode: Option[CometMetricNode] = None
 
   override protected def getPartitions: Array[Partition] =
     (0 until numPartitionsParam).map { i =>
@@ -65,7 +64,7 @@ private[shuffle] class CometNativeShuffleInputRDD(
   override def compute(
       split: Partition,
       context: TaskContext): Iterator[Product2[Int, ColumnarBatch]] = {
-    spillMetricNode.foreach(_.reportSpillMetrics(context))
+    spillMetricNode.reportSpillMetrics(context)
     val partition = split.asInstanceOf[CometNativeShuffleInputPartition]
     val (inputObjects, shuffleBlockIters) =
       CometExecRDD.resolveInputObjects(

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleWriter.scala
@@ -137,8 +137,6 @@ class CometNativeShuffleWriter[K, V](
       Option(context).foreach(nativeMetrics.reportScanInputMetrics)
     }
 
-    Option(context).foreach(nativeMetrics.reportSpillMetrics)
-
     val cometIter = new CometExecIterator(
       CometExec.newIterId,
       inputObjects,

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -769,6 +769,7 @@ object CometShuffleExchangeExec
       serializer: Serializer,
       metrics: Map[String, SQLMetric],
       spec: NativeShuffleSpec): ShuffleDependency[Int, ColumnarBatch, ColumnarBatch] = {
+    thinRDD.spillMetricNode = Some(CometMetricNode(metrics, Seq(spec.childMetricNode)))
     val numParts = thinRDD.getNumPartitions
 
     // Subqueries in the partitioning expressions (e.g. DISTRIBUTE BY over a subquery) belong to

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -115,6 +115,9 @@ case class CometShuffleExchangeExec(
     case _ => None
   }
 
+  @transient private lazy val nativeChildMetricNode: CometMetricNode =
+    CometMetricNode.fromCometPlan(child)
+
   @transient lazy val inputRDD: RDD[_] = if (shuffleType == CometNativeShuffle) {
     nativeChildContext match {
       case Some(ctx) =>
@@ -123,6 +126,7 @@ case class CometShuffleExchangeExec(
           ctx.inputs,
           ctx.numPartitions,
           ctx.shuffleScanIndices,
+          CometMetricNode(metrics, Seq(nativeChildMetricNode)),
           ctx.perPartitionByKey)
       case None =>
         // Non-native child (e.g. CometSparkToColumnarExec): no subtree to inline. The dep gets
@@ -189,10 +193,7 @@ case class CometShuffleExchangeExec(
             outputPartitioning,
             serializer,
             metrics,
-            NativeShuffleSpec(
-              nativeChild.nativeOp,
-              CometMetricNode.fromCometPlan(nativeChild),
-              ctx))
+            NativeShuffleSpec(nativeChild.nativeOp, nativeChildMetricNode, ctx))
         case None =>
           CometShuffleExchangeExec.prepareShuffleDependency(
             inputRDD.asInstanceOf[RDD[ColumnarBatch]],
@@ -717,11 +718,13 @@ object CometShuffleExchangeExec
       CometArrowStream.NATIVE_TIMEZONE,
       "ShuffleWriterInput")
 
+    val childMetricNode = CometMetricNode(Map.empty)
     val thinRDD = new CometNativeShuffleInputRDD(
       rdd.sparkContext,
       Seq(streamRDD),
       rdd.getNumPartitions,
-      shuffleScanIndices = Set.empty)
+      shuffleScanIndices = Set.empty,
+      spillMetricNode = CometMetricNode(metrics, Seq(childMetricNode)))
 
     val ctx = NativeExecContext(
       inputs = Seq(streamRDD),
@@ -743,7 +746,7 @@ object CometShuffleExchangeExec
       outputPartitioning,
       serializer,
       metrics,
-      NativeShuffleSpec(scanOp, CometMetricNode(Map.empty), ctx))
+      NativeShuffleSpec(scanOp, childMetricNode, ctx))
   }
 
   /**
@@ -769,7 +772,6 @@ object CometShuffleExchangeExec
       serializer: Serializer,
       metrics: Map[String, SQLMetric],
       spec: NativeShuffleSpec): ShuffleDependency[Int, ColumnarBatch, ColumnarBatch] = {
-    thinRDD.spillMetricNode = Some(CometMetricNode(metrics, Seq(spec.childMetricNode)))
     val numParts = thinRDD.getNumPartitions
 
     // Subqueries in the partitioning expressions (e.g. DISTRIBUTE BY over a subquery) belong to

--- a/spark/src/test/scala/org/apache/spark/sql/comet/CometTaskMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/CometTaskMetricsSuite.scala
@@ -231,8 +231,8 @@ class CometTaskMetricsSuite extends CometTestBase with AdaptiveSparkPlanHelper {
 
         val shuffleWriteStages = store
           .stageList(null)
-          .filterNot(stage => stagesBefore.contains(stage.stageId))
-          .filter(_.shuffleWriteRecords > 0L)
+          .filter(stage =>
+            !stagesBefore.contains(stage.stageId) && stage.shuffleWriteRecords > 0L)
 
         assert(shuffleWriteStages.nonEmpty, "No native shuffle write stage was recorded")
         assert(

--- a/spark/src/test/scala/org/apache/spark/sql/comet/CometTaskMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/CometTaskMetricsSuite.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
+import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.SQLConf
 
 import org.apache.comet.CometConf
@@ -47,6 +48,35 @@ class CometTaskMetricsSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   import testImplicits._
+
+  test("spill metric tree counts nested shared accumulators once") {
+    def metric(name: String, value: Long): SQLMetric = {
+      val sqlMetric = new SQLMetric(name)
+      sqlMetric.set(value)
+      sqlMetric
+    }
+
+    val writerDisk = metric("writerDisk", 5L)
+    val writerMemory = metric("writerMemory", 3L)
+    val childDisk = metric("childDisk", 7L)
+    val nestedDisk = metric("nestedDisk", 11L)
+    val sharedDisk = metric("sharedDisk", 13L)
+    val sharedMemory = metric("sharedMemory", 17L)
+    val metricTree = CometMetricNode(
+      Map("spilled_bytes" -> writerDisk, "memory_spilled_bytes" -> writerMemory),
+      Seq(
+        CometMetricNode(
+          Map("spilled_bytes" -> childDisk),
+          Seq(
+            CometMetricNode(
+              Map("spilled_bytes" -> nestedDisk, "memory_spilled_bytes" -> sharedMemory)))),
+        CometMetricNode(
+          Map("spilled_bytes" -> sharedDisk, "memory_spilled_bytes" -> sharedMemory),
+          Seq(CometMetricNode(Map("spilled_bytes" -> sharedDisk))))))
+
+    assert(metricTree.sumMetricValues("spilled_bytes") == 36L)
+    assert(metricTree.sumMetricValues("memory_spilled_bytes") == 20L)
+  }
 
   test("per-task native shuffle metrics") {
     withParquetTable((0 until 10000).map(i => (i, (i + 1).toLong)), "tbl") {
@@ -156,6 +186,59 @@ class CometTaskMetricsSuite extends CometTestBase with AdaptiveSparkPlanHelper {
         assert(shuffleWriteStages.map(_.shuffleWriteTime).sum > 0L)
         assert(shuffleWriteStages.map(_.memoryBytesSpilled).sum == sqlMemorySpilled)
         assert(shuffleWriteStages.map(_.diskBytesSpilled).sum == sqlDiskSpilled)
+      }
+    }
+  }
+
+  test("native shuffle task metrics include existing child sort spill metrics once") {
+    val expectedRecords = 20000L
+    val compressibleValue = "native-child-sort-spill-metrics-" * 8
+    withParquetTable(
+      (0 until expectedRecords.toInt).map(index => (index, compressibleValue)),
+      "tbl") {
+      withSQLConf(
+        CometConf.COMET_SHUFFLE_MODE.key -> "native",
+        CometConf.COMET_SHUFFLE_COMPRESSION_CODEC.key -> "zstd",
+        CometConf.COMET_SHUFFLE_NATIVE_MAX_BUFFER_BYTES.key -> "32k",
+        CometConf.COMET_BATCH_SIZE.key -> "1024",
+        CometConf.COMET_OFFHEAP_MEMORY_POOL_FRACTION.key -> "0.002",
+        CometConf.COMET_RESPECT_DATAFUSION_CONFIGS.key -> "true",
+        "spark.comet.datafusion.execution.spill_compression" -> "zstd",
+        "spark.comet.datafusion.execution.sort_spill_reservation_bytes" -> "65536",
+        SQLConf.SHUFFLE_PARTITIONS.key -> "4") {
+        val shuffled = sql("SELECT * FROM tbl")
+          .sortWithinPartitions($"_1".desc)
+          .repartition(4, $"_1")
+        val store = spark.sparkContext.statusStore
+        spark.sparkContext.listenerBus.waitUntilEmpty()
+        val stagesBefore = store.stageList(null).map(_.stageId).toSet
+
+        assert(shuffled.collect().length == expectedRecords)
+        spark.sparkContext.listenerBus.waitUntilEmpty()
+
+        val exchange = collectFirst(shuffled.queryExecution.executedPlan) {
+          case native: CometShuffleExchangeExec if native.shuffleType == CometNativeShuffle =>
+            native
+        }.getOrElse(fail("Expected a native shuffle exchange"))
+        val childSorts = collect(exchange.child) { case sort: CometSortExec => sort }
+        assert(childSorts.nonEmpty, s"Expected a native child sort:\n${exchange.treeString}")
+
+        val writerDiskSpilled = exchange.metrics("spilled_bytes").value
+        val writerMemorySpilled = exchange.metrics("memory_spilled_bytes").value
+        val childDiskSpilled = childSorts.map(_.metrics("spilled_bytes").value).sum
+        assert(childDiskSpilled > 0L, "Native child sort did not spill")
+        assert(childSorts.forall(!_.metrics.contains("memory_spilled_bytes")))
+
+        val shuffleWriteStages = store
+          .stageList(null)
+          .filterNot(stage => stagesBefore.contains(stage.stageId))
+          .filter(_.shuffleWriteRecords > 0L)
+
+        assert(shuffleWriteStages.nonEmpty, "No native shuffle write stage was recorded")
+        assert(
+          shuffleWriteStages.map(_.diskBytesSpilled).sum ==
+            writerDiskSpilled + childDiskSpilled)
+        assert(shuffleWriteStages.map(_.memoryBytesSpilled).sum == writerMemorySpilled)
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleInputRDDSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleInputRDDSuite.scala
@@ -67,11 +67,14 @@ class CometNativeShuffleInputRDDSuite extends CometTestBase {
           Iterator.single(null)
         }
       }
-      val inputRDD =
-        new CometNativeShuffleInputRDD(spark.sparkContext, Seq(nestedInput), 1, Set.empty)
       val writerMetrics =
         Map("spilled_bytes" -> writerDisk, "memory_spilled_bytes" -> writerMemory)
-      inputRDD.spillMetricNode = Some(CometMetricNode(writerMetrics, Seq(childMetrics)))
+      val inputRDD = new CometNativeShuffleInputRDD(
+        spark.sparkContext,
+        Seq(nestedInput),
+        1,
+        Set.empty,
+        CometMetricNode(writerMetrics, Seq(childMetrics)))
 
       inputRDD.iterator(inputRDD.partitions.head, taskContext)
       new CometNativeShuffleWriter[Int, Any](
@@ -107,11 +110,16 @@ class CometNativeShuffleInputRDDSuite extends CometTestBase {
         CometShuffleDependency[Int, ColumnarBatch, ColumnarBatch]) = {
       val perPartitionByKey =
         Map("scan-0" -> Array.fill(numPartitions)(new Array[Byte](1024)))
+      val childMetricNode = CometMetricNode(Map.empty)
+      val writerMetrics = Map(
+        "spilled_bytes" -> SQLMetrics.createSizeMetric(sc, "disk spilled bytes"),
+        "memory_spilled_bytes" -> SQLMetrics.createSizeMetric(sc, "memory spilled bytes"))
       val rdd = new CometNativeShuffleInputRDD(
         sc,
         inputRDDs = Seq.empty,
         numPartitionsParam = numPartitions,
         shuffleScanIndices = Set.empty,
+        spillMetricNode = CometMetricNode(writerMetrics, Seq(childMetricNode)),
         perPartitionByKey = perPartitionByKey)
       val execContext = NativeExecContext(
         inputs = Seq.empty,
@@ -123,12 +131,7 @@ class CometNativeShuffleInputRDDSuite extends CometTestBase {
         perPartitionByKey = perPartitionByKey,
         shuffleScanIndices = Set.empty,
         hasScanInput = false)
-      val spec =
-        NativeShuffleSpec(Operator.getDefaultInstance, CometMetricNode(Map.empty), execContext)
-      val writerMetrics = Map(
-        "spilled_bytes" -> SQLMetrics.createSizeMetric(sc, "disk spilled bytes"),
-        "memory_spilled_bytes" -> SQLMetrics.createSizeMetric(sc, "memory spilled bytes"))
-      rdd.spillMetricNode = Some(CometMetricNode(writerMetrics, Seq(spec.childMetricNode)))
+      val spec = NativeShuffleSpec(Operator.getDefaultInstance, childMetricNode, execContext)
       val dep = new CometShuffleDependency[Int, ColumnarBatch, ColumnarBatch](
         _rdd = rdd,
         partitioner = new HashPartitioner(numPartitions),

--- a/spark/src/test/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleInputRDDSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/execution/shuffle/CometNativeShuffleInputRDDSuite.scala
@@ -19,11 +19,12 @@
 
 package org.apache.spark.sql.comet.execution.shuffle
 
-import org.apache.spark.HashPartitioner
+import org.apache.spark.{HashPartitioner, Partition, TaskContext}
+import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.JavaSerializer
 import org.apache.spark.sql.CometTestBase
 import org.apache.spark.sql.comet.{CometMetricNode, NativeExecContext}
-import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import org.apache.comet.serde.OperatorOuterClass.Operator
@@ -43,6 +44,56 @@ import org.apache.comet.serde.OperatorOuterClass.Operator
  * [[CometNativeShuffleInputRDD]] and the `private[comet]` [[NativeExecContext]] directly.
  */
 class CometNativeShuffleInputRDDSuite extends CometTestBase {
+
+  test("spill reporting is registered before native shuffle input producers") {
+    Seq(None, Some(new IllegalStateException("failed native shuffle"))).foreach { failure =>
+      val writerDisk = new SQLMetric("writerDisk")
+      val writerMemory = new SQLMetric("writerMemory")
+      val childDisk = new SQLMetric("childDisk")
+      val childMemory = new SQLMetric("childMemory")
+      val childMetrics =
+        CometMetricNode(Map("spilled_bytes" -> childDisk, "memory_spilled_bytes" -> childMemory))
+      val taskContext = TaskContext.empty()
+      val nestedInput = new RDD[AnyRef](spark.sparkContext, Nil) {
+        override protected def getPartitions: Array[Partition] = Array(new Partition {
+          override def index: Int = 0
+        })
+
+        override def compute(split: Partition, context: TaskContext): Iterator[AnyRef] = {
+          context.addTaskCompletionListener[Unit] { _ =>
+            childDisk.set(19L)
+            childMemory.set(37L)
+          }
+          Iterator.single(null)
+        }
+      }
+      val inputRDD =
+        new CometNativeShuffleInputRDD(spark.sparkContext, Seq(nestedInput), 1, Set.empty)
+      val writerMetrics =
+        Map("spilled_bytes" -> writerDisk, "memory_spilled_bytes" -> writerMemory)
+      inputRDD.spillMetricNode = Some(CometMetricNode(writerMetrics, Seq(childMetrics)))
+
+      inputRDD.iterator(inputRDD.partitions.head, taskContext)
+      new CometNativeShuffleWriter[Int, Any](
+        NativeShuffleSpec(null, childMetrics, null),
+        null,
+        Nil,
+        writerMetrics,
+        1,
+        0,
+        0L,
+        taskContext,
+        null)
+      taskContext.addTaskCompletionListener[Unit] { _ =>
+        writerDisk.set(23L)
+        writerMemory.set(41L)
+      }
+      taskContext.markTaskCompleted(failure)
+
+      assert(taskContext.taskMetrics.diskBytesSpilled == 42L)
+      assert(taskContext.taskMetrics.memoryBytesSpilled == 78L)
+    }
+  }
 
   test("serialized (rdd, dep) task binary size is independent of partition count") {
     val sc = spark.sparkContext
@@ -74,10 +125,15 @@ class CometNativeShuffleInputRDDSuite extends CometTestBase {
         hasScanInput = false)
       val spec =
         NativeShuffleSpec(Operator.getDefaultInstance, CometMetricNode(Map.empty), execContext)
+      val writerMetrics = Map(
+        "spilled_bytes" -> SQLMetrics.createSizeMetric(sc, "disk spilled bytes"),
+        "memory_spilled_bytes" -> SQLMetrics.createSizeMetric(sc, "memory spilled bytes"))
+      rdd.spillMetricNode = Some(CometMetricNode(writerMetrics, Seq(spec.childMetricNode)))
       val dep = new CometShuffleDependency[Int, ColumnarBatch, ColumnarBatch](
         _rdd = rdd,
         partitioner = new HashPartitioner(numPartitions),
         decodeTime = SQLMetrics.createMetric(sc, "decode time"),
+        shuffleWriteMetrics = writerMetrics,
         nativeShuffleSpec = Some(spec))
       (rdd, dep)
     }


### PR DESCRIPTION
## Why are the changes needed?

Closes #5382.

When a Spark task spills data, the task-level spill metrics are the natural place to understand how much memory pressure that task experienced. They populate the Spark UI's stage and task views and are commonly used when investigating slow shuffles, tuning memory, or comparing execution engines. For a native Comet shuffle, however, those totals currently describe only part of the work that actually happened.

Consider a query that sorts rows within each input partition before repartitioning them:

```scala
spark.table("orders")
  .sortWithinPartitions($"amount".desc)
  .repartition(4, $"customer_id")
  .count()
```

Comet can execute the sort and shuffle writer together within the same native shuffle task:

```text
CometShuffleExchangeExec
  CometSortExec
    Scan
```

Both the shuffle writer and the sort can spill independently. Their individual spill values are already available on their corresponding Spark SQL operators, but the existing task-metric bridge reads only the shuffle writer's metrics. Consequently, the SQL operator view and the task/stage view can tell conflicting stories about the same execution.

Suppose the shuffle writer spills 32 MiB to disk and the child sort spills another 128 MiB. Suppose also that the writer reports 96 MiB of in-memory spill, while the child sort exposes no in-memory spill counter:

| Spill metric | Shuffle writer | Child sort | Task total before | Task total after |
| --- | ---: | ---: | ---: | ---: |
| Disk bytes spilled | 32 MiB | 128 MiB | **32 MiB** | **160 MiB** |
| Memory bytes spilled | 96 MiB | Not reported | **96 MiB** | **96 MiB** |

Before this change, the task appears to have spilled only 32 MiB to disk even though its own operators report five times that amount. This is not a difference in how much data the query actually spilled: it is missing accounting at the boundary between Comet's operator metrics and Spark's task metrics.

The unchanged memory total in this example is equally important. Disk spill bytes can represent compressed data written to storage, while memory spill bytes represent the corresponding in-memory volume. Treating the child's 128 MiB of disk spill as though it were also 128 MiB of memory spill would merely replace one misleading metric with another. A child should contribute to task-level memory spill only when it actually exposes a trustworthy memory-spill measurement.

## What changes were proposed in this PR?

The change makes task-level spill reporting represent the complete native shuffle task rather than only its outer shuffle writer.

Comet already maintains an operator-shaped tree of SQL metrics for the native plan. Instead of introducing a second accounting system, this PR connects the shuffle writer's existing metrics to that existing child-operator tree and reports the combined tree when the task completes. Disk spill is aggregated from the disk counters that operators actually expose; memory spill is aggregated independently from genuine memory counters. The traversal also recognizes shared metric objects, so a reused accumulator contributes once even if it appears through multiple paths in the tree.

Returning to the example above, the completed task now reports `32 MiB + 128 MiB = 160 MiB` of disk spill. Its memory-spill total remains 96 MiB because the child sort has no memory counter to contribute. If a different child operator exposes, for example, 384 MiB of memory spill, that value is included naturally and the task reports `96 MiB + 384 MiB = 480 MiB` instead. No memory value is inferred from compressed disk bytes.

The other subtlety is timing. Native operators can publish their final metrics only while their iterators are being closed at task completion, and a shuffle task can initialize nested input producers before its writer is constructed. Registering the reporting callback too late can therefore observe incomplete child metrics, particularly when an attempt fails. This PR establishes one task-level reporting callback before those producers are initialized, so Spark's completion-listener ordering first finalizes the native operators and then reads the complete metric tree. That single callback replaces the previous writer-only callback rather than layering additional reporting on top of it.

The result is intentionally narrow: it changes how already-existing metrics are collected into Spark's task totals, without changing query execution, spill behavior, native memory management, the planner, or JNI.

## How was this PR tested?

A Spark integration regression runs a real native sort beneath a native shuffle, applies enough memory pressure to make the sort spill, and then compares the Spark stage metrics with the SQL metrics of the actual executed operators. It verifies that task-level disk spill equals the writer's disk spill plus the child sort's disk spill exactly once. It also verifies that the child sort has no memory-spill counter and that the task's memory-spill total therefore remains equal to the writer's real memory metric.

A separate deterministic task-completion test models a nested input producer and a shuffle writer publishing their metrics at completion time. It verifies that both disk and memory values are collected after those final updates, for both successful and failed task attempts. Additional coverage constructs a nested metric tree with shared accumulators to ensure reused metrics are not counted multiple times. Existing shuffle spill, failed-attempt, scan-input, output, and task-binary-size tests continue to run alongside the new regressions.

Both focused suites passed on **Spark 3.5, Spark 4.0, and Spark 4.1**, with **12 passing tests per version**.

<details>
<summary>Focused validation commands</summary>

```bash
SUITES=org.apache.spark.sql.comet.CometTaskMetricsSuite,org.apache.spark.sql.comet.execution.shuffle.CometNativeShuffleInputRDDSuite

./mvnw -Pspark-3.5 test -Dtest=none -DfailIfNoTests=false -Dsuites="$SUITES"
./mvnw -Pspark-4.0 test -Dtest=none -DfailIfNoTests=false -Dsuites="$SUITES"
./mvnw -Pspark-4.1 test -Dtest=none -DfailIfNoTests=false -Dsuites="$SUITES"
```

</details>
