### PR TITLE
[draft] ci: add pinned Linux CI image recipe and offline validation

### DIFF
--- a/dev/ci/images/CometCiRepositories.scala
+++ b/dev/ci/images/CometCiRepositories.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import sbt._
+import sbt.Keys._
+
+/** Use the same repositories for Spark's separate BOM resolver as for Coursier. */
+object CometCiRepositories extends AutoPlugin {
+  override def trigger = allRequirements
+
+  override def projectSettings = Seq(
+    update / resolvers := Seq(
+      Resolver.mavenLocal,
+      "maven-central" at "https://repo.maven.apache.org/maven2/"))
+}

--- a/dev/ci/images/Dockerfile
+++ b/dev/ci/images/Dockerfile
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Pin the platform-specific manifests; this pilot intentionally targets amd64.
+FROM docker.io/azul/zulu-openjdk:17@sha256:e5ca962bc4dde62036176b7af408c320269164428aa2462f925288d7600a979b AS jdk
+FROM docker.io/library/rust:1.98.0-trixie@sha256:8aea3a845c48caac4091a8d0e6494d213061f8f014dc2f5a5f1a88a1a8c9f301 AS toolchain
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+COPY --from=jdk /usr/lib/jvm/zulu17-ca-amd64/ /opt/comet-ci/jdk/
+COPY dev/ci/images/versions.env dev/ci/images/install-tools.sh dev/ci/images/check-tools.sh /opt/comet-ci/bin/
+COPY dev/ci/images/maven-settings.xml /opt/comet-ci/maven/settings.xml
+COPY dev/ci/images/maven-settings.xml dev/ci/images/repositories /opt/comet-ci/bin/
+
+# GitHub mounts HOME and the workspace. Keep toolchains and caches outside both.
+# Set Java's user.home explicitly too: it need not agree with the shell's HOME.
+ENV JAVA_HOME=/opt/comet-ci/jdk \
+    CARGO_HOME=/opt/comet-ci/cargo \
+    MAVEN_USER_HOME=/opt/comet-ci/maven \
+    COURSIER_CACHE=/opt/comet-ci/coursier \
+    LC_ALL=C.UTF-8 \
+    RUST_BACKTRACE=1 \
+    CARGO_NET_RETRY=3 \
+    RUSTFLAGS="-Ctarget-cpu=x86-64-v3 -Clink-arg=-fuse-ld=bfd"
+ENV PATH="${JAVA_HOME}/bin:${PATH}" \
+    LD_LIBRARY_PATH="${JAVA_HOME}/lib/server" \
+    JAVA_TOOL_OPTIONS="-Duser.home=/opt/comet-ci/home -Dmaven.repo.local=/opt/comet-ci/maven/repository -Dsbt.boot.directory=/opt/comet-ci/sbt/boot -Dsbt.global.base=/opt/comet-ci/sbt/global -Dsbt.ivy.home=/opt/comet-ci/ivy -Dsbt.coursier.home=/opt/comet-ci/coursier -Dsbt.override.build.repos=true -Dsbt.repository.config=/opt/comet-ci/bin/repositories" \
+    MAVEN_OPTS="-Xmx2g -Daether.connector.http.retryHandler.count=3"
+
+RUN bash /opt/comet-ci/bin/install-tools.sh
+
+# Override the checkout's floating "stable" selector even in a fresh workspace.
+ENV RUSTUP_TOOLCHAIN=1.98.0
+
+# Never use this intermediate stage as the published image or export its layers
+# as a public build cache: it contains locally built Comet and Spark artifacts.
+FROM toolchain AS dependencies
+ARG BUILD_JOBS=4
+WORKDIR /warmup/comet
+COPY . .
+COPY dev/ci/images/ /opt/comet-ci/bin/
+RUN --mount=type=cache,id=apache-comet-ci-image-native,target=/tmp/comet-ci-native-target,sharing=locked \
+    source /opt/comet-ci/bin/versions.env \
+    && bash /opt/comet-ci/bin/fetch-spark.sh /tmp/spark.tar.gz \
+    && mkdir apache-spark \
+    && tar -xzf /tmp/spark.tar.gz -C apache-spark --strip-components=1 \
+    && git -C apache-spark apply "/warmup/comet/dev/diffs/$SPARK_VERSION.diff" \
+    && CARGO_TARGET_DIR=/tmp/comet-ci-native-target CARGO_BUILD_JOBS="$BUILD_JOBS" bash /opt/comet-ci/bin/run-build.sh warm \
+    && python3 /opt/comet-ci/bin/cache.py export /opt/comet-ci /export \
+    && python3 /opt/comet-ci/bin/cache.py inputs . --spark-version "$SPARK_VERSION" > /export/inputs.sha256
+ARG SOURCE_REVISION=unknown
+RUN printf '%s\n' "$SOURCE_REVISION" > /export/source-revision
+
+# Start from the toolchain, not dependencies. Deleted build outputs must not
+# remain recoverable from earlier layers of the final image.
+FROM toolchain AS ci
+ARG SOURCE_REVISION=unknown
+LABEL org.opencontainers.image.source="https://github.com/apache/datafusion-comet" \
+      org.opencontainers.image.description="Comet CI toolchains and third-party dependencies; not a Comet release" \
+      org.opencontainers.image.revision="${SOURCE_REVISION}"
+COPY dev/ci/images/ /opt/comet-ci/bin/
+COPY --from=dependencies /export/ /opt/comet-ci/
+RUN python3 /opt/comet-ci/bin/cache.py audit /opt/comet-ci
+WORKDIR /work

--- a/dev/ci/images/Dockerfile.dockerignore
+++ b/dev/ci/images/Dockerfile.dockerignore
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+.git
+.github
+**/.git
+**/target
+**/.idea
+**/.m2
+**/.cargo
+**/.sbt
+**/.ivy2
+**/.cache
+**/.env
+**/__pycache__
+**/*.pyc
+**/*.log
+**/metastore_db
+**/spark-warehouse
+apache-spark
+apache-iceberg
+docs/build
+docs/temp
+docs/venv
+venv
+dev/ci/images/README.md
+dev/ci/images/test_image.py

--- a/dev/ci/images/README.md
+++ b/dev/ci/images/README.md
@@ -1,0 +1,163 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Linux Spark CI image pilot
+
+This directory implements the image recipe and offline verification for
+[GH-5490](https://github.com/apache/datafusion-comet/issues/5490). It does not
+publish images or change the images used by the existing Spark test jobs.
+
+The pilot is Linux/amd64 with x86-64-v3 support, Spark 4.1.3, and Zulu JDK 17.
+The Dockerfile pins the
+Rust and JDK base images by digest. `versions.env` pins the tool versions,
+clang/protoc Debian packages, Maven wrapper distribution, and Spark's SBT version.
+`RUSTUP_TOOLCHAIN` selects the pinned compiler instead of the checkout's floating
+`stable` selector, including when networking is disabled.
+The Spark source archive is pinned by commit and SHA-256, and the SBT launcher
+has a pinned SHA-256. The Debian package inventory is recorded in
+`/opt/comet-ci/os-packages.txt`.
+
+## Build
+
+Run from the Comet repository root, with Docker and BuildKit available:
+
+```bash
+bash dev/ci/images/build.sh comet-ci:spark-4.1.3-jdk17
+```
+
+To check just the toolchain, without the dependency build:
+
+```bash
+bash dev/ci/images/build.sh comet-ci:toolchain toolchain
+```
+
+`COMET_CI_BUILD_JOBS` controls native compilation parallelism (default: 4).
+Set it to 2 on a runner with limited memory. The complete build compiles native
+Comet, runs the full Maven reactor with the Spark 4.1 release profile, compiles
+Spark's catalyst/sql/hive test classes, and runs two smoke suites. Allow enough
+time and disk space for both the image build and the later independent rebuild.
+
+The recipe uses a local BuildKit cache for native compiler output to make
+iteration practical. This cache is not copied into the image, and the offline
+validator never mounts it. Do not publish the intermediate
+`dependencies` stage or export its layers as a public build cache.
+
+## Verify the final image offline
+
+Stage any new source files first: the validator archives tracked working files,
+including modifications, but excludes untracked files and host build caches.
+It downloads and verifies the pinned Spark sources before disabling networking.
+
+```bash
+bash dev/ci/images/validate.sh comet-ci:spark-4.1.3-jdk17
+```
+
+The validator starts a new container with `--network=none`, an empty
+`/github/home`, and a different workspace path from the warmup stage.
+Only Comet and Spark source archives are mounted from the host. It then:
+
+1. Audits the image for forbidden artifacts and compares its dependency input
+   fingerprints against the current checkout.
+2. Boots the Maven wrapper without downloading its distribution.
+3. Builds native Comet with Cargo offline and the lockfile enforced.
+4. Installs the current Comet JVM artifacts with Maven offline, from the
+   repository root. It does not use `-pl`.
+5. Compiles Spark's catalyst, SQL, and Hive test classes with SBT offline.
+6. Runs `LiteralExpressionSuite` and `MathFunctionsSuite` with Comet enabled,
+   checking that each suite actually ran tests.
+
+GitHub checkout and artifact transport are deliberately outside this offline
+test. Loopback networking remains available for local Spark services. This is
+a dependency-completeness check for the pinned pilot, not a claim that every
+Spark test or every changed dependency graph can run offline.
+
+A missing dependency is a validation failure. Do not mount a host Maven/Cargo
+cache or turn networking back on to make it pass. Warm the required dependency
+in the recipe, rebuild the image, and repeat the fresh-container check instead.
+
+## What is in the image
+
+Toolchains and downloaded third-party dependencies live under
+`/opt/comet-ci`. Explicit Cargo, Maven, SBT, Coursier, and Ivy paths survive
+GitHub's mounted home and workspace directories. Java's `user.home` is also
+set explicitly, and its `.m2` points to the same repository used by Maven.
+No container entrypoint is required to initialize these paths.
+
+Maven and SBT's standard resolver use Maven Central, plus the job's local Maven
+repository for freshly built Comet artifacts. The checked-in, credential-free
+Maven settings redirect Spark's Google Maven Central mirror to the canonical
+repository; SBT uses the explicit `repositories` file. This keeps Coursier's
+URL-based cache paths consistent. Spark's BOM plugin constructs a separate Ivy
+resolver, so the runner copies `CometCiRepositories.scala` into the temporary
+Spark build definition to direct that resolver to the same repositories. Its
+Ivy cache is exported and checked by the offline build too. No existing CI
+workflow's repository configuration changes.
+
+The dependency stage may compile Comet and Spark to discover the dependencies
+actually used by the build. The final stage starts again from the toolchain
+image and copies only the exported caches. It excludes:
+
+- Comet Maven artifacts, including released versions, and all SNAPSHOT artifacts.
+- Locally installed Maven artifacts, identified by Maven Resolver origin records.
+- User Maven settings/credentials, Ivy local publications, Coursier file repositories,
+  and SBT's locally compiled Zinc bridge cache.
+- Comet and Spark build workspaces and outputs, including Comet libraries/JARs, Spark test
+  classes, and native compiler output.
+
+The exporter keeps Maven's downloaded dependencies before applying the existing
+partial-POM/Parquet workaround. Warmup and offline verification both apply that
+workaround before SBT resolution, ensuring Parquet test classifiers come from
+the warmed Coursier cache. The SBT launcher is also stored explicitly because
+Spark otherwise downloads it into its source checkout.
+
+Downloads of Spark sources and the SBT launcher have bounded curl retries.
+Cargo's download retry count and Maven's HTTP transfer retry count are bounded.
+No compilation or test command is retried.
+
+## Maintenance and scope
+
+Update the pins in `versions.env`, the matching Dockerfile image digests, and
+`RUSTUP_TOOLCHAIN` together, build, and rerun offline validation.
+If a pinned Debian package disappears from the configured repositories, update
+the pin; do not silently fall back to an unpinned version. The base digest and
+tool pins do not make all OS dependencies reproducible: apt may install newer
+transitive dependencies, whose versions are recorded in the image inventory.
+
+`inputs.sha256` records the Maven POMs, Cargo manifests and lockfiles, Maven
+wrapper properties, Spark patch, image recipe and scripts, repository settings,
+and version manifest. `source-revision`
+records the Comet revision used for warmup, with a dirty suffix when applicable.
+The fingerprint deliberately excludes source files and generated output.
+
+Future PRs will add trusted main-only publishing, scheduled refreshes,
+digest-based adoption, rollback, and measurements against the existing CI
+workflow. New dependency downloads must remain possible in normal PR jobs.
+The image is CI infrastructure, not a Comet release artifact.
+
+## Fast regression checks
+
+```bash
+python3 dev/ci/images/test_image.py
+```
+
+These standard-library tests cover cache filtering, Maven origin records,
+snapshot/local-artifact rejection, missing classifiers, the Parquet workaround,
+dependency fingerprints, and shell syntax. They do not require Docker and do
+not replace the full offline validation. Wiring these checks into CI is left
+to the workflow follow-up.

--- a/dev/ci/images/build.sh
+++ b/dev/ci/images/build.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+script_dir=$(cd "$(dirname "$0")" && pwd)
+repo_dir=$(cd "$script_dir/../../.." && pwd)
+source "$script_dir/versions.env"
+default_image="comet-ci:spark-$SPARK_VERSION-jdk${JDK_VERSION%%.*}"
+image=${1:-$default_image}
+target=${2:-ci}
+case "$target" in ci|toolchain) ;; *) echo "Target must be ci or toolchain" >&2; exit 2 ;; esac
+revision=$(git -C "$repo_dir" rev-parse HEAD)
+if [ -n "$(git -C "$repo_dir" status --porcelain)" ]; then
+  revision="$revision-dirty"
+fi
+exec docker build --platform linux/amd64 --progress plain \
+  --build-arg "SOURCE_REVISION=$revision" \
+  --build-arg "BUILD_JOBS=${COMET_CI_BUILD_JOBS:-4}" \
+  --target "$target" --tag "$image" --file "$script_dir/Dockerfile" "$repo_dir"

--- a/dev/ci/images/cache.py
+++ b/dev/ci/images/cache.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Export downloaded dependencies only; never export a build workspace."""
+
+import argparse
+import hashlib
+from pathlib import Path
+import shutil
+import sys
+import xml.etree.ElementTree as ET
+
+# These are caches of downloaded sources/distributions, not compiler outputs.
+CACHE_PATHS = (
+    "cargo/registry",
+    "cargo/git",
+    "maven/wrapper",
+    "coursier",
+    "sbt/boot",
+    "ivy/cache",
+)
+BINARY_CACHES = ("maven", "coursier", "sbt", "ivy")
+
+
+def forbidden(path):
+    parts = path.parts
+    return (
+        any("SNAPSHOT" in part.upper() for part in parts)
+        or "org.apache.datafusion" in parts
+        or "org/apache/datafusion" in path.as_posix()
+        or path.name.startswith("comet-")
+        or path.name in {"maven-metadata-local.xml", "ivy-local.xml"}
+        or path.name.endswith((".lastUpdated", ".part", ".lock", ".lck"))
+    )
+
+
+def copy_file(source, destination):
+    if source.is_symlink():
+        raise ValueError(f"Unexpected cache symlink: {source}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+
+
+def export_maven(source, destination):
+    """Use Maven Resolver's origin records to exclude locally installed files."""
+    destination.mkdir(parents=True, exist_ok=True)
+    count = 0
+    for marker in sorted(source.rglob("_remote.repositories")):
+        if forbidden(marker.relative_to(source)):
+            continue
+        records = []
+        lines = marker.read_text().splitlines()
+        local_files = {line.partition(">")[0] for line in lines if ">=" in line}
+        for line in lines:
+            if not line or line.startswith("#"):
+                continue
+            filename, separator, origin = line.partition(">")
+            repository, equals, _ = origin.partition("=")
+            if not separator or not equals or not repository or filename in local_files:
+                continue  # An empty repository id denotes a local install.
+            if Path(filename).name != filename:
+                raise ValueError(f"Invalid Maven origin record: {marker}: {line}")
+            artifact = marker.parent / filename
+            relative = artifact.relative_to(source)
+            if forbidden(relative) or not artifact.is_file():
+                continue
+            if artifact.is_symlink():
+                raise ValueError(f"Unexpected Maven symlink: {artifact}")
+            copy_file(artifact, destination / relative)
+            records.append(line)
+            count += 1
+            for suffix in (".sha1", ".sha256", ".sha512", ".md5"):
+                checksum = artifact.with_name(artifact.name + suffix)
+                if checksum.is_file():
+                    copy_file(checksum, destination / checksum.relative_to(source))
+        if records:
+            target = destination / marker.relative_to(source)
+            target.write_text("\n".join(records) + "\n")
+    # Version-range metadata is not recorded in _remote.repositories.
+    for metadata in source.rglob("maven-metadata-*.xml"):
+        relative = metadata.relative_to(source)
+        if not forbidden(relative):
+            copy_file(metadata, destination / relative)
+    return count
+
+
+def purge_partial_maven(repository):
+    """Match the existing Spark setup workaround, but use one explicit repo."""
+    for pom in repository.rglob("*.pom"):
+        if pom.with_suffix(".jar").exists():
+            continue
+        try:
+            root = ET.parse(pom).getroot()
+        except ET.ParseError:
+            continue
+        packaging = root.find("{*}packaging")
+        # Missing packaging means jar in Maven.
+        if packaging is not None and packaging.text not in ("jar", "bundle"):
+            continue
+        for path in (pom, pom.with_name(pom.name + ".sha1")):
+            path.unlink(missing_ok=True)
+    # Main JARs alone are insufficient: Spark also requires tests classifiers.
+    shutil.rmtree(repository / "org/apache/parquet", ignore_errors=True)
+
+
+def export_caches(source, destination):
+    for relative in CACHE_PATHS:
+        src, dst = source / relative, destination / relative
+        if src.exists():
+            shutil.copytree(src, dst, symlinks=True, dirs_exist_ok=True)
+        else:
+            dst.mkdir(parents=True, exist_ok=True)
+    copy_file(source / "sbt/launcher.jar", destination / "sbt/launcher.jar")
+    for relative in BINARY_CACHES:
+        for path in sorted((destination / relative).rglob("*"), reverse=True):
+            if forbidden(path.relative_to(destination)):
+                if path.is_dir() and not path.is_symlink():
+                    shutil.rmtree(path)
+                else:
+                    path.unlink(missing_ok=True)
+    # Never retain Coursier's file:// cache or an Ivy local publication.
+    shutil.rmtree(destination / "coursier/file", ignore_errors=True)
+    audit(destination)
+
+
+def audit(root):
+    settings = root / "maven/settings.xml"
+    template = root / "bin/maven-settings.xml"
+    if settings.exists() and (
+        not template.is_file() or settings.read_bytes() != template.read_bytes()
+    ):
+        raise ValueError(
+            "Unexpected Maven settings: only the checked-in CI settings are allowed"
+        )
+    for relative in BINARY_CACHES:
+        for path in (root / relative).rglob("*"):
+            if forbidden(path.relative_to(root)):
+                raise ValueError(f"Forbidden cached artifact: {path}")
+            if path.is_symlink():
+                raise ValueError(f"Unexpected cache symlink: {path}")
+    for relative in ("cargo/bin", "ivy/local", "sbt/global", "native", "apache-spark"):
+        if (root / relative).exists():
+            raise ValueError(f"Unexpected build output: {root / relative}")
+    for marker in (root / "maven/repository").rglob("_remote.repositories"):
+        for line in marker.read_text().splitlines():
+            if not line.startswith("#") and ">=" in line:
+                raise ValueError(f"Locally installed Maven artifact: {marker}")
+    for artifact in (root / "maven/repository").rglob("*"):
+        if not artifact.is_file() or artifact.suffix not in (".jar", ".pom", ".zip"):
+            continue
+        marker = artifact.parent / "_remote.repositories"
+        if not marker.is_file() or not any(
+            line.startswith(artifact.name + ">")
+            and not line.startswith(artifact.name + ">=")
+            for line in marker.read_text().splitlines()
+        ):
+            raise ValueError(f"Maven artifact has no download origin: {artifact}")
+
+
+def input_hashes(root, spark_version="4.1.3"):
+    """Changes to code need no new image, changes to dependency inputs do."""
+    paths = {root / ".mvn/wrapper/maven-wrapper.properties"}
+    for pattern in ("**/pom.xml", "**/Cargo.toml", "**/Cargo.lock"):
+        paths.update(root.glob(pattern))
+    paths.add(root / f"dev/diffs/{spark_version}.diff")
+    paths.add(root / "dev/ci/images/versions.env")
+    paths.add(root / "dev/ci/images/maven-settings.xml")
+    paths.add(root / "dev/ci/images/repositories")
+    paths.add(root / "dev/ci/images/CometCiRepositories.scala")
+    paths.add(root / "dev/ci/images/Dockerfile")
+    paths.add(root / "dev/ci/images/Dockerfile.dockerignore")
+    paths.add(root / "dev/ci/images/cache.py")
+    paths.update((root / "dev/ci/images").glob("*.sh"))
+    for path in sorted(paths):
+        relative = path.relative_to(root)
+        if any(part in ("target", "apache-spark", ".git") for part in relative.parts):
+            continue
+        if path.is_file():
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            print(f"{digest}  {relative.as_posix()}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "operation", choices=("maven", "purge", "export", "audit", "inputs")
+    )
+    parser.add_argument("source", type=Path)
+    parser.add_argument("destination", type=Path, nargs="?")
+    parser.add_argument("--spark-version", default="4.1.3")
+    args = parser.parse_args()
+    if args.operation in ("maven", "export") and args.destination is None:
+        parser.error("destination is required for export")
+    if args.operation == "maven":
+        count = export_maven(args.source, args.destination)
+        if not count:
+            parser.error("no downloaded Maven artifacts were found")
+    elif args.operation == "purge":
+        purge_partial_maven(args.source)
+    elif args.operation == "export":
+        export_caches(args.source, args.destination)
+    elif args.operation == "audit":
+        audit(args.source)
+    else:
+        input_hashes(args.source, args.spark_version)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, ValueError) as error:
+        sys.exit(str(error))

--- a/dev/ci/images/check-tools.sh
+++ b/dev/ci/images/check-tools.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+source /opt/comet-ci/bin/versions.env
+[[ "$(rustc --version)" == "rustc $RUST_VERSION "* ]]
+grep -Fx "JAVA_VERSION=\"$JDK_VERSION\"" "$JAVA_HOME/release"
+test -r "$JAVA_HOME/lib/security/cacerts"
+test "$(dpkg-query -W -f='${Version}' clang)" = "$CLANG_PACKAGE_VERSION"
+test "$(dpkg-query -W -f='${Version}' clang-19)" = "$CLANG19_PACKAGE_VERSION"
+test "$(dpkg-query -W -f='${Version}' protobuf-compiler)" = "$PROTOC_PACKAGE_VERSION"
+rustfmt --version
+cargo clippy --version
+java -version
+clang --version
+protoc --version

--- a/dev/ci/images/fetch-spark.sh
+++ b/dev/ci/images/fetch-spark.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Download sources before starting the container with --network=none.
+set -euo pipefail
+script_dir=$(cd "$(dirname "$0")" && pwd)
+source "$script_dir/versions.env"
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 OUTPUT_TAR_GZ" >&2
+  exit 2
+fi
+archive=$1
+if [ ! -f "$archive" ]; then
+  curl --fail --location --retry 3 --retry-delay 5 --connect-timeout 30 \
+    --output "$archive.part" \
+    "https://codeload.github.com/apache/spark/tar.gz/$SPARK_COMMIT"
+  mv "$archive.part" "$archive"
+fi
+printf '%s  %s\n' "$SPARK_ARCHIVE_SHA256" "$archive" | sha256sum --check

--- a/dev/ci/images/install-tools.sh
+++ b/dev/ci/images/install-tools.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+source /opt/comet-ci/bin/versions.env
+test "$(dpkg --print-architecture)" = amd64
+apt-get update
+apt-get install --no-install-recommends -y \
+  "clang=$CLANG_PACKAGE_VERSION" "clang-19=$CLANG19_PACKAGE_VERSION" \
+  "protobuf-compiler=$PROTOC_PACKAGE_VERSION" \
+  cmake python3 unzip zip
+rm -rf /var/lib/apt/lists/*
+rustup component add --toolchain "$RUST_VERSION" rustfmt clippy
+mkdir -p /opt/comet-ci/home /opt/comet-ci/maven /opt/comet-ci/cargo \
+  /opt/comet-ci/coursier /opt/comet-ci/sbt/boot /opt/comet-ci/ivy/cache
+ln -s /opt/comet-ci/maven /opt/comet-ci/home/.m2
+bash /opt/comet-ci/bin/check-tools.sh
+dpkg-query -W > /opt/comet-ci/os-packages.txt

--- a/dev/ci/images/maven-settings.xml
+++ b/dev/ci/images/maven-settings.xml
@@ -1,0 +1,29 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0">
+  <!-- Use the canonical repository consistently in warmup and consumer jobs. -->
+  <mirrors>
+    <mirror>
+      <id>comet-ci-central</id>
+      <mirrorOf>gcs-maven-central-mirror</mirrorOf>
+      <url>https://repo.maven.apache.org/maven2/</url>
+    </mirror>
+  </mirrors>
+</settings>

--- a/dev/ci/images/repositories
+++ b/dev/ci/images/repositories
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[repositories]
+maven-local: file:///opt/comet-ci/maven/repository
+maven-central: https://repo.maven.apache.org/maven2/

--- a/dev/ci/images/run-build.sh
+++ b/dev/ci/images/run-build.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Run from a fresh Comet checkout containing the patched apache-spark/ tree.
+# Both warmup and offline verification execute the same build and smoke tests.
+set -euo pipefail
+source /opt/comet-ci/bin/versions.env
+mode=${1:?Usage: run-build.sh warm|offline}
+maven_args=(-B -Prelease -DskipTests "-Pspark-$SPARK_SHORT_VERSION" -Dmaven.gitcommitid.skip=true)
+sbt_args=(-batch -Dsbt.log.noformat=true -mem 3072)
+case "$mode" in
+  warm) ;;
+  offline)
+    export CARGO_NET_OFFLINE=true
+    maven_args+=(-o)
+    sbt_args+=(-Dsbt.offline=true)
+    python3 /opt/comet-ci/bin/cache.py audit /opt/comet-ci
+    python3 /opt/comet-ci/bin/cache.py inputs . --spark-version "$SPARK_VERSION" > /tmp/comet-ci-inputs.sha256
+    diff -u /opt/comet-ci/inputs.sha256 /tmp/comet-ci-inputs.sha256
+    ;;
+  *) echo "Expected warm or offline" >&2; exit 2 ;;
+esac
+bash /opt/comet-ci/bin/check-tools.sh
+test ! -d native/target
+test ! -d spark/target
+test ! -d apache-spark/sql/core/target
+# The first command must work without fetching a Maven distribution offline.
+./mvnw -B --version | tee /tmp/comet-ci-maven-version.log
+grep -F "Apache Maven $MAVEN_VERSION" /tmp/comet-ci-maven-version.log
+grep -Fx "sbt.version=$SBT_VERSION" apache-spark/project/build.properties
+
+if [ "$mode" = warm ]; then
+  # proto/build.rs writes generated sources into the checkout, outside target/.
+  # A reused native target cache otherwise skips that generator in a fresh tree.
+  (cd native && cargo clean --profile ci -p datafusion-comet-proto)
+fi
+(cd native && cargo build --locked --profile ci)
+mkdir -p native/target/release
+native_target=${CARGO_TARGET_DIR:-$PWD/native/target}
+cp "$native_target/ci/libcomet.so" native/target/release/libcomet.so
+./mvnw "${maven_args[@]}" install
+
+if [ "$mode" = warm ]; then
+  # Capture Maven's dependencies BEFORE the Parquet/POM workaround deletes any.
+  python3 /opt/comet-ci/bin/cache.py maven \
+    "$MAVEN_USER_HOME/repository" /export/maven/repository
+  curl --fail --location --retry 3 --retry-delay 5 \
+    --output /opt/comet-ci/sbt/launcher.jar \
+    "https://repo.maven.apache.org/maven2/org/scala-sbt/sbt-launch/$SBT_VERSION/sbt-launch-$SBT_VERSION.jar"
+fi
+printf '%s  %s\n' "$SBT_LAUNCH_SHA256" /opt/comet-ci/sbt/launcher.jar | sha256sum --check
+python3 /opt/comet-ci/bin/cache.py purge "$MAVEN_USER_HOME/repository"
+# Spark's build/sbt checks this path before processing its command-line options.
+cp /opt/comet-ci/sbt/launcher.jar "apache-spark/build/sbt-launch-$SBT_VERSION.jar"
+# Spark's BOM plugin constructs its own Ivy resolver and does not honor the
+# launcher repository override. A scoped setting also directs it to Central.
+cp /opt/comet-ci/bin/CometCiRepositories.scala apache-spark/project/
+
+cd apache-spark
+export NOLINT_ON_COMPILE=true
+export ENABLE_COMET=true
+export ENABLE_COMET_ONHEAP=true
+export SERIAL_SBT_TESTS=1
+export SPARK_LOCAL_IP=127.0.0.1
+export HEAP_SIZE=3g
+export METASPACE_SIZE=1g
+build/sbt "${sbt_args[@]}" \
+  'catalyst/Test/compile' 'sql/Test/compile' 'hive/Test/compile'
+# A successful sbt invocation with zero matched tests is not a passing smoke test.
+for suite in \
+  'catalyst/testOnly org.apache.spark.sql.catalyst.expressions.LiteralExpressionSuite' \
+  'sql/testOnly org.apache.spark.sql.MathFunctionsSuite'; do
+  build/sbt "${sbt_args[@]}" "$suite" | tee /tmp/comet-ci-smoke.log
+  grep -E 'Total number of tests run: [1-9][0-9]*' /tmp/comet-ci-smoke.log
+  grep -F 'All tests passed.' /tmp/comet-ci-smoke.log
+done

--- a/dev/ci/images/test_image.py
+++ b/dev/ci/images/test_image.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Fast, dependency-free regression tests for the CI image export boundary."""
+
+from contextlib import redirect_stdout
+import hashlib
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+DIRECTORY = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location("image_cache", DIRECTORY / "cache.py")
+cache = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(cache)
+
+
+class ImageCacheTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.source = self.root / "source"
+        self.destination = self.root / "destination"
+        self.source.mkdir()
+
+    def write(self, relative, contents="artifact"):
+        path = self.source / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents)
+        return path
+
+    def maven_artifact(self, relative, origin="central"):
+        path = self.write(relative)
+        marker = path.parent / "_remote.repositories"
+        with marker.open("a") as stream:
+            stream.write(f"{path.name}>{origin}=\n")
+        return path
+
+    def test_remote_jars_poms_checksums_and_origin_survive(self):
+        self.maven_artifact("example/lib/1/lib-1.jar")
+        self.maven_artifact("example/lib/1/lib-1.pom")
+        self.write("example/lib/1/lib-1.jar.sha1")
+        count = cache.export_maven(self.source, self.destination)
+        self.assertEqual(count, 2)
+        self.assertTrue((self.destination / "example/lib/1/lib-1.jar.sha1").is_file())
+        marker = self.destination / "example/lib/1/_remote.repositories"
+        self.assertIn("lib-1.jar>central=", marker.read_text())
+
+    def test_remote_parent_pom_without_a_jar_survives(self):
+        self.maven_artifact("example/parent/1/parent-1.pom")
+        cache.export_maven(self.source, self.destination)
+        self.assertTrue((self.destination / "example/parent/1/parent-1.pom").exists())
+
+    def test_locally_installed_release_is_excluded(self):
+        self.maven_artifact("example/lib/1/lib-1.jar", origin="")
+        self.maven_artifact("example/lib/1/lib-1.pom", origin="")
+        cache.export_maven(self.source, self.destination)
+        self.assertEqual(list(self.destination.rglob("*")), [])
+
+    def test_artifact_without_origin_is_excluded(self):
+        self.write("example/lib/1/lib-1.jar")
+        cache.export_maven(self.source, self.destination)
+        self.assertEqual(list(self.destination.rglob("*")), [])
+
+    def test_local_install_overwriting_a_download_is_excluded(self):
+        self.maven_artifact("example/lib/1/lib-1.jar", origin="central")
+        self.maven_artifact("example/lib/1/lib-1.jar", origin="")
+        cache.export_maven(self.source, self.destination)
+        self.assertEqual(list(self.destination.rglob("*")), [])
+
+    def test_comet_release_is_excluded_even_if_downloaded(self):
+        self.maven_artifact("org/apache/datafusion/comet-spark/1.0/comet-spark-1.0.jar")
+        cache.export_maven(self.source, self.destination)
+        self.assertEqual(list(self.destination.rglob("*")), [])
+
+    def test_snapshot_and_timestamped_snapshot_are_excluded(self):
+        self.maven_artifact("example/lib/1-SNAPSHOT/lib-1-SNAPSHOT.jar")
+        self.maven_artifact("example/lib/1-SNAPSHOT/lib-1-20260827.123456-1.jar")
+        cache.export_maven(self.source, self.destination)
+        self.assertEqual(list(self.destination.rglob("*")), [])
+
+    def test_missing_classifier_is_not_exported_as_present(self):
+        self.maven_artifact("example/lib/1/lib-1.jar")
+        self.write(
+            "example/lib/1/_remote.repositories",
+            "lib-1.jar>central=\nlib-1-tests.jar>central=\n",
+        )
+        cache.export_maven(self.source, self.destination)
+        marker = self.destination / "example/lib/1/_remote.repositories"
+        self.assertNotIn("tests.jar", marker.read_text())
+
+    def test_remote_metadata_is_retained_but_local_metadata_is_not(self):
+        self.write("example/lib/maven-metadata-central.xml")
+        self.write("example/lib/maven-metadata-local.xml")
+        cache.export_maven(self.source, self.destination)
+        self.assertTrue(
+            (self.destination / "example/lib/maven-metadata-central.xml").exists()
+        )
+        self.assertFalse(
+            (self.destination / "example/lib/maven-metadata-local.xml").exists()
+        )
+
+    def test_maven_path_traversal_is_rejected(self):
+        self.write("example/lib/1/_remote.repositories", "../outside.jar>central=\n")
+        with self.assertRaisesRegex(ValueError, "Invalid Maven origin"):
+            cache.export_maven(self.source, self.destination)
+
+    def test_maven_symlink_is_rejected(self):
+        path = self.maven_artifact("example/lib/1/lib-1.jar")
+        path.unlink()
+        path.symlink_to(self.write("outside.jar"))
+        with self.assertRaisesRegex(ValueError, "symlink"):
+            cache.export_maven(self.source, self.destination)
+
+    def test_purge_preserves_parent_poms_and_current_comet(self):
+        self.write(
+            "example/parent.pom", "<project><packaging>pom</packaging></project>"
+        )
+        self.write("example/partial.pom", "<project/>")
+        self.write(
+            "example/bundle.pom", "<project><packaging>bundle</packaging></project>"
+        )
+        self.write("example/complete.pom", "<project/>")
+        self.write("example/complete.jar")
+        comet = "org/apache/datafusion/comet/1-SNAPSHOT/comet-1-SNAPSHOT"
+        self.write(comet + ".pom", "<project/>")
+        self.write(comet + ".jar")
+        self.write("org/apache/parquet/parquet-common/1/lib.pom", "<project/>")
+        self.write("org/apache/parquet/parquet-common/1/lib.jar")
+        cache.purge_partial_maven(self.source)
+        self.assertTrue((self.source / "example/parent.pom").exists())
+        self.assertFalse((self.source / "example/partial.pom").exists())
+        self.assertFalse((self.source / "example/bundle.pom").exists())
+        self.assertTrue((self.source / "example/complete.pom").exists())
+        self.assertTrue((self.source / (comet + ".jar")).exists())
+        self.assertFalse((self.source / "org/apache/parquet").exists())
+
+    def test_export_keeps_downloads_but_not_build_outputs(self):
+        self.write("cargo/registry/src/public/lib.rs")
+        self.write("cargo/git/checkouts/public/lib.rs")
+        self.write("cargo/bin/locally-built-tool")
+        self.write("maven/settings.xml", "credentials must not be exported")
+        self.write("maven/wrapper/dists/maven/apache-maven/bin/mvn")
+        self.write("coursier/https/central/example/1/lib.jar")
+        self.write("coursier/https/central/example/1-SNAPSHOT/lib.jar")
+        self.write("coursier/file/warmup/comet.jar")
+        self.write("sbt/boot/scala/sbt.jar")
+        self.write("sbt/boot/sbt.boot.lock")
+        self.write("sbt/global/zinc/compiled-bridge.jar")
+        self.write("sbt/launcher.jar")
+        self.write("ivy/local/locally-built.jar")
+        self.write("native/target/ci/libcomet.so")
+        cache.export_caches(self.source, self.destination)
+        self.assertTrue(
+            (self.destination / "cargo/registry/src/public/lib.rs").exists()
+        )
+        self.assertTrue((self.destination / "sbt/launcher.jar").exists())
+        self.assertTrue(
+            (self.destination / "coursier/https/central/example/1/lib.jar").exists()
+        )
+        for forbidden in (
+            "cargo/bin",
+            "maven/settings.xml",
+            "sbt/global",
+            "ivy/local",
+            "native",
+            "coursier/file",
+            "coursier/https/central/example/1-SNAPSHOT",
+            "sbt/boot/sbt.boot.lock",
+        ):
+            self.assertFalse((self.destination / forbidden).exists(), forbidden)
+
+    def test_audit_rejects_unsourced_maven_artifact(self):
+        self.write("maven/repository/example/lib/1/lib.jar")
+        with self.assertRaisesRegex(ValueError, "no download origin"):
+            cache.audit(self.source)
+
+    def test_audit_allows_only_checked_in_maven_settings(self):
+        settings = self.write("maven/settings.xml", "unexpected user settings")
+        with self.assertRaisesRegex(ValueError, "Unexpected Maven settings"):
+            cache.audit(self.source)
+        template = self.write("bin/maven-settings.xml", "credential-free CI settings")
+        settings.write_bytes(template.read_bytes())
+        cache.audit(self.source)
+
+    def test_audit_rejects_snapshot_local_origin_and_symlink(self):
+        for name, content in (
+            ("maven/repository/example/1-SNAPSHOT/lib.jar", ""),
+            ("maven/repository/example/1/_remote.repositories", "lib.jar>=\n"),
+        ):
+            with self.subTest(name=name):
+                path = self.write(name, content)
+                with self.assertRaises(ValueError):
+                    cache.audit(self.source)
+                path.unlink()
+                # Remove empty SNAPSHOT directories too.
+                for parent in list(path.parents):
+                    if parent == self.source:
+                        break
+                    if parent.exists() and not list(parent.iterdir()):
+                        parent.rmdir()
+        path = self.source / "sbt/boot/link"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.symlink_to("/warmup/comet/target")
+        with self.assertRaisesRegex(ValueError, "symlink"):
+            cache.audit(self.source)
+
+    def test_input_fingerprint_tracks_new_manifests_but_not_build_outputs(self):
+        self.write("pom.xml")
+        self.write("native/Cargo.toml")
+        self.write("native/Cargo.lock")
+        self.write("contrib/delta/native/Cargo.toml")
+        self.write("dev/ci/images/Dockerfile")
+        self.write("dev/ci/images/CometCiRepositories.scala")
+        self.write("dev/ci/images/run-build.sh")
+        self.write("apache-spark/pom.xml", "excluded")
+        self.write("spark/target/pom.xml", "excluded")
+        output = io.StringIO()
+        with redirect_stdout(output):
+            cache.input_hashes(self.source)
+        self.assertIn("contrib/delta/native/Cargo.toml", output.getvalue())
+        self.assertIn("dev/ci/images/Dockerfile", output.getvalue())
+        self.assertIn("dev/ci/images/CometCiRepositories.scala", output.getvalue())
+        self.assertIn("dev/ci/images/run-build.sh", output.getvalue())
+        self.assertNotIn("excluded", output.getvalue())
+        self.assertNotIn("apache-spark", output.getvalue())
+        self.assertNotIn("target", output.getvalue())
+        self.write("new-module/pom.xml")
+        updated = io.StringIO()
+        with redirect_stdout(updated):
+            cache.input_hashes(self.source)
+        self.assertNotEqual(output.getvalue(), updated.getvalue())
+
+    def test_shell_scripts_parse(self):
+        for script in DIRECTORY.glob("*.sh"):
+            with self.subTest(script=script.name):
+                subprocess.run(["bash", "-n", str(script)], check=True)
+
+    def run_validator(self, docker_status=0, bad_checksum=False):
+        """Exercise the host driver without Docker or external downloads."""
+        repo = self.root / "repo"
+        scripts = repo / "dev/ci/images"
+        scripts.mkdir(parents=True)
+        for name in ("validate.sh", "fetch-spark.sh"):
+            shutil.copy2(DIRECTORY / name, scripts / name)
+        checksum = hashlib.sha256(b"spark sources").hexdigest()
+        if bad_checksum:
+            checksum = "0" * 64
+        (scripts / "versions.env").write_text(
+            "SPARK_VERSION=4.1.3\nJDK_VERSION=17.0.20.1\n"
+            f"SPARK_COMMIT={'1' * 40}\nSPARK_ARCHIVE_SHA256={checksum}\n"
+        )
+        (repo / "pom.xml").write_text("tracked working source")
+        (repo / "untracked-secret").write_text("must not enter container")
+        temporary = self.root / "tmp"
+        temporary.mkdir()
+        binaries = self.root / "bin"
+        binaries.mkdir()
+        stubs = {
+            "git": "import sys\nassert sys.argv[-2:] == ['ls-files', '-z']\n"
+            "sys.stdout.buffer.write(b'pom.xml\\0')\n",
+            "curl": "import sys\nfrom pathlib import Path\n"
+            "Path(sys.argv[sys.argv.index('--output') + 1]).write_bytes(b'spark sources')\n",
+            "docker": "import json, os, sys, tarfile\nfrom pathlib import Path\n"
+            "args = sys.argv[1:]\n"
+            "mount = args[args.index('--mount') + 1]\n"
+            "source = next(part[4:] for part in mount.split(',') if part.startswith('src='))\n"
+            "with tarfile.open(Path(source) / 'comet.tar.gz') as archive:\n"
+            "    files = archive.getnames()\n"
+            "Path(os.environ['TEST_RECORD']).write_text(json.dumps({'args': args, 'files': files}))\n"
+            "sys.exit(int(os.environ['TEST_DOCKER_STATUS']))\n",
+        }
+        for name, contents in stubs.items():
+            executable = binaries / name
+            executable.write_text("#!/usr/bin/env python3\n" + contents)
+            executable.chmod(0o755)
+        record = self.root / "docker.json"
+        result = subprocess.run(
+            ["bash", str(scripts / "validate.sh"), "ci-image:test"],
+            env={
+                **os.environ,
+                "PATH": str(binaries) + os.pathsep + os.environ["PATH"],
+                "TMPDIR": str(temporary),
+                "TEST_RECORD": str(record),
+                "TEST_DOCKER_STATUS": str(docker_status),
+            },
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            list(temporary.iterdir()), [], "source staging leaked after exit"
+        )
+        return result, json.loads(record.read_text()) if record.exists() else None
+
+    def test_validator_uses_only_sources_and_disables_network(self):
+        result, record = self.run_validator()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(record["files"], ["pom.xml"])
+        self.assertIn("--network=none", record["args"])
+        self.assertIn("HOME=/github/home", record["args"])
+        self.assertIn("/__w", record["args"])
+        self.assertIn("ci-image:test", record["args"])
+        mounts = [item for item in record["args"] if item.startswith("type=bind,")]
+        self.assertEqual(len(mounts), 1)
+        self.assertTrue(mounts[0].endswith(",dst=/inputs,readonly"))
+
+    def test_validator_propagates_failure_and_cleans_sources(self):
+        result, record = self.run_validator(docker_status=7)
+        self.assertEqual(result.returncode, 7)
+        self.assertIsNotNone(record)
+
+    def test_validator_rejects_wrong_spark_archive_before_docker(self):
+        result, record = self.run_validator(bad_checksum=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIsNone(record)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/dev/ci/images/validate-container.sh
+++ b/dev/ci/images/validate-container.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+source /opt/comet-ci/bin/versions.env
+# The host supplies source archives only, not previous target/ or ~/.m2 output.
+test ! -e native
+tar -xzf /inputs/comet.tar.gz
+mkdir apache-spark
+tar -xzf /inputs/spark.tar.gz -C apache-spark --strip-components=1
+git -C apache-spark apply "$PWD/dev/diffs/$SPARK_VERSION.diff"
+bash /opt/comet-ci/bin/run-build.sh offline

--- a/dev/ci/images/validate.sh
+++ b/dev/ci/images/validate.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Host-side driver. Only source archives enter the fresh offline container.
+set -euo pipefail
+script_dir=$(cd "$(dirname "$0")" && pwd)
+repo_dir=$(cd "$script_dir/../../.." && pwd)
+source "$script_dir/versions.env"
+default_image="comet-ci:spark-$SPARK_VERSION-jdk${JDK_VERSION%%.*}"
+image=${1:-$default_image}
+inputs=$(mktemp -d)
+trap 'rm -rf "$inputs"' EXIT
+bash "$script_dir/fetch-spark.sh" "$inputs/spark.tar.gz"
+# Read tracked working files, including unstaged edits, but never host caches.
+# Stage newly added source files with git add before running this script.
+git -C "$repo_dir" ls-files -z | \
+  tar -C "$repo_dir" --null -T - -czf "$inputs/comet.tar.gz"
+exec_args=(
+  --rm --platform linux/amd64 --network=none
+  --mount "type=bind,src=$inputs,dst=/inputs,readonly"
+  # Reproduce GitHub's empty runtime home and workspace mounts.
+  --tmpfs /github/home
+  --volume /__w
+  --env "CARGO_BUILD_JOBS=${COMET_CI_BUILD_JOBS:-4}"
+  --env SPARK_LOCAL_IP=127.0.0.1
+  --workdir /__w/comet/comet
+)
+# docker exec/container steps use /github/home even though Java's user.home
+# differs. Supply the container environment without changing the host's HOME.
+docker run "${exec_args[@]}" --env HOME=/github/home "$image" \
+  bash /opt/comet-ci/bin/validate-container.sh

--- a/dev/ci/images/versions.env
+++ b/dev/ci/images/versions.env
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# One Linux/amd64 pilot. Base-image digests are pinned in Dockerfile.
+# Update the matching pins together and rerun validate.sh.
+RUST_VERSION=1.98.0
+JDK_VERSION=17.0.20.1
+CLANG_PACKAGE_VERSION=1:19.0-63
+CLANG19_PACKAGE_VERSION=1:19.1.7-3+b1
+PROTOC_PACKAGE_VERSION=3.21.12-11+deb13u1
+MAVEN_VERSION=3.9.6
+SBT_VERSION=1.11.7
+SBT_LAUNCH_SHA256=f92a2095ac75008764fe3b2b793ffe624c4fbef5bfd9b0022e4bc2daf668c651
+SPARK_VERSION=4.1.3
+SPARK_SHORT_VERSION=4.1
+SPARK_COMMIT=77bbf77e86ad48f58b5dfbc6ac882b3e70cf1989
+SPARK_ARCHIVE_SHA256=04f370cda5985f19e64a39d063cc7d9da3ed99241777806fd09bd120258c355e


### PR DESCRIPTION
## Which issue does this PR close?

Part 1 of #5490. This PR does not close the issue; image publication and CI adoption will follow separately.

## Rationale for this change

Linux Spark CI jobs repeatedly install toolchains and download the same dependencies. Before switching those jobs to a prebuilt image, we need a pinned toolchain recipe and a check that its dependency caches are sufficient without carrying forward Comet binaries or previous build outputs.

## What changes are included in this PR?

- Add a Linux/amd64 pilot for Spark 4.1.3 and Zulu JDK 17, with pinned base-image digests, tool versions, Spark sources, and SBT launcher checksums.
- Build Comet and Spark in an intermediate stage, then export third-party Cargo, Maven, Coursier, SBT, and Ivy caches under `/opt/comet-ci`. The final image starts from the toolchain stage and excludes Comet artifacts, SNAPSHOTs, local Maven installations, credentials, and workspace build outputs.
- Add a fresh-source validator that disables networking, mounts an empty runtime home and workspace, checks dependency fingerprints, rebuilds native and JVM Comet, compiles Catalyst/SQL/Hive tests, and runs two Spark smoke suites.
- Document the build and cache contract, and add dependency-free regression tests. Existing CI workflows remain unchanged.

Publishing, scheduled refreshes, digest-based adoption, rollback, and performance measurements are outside this PR.

## How are these changes tested?

- `python3 dev/ci/images/test_image.py`: 21 tests passed.
- Complete image build passed, including native compilation, the full Maven reactor (`-DskipTests`, with test classes compiled), Catalyst/SQL/Hive test compilation, and 104 Spark smoke tests: 42 in `LiteralExpressionSuite` and 62 in `MathFunctionsSuite`.
- `COMET_CI_BUILD_JOBS=16 bash dev/ci/images/validate.sh`: passed the same builds and all 104 smoke tests in a fresh container with `--network=none`, an empty runtime home, and no host dependency-cache mounts.
- Toolchain checks passed with networking disabled. ShellCheck, Ruff, Prettier, and Maven RAT checks passed.
