### PR TITLE
fix: enforce fair memory share per reservation

### DIFF
--- a/native/core/src/execution/memory_pools/fair_pool.rs
+++ b/native/core/src/execution/memory_pools/fair_pool.rs
@@ -24,10 +24,9 @@ use jni::objects::{Global, JObject};
 
 use crate::{errors::CometResult, jvm_bridge::JVMClasses};
 use datafusion::common::resources_err;
-use datafusion::execution::memory_pool::MemoryConsumer;
 use datafusion::{
     common::DataFusionError,
-    execution::memory_pool::{MemoryPool, MemoryReservation},
+    execution::memory_pool::{MemoryConsumer, MemoryLimit, MemoryPool, MemoryReservation},
 };
 use parking_lot::Mutex;
 
@@ -42,6 +41,17 @@ pub struct CometFairMemoryPool {
 struct CometFairPoolState {
     used: usize,
     num: usize,
+}
+
+fn fair_limit_exceeded(
+    pool_size: usize,
+    num: usize,
+    reservation: &MemoryReservation,
+    additional: usize,
+) -> Option<(usize, usize)> {
+    let used = reservation.size();
+    let limit = pool_size.checked_div(num).expect("overflow in checked_div");
+    (limit < used.saturating_add(additional)).then_some((used, limit))
 }
 
 impl Debug for CometFairMemoryPool {
@@ -142,21 +152,15 @@ impl MemoryPool for CometFairMemoryPool {
 
     fn try_grow(
         &self,
-        _reservation: &MemoryReservation,
+        reservation: &MemoryReservation,
         additional: usize,
     ) -> Result<(), DataFusionError> {
         if additional > 0 {
             let mut state = self.state.lock();
             let num = state.num;
-            let limit = self
-                .pool_size
-                .checked_div(num)
-                .expect("overflow in checked_div");
-            // We use state.used instead of reservation.size() because DataFusion 53+
-            // calls pool.try_grow() before incrementing the reservation's atomic size,
-            // so reservation.size() would not include prior grows.
-            let used = state.used;
-            if limit < used + additional {
+            if let Some((used, limit)) =
+                fair_limit_exceeded(self.pool_size, num, reservation, additional)
+            {
                 return resources_err!(
                     "Failed to acquire {additional} bytes where {used} bytes already reserved and the fair limit is {limit} bytes, {num} registered"
                 );
@@ -186,5 +190,30 @@ impl MemoryPool for CometFairMemoryPool {
 
     fn reserved(&self) -> usize {
         self.state.lock().used
+    }
+
+    fn memory_limit(&self) -> MemoryLimit {
+        MemoryLimit::Finite(self.pool_size)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::execution::memory_pool::UnboundedMemoryPool;
+
+    #[test]
+    fn fair_share_uses_requesting_reservation_and_reports_pool_limit() {
+        let backing: Arc<dyn MemoryPool> = Arc::new(UnboundedMemoryPool::default());
+        let other = MemoryConsumer::new("other").register(&backing);
+        let requesting = MemoryConsumer::new("requesting").register(&backing);
+        other.grow(10);
+        requesting.grow(6);
+
+        assert_eq!(fair_limit_exceeded(32, 2, &requesting, 10), None);
+        assert_eq!(fair_limit_exceeded(32, 2, &requesting, 11), Some((6, 16)));
+
+        let pool = CometFairMemoryPool::new(Arc::new(Global::null()), 32);
+        assert!(matches!(pool.memory_limit(), MemoryLimit::Finite(32)));
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Addresses finding 1 and the fair-pool portion of finding 16 in #5212.

Follow-up #5465 tracks spillable versus unspillable consumer accounting separately.

## Rationale for this change

`CometFairMemoryPool` calculates a per-consumer fair share but compares it with pool-wide usage. With a 32 MiB pool and two consumers, one reservation holding 10 MiB and the requester holding 6 MiB make total usage equal the 16 MiB fair share. Main then rejects any positive growth from the requester, even though that requester has 10 MiB of fair-share headroom.

The fair pool also has a fixed configured capacity, so reporting an unknown memory limit is inaccurate.

## What changes are included in this PR?

- Compare the fair share with the requesting reservation's size plus the requested growth.
- Report `MemoryLimit::Finite(pool_size)` for `CometFairMemoryPool`.
- Add a focused regression test for the 10 MiB + 6 MiB reservation case and finite-limit reporting.
- Preserve the existing policy of counting all registered consumers. Restricting the count to spillable consumers is the separate policy and annotation change tracked by #5465.

## How are these changes tested?

Focused native test:

```shell
cargo test --release -p datafusion-comet fair_share_uses_requesting_reservation_and_reports_pool_limit --lib
```

Formatting and diff checks:

```shell
cargo fmt --all -- --check
git diff --check
```

A warmed local A/B used `local[1]`, a 32 MiB fair pool, one sort partition, three warmups, and seven measured runs:

| Workload | Spills | Native spilled bytes | Wall time, median (range) | Max task, median (range) |
| --- | ---: | ---: | ---: | ---: |
| 200K rows | 5 → 2 | 13,014,520 → 13,013,008 | 92 (78–121) → 99 (87–115) ms | 51 (44–65) → 54 (51–76) ms |
| 2M rows | 43 → 16 | 232,467,592 → 130,125,664 | 406 (372–507) → 369 (326–632) ms | 371 (338–481) → 341 (300–603) ms |

Spill counts and bytes were identical across the seven runs for each build. Runtime ranges overlap, so this PR makes no speed claim; the demonstrated benefit is restoring the requesting consumer's fair-share capacity and avoiding premature spills.