### PR TITLE
fix: preserve aggregate result identity during exchange reuse

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -30,7 +30,7 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeSet, Expression, ExpressionSet, Generator, NamedExpression, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeSeq, AttributeSet, Expression, ExpressionSet, Generator, NamedExpression, SortOrder}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateMode, CollectList, CollectSet, Final, Partial, PartialMerge, Percentile}
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
 import org.apache.spark.sql.catalyst.plans._
@@ -1974,6 +1974,7 @@ object CometHashAggregateExec
       op.output,
       op.groupingExpressions,
       op.aggregateExpressions,
+      op.aggregateAttributes,
       op.resultExpressions,
       op.child.output,
       op.child,
@@ -2024,6 +2025,7 @@ object CometObjectHashAggregateExec
       adjustOutputForNativeState(op),
       op.groupingExpressions,
       op.aggregateExpressions,
+      op.aggregateAttributes,
       op.resultExpressions,
       op.child.output,
       op.child,
@@ -2037,6 +2039,7 @@ case class CometHashAggregateExec(
     override val output: Seq[Attribute],
     groupingExpressions: Seq[NamedExpression],
     aggregateExpressions: Seq[AggregateExpression],
+    aggregateAttributes: Seq[Attribute],
     resultExpressions: Seq[NamedExpression],
     input: Seq[Attribute],
     child: SparkPlan,
@@ -2049,7 +2052,15 @@ case class CometHashAggregateExec(
   // modes is empty too.
   val modes: Seq[AggregateMode] = aggregateExpressions.map(_.mode).distinct
 
-  override def producedAttributes: AttributeSet = outputSet ++ AttributeSet(resultExpressions)
+  // Match Spark's aggregate canonicalization, including the original result attributes that
+  // rewritten DISTINCT aggregate expressions do not necessarily retain in their resultIds.
+  override lazy val allAttributes: AttributeSeq =
+    child.output ++ aggregateExpressions.flatMap(_.aggregateFunction.aggBufferAttributes) ++
+      aggregateAttributes ++
+      aggregateExpressions.flatMap(_.aggregateFunction.inputAggBufferAttributes)
+
+  override def producedAttributes: AttributeSet =
+    outputSet ++ AttributeSet(resultExpressions) ++ AttributeSet(aggregateAttributes)
 
   override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
     this.copy(child = newChild)
@@ -2072,6 +2083,8 @@ case class CometHashAggregateExec(
         this.output == other.output &&
         this.groupingExpressions == other.groupingExpressions &&
         this.aggregateExpressions == other.aggregateExpressions &&
+        this.aggregateAttributes == other.aggregateAttributes &&
+        this.resultExpressions == other.resultExpressions &&
         this.input == other.input &&
         this.modes == other.modes &&
         this.child == other.child &&
@@ -2082,7 +2095,15 @@ case class CometHashAggregateExec(
   }
 
   override def hashCode(): Int =
-    Objects.hashCode(output, groupingExpressions, aggregateExpressions, input, modes, child)
+    Objects.hashCode(
+      output,
+      groupingExpressions,
+      aggregateExpressions,
+      aggregateAttributes,
+      resultExpressions,
+      input,
+      modes,
+      child)
 
   override lazy val metrics: Map[String, SQLMetric] = {
     val baseline = CometMetricNode.baselineMetrics(sparkContext)

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.plans.physical.RangePartitioning
 import org.apache.spark.sql.comet.CometHashAggregateExec
 import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 import org.apache.spark.sql.execution.SQLExecution
-import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveSparkPlanHelper}
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.functions.{avg, col, count_distinct, expr, sum}
 import org.apache.spark.sql.internal.SQLConf
@@ -1307,29 +1307,31 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
   }
 
   Seq(
-    ("COUNT(*)", 2L),
-    ("COUNT(DISTINCT _2)", 2L),
-    ("COUNT(DISTINCT _2) + SUM(_2)", 7L),
-    ("CAST(SIZE(COLLECT_SET(_2)) AS BIGINT)", 2L)).foreach { case (function, expected) =>
+    ("COUNT(*)", 2L, false),
+    ("COUNT(DISTINCT _2)", 2L, false),
+    ("COUNT(DISTINCT _2) + SUM(_2)", 7L, false),
+    ("CAST(SIZE(COLLECT_SET(_2)) AS BIGINT)", 2L, false),
+    ("COUNT(*)", 2L, true)).foreach { case (function, expected, adaptive) =>
     test(
-      s"aggregate canonicalization preserves result expressions and equivalent reuse: $function") {
+      s"aggregate canonicalization preserves result expressions and equivalent reuse: " +
+        s"$function, AQE=$adaptive") {
       withSQLConf(
-        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString,
         SQLConf.EXCHANGE_REUSE_ENABLED.key -> "true",
         SQLConf.SHUFFLE_PARTITIONS.key -> "2",
         CometConf.COMET_SHUFFLE_ENABLED.key -> "true",
         CometConf.COMET_SHUFFLE_MODE.key -> "native") {
         withParquetTable(Seq((0, 2), (0, 3)), "tbl") {
+          // Build independent branches with an exchange above Final and the requested output alias.
           def aggregate(result: String, alias: String = "c"): DataFrame =
             sql(s"SELECT $result AS $alias, _1 FROM tbl GROUP BY _1")
               .repartition(2, col(alias), col("_1"))
 
+          // Traverse adaptive/query-stage wrappers and fail if the native Final fell back to Spark.
           def finalAggregate(df: DataFrame): CometHashAggregateExec =
-            df.queryExecution.executedPlan
-              .collectFirst {
-                case agg: CometHashAggregateExec if agg.modes.contains(Final) => agg
-              }
-              .getOrElse(fail("Expected a native final aggregate"))
+            collectFirst(df.queryExecution.executedPlan) {
+              case agg: CometHashAggregateExec if agg.modes.contains(Final) => agg
+            }.getOrElse(fail("Expected a native final aggregate"))
 
           val plus = aggregate(s"($function) + 1")
           val minus = aggregate(s"($function) - 1")
@@ -1346,11 +1348,14 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
           assert(finalAggregate(plus).semanticHash() == finalAggregate(same).semanticHash())
           val (_, reusedPlan) =
             checkSparkAnswerAndOperator(plus.unionAll(same), classOf[ReusedExchangeExec])
-          val reusedFinalAggregates = reusedPlan.collect {
-            case reused: ReusedExchangeExec if reused.child.exists {
-                  case agg: CometHashAggregateExec => agg.modes.contains(Final)
-                  case _ => false
-                } =>
+          if (adaptive) {
+            assert(reusedPlan.isInstanceOf[AdaptiveSparkPlanExec])
+          }
+          // Adaptive-aware traversal must find reuse above Final, not just a shared Partial stage.
+          val reusedFinalAggregates = collect(reusedPlan) {
+            case reused: ReusedExchangeExec if collect(reused.child) {
+                  case agg: CometHashAggregateExec if agg.modes.contains(Final) => agg
+                }.nonEmpty =>
               reused
           }
           assert(

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -1313,7 +1313,7 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     ("CAST(SIZE(COLLECT_SET(_2)) AS BIGINT)", 2L, false),
     ("COUNT(*)", 2L, true)).foreach { case (function, expected, adaptive) =>
     test(
-      s"aggregate canonicalization preserves result expressions and equivalent reuse: " +
+      "aggregate canonicalization preserves result expressions and equivalent reuse: " +
         s"$function, AQE=$adaptive") {
       withSQLConf(
         SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString,

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.comet.CometHashAggregateExec
 import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.functions.{avg, col, count_distinct, expr, sum}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
@@ -1300,6 +1301,61 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
             "SELECT _2, MIN(_1) + java_method('java.lang.Math', 'random') " +
               "FROM tbl GROUP BY _2")
           assert(getNumCometHashAggregate(df) == 1)
+        }
+      }
+    }
+  }
+
+  Seq(
+    ("COUNT(*)", 2L),
+    ("COUNT(DISTINCT _2)", 2L),
+    ("COUNT(DISTINCT _2) + SUM(_2)", 7L),
+    ("CAST(SIZE(COLLECT_SET(_2)) AS BIGINT)", 2L)).foreach { case (function, expected) =>
+    test(
+      s"aggregate canonicalization preserves result expressions and equivalent reuse: $function") {
+      withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+        SQLConf.EXCHANGE_REUSE_ENABLED.key -> "true",
+        SQLConf.SHUFFLE_PARTITIONS.key -> "2",
+        CometConf.COMET_SHUFFLE_ENABLED.key -> "true",
+        CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+        withParquetTable(Seq((0, 2), (0, 3)), "tbl") {
+          def aggregate(result: String, alias: String = "c"): DataFrame =
+            sql(s"SELECT $result AS $alias, _1 FROM tbl GROUP BY _1")
+              .repartition(2, col(alias), col("_1"))
+
+          def finalAggregate(df: DataFrame): CometHashAggregateExec =
+            df.queryExecution.executedPlan
+              .collectFirst {
+                case agg: CometHashAggregateExec if agg.modes.contains(Final) => agg
+              }
+              .getOrElse(fail("Expected a native final aggregate"))
+
+          val plus = aggregate(s"($function) + 1")
+          val minus = aggregate(s"($function) - 1")
+          // The shuffles above the final aggregates must not reuse each other: doing so
+          // would return the first projection twice, even without an existence join.
+          checkSparkAnswerAndOperator(plus.unionAll(minus), classOf[ReusedExchangeExec])
+          checkAnswer(plus.unionAll(minus), Seq(Row(expected + 1L, 0), Row(expected - 1L, 0)))
+          assert(!finalAggregate(plus).sameResult(finalAggregate(minus)))
+
+          // Comparing result expressions must still normalize aggregate-result attributes.
+          // Fresh expression IDs and a different output alias do not change the computation.
+          val same = aggregate(s"($function) + 1", "renamed")
+          assert(finalAggregate(plus).sameResult(finalAggregate(same)))
+          assert(finalAggregate(plus).semanticHash() == finalAggregate(same).semanticHash())
+          val (_, reusedPlan) =
+            checkSparkAnswerAndOperator(plus.unionAll(same), classOf[ReusedExchangeExec])
+          val reusedFinalAggregates = reusedPlan.collect {
+            case reused: ReusedExchangeExec if reused.child.exists {
+                  case agg: CometHashAggregateExec => agg.modes.contains(Final)
+                  case _ => false
+                } =>
+              reused
+          }
+          assert(
+            reusedFinalAggregates.nonEmpty,
+            s"Expected equivalent aggregate reuse:\n$reusedPlan")
         }
       }
     }


### PR DESCRIPTION
## Which issue does this PR close?

No issue is automatically closed. This is a standalone correctness fix for aggregate exchange reuse.

## Rationale for this change

Spark can reuse a shuffle when another branch of the query has already computed the same data. That decision depends on the identity of the plan below the exchange. Comet currently compares an aggregate's grouping keys and aggregate functions without comparing its final result expressions. Two aggregates can therefore look equivalent even when they return different values.

For example, suppose a Parquet table `t(k, v)` contains `(0, 2)` and `(0, 3)`. This excerpt shows the query shape covered by the regression, including a shuffle above each final aggregate:

```scala
import org.apache.spark.sql.functions.col

def branch(result: String) =
  spark.sql(s"SELECT $result AS c, k FROM t GROUP BY k")
    .repartition(2, col("c"), col("k"))

val plus = branch("COUNT(*) + 1")
val minus = branch("COUNT(*) - 1")
plus.unionAll(minus).collect()
```

The expected `(c, k)` rows are `(3, 0)` and `(1, 0)`. Both branches count the same rows, but their final arithmetic differs. If Spark incorrectly reuses the first shuffle for the second, the query can finish successfully with `(3, 0)` twice.

The fix must also preserve legitimate reuse. Repeating `COUNT(*) + 1` under a different column alias still computes the same values, even though Spark assigns fresh expression IDs. Treating those plans as different would avoid incorrect sharing at the cost of unnecessary computation and shuffling.

## What changes are included in this PR?

Aggregate identity now includes the final result expressions, so equality and hashing distinguish computations such as `COUNT(*) + 1` and `COUNT(*) - 1` before Spark decides whether to share an exchange. The native aggregate already evaluates these projections; this change makes the plan's identity describe the result it actually produces.

To retain valid reuse, Comet also preserves Spark's original aggregate result attributes and uses them when normalizing plan identity. This is especially important for distinct aggregates, whose rewritten expressions do not always retain the original result IDs. Equivalent computations can still compare equal across fresh IDs and aliases, while different projections remain separate. This applies to both hash and object hash aggregate conversion. The scope is the aggregate implementation and its existing test suite; native execution kernels and dependencies are unchanged.

## How are these changes tested?

Five regressions in `CometAggregateSuite` cover count, distinct count, distinct count combined with sum, and collect-set size. COUNT runs with AQE both disabled and enabled; the other three cases run with AQE disabled. Each case checks that different final projections return the correct results and that equivalent projections with different aliases still reuse an exchange above a native final aggregate. The AQE case also requires an adaptive plan and traverses query-stage wrappers when checking reuse. All cases use Parquet input, native Comet shuffle, and exchange reuse enabled.

At commit `49e821a24`, the five regressions passed again on Spark 3.4.3 / Scala 2.12.17 / JDK 17, together with the full Scalafix CHECK using the `semanticdb` profile, packaging, Scalastyle, and Spotless checks. This commit only removes a redundant string-interpolation prefix from the test name. Spark 4.1 was not rerun for this lint-only cleanup.

Previously, at commit `2ea7ed82c`, all five regressions passed locally on each of Spark 3.4.3 / Scala 2.12.17 / JDK 17 and Spark 4.1.3 / Scala 2.13.17 / JDK 21: **10 tests passed, zero failures**. Reactor compilation, Scalastyle, and Spotless checks passed on both profiles. Native sources are unchanged; these runs used a verified Apache CI native library built from the exact upstream base `fefee03d`, rather than a fresh local native build.

For historical context, the [earlier macOS Spark 4.0 execution job](https://github.com/apache/datafusion-comet/actions/runs/32933515258/job/98075229919) validated commit `b448894b` before the rebase. That result is not validation of the current head. Hosted CI for `49e821a24` is pending after this update; the local results above do not imply full CI has passed.
