### PR TITLE
docs: document C2R cost for wide/nested schemas in tuning guide

### DIFF
--- a/docs/source/user-guide/latest/tuning.md
+++ b/docs/source/user-guide/latest/tuning.md
@@ -273,6 +273,14 @@ when the number of columnar-to-row transitions exceeds
 `spark.comet.exec.transitionRevert.maxTransitions` (default `2`). This trades native execution of a small
 subset of operators for eliminating conversion overhead across the stage.
 
+The cost of each conversion also grows sharply with schema shape: for wide or deeply nested schemas,
+columnar-to-row conversion is especially expensive because the conversion work scales with the number of
+columns and nested fields. If profiling shows these conversions dominating a query stage over such a schema,
+set `spark.comet.exec.transitionRevert.enabled=true` and lower
+`spark.comet.exec.transitionRevert.maxTransitions` to `1` so that the stage reverts entirely to Spark
+row-based execution once it needs more than one conversion, which can be cheaper than paying the conversion
+repeatedly across many operators.
+
 ## Metrics Overhead
 
 Comet exposes rich native operator metrics for observability (see [Metrics](metrics.md)), but they are

--- a/docs/source/user-guide/latest/tuning.md
+++ b/docs/source/user-guide/latest/tuning.md
@@ -273,13 +273,16 @@ when the number of columnar-to-row transitions exceeds
 `spark.comet.exec.transitionRevert.maxTransitions` (default `2`). This trades native execution of a small
 subset of operators for eliminating conversion overhead across the stage.
 
+### Entire-Plan Fallback for Wide or Deeply Nested Schemas
+
 The cost of each conversion also grows sharply with schema shape: for wide or deeply nested schemas,
 columnar-to-row conversion is especially expensive because the conversion work scales with the number of
-columns and nested fields. If profiling shows these conversions dominating a query stage over such a schema,
-set `spark.comet.exec.transitionRevert.enabled=true` and lower
-`spark.comet.exec.transitionRevert.maxTransitions` to `1` so that the stage reverts entirely to Spark
-row-based execution once it needs more than one conversion, which can be cheaper than paying the conversion
-repeatedly across many operators.
+columns and nested fields. If profiling shows these conversions dominating a query over such a schema, set
+`spark.comet.exec.transitionRevert.enabled=true` and lower
+`spark.comet.exec.transitionRevert.maxTransitions` (default `2`) to `1`. Note that this causes the entire
+plan to fall back to Spark row-based execution — Comet removes its native operators rather than running a
+mix of native and fallback operators joined by repeated conversions — which can be cheaper than paying the
+expensive conversions again and again.
 
 ## Metrics Overhead
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5455.

## Rationale for this change

The tuning guide documents the transitionRevert mechanism but never mentions schema shape as the cost driver. As reported in #5455, columnar-to-row conversion becomes very expensive for wide or deeply nested schemas, where reverting the entire stage can be cheaper than paying repeated transitions.

## What changes are included in this PR?

Extends the "Reducing Row/Columnar Conversion Overhead" section of the tuning guide with one short paragraph covering schema-shape-driven C2R cost and earlier-revert guidance using full config keys.

## How are these changes tested?

Docs-only change; validated with a clean local Sphinx build of the site (no warnings for the changed file). Config keys and defaults match their definitions in `CometConf.scala`.