### PR TITLE
fix: ignore structural tags when lifting expression coverage

### DIFF
--- a/spark/src/main/scala/org/apache/comet/ExtendedExplainInfo.scala
+++ b/spark/src/main/scala/org/apache/comet/ExtendedExplainInfo.scala
@@ -311,7 +311,8 @@ object CometExplainInfo {
   }
 
   /**
-   * Union of a `Set`-valued tag over `exprs`, skipping nodes the serde never tags.
+   * Union of a coverage or info tag over `exprs`, skipping nodes the serde never tags for those
+   * purposes. This filter must not be used for `FALLBACK_REASONS`, which literals can carry.
    *
    * Catalyst copies a rewritten node's tags onto its replacement (`TreeNode.copyTagsFrom`, which
    * copies whenever the replacement has no tags of its own). Rewriting a tagged expression into a
@@ -328,10 +329,10 @@ object CometExplainInfo {
   }
 
   /**
-   * Nodes that never carry a Comet tag of their own, so anything found on one arrived by the
-   * copying described in [[collectExprTagValues]]. `Literal` is the node that matters, being the
-   * only one with JVM-wide singletons (`Literal.TrueLiteral`, `Literal.FalseLiteral`); the other
-   * two are listed because nothing legitimate can live on them either.
+   * Nodes that never carry their own coverage or info tags, so those tags can only arrive by the
+   * copying described in [[collectExprTagValues]]. This set must match
+   * `QueryPlanSerde.isStructuralExpr` minus `Alias`; changing either set requires checking the
+   * other. This invariant does not apply to `FALLBACK_REASONS`.
    *
    * `Alias` is deliberately absent even though the serde does not tag one directly:
    * `QueryPlanSerde.liftCoverageTags` lands names on whichever node the operator holds, and for a

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -1032,6 +1032,11 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
    * Nodes that carry no computation of their own. They are excluded from the expression coverage
    * stats in extended explain because they appear in nearly every expression tree and would swamp
    * the names a user actually cares about.
+   *
+   * `CometExplainInfo.isNeverTagged` must be this set minus `Alias`: the read-side filter retains
+   * aliases because [[liftCoverageTags]] uses them to hold names from rewritten children. Keep
+   * both sets in sync. This coverage invariant does not exclude structural nodes from carrying
+   * `FALLBACK_REASONS`.
    */
   private def isStructuralExpr(expr: Expression): Boolean = expr match {
     case _: Attribute | _: BoundReference | _: Literal | _: Alias => true

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -879,14 +879,10 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
   }
 
   private def liftCoverageTags(from: Expression, to: Expression): Unit = {
-    val native = mutable.Set.empty[String]
-    val dispatched = mutable.Set.empty[String]
-    from.foreach { e =>
-      e.getTagValue(CometExplainInfo.NATIVE_EXPRS).foreach(native ++= _)
-      e.getTagValue(CometExplainInfo.CODEGEN_DISPATCH_EXPRS).foreach(dispatched ++= _)
+    val exprs = from.collect { case e: Expression => e }
+    Seq(CometExplainInfo.NATIVE_EXPRS, CometExplainInfo.CODEGEN_DISPATCH_EXPRS).foreach { tag =>
+      appendTagValues(to, tag, CometExplainInfo.collectExprTagValues(exprs, tag))
     }
-    appendTagValues(to, CometExplainInfo.NATIVE_EXPRS, native.toSet)
-    appendTagValues(to, CometExplainInfo.CODEGEN_DISPATCH_EXPRS, dispatched.toSet)
   }
 
   /**

--- a/spark/src/test/scala/org/apache/comet/CometCodegenSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCodegenSuite.scala
@@ -25,7 +25,7 @@ import org.apache.arrow.vector._
 import org.apache.spark.{SparkConf, SparkEnv, TaskContext}
 import org.apache.spark.sql.CometTestBase
 import org.apache.spark.sql.api.java.UDF1
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, BoundReference, CreateArray, CreateMap, CreateNamedStruct, Expression, Literal, MapConcat}
+import org.apache.spark.sql.catalyst.expressions.{Add, Alias, AttributeReference, BoundReference, CreateArray, CreateMap, CreateNamedStruct, Expression, Literal, MapConcat}
 import org.apache.spark.sql.catalyst.expressions.objects.Invoke
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.internal.SQLConf
@@ -358,7 +358,20 @@ class CometCodegenSuite
     val planted = Literal.TrueLiteral
     planted.setTagValue(CometExplainInfo.EXTENSION_INFO, Set("PLANTED_INFO"))
     planted.setTagValue(CometExplainInfo.NATIVE_EXPRS, Set("plantedexpr"))
+    planted.setTagValue(CometExplainInfo.CODEGEN_DISPATCH_EXPRS, Set("planteddispatch"))
     try {
+      // Decimal promotion rebuilds this projection. Its coverage lift must not copy the
+      // singleton's stale tags onto the Alias, which is a legitimate coverage owner.
+      val decimal = AttributeReference("amount", DecimalType(10, 2), nullable = false)()
+      val projection = Alias(
+        CreateNamedStruct(Seq(Literal("flag"), planted, Literal("sum"), Add(decimal, decimal))),
+        "value")()
+      assert(QueryPlanSerde.exprToProto(projection, Seq(decimal)).isDefined)
+      val native = projection.getTagValue(CometExplainInfo.NATIVE_EXPRS).getOrElse(Set.empty)
+      assert(native.contains("checkoverflow"), s"expected lifted decimal coverage, got: $native")
+      assert(!native.contains("plantedexpr"))
+      assert(projection.getTagValue(CometExplainInfo.CODEGEN_DISPATCH_EXPRS).isEmpty)
+
       withSQLConf(
         CometConf.COMET_EXTENDED_EXPLAIN_FORMAT.key ->
           CometConf.COMET_EXTENDED_EXPLAIN_FORMAT_VERBOSE,
@@ -381,6 +394,7 @@ class CometCodegenSuite
 
           val info = new ExtendedExplainInfo()
           assert(!info.getNativeExpressions(plan).contains("plantedexpr"))
+          assert(!info.getCodegenDispatchExpressions(plan).contains("planteddispatch"))
           val explain = info.generateExtendedInfo(plan)
           assert(!explain.contains("PLANTED_INFO"), s"tag leaked into:\n$explain")
         }
@@ -388,6 +402,7 @@ class CometCodegenSuite
     } finally {
       planted.unsetTagValue(CometExplainInfo.EXTENSION_INFO)
       planted.unsetTagValue(CometExplainInfo.NATIVE_EXPRS)
+      planted.unsetTagValue(CometExplainInfo.CODEGEN_DISPATCH_EXPRS)
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/CometCodegenSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCodegenSuite.scala
@@ -25,7 +25,7 @@ import org.apache.arrow.vector._
 import org.apache.spark.{SparkConf, SparkEnv, TaskContext}
 import org.apache.spark.sql.CometTestBase
 import org.apache.spark.sql.api.java.UDF1
-import org.apache.spark.sql.catalyst.expressions.{Add, Alias, AttributeReference, BoundReference, CreateArray, CreateMap, CreateNamedStruct, Expression, Literal, MapConcat}
+import org.apache.spark.sql.catalyst.expressions.{Add, Alias, AttributeReference, BoundReference, Cast, CreateArray, CreateMap, CreateNamedStruct, Expression, Hypot, Literal, MapConcat}
 import org.apache.spark.sql.catalyst.expressions.objects.Invoke
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.internal.SQLConf
@@ -346,6 +346,22 @@ class CometCodegenSuite
         assert(native.contains("add"), s"expected the arithmetic expression, got: $native")
       }
     }
+  }
+
+  test("codegen dispatch coverage survives the decimal promotion rewrite") {
+    val decimal = AttributeReference("amount", DecimalType(10, 2), nullable = false)()
+    val dispatched = Hypot(Cast(Add(decimal, decimal), DoubleType), Literal(4.0d))
+    val projection = Alias(dispatched, "value")()
+
+    // Promotion rebuilds Hypot as well as the Alias above it. Unlike the original Add, the
+    // dispatched copy is not reachable from the original tree, so only the coverage lift can
+    // bring its name back to the projection owner.
+    val proto = QueryPlanSerde.exprToProto(projection, Seq(decimal)).get
+    assert(proto.hasJvmScalarUdf)
+    assert(proto.getJvmScalarUdf.getClassName === classOf[CometScalaUDFCodegen].getName)
+    assert(dispatched.getTagValue(CometExplainInfo.DISPATCHED_SELF).isEmpty)
+    assert(dispatched.getTagValue(CometExplainInfo.CODEGEN_DISPATCH_EXPRS).isEmpty)
+    assert(projection.getTagValue(CometExplainInfo.CODEGEN_DISPATCH_EXPRS).contains(Set("hypot")))
   }
 
   test("tags copied onto the shared TrueLiteral do not leak into unrelated plans") {


### PR DESCRIPTION
## Which issue does this PR close?

No issue is automatically closed. This is a follow-up to the structural-expression tag filtering associated with #5229, which is already closed.

## Rationale for this change

Comet's extended explain reports how much of a query runs natively or through the JVM codegen dispatcher. Its expression-coverage counts come from metadata recording the expressions used by the plan. Stale names in that metadata can inflate coverage counts or add misleading dispatch labels, making it harder to understand what Comet actually accelerated.

Spark's rewrites can copy a tagged expression's metadata onto the process-wide `Literal.TrueLiteral` singleton. Later queries in that JVM share the same literal. Existing filtering ignores tags found directly on literals, but decimal promotion leaves another path for them to escape.

For example, suppose an earlier query left `greaterthanorequal` coverage on the shared literal. Consider this illustrative projection, where `amount` is `DECIMAL(10, 2)`:

```sql
SELECT named_struct('flag', true, 'sum', amount + amount) AS value
FROM payments;
```

There is no comparison in this projection. However, decimal promotion rebuilds its expression tree to add overflow checking. The current coverage lift collects tags from that rebuilt tree, including the stale literal tag, and copies them onto the projection's original output alias. An alias can legitimately hold coverage collected from its child expressions, so subsequent filtering accepts the copied name. The query's native coverage now includes `greaterthanorequal` even though the query does not contain it. Codegen-dispatch coverage can be contaminated in the same way.

This makes diagnostics depend on earlier queries in the JVM and can produce misleading coverage counts or unstable explain output. It does not corrupt query results.

## What changes are included in this PR?

The coverage lift now applies the existing structural-node filtering before copying native and codegen-dispatch names back to the original expression. Stale tags on literals and other nodes that cannot legitimately own coverage are discarded before they can be attached to an alias.

Genuine coverage still needs to survive the rewrite. In particular, decimal promotion introduces a `CheckOverflow` expression that is absent from the original tree; its coverage must still reach the original owner. The change preserves that behavior and keeps aliases as valid recipients. It changes expression metadata and the existing regression test, without changing query results, execution routing, or fallback decisions.

## How are these changes tested?

The expanded `CometCodegenSuite` regression seeds both coverage-tag categories on the shared literal, checks that decimal promotion excludes them while retaining real `checkoverflow` coverage, and checks an unrelated plan. The seeded tags deliberately stand in for earlier-query contamination; this is not a claim that the test reproduces the entire preceding query history.

At head `37004235`, the [Spark 4.0 / JDK 21 expression job](https://github.com/apache/datafusion-comet/actions/runs/32933543592/job/98075971394) passed this regression and the existing expression-coverage tests. Local JVM validation had been blocked by dependency resolution; the passing runtime evidence comes from CI.

CI on `37004235` is now green, with 63 passing checks and 9 skips. The [Spark 3.5 shuffle rerun](https://github.com/apache/datafusion-comet/actions/runs/32933543592/job/98261490884) and the Iceberg 1.11 [Spark](https://github.com/apache/datafusion-comet/actions/runs/32933543592/job/98261485434), [extensions](https://github.com/apache/datafusion-comet/actions/runs/32933543592/job/98261487058), and [runtime](https://github.com/apache/datafusion-comet/actions/runs/32933543592/job/98261486905) jobs passed. The review follow-up also compiled the full Spark 4.1.3 JVM reactor locally and passed five coverage/singleton tests; disabling the coverage lift made the new positive dispatcher regression fail. These local tests reused a previously built OSS native library and did not rebuild native code. CI for the review follow-up commit is not yet confirmed.
