### PR TITLE
feat: support Map for `CreateArray` literal

### DIFF
--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -49,7 +49,9 @@ use crate::execution::{
 };
 use crate::jvm_bridge::{jni_call, JVMClasses, ShufflePartitionPusher};
 use arrow::compute::CastOptions;
-use arrow::datatypes::{DataType, Field, FieldRef, Schema, TimeUnit, DECIMAL128_MAX_PRECISION};
+use arrow::datatypes::{
+    DataType, Field, FieldRef, Fields, Schema, TimeUnit, DECIMAL128_MAX_PRECISION,
+};
 use arrow::ffi_stream::FFI_ArrowArrayStream;
 use datafusion::functions_aggregate::bit_and_or_xor::{bit_and_udaf, bit_or_udaf, bit_xor_udaf};
 use datafusion::functions_aggregate::count::count_udaf;
@@ -214,6 +216,39 @@ fn make_all_fields_nullable(data_type: &DataType) -> DataType {
                 _ => data_type.clone(),
             }
         }
+        other => other.clone(),
+    }
+}
+
+/// Return a copy of a `Map` type with only the outer entries `value` field marked nullable, keeping
+/// the key field non-nullable and every nested key/value type byte-for-byte unchanged. Any non-`Map`
+/// type is returned unchanged.
+///
+/// This is the shallow counterpart of `make_all_fields_nullable`, used for `map_entries`.
+/// `map_entries` reuses the input map's entries array as its output list values but declares that
+/// element's `value` field nullable (`Struct(key non-null, value nullable)`), deriving both nested
+/// types verbatim from the input. Arrow's `GenericListArray::try_new` compares the declared element
+/// field's type against the reused values array's type in full, so the ONLY field that can mismatch
+/// is the entries `value` field's own `nullable` flag; widening just that field is sufficient.
+/// Recursing into nested types (as `make_all_fields_nullable` does) would additionally flip, say, a
+/// nested `Map`'s `valueContainsNull`, which then diverges from the Spark-serialized `return_type`
+/// and makes a downstream `make_array` see unequal map types and panic.
+fn widen_map_entry_value_nullable(data_type: &DataType) -> DataType {
+    match data_type {
+        DataType::Map(entries, sorted) => match entries.data_type() {
+            DataType::Struct(kv) if kv.len() == 2 && !kv[1].is_nullable() => {
+                let new_value = Arc::new(kv[1].as_ref().clone().with_nullable(true));
+                let new_kv: Fields = vec![Arc::clone(&kv[0]), new_value].into();
+                let new_entries = Arc::new(
+                    entries
+                        .as_ref()
+                        .clone()
+                        .with_data_type(DataType::Struct(new_kv)),
+                );
+                DataType::Map(new_entries, *sorted)
+            }
+            _ => data_type.clone(),
+        },
         other => other.clone(),
     }
 }
@@ -3490,6 +3525,17 @@ impl PhysicalPlanner {
             .collect::<Result<Vec<_>, _>>()?;
 
         let fun_name = &expr.func;
+        // `map_entries` needs its argument's entry `value` field widened to nullable first (only
+        // that outer field). See `widen_map_entry_value_nullable`.
+        let args = if fun_name == "map_entries" {
+            args.into_iter()
+                .map(|arg| {
+                    Self::coerce_child_to(arg, &input_schema, widen_map_entry_value_nullable)
+                })
+                .collect::<Result<Vec<_>, ExecutionError>>()?
+        } else {
+            args
+        };
         let input_expr_types = args
             .iter()
             .map(|x| x.data_type(input_schema.as_ref()))
@@ -3651,6 +3697,26 @@ impl PhysicalPlanner {
         }
         let nullable_type = make_all_fields_nullable(&child_type);
         Ok(Arc::new(CastExpr::new(child, nullable_type, None)))
+    }
+
+    /// Casts `child` so its type matches `widen(child_type)`, wrapping it in a `CastExpr` only when
+    /// the widened type differs. Used for the `map_entries` argument widening (with
+    /// `widen_map_entry_value_nullable`). Unlike `coerce_collect_child_nullability`, which casts
+    /// unconditionally as a normalization barrier for aggregate accumulators, this casts only when
+    /// the type actually changes. That is sufficient for the scalar `map_entries`, whose reused
+    /// entries array only needs its declared element type to line up.
+    fn coerce_child_to(
+        child: Arc<dyn PhysicalExpr>,
+        schema: &SchemaRef,
+        widen: impl Fn(&DataType) -> DataType,
+    ) -> Result<Arc<dyn PhysicalExpr>, ExecutionError> {
+        let child_type = child.data_type(schema.as_ref())?;
+        let widened = widen(&child_type);
+        if child_type.equals_datatype(&widened) {
+            Ok(child)
+        } else {
+            Ok(Arc::new(CastExpr::new(child, widened, None)))
+        }
     }
 
     fn create_aggr_func_expr(

--- a/native/spark-expr/src/struct_funcs/create_named_struct.rs
+++ b/native/spark-expr/src/struct_funcs/create_named_struct.rs
@@ -18,7 +18,7 @@
 use arrow::array::StructArray;
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
-use datafusion::common::Result as DataFusionResult;
+use datafusion::common::{Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::ColumnarValue;
 use datafusion::physical_expr::PhysicalExpr;
 use std::{
@@ -71,13 +71,25 @@ impl PhysicalExpr for CreateNamedStruct {
             .iter()
             .map(|expr| expr.evaluate(batch))
             .collect::<datafusion::common::Result<Vec<_>>>()?;
+        // When every field value is a scalar (e.g. an all-literal `named_struct` that reaches native
+        // as a `CreateNamedStruct` because constant folding is disabled), return a scalar struct
+        // rather than a length-1 `StructArray`. A downstream consumer such as `make_array` then
+        // broadcasts the constant struct to the batch row count instead of failing with a
+        // mixed-length error when a sibling child is a full-length column. This matches what a
+        // constant-folded struct literal produces, and `GetStructField::evaluate` already handles a
+        // scalar struct input.
+        let all_scalar =
+            !values.is_empty() && values.iter().all(|v| matches!(v, ColumnarValue::Scalar(_)));
         let arrays = ColumnarValue::values_to_arrays(&values)?;
         let fields = self.fields(&batch.schema())?;
-        Ok(ColumnarValue::Array(Arc::new(StructArray::new(
-            fields.into(),
-            arrays,
-            None,
-        ))))
+        let struct_array = StructArray::new(fields.into(), arrays, None);
+        if all_scalar {
+            Ok(ColumnarValue::Scalar(ScalarValue::Struct(Arc::new(
+                struct_array,
+            ))))
+        } else {
+            Ok(ColumnarValue::Array(Arc::new(struct_array)))
+        }
     }
 
     fn children(&self) -> Vec<&Arc<dyn PhysicalExpr>> {

--- a/spark/src/main/java/org/apache/comet/codegen/CometBatchKernel.java
+++ b/spark/src/main/java/org/apache/comet/codegen/CometBatchKernel.java
@@ -31,7 +31,13 @@ import org.apache.arrow.vector.ValueVector;
  */
 public abstract class CometBatchKernel extends CometInternalRow {
 
-  protected final Object[] references;
+  // `public` (not `protected`) so that the nested helper classes Spark's codegen emits when it
+  // splits a large expression (e.g. a folded map rebuilt as a big `CreateMap`) can read it. Those
+  // helpers are separate classes in the generated package, not subclasses of this one, so a
+  // `protected` field would raise `IllegalAccessError` at runtime under cross-package protected
+  // access rules. Spark's own generated classes avoid this by declaring `references` on the
+  // generated class itself; Comet inherits it here instead, so it must be public.
+  public final Object[] references;
 
   protected CometBatchKernel(Object[] references) {
     this.references = references;

--- a/spark/src/main/scala/org/apache/comet/DataTypeSupport.scala
+++ b/spark/src/main/scala/org/apache/comet/DataTypeSupport.scala
@@ -80,6 +80,21 @@ object DataTypeSupport {
     case _ => false
   }
 
+  /**
+   * `dt` with every array/map/struct nullability flag forced to `true` at all nesting levels (map
+   * key fields stay non-null per Arrow's map invariant). Re-derives Spark's `private[spark]`
+   * `DataType.asNullable`, used as a common cast target to unify types whose Comet runtime
+   * nullability exceeds Spark's Catalyst nullability.
+   */
+  def deepNullable(dt: DataType): DataType = dt match {
+    case ArrayType(et, _) => ArrayType(deepNullable(et), containsNull = true)
+    case MapType(kt, vt, _) =>
+      MapType(deepNullable(kt), deepNullable(vt), valueContainsNull = true)
+    case StructType(fields) =>
+      StructType(fields.map(f => f.copy(dataType = deepNullable(f.dataType), nullable = true)))
+    case other => other
+  }
+
   def hasTemporalType(t: DataType): Boolean = t match {
     case DataTypes.DateType | DataTypes.TimestampType | DataTypes.TimestampNTZType =>
       true

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -531,6 +531,22 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
     }
   }
 
+  /**
+   * Attach a fresh `expr_id` and, when the expression's origin carries one, its `QueryContext` to
+   * `protoExpr`. Native ANSI errors resolve their context by the `expr_id` of the `Expr` that
+   * throws (see `register_query_context` and `ListExtract` in the native planner), so the
+   * metadata has to sit on that `Expr`. The generic serde path applies this to the top-level
+   * `Expr` it returns; a serde that nests a throwing expression inside a wrapper (e.g.
+   * `CometElementAt`'s CASE-WHEN NULL guard) must also call it on the inner `Expr`, or that
+   * expression's error renders without Spark's `== SQL ... ==` query context.
+   */
+  private[serde] def attachExprIdAndContext(expr: Expression, protoExpr: Expr): Expr = {
+    val builder = protoExpr.toBuilder
+    builder.setExprId(nextExprId())
+    extractQueryContext(expr).foreach(builder.setQueryContext)
+    builder.build()
+  }
+
   def supportedDataType(dt: DataType, allowComplex: Boolean = false): Boolean = dt match {
     case _: ByteType | _: ShortType | _: IntegerType | _: LongType | _: FloatType |
         _: DoubleType | _: StringType | _: BinaryType | _: TimestampType | _: TimestampNTZType |
@@ -1004,12 +1020,7 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
           withNativeExpr(expr, CometExplainInfo.exprDisplayName(expr))
         }
         // Attach QueryContext and expr_id to the expression
-        val builder = protoExpr.toBuilder
-        builder.setExprId(nextExprId())
-        extractQueryContext(expr).foreach { ctx =>
-          builder.setQueryContext(ctx)
-        }
-        builder.build()
+        attachExprIdAndContext(expr, protoExpr)
       }
   }
 

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.types._
 
 import org.apache.comet.CometConf
 import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
+import org.apache.comet.DataTypeSupport.{deepNullable, isComplexType}
 import org.apache.comet.serde.QueryPlanSerde._
 import org.apache.comet.shims.{CometExprShim, CometTypeShim}
 
@@ -100,7 +101,28 @@ object CometArrayAppend extends CometExpressionSerde[ArrayAppend] {
   }
 }
 
-object CometArrayContains extends CometExpressionSerde[ArrayContains] {
+object CometArrayContains
+    extends CometExpressionSerde[ArrayContains]
+    with CodegenDispatchFallback {
+
+  private val floatingPointReason: String =
+    "Spark compares array elements with ordering.equiv, so -0.0 matches +0.0 and all NaNs match " +
+      "each other; Comet's native array_contains compares the raw Arrow values bitwise"
+
+  override def getIncompatibleReasons(): Seq[String] = Seq(floatingPointReason)
+
+  override def getSupportLevel(expr: ArrayContains): SupportLevel = expr.left.dataType match {
+    // Native array_contains compares floating-point elements bitwise, disagreeing with Spark for
+    // -0.0/+0.0 and NaN. Report Incompatible (not Unsupported) for float/double element types (at
+    // any nesting level) so the expression routes through the JVM codegen dispatcher (Spark's own
+    // doGenCode) and stays native + Spark-exact under the default config, while non-float arrays
+    // keep the fast native kernel. Under allowIncompatible=true the native kernel is used
+    // as before.
+    case ArrayType(elementType, _)
+        if SupportLevel.containsType(elementType, classOf[FloatType], classOf[DoubleType]) =>
+      Incompatible(Some(floatingPointReason))
+    case _ => Compatible()
+  }
 
   override def convert(
       expr: ArrayContains,
@@ -384,7 +406,7 @@ object CometArrayJoin
   }
 }
 
-object CometArrayInsert extends CometExpressionSerde[ArrayInsert] {
+object CometArrayInsert extends CometExpressionSerde[ArrayInsert] with ArraysBase {
 
   override def getSupportLevel(expr: ArrayInsert): SupportLevel = Compatible()
 
@@ -392,9 +414,32 @@ object CometArrayInsert extends CometExpressionSerde[ArrayInsert] {
       expr: ArrayInsert,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val srcExprProto = exprToProtoInternal(expr.children.head, inputs, binding)
+    val srcArray = expr.children.head
+    val item = expr.children(2)
+    val srcElementType = srcArray.dataType.asInstanceOf[ArrayType].elementType
+
+    // Native ArrayInsert requires the item's Arrow type to equal the source array's element type
+    // exactly, including nested nullability. For complex element types the two sides can disagree:
+    // a `CreateArray` source is widened to a deeply-nullable element type (see CometCreateArray),
+    // while a standalone item (e.g. `map(2, coalesce(id, 0))`) keeps Spark's Catalyst nullability.
+    // Cast BOTH sides in lockstep to the same deeply-nullable element type so their Arrow types
+    // match; Spark's `ArrayInsert.dataType` is `first.dataType.asNullable`, so this also
+    // matches the declared output element type. Casting only widens metadata and never
+    // changes values. Primitive element types are byte-identical on both sides, so the gate
+    // leaves them untouched.
+    val (srcChild, itemChild) = if (isComplexType(srcElementType)) {
+      val elementType = deepNullable(srcElementType)
+      val arrayType = ArrayType(elementType, containsNull = true)
+      val widenedSrc = if (srcArray.dataType == arrayType) srcArray else Cast(srcArray, arrayType)
+      val widenedItem = if (item.dataType == elementType) item else Cast(item, elementType)
+      (widenedSrc, widenedItem)
+    } else {
+      (srcArray, item)
+    }
+
+    val srcExprProto = exprToProtoInternal(srcChild, inputs, binding)
     val posExprProto = exprToProtoInternal(expr.children(1), inputs, binding)
-    val itemExprProto = exprToProtoInternal(expr.children(2), inputs, binding)
+    val itemExprProto = exprToProtoInternal(itemChild, inputs, binding)
     val legacyNegativeIndex =
       SQLConf.get.getConfString("spark.sql.legacy.negativeIndexInArrayInsert").toBoolean
     if (srcExprProto.isDefined && posExprProto.isDefined && itemExprProto.isDefined) {
@@ -455,7 +500,7 @@ object CometArrayUnion extends CometExpressionSerde[ArrayUnion] {
   }
 }
 
-object CometCreateArray extends CometExpressionSerde[CreateArray] {
+object CometCreateArray extends CometExpressionSerde[CreateArray] with ArraysBase {
   override def convert(
       expr: CreateArray,
       inputs: Seq[Attribute],
@@ -472,26 +517,19 @@ object CometCreateArray extends CometExpressionSerde[CreateArray] {
 
     // DataFusion's `make_array` asserts strict element-type equality in
     // `MutableArrayData::with_capacities` and panics on a mismatch. Spark's CreateArray is more
-    // permissive: its type coercion compares element types with `sameType`, which ignores
-    // nullability, so children that share a surface type but differ only in nested field
-    // nullability get no unifying cast. DataFusion tolerates container nullability differences
-    // (an `ArrayType.containsNull` / `MapType.valueContainsNull` mismatch is coerced), but NOT a
-    // struct field's nullability -- `array(struct(a not null), struct(a nullable))` panics inside
-    // `make_array_inner`. Decline only those cases (i.e. children that still differ after
-    // normalizing container nullability) so Spark's evaluator handles them.
-    //
-    // TODO: remove this decline once apache/datafusion#22366 lands; the upstream fix widens the
-    // element type via nullability-OR-merge and casts each child before MutableArrayData.
-    val normalizedTypes = children.map(c => normalizeContainerNullability(c.dataType))
-    if (normalizedTypes.distinct.size > 1) {
-      withFallbackReason(
-        expr,
-        "CreateArray children have mismatched data types: " +
-          children.map(_.dataType).distinct.mkString(", "))
-      return None
+    // permissive: its coercion compares element types with `sameType` (nullability ignored), so
+    // children that share a surface type but differ in nullability reach here as distinct types.
+    // Comet's native runtime types are also frequently MORE nullable than Spark's Catalyst types
+    // (`map_entries` forces the entry `value` field nullable, list elements are nullable, ...), so
+    // casting to Spark's declared element type does not reliably unify them. Cast every child to a
+    // deeply-nullable element type instead (every array/map/struct field nullable at all nesting
+    // levels; the cast only widens metadata and never changes values), so `make_array` always sees
+    // identical Arrow types. A child whose cast is unsupported declines below.
+    val elementType = deepNullable(expr.dataType.asInstanceOf[ArrayType].elementType)
+    val childExprs = children.map { c =>
+      val unified = if (c.dataType == elementType) c else Cast(c, elementType)
+      exprToProtoInternal(unified, inputs, binding)
     }
-
-    val childExprs = children.map(exprToProtoInternal(_, inputs, binding))
 
     if (childExprs.forall(_.isDefined)) {
       scalarFunctionExprToProto("make_array", childExprs: _*)
@@ -499,26 +537,6 @@ object CometCreateArray extends CometExpressionSerde[CreateArray] {
       withFallbackReason(expr, "unsupported arguments for CreateArray")
       None
     }
-  }
-
-  /**
-   * Rewrites a type so that container nullability (`ArrayType.containsNull`,
-   * `MapType.valueContainsNull`) is forced to `true` everywhere, while struct field nullability
-   * is left intact. Two CreateArray children whose types differ ONLY in container nullability are
-   * tolerated by DataFusion's `make_array` (coerced), so they normalize equal here; a difference
-   * in a struct field's nullability survives normalization and triggers the decline above.
-   */
-  private def normalizeContainerNullability(dt: DataType): DataType = dt match {
-    case ArrayType(elementType, _) =>
-      ArrayType(normalizeContainerNullability(elementType), containsNull = true)
-    case MapType(keyType, valueType, _) =>
-      MapType(
-        normalizeContainerNullability(keyType),
-        normalizeContainerNullability(valueType),
-        valueContainsNull = true)
-    case StructType(fields) =>
-      StructType(fields.map(f => f.copy(dataType = normalizeContainerNullability(f.dataType))))
-    case other => other
   }
 }
 
@@ -593,7 +611,7 @@ object CometElementAt extends CometExpressionSerde[ElementAt] {
   override def getSupportLevel(expr: ElementAt): SupportLevel = {
     expr.left.dataType match {
       case _: ArrayType => Compatible()
-      case _: MapType => Compatible()
+      case MapType(keyType, _, _) => MapKeySupport.keySupport(keyType)
       case _ => Unsupported(Some("Input must be an array or map"))
     }
   }
@@ -605,10 +623,9 @@ object CometElementAt extends CometExpressionSerde[ElementAt] {
     val childExpr = exprToProtoInternal(expr.left, inputs, binding)
     val ordinalExpr = exprToProtoInternal(expr.right, inputs, binding)
 
-    expr.left.dataType match {
+    val baseExpr = expr.left.dataType match {
       case _: MapType =>
-        val mapExtractExpr = scalarFunctionExprToProto("map_extract", childExpr, ordinalExpr)
-        mapExtractExpr
+        scalarFunctionExprToProto("map_extract", childExpr, ordinalExpr)
       case _ =>
         val defaultExpr =
           expr.defaultValueOutOfBound.flatMap(exprToProtoInternal(_, inputs, binding))
@@ -633,6 +650,49 @@ object CometElementAt extends CometExpressionSerde[ElementAt] {
           withFallbackReason(expr, "unsupported arguments for ElementAt")
           None
         }
+    }
+
+    // Spark's ElementAt is a BinaryExpression: for a NULL map/array it returns NULL WITHOUT
+    // evaluating the key/index child. Native scalar functions evaluate the key eagerly over the
+    // whole batch, so under ANSI (failOnError) a throwing key (e.g. a divide-by-zero) fires even on
+    // rows whose map/array is NULL, where Spark short-circuits. When the left can actually be NULL,
+    // guard the lookup with CASE WHEN left IS NOT NULL THEN <lookup> ELSE null so the key is only
+    // evaluated on the selected rows (DataFusion's CaseExpr filters the batch before the THEN
+    // branch), reproducing the short-circuit. Mirrors the CASE-WHEN idiom in CometArrayAppend /
+    // CometSize; the ELSE null literal carries the result type, as in CometArraysZip.
+    if (expr.failOnError && expr.left.nullable) {
+      val isNotNullExpr = createUnaryExpr(
+        expr,
+        expr.left,
+        inputs,
+        binding,
+        (builder, unaryExpr) => builder.setIsNotNull(unaryExpr))
+      val nullLiteralProto = exprToProto(Literal(null, expr.dataType), Seq.empty)
+      for {
+        base <- baseExpr
+        notNull <- isNotNullExpr
+        nullLit <- nullLiteralProto
+      } yield {
+        // The generic serde path attaches this ElementAt's expr_id and QueryContext to the CASE we
+        // return here, but the lookup that actually throws under ANSI (ListExtract, for the array
+        // case) is nested inside the THEN branch. Attach them to that inner Expr too, so a native
+        // INVALID_ARRAY_INDEX_IN_ELEMENT_AT / INVALID_INDEX_OF_ZERO error still renders Spark's
+        // `== SQL ... ==` query context. (map_extract ignores expr_id, so the map case is
+        // unaffected and never throws an index error anyway.)
+        val guardedBase = QueryPlanSerde.attachExprIdAndContext(expr, base)
+        val caseWhenExpr = ExprOuterClass.CaseWhen
+          .newBuilder()
+          .addWhen(notNull)
+          .addThen(guardedBase)
+          .setElseExpr(nullLit)
+          .build()
+        ExprOuterClass.Expr
+          .newBuilder()
+          .setCaseWhen(caseWhenExpr)
+          .build()
+      }
+    } else {
+      baseExpr
     }
   }
 }

--- a/spark/src/main/scala/org/apache/comet/serde/literals.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/literals.scala
@@ -22,10 +22,9 @@ package org.apache.comet.serde.literals
 import java.lang
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, CreateArray, CreateMap, CreateNamedStruct, Expression, KnownNullable, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, CreateArray, CreateMap, Expression, KnownNullable, Literal}
 import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
-import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteType, DataType, DateType, DayTimeIntervalType, Decimal, DecimalType, DoubleType, FloatType, IntegerType, LongType, MapType, NullType, ShortType, StringType, StructType, TimestampNTZType, TimestampType}
+import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteType, DataType, DateType, DayTimeIntervalType, Decimal, DecimalType, DoubleType, FloatType, IntegerType, LongType, MapType, NullType, ShortType, StringType, TimestampNTZType, TimestampType}
 import org.apache.spark.unsafe.types.UTF8String
 
 import com.google.protobuf.ByteString
@@ -230,11 +229,21 @@ object CometLiteral extends CometExpressionSerde[Literal] with Logging {
    * True when a non-null Literal of this type is not encodable in the native `Literal` proto and
    * `convert` should try to rebuild it from primitive-typed Literals. The native proto today
    * carries scalars and nested `ListLiteral`s (arrays of arrays / arrays of scalars). It does not
-   * carry Map or Struct values, so any Literal whose type contains a `MapType` or a `StructType`
-   * needs to be expanded before serialization.
+   * carry Map values, so any Literal whose type contains a `MapType` needs to be expanded before
+   * serialization.
+   *
+   * `StructType` (at any nesting depth) is deliberately excluded. Native `CometCreateNamedStruct`
+   * (`spark/src/main/scala/org/apache/comet/serde/structs.scala`) uses `values_to_arrays` in
+   * `native/spark-expr/src/struct_funcs/create_named_struct.rs`, which returns a 1-row
+   * `StructArray` whenever all children are scalar values. That collides with the row count of
+   * the surrounding batch and fails `make_array`'s length check. Field nullability is likewise
+   * inferred from the concrete child expressions, and `CometKnownNullable`
+   * (`spark/src/main/scala/org/apache/comet/serde/contraintExpressions.scala:99`) drops the tag
+   * on the wire, so wrapping a non-null child in `KnownNullable` does not carry across. Fall back
+   * to Spark for those shapes.
    */
   private def needsExpansion(dataType: DataType): Boolean = dataType match {
-    case _: MapType | _: StructType => true
+    case _: MapType => true
     case ArrayType(et, _) => needsExpansion(et)
     case _ => false
   }
@@ -242,24 +251,48 @@ object CometLiteral extends CometExpressionSerde[Literal] with Logging {
   /**
    * True when the Literal is a non-null complex value that we can rebuild from primitive Literals
    * via [[expandComplexLiteral]]. Empty top-level containers are excluded because a synthesized
-   * `Create[Array|Map]` with no children cannot recover the original element type.
+   * `Create[Array|Map]` with no children cannot recover the original element type. A folded
+   * `MapData` with duplicate keys is also excluded: Spark's `CreateMap.eval`
+   * (`sql/catalyst/.../complexTypeCreator.scala:250`) feeds every entry through
+   * `ArrayBasedMapBuilder`, which throws under the default `MAP_KEY_DEDUP_POLICY=EXCEPTION`
+   * (`sql/catalyst/.../util/ArrayBasedMapBuilder.scala`). Rebuilding a folded literal that came
+   * from `from_json` or a similar source would then throw where the original literal had executed
+   * cleanly.
    */
   private def canExpandComplexLiteral(expr: Literal): Boolean = {
-    val value = expr.value
-    if (value == null || !needsExpansion(expr.dataType)) return false
+    if (expr.value == null) return false
     expr.dataType match {
-      case _: ArrayType => value.asInstanceOf[ArrayData].numElements() > 0
-      case _: MapType => value.asInstanceOf[MapData].numElements() > 0
-      case _: StructType => true
+      case at: ArrayType if needsExpansion(at) =>
+        expr.value.asInstanceOf[ArrayData].numElements() > 0
+      case MapType(kt, _, _) =>
+        val mapData = expr.value.asInstanceOf[MapData]
+        mapData.numElements() > 0 && !hasDuplicateMapKeys(mapData.keyArray(), kt)
       case _ => false
     }
   }
 
   /**
-   * Rebuild a folded complex Literal as an equivalent tree of `CreateArray` / `CreateMap` /
-   * `CreateNamedStruct` over primitive-typed Literals. Callers must gate on
-   * [[canExpandComplexLiteral]] so `dataType` is one of the three complex cases and top-level
-   * containers are non-empty.
+   * True when the folded map's key array contains any duplicate values. Uses Catalyst internal
+   * equality (`UTF8String`, `Decimal`, `ArrayData`, `InternalRow`, and boxed primitives all
+   * implement `equals` / `hashCode`), matching `ArrayBasedMapBuilder`'s own dedup semantics.
+   */
+  private def hasDuplicateMapKeys(keys: ArrayData, keyType: DataType): Boolean = {
+    val n = keys.numElements()
+    if (n < 2) return false
+    val seen = new java.util.HashSet[Any](n)
+    var i = 0
+    while (i < n) {
+      val k = if (keys.isNullAt(i)) null else keys.get(i, keyType)
+      if (!seen.add(k)) return true
+      i += 1
+    }
+    false
+  }
+
+  /**
+   * Rebuild a folded complex Literal as an equivalent tree of `CreateArray` / `CreateMap` over
+   * primitive-typed Literals. Callers must gate on [[canExpandComplexLiteral]] so `dataType` is
+   * one of the two complex cases and top-level containers are non-empty and have unique keys.
    */
   private def expandComplexLiteral(value: Any, dataType: DataType): Expression =
     dataType match {
@@ -282,15 +315,6 @@ object CometLiteral extends CometExpressionSerde[Literal] with Logging {
           Seq(k, v)
         }
         CreateMap(children, useStringTypeWhenEmpty = false)
-      case StructType(fields) =>
-        val row = value.asInstanceOf[InternalRow]
-        val children = fields.zipWithIndex.flatMap { case (f, i) =>
-          val v =
-            if (row.isNullAt(i)) Literal(null, f.dataType)
-            else asNullable(Literal(row.get(i, f.dataType), f.dataType))
-          Seq(Literal(f.name), v)
-        }
-        CreateNamedStruct(children.toSeq)
       case other =>
         throw new IllegalStateException(s"expandComplexLiteral called on $other")
     }

--- a/spark/src/main/scala/org/apache/comet/serde/literals.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/literals.scala
@@ -22,17 +22,17 @@ package org.apache.comet.serde.literals
 import java.lang
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Literal}
-import org.apache.spark.sql.catalyst.util.ArrayData
-import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteType, DateType, DayTimeIntervalType, Decimal, DecimalType, DoubleType, FloatType, IntegerType, LongType, NullType, ShortType, StringType, TimestampNTZType, TimestampType}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, CreateArray, CreateMap, Expression, KnownNullable, Literal}
+import org.apache.spark.sql.catalyst.util.{ArrayData, MapData, TypeUtils}
+import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteType, CalendarIntervalType, DataType, DateType, DayTimeIntervalType, Decimal, DecimalType, DoubleType, FloatType, IntegerType, LongType, MapType, NullType, ShortType, StringType, StructType, TimestampNTZType, TimestampType}
 import org.apache.spark.unsafe.types.UTF8String
 
 import com.google.protobuf.ByteString
 
 import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
 import org.apache.comet.DataTypeSupport.isComplexType
-import org.apache.comet.serde.{CometExpressionSerde, Compatible, ExprOuterClass, LiteralOuterClass, SupportLevel, Unsupported}
-import org.apache.comet.serde.QueryPlanSerde.{isTimeType, serializeDataType, supportedDataType}
+import org.apache.comet.serde.{CometExpressionSerde, Compatible, ExprOuterClass, LiteralOuterClass, MapKeySupport, SupportLevel, Unsupported}
+import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, isTimeType, serializeDataType, supportedDataType}
 import org.apache.comet.serde.Types.ListLiteral
 
 object CometLiteral extends CometExpressionSerde[Literal] with Logging {
@@ -55,6 +55,9 @@ object CometLiteral extends CometExpressionSerde[Literal] with Logging {
             .elementType
             .isInstanceOf[ArrayType])))) {
       Compatible(None)
+    } else if (canExpandComplexLiteral(expr)) {
+      // Rebuilt as a `CreateArray` / `CreateMap` tree in `convert`.
+      Compatible(None)
     } else {
       expr.dataType match {
         case _: DayTimeIntervalType => Compatible(None)
@@ -70,6 +73,13 @@ object CometLiteral extends CometExpressionSerde[Literal] with Logging {
     val dataType = expr.dataType
     val value = expr.value
 
+    val expanded = expandComplexLiteral(expr)
+    if (expanded.isDefined) {
+      return exprToProtoInternal(expanded.get, inputs, binding).orElse {
+        withFallbackReason(expr, s"Unsupported data type $dataType")
+        None
+      }
+    }
     val exprBuilder = LiteralOuterClass.Literal.newBuilder()
 
     if (value == null) {
@@ -215,4 +225,175 @@ object CometLiteral extends CometExpressionSerde[Literal] with Logging {
     }
     listLiteralBuilder
   }
+
+  /**
+   * Rebuild a folded complex Literal as an equivalent tree of `CreateArray` / `CreateMap` over
+   * primitive-typed Literals, or `None` when [[canExpandComplexLiteral]] rejects the shape.
+   * `getSupportLevel` probes cheaply with [[canExpandComplexLiteral]], which shares this method's
+   * admission checks, so the two cannot diverge and only `convert` materializes the tree. The
+   * native `Literal` proto carries scalars and nested `ListLiteral`s but no map values, so a
+   * Literal whose type contains a `MapType` has to be expanded before serialization. Teaching the
+   * proto to transport maps directly would remove the need for this rewrite and for the declines
+   * below: https://github.com/apache/datafusion-comet/issues/1937
+   *
+   * The rebuilt tree is the tree Spark itself had before `ConstantFolding` collapsed it, down to
+   * every container's declared nullability (see [[withNullability]]). That equivalence is the
+   * safety property this rewrite rests on: whatever the rebuilt expression does natively is what
+   * the same query already does with `ConstantFolding` disabled, so expansion cannot introduce a
+   * folding-only behaviour difference. A non-nullable-value map into `map_entries` is handled by
+   * the native planner widening its argument rather than declined here.
+   *
+   * Map key semantics are declined here at admission rather than left to consumers, because not
+   * every native map consumer gates on [[MapKeySupport]]; see [[mapKeyTypesExpandable]] for why.
+   *
+   * Declined shapes:
+   *   - Null values and empty top-level containers: a synthesized `Create*` with no children
+   *     cannot recover the original element type. Empty `ArrayType` literals still serialize via
+   *     `makeListLiteral`, which keeps the type.
+   *   - Any map key type native map kernels cannot reproduce Spark equality for (floating-point,
+   *     collated string, complex), or whose interpreted ordering is undefined
+   *     (`CalendarIntervalType`), at any nesting level. See [[mapKeyTypesExpandable]].
+   *   - Arrays whose elements are structs, because [[needsExpansion]] does not walk into a
+   *     `StructType`. Native `CreateNamedStruct` builds a 1-row `StructArray` whenever all of its
+   *     children are scalars (`values_to_arrays`), which collides with the surrounding batch's
+   *     row count, and its proto message carries no type, so Spark's declared field nullability
+   *     cannot survive the wire either way. A struct that is only a map value is safe:
+   *     `CometCreateMap` hands the whole rebuilt `CreateMap` to the JVM codegen dispatcher, so
+   *     Spark's own code builds the struct.
+   *   - Folded maps with duplicate keys, see [[hasDuplicateMapKeys]].
+   */
+  private def expandComplexLiteral(expr: Literal): Option[Expression] = {
+    if (!canExpandComplexLiteral(expr)) return None
+    expr.dataType match {
+      case ArrayType(et, containsNull) =>
+        val arr = expr.value.asInstanceOf[ArrayData]
+        val elements = (0 until arr.numElements())
+          .map(i => withNullability(literalAt(arr, i, et), containsNull))
+        Some(CreateArray(elements, useStringTypeWhenEmpty = false))
+      case MapType(kt, vt, valueContainsNull) =>
+        val mapData = expr.value.asInstanceOf[MapData]
+        val keys = mapData.keyArray()
+        val values = mapData.valueArray()
+        val children = (0 until keys.numElements()).flatMap(i =>
+          Seq(
+            literalAt(keys, i, kt),
+            withNullability(literalAt(values, i, vt), valueContainsNull)))
+        Some(CreateMap(children, useStringTypeWhenEmpty = false))
+      case _ => None
+    }
+  }
+
+  /**
+   * Cheap admission test that mirrors [[expandComplexLiteral]] without materializing the rebuilt
+   * `Create*` tree, so `getSupportLevel` can probe a large folded literal without allocating the
+   * N `Literal`s `convert` would immediately rebuild. Declines a null value or empty top-level
+   * container (no children to recover the element type), a folded map with duplicate keys (see
+   * [[hasDuplicateMapKeys]]), any unsupported or non-orderable map key type at any nesting level
+   * (see [[mapKeyTypesExpandable]]), and an array of structs ([[needsExpansion]] stops at a
+   * `StructType`). [[expandComplexLiteral]] gates on this, so the two cannot diverge.
+   */
+  private def canExpandComplexLiteral(expr: Literal): Boolean = {
+    if (expr.value == null || !mapKeyTypesExpandable(expr.dataType)) return false
+    expr.dataType match {
+      case ArrayType(et, _) if needsExpansion(et) =>
+        expr.value.asInstanceOf[ArrayData].numElements() > 0
+      case MapType(kt, _, _) =>
+        val mapData = expr.value.asInstanceOf[MapData]
+        mapData.numElements() > 0 && !hasDuplicateMapKeys(mapData.keyArray(), kt)
+      case _ => false
+    }
+  }
+
+  /**
+   * True when every map key type reachable inside `dataType` can be rebuilt and consumed
+   * natively. A folded map is rebuilt as a `CreateMap`; once native it may reach a map consumer
+   * that has no key-type gate of its own -- `map_contains_key` lowers to
+   * `array_contains(map_keys(...), key)`, and neither `map_keys` nor `array_contains` consults
+   * [[MapKeySupport]]. A map that is only the value of another map is handed to the JVM
+   * dispatcher whole by `CometCreateMap` and never revisits this serde, so a nested unsupported
+   * key type would otherwise slip through. Mirror the [[MapKeySupport]] gate here, walking into
+   * map values, array elements, and struct fields, so an unsupported key type (floating-point,
+   * collated string, complex) declines expansion instead of reaching a native kernel whose key
+   * equality disagrees with Spark.
+   *
+   * Also decline a key type whose interpreted ordering is undefined -- one that recursively
+   * contains a `CalendarIntervalType`, whose `PhysicalCalendarIntervalType` ordering throws "does
+   * not support ordered operations". `ArrayBasedMapBuilder` dedups such keys by hash equality and
+   * never asks for an ordering, but [[hasDuplicateMapKeys]] compares keys through that ordering,
+   * so gating here keeps it from being called on a type it cannot order. Such literals fell back
+   * before this rewrite too, so declining them matches the prior behaviour.
+   */
+  private def mapKeyTypesExpandable(dataType: DataType): Boolean = dataType match {
+    case MapType(kt, vt, _) =>
+      MapKeySupport.keySupport(kt).isInstanceOf[Compatible] &&
+      !SupportLevel.containsType(kt, classOf[CalendarIntervalType]) &&
+      mapKeyTypesExpandable(vt)
+    case ArrayType(et, _) => mapKeyTypesExpandable(et)
+    case StructType(fields) => fields.forall(f => mapKeyTypesExpandable(f.dataType))
+    case _ => true
+  }
+
+  /**
+   * True when a Literal of this type has to be expanded rather than serialized, because the
+   * native `Literal` proto carries no map values. Walks array nesting only: an array of structs
+   * is not expandable (see [[expandComplexLiteral]]), so the walk stops at a `StructType`.
+   */
+  private def needsExpansion(dataType: DataType): Boolean = dataType match {
+    case _: MapType => true
+    case ArrayType(et, _) => needsExpansion(et)
+    case _ => false
+  }
+
+  /** Element `i` of `arr` as a Literal of type `dt`, or a null Literal for a null slot. */
+  private def literalAt(arr: ArrayData, i: Int, dt: DataType): Literal =
+    Literal(if (arr.isNullAt(i)) null else arr.get(i, dt), dt)
+
+  /**
+   * True when the folded map's key array holds duplicates under Spark's own key equality, in
+   * which case rebuilding the value as a `CreateMap` would change semantics the folded `MapData`
+   * had already settled: `ArrayBasedMapBuilder` throws `DUPLICATED_MAP_KEY` under
+   * `MAP_KEY_DEDUP_POLICY=EXCEPTION` and silently drops the earlier entry under `LAST_WIN`, where
+   * the original literal (from `from_json`, or a cast of one) kept both entries.
+   *
+   * Only reached for key types [[mapKeyTypesExpandable]] admits, i.e. atomic non-floating-point,
+   * default-collation `StringType`, and `BinaryType` -- floating-point, collated, complex, and
+   * `CalendarIntervalType` keys are already declined before this runs. Every admitted key type is
+   * orderable, so `TypeUtils.getInterpretedOrdering` (which `ArrayBasedMapBuilder` itself uses
+   * for `BinaryType`) is safe and matches Spark's equality: `Array[Byte]` keys compare by content
+   * rather than by identity, and the atomic orderings agree with hash equality. A null key cannot
+   * occur in a map Spark built, so treat one as a duplicate and keep the projection on Spark
+   * instead of asking the ordering to compare it.
+   */
+  private def hasDuplicateMapKeys(keys: ArrayData, keyType: DataType): Boolean = {
+    val n = keys.numElements()
+    if (n < 2) {
+      false
+    } else if ((0 until n).exists(keys.isNullAt)) {
+      true
+    } else {
+      val ordering = TypeUtils.getInterpretedOrdering(keyType)
+      val sorted = (0 until n).map(i => keys.get(i, keyType)).sorted(ordering)
+      (1 until sorted.length).exists(i => ordering.compare(sorted(i - 1), sorted(i)) == 0)
+    }
+  }
+
+  /**
+   * Wrap `expr` in `KnownNullable` when the container it came out of declares its elements or
+   * values nullable, so the rebuilt `Create*` reports exactly the literal's declared
+   * `ArrayType.containsNull` / `MapType.valueContainsNull`. Both directions matter:
+   *   - when the flag is true, a null slot yields a nullable `Literal` while a populated slot
+   *     does not, and DataFusion `make_array` asserts strict Arrow-type equality across siblings
+   *     (apache/datafusion#22366), so all children have to agree.
+   *   - when the flag is false, widening it would make the rebuilt map disagree with a non-folded
+   *     `CreateMap` sibling whose type Spark's own coercion had already accepted, which
+   *     `CometCreateArray` no longer normalizes away because DataFusion 54.1 cannot coerce a
+   *     `MapType.valueContainsNull` mismatch.
+   *
+   * A container that declares itself non-nullable never holds a null slot: `CreateArray` and
+   * `CreateMap` only report `false` when every child is non-nullable, and Spark's other sources
+   * of a complex type (a `CAST` target, a `from_json` schema, `MapType.apply`) default the flag
+   * to `true`. `CometKnownNullable` forwards the child on the wire, so runtime is unaffected.
+   */
+  private def withNullability(expr: Expression, nullable: Boolean): Expression =
+    if (nullable && !expr.nullable) KnownNullable(expr) else expr
 }

--- a/spark/src/main/scala/org/apache/comet/serde/literals.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/literals.scala
@@ -32,7 +32,7 @@ import com.google.protobuf.ByteString
 import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
 import org.apache.comet.DataTypeSupport.isComplexType
 import org.apache.comet.serde.{CometExpressionSerde, Compatible, ExprOuterClass, LiteralOuterClass, SupportLevel, Unsupported}
-import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, isTimeType, serializeDataType, supportedDataType}
+import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, hasNonDefaultStringCollation, isTimeType, serializeDataType, supportedDataType}
 import org.apache.comet.serde.Types.ListLiteral
 
 object CometLiteral extends CometExpressionSerde[Literal] with Logging {
@@ -55,8 +55,8 @@ object CometLiteral extends CometExpressionSerde[Literal] with Logging {
             .elementType
             .isInstanceOf[ArrayType])))) {
       Compatible(None)
-    } else if (canExpandComplexLiteral(expr)) {
-      // Rebuilt as a Create[Array|Map|NamedStruct] tree in `convert`.
+    } else if (expandComplexLiteral(expr).isDefined) {
+      // Rebuilt as a `CreateArray` / `CreateMap` tree in `convert`.
       Compatible(None)
     } else {
       expr.dataType match {
@@ -73,8 +73,9 @@ object CometLiteral extends CometExpressionSerde[Literal] with Logging {
     val dataType = expr.dataType
     val value = expr.value
 
-    if (canExpandComplexLiteral(expr)) {
-      return exprToProtoInternal(expandComplexLiteral(value, dataType), inputs, binding).orElse {
+    val expanded = expandComplexLiteral(expr)
+    if (expanded.isDefined) {
+      return exprToProtoInternal(expanded.get, inputs, binding).orElse {
         withFallbackReason(expr, s"Unsupported data type $dataType")
         None
       }
@@ -226,21 +227,58 @@ object CometLiteral extends CometExpressionSerde[Literal] with Logging {
   }
 
   /**
-   * True when a non-null Literal of this type is not encodable in the native `Literal` proto and
-   * `convert` should try to rebuild it from primitive-typed Literals. The native proto today
-   * carries scalars and nested `ListLiteral`s (arrays of arrays / arrays of scalars). It does not
-   * carry Map values, so any Literal whose type contains a `MapType` needs to be expanded before
-   * serialization.
+   * Rebuild a folded complex Literal as an equivalent tree of `CreateArray` / `CreateMap` over
+   * primitive-typed Literals, or `None` when the shape cannot be rebuilt. The native `Literal`
+   * proto carries scalars and nested `ListLiteral`s but no map values, so a Literal whose type
+   * contains a `MapType` has to be expanded before serialization. Teaching the proto to transport
+   * maps directly would remove the need for this rewrite and for the declines below:
+   * https://github.com/apache/datafusion-comet/issues/1937
    *
-   * `StructType` (at any nesting depth) is deliberately excluded. Native `CometCreateNamedStruct`
-   * (`spark/src/main/scala/org/apache/comet/serde/structs.scala`) uses `values_to_arrays` in
-   * `native/spark-expr/src/struct_funcs/create_named_struct.rs`, which returns a 1-row
-   * `StructArray` whenever all children are scalar values. That collides with the row count of
-   * the surrounding batch and fails `make_array`'s length check. Field nullability is likewise
-   * inferred from the concrete child expressions, and `CometKnownNullable`
-   * (`spark/src/main/scala/org/apache/comet/serde/contraintExpressions.scala:99`) drops the tag
-   * on the wire, so wrapping a non-null child in `KnownNullable` does not carry across. Fall back
-   * to Spark for those shapes.
+   * Declined shapes:
+   *   - Null values and empty top-level containers: a synthesized `Create*` with no children
+   *     cannot recover the original element type. Empty `ArrayType` literals still serialize via
+   *     `makeListLiteral`, which keeps the type.
+   *   - `StructType` at any depth. Native `CreateNamedStruct` builds a 1-row `StructArray`
+   *     whenever all of its children are scalars (`values_to_arrays`), which collides with the
+   *     surrounding batch's row count. Its proto message also carries no type, so Spark's
+   *     declared field nullability cannot survive the wire either way.
+   *   - Map key types whose Spark equality semantics native lookup cannot honor, see
+   *     [[hasUnsafeMapKeyType]].
+   *   - Folded maps with duplicate keys. The rebuilt `CreateMap` evaluates through
+   *     `ArrayBasedMapBuilder`, which throws under `MAP_KEY_DEDUP_POLICY=EXCEPTION`, where the
+   *     original literal had already folded cleanly.
+   */
+  private def expandComplexLiteral(expr: Literal): Option[Expression] = {
+    if (expr.value == null) return None
+    expr.dataType match {
+      case ArrayType(et, _) if needsExpansion(et) =>
+        val arr = expr.value.asInstanceOf[ArrayData]
+        if (arr.numElements() == 0) {
+          None
+        } else {
+          val elements = (0 until arr.numElements()).map(i => asNullable(literalAt(arr, i, et)))
+          Some(CreateArray(elements, useStringTypeWhenEmpty = false))
+        }
+      case MapType(kt, vt, _) =>
+        val mapData = expr.value.asInstanceOf[MapData]
+        val keys = mapData.keyArray()
+        if (mapData.numElements() == 0 || hasUnsafeMapKeyType(kt) ||
+          hasDuplicateMapKeys(keys, kt)) {
+          None
+        } else {
+          val values = mapData.valueArray()
+          val children = (0 until keys.numElements()).flatMap(i =>
+            Seq(literalAt(keys, i, kt), asNullable(literalAt(values, i, vt))))
+          Some(CreateMap(children, useStringTypeWhenEmpty = false))
+        }
+      case _ => None
+    }
+  }
+
+  /**
+   * True when a Literal of this type has to be expanded rather than serialized, because the
+   * native `Literal` proto carries no map values. Walks array nesting only: a `StructType` is not
+   * expandable at all (see [[expandComplexLiteral]]), so the walk stops there.
    */
   private def needsExpansion(dataType: DataType): Boolean = dataType match {
     case _: MapType => true
@@ -248,81 +286,41 @@ object CometLiteral extends CometExpressionSerde[Literal] with Logging {
     case _ => false
   }
 
-  /**
-   * True when the Literal is a non-null complex value that we can rebuild from primitive Literals
-   * via [[expandComplexLiteral]]. Empty top-level containers are excluded because a synthesized
-   * `Create[Array|Map]` with no children cannot recover the original element type. A folded
-   * `MapData` with duplicate keys is also excluded: Spark's `CreateMap.eval`
-   * (`sql/catalyst/.../complexTypeCreator.scala:250`) feeds every entry through
-   * `ArrayBasedMapBuilder`, which throws under the default `MAP_KEY_DEDUP_POLICY=EXCEPTION`
-   * (`sql/catalyst/.../util/ArrayBasedMapBuilder.scala`). Rebuilding a folded literal that came
-   * from `from_json` or a similar source would then throw where the original literal had executed
-   * cleanly.
-   */
-  private def canExpandComplexLiteral(expr: Literal): Boolean = {
-    if (expr.value == null) return false
-    expr.dataType match {
-      case at: ArrayType if needsExpansion(at) =>
-        expr.value.asInstanceOf[ArrayData].numElements() > 0
-      case MapType(kt, _, _) =>
-        val mapData = expr.value.asInstanceOf[MapData]
-        mapData.numElements() > 0 && !hasDuplicateMapKeys(mapData.keyArray(), kt)
-      case _ => false
-    }
-  }
+  /** Element `i` of `arr`, or `null` for a null slot. */
+  private def valueAt(arr: ArrayData, i: Int, dt: DataType): Any =
+    if (arr.isNullAt(i)) null else arr.get(i, dt)
+
+  /** Element `i` of `arr` as a Literal of type `dt`. */
+  private def literalAt(arr: ArrayData, i: Int, dt: DataType): Literal =
+    Literal(valueAt(arr, i, dt), dt)
 
   /**
-   * True when the folded map's key array contains any duplicate values. Uses Catalyst internal
-   * equality (`UTF8String`, `Decimal`, `ArrayData`, `InternalRow`, and boxed primitives all
-   * implement `equals` / `hashCode`), matching `ArrayBasedMapBuilder`'s own dedup semantics.
+   * True when the map key type has Spark equality semantics that native map lookup (Arrow
+   * bytewise comparison) cannot honor, in which case declining expansion keeps the projection on
+   * Spark. `NormalizeFloatingNumbers` makes Spark treat `+0.0` and `-0.0` as the same key and
+   * canonicalises NaN, and a non-default collation compares under rules native applies as
+   * `UTF8_BINARY`. Both are checked at every nesting level of the key type.
+   */
+  private def hasUnsafeMapKeyType(kt: DataType): Boolean =
+    hasNonDefaultStringCollation(kt) ||
+      SupportLevel.containsType(kt, classOf[FloatType], classOf[DoubleType])
+
+  /**
+   * True when the folded map's key array holds duplicates under Catalyst internal equality
+   * (`UTF8String`, `Decimal`, `ArrayData`, `InternalRow` and boxed primitives all implement
+   * `equals` / `hashCode`), which is what `ArrayBasedMapBuilder` uses for the key types reachable
+   * here.
    */
   private def hasDuplicateMapKeys(keys: ArrayData, keyType: DataType): Boolean = {
     val n = keys.numElements()
-    if (n < 2) return false
-    val seen = new java.util.HashSet[Any](n)
-    var i = 0
-    while (i < n) {
-      val k = if (keys.isNullAt(i)) null else keys.get(i, keyType)
-      if (!seen.add(k)) return true
-      i += 1
-    }
-    false
+    n > 1 && (0 until n).map(i => valueAt(keys, i, keyType)).distinct.size < n
   }
 
   /**
-   * Rebuild a folded complex Literal as an equivalent tree of `CreateArray` / `CreateMap` over
-   * primitive-typed Literals. Callers must gate on [[canExpandComplexLiteral]] so `dataType` is
-   * one of the two complex cases and top-level containers are non-empty and have unique keys.
-   */
-  private def expandComplexLiteral(value: Any, dataType: DataType): Expression =
-    dataType match {
-      case ArrayType(et, _) =>
-        val arr = value.asInstanceOf[ArrayData]
-        val elems = (0 until arr.numElements()).map { i =>
-          if (arr.isNullAt(i)) Literal(null, et)
-          else asNullable(Literal(arr.get(i, et), et))
-        }
-        CreateArray(elems, useStringTypeWhenEmpty = false)
-      case MapType(kt, vt, _) =>
-        val mapData = value.asInstanceOf[MapData]
-        val keys = mapData.keyArray()
-        val vals = mapData.valueArray()
-        val children = (0 until keys.numElements()).flatMap { i =>
-          val k = if (keys.isNullAt(i)) Literal(null, kt) else Literal(keys.get(i, kt), kt)
-          val v =
-            if (vals.isNullAt(i)) Literal(null, vt)
-            else asNullable(Literal(vals.get(i, vt), vt))
-          Seq(k, v)
-        }
-        CreateMap(children, useStringTypeWhenEmpty = false)
-      case other =>
-        throw new IllegalStateException(s"expandComplexLiteral called on $other")
-    }
-
-  /**
-   * Wrap a non-null expression in `KnownNullable` so a surrounding `Create*` sees every sibling
-   * as nullable. DataFusion `make_array` asserts strict Arrow-type equality across siblings and
-   * would panic if a folded literal produced a non-nullable child next to a nullable one.
+   * Wrap a non-null expression in `KnownNullable` so the surrounding `Create*` derives a nullable
+   * element / value type. DataFusion `make_array` asserts strict Arrow-type equality across
+   * siblings and would panic on a non-nullable child next to a nullable one. Same root cause as
+   * the mismatched-type decline in `CometCreateArray` (apache/datafusion#22366).
    * `CometKnownNullable` forwards the child on the wire, so runtime is unaffected.
    */
   private def asNullable(expr: Expression): Expression =

--- a/spark/src/main/scala/org/apache/comet/serde/literals.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/literals.scala
@@ -22,9 +22,10 @@ package org.apache.comet.serde.literals
 import java.lang
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Literal}
-import org.apache.spark.sql.catalyst.util.ArrayData
-import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteType, DateType, DayTimeIntervalType, Decimal, DecimalType, DoubleType, FloatType, IntegerType, LongType, NullType, ShortType, StringType, TimestampNTZType, TimestampType}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, CreateArray, CreateMap, CreateNamedStruct, Expression, KnownNullable, Literal}
+import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
+import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteType, DataType, DateType, DayTimeIntervalType, Decimal, DecimalType, DoubleType, FloatType, IntegerType, LongType, MapType, NullType, ShortType, StringType, StructType, TimestampNTZType, TimestampType}
 import org.apache.spark.unsafe.types.UTF8String
 
 import com.google.protobuf.ByteString
@@ -32,7 +33,7 @@ import com.google.protobuf.ByteString
 import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
 import org.apache.comet.DataTypeSupport.isComplexType
 import org.apache.comet.serde.{CometExpressionSerde, Compatible, ExprOuterClass, LiteralOuterClass, SupportLevel, Unsupported}
-import org.apache.comet.serde.QueryPlanSerde.{isTimeType, serializeDataType, supportedDataType}
+import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, isTimeType, serializeDataType, supportedDataType}
 import org.apache.comet.serde.Types.ListLiteral
 
 object CometLiteral extends CometExpressionSerde[Literal] with Logging {
@@ -55,6 +56,9 @@ object CometLiteral extends CometExpressionSerde[Literal] with Logging {
             .elementType
             .isInstanceOf[ArrayType])))) {
       Compatible(None)
+    } else if (canExpandComplexLiteral(expr)) {
+      // Rebuilt as a Create[Array|Map|NamedStruct] tree in `convert`.
+      Compatible(None)
     } else {
       expr.dataType match {
         case _: DayTimeIntervalType => Compatible(None)
@@ -70,6 +74,12 @@ object CometLiteral extends CometExpressionSerde[Literal] with Logging {
     val dataType = expr.dataType
     val value = expr.value
 
+    if (canExpandComplexLiteral(expr)) {
+      return exprToProtoInternal(expandComplexLiteral(value, dataType), inputs, binding).orElse {
+        withFallbackReason(expr, s"Unsupported data type $dataType")
+        None
+      }
+    }
     val exprBuilder = LiteralOuterClass.Literal.newBuilder()
 
     if (value == null) {
@@ -215,4 +225,82 @@ object CometLiteral extends CometExpressionSerde[Literal] with Logging {
     }
     listLiteralBuilder
   }
+
+  /**
+   * True when a non-null Literal of this type is not encodable in the native `Literal` proto and
+   * `convert` should try to rebuild it from primitive-typed Literals. The native proto today
+   * carries scalars and nested `ListLiteral`s (arrays of arrays / arrays of scalars). It does not
+   * carry Map or Struct values, so any Literal whose type contains a `MapType` or a `StructType`
+   * needs to be expanded before serialization.
+   */
+  private def needsExpansion(dataType: DataType): Boolean = dataType match {
+    case _: MapType | _: StructType => true
+    case ArrayType(et, _) => needsExpansion(et)
+    case _ => false
+  }
+
+  /**
+   * True when the Literal is a non-null complex value that we can rebuild from primitive Literals
+   * via [[expandComplexLiteral]]. Empty top-level containers are excluded because a synthesized
+   * `Create[Array|Map]` with no children cannot recover the original element type.
+   */
+  private def canExpandComplexLiteral(expr: Literal): Boolean = {
+    val value = expr.value
+    if (value == null || !needsExpansion(expr.dataType)) return false
+    expr.dataType match {
+      case _: ArrayType => value.asInstanceOf[ArrayData].numElements() > 0
+      case _: MapType => value.asInstanceOf[MapData].numElements() > 0
+      case _: StructType => true
+      case _ => false
+    }
+  }
+
+  /**
+   * Rebuild a folded complex Literal as an equivalent tree of `CreateArray` / `CreateMap` /
+   * `CreateNamedStruct` over primitive-typed Literals. Callers must gate on
+   * [[canExpandComplexLiteral]] so `dataType` is one of the three complex cases and top-level
+   * containers are non-empty.
+   */
+  private def expandComplexLiteral(value: Any, dataType: DataType): Expression =
+    dataType match {
+      case ArrayType(et, _) =>
+        val arr = value.asInstanceOf[ArrayData]
+        val elems = (0 until arr.numElements()).map { i =>
+          if (arr.isNullAt(i)) Literal(null, et)
+          else asNullable(Literal(arr.get(i, et), et))
+        }
+        CreateArray(elems, useStringTypeWhenEmpty = false)
+      case MapType(kt, vt, _) =>
+        val mapData = value.asInstanceOf[MapData]
+        val keys = mapData.keyArray()
+        val vals = mapData.valueArray()
+        val children = (0 until keys.numElements()).flatMap { i =>
+          val k = if (keys.isNullAt(i)) Literal(null, kt) else Literal(keys.get(i, kt), kt)
+          val v =
+            if (vals.isNullAt(i)) Literal(null, vt)
+            else asNullable(Literal(vals.get(i, vt), vt))
+          Seq(k, v)
+        }
+        CreateMap(children, useStringTypeWhenEmpty = false)
+      case StructType(fields) =>
+        val row = value.asInstanceOf[InternalRow]
+        val children = fields.zipWithIndex.flatMap { case (f, i) =>
+          val v =
+            if (row.isNullAt(i)) Literal(null, f.dataType)
+            else asNullable(Literal(row.get(i, f.dataType), f.dataType))
+          Seq(Literal(f.name), v)
+        }
+        CreateNamedStruct(children.toSeq)
+      case other =>
+        throw new IllegalStateException(s"expandComplexLiteral called on $other")
+    }
+
+  /**
+   * Wrap a non-null expression in `KnownNullable` so a surrounding `Create*` sees every sibling
+   * as nullable. DataFusion `make_array` asserts strict Arrow-type equality across siblings and
+   * would panic if a folded literal produced a non-nullable child next to a nullable one.
+   * `CometKnownNullable` forwards the child on the wire, so runtime is unaffected.
+   */
+  private def asNullable(expr: Expression): Expression =
+    if (expr.nullable) expr else KnownNullable(expr)
 }

--- a/spark/src/main/scala/org/apache/comet/serde/maps.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/maps.scala
@@ -23,8 +23,60 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
-import org.apache.comet.serde.QueryPlanSerde.{createBinaryExpr, exprToProtoInternal, scalarFunctionExprToProto}
+import org.apache.comet.DataTypeSupport.isComplexType
+import org.apache.comet.serde.QueryPlanSerde.{createBinaryExpr, exprToProtoInternal, hasNonDefaultStringCollation, scalarFunctionExprToProto}
 import org.apache.comet.shims.CometTypeShim
+
+/**
+ * Shared gate for the native map kernels that compare a lookup key against a map's stored keys
+ * (`map_extract`, reached from both `GetMapValue` and `ElementAt`).
+ */
+private[serde] object MapKeySupport {
+
+  private val floatingPointReason: String =
+    "Spark normalizes floating-point map keys, so `-0.0` matches a `+0.0` key and all `NaN`s " +
+      "match each other; Comet's native map lookup compares the raw Arrow values."
+
+  private val collationReason: String =
+    "Comet's native map lookup compares string keys as `UTF8_BINARY` and cannot honour a " +
+      "non-default collation."
+
+  private val complexKeyReason: String =
+    "Comet's native `map_extract` casts the lookup key to the map's exact Arrow key type, which " +
+      "cannot reproduce Spark's equality for a complex key type (for example a `NULL` inside the " +
+      "lookup key aborts the cast against a non-nullable nested component)."
+
+  /**
+   * The `SupportLevel` for a map-consuming expression whose stored-key type is `keyType`. Spark
+   * finds a key with `TypeUtils.getInterpretedOrdering` over the keys `ArrayBasedMapBuilder`
+   * stored, having first normalized them, while native `map_extract` compares the Arrow values as
+   * they are, so decline the key types where those disagree:
+   *   - `ArrayBasedMapBuilder` rewrites a `-0.0` key to `+0.0` and canonicalises `NaN`, and
+   *     `nanSafeCompareDoubles` treats `-0.0` and `+0.0` as equal, so Spark answers a `-0.0`
+   *     lookup from a `+0.0` key where native finds nothing.
+   *   - a non-default collation compares under rules native applies as `UTF8_BINARY`.
+   *   - for a complex key type, `map_extract`'s `coerce_types` returns the map's exact key field
+   *     type, so Comet's planner casts the lookup key to it. That cannot reproduce Spark's
+   *     interpreted-ordering equality, and a `NULL` inside the lookup key aborts the cast with
+   *     `Non-nullable field of ListArray "item" cannot contain nulls` rather than missing the
+   *     lookup. Declined for every complex key type, since which of these trips is a runtime
+   *     property of the lookup.
+   *
+   * `BinaryType` keys need no decline: Arrow compares them by content, as Spark's ordering does.
+   * The floating-point and collation checks walk every nesting level of the key type.
+   */
+  def keySupport(keyType: DataType): SupportLevel = {
+    if (SupportLevel.containsType(keyType, classOf[FloatType], classOf[DoubleType])) {
+      Unsupported(Some(floatingPointReason))
+    } else if (hasNonDefaultStringCollation(keyType)) {
+      Unsupported(Some(collationReason))
+    } else if (isComplexType(keyType)) {
+      Unsupported(Some(complexKeyReason))
+    } else {
+      Compatible()
+    }
+  }
+}
 
 object CometMapKeys extends CometExpressionSerde[MapKeys] {
 
@@ -63,6 +115,11 @@ object CometMapValues extends CometExpressionSerde[MapValues] {
 }
 
 object CometMapExtract extends CometExpressionSerde[GetMapValue] {
+
+  override def getSupportLevel(expr: GetMapValue): SupportLevel = expr.child.dataType match {
+    case MapType(keyType, _, _) => MapKeySupport.keySupport(keyType)
+    case _ => Compatible()
+  }
 
   override def convert(
       expr: GetMapValue,

--- a/spark/src/test/resources/sql-tests/expressions/array/array_contains.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_contains.sql
@@ -56,3 +56,37 @@ SELECT array_contains(cast(NULL as array<int>), cast(NULL as int))
 -- NULL array with column value
 query
 SELECT array_contains(cast(NULL as array<int>), val) FROM test_array_contains
+
+-- ============================================================
+-- Floating-point elements: Spark compares with ordering.equiv, so -0.0 == +0.0 and NaN == NaN.
+-- Native array_contains compares raw Arrow values bitwise, so float/double element types route
+-- through the JVM codegen dispatcher (Spark's own doGenCode) to stay native and Spark-exact.
+-- ============================================================
+
+statement
+CREATE TABLE test_array_contains_fp(arr array<double>, val double) USING parquet
+
+statement
+INSERT INTO test_array_contains_fp VALUES
+  (array(0.0D, 1.0D), -0.0D),
+  (array(-0.0D, 2.0D), 0.0D),
+  (array(cast('NaN' as double), 3.0D), cast('NaN' as double)),
+  (array(1.0D, 2.0D), 5.0D),
+  (array(1.0D, NULL), cast(NULL as double)),
+  (array(1.0D, NULL), 4.0D),
+  (NULL, 1.0D)
+
+query
+SELECT array_contains(arr, val) FROM test_array_contains_fp
+
+-- literal forms: -0.0 vs +0.0 and NaN vs NaN, for DOUBLE and FLOAT
+query
+SELECT array_contains(array(-0.0D, 1.0D), 0.0D),
+       array_contains(array(0.0D, 1.0D), -0.0D),
+       array_contains(array(cast('NaN' as double), 1.0D), cast('NaN' as double)),
+       array_contains(array(cast('-0.0' as float), 1.0F), cast('0.0' as float)),
+       array_contains(array(cast('NaN' as float), 1.0F), cast('NaN' as float))
+
+-- nested float element: the element type is array<double>, so the float decline must recurse
+query
+SELECT array_contains(array(array(0.0D), array(1.0D)), array(-0.0D))

--- a/spark/src/test/resources/sql-tests/expressions/array/array_insert.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_insert.sql
@@ -280,3 +280,20 @@ SELECT array_insert(array(CAST(1 AS TINYINT), CAST(2 AS TINYINT)), 2, CAST(3 AS 
 
 query
 SELECT array_insert(array(CAST(1.1 AS FLOAT), CAST(2.2 AS FLOAT)), 2, CAST(3.3 AS FLOAT))
+
+-- ============================================================
+-- Array of maps (complex element type)
+-- The source array's map value is widened to nullable by CometCreateArray, while the standalone
+-- item map keeps value non-null because coalesce(id, 0) is non-null. Native ArrayInsert requires
+-- the item Arrow type to equal the source element type exactly, so the serde casts both sides to a
+-- common deeply-nullable element type. id includes a NULL row (coalesce yields 0).
+-- ============================================================
+
+statement
+CREATE TABLE test_array_insert_map(id int) USING parquet
+
+statement
+INSERT INTO test_array_insert_map VALUES (1), (2), (NULL)
+
+query
+SELECT array_insert(array(map(1, coalesce(id, 0))), 2, map(2, coalesce(id, 0))) FROM test_array_insert_map

--- a/spark/src/test/resources/sql-tests/expressions/array/create_array.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/create_array.sql
@@ -57,22 +57,9 @@ SELECT array(array(a, b), array(b, c)) FROM test_create_array
 query
 SELECT array(map(1, 10), map(2, 20))
 
--- Array of maps whose values are arrays. This is the exact fallback shape reported in
--- https://github.com/apache/datafusion-comet — `MapType(IntegerType, ArrayType(IntegerType, false), true)`.
+-- Array of maps whose values are arrays: `MapType(IntegerType, ArrayType(IntegerType, false), true)`.
 query
 SELECT array(map(1, array(1, 2, 3)), map(2, array(4, 5, 6)))
-
--- Array of maps with a NULL value inside (map value expansion must handle NULLs).
-query
-SELECT array(map('x', CAST(NULL AS INT), 'y', 2), map('z', 3))
-
--- Array containing a folded NULL map literal alongside a non-null map.
-query
-SELECT array(CAST(NULL AS MAP<INT,INT>), map(1, 2))
-
--- Deeply nested folded complex literal: array of struct of map of array of struct.
-query
-SELECT array(named_struct('m', map(1, array(named_struct('id', 1, 's', 'x')))))
 
 -- Array of maps with string keys.
 query
@@ -86,8 +73,9 @@ SELECT array(map(1, 2))
 query
 SELECT array(array(map(1, 'a')), array(map(2, 'b')))
 
--- Array of structs. Under constant folding each named_struct(...) folds to a StructType
--- Literal; expansion rebuilds it as CreateNamedStruct of primitive literals.
+-- Array of structs. The SQL-file harness disables ConstantFolding, so `named_struct(...)`
+-- stays as `CreateNamedStruct` (not a folded Literal) and this exercises the constructor
+-- path, not `CometLiteral` expansion.
 query
 SELECT array(named_struct('a', 1, 'b', 'x'), named_struct('a', 2, 'b', 'y'))
 

--- a/spark/src/test/resources/sql-tests/expressions/array/create_array.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/create_array.sql
@@ -15,6 +15,8 @@
 -- specific language governing permissions and limitations
 -- under the License.
 
+-- ConfigMatrix: parquet.enable.dictionary=false,true
+
 statement
 CREATE TABLE test_create_array(a int, b int, c int) USING parquet
 
@@ -26,3 +28,115 @@ SELECT array(a, b, c) FROM test_create_array
 
 query
 SELECT array(1, 2, 3, NULL)
+
+-- Boundary integer values including int min/max.
+query
+SELECT array(2147483647, -2147483648, 0, NULL)
+
+-- Table for column-based coverage of map/struct/nested-array children.
+statement
+CREATE TABLE test_create_array_complex(k int, v int, s string, arr array<int>) USING parquet
+
+statement
+INSERT INTO test_create_array_complex VALUES
+  (1, 10, 'a', array(1, 2, 3)),
+  (2, 20, NULL, array(4, NULL, 6)),
+  (NULL, NULL, 'c', array()),
+  (NULL, NULL, NULL, NULL)
+
+-- Array of nested arrays.
+query
+SELECT array(array(1, 2), array(3, NULL))
+
+query
+SELECT array(array(a, b), array(b, c)) FROM test_create_array
+
+-- Array of maps built from primitive int values. The SQL-file harness always excludes
+-- ConstantFolding, so every `map(...)` below stays a `CreateMap` and reaches native
+-- `make_array` through the constructor path. Folded-literal expansion in `CometLiteral` is
+-- covered by `CometArrayExpressionSuite` instead, where folding is left enabled.
+query
+SELECT array(map(1, 10), map(2, 20))
+
+-- Array of maps whose values are arrays: `MapType(IntegerType, ArrayType(IntegerType, false), true)`.
+query
+SELECT array(map(1, array(1, 2, 3)), map(2, array(4, 5, 6)))
+
+-- Array of maps with string keys.
+query
+SELECT array(map('x', 1, 'y', 2), map('z', 3))
+
+-- Array of maps whose children disagree on `valueContainsNull`. Spark's CreateArray coercion
+-- compares element types with `sameType`, which ignores nullability, so it inserts no unifying
+-- cast; it reports the nullability-merged map type as the array's element type. `make_array`
+-- needs identical Arrow types, so `CometCreateArray` casts each child to that merged type
+-- (`cast_map_to_map` widens `valueContainsNull`) and runs natively.
+query
+SELECT array(map('x', CAST(NULL AS INT), 'y', 2), map('z', 3))
+
+-- Both children agree that the value is nullable, so this needs no cast.
+query
+SELECT array(map('x', CAST(NULL AS INT)), map('z', CAST(NULL AS INT)))
+
+-- Array of maps whose values are arrays that disagree only on the array's `containsNull`:
+-- `map(1, array(1))` has value `ArrayType(IntegerType, containsNull = false)` while
+-- `map(2, array(a))` has `ArrayType(IntegerType, true)`. The difference is container nullability
+-- nested inside the map value, which Comet's map cast widens, so `CometCreateArray` casts each
+-- child to the merged element type and runs natively.
+query
+SELECT array(map(1, array(1)), map(2, array(a))) FROM test_create_array
+
+-- Single-element array of map.
+query
+SELECT array(map(1, 2))
+
+-- Array of arrays of maps: `ArrayType(ArrayType(MapType(IntegerType, StringType)))`.
+query
+SELECT array(array(map(1, 'a')), array(map(2, 'b')))
+
+-- Array of structs.
+query
+SELECT array(named_struct('a', 1, 'b', 'x'), named_struct('a', 2, 'b', 'y'))
+
+-- Array of structs differing only in a field's nullability: the first `ct` is a non-null literal,
+-- the second is a nullable CASE. Spark compares element types with `sameType` (nullability ignored)
+-- so it keeps distinct StructTypes; `CometCreateArray` casts each child to the merged struct type
+-- (widening `ct` to nullable) before `make_array`, so this runs natively.
+query
+SELECT array(
+  named_struct('id', a, 'ct', 'x'),
+  named_struct('id', a, 'ct', CASE WHEN a = 0 THEN 'y' END)) FROM test_create_array
+
+-- Same nested-field-nullability divergence wrapped in a map value.
+query
+SELECT array(
+  map('k', named_struct('id', a, 'ct', 'x')),
+  map('k', named_struct('id', a, 'ct', CASE WHEN a = 0 THEN 'y' END))) FROM test_create_array
+
+-- Column-based array of maps. Filter out NULL keys because Spark forbids them.
+query
+SELECT array(map(k, v)) FROM test_create_array_complex WHERE k IS NOT NULL
+
+-- Column-based array of structs.
+query
+SELECT array(named_struct('k', k, 's', s)) FROM test_create_array_complex
+
+-- Column-based array of nested arrays.
+query
+SELECT array(arr, array(k, v)) FROM test_create_array_complex
+
+-- Array of maps whose value is a nested array column.
+query
+SELECT array(map(k, arr)) FROM test_create_array_complex WHERE k IS NOT NULL
+
+-- Array combining an all-literal struct child with a column-referencing struct child. The SQL
+-- harness always excludes ConstantFolding, so the literal `named_struct('a', 1)` stays a
+-- `CreateNamedStruct` whose native evaluation is a constant (row-count-independent) struct. It must
+-- broadcast to the batch row count to sit alongside the column-based `named_struct('a', a)` inside
+-- `make_array`, which otherwise rejects the length-1 vs length-N mismatch.
+query
+SELECT array(named_struct('a', 1), named_struct('a', a)) FROM test_create_array
+
+-- Empty array cast to a nested array type: the element type has to survive with no children.
+query
+SELECT CAST(array() AS ARRAY<ARRAY<INT>>)

--- a/spark/src/test/resources/sql-tests/expressions/array/create_array.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/create_array.sql
@@ -51,9 +51,10 @@ SELECT array(array(1, 2), array(3, NULL))
 query
 SELECT array(array(a, b), array(b, c)) FROM test_create_array
 
--- Array of maps built from primitive int values. Under Spark constant folding this collapses
--- each `map(...)` to a MapType Literal; CometLiteral expands it back to a CreateMap of int
--- literals so the outer `array(...)` runs natively via `make_array`.
+-- Array of maps built from primitive int values. The SQL-file harness always excludes
+-- ConstantFolding, so every `map(...)` below stays a `CreateMap` and reaches native
+-- `make_array` through the constructor path. Folded-literal expansion in `CometLiteral` is
+-- covered by `CometArrayExpressionSuite` instead, where folding is left enabled.
 query
 SELECT array(map(1, 10), map(2, 20))
 
@@ -69,19 +70,15 @@ SELECT array(map('x', 1, 'y', 2), map('z', 3))
 query
 SELECT array(map(1, 2))
 
--- Array of arrays of maps (recursive expansion of ArrayType(ArrayType(MapType)) literal).
+-- Array of arrays of maps: `ArrayType(ArrayType(MapType(IntegerType, StringType)))`.
 query
 SELECT array(array(map(1, 'a')), array(map(2, 'b')))
 
--- Array of structs. The SQL-file harness disables ConstantFolding, so `named_struct(...)`
--- stays as `CreateNamedStruct` (not a folded Literal) and this exercises the constructor
--- path, not `CometLiteral` expansion.
+-- Array of structs.
 query
 SELECT array(named_struct('a', 1, 'b', 'x'), named_struct('a', 2, 'b', 'y'))
 
--- Column-based array of maps. With constant folding disabled by the SQL-file harness this
--- flows through CometCreateMap's codegen dispatch, not through Literal expansion, but it
--- must remain natively supported. Filter out NULL keys because Spark forbids them.
+-- Column-based array of maps. Filter out NULL keys because Spark forbids them.
 query
 SELECT array(map(k, v)) FROM test_create_array_complex WHERE k IS NOT NULL
 
@@ -97,7 +94,6 @@ SELECT array(arr, array(k, v)) FROM test_create_array_complex
 query
 SELECT array(map(k, arr)) FROM test_create_array_complex WHERE k IS NOT NULL
 
--- Empty complex ArrayType literal takes the pre-expansion makeListLiteral path (empty
--- ListLiteral) so its element type survives even without any children.
+-- Empty array cast to a nested array type: the element type has to survive with no children.
 query
 SELECT CAST(array() AS ARRAY<ARRAY<INT>>)

--- a/spark/src/test/resources/sql-tests/expressions/array/create_array.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/create_array.sql
@@ -15,6 +15,8 @@
 -- specific language governing permissions and limitations
 -- under the License.
 
+-- ConfigMatrix: parquet.enable.dictionary=false,true
+
 statement
 CREATE TABLE test_create_array(a int, b int, c int) USING parquet
 
@@ -26,3 +28,88 @@ SELECT array(a, b, c) FROM test_create_array
 
 query
 SELECT array(1, 2, 3, NULL)
+
+-- Boundary integer values including int min/max.
+query
+SELECT array(2147483647, -2147483648, 0, NULL)
+
+-- Table for column-based coverage of map/struct/nested-array children.
+statement
+CREATE TABLE test_create_array_complex(k int, v int, s string, arr array<int>) USING parquet
+
+statement
+INSERT INTO test_create_array_complex VALUES
+  (1, 10, 'a', array(1, 2, 3)),
+  (2, 20, NULL, array(4, NULL, 6)),
+  (NULL, NULL, 'c', array()),
+  (NULL, NULL, NULL, NULL)
+
+-- Array of nested arrays.
+query
+SELECT array(array(1, 2), array(3, NULL))
+
+query
+SELECT array(array(a, b), array(b, c)) FROM test_create_array
+
+-- Array of maps built from primitive int values. Under Spark constant folding this collapses
+-- each `map(...)` to a MapType Literal; CometLiteral expands it back to a CreateMap of int
+-- literals so the outer `array(...)` runs natively via `make_array`.
+query
+SELECT array(map(1, 10), map(2, 20))
+
+-- Array of maps whose values are arrays. This is the exact fallback shape reported in
+-- https://github.com/apache/datafusion-comet — `MapType(IntegerType, ArrayType(IntegerType, false), true)`.
+query
+SELECT array(map(1, array(1, 2, 3)), map(2, array(4, 5, 6)))
+
+-- Array of maps with a NULL value inside (map value expansion must handle NULLs).
+query
+SELECT array(map('x', CAST(NULL AS INT), 'y', 2), map('z', 3))
+
+-- Array containing a folded NULL map literal alongside a non-null map.
+query
+SELECT array(CAST(NULL AS MAP<INT,INT>), map(1, 2))
+
+-- Deeply nested folded complex literal: array of struct of map of array of struct.
+query
+SELECT array(named_struct('m', map(1, array(named_struct('id', 1, 's', 'x')))))
+
+-- Array of maps with string keys.
+query
+SELECT array(map('x', 1, 'y', 2), map('z', 3))
+
+-- Single-element array of map.
+query
+SELECT array(map(1, 2))
+
+-- Array of arrays of maps (recursive expansion of ArrayType(ArrayType(MapType)) literal).
+query
+SELECT array(array(map(1, 'a')), array(map(2, 'b')))
+
+-- Array of structs. Under constant folding each named_struct(...) folds to a StructType
+-- Literal; expansion rebuilds it as CreateNamedStruct of primitive literals.
+query
+SELECT array(named_struct('a', 1, 'b', 'x'), named_struct('a', 2, 'b', 'y'))
+
+-- Column-based array of maps. With constant folding disabled by the SQL-file harness this
+-- flows through CometCreateMap's codegen dispatch, not through Literal expansion, but it
+-- must remain natively supported. Filter out NULL keys because Spark forbids them.
+query
+SELECT array(map(k, v)) FROM test_create_array_complex WHERE k IS NOT NULL
+
+-- Column-based array of structs.
+query
+SELECT array(named_struct('k', k, 's', s)) FROM test_create_array_complex
+
+-- Column-based array of nested arrays.
+query
+SELECT array(arr, array(k, v)) FROM test_create_array_complex
+
+-- Array of maps whose value is a nested array column.
+query
+SELECT array(map(k, arr)) FROM test_create_array_complex WHERE k IS NOT NULL
+
+-- Empty complex ArrayType literal takes the pre-expansion makeListLiteral path (empty
+-- ListLiteral) so its element type survives even without any children.
+query
+SELECT CAST(array() AS ARRAY<ARRAY<INT>>)

--- a/spark/src/test/resources/sql-tests/expressions/array/element_at.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/element_at.sql
@@ -21,9 +21,17 @@ CREATE TABLE test_element_at(arr array<int>) USING parquet
 statement
 INSERT INTO test_element_at VALUES (array(1, 2, 3)), (array(10)), (NULL)
 
-query spark_answer_only
+query
 SELECT element_at(arr, 1), element_at(arr, -1) FROM test_element_at
 
--- literal arguments
-query ignore(Spark codegen bug with literal element_at when constant folding is disabled)
-SELECT element_at(array(1, 2, 3), 1), element_at(array(1, 2, 3), -1)
+statement
+CREATE TABLE t(id int) USING parquet
+
+statement
+INSERT INTO t VALUES (1), (2), (3), (-1), (NULL)
+
+query
+SELECT element_at(array(1, 2, 3), id), element_at(array(1, 2, 3), -id) FROM t
+
+query
+SELECT element_at(element_at(array(CAST(NULL AS ARRAY<BIGINT>),array(monotonically_increasing_id(), CAST(NULL AS BIGINT))),id),id - 1) FROM t

--- a/spark/src/test/resources/sql-tests/expressions/array/try_element_at.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/try_element_at.sql
@@ -42,9 +42,14 @@ SELECT try_element_at(arr, 100) FROM test_try_element_at
 query
 SELECT try_element_at(CAST(NULL AS ARRAY<INT>), 1)
 
--- literal array arguments: same codegen bug as element_at with literal arrays
-query ignore(Spark codegen bug with literal element_at when constant folding is disabled)
-SELECT try_element_at(array(10, 20, 30), 1), try_element_at(array(10, 20, 30), 99)
+statement
+CREATE TABLE t(id int) USING parquet
+
+statement
+INSERT INTO t VALUES (1), (3), (-1), (99), (NULL)
+
+query
+SELECT try_element_at(array(10, 20, 30), id) FROM t
 
 -- map input
 query

--- a/spark/src/test/resources/sql-tests/expressions/map/element_at_map.sql
+++ b/spark/src/test/resources/sql-tests/expressions/map/element_at_map.sql
@@ -51,3 +51,48 @@ SELECT element_at(mi, CAST(1 AS BIGINT)), element_at(mi, CAST(2 AS SMALLINT)) FR
 -- literal map arguments
 query
 SELECT element_at(map('a', 1, 'b', 2), 'a'), element_at(map('a', 1, 'b', 2), 'missing'), element_at(map('a', 1, 'b', 2), NULL)
+
+-- Map key types whose Spark equality Comet's native `map_extract` cannot reproduce fall back to
+-- Spark. These stay on the constructor path here because the SQL harness excludes
+-- `ConstantFolding`; `CometMapExpressionSuite` covers the folded-literal form of each.
+
+-- Spark stores `-0.0` map keys as `+0.0` and compares with `nanSafeCompareDoubles`, so a `-0.0`
+-- lookup finds the `+0.0` key. Native lookup compares the raw Arrow values.
+query expect_fallback(Spark normalizes floating-point map keys)
+SELECT element_at(map(CAST(0 AS DOUBLE), 7), CAST(-0.0 AS DOUBLE))
+
+query expect_fallback(Spark normalizes floating-point map keys)
+SELECT element_at(map(CAST(0 AS FLOAT), 7), CAST(-0.0 AS FLOAT))
+
+-- The floating-point decline walks every nesting level of the key type, so an array-of-double key
+-- falls back for the same reason.
+query expect_fallback(Spark normalizes floating-point map keys)
+SELECT element_at(map(array(CAST(0 AS DOUBLE)), 7), array(CAST(-0.0 AS DOUBLE)))
+
+-- A complex key type: `map_extract` casts the lookup key to the map's exact Arrow key type, so a
+-- NULL inside the lookup key would abort the cast instead of missing the lookup.
+query expect_fallback(casts the lookup key to the map's exact Arrow key type)
+SELECT element_at(map(array(1), 7), array(CAST(NULL AS INT)))
+
+query expect_fallback(casts the lookup key to the map's exact Arrow key type)
+SELECT element_at(map(named_struct('a', 1), 7), named_struct('a', 1))
+
+-- `BinaryType` keys need no decline: Arrow compares them by content, as Spark's ordering does.
+query
+SELECT element_at(map(CAST('a' AS BINARY), 1, CAST('b' AS BINARY), 2), CAST('b' AS BINARY))
+
+-- Nested INT-keyed map: the inner `element_at` returns NULL for ids not in the outer map (2, 3),
+-- and the outer `element_at` looks it up with a per-row key `id % (id - 2)`. This harness runs with
+-- ANSI disabled, so the remainder-by-zero at id = 2 evaluates to NULL rather than throwing, and
+-- `element_at(NULL_map, NULL)` returns NULL -- matching Spark's 7, NULL, NULL natively. (Under ANSI,
+-- native scalar functions evaluate the key eagerly and throw where Spark short-circuits after the
+-- NULL inner map; that is a pre-existing eager-evaluation difference in native `ElementAt`.)
+statement
+CREATE TABLE test_element_at_nested(id int) USING parquet
+
+statement
+INSERT INTO test_element_at_nested VALUES (1), (2), (3)
+
+query
+SELECT id, element_at(element_at(map(1, map(0, 7)), id), id % (id - 2)) AS v
+FROM test_element_at_nested

--- a/spark/src/test/resources/sql-tests/expressions/map/element_at_map_ansi.sql
+++ b/spark/src/test/resources/sql-tests/expressions/map/element_at_map_ansi.sql
@@ -1,0 +1,36 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- ANSI-mode element_at over maps. The non-ANSI forms live in element_at_map.sql.
+
+-- Config: spark.sql.ansi.enabled=true
+
+statement
+CREATE TABLE test_element_at_nested_ansi(id int) USING parquet
+
+statement
+INSERT INTO test_element_at_nested_ansi VALUES (1), (2), (3)
+
+-- Nested INT-keyed map lookup with a per-row key. The inner element_at returns NULL for ids not in
+-- the outer map (2, 3); the outer element_at looks it up with `id % (id - 2)`, which is 2 % 0 at
+-- id = 2. Spark's ElementAt is a BinaryExpression that short-circuits the NULL inner map and never
+-- evaluates the throwing key, so under ANSI it returns 7, NULL, NULL. CometElementAt reproduces the
+-- short-circuit natively with a CASE WHEN <map> IS NOT NULL guard, so the key runs only where the
+-- map is non-null and the query runs with native acceleration.
+query
+SELECT id, element_at(element_at(map(1, map(0, 7)), id), id % (id - 2)) AS v
+FROM test_element_at_nested_ansi

--- a/spark/src/test/resources/sql-tests/expressions/map/element_at_map_collation.sql
+++ b/spark/src/test/resources/sql-tests/expressions/map/element_at_map_collation.sql
@@ -1,0 +1,35 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- MinSparkVersion: 4.0
+
+-- Spark 4.0+ supports string collations. Spark compares a map key under its declared collation,
+-- so a `UTF8_LCASE` map matches `A1` against a dynamic `a1` lookup and returns `7`. Comet's native
+-- `map_extract` compares string keys as `UTF8_BINARY`, so `CometElementAt` declines the lookup and
+-- Spark evaluates the projection. The `element_at` form is used rather than `m[key]` because
+-- Spark's `SimplifyExtractValueOps` rewrites `map(...)[key]` over a literal map into a `CASE`
+-- before it can reach the native map lookup.
+
+statement
+CREATE TABLE test_element_at_collation(k string) USING parquet
+
+statement
+INSERT INTO test_element_at_collation VALUES ('a1'), ('A1'), ('zz'), (NULL)
+
+query expect_fallback(cannot honour a non-default collation)
+SELECT element_at(map(CAST('A1' AS STRING COLLATE UTF8_LCASE), 7), CAST(k AS STRING COLLATE UTF8_LCASE))
+FROM test_element_at_collation

--- a/spark/src/test/resources/sql-tests/expressions/map/get_map_value.sql
+++ b/spark/src/test/resources/sql-tests/expressions/map/get_map_value.sql
@@ -30,3 +30,19 @@ SELECT m['x'], m['missing'] FROM test_map
 -- literal arguments
 query spark_answer_only
 SELECT map('a', 1, 'b', 2)['a'], map('a', 1, 'b', 2)['missing'], map('a', 1, 'b', 2)[NULL]
+
+-- Map key types whose Spark equality Comet's native `map_extract` cannot reproduce fall back to
+-- Spark. `x[key]` routes through `GetMapValue` / `CometMapExtract` (the `element_at` form in
+-- `element_at_map.sql` exercises the same guard on `CometElementAt`). A `map<double,int>` column
+-- is used rather than a `map(...)` literal because Spark's `SimplifyExtractValueOps` rewrites
+-- `map(...)[key]` over a literal map into a `CASE` before it can reach the native lookup. Spark
+-- stores a `-0.0` key as `+0.0` and finds it with `nanSafeCompareDoubles`, so it returns `7` for a
+-- `-0.0` lookup; native lookup compares the raw Arrow values.
+statement
+CREATE TABLE test_map_double(m map<double, int>) USING parquet
+
+statement
+INSERT INTO test_map_double VALUES (map(CAST(0 AS DOUBLE), 7)), (map(CAST(1 AS DOUBLE), 8)), (NULL)
+
+query expect_fallback(Spark normalizes floating-point map keys)
+SELECT m[CAST(-0.0 AS DOUBLE)] FROM test_map_double

--- a/spark/src/test/resources/sql-tests/expressions/map/map_entries.sql
+++ b/spark/src/test/resources/sql-tests/expressions/map/map_entries.sql
@@ -21,5 +21,45 @@ CREATE TABLE test_map_entries(m map<string, int>) USING parquet
 statement
 INSERT INTO test_map_entries VALUES (map('a', 1, 'b', 2)), (map()), (NULL)
 
-query spark_answer_only
+query
 SELECT map_entries(m) FROM test_map_entries
+
+-- `MapType(_, _, valueContainsNull = false)`, which every `map(...)` over non-null values
+-- produces. DataFusion's `map_entries` declares the entry `value` field nullable but reuses the
+-- input map's entries array, so the planner widens the argument before the call.
+query
+SELECT map_entries(map(1, 2, 3, 4))
+
+query
+SELECT map_entries(map('a', array(1, 2)))
+
+-- A map nested in a map value keeps `valueContainsNull = false` through the extract.
+query
+SELECT map_entries(element_at(map(1, map(1, 2)), 1))
+
+-- The `map_entries` argument is widened so its entry `value` field is nullable, but ONLY that outer
+-- field: the nested `map(1, 2)` value must keep `valueContainsNull = false`. Extracting it with
+-- `[0].value` and pairing it with the `map(2, coalesce(id, 0))` sibling would otherwise hit
+-- `make_array` with unequal map types (one widened to `valueContainsNull = true`) and panic.
+statement
+CREATE TABLE test_map_entries_nested(id int) USING parquet
+
+statement
+INSERT INTO test_map_entries_nested VALUES (1), (2), (3)
+
+query
+SELECT array(
+  map_entries(map(1, IF(id = 1, map(1, 2), NULL)))[0].value,
+  map(2, coalesce(id, 0))) AS a
+FROM test_map_entries_nested
+
+-- `map_entries` declares its entry `value` field nullable, so the extracted entry struct has a
+-- nullable `value` while the sibling `named_struct('key', 1, 'value', id IS NOT NULL)` has a
+-- non-nullable one. The two struct children differ only in that field's nullability, so
+-- `CometCreateArray` casts each to the merged struct type before `make_array` and this runs
+-- natively rather than panicking on the struct-field mismatch.
+query
+SELECT array(
+  map_entries(element_at(map(1, map(1, true)), id))[0],
+  named_struct('key', 1, 'value', id IS NOT NULL)) AS a
+FROM test_map_entries_nested

--- a/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
@@ -1173,6 +1173,63 @@ class CometArrayExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelp
     }
   }
 
+  // Constant folding is enabled by default here, so each `map(...)` collapses to a MapType
+  // Literal and the outer `array(...)` reaches `CometCreateArray` with folded-Literal children.
+  // `CometLiteral` rebuilds each folded map as an equivalent `CreateMap` of primitive literals.
+  test("array of folded map literals with array values (multirow)") {
+    withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
+      val df =
+        spark.table("tbl").selectExpr("array(map(1, array(1, 2, 3)), map(2, array(4, 5, 6)))")
+      checkSparkAnswerAndOperator(df)
+    }
+  }
+
+  test("array of folded map literals (multirow)") {
+    withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndOperator(spark.table("tbl").selectExpr("array(map(1, 10), map(2, 20))"))
+    }
+  }
+
+  // P2 regression: standalone folded struct literal reaches native `CreateNamedStruct` with all
+  // scalar children. `values_to_arrays` returns a 1-row `StructArray` regardless of batch size,
+  // which fails length checks. `CometLiteral` excludes StructType from expansion so the projection
+  // falls back to Spark rather than producing a truncated result.
+  test("folded struct literal in multirow projection falls back") {
+    withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
+      // Spark's `named_struct(...)` folds to a single struct Literal. Comet must not run
+      // `CreateNamedStruct` with all-scalar children against a 3-row batch.
+      val df = spark.table("tbl").selectExpr("_1 AS id", "named_struct('a', 1) AS s")
+      checkSparkAnswerAndFallbackReason(df, "Unsupported data type StructType")
+    }
+  }
+
+  // P2 regression: `array(named_struct(...), named_struct(...))` with divergent field
+  // nullabilities folds to a single ArrayType(StructType) Literal. `KnownNullable` is dropped on
+  // the wire, so recursive expansion would produce sibling struct arrays with divergent per-field
+  // nullabilities and `make_array` would panic. Excluding StructType keeps this on Spark.
+  test("folded array of structs with divergent field nullability falls back (multirow)") {
+    withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
+      val df = spark
+        .table("tbl")
+        .selectExpr("array(named_struct('a', CAST(NULL AS INT)), named_struct('a', 1)) AS arr")
+      checkSparkAnswerAndFallbackReason(df, "Unsupported data type ArrayType")
+    }
+  }
+
+  // P2 regression: `from_json` produces a MapData whose keys may be duplicated. Rebuilding via
+  // `CreateMap` invokes `ArrayBasedMapBuilder`, which throws under the default
+  // `MAP_KEY_DEDUP_POLICY=EXCEPTION` policy. `CometLiteral` inspects the folded map's key array
+  // and declines expansion when duplicates are present, letting Spark evaluate the projection.
+  test("folded map literal with duplicate keys falls back (multirow)") {
+    assume(isSpark35Plus)
+    withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
+      val df = spark
+        .table("tbl")
+        .selectExpr("_1 AS id", "from_json('{\"a\":1,\"a\":2}', 'MAP<STRING,INT>') AS m")
+      checkSparkAnswerAndFallbackReason(df, "Unsupported data type MapType")
+    }
+  }
+
   // Local table scan carries non-null array child fields (an in-memory Seq encodes
   // containsNull=false) into native kernels that promise nullable elements. ConvertToLocalRelation
   // must be disabled or the optimizer folds the expression at plan time and nothing runs natively.

--- a/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
@@ -1134,42 +1134,160 @@ class CometArrayExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelp
     }
   }
 
-  test("array of structs with nullability-divergent children") {
-    // Spark's type coercion compares element types with `sameType`, which ignores nullability,
-    // so two struct children that differ ONLY in a nested field's nullability get no unifying
-    // cast -- CreateArray keeps children of different StructTypes. DataFusion's make_array asserts
-    // strict element-type equality (down to nested nullability) and panics on the mismatch. Comet
-    // must decline this CreateArray so Spark's evaluator handles it.
-    withParquetTable((0 until 5).map(i => (i, i.toLong)), "tbl") {
-      val df = spark
-        .table("tbl")
-        .select(
-          array(
-            // ct is NOT NULL (literal)
-            struct(col("_1").as("id"), lit("a").as("ct")),
-            // ct is NULLABLE (when without otherwise) -- same type, different nullability
-            struct(col("_1").as("id"), when(col("_1") === 0, lit("b")).as("ct"))).as("arr"))
-      checkSparkAnswerAndFallbackReason(df, "CreateArray children have mismatched data types")
+  // The tests below deliberately live in this suite, not a `sql-tests` fixture: constant folding is
+  // enabled by default here, so each `map(...)` collapses to a MapType Literal and the outer
+  // `array(...)` reaches `CometCreateArray` with folded-Literal children, which `CometLiteral`
+  // rebuilds as an equivalent `CreateMap` of primitive literals -- the folded-literal expansion path
+  // under review. `CometSqlFileTestSuite` force-disables `ConstantFolding`, so an equivalent SQL
+  // fixture would only exercise the constructor path (which `create_array.sql` already covers).
+  test("array of folded map literals with array values (multirow)") {
+    withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndOperator(
+        "SELECT array(map(1, array(1, 2, 3)), map(2, array(4, 5, 6))) FROM tbl")
     }
   }
 
-  test("array of maps with nullability-divergent struct values") {
-    // Same nested-nullability divergence as the struct case, but wrapped in a MapType value so we
-    // exercise normalizeContainerNullability's MapType branch: the two map children share a surface
-    // type and differ only in a nested struct field's nullability, so they survive container
-    // (`MapType.valueContainsNull`) normalization as distinct types and CreateArray must still
-    // decline -- DataFusion's make_array would otherwise panic on the struct-field mismatch.
-    withParquetTable((0 until 5).map(i => (i, i.toLong)), "tbl") {
-      val df = spark
-        .table("tbl")
-        .select(
-          array(
-            // map value struct has ct NOT NULL (literal)
-            map(lit("k"), struct(col("_1").as("id"), lit("a").as("ct"))),
-            // map value struct has ct NULLABLE -- same type, different nested nullability
-            map(lit("k"), struct(col("_1").as("id"), when(col("_1") === 0, lit("b")).as("ct"))))
-            .as("arr"))
-      checkSparkAnswerAndFallbackReason(df, "CreateArray children have mismatched data types")
+  // A folded `map(1, array(1))` (value `ArrayType(IntegerType, containsNull = false)`) sits beside a
+  // dynamic `map(2, array(_1))` (value `ArrayType(IntegerType, true)`). Both maps still declare
+  // `valueContainsNull = false`, so only the nested array's `containsNull` differs. `CometCreateArray`
+  // casts each child to the nullability-merged element type (`cast_map_to_map` widens the nested
+  // array), so `make_array` sees identical Arrow types and this runs natively.
+  test(
+    "folded map with non-null nested array beside a dynamic map sibling runs natively (multirow)") {
+    withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndOperator(
+        "SELECT array(map(1, array(1)), map(2, array(_1))) AS a FROM tbl")
+    }
+  }
+
+  test("array of folded map literals (multirow)") {
+    withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndOperator("SELECT array(map(1, 10), map(2, 20)) FROM tbl")
+    }
+  }
+
+  // The folded `map(1, 2)` and the dynamic `map(2, coalesce(...))` both declare
+  // `MapType(IntegerType, IntegerType, valueContainsNull = false)`, so `CometCreateArray` admits
+  // the pair. Rebuilding the literal has to report that exact type: widening the rebuilt map's
+  // value to nullable would leave the sibling behind and `make_array` would panic, because
+  // DataFusion 54.1 cannot coerce a `MapType.valueContainsNull` mismatch away.
+  test("folded map literal keeps non-nullable values next to a dynamic map sibling (multirow)") {
+    withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndOperator(
+        "SELECT _1 AS id, array(map(1, 2), map(2, coalesce(_1, 0))) AS arr FROM tbl")
+    }
+  }
+
+  // The whole `array(...)` folds to one `ArrayType(MapType(IntegerType, IntegerType, true))`
+  // literal, so every rebuilt element must report the unified nullable value type.
+  test("folded array of maps with a NULL value (multirow)") {
+    withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndOperator(
+        "SELECT array(map(1, CAST(NULL AS INT)), map(2, 3)) AS arr FROM tbl")
+    }
+  }
+
+  // A NULL element sits next to a populated one inside a single folded
+  // `ArrayType(MapType(IntegerType, IntegerType, false), containsNull = true)` literal. The null
+  // slot serializes as a typed null literal carrying the declared map type, so the rebuilt sibling
+  // has to report that same type for `make_array` to accept the pair.
+  test("folded array mixing a map literal and a NULL element (multirow)") {
+    withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndOperator("SELECT array(map(1, 2), NULL) AS arr FROM tbl")
+      checkSparkAnswerAndOperator("SELECT array(NULL, map(1, 2)) AS arr FROM tbl")
+    }
+  }
+
+  // A map value that is itself a map or an array of maps is built by Spark's own generated code
+  // inside `CometCreateMap`, so it keeps its declared nullability all the way to the consumer.
+  test("folded map literals with nested map values (multirow)") {
+    withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndOperator("SELECT _1 AS id, map(1, map(1, 2)) AS m FROM tbl")
+      checkSparkAnswerAndOperator("SELECT _1 AS id, map(1, array(map(2, 3))) AS m FROM tbl")
+      checkSparkAnswerAndOperator(
+        "SELECT _1 AS id, map(1, named_struct('a', 1, 'b', 'x')) AS m FROM tbl")
+    }
+  }
+
+  // An empty container has no children to recover the element type from, and a NULL literal
+  // serializes as a typed null without expansion, so only the empty cases fall back.
+  test("folded empty and NULL complex literals") {
+    withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndFallbackReason(
+        "SELECT _1 AS id, CAST(map() AS MAP<INT,INT>) AS m FROM tbl",
+        "Unsupported data type MapType")
+      checkSparkAnswerAndFallbackReason(
+        "SELECT _1 AS id, CAST(array() AS ARRAY<MAP<INT,INT>>) AS a FROM tbl",
+        "Unsupported data type ArrayType")
+      checkSparkAnswerAndOperator("SELECT _1 AS id, CAST(NULL AS MAP<INT,INT>) AS m FROM tbl")
+      checkSparkAnswerAndOperator(
+        "SELECT _1 AS id, CAST(NULL AS ARRAY<MAP<INT,INT>>) AS a FROM tbl")
+    }
+  }
+
+  // A folded struct literal would reach native `CreateNamedStruct` with all-scalar children,
+  // which builds a 1-row `StructArray` regardless of batch size. `CometLiteral` excludes
+  // StructType from expansion so the projection falls back instead of truncating the result.
+  test("folded struct literal in multirow projection falls back") {
+    withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndFallbackReason(
+        "SELECT _1 AS id, named_struct('a', 1) AS s FROM tbl",
+        "Unsupported data type StructType")
+    }
+  }
+
+  // Folds to one ArrayType(StructType) Literal whose structs disagree on field nullability.
+  // `KnownNullable` is dropped on the wire, so expansion could not make the sibling struct
+  // arrays agree and `make_array` would panic. Excluding StructType keeps this on Spark.
+  test("folded array of structs with divergent field nullability falls back (multirow)") {
+    withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndFallbackReason(
+        "SELECT array(named_struct('a', CAST(NULL AS INT)), named_struct('a', 1)) AS arr FROM tbl",
+        "Unsupported data type ArrayType")
+    }
+  }
+
+  // `from_json` can fold to a MapData with duplicate keys. Rebuilding it as a `CreateMap` would
+  // run `ArrayBasedMapBuilder`, which throws under `MAP_KEY_DEDUP_POLICY=EXCEPTION` and silently
+  // drops the earlier entry under `LAST_WIN`, so `CometLiteral` declines expansion under either
+  // policy and Spark evaluates the projection.
+  test("folded map literal with duplicate keys falls back (multirow)") {
+    assume(isSpark35Plus)
+    withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
+      Seq("EXCEPTION", "LAST_WIN").foreach { policy =>
+        withSQLConf(SQLConf.MAP_KEY_DEDUP_POLICY.key -> policy) {
+          checkSparkAnswerAndFallbackReason(
+            "SELECT _1 AS id, from_json('{\"a\":1,\"a\":2}', 'MAP<STRING,INT>') AS m FROM tbl",
+            "Unsupported data type MapType")
+        }
+      }
+    }
+  }
+
+  // Spark's map cast preserves both entries, so the folded value still holds duplicate keys after
+  // the key type becomes BinaryType. `Array[Byte]` has no value-based `equals`, so the duplicate
+  // check has to compare keys the way `ArrayBasedMapBuilder` does, through
+  // `TypeUtils.getInterpretedOrdering`.
+  test("folded map literal with duplicate binary keys falls back (multirow)") {
+    assume(isSpark35Plus)
+    withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
+      Seq("EXCEPTION", "LAST_WIN").foreach { policy =>
+        withSQLConf(SQLConf.MAP_KEY_DEDUP_POLICY.key -> policy) {
+          checkSparkAnswerAndFallbackReason(
+            "SELECT _1 AS id, CAST(from_json('{\"a\":1,\"a\":2}', 'MAP<STRING,INT>') " +
+              "AS MAP<BINARY,INT>) AS m FROM tbl",
+            "Unsupported data type MapType")
+        }
+      }
+    }
+  }
+
+  // Distinct binary keys are fine: Arrow compares them by content, as Spark's ordering does.
+  test("folded map literal with distinct binary keys (multirow)") {
+    withParquetTable((1 until 4).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndOperator(
+        "SELECT _1 AS id, element_at(map(CAST('1' AS BINARY), 10, CAST('2' AS BINARY), 20), " +
+          "CAST(CAST(_1 AS STRING) AS BINARY)) AS v FROM tbl")
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
@@ -1178,55 +1178,69 @@ class CometArrayExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelp
   // `CometLiteral` rebuilds each folded map as an equivalent `CreateMap` of primitive literals.
   test("array of folded map literals with array values (multirow)") {
     withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
-      val df =
-        spark.table("tbl").selectExpr("array(map(1, array(1, 2, 3)), map(2, array(4, 5, 6)))")
-      checkSparkAnswerAndOperator(df)
+      checkSparkAnswerAndOperator(
+        "SELECT array(map(1, array(1, 2, 3)), map(2, array(4, 5, 6))) FROM tbl")
     }
   }
 
   test("array of folded map literals (multirow)") {
     withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
-      checkSparkAnswerAndOperator(spark.table("tbl").selectExpr("array(map(1, 10), map(2, 20))"))
+      checkSparkAnswerAndOperator("SELECT array(map(1, 10), map(2, 20)) FROM tbl")
     }
   }
 
-  // P2 regression: standalone folded struct literal reaches native `CreateNamedStruct` with all
-  // scalar children. `values_to_arrays` returns a 1-row `StructArray` regardless of batch size,
-  // which fails length checks. `CometLiteral` excludes StructType from expansion so the projection
-  // falls back to Spark rather than producing a truncated result.
+  // A folded struct literal would reach native `CreateNamedStruct` with all-scalar children,
+  // which builds a 1-row `StructArray` regardless of batch size. `CometLiteral` excludes
+  // StructType from expansion so the projection falls back instead of truncating the result.
   test("folded struct literal in multirow projection falls back") {
     withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
-      // Spark's `named_struct(...)` folds to a single struct Literal. Comet must not run
-      // `CreateNamedStruct` with all-scalar children against a 3-row batch.
-      val df = spark.table("tbl").selectExpr("_1 AS id", "named_struct('a', 1) AS s")
-      checkSparkAnswerAndFallbackReason(df, "Unsupported data type StructType")
+      checkSparkAnswerAndFallbackReason(
+        "SELECT _1 AS id, named_struct('a', 1) AS s FROM tbl",
+        "Unsupported data type StructType")
     }
   }
 
-  // P2 regression: `array(named_struct(...), named_struct(...))` with divergent field
-  // nullabilities folds to a single ArrayType(StructType) Literal. `KnownNullable` is dropped on
-  // the wire, so recursive expansion would produce sibling struct arrays with divergent per-field
-  // nullabilities and `make_array` would panic. Excluding StructType keeps this on Spark.
+  // Folds to one ArrayType(StructType) Literal whose structs disagree on field nullability.
+  // `KnownNullable` is dropped on the wire, so expansion could not make the sibling struct
+  // arrays agree and `make_array` would panic. Excluding StructType keeps this on Spark.
   test("folded array of structs with divergent field nullability falls back (multirow)") {
     withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
-      val df = spark
-        .table("tbl")
-        .selectExpr("array(named_struct('a', CAST(NULL AS INT)), named_struct('a', 1)) AS arr")
-      checkSparkAnswerAndFallbackReason(df, "Unsupported data type ArrayType")
+      checkSparkAnswerAndFallbackReason(
+        "SELECT array(named_struct('a', CAST(NULL AS INT)), named_struct('a', 1)) AS arr FROM tbl",
+        "Unsupported data type ArrayType")
     }
   }
 
-  // P2 regression: `from_json` produces a MapData whose keys may be duplicated. Rebuilding via
-  // `CreateMap` invokes `ArrayBasedMapBuilder`, which throws under the default
-  // `MAP_KEY_DEDUP_POLICY=EXCEPTION` policy. `CometLiteral` inspects the folded map's key array
-  // and declines expansion when duplicates are present, letting Spark evaluate the projection.
+  // `from_json` can fold to a MapData with duplicate keys. Rebuilding it as a `CreateMap` would
+  // run `ArrayBasedMapBuilder`, which throws under `MAP_KEY_DEDUP_POLICY=EXCEPTION`, so
+  // `CometLiteral` declines expansion and Spark evaluates the projection.
   test("folded map literal with duplicate keys falls back (multirow)") {
     assume(isSpark35Plus)
     withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
-      val df = spark
-        .table("tbl")
-        .selectExpr("_1 AS id", "from_json('{\"a\":1,\"a\":2}', 'MAP<STRING,INT>') AS m")
-      checkSparkAnswerAndFallbackReason(df, "Unsupported data type MapType")
+      checkSparkAnswerAndFallbackReason(
+        "SELECT _1 AS id, from_json('{\"a\":1,\"a\":2}', 'MAP<STRING,INT>') AS m FROM tbl",
+        "Unsupported data type MapType")
+    }
+  }
+
+  // Spark treats `+0.0` and `-0.0` as the same map key; native lookup compares bytes.
+  test("folded map literal with double keys falls back to Spark for +/-0.0 equality") {
+    withParquetTable((1 until 4).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndFallbackReason(
+        "SELECT _1 AS id, element_at(map(CAST(0 AS DOUBLE), 7), " +
+          "CAST(concat('-', CAST(_1 - 1 AS STRING), '.0') AS DOUBLE)) AS v FROM tbl",
+        "Unsupported data type MapType")
+    }
+  }
+
+  // Spark compares the key under its declared collation; native compares under UTF8_BINARY.
+  test("folded map literal with collated string keys falls back") {
+    assume(isSpark40Plus)
+    withParquetTable(Seq(("a1", 0)), "tbl") {
+      checkSparkAnswerAndFallbackReason(
+        "SELECT element_at(map(CAST('A1' AS STRING COLLATE UTF8_LCASE), 7), " +
+          "CAST(_1 AS STRING COLLATE UTF8_LCASE)) AS v FROM tbl",
+        "Unsupported data type MapType")
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/CometMapExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometMapExpressionSuite.scala
@@ -23,6 +23,7 @@ import scala.util.Random
 
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.catalyst.expressions.ArrayContains
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.BinaryType
@@ -269,6 +270,193 @@ class CometMapExpressionSuite extends CometTestBase {
       import testImplicits._
       val df = Seq(Map(1 -> 100, 2 -> 200)).toDF("m")
       checkSparkAnswerAndOperator(df.selectExpr("map_entries(m)"))
+    }
+  }
+
+  // ==============================================================================================
+  // Folded complex-literal tests. These live in this suite, not a `sql-tests` fixture, on purpose:
+  // they need `ConstantFolding` ON so `map(...)` / `array(...)` collapses to a `Literal` that
+  // `CometLiteral` then rebuilds -- the folded-literal expansion path under review. The SQL harness
+  // (`CometSqlFileTestSuite`) force-disables `ConstantFolding`, so an equivalent fixture would only
+  // exercise the constructor path. The `*.sql` files cover that constructor path where the same
+  // guard fires regardless of folding.
+  // ==============================================================================================
+
+  // A map that reaches `map_entries` through an expression rather than a scan keeps
+  // `valueContainsNull = false`, which every `map(...)` over non-null values produces. DataFusion's
+  // `map_entries` declares the entry `value` field nullable but reuses the input map's entries
+  // array, so the planner widens the argument before the call. Here the inner `map(1, map(1, 2))`
+  // folds to a literal that `CometLiteral` rebuilds, and the outer `element_at` yields a
+  // non-nullable-value map straight into native `map_entries`. This exercises the widening on the
+  // default folding-on path; `map_entries.sql` covers the constructor path, where the harness
+  // excludes `ConstantFolding`.
+  test("map_entries on a folded non-nullable-value map (multirow)") {
+    withParquetTable((1 until 4).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndOperator(
+        "SELECT _1 AS id, map_entries(element_at(map(1, map(1, 2)), _1)) AS e FROM tbl")
+    }
+  }
+
+  // Finding E: a map nested inside a map value is handed to the JVM dispatcher whole, so its double
+  // keys never revisit `CometLiteral`. The guard has to live on the lookup instead. The outer key
+  // type is INT, so inspecting only the outermost map would admit the query; the fallback comes
+  // from the inner `element_at`, whose child is `MapType(DoubleType, IntegerType)`. Constant folding
+  // is on here, which is the only configuration where the inner map becomes such a literal, so this
+  // regression cannot be expressed in a SQL fixture (the harness disables folding). The direct
+  // single-level double-key lookups live in `element_at_map.sql` / `get_map_value.sql`.
+  test("nested map lookup with floating-point keys falls back") {
+    withParquetTable((1 until 4).map(i => (i, i.toLong)), "tbl") {
+      val negZero = "CAST(concat('-', CAST(_1 - 1 AS STRING), '.0') AS DOUBLE)"
+      checkSparkAnswerAndFallbackReason(
+        "SELECT _1 AS id, element_at(element_at(map(1, map(CAST(0 AS DOUBLE), 7)), _1), " +
+          s"$negZero) AS v FROM tbl",
+        "Spark normalizes floating-point map keys")
+    }
+  }
+
+  // Finding E for a collated inner key. Same folding-on-only bypass as the double-key case above;
+  // the direct single-level collated lookup lives in `element_at_map_collation.sql`.
+  test("nested map lookup with collated string keys falls back") {
+    assume(isSpark40Plus)
+    withParquetTable(Seq(("a1", 0)), "tbl") {
+      checkSparkAnswerAndFallbackReason(
+        "SELECT element_at(element_at(map(1, map(CAST('A1' AS STRING COLLATE UTF8_LCASE), 7)), 1), " +
+          "CAST(_1 AS STRING COLLATE UTF8_LCASE)) AS v FROM tbl",
+        "cannot honour a non-default collation")
+    }
+  }
+
+  // A folded map with `CalendarIntervalType` keys reaches `CometLiteral`. `ArrayBasedMapBuilder`
+  // dedups such keys by hash equality, but the folded-literal duplicate-key check needs an
+  // interpreted ordering and `PhysicalCalendarIntervalType` has none ("does not support ordered
+  // operations"). Expansion must decline these keys and keep the projection on Spark rather than
+  // crash planning by asking for that ordering; such literals fell back before this rewrite too.
+  test("folded map literal with calendar-interval keys falls back (multirow)") {
+    withParquetTable((0 until 3).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndFallbackReason(
+        "SELECT _1 AS id, map(make_interval(1), 1, make_interval(2), 2) AS m FROM tbl",
+        "Unsupported data type MapType")
+    }
+  }
+
+  // `map_entries` widens its argument so the entry `value` field is nullable, but it must widen ONLY
+  // that outer field. The outer `map(1, IF(...))` has `valueContainsNull = true`, and its value is a
+  // folded `map(1, 2)` with `valueContainsNull = false`. Widening the nested map too would extract a
+  // `valueContainsNull = true` map that disagrees with the dynamic `map(2, coalesce(...))` sibling,
+  // and native `make_array` would panic; the shallow widen keeps the nested type intact.
+  test("map_entries widening keeps nested map value nullability (multirow)") {
+    withParquetTable((1 until 4).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndOperator(
+        "SELECT _1 AS id, array(" +
+          "map_entries(map(1, IF(_1 = 1, map(1, 2), NULL)))[0].value, " +
+          "map(2, coalesce(_1, 0))) AS a FROM tbl")
+    }
+  }
+
+  // `map_contains_key` lowers to `array_contains(map_keys(...), key)`. `CometArrayContains` reports
+  // Incompatible for floating-point element types, because native `array_contains` compares
+  // -0.0/+0.0 and NaN bitwise unlike Spark. So under the default config it codegen-dispatches to
+  // Spark and the query stays native with Spark-exact results and no fallback. Forcing the native
+  // kernel with `ArrayContains.allowIncompatible=true` makes it serialize its children instead, so
+  // the folded double-keyed map literal reaches the literal-expansion path. That map is nested
+  // inside the INT-keyed outer map, past the outer `element_at` key guard which only sees the INT
+  // key. The nested-key walk in the expansion (`mapKeyTypesExpandable`) is what has to decline the
+  // floating-point keys. Otherwise a rebuilt `CreateMap` would reach the native kernel whose key
+  // equality disagrees with Spark. Spark returns `7, NULL, NULL`.
+  test("map_contains_key over nested floating-point map keys falls back (multirow)") {
+    withParquetTable((1 until 4).map(i => (i, i.toLong)), "tbl") {
+      val negZero = "CAST(concat('-', CAST(_1 - 1 AS STRING), '.0') AS DOUBLE)"
+      // allowIncompatible flips array_contains from codegen dispatch to the native kernel, so the
+      // nested-map literal is actually serialized and the expansion guard runs.
+      withSQLConf(CometConf.getExprAllowIncompatConfigKey(classOf[ArrayContains]) -> "true") {
+        checkSparkAnswerAndFallbackReason(
+          "SELECT _1 AS id, map_contains_key(" +
+            s"element_at(map(1, map(CAST(0 AS DOUBLE), 7)), _1), $negZero) AS present FROM tbl",
+          "Unsupported data type MapType")
+      }
+    }
+  }
+
+  // The collated counterpart of the double-key `map_contains_key` case above: a nested
+  // `UTF8_LCASE`-keyed map would reach `array_contains` with bytewise comparison. Expansion declines
+  // the folded literal so the case-insensitive lookup stays on Spark. The outer lookup key is the
+  // dynamic `_1` so the inner map survives as a literal (a constant key would let Spark fold
+  // `map_keys` into a collated-string array literal instead, which never reaches this guard).
+  test("map_contains_key over nested collated map keys falls back (multirow)") {
+    assume(isSpark40Plus)
+    withParquetTable((1 until 4).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndFallbackReason(
+        "SELECT _1 AS id, map_contains_key(" +
+          "element_at(map(1, map(CAST('A1' AS STRING COLLATE UTF8_LCASE), 7)), _1), " +
+          "CAST('a1' AS STRING COLLATE UTF8_LCASE)) AS present FROM tbl",
+        "Unsupported data type MapType")
+    }
+  }
+
+  // Direct single-level folded map with floating-point keys: `map(CAST(0 AS DOUBLE), 7)` folds to a
+  // literal and `element_at` with a dynamic `-0.0` lookup must match Spark's `+0.0`-normalized key.
+  // Native `map_extract` compares raw Arrow values, so `MapKeySupport` declines it at `element_at`.
+  // Spark returns 7, NULL, NULL. (`element_at_map.sql` covers the folding-off constructor form.)
+  test("folded map literal with floating-point keys in element_at falls back (multirow)") {
+    withParquetTable((1 until 4).map(i => (i, i.toLong)), "tbl") {
+      val lookup = "CAST(concat('-', CAST(_1 - 1 AS STRING), '.0') AS DOUBLE)"
+      checkSparkAnswerAndFallbackReason(
+        s"SELECT _1 AS id, element_at(map(CAST(0 AS DOUBLE), 7), $lookup) AS v FROM tbl",
+        "Spark normalizes floating-point map keys")
+    }
+  }
+
+  // Direct single-level folded map with collated string keys. Native lookup is bytewise, so a
+  // case-insensitive `a1` lookup against a stored `A1` cannot match; `MapKeySupport` declines it.
+  test("folded map literal with collated string keys in element_at falls back (multirow)") {
+    assume(isSpark40Plus)
+    withParquetTable(Seq(("a1", 0)), "tbl") {
+      checkSparkAnswerAndFallbackReason(
+        "SELECT element_at(map(CAST('A1' AS STRING COLLATE UTF8_LCASE), 7), " +
+          "CAST(_1 AS STRING COLLATE UTF8_LCASE)) AS v FROM tbl",
+        "cannot honour a non-default collation")
+    }
+  }
+
+  // Folded map with a complex (array) key. Spark permits a dynamic lookup array containing a NULL
+  // element; native `map_extract` casts the lookup to the key's exact Arrow type and cannot
+  // reproduce Spark's equality, so `MapKeySupport` declines every complex key type. Spark returns
+  // 7, NULL, NULL. (`element_at_map.sql` covers the constructor form with a non-null lookup.)
+  test("folded map literal with complex array key in element_at falls back (multirow)") {
+    withParquetTable((1 until 4).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndFallbackReason(
+        "SELECT _1 AS id, element_at(map(array(1), 7), " +
+          "array(IF(_1 = 2, CAST(NULL AS INT), _1))) AS v FROM tbl",
+        "casts the lookup key to the map's exact Arrow key type")
+    }
+  }
+
+  // A folded nested INT-keyed map is admitted natively (all key-type guards pass), so the outer
+  // `element_at` runs as native `map_extract`. With ANSI disabled, a remainder-by-zero lookup key
+  // evaluates to NULL instead of throwing, so `map_extract(NULL_map, NULL)` returns NULL and the
+  // result matches Spark's 7, NULL, NULL. Under ANSI, native scalar functions evaluate the key
+  // eagerly and throw where Spark short-circuits after the NULL inner map -- a pre-existing eager
+  // evaluation difference in native `ElementAt`, not specific to folded literals.
+  test("folded nested map lookup with per-row key evaluation (multirow, non-ansi)") {
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "false") {
+      withParquetTable((1 until 4).map(i => (i, i.toLong)), "tbl") {
+        checkSparkAnswerAndOperator(
+          "SELECT _1 AS id, element_at(element_at(map(1, map(0, 7)), _1), _1 % (_1 - 2)) AS v " +
+            "FROM tbl")
+      }
+    }
+  }
+
+  // A large folded map (`map_from_arrays(sequence(...), sequence(...))` collapses to a many-entry
+  // MapType literal) rebuilds as a big `CreateMap` whose generated code Spark's codegen splits into
+  // nested helper classes. Those helpers read `CometBatchKernel.references`, which must be public
+  // (not protected) or the split code raises `IllegalAccessError` at runtime. 100k entries is large
+  // enough to force the split.
+  test("large folded map literal in element_at runs natively (multirow)") {
+    withParquetTable((1 until 4).map(i => (i, i.toLong)), "tbl") {
+      checkSparkAnswerAndOperator(
+        "SELECT _1 AS id, element_at(" +
+          "map_from_arrays(sequence(1, 100000), sequence(1, 100000)), _1) AS v FROM tbl")
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5448 .

 Extends `CometLiteral` to serialize complex `Literal` values that Spark's `ConstantFolding` produces from `map(...)`, `named_struct(...)`, or `array(...)` sub-trees. The native `Literal` proto encodes scalars and nested `ListLiteral` only, so folded values containing `MapType` or `StructType` previously fell back to Spark.

  ## Changes

  - `CometLiteral.getSupportLevel` reports `Compatible` for folded complex literals gated by `canExpandComplexLiteral`.
  - `CometLiteral.convert` calls `expandComplexLiteral(value, dataType)` which rebuilds the value as a tree of `CreateArray` / `CreateMap` / `CreateNamedStruct` over primitive-typed `Literal`s, then recurses via `exprToProtoInternal`. Existing `CometCreateArray` / `CometCreateMap` / `CometCreateNamedStruct` serdes take over from there.
  - Non-null child literals are wrapped in `KnownNullable`. DataFusion `make_array` asserts strict Arrow-type equality across siblings and would panic on a nullability mismatch. `CometKnownNullable` is a no-op on the wire.
  - Empty top-level `ArrayType` literals stay on the pre-existing `makeListLiteral` path (element type cannot be recovered from a childless `Create*`).
