### PR TITLE
chore: bench additional math function

### DIFF
--- a/native/spark-expr/Cargo.toml
+++ b/native/spark-expr/Cargo.toml
@@ -238,3 +238,11 @@ harness = false
 [[bench]]
 name = "abs"
 harness = false
+
+[[bench]]
+name = "modulo"
+harness = false
+
+[[bench]]
+name = "negative"
+harness = false

--- a/native/spark-expr/benches/modulo.rs
+++ b/native/spark-expr/benches/modulo.rs
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use datafusion::physical_plan::ColumnarValue;
+use datafusion_comet_spark_expr::spark_modulo;
+use std::hint::black_box;
+use std::sync::Arc;
+
+#[path = "common/mod.rs"]
+mod common;
+use common::{i64_array, NULL_RATIOS, ROW_COUNTS};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("spark_modulo");
+    for rows in ROW_COUNTS {
+        // Divisor fully populated and non-zero so the benchmark measures the modulo, not the
+        // divide-by-zero null path.
+        let divisor = i64_array(rows, 0.0, |i| (i as i64 % 7) + 1);
+        for (null_ratio, tag) in NULL_RATIOS {
+            let dividend = i64_array(rows, null_ratio, |i| i as i64 % 1000);
+            let args = vec![
+                ColumnarValue::Array(dividend),
+                ColumnarValue::Array(Arc::clone(&divisor)),
+            ];
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!("{rows}/{tag}")),
+                &args,
+                |b, args| b.iter(|| black_box(spark_modulo(black_box(args), false).unwrap())),
+            );
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/native/spark-expr/benches/negative.rs
+++ b/native/spark-expr/benches/negative.rs
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::RecordBatch;
+use arrow::datatypes::{DataType, Field, Schema};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use datafusion::physical_expr::expressions::Column;
+use datafusion_comet_spark_expr::create_negate_expr;
+use std::hint::black_box;
+use std::sync::Arc;
+
+#[path = "common/mod.rs"]
+mod common;
+use common::{i64_array, NULL_RATIOS, ROW_COUNTS};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, true)]));
+    let expr = create_negate_expr(Arc::new(Column::new("a", 0)), false).unwrap();
+
+    let mut group = c.benchmark_group("negative");
+    for rows in ROW_COUNTS {
+        for (null_ratio, tag) in NULL_RATIOS {
+            let batch = RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![i64_array(rows, null_ratio, |i| i as i64 % 1000)],
+            )
+            .unwrap();
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!("{rows}/{tag}")),
+                &batch,
+                |b, batch| b.iter(|| black_box(expr.evaluate(black_box(batch)).unwrap())),
+            );
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/native/spark-expr/src/lib.rs
+++ b/native/spark-expr/src/lib.rs
@@ -86,9 +86,9 @@ pub use json_funcs::{FromJson, ToJson};
 pub use math_funcs::{
     abs, checked_add, checked_div, checked_mul, checked_sub, create_modulo_expr,
     create_negate_expr, spark_ceil, spark_decimal_div, spark_decimal_integral_div, spark_floor,
-    spark_log, spark_make_decimal, spark_pow, spark_round, spark_unhex, spark_unscaled_value,
-    CheckOverflow, DecimalRescaleCheckOverflow, NegativeExpr, NormalizeNaNAndZero,
-    WideDecimalBinaryExpr, WideDecimalOp,
+    spark_log, spark_make_decimal, spark_modulo, spark_pow, spark_round, spark_unhex,
+    spark_unscaled_value, CheckOverflow, DecimalRescaleCheckOverflow, NegativeExpr,
+    NormalizeNaNAndZero, WideDecimalBinaryExpr, WideDecimalOp,
 };
 pub use query_context::{create_query_context_map, QueryContext, QueryContextMap};
 pub use string_funcs::*;

--- a/native/spark-expr/src/math_funcs/mod.rs
+++ b/native/spark-expr/src/math_funcs/mod.rs
@@ -38,7 +38,7 @@ pub use div::spark_decimal_integral_div;
 pub use floor::spark_floor;
 pub use internal::*;
 pub use log::spark_log;
-pub use modulo_expr::create_modulo_expr;
+pub use modulo_expr::{create_modulo_expr, spark_modulo};
 pub use negative::{create_negate_expr, NegativeExpr};
 pub use pow::spark_pow;
 pub use round::spark_round;


### PR DESCRIPTION
## Which issue does this PR close?
Part of #5396
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

## Rationale for this change
Add benches/modulo.rs benches/negative.rs. With this, all native Comet math_funcs kernels have criterion coverage

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## How are these changes tested?
Benchmark-only, no behavior change

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
