### PR TITLE
docs: update stale interval multiplication note in expressions.md

### DIFF
--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -414,7 +414,7 @@ The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `deci
 | Function | Status | Implementation | Notes |
 | --- | --- | --- | --- |
 | `%` | ✅ | Native |  |
-| `*` | ✅ | Native | Interval multiplication falls back |
+| `*` | ✅ | Native | DayTime interval multiplication routes through the JVM codegen dispatcher; YearMonth and Calendar interval multiplication fall back |
 | `+` | ✅ | Native |  |
 | `-` | ✅ | Native |  |
 | `/` | ✅ | Native |  |


### PR DESCRIPTION
## Which issue does this PR close?

N/A — small documentation correction.

## Rationale for this change

The `*` row in the math_funcs table of `docs/source/user-guide/latest/expressions.md` still says "Interval multiplication falls back". This has been stale since #4900: `MultiplyDTInterval` routes through the JVM codegen dispatcher (`CometMultiplyDTInterval extends CometCodegenDispatch` in `spark/src/main/scala/org/apache/comet/serde/datetime.scala`, registered in `QueryPlanSerde`). Only YearMonth (`MultiplyYMInterval`) and Calendar interval multiplication still fall back.

## What changes are included in this PR?

Update the note to mirror the wording the `/` row uses for division (#4901): "DayTime interval multiplication routes through the JVM codegen dispatcher; YearMonth and Calendar interval multiplication fall back".

Only the Implementation column of this table is auto-generated by `GenerateDocs.scala`; the Notes column is hand-maintained, so a direct edit is the correct fix.

## How are these changes tested?

Documentation-only change; verified the serde mappings in `QueryPlanSerde.scala` on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
