### PR TITLE
fix: track peak memory before JVM shuffle spill

### DIFF
--- a/spark/src/main/java/org/apache/spark/shuffle/sort/CometShuffleExternalSorter.java
+++ b/spark/src/main/java/org/apache/spark/shuffle/sort/CometShuffleExternalSorter.java
@@ -196,6 +196,7 @@ public final class CometShuffleExternalSorter implements CometShuffleChecksumSup
     activeSpillSorter.setSpillInfo(spillInfo);
 
     activeSpillSorter.writeSortedFileNative(false, tracingEnabled);
+    updatePeakMemoryUsed();
     final long spillSize = activeSpillSorter.freeMemory();
     activeSpillSorter.reset();
 

--- a/spark/src/test/scala/org/apache/spark/sql/comet/CometTaskMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/CometTaskMetricsSuite.scala
@@ -23,13 +23,17 @@ import java.io.File
 
 import scala.collection.mutable
 
-import org.apache.spark.{SparkConf, SparkContext, Success}
+import org.apache.spark.{SparkConf, SparkContext, SparkEnv, Success, TaskContext}
 import org.apache.spark.executor.ShuffleReadMetrics
 import org.apache.spark.executor.ShuffleWriteMetrics
+import org.apache.spark.memory.{TaskMemoryManager, TestMemoryManager}
 import org.apache.spark.scheduler.SparkListener
 import org.apache.spark.scheduler.SparkListenerJobStart
 import org.apache.spark.scheduler.SparkListenerTaskEnd
+import org.apache.spark.shuffle.comet.CometShuffleMemoryAllocator
+import org.apache.spark.shuffle.sort.CometShuffleExternalSorter
 import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.comet.execution.shuffle.CometNativeShuffle
 import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 import org.apache.spark.sql.execution.SparkPlan
@@ -37,6 +41,8 @@ import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{IntegerType, StructType}
+import org.apache.spark.unsafe.Platform
 
 import org.apache.comet.CometConf
 import org.apache.comet.CometSparkSessionExtensions.isSpark41Plus
@@ -76,6 +82,69 @@ class CometTaskMetricsSuite extends CometTestBase with AdaptiveSparkPlanHelper {
 
     assert(metricTree.sumMetricValues("spilled_bytes") == 36L)
     assert(metricTree.sumMetricValues("memory_spilled_bytes") == 20L)
+  }
+
+  test("JVM shuffle peak memory includes a larger earlier spill") {
+    withSQLConf(CometConf.COMET_SHUFFLE_JVM_SPILL_THRESHOLD.key -> Int.MaxValue.toString) {
+      val pageSize = 256L
+      val initialSize = 128
+      val conf = new SparkConf(false)
+        .set("spark.memory.offHeap.enabled", "true")
+        .set("spark.memory.offHeap.size", "10m")
+      val memoryManager = new TestMemoryManager(conf)
+      memoryManager.limit(10 * 1024 * 1024)
+      val taskMemoryManager = new TaskMemoryManager(memoryManager, 0)
+      val allocator =
+        CometShuffleMemoryAllocator.getInstance(conf, taskMemoryManager, pageSize)
+      val taskContext = TaskContext.empty()
+      val writeMetrics = taskContext.taskMetrics.shuffleWriteMetrics
+      val sorter = new CometShuffleExternalSorter(
+        allocator,
+        SparkEnv.get.blockManager,
+        taskContext,
+        initialSize,
+        2,
+        conf,
+        writeMetrics,
+        new StructType().add("id", IntegerType))
+
+      def insert(value: Int): Unit = {
+        val bytes = new Array[Byte](4 + 16)
+        Platform.putInt(bytes, Platform.BYTE_ARRAY_OFFSET, value)
+        val row = new UnsafeRow(1)
+        row.pointTo(bytes, Platform.BYTE_ARRAY_OFFSET + 4, 16)
+        row.setInt(0, value)
+        sorter.insertRecord(bytes, Platform.BYTE_ARRAY_OFFSET, bytes.length, value % 2)
+      }
+
+      try {
+        val initialMemory = allocator.getUsed
+        assert(initialMemory == initialSize * 8L)
+
+        (0 until 21).foreach(insert)
+        val firstHighWater = allocator.getUsed
+        sorter.spill()
+        val firstSpillBytes = taskContext.taskMetrics.memoryBytesSpilled
+
+        (21 until 26).foreach(insert)
+        val secondHighWater = allocator.getUsed
+        sorter.spill()
+        val secondSpillBytes = taskContext.taskMetrics.memoryBytesSpilled - firstSpillBytes
+        val spills = sorter.closeAndGetSpills()
+
+        assert(firstHighWater == initialMemory + firstSpillBytes)
+        assert(secondHighWater == initialMemory + secondSpillBytes)
+        assert(firstHighWater > secondHighWater)
+        assert(spills.length == 2)
+        assert(writeMetrics.recordsWritten == 26L)
+        assert(spills.map(_.file.length()).sum == taskContext.taskMetrics.diskBytesSpilled)
+        assert(spills.map(_.partitionLengths.sum).sum == taskContext.taskMetrics.diskBytesSpilled)
+        assert(sorter.getPeakMemoryUsedBytes() == firstHighWater)
+      } finally {
+        sorter.cleanupResources()
+        assert(taskMemoryManager.cleanUpAllAllocatedMemory() == 0L)
+      }
+    }
   }
 
   test("per-task native shuffle metrics") {


### PR DESCRIPTION
## Which issue does this PR close?

Part of #5212 (finding #12). This does not close the parent audit epic.

Follow-up performance work for O(1) page-byte accounting is tracked in #5462.

## Rationale for this change

`CometShuffleExternalSorter.spill()` frees the active sorter's data pages without first updating `peakMemoryUsedBytes`. If an earlier spill has a larger working set than later spills, the final getter only observes the reset pointer array and under-reports the actual peak.

On unmodified upstream main, a deterministic two-spill reproducer reached a known first-spill high-water mark of 1,792 bytes but reported 1,024 bytes.

## What changes are included in this PR?

- Update peak memory immediately before an active spill sorter's pages are freed.
- Add a focused two-spill regression whose first working set is larger and which does not poll the peak between spills.
- Assert exact allocator/spill relationships, two spill files, record count, disk-byte accounting, partition lengths, and cleanup.

## How are these changes tested?

- `make core`
- `./mvnw -q -Prelease test -Dtest=none -Dsuites="org.apache.spark.sql.comet.CometTaskMetricsSuite JVM shuffle peak memory includes a larger earlier spill" -Djacoco.skip=true`
  - Exactly 1 test expected and run; 1 succeeded.
- `./mvnw -q spotless:check -DskipTests -Dscalastyle.skip=true`
- `git diff --check`

The regression failed against unmodified upstream main with `1024 did not equal 1792` after its preceding spill-count, record-count, and exact byte-accounting assertions passed. It passes with this change.

A warmed release-mode A-B-B-A check used 5 warmups and 15 recorded samples per block for tiny and representative two-spill workloads. Combined medians were 1.705 ms before versus 1.698 ms after for the tiny workload, and 52.65 ms before versus 53.90 ms after for the representative workload; both differences were within measured variability. Spill bytes, record counts, partition lengths, and spill-file SHA-256 digests were unchanged across all recorded samples.
