### PR TITLE
feat: add raw Celeborn native shuffle reader (7/n)

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -330,6 +330,7 @@ jobs:
               org.apache.comet.shuffle.CelebornShufflePartitionPusherSuite
               org.apache.spark.sql.comet.execution.shuffle.CometCelebornShuffleManagerSuite
               org.apache.spark.sql.comet.execution.shuffle.CometCelebornNativeShuffleWriterSuite
+              org.apache.spark.sql.comet.execution.shuffle.CometCelebornShuffleReaderSuite
               org.apache.spark.sql.comet.execution.shuffle.CometNativeShuffleInputRDDSuite
               org.apache.comet.exec.CometShuffleEncryptionSuite
               org.apache.comet.exec.CometShuffleManagerSuite

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -146,6 +146,7 @@ jobs:
               org.apache.comet.shuffle.CelebornShufflePartitionPusherSuite
               org.apache.spark.sql.comet.execution.shuffle.CometCelebornShuffleManagerSuite
               org.apache.spark.sql.comet.execution.shuffle.CometCelebornNativeShuffleWriterSuite
+              org.apache.spark.sql.comet.execution.shuffle.CometCelebornShuffleReaderSuite
               org.apache.spark.sql.comet.execution.shuffle.CometNativeShuffleInputRDDSuite
               org.apache.comet.exec.CometShuffleEncryptionSuite
               org.apache.comet.exec.CometShuffleManagerSuite

--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -41,7 +41,7 @@ use datafusion::{
     physical_plan::{display::DisplayableExecutionPlan, SendableRecordBatchStream},
     prelude::{SessionConfig, SessionContext},
 };
-use datafusion_comet_proto::spark_operator::Operator;
+use datafusion_comet_proto::spark_operator::{Operator, ShuffleScan};
 use datafusion_comet_spark_expr::url_funcs::{CometParseUrl, CometTryParseUrl};
 use datafusion_spark::function::array::array_contains::SparkArrayContains;
 use datafusion_spark::function::array::repeat::SparkArrayRepeat;
@@ -89,6 +89,7 @@ use jni::{
     Env, EnvUnowned,
 };
 use parking_lot::Mutex;
+use prost::Message;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -100,7 +101,9 @@ use crate::execution::memory_pools::{
     create_memory_pool, handle_task_shared_pool_release, parse_memory_pool_config, MemoryPoolConfig,
 };
 use crate::execution::operators::{ScanExec, ShuffleScanExec};
-use crate::execution::shuffle::{read_ipc_compressed, CompressionCodec};
+use crate::execution::shuffle::{
+    read_ipc_compressed, read_ipc_compressed_validated, validate_remote_schema, CompressionCodec,
+};
 use crate::execution::spark_plan::SparkPlan;
 
 use crate::execution::tracing::{
@@ -1249,13 +1252,65 @@ pub unsafe extern "system" fn Java_org_apache_comet_Native_decodeShuffleBlock(
 ) -> jlong {
     try_unwrap_or_throw(&e, |env| {
         with_trace("decodeShuffleBlock", tracing_enabled != JNI_FALSE, || {
-            let raw_pointer = env.get_direct_buffer_address(&byte_buffer)?;
-            let length = length as usize;
-            let slice: &[u8] = unsafe { std::slice::from_raw_parts(raw_pointer, length) };
-            let batch = read_ipc_compressed(slice)?;
-            prepare_output(env, array_addrs, schema_addrs, batch, false)
+            decode_shuffle_block(env, byte_buffer, length, array_addrs, schema_addrs, None)
         })
     })
+}
+
+#[no_mangle]
+/// Decode a remote native shuffle block with Arrow array and logical type validation enabled.
+/// # Safety
+/// This function is inherently unsafe since it deals with raw pointers passed from JNI.
+pub unsafe extern "system" fn Java_org_apache_comet_Native_decodeShuffleBlockWithValidation(
+    e: EnvUnowned,
+    _class: JClass,
+    byte_buffer: JByteBuffer,
+    length: jint,
+    array_addrs: JLongArray,
+    schema_addrs: JLongArray,
+    tracing_enabled: jboolean,
+    expected_schema: JByteArray,
+) -> jlong {
+    try_unwrap_or_throw(&e, |env| {
+        with_trace("decodeShuffleBlock", tracing_enabled != JNI_FALSE, || {
+            let bytes = env.convert_byte_array(expected_schema)?;
+            let schema = ShuffleScan::decode(bytes.as_slice()).map_err(|error| {
+                CometError::Internal(format!("Invalid expected remote shuffle schema: {error}"))
+            })?;
+            let expected_types: Vec<_> = schema.fields.iter().map(to_arrow_datatype).collect();
+            decode_shuffle_block(
+                env,
+                byte_buffer,
+                length,
+                array_addrs,
+                schema_addrs,
+                Some(&expected_types),
+            )
+        })
+    })
+}
+
+fn decode_shuffle_block(
+    env: &mut Env,
+    byte_buffer: JByteBuffer,
+    length: jint,
+    array_addrs: JLongArray,
+    schema_addrs: JLongArray,
+    expected_types: Option<&[ArrowDataType]>,
+) -> CometResult<jlong> {
+    let raw_pointer = env.get_direct_buffer_address(&byte_buffer)?;
+    let length = length as usize;
+    let slice: &[u8] = unsafe { std::slice::from_raw_parts(raw_pointer, length) };
+    let batch = if let Some(expected_types) = expected_types {
+        let batch = read_ipc_compressed_validated(slice)?;
+        // Reject incompatible remote schemas before exporting arrays to the JVM. Casting or
+        // importing first can silently change values or bypass remote fetch-failure reporting.
+        validate_remote_schema(&batch, expected_types)?;
+        batch
+    } else {
+        read_ipc_compressed(slice)?
+    };
+    prepare_output(env, array_addrs, schema_addrs, batch, false)
 }
 
 #[no_mangle]

--- a/native/core/src/execution/operators/shuffle_scan.rs
+++ b/native/core/src/execution/operators/shuffle_scan.rs
@@ -18,11 +18,13 @@
 use crate::{
     errors::CometError,
     execution::{
-        operators::ExecutionError, planner::TEST_EXEC_CONTEXT_ID, shuffle::ipc::read_ipc_compressed,
+        operators::ExecutionError,
+        planner::TEST_EXEC_CONTEXT_ID,
+        shuffle::{read_ipc_compressed, read_ipc_compressed_validated, validate_remote_schema},
     },
     jvm_bridge::{jni_call, JVMClasses},
 };
-use arrow::array::ArrayRef;
+use arrow::array::{ArrayRef, RecordBatch};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::common::Result as DataFusionResult;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
@@ -68,6 +70,8 @@ pub struct ShuffleScanExec {
     baseline_metrics: BaselineMetrics,
     /// Time spent decoding compressed shuffle blocks.
     decode_time: Time,
+    /// Remote inputs require Arrow array and logical schema validation; queried once at construction.
+    requires_validation: bool,
 }
 
 impl ShuffleScanExec {
@@ -76,6 +80,16 @@ impl ShuffleScanExec {
         input_source: Option<Arc<Global<JObject<'static>>>>,
         data_types: Vec<DataType>,
     ) -> Result<Self, CometError> {
+        let requires_validation = if exec_context_id == TEST_EXEC_CONTEXT_ID {
+            false
+        } else if let Some(input) = &input_source {
+            JVMClasses::with_env(|env| unsafe {
+                jni_call!(env,
+                    comet_shuffle_block_iterator(input.as_obj()).requires_validation() -> bool)
+            })?
+        } else {
+            false
+        };
         let metrics_set = ExecutionPlanMetricsSet::default();
         let baseline_metrics = BaselineMetrics::new(&metrics_set, 0);
         let decode_time = MetricBuilder::new(&metrics_set).subset_time("decode_time", 0);
@@ -99,6 +113,7 @@ impl ShuffleScanExec {
             baseline_metrics,
             schema,
             decode_time,
+            requires_validation,
         })
     }
 
@@ -123,6 +138,7 @@ impl ShuffleScanExec {
                 self.input_source.as_ref().unwrap().as_obj(),
                 &self.data_types,
                 &self.decode_time,
+                self.requires_validation,
             )?;
             *current_batch = Some(next_batch);
         }
@@ -138,6 +154,7 @@ impl ShuffleScanExec {
         iter: &JObject,
         data_types: &[DataType],
         decode_time: &Time,
+        requires_validation: bool,
     ) -> Result<InputBatch, CometError> {
         if exec_context_id == TEST_EXEC_CONTEXT_ID {
             return Ok(InputBatch::EOF);
@@ -173,7 +190,21 @@ impl ShuffleScanExec {
 
             // Decode the compressed IPC data
             let mut timer = decode_time.timer();
-            let batch = read_ipc_compressed(slice)?;
+            let batch = match decode_shuffle_batch(slice, data_types, requires_validation) {
+                Ok(batch) => batch,
+                Err(failure) => {
+                    // Remote inputs must invalidate the failed shuffle generation even when
+                    // fetching bytes succeeded and only IPC/codec decoding or logical schema
+                    // validation detects the corruption. JNI preserves FetchFailedException.
+                    // Local inputs leave this callback as a no-op and keep the native error.
+                    let message = env.new_string(failure.to_string())?;
+                    unsafe {
+                        jni_call!(env,
+                            comet_shuffle_block_iterator(iter).on_decode_failure(&message) -> ())?;
+                    }
+                    return Err(failure.into());
+                }
+            };
             timer.stop();
 
             let num_rows = batch.num_rows();
@@ -188,17 +219,35 @@ impl ShuffleScanExec {
                 .map(|col| unpack_dictionary(col))
                 .collect();
 
-            debug_assert_eq!(
-                columns.len(),
-                data_types.len(),
-                "Shuffle block column count mismatch: got {} but expected {}",
-                columns.len(),
-                data_types.len()
-            );
-
             Ok(InputBatch::new(columns, Some(num_rows)))
         })
     }
+}
+
+fn decode_shuffle_batch(
+    bytes: &[u8],
+    expected_types: &[DataType],
+    requires_validation: bool,
+) -> DataFusionResult<RecordBatch> {
+    if requires_validation {
+        let batch = read_ipc_compressed_validated(bytes)?;
+        // Validate before unpack_dictionary or cast_and_stamp_schema can hide an incompatible
+        // wire type by changing values. Keep failures inside get_next's recovery callback.
+        validate_remote_schema(&batch, expected_types)?;
+        Ok(batch)
+    } else {
+        check_column_count(read_ipc_compressed(bytes)?, expected_types.len())
+    }
+}
+
+fn check_column_count(batch: RecordBatch, expected: usize) -> DataFusionResult<RecordBatch> {
+    if batch.num_columns() != expected {
+        return Err(datafusion::common::DataFusionError::Execution(format!(
+            "Shuffle block column count mismatch: got {} but expected {expected}",
+            batch.num_columns()
+        )));
+    }
+    Ok(batch)
 }
 
 /// If `array` is dictionary-encoded, cast it to the value type. Otherwise return as-is.
@@ -350,7 +399,7 @@ impl RecordBatchStream for ShuffleScanStream {
 #[cfg(test)]
 mod tests {
     use crate::execution::shuffle::{CompressionCodec, ShuffleBlockWriter};
-    use arrow::array::{Int32Array, StringArray};
+    use arrow::array::{Int32Array, RecordBatchOptions, StringArray, UInt32Array};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::ipc::writer::CompressionContext;
     use arrow::record_batch::RecordBatch;
@@ -359,6 +408,107 @@ mod tests {
     use std::sync::Arc;
 
     use crate::execution::shuffle::ipc::read_ipc_compressed;
+
+    fn uncompressed_shuffle_payload(batch: &RecordBatch) -> Vec<u8> {
+        let writer = ShuffleBlockWriter::try_new(&batch.schema(), CompressionCodec::None).unwrap();
+        let mut output = Cursor::new(Vec::new());
+        writer
+            .write_batch(
+                batch,
+                &mut output,
+                &mut CompressionContext::default(),
+                &Time::new(),
+            )
+            .unwrap();
+        // The iterator has already checked the 8-byte frame length and 8-byte field count.
+        output.into_inner()[16..].to_vec()
+    }
+
+    #[test]
+    fn remote_shuffle_rejects_schema_signedness_flip_before_casting() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![-1]))]).unwrap();
+        let mut payload = uncompressed_shuffle_payload(&batch);
+
+        // Corrupt only the schema's signed flag, leaving the field count, row count and all
+        // value buffers valid. The same -1 bytes now represent UINT_MAX, which a later cast to
+        // the Spark IntegerType would silently turn into null.
+        let schema_start = 4 + 8; // codec, then IPC continuation marker and metadata length
+        let signed_flag = {
+            let message = arrow::ipc::root_as_message(&payload[schema_start..]).unwrap();
+            let integer = message
+                .header_as_schema()
+                .unwrap()
+                .fields()
+                .unwrap()
+                .get(0)
+                .type_as_int()
+                .unwrap();
+            assert!(integer.is_signed());
+            let offset = integer._tab.vtable().get(arrow::ipc::Int::VT_IS_SIGNED);
+            assert_ne!(offset, 0);
+            schema_start + integer._tab.loc() + usize::from(offset)
+        };
+        payload[signed_flag] = 0;
+
+        let decoded = super::read_ipc_compressed_validated(&payload).unwrap();
+        assert_eq!(decoded.num_columns(), 1);
+        assert_eq!(decoded.column(0).data_type(), &DataType::UInt32);
+        assert_eq!(
+            decoded
+                .column(0)
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .unwrap()
+                .values(),
+            &[u32::MAX]
+        );
+        let error = super::decode_shuffle_batch(&payload, &[DataType::Int32], true)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("type mismatch at column 0"), "{error}");
+        assert!(error.contains("UInt32"), "{error}");
+        assert!(error.contains("Int32"), "{error}");
+
+        // The new logical validation is confined to remote inputs.
+        assert_eq!(
+            super::decode_shuffle_batch(&payload, &[DataType::Int32], false)
+                .unwrap()
+                .column(0)
+                .data_type(),
+            &DataType::UInt32
+        );
+    }
+
+    #[test]
+    fn remote_shuffle_preserves_rows_for_zero_column_batches() {
+        let batch = RecordBatch::try_new_with_options(
+            Arc::new(Schema::empty()),
+            vec![],
+            &RecordBatchOptions::new().with_row_count(Some(3)),
+        )
+        .unwrap();
+        let payload = uncompressed_shuffle_payload(&batch);
+        let decoded = super::decode_shuffle_batch(&payload, &[], true).unwrap();
+        assert_eq!(decoded.num_columns(), 0);
+        assert_eq!(decoded.num_rows(), 3);
+    }
+
+    #[test]
+    fn test_shuffle_column_count_mismatch_returns_error() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3]))]).unwrap();
+
+        assert!(super::check_column_count(batch.clone(), 1).is_ok());
+        for expected in [0, 2] {
+            let error = super::check_column_count(batch.clone(), expected)
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("column count mismatch"), "{error}");
+        }
+    }
 
     #[test]
     #[cfg_attr(miri, ignore)] // Miri cannot call FFI functions (zstd)
@@ -464,8 +614,9 @@ mod tests {
         let bytes = buf.into_inner();
         let body = &bytes[16..];
 
-        // Confirm that read_ipc_compressed returns dictionary-encoded arrays
-        let decoded = read_ipc_compressed(body).unwrap();
+        // Remote schema validation must preserve the writer's dictionary representation.
+        let decoded =
+            super::decode_shuffle_batch(body, &[DataType::Int32, DataType::Utf8], true).unwrap();
         assert!(
             matches!(decoded.column(1).data_type(), DataType::Dictionary(_, _)),
             "Expected dictionary-encoded column from IPC, got {:?}",
@@ -536,13 +687,17 @@ mod tests {
         // declared the `flag` child nullable.
         let block_column = list_of_struct(false);
         let declared = list_of_struct_type(true);
+        let block = RecordBatch::try_from_iter([("payload", block_column)]).unwrap();
+        let payload = uncompressed_shuffle_payload(&block);
+        let decoded =
+            super::decode_shuffle_batch(&payload, std::slice::from_ref(&declared), true).unwrap();
         let mut scan = ShuffleScanExec::new(
             super::super::super::planner::TEST_EXEC_CONTEXT_ID,
             None,
             vec![declared.clone()],
         )
         .unwrap();
-        scan.set_input_batch(InputBatch::new(vec![block_column], Some(2)));
+        scan.set_input_batch(InputBatch::new(decoded.columns().to_vec(), Some(2)));
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {

--- a/native/jni-bridge/src/shuffle_block_iterator.rs
+++ b/native/jni-bridge/src/shuffle_block_iterator.rs
@@ -34,6 +34,10 @@ pub struct CometShuffleBlockIterator<'a> {
     pub method_get_buffer_ret: ReturnType,
     pub method_get_current_block_length: JMethodID,
     pub method_get_current_block_length_ret: ReturnType,
+    pub method_on_decode_failure: JMethodID,
+    pub method_on_decode_failure_ret: ReturnType,
+    pub method_requires_validation: JMethodID,
+    pub method_requires_validation_ret: ReturnType,
 }
 
 impl<'a> CometShuffleBlockIterator<'a> {
@@ -62,6 +66,18 @@ impl<'a> CometShuffleBlockIterator<'a> {
                 jni::jni_sig!("()I"),
             )?,
             method_get_current_block_length_ret: ReturnType::Primitive(Primitive::Int),
+            method_on_decode_failure: env.get_method_id(
+                JNIString::new(Self::JVM_CLASS),
+                jni::jni_str!("onDecodeFailure"),
+                jni::jni_sig!("(Ljava/lang/String;)V"),
+            )?,
+            method_on_decode_failure_ret: ReturnType::Primitive(Primitive::Void),
+            method_requires_validation: env.get_method_id(
+                JNIString::new(Self::JVM_CLASS),
+                jni::jni_str!("requiresValidation"),
+                jni::jni_sig!("()Z"),
+            )?,
+            method_requires_validation_ret: ReturnType::Primitive(Primitive::Boolean),
         })
     }
 }

--- a/native/shuffle/src/ipc.rs
+++ b/native/shuffle/src/ipc.rs
@@ -19,34 +19,252 @@ use arrow::array::RecordBatch;
 use arrow::ipc::reader::StreamReader;
 use datafusion::common::DataFusionError;
 use datafusion::error::Result;
+use std::io::{Error, ErrorKind, Read};
 
+/// Decode trusted local Comet output without revalidating every Arrow array value or offset.
 pub fn read_ipc_compressed(bytes: &[u8]) -> Result<RecordBatch> {
-    match &bytes[0..4] {
-        b"SNAP" => {
-            let decoder = snap::read::FrameDecoder::new(&bytes[4..]);
-            let mut reader =
-                unsafe { StreamReader::try_new(decoder, None)?.with_skip_validation(true) };
-            reader.next().unwrap().map_err(|e| e.into())
+    read_ipc_compressed_impl(bytes, false)
+}
+
+/// Decode remotely fetched Comet output, including Arrow buffer and offset validation.
+pub fn read_ipc_compressed_validated(bytes: &[u8]) -> Result<RecordBatch> {
+    read_ipc_compressed_impl(bytes, true)
+}
+
+fn read_ipc_compressed_impl(bytes: &[u8], validate: bool) -> Result<RecordBatch> {
+    let codec = bytes.get(..4).ok_or_else(|| {
+        DataFusionError::Execution("Failed to decode batch: truncated compression codec".to_owned())
+    })?;
+    let mut encoded = &bytes[4..];
+    let batch = match codec {
+        b"SNAP" => read_single_batch(snap::read::FrameDecoder::new(&mut encoded), validate)?,
+        b"LZ4_" => read_single_batch(
+            lz4_flex::frame::FrameDecoder::new(RequireLz4EndMark(&mut encoded)),
+            validate,
+        )?,
+        // The slice already implements BufRead. Adding another BufReader would let read-ahead
+        // conceal compressed bytes left over after the decoder reaches its end marker.
+        b"ZSTD" => read_single_batch(zstd::Decoder::with_buffer(&mut encoded)?, validate)?,
+        b"NONE" => read_single_batch(&mut encoded, validate)?,
+        other => {
+            return Err(DataFusionError::Execution(format!(
+                "Failed to decode batch: invalid compression codec: {other:?}"
+            )))
         }
-        b"LZ4_" => {
-            let decoder = lz4_flex::frame::FrameDecoder::new(&bytes[4..]);
-            let mut reader =
-                unsafe { StreamReader::try_new(decoder, None)?.with_skip_validation(true) };
-            reader.next().unwrap().map_err(|e| e.into())
+    };
+    // LZ4 returns EOF at the end of one compressed frame without consuming the next one. Check
+    // the encoded source as well as the decoded IPC tail so an oversized outer frame cannot
+    // silently swallow another native frame's bytes.
+    if !encoded.is_empty() {
+        return Err(DataFusionError::Execution(
+            "Failed to decode batch: trailing data after compressed stream".to_owned(),
+        ));
+    }
+    Ok(batch)
+}
+
+// lz4_flex treats physical EOF (including a partial block header) as a clean end of frame.
+// Comet always writes an explicit LZ4 EndMark, so a decoder trying to read past the supplied
+// bytes has encountered a truncated frame. InvalidData is deliberate: UnexpectedEof is swallowed
+// by lz4_flex::frame::FrameDecoder::read_block.
+struct RequireLz4EndMark<R>(R);
+
+impl<R: Read> Read for RequireLz4EndMark<R> {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        let count = self.0.read(buffer)?;
+        if count == 0 && !buffer.is_empty() {
+            Err(Error::new(
+                ErrorKind::InvalidData,
+                "Failed to decode batch: truncated LZ4 shuffle frame",
+            ))
+        } else {
+            Ok(count)
         }
-        b"ZSTD" => {
-            let decoder = zstd::Decoder::new(&bytes[4..])?;
-            let mut reader =
-                unsafe { StreamReader::try_new(decoder, None)?.with_skip_validation(true) };
-            reader.next().unwrap().map_err(|e| e.into())
+    }
+}
+
+fn read_single_batch<R: Read>(input: R, validate: bool) -> Result<RecordBatch> {
+    let reader = StreamReader::try_new(input, None)?;
+    let mut reader = if validate {
+        // Remote data must not escape as unchecked arrays and fail later in a native operator.
+        reader
+    } else {
+        // Preserve the existing local-shuffle fast path for trusted Comet-written arrays.
+        unsafe { reader.with_skip_validation(true) }
+    };
+    let batch = reader.next().transpose()?.ok_or_else(|| {
+        DataFusionError::Execution("Failed to decode batch: empty IPC stream".to_owned())
+    })?;
+
+    // Each Comet frame contains one complete IPC stream with exactly one record batch.
+    // Stopping after that batch would skip codec footer/checksum validation and could silently
+    // discard further frames swallowed by a corrupt outer length prefix.
+    if reader.next().transpose()?.is_some() {
+        return Err(DataFusionError::Execution(
+            "Failed to decode batch: multiple record batches in one shuffle frame".to_owned(),
+        ));
+    }
+    if reader.get_mut().read(&mut [0])? != 0 {
+        return Err(DataFusionError::Execution(
+            "Failed to decode batch: trailing data after IPC stream".to_owned(),
+        ));
+    }
+    Ok(batch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{read_ipc_compressed, read_ipc_compressed_validated};
+    use arrow::array::{Int32Array, RecordBatch, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::ipc::writer::StreamWriter;
+    use std::io::Write;
+    use std::sync::Arc;
+
+    fn ipc_stream(batch_count: usize) -> Vec<u8> {
+        let schema = Arc::new(Schema::new(vec![Field::new("n", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let mut bytes = Vec::new();
+        let mut writer = StreamWriter::try_new(&mut bytes, &schema).unwrap();
+        for _ in 0..batch_count {
+            writer.write(&batch).unwrap();
         }
-        b"NONE" => {
-            let mut reader =
-                unsafe { StreamReader::try_new(&bytes[4..], None)?.with_skip_validation(true) };
-            reader.next().unwrap().map_err(|e| e.into())
+        writer.finish().unwrap();
+        bytes
+    }
+
+    fn encode(codec: &[u8; 4], payload: &[u8]) -> Vec<u8> {
+        let mut bytes = codec.to_vec();
+        match codec {
+            b"NONE" => bytes.extend_from_slice(payload),
+            b"SNAP" => {
+                let mut writer = snap::write::FrameEncoder::new(&mut bytes);
+                writer.write_all(payload).unwrap();
+                writer.into_inner().unwrap();
+            }
+            b"LZ4_" => {
+                let mut writer = lz4_flex::frame::FrameEncoder::new(&mut bytes);
+                writer.write_all(payload).unwrap();
+                writer.finish().unwrap();
+            }
+            b"ZSTD" => {
+                let mut writer = zstd::Encoder::new(&mut bytes, 1).unwrap();
+                writer.write_all(payload).unwrap();
+                writer.finish().unwrap();
+            }
+            _ => unreachable!(),
         }
-        other => Err(DataFusionError::Execution(format!(
-            "Failed to decode batch: invalid compression codec: {other:?}"
-        ))),
+        bytes
+    }
+
+    #[test]
+    fn malformed_codec_prefix_returns_error() {
+        for prefix in [&b""[..], b"N", b"NO", b"NON", b"BAD!"] {
+            assert!(read_ipc_compressed(prefix).is_err());
+            assert!(read_ipc_compressed_validated(prefix).is_err());
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Miri cannot call Zstd's C FFI.
+    fn empty_or_multiple_batch_stream_returns_error() {
+        for codec in [b"NONE", b"SNAP", b"LZ4_", b"ZSTD"] {
+            for batch_count in [0, 2] {
+                let error = read_ipc_compressed(&encode(codec, &ipc_stream(batch_count)))
+                    .unwrap_err()
+                    .to_string();
+                assert!(
+                    error.contains(if batch_count == 0 {
+                        "empty IPC stream"
+                    } else {
+                        "multiple record batches"
+                    }),
+                    "{codec:?}: {error}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Miri cannot call Zstd's C FFI.
+    fn trailing_data_after_ipc_stream_returns_error() {
+        let mut payload = ipc_stream(1);
+        payload.extend_from_slice(b"another shuffle frame");
+        for codec in [b"NONE", b"SNAP", b"LZ4_", b"ZSTD"] {
+            let error = read_ipc_compressed(&encode(codec, &payload))
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("trailing data"), "{codec:?}: {error}");
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Miri cannot call Zstd's C FFI.
+    fn trailing_data_after_compressed_stream_returns_error() {
+        for codec in [b"NONE", b"SNAP", b"LZ4_", b"ZSTD"] {
+            let mut frame = encode(codec, &ipc_stream(1));
+            frame.extend_from_slice(&20_u64.to_le_bytes());
+            frame.extend_from_slice(b"another native frame");
+            assert!(read_ipc_compressed(&frame).is_err(), "{codec:?}");
+        }
+    }
+
+    #[test]
+    fn truncated_lz4_end_mark_returns_error() {
+        let frame = encode(b"LZ4_", &ipc_stream(1));
+        for truncated in 1..=4 {
+            let error = read_ipc_compressed(&frame[..frame.len() - truncated])
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("truncated LZ4"), "{truncated}: {error}");
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Miri cannot call Zstd's C FFI.
+    fn invalid_array_offsets_return_error() {
+        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8, false)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(StringArray::from(vec!["abc", "def"]))],
+        )
+        .unwrap();
+        let mut payload = Vec::new();
+        let mut writer = StreamWriter::try_new(&mut payload, &schema).unwrap();
+        writer.write(&batch).unwrap();
+        writer.finish().unwrap();
+
+        let offsets: Vec<u8> = [0_i32, 3, 6]
+            .into_iter()
+            .flat_map(i32::to_le_bytes)
+            .collect();
+        let positions: Vec<usize> = payload
+            .windows(offsets.len())
+            .enumerate()
+            .filter_map(|(position, bytes)| (bytes == offsets).then_some(position))
+            .collect();
+        assert_eq!(positions.len(), 1);
+        // Change [0, 3, 6] to [0, 3, 2]: the second string now has decreasing offsets.
+        payload[positions[0] + 8..positions[0] + 12].copy_from_slice(&2_i32.to_le_bytes());
+        for codec in [b"NONE", b"SNAP", b"LZ4_", b"ZSTD"] {
+            assert!(read_ipc_compressed_validated(&encode(codec, &payload)).is_err());
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Miri cannot call Zstd's C FFI.
+    fn valid_single_batch_frames_decode_with_all_codecs() {
+        for codec in [b"NONE", b"SNAP", b"LZ4_", b"ZSTD"] {
+            let frame = encode(codec, &ipc_stream(1));
+            let batch = read_ipc_compressed(&frame).unwrap();
+            let validated = read_ipc_compressed_validated(&frame).unwrap();
+            assert_eq!(batch.num_rows(), 3);
+            assert_eq!(batch.num_columns(), 1);
+            assert_eq!(batch, validated);
+        }
     }
 }

--- a/native/shuffle/src/lib.rs
+++ b/native/shuffle/src/lib.rs
@@ -19,6 +19,7 @@ pub(crate) mod comet_partitioning;
 pub mod ipc;
 pub(crate) mod metrics;
 pub(crate) mod partitioners;
+mod remote_schema;
 #[cfg(test)]
 mod rss_execution_tests;
 mod schema_align;
@@ -28,7 +29,8 @@ pub mod spark_unsafe;
 pub(crate) mod writers;
 
 pub use comet_partitioning::CometPartitioning;
-pub use ipc::read_ipc_compressed;
+pub use ipc::{read_ipc_compressed, read_ipc_compressed_validated};
+pub use remote_schema::validate_remote_schema;
 pub use schema_align::SchemaAlignExec;
 pub use shuffle_writer::{ShuffleWriterDestination, ShuffleWriterExec};
 pub use writers::{CompressionCodec, ShuffleBlockWriter};

--- a/native/shuffle/src/remote_schema.rs
+++ b/native/shuffle/src/remote_schema.rs
@@ -1,0 +1,441 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::array::RecordBatch;
+use arrow::datatypes::DataType;
+use datafusion::common::DataFusionError;
+use datafusion::error::Result;
+
+/// Check a remotely fetched batch against the logical types declared by Spark before any cast
+/// or JVM Arrow import. Arrow buffer validation alone cannot detect a valid but incorrect IPC
+/// type, and a general cast can silently change values or turn them into nulls.
+///
+/// Native shuffle writers align their input with Spark's types before partitioning; row writers
+/// build those types directly. Row writers may use top-level Int32-keyed string/binary
+/// dictionaries, but disable dictionaries inside containers. Do not accept other dictionary
+/// layouts just because Arrow can cast them: the JVM importer does not support all of them.
+///
+/// Nested nullability and metadata are normalized separately. List element and map entries names
+/// are synthetic (for example, Rust uses `item` while the JVM uses `element`), but struct member
+/// names and order must agree: Arrow's struct cast can otherwise reorder values by name.
+/// Map entries and keys must remain non-nullable, as required by the JVM Arrow importer.
+pub fn validate_remote_schema(batch: &RecordBatch, expected_types: &[DataType]) -> Result<()> {
+    if batch.num_columns() != expected_types.len() {
+        return Err(DataFusionError::Execution(format!(
+            "Shuffle block column count mismatch: got {} but expected {}",
+            batch.num_columns(),
+            expected_types.len()
+        )));
+    }
+
+    for (index, (column, expected)) in batch.columns().iter().zip(expected_types).enumerate() {
+        let actual = column.data_type();
+        let value_type = match actual {
+            DataType::Dictionary(keys, values)
+                if keys.as_ref() == &DataType::Int32
+                    && matches!(values.as_ref(), DataType::Utf8 | DataType::Binary) =>
+            {
+                values.as_ref()
+            }
+            _ => actual,
+        };
+        if !same_logical_type(value_type, expected) {
+            return Err(DataFusionError::Execution(format!(
+                "Shuffle block type mismatch at column {index}: got {actual} but expected {expected}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn same_logical_type(actual: &DataType, expected: &DataType) -> bool {
+    match (actual, expected) {
+        (DataType::List(a), DataType::List(e))
+        | (DataType::LargeList(a), DataType::LargeList(e)) => {
+            same_logical_type(a.data_type(), e.data_type())
+        }
+        (DataType::FixedSizeList(a, a_len), DataType::FixedSizeList(e, e_len)) => {
+            a_len == e_len && same_logical_type(a.data_type(), e.data_type())
+        }
+        (DataType::Map(a, a_sorted), DataType::Map(e, e_sorted)) => {
+            !a.is_nullable()
+                && matches!(a.data_type(), DataType::Struct(fields)
+                    if fields.len() == 2 && !fields[0].is_nullable())
+                && a_sorted == e_sorted
+                && same_logical_type(a.data_type(), e.data_type())
+        }
+        (DataType::Struct(a), DataType::Struct(e)) => {
+            a.len() == e.len()
+                && a.iter().zip(e.iter()).all(|(a, e)| {
+                    a.name() == e.name() && same_logical_type(a.data_type(), e.data_type())
+                })
+        }
+        // Do not broaden this to can_cast_types: signedness, width, temporal units/timezones,
+        // decimal precision/scale, and string/binary conversions change Spark's logical type.
+        _ => actual == expected,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_remote_schema;
+    use crate::read_ipc_compressed_validated;
+    use arrow::array::{
+        Array, ArrayRef, BinaryArray, BinaryDictionaryBuilder, Decimal128Array, Int32Array,
+        ListArray, MapArray, RecordBatch, StringArray, StringDictionaryBuilder, StructArray,
+        TimestampMicrosecondArray,
+    };
+    use arrow::buffer::OffsetBuffer;
+    use arrow::datatypes::{DataType, Field, Fields, Int32Type, IntervalUnit, Schema, TimeUnit};
+    use arrow::ipc::writer::StreamWriter;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn batch_of_type(data_type: DataType) -> RecordBatch {
+        RecordBatch::new_empty(Arc::new(Schema::new(vec![Field::new(
+            "wire_name",
+            data_type,
+            true,
+        )])))
+    }
+
+    fn list(data_type: DataType) -> DataType {
+        DataType::List(Arc::new(Field::new_list_field(data_type, true)))
+    }
+
+    fn structure(fields: &[(&str, DataType)]) -> DataType {
+        DataType::Struct(
+            fields
+                .iter()
+                .map(|(name, data_type)| Field::new(*name, data_type.clone(), true))
+                .collect(),
+        )
+    }
+
+    fn map(value_type: DataType) -> DataType {
+        DataType::Map(
+            Arc::new(Field::new(
+                "entries",
+                DataType::Struct(Fields::from(vec![
+                    Field::new("key", DataType::Utf8, false),
+                    Field::new("value", value_type, true),
+                ])),
+                false,
+            )),
+            false,
+        )
+    }
+
+    fn dictionary(key_type: DataType, value_type: DataType) -> DataType {
+        DataType::Dictionary(Box::new(key_type), Box::new(value_type))
+    }
+
+    fn roundtrip(columns: Vec<ArrayRef>) -> RecordBatch {
+        let fields: Vec<_> = columns
+            .iter()
+            .enumerate()
+            .map(|(i, column)| Field::new(format!("wire_{i}"), column.data_type().clone(), true))
+            .collect();
+        let schema = Arc::new(Schema::new(fields));
+        let batch = RecordBatch::try_new(Arc::clone(&schema), columns).unwrap();
+        let mut bytes = b"NONE".to_vec();
+        let mut writer = StreamWriter::try_new(&mut bytes, &schema).unwrap();
+        writer.write(&batch).unwrap();
+        writer.finish().unwrap();
+        read_ipc_compressed_validated(&bytes).unwrap()
+    }
+
+    #[test]
+    fn column_count_and_empty_schema_are_checked() {
+        let empty = RecordBatch::new_empty(Arc::new(Schema::empty()));
+        validate_remote_schema(&empty, &[]).unwrap();
+        for expected in [vec![], vec![DataType::Int32, DataType::Int32]] {
+            let error = validate_remote_schema(&batch_of_type(DataType::Int32), &expected)
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("column count mismatch"), "{error}");
+        }
+    }
+
+    #[test]
+    fn incompatible_scalar_logical_types_are_rejected() {
+        use DataType::*;
+        let utc = Some("UTC".into());
+        for (actual, expected) in [
+            (UInt32, Int32),
+            (Int16, Int32),
+            (Int64, Int32),
+            (Int32, Float32),
+            (Float32, Float64),
+            (Float64, Int64),
+            (Utf8, Binary),
+            (LargeUtf8, Utf8),
+            (Utf8View, Utf8),
+            (BinaryView, Binary),
+            (LargeBinary, Binary),
+            (Null, Int32),
+            (Date32, Int32),
+            (Date64, Date32),
+            (
+                Timestamp(TimeUnit::Millisecond, utc.clone()),
+                Timestamp(TimeUnit::Microsecond, utc.clone()),
+            ),
+            (
+                Timestamp(TimeUnit::Microsecond, None),
+                Timestamp(TimeUnit::Microsecond, utc.clone()),
+            ),
+            (
+                Timestamp(TimeUnit::Microsecond, utc.clone()),
+                Timestamp(TimeUnit::Microsecond, None),
+            ),
+            (
+                Timestamp(TimeUnit::Microsecond, Some("America/Los_Angeles".into())),
+                Timestamp(TimeUnit::Microsecond, utc),
+            ),
+            (Time64(TimeUnit::Microsecond), Time64(TimeUnit::Nanosecond)),
+            (
+                Duration(TimeUnit::Millisecond),
+                Duration(TimeUnit::Microsecond),
+            ),
+            (Decimal128(12, 2), Decimal128(12, 3)),
+            (Decimal128(12, 2), Decimal128(10, 2)),
+            (Decimal64(12, 2), Decimal128(12, 2)),
+        ] {
+            let error = validate_remote_schema(
+                &batch_of_type(actual.clone()),
+                std::slice::from_ref(&expected),
+            )
+            .unwrap_err()
+            .to_string();
+            assert!(error.contains("type mismatch at column 0"), "{error}");
+            assert!(error.contains(&actual.to_string()), "{error}");
+            assert!(error.contains(&expected.to_string()), "{error}");
+        }
+    }
+
+    #[test]
+    fn nested_logical_type_and_shape_changes_are_rejected() {
+        use DataType::*;
+        for (actual, expected) in [
+            (list(UInt32), list(Int32)),
+            (
+                structure(&[("payload", list(UInt32))]),
+                structure(&[("payload", list(Int32))]),
+            ),
+            (map(UInt32), map(Int32)),
+            (structure(&[("a", Int32)]), structure(&[("b", Int32)])),
+            (
+                structure(&[("a", Int32), ("b", Int32)]),
+                structure(&[("b", Int32), ("a", Int32)]),
+            ),
+            (
+                structure(&[("a", Int32), ("b", Int32)]),
+                structure(&[("a", Int32)]),
+            ),
+            (
+                LargeList(Arc::new(Field::new_list_field(Int32, true))),
+                list(Int32),
+            ),
+            (
+                FixedSizeList(Arc::new(Field::new_list_field(Int32, true)), 2),
+                FixedSizeList(Arc::new(Field::new_list_field(Int32, true)), 3),
+            ),
+        ] {
+            let error = validate_remote_schema(&batch_of_type(actual), &[expected])
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("type mismatch"), "{error}");
+        }
+    }
+
+    #[test]
+    fn unsupported_or_wrongly_typed_dictionaries_are_rejected() {
+        use DataType::*;
+        for (actual, expected) in [
+            (dictionary(Int32, UInt32), Int32),
+            (dictionary(Int32, Utf8), Int32),
+            (dictionary(Int32, Int32), Int32),
+            (dictionary(Int32, Null), Null),
+            (
+                dictionary(Int32, Interval(IntervalUnit::MonthDayNano)),
+                Interval(IntervalUnit::MonthDayNano),
+            ),
+            (dictionary(Int8, Utf8), Utf8),
+            (dictionary(UInt32, Utf8), Utf8),
+            (dictionary(Int32, list(Utf8)), list(Utf8)),
+            (dictionary(Int32, dictionary(Int32, Utf8)), Utf8),
+            (list(dictionary(Int32, Utf8)), list(Utf8)),
+        ] {
+            let error = validate_remote_schema(&batch_of_type(actual), &[expected])
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("type mismatch"), "{error}");
+        }
+    }
+
+    #[test]
+    fn map_keys_must_remain_non_nullable() {
+        let actual = DataType::Map(
+            Arc::new(Field::new(
+                "entries",
+                structure(&[("key", DataType::Utf8), ("value", DataType::Int32)]),
+                false,
+            )),
+            false,
+        );
+        let error = validate_remote_schema(&batch_of_type(actual), &[map(DataType::Int32)])
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("type mismatch"), "{error}");
+    }
+
+    #[test]
+    fn ordinary_and_dictionary_values_survive_validation() {
+        let mut strings = StringDictionaryBuilder::<Int32Type>::new();
+        strings.append_value("hello");
+        strings.append_null();
+        strings.append_value("hello");
+        let mut binaries = BinaryDictionaryBuilder::<Int32Type>::new();
+        binaries.append_value(b"\0\xff");
+        binaries.append_null();
+        binaries.append_value(b"\0\xff");
+        let decimals = Decimal128Array::from(vec![Some(-12345), None, Some(999999999999)])
+            .with_precision_and_scale(12, 2)
+            .unwrap();
+        let timestamps =
+            TimestampMicrosecondArray::from(vec![Some(-1), None, Some(1727398000000001)])
+                .with_timezone("UTC");
+        let batch = roundtrip(vec![
+            Arc::new(Int32Array::from(vec![Some(-1), None, Some(i32::MAX)])),
+            Arc::new(strings.finish()),
+            Arc::new(binaries.finish()),
+            Arc::new(decimals.clone()),
+            Arc::new(timestamps.clone()),
+        ]);
+        validate_remote_schema(
+            &batch,
+            &[
+                DataType::Int32,
+                DataType::Utf8,
+                DataType::Binary,
+                decimals.data_type().clone(),
+                timestamps.data_type().clone(),
+            ],
+        )
+        .unwrap();
+        assert_eq!(
+            batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap(),
+            &Int32Array::from(vec![Some(-1), None, Some(i32::MAX)])
+        );
+        let strings = arrow::compute::cast(batch.column(1), &DataType::Utf8).unwrap();
+        assert_eq!(
+            strings.as_any().downcast_ref::<StringArray>().unwrap(),
+            &StringArray::from(vec![Some("hello"), None, Some("hello")])
+        );
+        let binaries = arrow::compute::cast(batch.column(2), &DataType::Binary).unwrap();
+        assert_eq!(
+            binaries.as_any().downcast_ref::<BinaryArray>().unwrap(),
+            &BinaryArray::from(vec![Some(&b"\0\xff"[..]), None, Some(&b"\0\xff"[..])])
+        );
+        assert_eq!(batch.column(3).to_data(), decimals.to_data());
+        assert_eq!(batch.column(4).to_data(), timestamps.to_data());
+    }
+
+    #[test]
+    fn map_entry_names_and_null_values_are_compatible() {
+        let fields = Fields::from(vec![
+            Field::new("key", DataType::Utf8, false),
+            Field::new("value", DataType::Int32, true),
+        ]);
+        let keys = StringArray::from(vec!["one", "two"]);
+        let values = Int32Array::from(vec![Some(1), None]);
+        let entries = StructArray::new(
+            fields.clone(),
+            vec![Arc::new(keys.clone()), Arc::new(values.clone())],
+            None,
+        );
+        let column = MapArray::new(
+            Arc::new(Field::new("map_entries", DataType::Struct(fields), false)),
+            OffsetBuffer::new(vec![0, 2].into()),
+            entries,
+            None,
+            false,
+        );
+        let batch = roundtrip(vec![Arc::new(column)]);
+        let expected = map(DataType::Int32);
+        validate_remote_schema(&batch, std::slice::from_ref(&expected)).unwrap();
+        let reconciled = arrow::compute::cast(batch.column(0), &expected).unwrap();
+        let result = reconciled.as_any().downcast_ref::<MapArray>().unwrap();
+        assert_eq!(result.value_offsets(), &[0, 2]);
+        assert_eq!(result.keys().to_data(), keys.to_data());
+        assert_eq!(result.values().to_data(), values.to_data());
+    }
+
+    #[test]
+    fn nested_nullability_metadata_and_synthetic_names_are_compatible() {
+        let fields = Fields::from(vec![Field::new("id", DataType::Int32, false)]);
+        let values = Arc::new(StructArray::new(
+            fields.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, -1, 3]))],
+            None,
+        ));
+        let column = Arc::new(ListArray::new(
+            Arc::new(Field::new("element", DataType::Struct(fields), false)),
+            OffsetBuffer::new(vec![0, 2, 3].into()),
+            values,
+            None,
+        ));
+        let batch = roundtrip(vec![column]);
+        let expected = DataType::List(Arc::new(Field::new(
+            "item",
+            DataType::Struct(Fields::from(vec![Field::new("id", DataType::Int32, true)
+                .with_metadata(HashMap::from([(
+                    "parquet.field.id".to_owned(),
+                    "1".to_owned(),
+                )]))])),
+            true,
+        )));
+        validate_remote_schema(&batch, std::slice::from_ref(&expected)).unwrap();
+        let reconciled = arrow::compute::cast(batch.column(0), &expected).unwrap();
+        let list = reconciled.as_any().downcast_ref::<ListArray>().unwrap();
+        assert_eq!(list.value_offsets(), &[0, 2, 3]);
+        let values = list
+            .values()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        assert_eq!(
+            values
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap()
+                .values(),
+            &[1, -1, 3]
+        );
+        // The existing normalization also supports narrowing nullability when there are no nulls.
+        validate_remote_schema(
+            &RecordBatch::try_from_iter([("normalized", reconciled)]).unwrap(),
+            &[batch.column(0).data_type().clone()],
+        )
+        .unwrap();
+    }
+}

--- a/spark/src/main/java/org/apache/comet/CometShuffleBlockIterator.java
+++ b/spark/src/main/java/org/apache/comet/CometShuffleBlockIterator.java
@@ -87,6 +87,13 @@ public class CometShuffleBlockIterator implements Closeable {
     // Field count discarded - schema determined by ShuffleScan protobuf fields
     headerBuf.getLong();
 
+    if (compressedLength < 12) {
+      throw new IOException(
+          "Data corrupt: native shuffle length "
+              + compressedLength
+              + " is smaller than the field count and codec header");
+    }
+
     // Subtract 8 because compressedLength includes the 8-byte field count we already read
     long bytesToRead = compressedLength - 8;
     if (bytesToRead > Integer.MAX_VALUE) {
@@ -117,6 +124,21 @@ public class CometShuffleBlockIterator implements Closeable {
     // not the buffer's position/limit. No flip needed.
 
     return currentBlockLength;
+  }
+
+  /**
+   * Reports a native IPC/codec failure to the remote stream that supplied the current block. Called
+   * by ShuffleScan via JNI; local streams preserve the original native exception.
+   */
+  public void onDecodeFailure(String message) throws IOException {
+    if (inputStream instanceof CometShuffleReadFailureHandler) {
+      ((CometShuffleReadFailureHandler) inputStream).onShuffleReadFailure(new IOException(message));
+    }
+  }
+
+  /** Whether fetched Arrow arrays require validation before native consumption. */
+  public boolean requiresValidation() {
+    return inputStream instanceof CometShuffleReadFailureHandler;
   }
 
   /**

--- a/spark/src/main/java/org/apache/comet/CometShuffleReadFailureHandler.java
+++ b/spark/src/main/java/org/apache/comet/CometShuffleReadFailureHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet;
+
+import java.io.IOException;
+
+/**
+ * Lets an input stream attribute native codec/IPC failures to its remote shuffle generation.
+ *
+ * <p>The native and JVM decoders invoke this only when decoding a fetched block. The stream itself
+ * classifies fetch and frame-boundary errors: metadata timeouts and cleanup failures must not be
+ * reclassified as corruption by this callback. If the handler returns, the caller propagates the
+ * original failure. Local shuffle streams need not implement this interface.
+ */
+public interface CometShuffleReadFailureHandler {
+  void onShuffleReadFailure(Throwable cause) throws IOException;
+}

--- a/spark/src/main/scala/org/apache/comet/Native.scala
+++ b/spark/src/main/scala/org/apache/comet/Native.scala
@@ -201,6 +201,19 @@ class Native extends NativeBase {
       tracingEnabled: Boolean): Long
 
   /**
+   * Decode a remote shuffle block with Arrow buffer/offset and logical type validation. The
+   * expected schema is serialized as a ShuffleScan protobuf. Keep the existing local decoder
+   * entry point unchanged so trusted local shuffle reads retain their fast path.
+   */
+  @native def decodeShuffleBlockWithValidation(
+      shuffleBlock: ByteBuffer,
+      length: Int,
+      arrayAddrs: Array[Long],
+      schemaAddrs: Array[Long],
+      tracingEnabled: Boolean,
+      expectedSchema: Array[Byte]): Long
+
+  /**
    * Log the beginning of an event.
    * @param name
    *   The name of the event.

--- a/spark/src/main/scala/org/apache/comet/vector/NativeUtil.scala
+++ b/spark/src/main/scala/org/apache/comet/vector/NativeUtil.scala
@@ -70,11 +70,16 @@ class NativeUtil {
     val arrays = new Array[ArrowArray](numCols)
     val schemas = new Array[ArrowSchema](numCols)
 
-    (0 until numCols).foreach { index =>
-      val arrowSchema = ArrowSchema.allocateNew(allocator)
-      val arrowArray = ArrowArray.allocateNew(allocator)
-      arrays(index) = arrowArray
-      schemas(index) = arrowSchema
+    try {
+      (0 until numCols).foreach { index =>
+        // Publish each allocation before the next one, so partial allocation failures can free it.
+        schemas(index) = ArrowSchema.allocateNew(allocator)
+        arrays(index) = ArrowArray.allocateNew(allocator)
+      }
+    } catch {
+      case failure: Throwable =>
+        releaseArrowStructs(arrays, schemas, failure)
+        throw failure
     }
 
     (arrays, schemas)
@@ -183,19 +188,57 @@ class NativeUtil {
       func: (Array[Long], Array[Long]) => Long): Option[ColumnarBatch] = {
     val (arrays, schemas) = allocateArrowStructs(numOutputCols)
 
-    val arrayAddrs = arrays.map(_.memoryAddress())
-    val schemaAddrs = schemas.map(_.memoryAddress())
-
-    val result = func(arrayAddrs, schemaAddrs)
+    val result =
+      try {
+        val arrayAddrs = arrays.map(_.memoryAddress())
+        val schemaAddrs = schemas.map(_.memoryAddress())
+        func(arrayAddrs, schemaAddrs)
+      } catch {
+        case failure: Throwable =>
+          // Native may have populated some fields before failing. Their C release callbacks own
+          // native buffers; closing the Arrow struct wrappers alone would leave those buffers live.
+          releaseArrowStructs(arrays, schemas, failure)
+          throw failure
+      }
 
     result match {
       case -1 =>
-        // EOF
+        // EOF has no importer to consume the allocated structs.
+        releaseArrowStructs(arrays, schemas)
         None
       case numRows =>
         val cometVectors = importVector(arrays, schemas)
         Some(new ColumnarBatch(cometVectors.toArray, numRows.toInt))
     }
+  }
+
+  private def releaseArrowStructs(
+      arrays: Array[ArrowArray],
+      schemas: Array[ArrowSchema],
+      originalFailure: Throwable = null): Unit = {
+    var failure = originalFailure
+    def release(resource: => Unit): Unit = {
+      try resource
+      catch {
+        case caught: Throwable =>
+          if (failure == null) failure = caught
+          else if (caught ne failure) failure.addSuppressed(caught)
+      }
+    }
+
+    arrays.foreach { array =>
+      if (array != null) {
+        release(array.release())
+        release(array.close())
+      }
+    }
+    schemas.foreach { schema =>
+      if (schema != null) {
+        release(schema.release())
+        release(schema.close())
+      }
+    }
+    if (originalFailure == null && failure != null) throw failure
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometBlockStoreShuffleReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometBlockStoreShuffleReader.scala
@@ -26,7 +26,6 @@ import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.serializer.SerializerManager
 import org.apache.spark.shuffle.BaseShuffleHandle
-import org.apache.spark.shuffle.ShuffleReader
 import org.apache.spark.shuffle.ShuffleReadMetricsReporter
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage.BlockId
@@ -51,7 +50,7 @@ class CometBlockStoreShuffleReader[K, C](
     blockManager: BlockManager = SparkEnv.get.blockManager,
     mapOutputTracker: MapOutputTracker = SparkEnv.get.mapOutputTracker,
     shouldBatchFetch: Boolean = false)
-    extends ShuffleReader[K, C]
+    extends CometShuffleReader[K, C]
     with Logging {
 
   private val dep = handle.dependency.asInstanceOf[CometShuffleDependency[_, _, _]]
@@ -157,7 +156,7 @@ class CometBlockStoreShuffleReader[K, C](
    * Returns the raw concatenated InputStream of all shuffle blocks, bypassing the decode step.
    * Used by ShuffleScan direct read path.
    */
-  def readAsRawStream(): InputStream = {
+  override def readAsRawStream(): InputStream = {
     val streams = fetchIterator.map(_._2)
     new java.io.SequenceInputStream(new java.util.Enumeration[InputStream] {
       override def hasMoreElements: Boolean = streams.hasNext

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometCelebornShuffleManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometCelebornShuffleManager.scala
@@ -40,17 +40,23 @@ import org.apache.comet.util.ClassLoaders
  * binding native Comet map output to Celeborn's application-owned client.
  *
  * Celeborn is an optional, application-provided dependency, so its shuffle manager is loaded
- * reflectively. Native reduce-side reads and JVM Comet shuffles remain unsupported.
+ * reflectively. Native map and reduce paths are available, but planner enablement is separate;
+ * JVM Comet shuffle remains unsupported.
  */
 class CometCelebornShuffleManager private[shuffle] (
     conf: SparkConf,
     isDriver: Boolean,
-    backendFactory: (SparkConf, Boolean) => ShuffleManager)
+    backendFactory: (SparkConf, Boolean) => ShuffleManager,
+    readerApi: CelebornRawPartitionReader.Api = CelebornRawPartitionReader.reflectedApi)
     extends ShuffleManager {
 
   /** Constructor used by Spark on both the driver and executors. */
   def this(conf: SparkConf, isDriver: Boolean) =
-    this(conf, isDriver, CometCelebornShuffleManager.createBackend)
+    this(
+      conf,
+      isDriver,
+      CometCelebornShuffleManager.createBackend,
+      CelebornRawPartitionReader.reflectedApi)
 
   private val backend = Option(backendFactory(conf, isDriver)).getOrElse {
     throw new IllegalStateException("Celeborn Spark shuffle manager factory returned null")
@@ -171,18 +177,51 @@ class CometCelebornShuffleManager private[shuffle] (
       endPartition: Int,
       context: TaskContext,
       metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
-    if (nativeDependency(handle).nonEmpty) {
-      rejectCometShuffle()
+    nativeDependency(handle) match {
+      case Some(dependency) =>
+        if (startMapIndex > endMapIndex) {
+          throw new UnsupportedOperationException(
+            "Celeborn physical-skew chunk reads are not supported by native Comet shuffle")
+        }
+        val backendReader = backend.getReader[K, C](
+          handle,
+          startMapIndex,
+          endMapIndex,
+          startPartition,
+          endPartition,
+          context,
+          metrics)
+        val rawReader = CelebornRawPartitionReader.fromBackendReader(
+          conf,
+          handle,
+          backendReader,
+          CelebornRawPartitionReader.ReadRange(
+            startMapIndex,
+            endMapIndex,
+            startPartition,
+            endPartition),
+          context,
+          metrics,
+          client => ownedNativeClients.put(client, java.lang.Boolean.TRUE),
+          (client, celebornShuffleId) => {
+            nativeShuffleClients
+              .computeIfAbsent(handle.shuffleId, _ => new ConcurrentHashMap[Int, AnyRef]())
+              .put(celebornShuffleId, client)
+          },
+          readerApi)
+        new CometCelebornShuffleReader[K, C](dependency, context, metrics, rawReader)
+
+      case None =>
+        rejectCometHandle(handle)
+        backend.getReader(
+          handle,
+          startMapIndex,
+          endMapIndex,
+          startPartition,
+          endPartition,
+          context,
+          metrics)
     }
-    rejectCometHandle(handle)
-    backend.getReader(
-      handle,
-      startMapIndex,
-      endMapIndex,
-      startPartition,
-      endPartition,
-      context,
-      metrics)
   }
 
   override def shuffleBlockResolver: ShuffleBlockResolver = backend.shuffleBlockResolver
@@ -354,7 +393,7 @@ class CometCelebornShuffleManager private[shuffle] (
 
   private def rejectCometShuffle(): Nothing = {
     throw new UnsupportedOperationException(
-      "Comet shuffle over Celeborn is not supported for JVM shuffle, local handles, or reads")
+      "Comet shuffle over Celeborn is not supported for JVM shuffle or local handles")
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometCelebornShuffleReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometCelebornShuffleReader.scala
@@ -1,0 +1,773 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet.execution.shuffle
+
+import java.io.{EOFException, FilterInputStream, InputStream, IOException}
+import java.lang.reflect.{InvocationHandler, InvocationTargetException, Method, Proxy}
+import java.nio.{ByteBuffer, ByteOrder}
+import java.util.{ArrayList, Map => JMap, Set => JSet}
+import java.util.concurrent.{ConcurrentHashMap, TimeoutException, TimeUnit}
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.util.control.NonFatal
+
+import org.apache.spark.{InterruptibleIterator, SparkConf, TaskContext}
+import org.apache.spark.internal.Logging
+import org.apache.spark.shuffle.{FetchFailedException, ShuffleHandle, ShuffleReader, ShuffleReadMetricsReporter}
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.{CompletionIterator, Utils}
+
+import org.apache.comet.{CometConf, CometShuffleReadFailureHandler, Native}
+import org.apache.comet.serde.{OperatorOuterClass, QueryPlanSerde}
+import org.apache.comet.util.ClassLoaders
+import org.apache.comet.vector.NativeUtil
+
+/** Reads native shuffle frames from Celeborn without applying Celeborn's row decompressor. */
+private[shuffle] final class CometCelebornShuffleReader[K, C](
+    dependency: CometShuffleDependency[_, _, _],
+    context: TaskContext,
+    readMetrics: ShuffleReadMetricsReporter,
+    partitionReader: CelebornRawPartitionReader)
+    extends CometShuffleReader[K, C] {
+
+  private val consumed = new AtomicBoolean(false)
+  private val metricsMerged = new AtomicBoolean(false)
+
+  private def mergeReadMetrics(): Unit = {
+    if (metricsMerged.compareAndSet(false, true)) {
+      context.taskMetrics().mergeShuffleReadMetrics()
+    }
+  }
+
+  override def readAsRawStream(): InputStream = {
+    context.killTaskIfInterrupted()
+    if (!consumed.compareAndSet(false, true)) {
+      throw new IllegalStateException("A Celeborn shuffle reader can only be consumed once")
+    }
+    val input = new FilterInputStream(
+      partitionReader.openPartitions(Some(dependency.outputAttributes.size)))
+      with CometShuffleReadFailureHandler {
+      override def onShuffleReadFailure(failure: Throwable): Unit =
+        partitionReader.onShuffleReadFailure(failure)
+
+      override def read(): Int = {
+        val value = in.read()
+        if (value < 0) mergeReadMetrics()
+        value
+      }
+
+      override def read(buffer: Array[Byte], offset: Int, length: Int): Int = {
+        val count = in.read(buffer, offset, length)
+        if (count < 0) mergeReadMetrics()
+        count
+      }
+
+      override def close(): Unit = {
+        Utils.tryWithSafeFinally(super.close())(mergeReadMetrics())
+      }
+    }
+    context.addTaskCompletionListener[Unit](_ => input.close())
+    input
+  }
+
+  override def read(): Iterator[Product2[K, C]] = {
+    if (dependency.aggregator.isDefined) {
+      throw new UnsupportedOperationException("aggregate not allowed")
+    }
+    if (dependency.keyOrdering.isDefined) {
+      throw new UnsupportedOperationException("order not allowed")
+    }
+
+    // Validate remote logical types before Arrow import, using the same expected types as the
+    // native ShuffleScan path. Serialize before opening inputs so unsupported declared types do
+    // not acquire shuffle resources or get reported as corrupt remote data.
+    val expectedSchema = OperatorOuterClass.ShuffleScan.newBuilder()
+    dependency.outputAttributes.foreach { attribute =>
+      expectedSchema.addFields(QueryPlanSerde.serializeDataType(attribute.dataType).getOrElse {
+        throw new UnsupportedOperationException(
+          s"Unsupported Celeborn native shuffle type: ${attribute.dataType}")
+      })
+    }
+    val serializedSchema = expectedSchema.build().toByteArray
+
+    val input = readAsRawStream()
+    val nativeUtil =
+      try new NativeUtil()
+      catch {
+        case NonFatal(failure) =>
+          Utils.tryWithSafeFinally(throw failure)(input.close())
+      }
+    val decoder =
+      try {
+        NativeBatchDecoderIterator(
+          input,
+          dependency.decodeTime,
+          new Native(),
+          nativeUtil,
+          CometConf.COMET_TRACING_ENABLED.get(),
+          Some(serializedSchema))
+      } catch {
+        case NonFatal(failure) =>
+          Utils.tryWithSafeFinally(throw failure) {
+            Utils.tryWithSafeFinally(input.close())(nativeUtil.close())
+          }
+      }
+    val resourcesClosed = new AtomicBoolean(false)
+    def closeDecoder(): Unit = {
+      if (resourcesClosed.compareAndSet(false, true)) {
+        Utils.tryWithSafeFinally(decoder.close())(nativeUtil.close())
+      }
+    }
+    // The constructor is lazy. Publish a fully initialized decoder before registering a listener,
+    // which Spark invokes immediately if the task has already completed.
+    try context.addTaskCompletionListener[Unit](_ => closeDecoder())
+    catch {
+      case NonFatal(failure) => Utils.tryWithSafeFinally(throw failure)(closeDecoder())
+    }
+
+    val rows = decoder.map { batch: ColumnarBatch =>
+      readMetrics.incRecordsRead(batch.numRows())
+      (0, batch)
+    }
+    val completed = CompletionIterator[(Int, ColumnarBatch), Iterator[(Int, ColumnarBatch)]](
+      rows,
+      mergeReadMetrics())
+    new InterruptibleIterator[(Int, ColumnarBatch)](context, completed)
+      .asInstanceOf[Iterator[Product2[K, C]]]
+  }
+}
+
+/**
+ * Reflects the optional application-owned Celeborn client and keeps one reducer-file-group
+ * snapshot for all reducers in an AQE partition.
+ */
+private[shuffle] final class CelebornRawPartitionReader(
+    client: AnyRef,
+    sparkShuffleId: Int,
+    celebornShuffleId: Int,
+    startMapIndex: Int,
+    endMapIndex: Int,
+    startPartition: Int,
+    endPartition: Int,
+    context: TaskContext,
+    readMetrics: ShuffleReadMetricsReporter,
+    rpcRetryLimit: Int,
+    stageRerunEnabled: Boolean = true)
+    extends Logging {
+
+  import CelebornRawPartitionReader._
+
+  require(startMapIndex >= 0, s"Invalid Celeborn start map index: $startMapIndex")
+  require(
+    startMapIndex <= endMapIndex,
+    "Celeborn physical-skew chunk reads are not supported by the native shuffle reader")
+  require(
+    startPartition >= 0 && startPartition <= endPartition,
+    s"Invalid Celeborn reducer range: [$startPartition, $endPartition)")
+  require(rpcRetryLimit >= 0, s"Invalid Celeborn RPC retry limit: $rpcRetryLimit")
+
+  private val updateFileGroup =
+    client.getClass.getMethod("updateFileGroup", java.lang.Integer.TYPE, java.lang.Integer.TYPE)
+  private val readPartitionMethod = client.getClass.getMethods
+    .filter(isRawPartitionReader)
+    .sortBy(_.getParameterCount)
+    .headOption
+    .getOrElse {
+      throw new IllegalStateException(
+        "The Celeborn client does not expose a compatible raw partition reader")
+    }
+  private val metricsCallback =
+    createMetricsCallback(
+      readPartitionMethod.getParameterTypes.apply(readPartitionMethod.getParameterCount - 2),
+      readMetrics)
+
+  private lazy val fileGroups: AnyRef = loadFileGroups()
+  @volatile private var lastReadPartition = startPartition
+  private var terminalFetchFailure: Throwable = _
+
+  private[shuffle] def onShuffleReadFailure(failure: Throwable): Nothing =
+    reportFetchFailure(lastReadPartition, failure)
+
+  private def loadFileGroups(): AnyRef = {
+    val started = System.nanoTime()
+    var retries = 0
+    try {
+      while (true) {
+        context.killTaskIfInterrupted()
+        val stageEnded =
+          try {
+            invoke(
+              client.getClass.getMethod("isShuffleStageEnd", java.lang.Integer.TYPE),
+              client,
+              Int.box(celebornShuffleId)).asInstanceOf[Boolean]
+          } catch {
+            case NonFatal(failure) =>
+              logInfo(
+                s"Could not check whether Celeborn shuffle $celebornShuffleId ended",
+                failure)
+              true
+          }
+
+        try {
+          context.killTaskIfInterrupted()
+          return Option(
+            invoke(updateFileGroup, client, Int.box(celebornShuffleId), Int.box(startPartition)))
+            .getOrElse {
+              throw new IllegalStateException(
+                "Celeborn returned a null reducer-file-group snapshot")
+            }
+        } catch {
+          case failure if isFileGroupTimeout(failure) && !stageEnded && retries < rpcRetryLimit =>
+            retries += 1
+            logInfo(
+              s"Retrying Celeborn reducer-file-group snapshot $celebornShuffleId " +
+                s"($retries/$rpcRetryLimit)",
+              failure)
+          case failure if isUnreportableFileGroupFailure(failure) =>
+            throw failure
+          case NonFatal(failure) =>
+            reportFetchFailure(startPartition, failure)
+        }
+      }
+      throw new IllegalStateException("The Celeborn file-group retry loop ended unexpectedly")
+    } finally {
+      readMetrics.incFetchWaitTime(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - started))
+    }
+  }
+
+  private def snapshotField(snapshot: AnyRef, name: String): AnyRef =
+    snapshot.getClass.getField(name).get(snapshot).asInstanceOf[AnyRef]
+
+  private def reducers: Iterator[(Int, ArrayList[AnyRef], AnyRef, Array[Int])] = {
+    val snapshot = fileGroups
+    val partitionGroups = Option(snapshotField(snapshot, "partitionGroups"))
+      .getOrElse {
+        throw new IllegalStateException("Celeborn returned null reducer partition groups")
+      }
+      .asInstanceOf[JMap[Integer, JSet[AnyRef]]]
+    val mapAttempts = Option(snapshotField(snapshot, "mapAttempts"))
+      .getOrElse {
+        throw new IllegalStateException("Celeborn returned null mapper-attempt metadata")
+      }
+      .asInstanceOf[Array[Int]]
+    val pushFailedBatches = snapshotField(snapshot, "pushFailedBatches")
+
+    (startPartition until endPartition).iterator.flatMap { partition =>
+      Option(partitionGroups.get(Int.box(partition)))
+        .filter(!_.isEmpty)
+        .map(locations =>
+          (partition, new ArrayList[AnyRef](locations), pushFailedBatches, mapAttempts))
+    }
+  }
+
+  private def openPartition(
+      partition: Int,
+      locations: ArrayList[AnyRef],
+      pushFailedBatches: AnyRef,
+      mapAttempts: Array[Int],
+      expectedFieldCount: Option[Int]): InputStream = {
+    context.killTaskIfInterrupted()
+    lastReadPartition = partition
+    val attempt = encodeAttemptNumber(context.stageAttemptNumber(), context.attemptNumber())
+    val arguments = Array[AnyRef](
+      Int.box(celebornShuffleId),
+      Int.box(sparkShuffleId),
+      Int.box(partition),
+      Int.box(attempt),
+      Long.box(context.taskAttemptId()),
+      Int.box(startMapIndex),
+      Int.box(endMapIndex),
+      null,
+      locations,
+      null,
+      pushFailedBatches,
+      null) ++
+      // Celeborn 0.6/0.7 use 15 arguments. Newer clients insert optional coalesced-partition
+      // metadata before the mapper attempts; native reads do not use physical-skew coalescing.
+      (if (readPartitionMethod.getParameterCount == 16) Array[AnyRef](null)
+       else Array.empty[AnyRef]) ++
+      Array[AnyRef](mapAttempts, metricsCallback, java.lang.Boolean.FALSE)
+    val stream =
+      try {
+        Option(invoke(readPartitionMethod, client, arguments: _*))
+          .getOrElse {
+            throw new IOException(s"Celeborn returned a null stream for reducer $partition")
+          }
+          .asInstanceOf[InputStream]
+      } catch {
+        case NonFatal(failure) => reportFetchFailure(partition, failure)
+      }
+
+    new FilterInputStream(new NativeFrameInputStream(stream, expectedFieldCount)) {
+      override def read(): Int =
+        try in.read()
+        catch { case failure: IOException => reportFetchFailure(partition, failure) }
+
+      override def read(buffer: Array[Byte], offset: Int, length: Int): Int =
+        try in.read(buffer, offset, length)
+        catch { case failure: IOException => reportFetchFailure(partition, failure) }
+
+      override def skip(length: Long): Long =
+        try in.skip(length)
+        catch { case failure: IOException => reportFetchFailure(partition, failure) }
+    }
+  }
+
+  private def reportFetchFailure(partition: Int, failure: Throwable): Nothing = synchronized {
+    if (failure.isInstanceOf[FetchFailedException] || context.isInterrupted() ||
+      context.isCompleted()) {
+      throw failure
+    }
+    if (terminalFetchFailure != null) throw terminalFetchFailure
+
+    val invalidated = if (stageRerunEnabled) {
+      try {
+        invoke(
+          client.getClass.getMethod(
+            "reportShuffleFetchFailure",
+            java.lang.Integer.TYPE,
+            java.lang.Integer.TYPE,
+            java.lang.Long.TYPE),
+          client,
+          Int.box(sparkShuffleId),
+          Int.box(celebornShuffleId),
+          Long.box(context.taskAttemptId())).asInstanceOf[Boolean]
+      } catch {
+        case NonFatal(reportFailure) =>
+          if (reportFailure ne failure) failure.addSuppressed(reportFailure)
+          terminalFetchFailure = failure
+          throw failure
+      }
+    } else false
+    if (invalidated) {
+      terminalFetchFailure = new FetchFailedException(
+        null,
+        sparkShuffleId,
+        -1L,
+        -1,
+        partition,
+        s"Celeborn FetchFailure appShuffleId/shuffleId: $sparkShuffleId/$celebornShuffleId",
+        failure)
+    } else {
+      terminalFetchFailure = failure
+    }
+    throw terminalFetchFailure
+  }
+
+  def openPartitions(expectedFieldCount: Option[Int] = None): InputStream = {
+    new InputStream {
+      private lazy val partitions = reducers
+      private val stateLock = new Object
+      @volatile private var current: InputStream = _
+      @volatile private var closed = false
+      @volatile private var exhausted = false
+
+      private def nextStream(): Boolean = {
+        context.killTaskIfInterrupted()
+        if (closed || exhausted) {
+          false
+        } else if (!partitions.hasNext) {
+          exhausted = true
+          false
+        } else {
+          val (partition, locations, pushFailedBatches, mapAttempts) = partitions.next()
+          if (closed) {
+            false
+          } else {
+            val opened =
+              openPartition(
+                partition,
+                locations,
+                pushFailedBatches,
+                mapAttempts,
+                expectedFieldCount)
+            try context.killTaskIfInterrupted()
+            catch {
+              case NonFatal(failure) =>
+                Utils.tryWithSafeFinally(throw failure)(opened.close())
+            }
+            val accepted = stateLock.synchronized {
+              if (closed) false
+              else {
+                current = opened
+                true
+              }
+            }
+            if (!accepted) opened.close()
+            accepted
+          }
+        }
+      }
+
+      private def releaseCurrent(stream: InputStream): Unit = {
+        val shouldClose = stateLock.synchronized {
+          if (current eq stream) {
+            current = null
+            true
+          } else false
+        }
+        if (shouldClose) stream.close()
+      }
+
+      private def currentStream(): InputStream = {
+        val active = current
+        if (active != null) active
+        else if (nextStream()) current
+        else null
+      }
+
+      override def read(): Int = {
+        context.killTaskIfInterrupted()
+        if (closed) throw new IOException("Celeborn shuffle input stream is closed")
+        var active = currentStream()
+        while (active != null && !closed) {
+          val value = active.read()
+          if (value >= 0) return value
+          releaseCurrent(active)
+          active = currentStream()
+        }
+        -1
+      }
+
+      override def read(buffer: Array[Byte], offset: Int, length: Int): Int = {
+        context.killTaskIfInterrupted()
+        java.util.Objects.checkFromIndexSize(offset, length, buffer.length)
+        if (closed) throw new IOException("Celeborn shuffle input stream is closed")
+        if (length == 0) return 0
+        var active = currentStream()
+        while (active != null && !closed) {
+          val count = active.read(buffer, offset, length)
+          if (count >= 0) return count
+          releaseCurrent(active)
+          active = currentStream()
+        }
+        -1
+      }
+
+      override def close(): Unit = {
+        val previous = stateLock.synchronized {
+          if (closed) null
+          else {
+            closed = true
+            exhausted = true
+            val active = current
+            current = null
+            active
+          }
+        }
+        if (previous != null) previous.close()
+      }
+    }
+  }
+}
+
+private[shuffle] object CelebornRawPartitionReader {
+
+  private val SPARK_UTILS_CLASS = "org.apache.spark.shuffle.celeborn.SparkUtils"
+  private val SHUFFLE_CLIENT_CLASS = "org.apache.celeborn.client.ShuffleClient"
+  private val SHUFFLE_READER_COMPANION_CLASS =
+    "org.apache.spark.shuffle.celeborn.CelebornShuffleReader$"
+  private val CELEBORN_RUNTIME_EXCEPTION =
+    "org.apache.celeborn.common.exception.CelebornRuntimeException"
+  private val MAX_STAGE_ATTEMPTS = 1 << 15
+  private val MAX_TASK_ATTEMPTS = 1 << 16
+
+  /**
+   * Validate frames before concatenating physical reducers. Otherwise a truncated frame can
+   * consume the next reducer's header as its body, hiding the fetch failure and corrupting the
+   * native input. Only the fixed-size header is buffered; compressed payloads are passed through
+   * unchanged.
+   */
+  private class NativeFrameInputStream(in: InputStream, expectedFieldCount: Option[Int])
+      extends FilterInputStream(in) {
+    private val header = new Array[Byte](16)
+    private val singleByte = new Array[Byte](1)
+    private var headerBytes = 0
+    private var bodyRemaining = 0L
+
+    override def read(): Int = {
+      val count = read(singleByte, 0, 1)
+      if (count < 0) -1 else singleByte(0) & 0xff
+    }
+
+    override def read(buffer: Array[Byte], offset: Int, length: Int): Int = {
+      java.util.Objects.checkFromIndexSize(offset, length, buffer.length)
+      if (length == 0) return 0
+      val readingHeader = bodyRemaining == 0
+      val remaining = if (readingHeader) header.length - headerBytes else bodyRemaining
+      val count = in.read(buffer, offset, math.min(length.toLong, remaining).toInt)
+      if (count < 0) {
+        if (headerBytes != 0 || bodyRemaining != 0) {
+          throw new EOFException("Truncated native Celeborn shuffle frame at reducer boundary")
+        }
+      } else if (readingHeader) {
+        System.arraycopy(buffer, offset, header, headerBytes, count)
+        headerBytes += count
+        if (headerBytes == header.length) {
+          val fields = ByteBuffer.wrap(header).order(ByteOrder.LITTLE_ENDIAN)
+          val compressedLength = fields.getLong()
+          val fieldCount = fields.getLong()
+          if (compressedLength < 12 || compressedLength - 8 > Int.MaxValue - 8L) {
+            throw new IOException(
+              s"Invalid native Celeborn shuffle frame length: $compressedLength")
+          }
+          if (fieldCount < 0 || fieldCount > Int.MaxValue ||
+            expectedFieldCount.exists(_ != fieldCount)) {
+            throw new IOException(s"Invalid native Celeborn shuffle field count: $fieldCount")
+          }
+          headerBytes = 0
+          bodyRemaining = compressedLength - 8
+        }
+      } else {
+        bodyRemaining -= count
+      }
+      count
+    }
+
+    override def skip(length: Long): Long = {
+      if (length <= 0) return 0L
+      val scratch = new Array[Byte](math.min(length, 8192L).toInt)
+      var remaining = length
+      while (remaining > 0) {
+        val count = read(scratch, 0, math.min(remaining, scratch.length.toLong).toInt)
+        if (count < 0) return length - remaining
+        remaining -= count
+      }
+      length
+    }
+
+    override def markSupported(): Boolean = false
+    override def mark(readLimit: Int): Unit = ()
+    override def reset(): Unit = throw new IOException("Native shuffle frames cannot be reset")
+  }
+
+  private def isRawPartitionReader(method: Method): Boolean = {
+    val parameters = method.getParameterTypes
+    val size = parameters.length
+    if (method.getName != "readPartition" || (size != 15 && size != 16) ||
+      !classOf[InputStream].isAssignableFrom(method.getReturnType)) {
+      return false
+    }
+    val callback = parameters(size - 2)
+    val metricsCompatible = callback.isInterface && Seq("incBytesRead", "incReadTime").forall {
+      name =>
+        try callback.getMethod(name, java.lang.Long.TYPE).getReturnType == java.lang.Void.TYPE
+        catch { case _: NoSuchMethodException => false }
+    }
+    Seq(0, 1, 2, 3, 5, 6).forall(parameters(_) == java.lang.Integer.TYPE) &&
+    parameters(4) == java.lang.Long.TYPE && !parameters(7).isPrimitive &&
+    parameters(8) == classOf[ArrayList[_]] && parameters(9) == classOf[ArrayList[_]] &&
+    parameters(10) == classOf[JMap[_, _]] && parameters(11) == classOf[JMap[_, _]] &&
+    (size == 15 || parameters(12) == classOf[JMap[_, _]]) &&
+    parameters(size - 3) == classOf[Array[Int]] && metricsCompatible &&
+    parameters(size - 1) == java.lang.Boolean.TYPE
+  }
+
+  private[shuffle] def encodeAttemptNumber(stageAttempt: Int, taskAttempt: Int): Int = {
+    require(
+      stageAttempt >= 0 && stageAttempt < MAX_STAGE_ATTEMPTS,
+      s"Celeborn stage attempt must be between 0 and ${MAX_STAGE_ATTEMPTS - 1}: " +
+        stageAttempt)
+    require(
+      taskAttempt >= 0 && taskAttempt < MAX_TASK_ATTEMPTS,
+      s"Celeborn task attempt must be between 0 and ${MAX_TASK_ATTEMPTS - 1}: " +
+        taskAttempt)
+    (stageAttempt << 16) | taskAttempt
+  }
+
+  private def isCelebornRuntimeException(failure: Throwable): Boolean = {
+    var current: Class[_] = failure.getClass
+    while (current != null) {
+      if (current.getName == CELEBORN_RUNTIME_EXCEPTION) return true
+      current = current.getSuperclass
+    }
+    false
+  }
+
+  private[shuffle] final case class ReadRange(
+      startMapIndex: Int,
+      endMapIndex: Int,
+      startPartition: Int,
+      endPartition: Int)
+
+  private[shuffle] trait Api {
+    def rpcRetryLimit(conf: SparkConf): Int
+
+    def shuffleId(
+        client: AnyRef,
+        handle: ShuffleHandle,
+        context: TaskContext,
+        isWriter: Boolean): Int
+  }
+
+  private[shuffle] val reflectedApi: Api = new Api {
+    override def rpcRetryLimit(conf: SparkConf): Int = {
+      val sparkUtilsClass = ClassLoaders.loadClass(SPARK_UTILS_CLASS)
+      val celebornConf =
+        invoke(sparkUtilsClass.getMethod("fromSparkConf", classOf[SparkConf]), null, conf)
+      invoke(celebornConf.getClass.getMethod("clientRpcMaxRetries"), celebornConf)
+        .asInstanceOf[Int]
+    }
+
+    override def shuffleId(
+        client: AnyRef,
+        handle: ShuffleHandle,
+        context: TaskContext,
+        isWriter: Boolean): Int = {
+      val sparkUtilsClass = ClassLoaders.loadClass(SPARK_UTILS_CLASS)
+      val shuffleClientClass = ClassLoaders.loadClass(SHUFFLE_CLIENT_CLASS)
+      val method = sparkUtilsClass.getMethod(
+        "celebornShuffleId",
+        shuffleClientClass,
+        handle.getClass,
+        classOf[TaskContext],
+        classOf[java.lang.Boolean])
+      invoke(method, null, client, handle, context, Boolean.box(isWriter)).asInstanceOf[Int]
+    }
+  }
+
+  def fromBackendReader(
+      conf: SparkConf,
+      handle: ShuffleHandle,
+      backendReader: ShuffleReader[_, _],
+      range: ReadRange,
+      context: TaskContext,
+      readMetrics: ShuffleReadMetricsReporter,
+      onClientAcquired: AnyRef => Unit,
+      onGenerationResolved: (AnyRef, Int) => Unit,
+      api: Api = reflectedApi): CelebornRawPartitionReader = {
+    try {
+      context.killTaskIfInterrupted()
+      val client = invoke(backendReader.getClass.getMethod("shuffleClient"), backendReader)
+      onClientAcquired(client)
+
+      // The delegated reader normally initializes this companion from read(). Its static setup
+      // registers the application client's broadcast reducer-file-group deserializer.
+      ClassLoaders.loadClass(SHUFFLE_READER_COMPANION_CLASS)
+
+      val stageRerunEnabled =
+        invoke(handle.getClass.getMethod("stageRerunEnabled"), handle).asInstanceOf[Boolean]
+      if (!stageRerunEnabled) {
+        throw new IllegalStateException("Native Celeborn shuffle requires stage reruns")
+      }
+
+      val retryLimit = api.rpcRetryLimit(conf)
+      val celebornShuffleId = {
+        val started = System.nanoTime()
+        try {
+          context.killTaskIfInterrupted()
+          api.shuffleId(client, handle, context, isWriter = false)
+        } catch {
+          case failure if isCelebornRuntimeException(failure) =>
+            throw new FetchFailedException(
+              null,
+              handle.shuffleId,
+              -1L,
+              -1,
+              range.startPartition,
+              s"Celeborn could not resolve shuffle generation ${handle.shuffleId}",
+              failure)
+        } finally {
+          readMetrics.incFetchWaitTime(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - started))
+        }
+      }
+
+      onGenerationResolved(client, celebornShuffleId)
+      new CelebornRawPartitionReader(
+        client,
+        handle.shuffleId,
+        celebornShuffleId,
+        range.startMapIndex,
+        range.endMapIndex,
+        range.startPartition,
+        range.endPartition,
+        context,
+        readMetrics,
+        retryLimit,
+        stageRerunEnabled)
+    } catch {
+      case failure: ReflectiveOperationException =>
+        throw new IllegalStateException(
+          "The Celeborn client does not expose the required native-shuffle reader API",
+          failure)
+    }
+  }
+
+  private def invoke(method: Method, instance: AnyRef, arguments: AnyRef*): AnyRef =
+    try method.invoke(instance, arguments: _*)
+    catch {
+      case failure: InvocationTargetException =>
+        throw Option(failure.getCause).getOrElse(failure)
+    }
+
+  private def isFileGroupTimeout(failure: Throwable): Boolean =
+    Option(failure.getCause).exists(_.isInstanceOf[TimeoutException])
+
+  private def isUnreportableFileGroupFailure(failure: Throwable): Boolean =
+    Option(failure.getCause).exists { cause =>
+      cause.isInstanceOf[InterruptedException] || cause.isInstanceOf[TimeoutException] ||
+      cause.getClass.getName == "org.apache.celeborn.common.exception.CelebornBroadcastException"
+    }
+
+  private def createMetricsCallback(
+      callbackClass: Class[_],
+      reporter: ShuffleReadMetricsReporter): AnyRef = {
+    val remoteWorkers = ConcurrentHashMap.newKeySet[String]()
+    val unavailableMetrics = ConcurrentHashMap.newKeySet[String]()
+
+    def optionalMetric(name: String, value: Long): Unit = {
+      if (!unavailableMetrics.contains(name)) {
+        try {
+          val method = reporter.getClass.getMethod(name, java.lang.Long.TYPE)
+          method.setAccessible(true)
+          invoke(method, reporter, Long.box(value))
+        } catch {
+          case NonFatal(_) => unavailableMetrics.add(name)
+        }
+      }
+      ()
+    }
+
+    val callback = new InvocationHandler {
+      override def invoke(proxy: AnyRef, method: Method, arguments: Array[AnyRef]): AnyRef = {
+        method.getName match {
+          case "incBytesRead" =>
+            reporter.incRemoteBytesRead(arguments(0).asInstanceOf[Long])
+            reporter.incRemoteBlocksFetched(1)
+          case "incReadTime" => reporter.incFetchWaitTime(arguments(0).asInstanceOf[Long])
+          case "recordRemoteReadWorker" =>
+            val worker = arguments(0).asInstanceOf[String]
+            if (worker != null && remoteWorkers.add(worker)) {
+              optionalMetric("incCelebornDistinctRemoteWorkersRead", 1)
+            }
+          case "hashCode" => return Int.box(System.identityHashCode(proxy))
+          case "equals" => return Boolean.box(proxy eq arguments(0))
+          case "toString" => return "CometCelebornShuffleMetricsCallback"
+          case name if name.startsWith("inc") =>
+            optionalMetric("incCeleborn" + name.substring(3), arguments(0).asInstanceOf[Long])
+          case _ =>
+        }
+        null
+      }
+    }
+
+    Proxy.newProxyInstance(callbackClass.getClassLoader, Array(callbackClass), callback)
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleReader.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet.execution.shuffle
+
+import java.io.InputStream
+
+import org.apache.spark.shuffle.ShuffleReader
+
+/** The local and remote shuffle readers support the same decoded and native consumption paths. */
+private[shuffle] trait CometShuffleReader[K, C] extends ShuffleReader[K, C] {
+  def readAsRawStream(): InputStream
+}

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffledRowRDD.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffledRowRDD.scala
@@ -31,8 +31,8 @@ import org.apache.comet.CometShuffleBlockIterator
 
 /**
  * Different from [[org.apache.spark.sql.execution.ShuffledRowRDD]], this RDD is specialized for
- * reading shuffled data through [[CometBlockStoreShuffleReader]]. The shuffled data is read in an
- * iterator of [[Product2[Int, ColumnarBatch]]] instead of [[Product2[Int, InternalRow]]].
+ * reading shuffled data through [[CometShuffleReader]]. The shuffled data is read in an iterator
+ * of [[Product2[Int, ColumnarBatch]]] instead of [[Product2[Int, InternalRow]]].
  */
 class CometShuffledBatchRDD(
     var dependency: ShuffleDependency[Int, _, _],
@@ -92,9 +92,7 @@ class CometShuffledBatchRDD(
     }
   }
 
-  private def createReader(
-      split: Partition,
-      context: TaskContext): CometBlockStoreShuffleReader[_, _] = {
+  private def createReader(split: Partition, context: TaskContext): CometShuffleReader[_, _] = {
     val tempMetrics = context.taskMetrics().createTempShuffleReadMetrics()
     // `SQLShuffleReadMetricsReporter` will update its own metrics for SQL exchange operator,
     // as well as the `tempMetrics` for basic shuffle metrics.
@@ -108,7 +106,7 @@ class CometShuffledBatchRDD(
             endReducerIndex,
             context,
             sqlMetricsReporter)
-          .asInstanceOf[CometBlockStoreShuffleReader[_, _]]
+          .asInstanceOf[CometShuffleReader[_, _]]
 
       case PartialReducerPartitionSpec(reducerIndex, startMapIndex, endMapIndex, _) =>
         SparkEnv.get.shuffleManager
@@ -120,7 +118,7 @@ class CometShuffledBatchRDD(
             reducerIndex + 1,
             context,
             sqlMetricsReporter)
-          .asInstanceOf[CometBlockStoreShuffleReader[_, _]]
+          .asInstanceOf[CometShuffleReader[_, _]]
 
       case PartialMapperPartitionSpec(mapIndex, startReducerIndex, endReducerIndex) =>
         SparkEnv.get.shuffleManager
@@ -132,7 +130,7 @@ class CometShuffledBatchRDD(
             endReducerIndex,
             context,
             sqlMetricsReporter)
-          .asInstanceOf[CometBlockStoreShuffleReader[_, _]]
+          .asInstanceOf[CometShuffleReader[_, _]]
 
       case CoalescedMapperPartitionSpec(startMapIndex, endMapIndex, numReducers) =>
         SparkEnv.get.shuffleManager
@@ -144,7 +142,7 @@ class CometShuffledBatchRDD(
             numReducers,
             context,
             sqlMetricsReporter)
-          .asInstanceOf[CometBlockStoreShuffleReader[_, _]]
+          .asInstanceOf[CometShuffleReader[_, _]]
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/NativeBatchDecoderIterator.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/NativeBatchDecoderIterator.scala
@@ -23,10 +23,12 @@ import java.io.{EOFException, InputStream}
 import java.nio.{ByteBuffer, ByteOrder}
 import java.nio.channels.{Channels, ReadableByteChannel}
 
+import scala.util.control.NonFatal
+
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-import org.apache.comet.Native
+import org.apache.comet.{CometShuffleReadFailureHandler, Native}
 import org.apache.comet.vector.NativeUtil
 
 /**
@@ -39,13 +41,19 @@ case class NativeBatchDecoderIterator(
     decodeTime: SQLMetric,
     nativeLib: Native,
     nativeUtil: NativeUtil,
-    tracingEnabled: Boolean)
+    tracingEnabled: Boolean,
+    expectedSchema: Option[Array[Byte]] = None)
     extends Iterator[ColumnarBatch] {
 
   private var isClosed = false
   private val longBuf = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN)
   private var currentBatch: ColumnarBatch = null
-  private var batch = fetchNext()
+  private var batch: Option[ColumnarBatch] = None
+  private val validateRemoteFrames = in.isInstanceOf[CometShuffleReadFailureHandler]
+
+  require(
+    !validateRemoteFrames || expectedSchema.exists(_ != null),
+    "Remote shuffle decoding requires the expected Spark schema")
 
   import NativeBatchDecoderIterator._
 
@@ -90,25 +98,65 @@ case class NativeBatchDecoderIterator(
   }
 
   private def fetchNext(): Option[ColumnarBatch] = {
+    // The remote input owns metadata, transport, and frame-boundary failure classification. Do
+    // not turn deliberately unreported metadata timeouts or stream-close failures into corruption.
+    val block = readNextBlock()
+    block.flatMap { case (fieldCount, dataBuf, bytesToRead) =>
+      // Allocation and Arrow import failures are not evidence of a corrupt remote shuffle. Only
+      // forward failures from native codec/IPC decoding and logical type validation.
+      val startTime = System.nanoTime()
+      val decoded = nativeUtil.getNextBatch(
+        fieldCount,
+        (arrayAddrs, schemaAddrs) => {
+          handleReadFailure {
+            if (validateRemoteFrames) {
+              nativeLib.decodeShuffleBlockWithValidation(
+                dataBuf,
+                bytesToRead,
+                arrayAddrs,
+                schemaAddrs,
+                tracingEnabled,
+                expectedSchema.get)
+            } else {
+              nativeLib.decodeShuffleBlock(
+                dataBuf,
+                bytesToRead,
+                arrayAddrs,
+                schemaAddrs,
+                tracingEnabled)
+            }
+          }
+        })
+      decodeTime.add(System.nanoTime() - startTime)
+      decoded
+    }
+  }
+
+  private def handleReadFailure[T](read: => T): T = {
+    try read
+    catch {
+      case NonFatal(failure) =>
+        in match {
+          case handler: CometShuffleReadFailureHandler => handler.onShuffleReadFailure(failure)
+          case _ =>
+        }
+        throw failure
+    }
+  }
+
+  private def readNextBlock(): Option[(Int, ByteBuffer, Int)] = {
     if (channel == null || isClosed) {
       return None
     }
 
     // read compressed batch size from header
-    try {
-      longBuf.clear()
-      while (longBuf.hasRemaining && channel.read(longBuf) >= 0) {}
-    } catch {
-      case _: EOFException =>
-        close()
-        return None
-    }
+    longBuf.clear()
+    while (longBuf.hasRemaining && channel.read(longBuf) >= 0) {}
 
     // If we reach the end of the stream, we are done, or if we read partial length
     // then the stream is corrupted.
     if (longBuf.hasRemaining) {
       if (longBuf.position() == 0) {
-        close()
         return None
       }
       throw new EOFException("Data corrupt: unexpected EOF while reading compressed ipc lengths")
@@ -150,33 +198,36 @@ case class NativeBatchDecoderIterator(
       throw new EOFException("Data corrupt: unexpected EOF while reading compressed batch")
     }
 
-    // make native call to decode batch
-    val startTime = System.nanoTime()
-    val batch = nativeUtil.getNextBatch(
-      fieldCount,
-      (arrayAddrs, schemaAddrs) => {
-        nativeLib.decodeShuffleBlock(
-          dataBuf,
-          bytesToRead.toInt,
-          arrayAddrs,
-          schemaAddrs,
-          tracingEnabled)
-      })
-    decodeTime.add(System.nanoTime() - startTime)
-
-    batch
+    Some((fieldCount, dataBuf, bytesToRead.toInt))
   }
 
   def close(): Unit = {
     synchronized {
       if (!isClosed) {
-        if (currentBatch != null) {
-          currentBatch.close()
-          currentBatch = null
-        }
-        in.close()
-        resetDataBuf()
+        // hasNext() owns a decoded batch even before next() exposes it to the consumer. Release
+        // that lookahead on early task completion as well as the last batch returned by next().
+        // Clear ownership before cleanup so a failing close remains idempotent.
         isClosed = true
+        val previous = currentBatch
+        currentBatch = null
+        val prefetched = batch
+        batch = None
+
+        var failure: Throwable = null
+        def release(resource: => Unit): Unit = {
+          try resource
+          catch {
+            case caught: Throwable =>
+              if (failure == null) failure = caught
+              else if (caught ne failure) failure.addSuppressed(caught)
+          }
+        }
+
+        if (previous != null) release(previous.close())
+        prefetched.filterNot(_ eq previous).foreach(pending => release(pending.close()))
+        if (in != null) release(in.close())
+        release(resetDataBuf())
+        if (failure != null) throw failure
       }
     }
   }

--- a/spark/src/test/java/org/apache/spark/sql/comet/execution/shuffle/RecordingCelebornRawClient.java
+++ b/spark/src/test/java/org/apache/spark/sql/comet/execution/shuffle/RecordingCelebornRawClient.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet.execution.shuffle;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import scala.Product2;
+import scala.collection.Iterator;
+
+import org.apache.spark.shuffle.ShuffleReader;
+
+/** Exposes the pinned Celeborn read contract without making Celeborn a Comet test dependency. */
+public final class RecordingCelebornRawClient {
+
+  private static final AtomicBoolean BROADCAST_DECODER_REGISTERED = new AtomicBoolean(false);
+
+  public static void registerBroadcastDecoder() {
+    BROADCAST_DECODER_REGISTERED.set(true);
+  }
+
+  public static boolean broadcastDecoderRegistered() {
+    return BROADCAST_DECODER_REGISTERED.get();
+  }
+
+  public interface MetricsCallback {
+    void incBytesRead(long bytes);
+
+    void incReadTime(long time);
+
+    default void incRemoteReadRetryCount(long count) {}
+
+    default void recordRemoteReadWorker(String worker) {}
+  }
+
+  public interface OptionalMetricsReporter {
+    void incCelebornRemoteReadRetryCount(long count);
+  }
+
+  public static final class BackendReader implements ShuffleReader<Object, Object> {
+    private final RecordingCelebornRawClient client;
+
+    public BackendReader(RecordingCelebornRawClient client) {
+      this.client = client;
+    }
+
+    public RecordingCelebornRawClient shuffleClient() {
+      return client;
+    }
+
+    @Override
+    public Iterator<Product2<Object, Object>> read() {
+      throw new UnsupportedOperationException("The delegated row reader must never be consumed");
+    }
+  }
+
+  /** Newer clients insert a coalesced-partition map into the stock 15-argument API. */
+  public static final class CoalescedClient {
+    public final RecordingCelebornRawClient delegate = new RecordingCelebornRawClient();
+
+    public boolean isShuffleStageEnd(int shuffleId) {
+      return delegate.isShuffleStageEnd(shuffleId);
+    }
+
+    public ReduceFileGroups updateFileGroup(int shuffleId, int partitionId) throws IOException {
+      return delegate.updateFileGroup(shuffleId, partitionId);
+    }
+
+    public boolean reportShuffleFetchFailure(int appShuffleId, int shuffleId, long taskId)
+        throws IOException {
+      return delegate.reportShuffleFetchFailure(appShuffleId, shuffleId, taskId);
+    }
+
+    public InputStream readPartition(
+        int shuffleId,
+        int appShuffleId,
+        int partitionId,
+        int attemptNumber,
+        long taskId,
+        int startMapIndex,
+        int endMapIndex,
+        Object exceptionMaker,
+        ArrayList<Object> locations,
+        ArrayList<Object> streamHandlers,
+        Map<String, Object> pushFailedBatches,
+        Map<String, Object> chunksRange,
+        Map<String, Object> coalescedPartitionInfos,
+        int[] mapAttempts,
+        MetricsCallback metricsCallback,
+        boolean needDecompress)
+        throws IOException {
+      if (coalescedPartitionInfos != null) {
+        throw new AssertionError("Native readers must not request physical-skew coalescing");
+      }
+      return delegate.readPartition(
+          shuffleId,
+          appShuffleId,
+          partitionId,
+          attemptNumber,
+          taskId,
+          startMapIndex,
+          endMapIndex,
+          exceptionMaker,
+          locations,
+          streamHandlers,
+          pushFailedBatches,
+          chunksRange,
+          mapAttempts,
+          metricsCallback,
+          needDecompress);
+    }
+  }
+
+  public static final class ReduceFileGroups {
+    public Map<Integer, Set<Object>> partitionGroups = new HashMap<>();
+    public Map<String, Object> pushFailedBatches = new HashMap<>();
+    public int[] mapAttempts = new int[] {0};
+  }
+
+  public static final class ReadRequest {
+    public final int shuffleId;
+    public final int appShuffleId;
+    public final int partitionId;
+    public final int attemptNumber;
+    public final long taskId;
+    public final int startMapIndex;
+    public final int endMapIndex;
+    public final Object exceptionMaker;
+    public final ArrayList<Object> locations;
+    public final ArrayList<Object> streamHandlers;
+    public final Map<String, Object> pushFailedBatches;
+    public final Map<String, Object> chunksRange;
+    public final Map<String, Object> coalescedPartitionInfos;
+    public final int[] mapAttempts;
+    public final MetricsCallback metricsCallback;
+    public final boolean needDecompress;
+
+    ReadRequest(
+        int shuffleId,
+        int appShuffleId,
+        int partitionId,
+        int attemptNumber,
+        long taskId,
+        int startMapIndex,
+        int endMapIndex,
+        Object exceptionMaker,
+        ArrayList<Object> locations,
+        ArrayList<Object> streamHandlers,
+        Map<String, Object> pushFailedBatches,
+        Map<String, Object> chunksRange,
+        Map<String, Object> coalescedPartitionInfos,
+        int[] mapAttempts,
+        MetricsCallback metricsCallback,
+        boolean needDecompress) {
+      this.shuffleId = shuffleId;
+      this.appShuffleId = appShuffleId;
+      this.partitionId = partitionId;
+      this.attemptNumber = attemptNumber;
+      this.taskId = taskId;
+      this.startMapIndex = startMapIndex;
+      this.endMapIndex = endMapIndex;
+      this.exceptionMaker = exceptionMaker;
+      this.locations = locations;
+      this.streamHandlers = streamHandlers;
+      this.pushFailedBatches = pushFailedBatches;
+      this.chunksRange = chunksRange;
+      this.coalescedPartitionInfos = coalescedPartitionInfos;
+      this.mapAttempts = mapAttempts;
+      this.metricsCallback = metricsCallback;
+      this.needDecompress = needDecompress;
+    }
+  }
+
+  public final ReduceFileGroups fileGroups = new ReduceFileGroups();
+  public final Map<Integer, InputStream> streams = new HashMap<>();
+  public final List<ReadRequest> requests = new ArrayList<>();
+  public int updateFileGroupCalls;
+  public int stageEndChecks;
+  public int failureReports;
+  public int cleanupCalls;
+  public int timeoutFailures;
+  public boolean stageEnded = true;
+  public boolean invalidateOnFetchFailure = true;
+  public boolean requiresBroadcastDecoder;
+  public CountDownLatch readPartitionStarted;
+  public CountDownLatch allowReadPartition;
+  public IOException updateFileGroupFailure;
+  public IOException readPartitionFailure;
+  public IOException reportFetchFailureFailure;
+  public Runnable beforeUpdateFileGroup;
+
+  public boolean isShuffleStageEnd(int shuffleId) {
+    stageEndChecks += 1;
+    return stageEnded;
+  }
+
+  public ReduceFileGroups updateFileGroup(int shuffleId, int partitionId) throws IOException {
+    updateFileGroupCalls += 1;
+    if (beforeUpdateFileGroup != null) {
+      beforeUpdateFileGroup.run();
+    }
+    if (requiresBroadcastDecoder && !broadcastDecoderRegistered()) {
+      throw new IOException("Celeborn's broadcast reducer-file-group decoder was not registered");
+    }
+    if (timeoutFailures > 0) {
+      timeoutFailures -= 1;
+      throw new IOException("reducer-file-group RPC timed out", new TimeoutException());
+    }
+    if (updateFileGroupFailure != null) {
+      throw updateFileGroupFailure;
+    }
+    return fileGroups;
+  }
+
+  public InputStream readPartition(
+      int shuffleId,
+      int appShuffleId,
+      int partitionId,
+      int attemptNumber,
+      long taskId,
+      int startMapIndex,
+      int endMapIndex,
+      Object exceptionMaker,
+      ArrayList<Object> locations,
+      ArrayList<Object> streamHandlers,
+      Map<String, Object> pushFailedBatches,
+      Map<String, Object> chunksRange,
+      int[] mapAttempts,
+      MetricsCallback metricsCallback,
+      boolean needDecompress)
+      throws IOException {
+    requests.add(
+        new ReadRequest(
+            shuffleId,
+            appShuffleId,
+            partitionId,
+            attemptNumber,
+            taskId,
+            startMapIndex,
+            endMapIndex,
+            exceptionMaker,
+            locations,
+            streamHandlers,
+            pushFailedBatches,
+            chunksRange,
+            null,
+            mapAttempts,
+            metricsCallback,
+            needDecompress));
+    if (readPartitionFailure != null) {
+      throw readPartitionFailure;
+    }
+    if (readPartitionStarted != null) {
+      readPartitionStarted.countDown();
+      try {
+        if (!allowReadPartition.await(5, TimeUnit.SECONDS)) {
+          throw new IOException("timed out waiting to open the test reducer stream");
+        }
+      } catch (InterruptedException failure) {
+        Thread.currentThread().interrupt();
+        throw new IOException("interrupted while opening the test reducer stream", failure);
+      }
+    }
+    return streams.get(partitionId);
+  }
+
+  public boolean reportShuffleFetchFailure(int appShuffleId, int shuffleId, long taskId)
+      throws IOException {
+    failureReports += 1;
+    if (reportFetchFailureFailure != null) {
+      throw reportFetchFailureFailure;
+    }
+    return invalidateOnFetchFailure;
+  }
+
+  public boolean cleanupShuffle(int shuffleId) {
+    cleanupCalls += 1;
+    return true;
+  }
+}

--- a/spark/src/test/scala/org/apache/celeborn/common/exception/CelebornRuntimeException.scala
+++ b/spark/src/test/scala/org/apache/celeborn/common/exception/CelebornRuntimeException.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.celeborn.common.exception
+
+/** Exact-name fixture for the optional Celeborn generation-failure contract. */
+class CelebornRuntimeException(message: String) extends RuntimeException(message)

--- a/spark/src/test/scala/org/apache/comet/vector/NativeUtilSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/vector/NativeUtilSuite.scala
@@ -19,13 +19,105 @@
 
 package org.apache.comet.vector
 
-import org.apache.arrow.c.{ArrowArray, ArrowSchema}
+import java.io.IOException
+
+import org.apache.arrow.c.{ArrowArray, ArrowSchema, Data}
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.IntVector
 import org.apache.spark.sql.CometTestBase
 import org.apache.spark.sql.execution.vectorized.ConstantColumnVector
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 
 class NativeUtilSuite extends CometTestBase {
+
+  private def withIsolatedStructAllocator(
+      check: (NativeUtil, RootAllocator, () => Array[ArrowArray]) => Unit): Unit = {
+    val allocator = new RootAllocator(Long.MaxValue)
+    var allocatedArrays = Array.empty[ArrowArray]
+    val nativeUtil = new NativeUtil {
+      override def allocateArrowStructs(numCols: Int): (Array[ArrowArray], Array[ArrowSchema]) = {
+        allocatedArrays = Array.fill(numCols)(ArrowArray.allocateNew(allocator))
+        val schemas = Array.fill(numCols)(ArrowSchema.allocateNew(allocator))
+        (allocatedArrays, schemas)
+      }
+    }
+    try check(nativeUtil, allocator, () => allocatedArrays)
+    finally {
+      nativeUtil.close()
+      allocator.close()
+    }
+  }
+
+  test("getNextBatch releases unconsumed Arrow structs on native failure and EOF") {
+    Seq(false, true).foreach { eof =>
+      withIsolatedStructAllocator { (nativeUtil, allocator, _) =>
+        val expected = new IOException("native decode failed")
+        val read = () =>
+          nativeUtil.getNextBatch(
+            2,
+            (_, _) => {
+              if (eof) -1L else throw expected
+            })
+        if (eof) assert(read().isEmpty)
+        else assert(intercept[IOException](read()) eq expected)
+        assert(allocator.getAllocatedMemory == 0)
+      }
+    }
+  }
+
+  test("getNextBatch invokes C release callbacks for partially exported native results") {
+    Seq(false, true).foreach { eof =>
+      withIsolatedStructAllocator { (nativeUtil, allocator, _) =>
+        val vector = new IntVector("value", allocator)
+        vector.allocateNew(4)
+        vector.setSafe(0, 42)
+        vector.setValueCount(1)
+        val expected = new IOException("native decode failed after exporting one column")
+        val read = () =>
+          nativeUtil.getNextBatch(
+            2,
+            (arrays, schemas) => {
+              Data.exportVector(
+                allocator,
+                vector,
+                null,
+                ArrowArray.wrap(arrays(0)),
+                ArrowSchema.wrap(schemas(0)))
+              // Only the exported C data now retains the vector's buffers.
+              vector.close()
+              if (eof) -1L else throw expected
+            })
+        try {
+          if (eof) assert(read().isEmpty)
+          else assert(intercept[IOException](read()) eq expected)
+          assert(allocator.getAllocatedMemory == 0)
+        } finally {
+          vector.close()
+        }
+      }
+    }
+  }
+
+  test("getNextBatch preserves a native failure and attempts all remaining struct cleanup") {
+    withIsolatedStructAllocator { (nativeUtil, allocator, arrays) =>
+      val expected = new IOException("native decode failed")
+      val actual = intercept[IOException] {
+        nativeUtil.getNextBatch(
+          2,
+          (_, _) => {
+            // Simulate another owner retiring one struct before cleanup. Its release() fails,
+            // but that must not hide the decode failure or leave any other struct allocated.
+            arrays()(0).close()
+            throw expected
+          })
+      }
+      assert(actual eq expected)
+      assert(actual.getSuppressed.length == 1)
+      assert(actual.getSuppressed.head.isInstanceOf[NullPointerException])
+      assert(allocator.getAllocatedMemory == 0)
+    }
+  }
 
   test("exportBatch round-trips a ConstantColumnVector through Arrow FFI") {
     // Smoke test for the ConstantColumnVector arm of NativeUtil.exportBatch: a batch carrying

--- a/spark/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleHandle.scala
+++ b/spark/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleHandle.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.shuffle.celeborn
+
+import org.apache.spark.ShuffleDependency
+import org.apache.spark.shuffle.BaseShuffleHandle
+
+/** Exact-name test handle for the optional Celeborn manager's reflective reader integration. */
+class CelebornShuffleHandle[K, V, C](
+    shuffleId: Int,
+    dependency: ShuffleDependency[K, V, C],
+    val stageRerunEnabled: Boolean = true)
+    extends BaseShuffleHandle[K, V, C](shuffleId, dependency)

--- a/spark/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/spark/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.shuffle.celeborn
+
+import org.apache.spark.sql.comet.execution.shuffle.RecordingCelebornRawClient
+
+/** Matches the pinned Celeborn companion's broadcast decoder-registration side effect. */
+object CelebornShuffleReader {
+  RecordingCelebornRawClient.registerBroadcastDecoder()
+}

--- a/spark/src/test/scala/org/apache/spark/sql/comet/execution/shuffle/CometCelebornShuffleReaderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/execution/shuffle/CometCelebornShuffleReaderSuite.scala
@@ -1,0 +1,1583 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet.execution.shuffle
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, EOFException, InputStream, IOException}
+import java.lang.reflect.{InvocationHandler, Method, Proxy}
+import java.nio.{ByteBuffer, ByteOrder}
+import java.nio.channels.Channels
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.{LinkedHashSet, Set => JSet}
+import java.util.concurrent.{CountDownLatch, TimeoutException, TimeUnit}
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.arrow.flatbuf.{Int => IpcInt, Message, MessageHeader, Schema => IpcSchema, Type => IpcType}
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.{FieldVector, IntVector, VarCharVector, VectorSchemaRoot}
+import org.apache.arrow.vector.complex.{ListVector, MapVector}
+import org.apache.arrow.vector.dictionary.{Dictionary, DictionaryProvider}
+import org.apache.arrow.vector.dictionary.DictionaryProvider.MapDictionaryProvider
+import org.apache.arrow.vector.ipc.ArrowStreamWriter
+import org.apache.arrow.vector.types.pojo.{ArrowType, DictionaryEncoding, Field, FieldType}
+import org.apache.spark.{HashPartitioner, ShuffleDependency, SparkConf, SparkEnv, TaskContext, TaskKilledException}
+import org.apache.spark.shuffle.{FetchFailedException, IndexShuffleBlockResolver, ShuffleBlockResolver, ShuffleHandle, ShuffleManager, ShuffleReader, ShuffleReadMetricsReporter, ShuffleWriteMetricsReporter, ShuffleWriter}
+import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.comet.{CometExec, CometMetricNode}
+import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.types.{ArrayType, IntegerType, MapType, StringType}
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+import com.google.flatbuffers.Table
+
+import org.apache.comet.{CometConf, CometExecIterator, CometShuffleBlockIterator, Native}
+import org.apache.comet.serde.{OperatorOuterClass, QueryPlanSerde}
+
+class CometCelebornShuffleReaderSuite extends CometTestBase {
+
+  import testImplicits._
+
+  private def frameBytes(payload: Byte*): Array[Byte] = ByteBuffer
+    .allocate(20 + payload.size)
+    .order(ByteOrder.LITTLE_ENDIAN)
+    .putLong(12L + payload.size)
+    .putLong(0L)
+    .put(Array[Byte](78, 79, 78, 69)) // NONE codec; raw-reader tests need only a framed payload.
+    .put(payload.toArray)
+    .array()
+
+  private final class TrackingInputStream(bytes: Array[Byte])
+      extends ByteArrayInputStream(bytes) {
+    var closeCalls = 0
+
+    override def close(): Unit = {
+      closeCalls += 1
+      super.close()
+    }
+  }
+
+  private final class RecordingReaderBackend(client: RecordingCelebornRawClient)
+      extends ShuffleManager {
+    var readRange: Option[(Int, Int, Int, Int)] = None
+    var unregistered: Option[Int] = None
+
+    override def registerShuffle[K, V, C](
+        shuffleId: Int,
+        dependency: ShuffleDependency[K, V, C]): ShuffleHandle =
+      throw new UnsupportedOperationException("This fixture only reads existing native shuffles")
+
+    override def getWriter[K, V](
+        handle: ShuffleHandle,
+        mapId: Long,
+        context: TaskContext,
+        metrics: ShuffleWriteMetricsReporter): ShuffleWriter[K, V] =
+      throw new UnsupportedOperationException("This fixture only reads existing native shuffles")
+
+    override def getReader[K, C](
+        handle: ShuffleHandle,
+        startMapIndex: Int,
+        endMapIndex: Int,
+        startPartition: Int,
+        endPartition: Int,
+        context: TaskContext,
+        metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
+      readRange = Some((startMapIndex, endMapIndex, startPartition, endPartition))
+      new RecordingCelebornRawClient.BackendReader(client).asInstanceOf[ShuffleReader[K, C]]
+    }
+
+    override def shuffleBlockResolver: ShuffleBlockResolver = null
+
+    override def unregisterShuffle(shuffleId: Int): Boolean = {
+      unregistered = Some(shuffleId)
+      true
+    }
+
+    override def stop(): Unit = ()
+  }
+
+  private final class RecordingReaderApi extends CelebornRawPartitionReader.Api {
+    var resolvedClient: AnyRef = _
+    var resolvedHandle: ShuffleHandle = _
+    var resolvedContext: TaskContext = _
+    var resolvedAsWriter: Option[Boolean] = None
+    var retryLimitFailure: Throwable = _
+    var generationFailure: Throwable = _
+
+    override def rpcRetryLimit(conf: SparkConf): Int = {
+      if (retryLimitFailure != null) throw retryLimitFailure
+      2
+    }
+
+    override def shuffleId(
+        client: AnyRef,
+        handle: ShuffleHandle,
+        context: TaskContext,
+        isWriter: Boolean): Int = {
+      resolvedClient = client
+      resolvedHandle = handle
+      resolvedContext = context
+      resolvedAsWriter = Some(isWriter)
+      if (generationFailure != null) throw generationFailure
+      91
+    }
+  }
+
+  private def location(values: String*): JSet[Object] = {
+    val locations = new LinkedHashSet[Object]()
+    values.foreach(locations.add)
+    locations
+  }
+
+  private def rawReader(
+      client: AnyRef,
+      context: TaskContext,
+      startMap: Int = 0,
+      endMap: Int = Int.MaxValue,
+      startPartition: Int = 0,
+      endPartition: Int = 3,
+      retries: Int = 2): CelebornRawPartitionReader =
+    new CelebornRawPartitionReader(
+      client,
+      sparkShuffleId = 17,
+      celebornShuffleId = 91,
+      startMap,
+      endMap,
+      startPartition,
+      endPartition,
+      context,
+      context.taskMetrics().createTempShuffleReadMetrics(),
+      retries)
+
+  private def simpleDependency(partitions: Int = 3, attributes: Seq[Attribute] = Seq.empty)
+      : CometShuffleDependency[Int, ColumnarBatch, ColumnarBatch] =
+    new CometShuffleDependency[Int, ColumnarBatch, ColumnarBatch](
+      spark.sparkContext.emptyRDD[(Int, ColumnarBatch)],
+      new HashPartitioner(partitions),
+      decodeTime = SQLMetrics.createMetric(spark.sparkContext, "Celeborn decode time"),
+      outputAttributes = attributes)
+
+  private def ownedClients(manager: CometCelebornShuffleManager)
+      : java.util.concurrent.ConcurrentHashMap[AnyRef, java.lang.Boolean] = {
+    val ownership = classOf[CometCelebornShuffleManager].getDeclaredField("ownedNativeClients")
+    ownership.setAccessible(true)
+    ownership
+      .get(manager)
+      .asInstanceOf[java.util.concurrent.ConcurrentHashMap[AnyRef, java.lang.Boolean]]
+  }
+
+  private def completionListenerCount(context: TaskContext): Int = {
+    val listeners = context.getClass.getDeclaredField("onCompleteCallbacks")
+    listeners.setAccessible(true)
+    listeners.get(context).asInstanceOf[java.util.Stack[_]].size()
+  }
+
+  private def reader(
+      dependency: CometShuffleDependency[Int, ColumnarBatch, ColumnarBatch],
+      client: RecordingCelebornRawClient,
+      context: TaskContext): CometCelebornShuffleReader[Int, ColumnarBatch] = {
+    val metrics = context.taskMetrics().createTempShuffleReadMetrics()
+    val partitions = new CelebornRawPartitionReader(
+      client,
+      dependency.shuffleId,
+      91,
+      0,
+      Int.MaxValue,
+      0,
+      dependency.partitioner.numPartitions,
+      context,
+      metrics,
+      2)
+    new CometCelebornShuffleReader[Int, ColumnarBatch](dependency, context, metrics, partitions)
+  }
+
+  private def withNativeFrame(
+      run: (CometShuffleDependency[Int, ColumnarBatch, ColumnarBatch], Array[Byte]) => Unit)
+      : Unit = {
+    withSQLConf(
+      CometConf.COMET_EXEC_ENABLED.key -> "true",
+      CometConf.COMET_SHUFFLE_MODE.key -> "native",
+      CometConf.COMET_SHUFFLE_ENABLED.key -> "true",
+      "spark.sql.adaptive.enabled" -> "false") {
+      withParquetTable((0 until 12).map(i => (i, s"row-$i")), "celeborn_reader_rows") {
+        val dependency = sql("SELECT * FROM celeborn_reader_rows")
+          .repartition(3, $"_1")
+          .queryExecution
+          .executedPlan
+          .collectFirst { case exchange: CometShuffleExchangeExec =>
+            exchange.shuffleDependency
+              .asInstanceOf[CometShuffleDependency[Int, ColumnarBatch, ColumnarBatch]]
+          }
+          .getOrElse(fail("Expected a native Comet shuffle exchange"))
+
+        val frames = spark.sparkContext
+          .runJob(
+            dependency.rdd,
+            (context: TaskContext, inputs: Iterator[Product2[Int, ColumnarBatch]]) => {
+              val writer = new CometNativeShuffleWriter[Int, ColumnarBatch](
+                dependency.nativeShuffleSpec.get,
+                dependency.outputPartitioning.get,
+                dependency.outputAttributes,
+                dependency.shuffleWriteMetrics,
+                dependency.numParts,
+                dependency.shuffleId,
+                context.taskAttemptId(),
+                context,
+                context.taskMetrics().shuffleWriteMetrics,
+                dependency.rangePartitionBounds)
+              writer.write(inputs)
+              writer.stop(success = true)
+              val dataFile = SparkEnv.get.shuffleManager.shuffleBlockResolver
+                .asInstanceOf[IndexShuffleBlockResolver]
+                .getDataFile(dependency.shuffleId, context.taskAttemptId())
+              val bytes = Files.readAllBytes(dataFile.toPath)
+              var offset = 0
+              writer.getPartitionLengths().flatMap { length =>
+                val end = offset + length.toInt
+                val frame = bytes.slice(offset, end)
+                offset = end
+                if (frame.nonEmpty) Some(frame) else None
+              }
+            })
+          .flatten
+
+        assert(frames.nonEmpty)
+        run(dependency, frames.head)
+      }
+    }
+  }
+
+  test("fresh Celeborn readers initialize the broadcast reducer-file-group decoder") {
+    assert(!RecordingCelebornRawClient.broadcastDecoderRegistered())
+    val context = TaskContext.empty()
+    val dependency = simpleDependency()
+    val client = new RecordingCelebornRawClient
+    client.requiresBroadcastDecoder = true
+    client.fileGroups.partitionGroups.put(0, location("worker"))
+    client.streams.put(0, new ByteArrayInputStream(frameBytes(9)))
+    val backend = new RecordingReaderBackend(client)
+    val api = new RecordingReaderApi
+    val handle = new org.apache.spark.shuffle.celeborn.CelebornShuffleHandle(17, dependency)
+    val manager =
+      new CometCelebornShuffleManager(new SparkConf(false), false, (_, _) => backend, api)
+
+    val remote = manager
+      .getReader[Int, ColumnarBatch](
+        handle,
+        0,
+        Int.MaxValue,
+        0,
+        1,
+        context,
+        context.taskMetrics.createTempShuffleReadMetrics())
+      .asInstanceOf[CometShuffleReader[Int, ColumnarBatch]]
+
+    assert(RecordingCelebornRawClient.broadcastDecoderRegistered())
+    assert(remote.readAsRawStream().readAllBytes().toSeq == frameBytes(9).toSeq)
+    assert(client.updateFileGroupCalls == 1)
+    context.markTaskCompleted(None)
+  }
+
+  test("the manager routes native Celeborn handles through its reflected raw reader") {
+    val context = TaskContext.empty()
+    val dependency = simpleDependency()
+    val client = new RecordingCelebornRawClient
+    client.fileGroups.partitionGroups.put(1, location("worker"))
+    client.streams.put(1, new ByteArrayInputStream(frameBytes(3, 4)))
+    val backend = new RecordingReaderBackend(client)
+    val api = new RecordingReaderApi
+    val handle = new org.apache.spark.shuffle.celeborn.CelebornShuffleHandle(17, dependency)
+    val manager =
+      new CometCelebornShuffleManager(new SparkConf(false), false, (_, _) => backend, api)
+
+    val remote = manager
+      .getReader[Int, ColumnarBatch](
+        handle,
+        2,
+        6,
+        1,
+        3,
+        context,
+        context.taskMetrics.createTempShuffleReadMetrics())
+      .asInstanceOf[CometShuffleReader[Int, ColumnarBatch]]
+
+    assert(backend.readRange.contains((2, 6, 1, 3)))
+    assert(api.resolvedClient eq client)
+    assert(api.resolvedHandle eq handle)
+    assert(api.resolvedContext eq context)
+    assert(api.resolvedAsWriter.contains(false))
+    assert(remote.readAsRawStream().readAllBytes().toSeq == frameBytes(3, 4).toSeq)
+    assert(client.requests.size() == 1)
+    assert(!client.requests.get(0).needDecompress)
+    assert(client.requests.get(0).startMapIndex == 2)
+    assert(client.requests.get(0).endMapIndex == 6)
+
+    assert(ownedClients(manager).containsKey(client))
+    assert(manager.unregisterShuffle(17))
+    assert(backend.unregistered.contains(17))
+    assert(client.cleanupCalls == 1)
+    context.markTaskCompleted(None)
+  }
+
+  test("the manager fails closed on disabled stage reruns and unavailable optional reader APIs") {
+    Seq(false, true).foreach { unavailableApi =>
+      val context = TaskContext.empty()
+      val dependency = simpleDependency()
+      val client = new RecordingCelebornRawClient
+      val backend = new RecordingReaderBackend(client)
+      val api = new RecordingReaderApi
+      if (unavailableApi) api.generationFailure = new NoSuchMethodException("celebornShuffleId")
+      val handle = new org.apache.spark.shuffle.celeborn.CelebornShuffleHandle(
+        17,
+        dependency,
+        stageRerunEnabled = unavailableApi)
+      val manager =
+        new CometCelebornShuffleManager(new SparkConf(false), false, (_, _) => backend, api)
+
+      val failure = intercept[IllegalStateException] {
+        manager.getReader[Int, ColumnarBatch](
+          handle,
+          0,
+          Int.MaxValue,
+          0,
+          1,
+          context,
+          context.taskMetrics.createTempShuffleReadMetrics())
+      }
+
+      if (unavailableApi) {
+        assert(failure.getMessage.contains("reader API"))
+        assert(failure.getCause.isInstanceOf[NoSuchMethodException])
+      } else {
+        assert(failure.getMessage.contains("stage reruns"))
+        assert(api.resolvedAsWriter.isEmpty)
+      }
+      assert(ownedClients(manager).containsKey(client))
+      assert(client.failureReports == 0)
+    }
+  }
+
+  test("reader clients remain owned when Celeborn retry configuration cannot be loaded") {
+    val context = TaskContext.empty()
+    val dependency = simpleDependency()
+    val client = new RecordingCelebornRawClient
+    val backend = new RecordingReaderBackend(client)
+    val api = new RecordingReaderApi
+    val expected = new IllegalStateException("Celeborn retry settings are unavailable")
+    api.retryLimitFailure = expected
+    val handle = new org.apache.spark.shuffle.celeborn.CelebornShuffleHandle(17, dependency)
+    val manager =
+      new CometCelebornShuffleManager(new SparkConf(false), false, (_, _) => backend, api)
+
+    val failure = intercept[IllegalStateException] {
+      manager.getReader[Int, ColumnarBatch](
+        handle,
+        0,
+        Int.MaxValue,
+        0,
+        1,
+        context,
+        context.taskMetrics.createTempShuffleReadMetrics())
+    }
+
+    assert(failure eq expected)
+    assert(ownedClients(manager).containsKey(client))
+    assert(api.resolvedAsWriter.isEmpty)
+  }
+
+  test("a genuine reducer-generation resolution failure becomes a Spark fetch failure") {
+    val context = TaskContext.empty()
+    val dependency = simpleDependency()
+    val client = new RecordingCelebornRawClient
+    val backend = new RecordingReaderBackend(client)
+    val api = new RecordingReaderApi
+    val expected =
+      new org.apache.celeborn.common.exception.CelebornRuntimeException(
+        "the reducer generation expired")
+    api.generationFailure = expected
+    val handle = new org.apache.spark.shuffle.celeborn.CelebornShuffleHandle(17, dependency)
+    val manager =
+      new CometCelebornShuffleManager(new SparkConf(false), false, (_, _) => backend, api)
+
+    val failure = intercept[FetchFailedException] {
+      manager.getReader[Int, ColumnarBatch](
+        handle,
+        0,
+        Int.MaxValue,
+        0,
+        1,
+        context,
+        context.taskMetrics.createTempShuffleReadMetrics())
+    }
+
+    assert(failure.getCause eq expected)
+    assert(api.resolvedAsWriter.contains(false))
+    assert(ownedClients(manager).containsKey(client))
+  }
+
+  test("reader adapter bugs are never misclassified as retryable generation failures") {
+    val context = TaskContext.empty()
+    val dependency = simpleDependency()
+    val client = new RecordingCelebornRawClient
+    val backend = new RecordingReaderBackend(client)
+    val api = new RecordingReaderApi
+    val expected = new ClassCastException("the optional client exposed an incompatible API")
+    api.generationFailure = expected
+    val handle = new org.apache.spark.shuffle.celeborn.CelebornShuffleHandle(17, dependency)
+    val manager =
+      new CometCelebornShuffleManager(new SparkConf(false), false, (_, _) => backend, api)
+
+    val failure = intercept[ClassCastException] {
+      manager.getReader[Int, ColumnarBatch](
+        handle,
+        0,
+        Int.MaxValue,
+        0,
+        1,
+        context,
+        context.taskMetrics.createTempShuffleReadMetrics())
+    }
+
+    assert(failure eq expected)
+    assert(ownedClients(manager).containsKey(client))
+    assert(client.failureReports == 0)
+  }
+
+  test("raw fetch preserves generation, reducer order, map ranges, and one file-group snapshot") {
+    val context = TaskContext.empty()
+    val client = new RecordingCelebornRawClient
+    val first = new TrackingInputStream(frameBytes(1, 2))
+    val third = new TrackingInputStream(frameBytes(3, 4, 5))
+    client.fileGroups.partitionGroups.put(1, location("worker-b", "worker-c"))
+    client.fileGroups.partitionGroups.put(2, location())
+    client.fileGroups.partitionGroups.put(3, location("worker-a"))
+    client.fileGroups.mapAttempts = Array(3, 1, 4)
+    client.fileGroups.pushFailedBatches.put("worker-b", "replayed-batch")
+    client.streams.put(1, first)
+    client.streams.put(3, third)
+
+    val input = rawReader(client, context, 4, 9, 1, 4).openPartitions()
+    assert(client.updateFileGroupCalls == 0)
+    assert(input.readAllBytes().toSeq == (frameBytes(1, 2) ++ frameBytes(3, 4, 5)).toSeq)
+    assert(client.updateFileGroupCalls == 1)
+    assert(client.requests.asScala.map(_.partitionId).toSeq == Seq(1, 3))
+
+    client.requests.asScala.foreach { request =>
+      assert(request.shuffleId == 91)
+      assert(request.appShuffleId == 17)
+      assert(request.startMapIndex == 4)
+      assert(request.endMapIndex == 9)
+      assert(request.taskId == context.taskAttemptId)
+      assert(!request.needDecompress)
+      assert(request.exceptionMaker == null)
+      assert(request.streamHandlers == null)
+      assert(request.chunksRange == null)
+      assert(request.coalescedPartitionInfos == null)
+      assert(request.pushFailedBatches eq client.fileGroups.pushFailedBatches)
+      assert(request.mapAttempts eq client.fileGroups.mapAttempts)
+    }
+    assert(client.requests.get(0).locations.asScala.toSeq == Seq("worker-b", "worker-c"))
+    assert(first.closeCalls == 1)
+    assert(third.closeCalls == 1)
+    input.close()
+    context.markTaskCompleted(None)
+  }
+
+  test("raw fetch forwards Celeborn byte, block, and wait metrics") {
+    val context = TaskContext.empty()
+    val client = new RecordingCelebornRawClient
+    client.fileGroups.partitionGroups.put(0, location("worker"))
+    client.streams.put(0, new ByteArrayInputStream(frameBytes(7)))
+    val input = rawReader(client, context).openPartitions()
+    assert(input.skip(20) == 20)
+    assert(input.read() == 7)
+
+    val callback = client.requests.get(0).metricsCallback
+    callback.incBytesRead(29)
+    callback.incBytesRead(11)
+    callback.incReadTime(13)
+    callback.incRemoteReadRetryCount(1)
+    callback.recordRemoteReadWorker("worker:9097")
+    callback.recordRemoteReadWorker("worker:9097")
+    context.taskMetrics.mergeShuffleReadMetrics()
+
+    assert(context.taskMetrics.shuffleReadMetrics.remoteBytesRead == 40)
+    assert(context.taskMetrics.shuffleReadMetrics.remoteBlocksFetched == 2)
+    assert(context.taskMetrics.shuffleReadMetrics.fetchWaitTime >= 13)
+    input.close()
+    context.markTaskCompleted(None)
+  }
+
+  test("raw fetch also supports the newer coalesced-metadata argument without decompression") {
+    val context = TaskContext.empty()
+    val client = new RecordingCelebornRawClient.CoalescedClient
+    client.delegate.fileGroups.partitionGroups.put(1, location("worker"))
+    client.delegate.streams.put(1, new ByteArrayInputStream(frameBytes(3, 4)))
+    val input = rawReader(client, context, 2, 6, 1, 3).openPartitions()
+
+    assert(input.readAllBytes().toSeq == frameBytes(3, 4).toSeq)
+    val request = client.delegate.requests.get(0)
+    assert(request.shuffleId == 91)
+    assert(request.appShuffleId == 17)
+    assert(request.partitionId == 1)
+    assert(request.startMapIndex == 2)
+    assert(request.endMapIndex == 6)
+    assert(request.mapAttempts eq client.delegate.fileGroups.mapAttempts)
+    assert(request.coalescedPartitionInfos == null)
+    assert(!request.needDecompress)
+    request.metricsCallback.incBytesRead(23)
+    context.taskMetrics.mergeShuffleReadMetrics()
+    assert(context.taskMetrics.shuffleReadMetrics.remoteBytesRead == 23)
+    input.close()
+    context.markTaskCompleted(None)
+  }
+
+  test("native raw consumption merges task shuffle metrics at EOF and close only once") {
+    Seq(false, true).foreach { closeEarly =>
+      val context = TaskContext.empty()
+      val client = new RecordingCelebornRawClient
+      client.fileGroups.partitionGroups.put(0, location("worker"))
+      client.streams.put(0, new ByteArrayInputStream(frameBytes(7, 8)))
+      val input = reader(simpleDependency(), client, context).readAsRawStream()
+      assert(input.skip(20) == 20)
+      assert(input.read() == 7)
+      client.requests.get(0).metricsCallback.incBytesRead(19)
+
+      if (closeEarly) input.close()
+      else assert(input.readAllBytes().toSeq == Seq[Byte](8))
+      input.close()
+      context.markTaskCompleted(None)
+
+      assert(context.taskMetrics.shuffleReadMetrics.remoteBytesRead == 19)
+      assert(context.taskMetrics.shuffleReadMetrics.remoteBlocksFetched == 1)
+    }
+  }
+
+  test("broken optional Celeborn metrics are disabled without failing remote reads") {
+    val context = TaskContext.empty()
+    val client = new RecordingCelebornRawClient
+    client.fileGroups.partitionGroups.put(0, location("worker"))
+    client.streams.put(0, new ByteArrayInputStream(frameBytes(7)))
+    val underlying = context.taskMetrics.createTempShuffleReadMetrics()
+    var optionalUpdates = 0
+    val reporter = Proxy
+      .newProxyInstance(
+        getClass.getClassLoader,
+        Array(
+          classOf[ShuffleReadMetricsReporter],
+          classOf[RecordingCelebornRawClient.OptionalMetricsReporter]),
+        new InvocationHandler {
+          override def invoke(proxy: AnyRef, method: Method, arguments: Array[AnyRef]): AnyRef = {
+            if (method.getName == "incCelebornRemoteReadRetryCount") {
+              optionalUpdates += 1
+              throw new IllegalStateException("an optional reporter is unavailable")
+            }
+            method.invoke(underlying, arguments: _*)
+          }
+        })
+      .asInstanceOf[ShuffleReadMetricsReporter]
+    val partitions =
+      new CelebornRawPartitionReader(client, 17, 91, 0, Int.MaxValue, 0, 1, context, reporter, 2)
+
+    val input = partitions.openPartitions()
+    assert(input.skip(20) == 20)
+    assert(input.read() == 7)
+    client.requests.get(0).metricsCallback.incRemoteReadRetryCount(1)
+    client.requests.get(0).metricsCallback.incRemoteReadRetryCount(1)
+
+    assert(optionalUpdates == 1)
+    input.close()
+    context.markTaskCompleted(None)
+  }
+
+  test("coalesced reducer reads retain only one task-completion stream listener") {
+    val reducers = 256
+    val context = TaskContext.empty()
+    val dependency = simpleDependency(reducers)
+    val client = new RecordingCelebornRawClient
+    val streams = (0 until reducers).map { partition =>
+      val stream = new TrackingInputStream(frameBytes(partition.toByte))
+      client.fileGroups.partitionGroups.put(partition, location(s"worker-$partition"))
+      client.streams.put(partition, stream)
+      stream
+    }
+
+    val input = reader(dependency, client, context).readAsRawStream()
+    assert(completionListenerCount(context) == 1)
+    assert(input.readAllBytes().length == reducers * frameBytes(0).length)
+    assert(client.requests.size() == reducers)
+    assert(completionListenerCount(context) == 1)
+    assert(streams.forall(_.closeCalls == 1))
+
+    context.markTaskCompleted(None)
+    assert(streams.forall(_.closeCalls == 1))
+  }
+
+  test("closing an unread or partially consumed stream never opens another reducer") {
+    val untouchedContext = TaskContext.empty()
+    val untouchedClient = new RecordingCelebornRawClient
+    rawReader(untouchedClient, untouchedContext).openPartitions().close()
+    assert(untouchedClient.updateFileGroupCalls == 0)
+
+    val context = TaskContext.empty()
+    val client = new RecordingCelebornRawClient
+    val first = new TrackingInputStream(frameBytes(1, 2))
+    val second = new TrackingInputStream(frameBytes(3))
+    client.fileGroups.partitionGroups.put(0, location("worker-a"))
+    client.fileGroups.partitionGroups.put(1, location("worker-b"))
+    client.streams.put(0, first)
+    client.streams.put(1, second)
+
+    val input = rawReader(client, context).openPartitions()
+    assert(input.skip(20) == 20)
+    assert(input.read() == 1)
+    input.close()
+    input.close()
+
+    assert(first.closeCalls == 1)
+    assert(second.closeCalls == 0)
+    assert(client.requests.size() == 1)
+    context.markTaskCompleted(None)
+    assert(first.closeCalls == 1)
+    assert(second.closeCalls == 0)
+  }
+
+  test("task completion closes an opened reducer stream") {
+    val context = TaskContext.empty()
+    val dependency = simpleDependency()
+    val client = new RecordingCelebornRawClient
+    val stream = new TrackingInputStream(frameBytes(1, 2))
+    client.fileGroups.partitionGroups.put(0, location("worker"))
+    client.streams.put(0, stream)
+
+    val input = reader(dependency, client, context).readAsRawStream()
+    assert(input.skip(20) == 20)
+    assert(input.read() == 1)
+    context.markTaskCompleted(None)
+
+    assert(stream.closeCalls == 1)
+  }
+
+  test("task completion racing reducer-stream creation closes the unpublished stream") {
+    val context = TaskContext.empty()
+    val dependency = simpleDependency()
+    val client = new RecordingCelebornRawClient
+    val stream = new TrackingInputStream(frameBytes(1))
+    client.fileGroups.partitionGroups.put(0, location("worker"))
+    client.streams.put(0, stream)
+    client.readPartitionStarted = new CountDownLatch(1)
+    client.allowReadPartition = new CountDownLatch(1)
+    val input = reader(dependency, client, context).readAsRawStream()
+    val result = new AtomicInteger(Int.MinValue)
+    val failure = new AtomicReference[Throwable]()
+    val worker = new Thread(() => {
+      try result.set(input.read())
+      catch { case caught: Throwable => failure.set(caught) }
+    })
+
+    worker.start()
+    try {
+      assert(client.readPartitionStarted.await(5, TimeUnit.SECONDS))
+      context.markTaskCompleted(None)
+    } finally {
+      client.allowReadPartition.countDown()
+      worker.join(5000)
+    }
+
+    assert(!worker.isAlive)
+    assert(failure.get() == null)
+    assert(result.get() == -1)
+    assert(stream.closeCalls == 1)
+    assert(client.requests.size() == 1)
+    assert(client.failureReports == 0)
+  }
+
+  test("file-group RPC timeouts retry only while the map stage is still running") {
+    val context = TaskContext.empty()
+    val client = new RecordingCelebornRawClient
+    client.stageEnded = false
+    client.timeoutFailures = 2
+    client.fileGroups.partitionGroups.put(0, location("worker"))
+    client.streams.put(0, new ByteArrayInputStream(frameBytes(9)))
+
+    val input = rawReader(client, context, retries = 2).openPartitions()
+    assert(input.skip(20) == 20)
+    assert(input.read() == 9)
+    assert(client.updateFileGroupCalls == 3)
+    assert(client.stageEndChecks == 3)
+    assert(client.failureReports == 0)
+    input.close()
+    context.markTaskCompleted(None)
+  }
+
+  test("exhausted file-group timeouts propagate without invalidating a shuffle generation") {
+    val context = TaskContext.empty()
+    val client = new RecordingCelebornRawClient
+    client.stageEnded = false
+    client.timeoutFailures = 4
+
+    val failure = intercept[IOException] {
+      rawReader(client, context, retries = 2).openPartitions().read()
+    }
+
+    assert(failure.getCause.isInstanceOf[TimeoutException])
+    assert(client.updateFileGroupCalls == 3)
+    assert(client.failureReports == 0)
+  }
+
+  test("file-group and partition-open failures invalidate and become Spark fetch failures") {
+    Seq(false, true).foreach { failAtOpen =>
+      val context = TaskContext.empty()
+      val client = new RecordingCelebornRawClient
+      val expected = new IOException(if (failAtOpen) "worker open failed" else "metadata lost")
+      if (failAtOpen) {
+        client.fileGroups.partitionGroups.put(2, location("worker"))
+        client.readPartitionFailure = expected
+      } else {
+        client.updateFileGroupFailure = expected
+      }
+
+      val failure = intercept[FetchFailedException] {
+        rawReader(client, context, startPartition = 2, endPartition = 3).openPartitions().read()
+      }
+
+      assert(failure.getCause eq expected)
+      assert(failure.getMessage.contains("17/91"))
+      assert(client.failureReports == 1)
+    }
+  }
+
+  test("lazy stream failures invalidate once and interrupted tasks never invalidate") {
+    Seq(false, true).foreach { interrupted =>
+      val context = TaskContext.empty()
+      val client = new RecordingCelebornRawClient
+      val expected = new IOException("worker failed after stream creation")
+      client.fileGroups.partitionGroups.put(1, location("worker"))
+      client.streams.put(
+        1,
+        new InputStream {
+          override def read(): Int = throw expected
+        })
+      val input =
+        rawReader(client, context, startPartition = 1, endPartition = 2).openPartitions()
+      if (interrupted) context.markInterrupted("the reduce task was cancelled")
+
+      val failure = intercept[Throwable](input.read())
+      if (interrupted) {
+        assert(failure.isInstanceOf[TaskKilledException])
+        assert(client.requests.isEmpty)
+        assert(client.failureReports == 0)
+      } else {
+        assert(failure.isInstanceOf[FetchFailedException])
+        assert(failure.getCause eq expected)
+        assert(client.failureReports == 1)
+      }
+    }
+  }
+
+  test("physical-skew encoded map ranges fail closed") {
+    val failure = intercept[IllegalArgumentException] {
+      rawReader(new RecordingCelebornRawClient, TaskContext.empty(), startMap = 9, endMap = 4)
+    }
+    assert(failure.getMessage.contains("physical-skew"))
+  }
+
+  test("cancelled raw tasks do not open streams or retry metadata RPCs") {
+    Seq(false, true).foreach { duringMetadata =>
+      val context = TaskContext.empty()
+      val client = new RecordingCelebornRawClient
+      client.fileGroups.partitionGroups.put(0, location("worker"))
+      client.streams.put(0, new ByteArrayInputStream(frameBytes(1)))
+      if (duringMetadata) {
+        client.stageEnded = false
+        client.timeoutFailures = 2
+        client.beforeUpdateFileGroup = () => context.markInterrupted("cancelled during metadata")
+      } else {
+        context.markInterrupted("cancelled before native scan")
+      }
+      val input = rawReader(client, context).openPartitions()
+
+      intercept[TaskKilledException](input.read())
+
+      assert(client.updateFileGroupCalls == (if (duringMetadata) 1 else 0))
+      assert(client.requests.isEmpty)
+      assert(client.failureReports == 0)
+      input.close()
+      context.markTaskCompleted(None)
+    }
+  }
+
+  test("cancellation between reducers never opens the next reducer") {
+    val context = TaskContext.empty()
+    val client = new RecordingCelebornRawClient
+    val first = new TrackingInputStream(frameBytes(1))
+    val second = new TrackingInputStream(frameBytes(2))
+    client.fileGroups.partitionGroups.put(0, location("worker-a"))
+    client.fileGroups.partitionGroups.put(1, location("worker-b"))
+    client.streams.put(0, first)
+    client.streams.put(1, second)
+    val input = rawReader(client, context).openPartitions()
+    assert(input.readNBytes(frameBytes(1).length).toSeq == frameBytes(1).toSeq)
+
+    context.markInterrupted("cancelled after the first frame")
+    intercept[TaskKilledException](input.read())
+    input.close()
+
+    assert(client.requests.size() == 1)
+    assert(client.failureReports == 0)
+    assert(first.closeCalls == 1)
+    assert(second.closeCalls == 0)
+    context.markTaskCompleted(None)
+  }
+
+  test("cancellation during partition open closes the unpublished stream without invalidation") {
+    val context = TaskContext.empty()
+    val client = new RecordingCelebornRawClient
+    val stream = new TrackingInputStream(frameBytes(1))
+    client.fileGroups.partitionGroups.put(0, location("worker"))
+    client.streams.put(0, stream)
+    client.readPartitionStarted = new CountDownLatch(1)
+    client.allowReadPartition = new CountDownLatch(1)
+    val input = rawReader(client, context).openPartitions()
+    val failure = new AtomicReference[Throwable]()
+    val worker = new Thread(() => {
+      try input.read()
+      catch { case caught: Throwable => failure.set(caught) }
+    })
+    worker.start()
+    try {
+      assert(client.readPartitionStarted.await(5, TimeUnit.SECONDS))
+      context.markInterrupted("cancelled while opening a reducer")
+    } finally {
+      client.allowReadPartition.countDown()
+      worker.join(5000)
+    }
+
+    assert(!worker.isAlive)
+    assert(failure.get().isInstanceOf[TaskKilledException])
+    assert(stream.closeCalls == 1)
+    assert(client.failureReports == 0)
+    input.close()
+    context.markTaskCompleted(None)
+  }
+
+  test("malformed native frames invalidate once before allocating or opening another reducer") {
+    def header(length: Long, fields: Long): Array[Byte] = ByteBuffer
+      .allocate(16)
+      .order(ByteOrder.LITTLE_ENDIAN)
+      .putLong(length)
+      .putLong(fields)
+      .array()
+
+    val corruptFrames = Seq(
+      frameBytes(1).take(3),
+      frameBytes(1).dropRight(1),
+      header(0L, 0L),
+      header(Long.MinValue, 0L),
+      header(Long.MaxValue, 0L),
+      header(Int.MaxValue.toLong + 1, 0L),
+      header(12L, -1L),
+      header(12L, Int.MaxValue.toLong + 1),
+      header(12L, 1L))
+    for (frame <- corruptFrames; raw <- Seq(false, true)) {
+      val context = TaskContext.empty()
+      val client = new RecordingCelebornRawClient
+      val broken = new TrackingInputStream(frame)
+      val next = new TrackingInputStream(frameBytes(2))
+      client.fileGroups.partitionGroups.put(0, location("worker-a"))
+      client.fileGroups.partitionGroups.put(1, location("worker-b"))
+      client.streams.put(0, broken)
+      client.streams.put(1, next)
+      val remote = reader(simpleDependency(), client, context)
+
+      val failure = if (raw) {
+        val blocks = new CometShuffleBlockIterator(remote.readAsRawStream())
+        intercept[FetchFailedException](blocks.hasNext())
+      } else {
+        intercept[FetchFailedException](remote.read().hasNext)
+      }
+
+      assert(failure.getCause.isInstanceOf[IOException])
+      assert(client.failureReports == 1)
+      assert(client.requests.size() == 1)
+      assert(next.closeCalls == 0)
+      context.markTaskCompleted(None)
+      assert(broken.closeCalls == 1)
+    }
+  }
+
+  test("failed generation invalidation preserves the original fetch error and is not retried") {
+    Seq(false, true).foreach { reportThrows =>
+      val context = TaskContext.empty()
+      val client = new RecordingCelebornRawClient
+      val expected = new IOException("worker read failed")
+      val reportFailure = new IOException("generation invalidation RPC failed")
+      client.fileGroups.partitionGroups.put(0, location("worker"))
+      client.readPartitionFailure = expected
+      client.invalidateOnFetchFailure = false
+      if (reportThrows) client.reportFetchFailureFailure = reportFailure
+      val remote = reader(simpleDependency(), client, context)
+      val blocks = new CometShuffleBlockIterator(remote.readAsRawStream())
+
+      assert(intercept[IOException](blocks.hasNext()) eq expected)
+      assert(client.failureReports == 1)
+      assert(
+        expected.getSuppressed.toSeq == (if (reportThrows) Seq(reportFailure) else Seq.empty))
+      context.markTaskCompleted(None)
+    }
+  }
+
+  test("raw and JVM consumers preserve metadata timeout and interruption classifications") {
+    for (raw <- Seq(false, true); interrupted <- Seq(false, true)) {
+      val context = TaskContext.empty()
+      val client = new RecordingCelebornRawClient
+      if (interrupted) {
+        client.updateFileGroupFailure =
+          new IOException("metadata interrupted", new InterruptedException())
+      } else {
+        client.stageEnded = false
+        client.timeoutFailures = 5
+      }
+      val remote = reader(simpleDependency(), client, context)
+
+      val failure = if (raw) {
+        val blocks = new CometShuffleBlockIterator(remote.readAsRawStream())
+        intercept[IOException](blocks.hasNext())
+      } else {
+        intercept[IOException](remote.read().hasNext)
+      }
+
+      assert(failure.getCause.isInstanceOf[InterruptedException] == interrupted)
+      assert(failure.getCause.isInstanceOf[TimeoutException] == !interrupted)
+      assert(client.updateFileGroupCalls == (if (interrupted) 1 else 3))
+      assert(client.failureReports == 0)
+      context.markTaskCompleted(None)
+    }
+  }
+
+  test("JVM readers never treat a truncated header as EOF when invalidation fails") {
+    Seq(false, true).foreach { reportThrows =>
+      val context = TaskContext.empty()
+      val client = new RecordingCelebornRawClient
+      val reportFailure = new IOException("generation invalidation RPC failed")
+      val stream = new TrackingInputStream(frameBytes(1).take(3))
+      client.fileGroups.partitionGroups.put(0, location("worker"))
+      client.streams.put(0, stream)
+      client.invalidateOnFetchFailure = false
+      if (reportThrows) client.reportFetchFailureFailure = reportFailure
+
+      val failure =
+        intercept[EOFException](reader(simpleDependency(), client, context).read().hasNext)
+
+      assert(failure.getMessage.contains("Truncated"))
+      assert(failure.getSuppressed.toSeq == (if (reportThrows) Seq(reportFailure) else Seq.empty))
+      assert(client.failureReports == 1)
+      context.markTaskCompleted(None)
+      assert(stream.closeCalls == 1)
+    }
+  }
+
+  test("reducer stream cleanup failures do not invalidate successfully fetched data") {
+    Seq(false, true).foreach { raw =>
+      val context = TaskContext.empty()
+      val client = new RecordingCelebornRawClient
+      val expected = new IOException("reducer cleanup failed")
+      client.fileGroups.partitionGroups.put(0, location("worker"))
+      client.streams.put(
+        0,
+        new ByteArrayInputStream(Array.empty[Byte]) {
+          override def close(): Unit = throw expected
+        })
+      val remote = reader(simpleDependency(), client, context)
+
+      val failure = if (raw) {
+        val blocks = new CometShuffleBlockIterator(remote.readAsRawStream())
+        intercept[IOException](blocks.hasNext())
+      } else {
+        intercept[IOException](remote.read().hasNext)
+      }
+
+      assert(failure eq expected)
+      assert(client.failureReports == 0)
+      context.markTaskCompleted(None)
+    }
+  }
+
+  test("JVM native decoding failures invalidate the Celeborn generation") {
+    val context = TaskContext.empty()
+    val client = new RecordingCelebornRawClient
+    val frame = frameBytes(1)
+    frame(16) = 0 // Unknown codec, with a complete and correctly sized outer frame.
+    client.fileGroups.partitionGroups.put(0, location("worker"))
+    val stream = new TrackingInputStream(frame)
+    client.streams.put(0, stream)
+
+    val failure =
+      intercept[FetchFailedException](reader(simpleDependency(), client, context).read().hasNext)
+
+    assert(failure.getCause.getMessage.contains("invalid compression codec"))
+    assert(client.failureReports == 1)
+    context.markTaskCompleted(None)
+    assert(stream.closeCalls == 1)
+  }
+
+  private def readRemoteFrame(
+      frame: Array[Byte],
+      attributes: Seq[Attribute],
+      raw: Boolean): (Seq[InternalRow], Option[String], Int) = {
+    val dependency = simpleDependency(1, attributes)
+    val scan = OperatorOuterClass.ShuffleScan.newBuilder().setSource("CelebornRawInput")
+    attributes.foreach(attribute =>
+      scan.addFields(QueryPlanSerde.serializeDataType(attribute.dataType).get))
+    val planBytes = OperatorOuterClass.Operator
+      .newBuilder()
+      .setShuffleScan(scan)
+      .build()
+      .toByteArray
+
+    val results = spark.sparkContext
+      .parallelize(Seq(frame), 1)
+      .mapPartitions { frames =>
+        val context = TaskContext.get()
+        val client = new RecordingCelebornRawClient
+        client.fileGroups.partitionGroups.put(
+          0,
+          java.util.Collections.singleton[Object]("worker"))
+        client.streams.put(0, new ByteArrayInputStream(frames.next()))
+        val metrics = context.taskMetrics.createTempShuffleReadMetrics()
+        val partitions = new CelebornRawPartitionReader(
+          client,
+          dependency.shuffleId,
+          91,
+          0,
+          Int.MaxValue,
+          0,
+          1,
+          context,
+          metrics,
+          2)
+        val remote = new CometCelebornShuffleReader[Int, ColumnarBatch](
+          dependency,
+          context,
+          metrics,
+          partitions)
+        val native = if (raw) {
+          val blocks = new CometShuffleBlockIterator(remote.readAsRawStream())
+          Some(
+            new CometExecIterator(
+              CometExec.newIterId,
+              Array[Object](blocks),
+              dependency.outputAttributes.size,
+              planBytes,
+              CometMetricNode(Map.empty),
+              1,
+              0,
+              shuffleBlockIterators = Map(0 -> blocks)))
+        } else {
+          None
+        }
+        val batches: Iterator[ColumnarBatch] = native match {
+          case Some(iterator) => iterator
+          case None => remote.read().map(_._2)
+        }
+        var rows = Vector.empty[InternalRow]
+        val result =
+          try {
+            while (batches.hasNext) {
+              rows ++= batches.next().rowIterator().asScala.map(_.copy())
+            }
+            (rows, None, client.failureReports)
+          } catch {
+            case failure: FetchFailedException =>
+              (rows, Some(failure.getCause.getMessage), client.failureReports)
+          } finally {
+            native.foreach(_.close())
+          }
+        Iterator.single(result)
+      }
+      .collect()
+
+    assert(results.length == 1)
+    results.head
+  }
+
+  private def assertNativeDecodeFailure(
+      frame: Array[Byte],
+      expectedMessage: String,
+      attributes: Seq[Attribute] = Seq.empty): Unit = {
+    val (rows, failure, reports) = readRemoteFrame(frame, attributes, raw = true)
+    assert(rows.isEmpty)
+    assert(
+      failure.exists(_.toLowerCase(java.util.Locale.ROOT)
+        .contains(expectedMessage.toLowerCase(java.util.Locale.ROOT))))
+    assert(reports == 1)
+  }
+
+  test("native ShuffleScan decode failures retain Spark fetch-failure identity across JNI") {
+    val frame = frameBytes()
+    frame(16) = 0
+    assertNativeDecodeFailure(frame, "invalid compression codec")
+  }
+
+  test("native ShuffleScan rejects IPC column counts inconsistent with the declared schema") {
+    withNativeFrame { (_, frame) =>
+      val mismatched = frame.clone()
+      // Keep a valid two-column IPC payload but claim zero fields in the outer header and plan.
+      ByteBuffer.wrap(mismatched).order(ByteOrder.LITTLE_ENDIAN).putLong(8, 0L)
+      assertNativeDecodeFailure(mismatched, "column count mismatch")
+    }
+  }
+
+  private def arrowFrame(
+      root: VectorSchemaRoot,
+      dictionaries: DictionaryProvider = null): Array[Byte] = {
+    val output = new ByteArrayOutputStream()
+    val writer = new ArrowStreamWriter(root, dictionaries, Channels.newChannel(output))
+    val payload =
+      try {
+        writer.start()
+        writer.writeBatch()
+        writer.end()
+        output.toByteArray
+      } finally writer.close()
+    val frame = frameBytes(payload: _*)
+    ByteBuffer
+      .wrap(frame)
+      .order(ByteOrder.LITTLE_ENDIAN)
+      .putLong(8, root.getFieldVectors.size().toLong)
+    frame
+  }
+
+  private def intFrame(): Array[Byte] = {
+    val allocator = new RootAllocator(Long.MaxValue)
+    val values = new IntVector("value", allocator)
+    val root = VectorSchemaRoot.of(values)
+    try {
+      values.allocateNew()
+      Seq(-1, 0, 1).zipWithIndex.foreach { case (value, index) => values.setSafe(index, value) }
+      values.setValueCount(3)
+      root.setRowCount(3)
+      arrowFrame(root)
+    } finally {
+      root.close()
+      allocator.close()
+    }
+  }
+
+  private def dictionaryFrame(): Array[Byte] = {
+    val allocator = new RootAllocator(Long.MaxValue)
+    val encoding = new DictionaryEncoding(0L, false, new ArrowType.Int(32, true))
+    val values = new VarCharVector("dictionary", allocator)
+    val keys = new IntVector(
+      "value",
+      new FieldType(true, new ArrowType.Int(32, true), encoding),
+      allocator)
+    val dictionaries = new MapDictionaryProvider(new Dictionary(values, encoding))
+    val root = VectorSchemaRoot.of(keys)
+    try {
+      values.allocateNew()
+      Seq("first", "second").zipWithIndex.foreach { case (value, index) =>
+        values.setSafe(index, value.getBytes(StandardCharsets.UTF_8))
+      }
+      values.setValueCount(2)
+      keys.allocateNew()
+      Seq(0, 1, 0).zipWithIndex.foreach { case (value, index) => keys.setSafe(index, value) }
+      keys.setValueCount(3)
+      root.setRowCount(3)
+      arrowFrame(root, dictionaries)
+    } finally {
+      root.close()
+      dictionaries.close()
+      allocator.close()
+    }
+  }
+
+  private def listFrame(): Array[Byte] = {
+    val allocator = new RootAllocator(Long.MaxValue)
+    val values = ListVector.empty("value", allocator)
+    values.initializeChildrenFromFields(
+      Seq(Field.nullable("element", new ArrowType.Int(32, true))).asJava)
+    val root = VectorSchemaRoot.of(values)
+    try {
+      values.allocateNew()
+      val elements = values.getDataVector.asInstanceOf[IntVector]
+      var offset = 0
+      Seq(Seq(-1, 0), Seq(1), Seq.empty).zipWithIndex.foreach { case (row, index) =>
+        values.startNewValue(index)
+        row.foreach { value =>
+          elements.setSafe(offset, value)
+          offset += 1
+        }
+        values.endValue(index, row.size)
+      }
+      values.setValueCount(3)
+      root.setRowCount(3)
+      assert(root.getSchema.getFields.get(0).getChildren.get(0).isNullable)
+      arrowFrame(root)
+    } finally {
+      root.close()
+      allocator.close()
+    }
+  }
+
+  private def mapFrame(nullableKeys: Boolean): Array[Byte] = {
+    val allocator = new RootAllocator(Long.MaxValue)
+    val intType = new ArrowType.Int(32, true)
+    val key = Field.notNullable("key", intType)
+    val value = Field.nullable("value", intType)
+    val entries = new Field(
+      "entries",
+      FieldType.notNullable(ArrowType.Struct.INSTANCE),
+      Seq(key, value).asJava)
+    val field =
+      new Field("value", FieldType.nullable(new ArrowType.Map(false)), Seq(entries).asJava)
+    val values = field.createVector(allocator).asInstanceOf[MapVector]
+    // Keep valid nonnull key buffers, but permit a deliberately invalid IPC key declaration.
+    val schemaKey = if (nullableKeys) Field.nullable("key", intType) else key
+    val schemaEntries =
+      new Field(entries.getName, entries.getFieldType, Seq(schemaKey, value).asJava)
+    val schemaField = new Field(field.getName, field.getFieldType, Seq(schemaEntries).asJava)
+    val root = new VectorSchemaRoot(Seq(schemaField).asJava, Seq[FieldVector](values).asJava, 0)
+    try {
+      values.allocateNew()
+      val writer = values.getWriter
+      Seq(Seq(-1 -> 1), Seq(0 -> 2, 1 -> 3), Seq.empty).zipWithIndex.foreach {
+        case (row, index) =>
+          writer.setPosition(index)
+          writer.startMap()
+          row.foreach { case (keyValue, mapValue) =>
+            writer.startEntry()
+            writer.key().integer().writeInt(keyValue)
+            writer.value().integer().writeInt(mapValue)
+            writer.endEntry()
+          }
+          writer.endMap()
+      }
+      values.setValueCount(3)
+      root.setRowCount(3)
+      arrowFrame(root)
+    } finally {
+      root.close()
+      allocator.close()
+    }
+  }
+
+  private final class MutableIpcInt extends Table {
+    def clearSignedness(): Int = {
+      // Int.is_signed is the second field in the FlatBuffer table (vtable offset 6).
+      val offset = __offset(6)
+      require(offset != 0 && bb.get(bb_pos + offset) == 1)
+      val position = bb_pos + offset
+      bb.put(position, 0.toByte)
+      position
+    }
+  }
+
+  Seq(false -> "JVM reader", true -> "native ShuffleScan").foreach { case (raw, consumer) =>
+    test(s"$consumer preserves valid negative Int32 shuffle values") {
+      val frame = intFrame()
+      val attributes = Seq(AttributeReference("value", IntegerType)())
+      val (rows, failure, reports) = readRemoteFrame(frame, attributes, raw)
+      assert(failure.isEmpty)
+      assert(rows.map(_.getInt(0)) == Seq(-1, 0, 1))
+      assert(rows.forall(!_.isNullAt(0)))
+      assert(reports == 0)
+    }
+
+    test(s"$consumer accepts dictionary encoding with the expected logical value type") {
+      val attributes = Seq(AttributeReference("value", StringType)())
+      val (rows, failure, reports) = readRemoteFrame(dictionaryFrame(), attributes, raw)
+      assert(failure.isEmpty)
+      assert(rows.map(_.getUTF8String(0).toString) == Seq("first", "second", "first"))
+      assert(reports == 0)
+    }
+
+    test(s"$consumer accepts array element nullability differences") {
+      val attributes = Seq(AttributeReference("value", ArrayType(IntegerType, false))())
+      val (rows, failure, reports) = readRemoteFrame(listFrame(), attributes, raw)
+      assert(failure.isEmpty)
+      assert(rows.map(_.getArray(0).toIntArray().toSeq) == Seq(Seq(-1, 0), Seq(1), Seq.empty))
+      assert(reports == 0)
+    }
+
+    test(s"$consumer accepts map value nullability differences") {
+      val attributes =
+        Seq(AttributeReference("value", MapType(IntegerType, IntegerType, false))())
+      val (rows, failure, reports) =
+        readRemoteFrame(mapFrame(nullableKeys = false), attributes, raw)
+      assert(failure.isEmpty)
+      val maps = rows.map { row =>
+        val map = row.getMap(0)
+        map.keyArray().toIntArray().zip(map.valueArray().toIntArray()).toMap
+      }
+      assert(maps == Seq(Map(-1 -> 1), Map(0 -> 2, 1 -> 3), Map.empty))
+      assert(reports == 0)
+    }
+
+    test(s"$consumer rejects nullable map keys before cast or import") {
+      val attributes =
+        Seq(AttributeReference("value", MapType(IntegerType, IntegerType, false))())
+      val (rows, failure, reports) =
+        readRemoteFrame(mapFrame(nullableKeys = true), attributes, raw)
+      assert(rows.isEmpty)
+      assert(failure.exists(_.toLowerCase(java.util.Locale.ROOT).contains("type mismatch")))
+      assert(reports == 1)
+    }
+
+    test(s"$consumer rejects an IPC signedness mismatch before cast or import") {
+      val pristine = intFrame()
+      val corrupted = pristine.clone()
+      val buffer = ByteBuffer.wrap(corrupted).order(ByteOrder.LITTLE_ENDIAN)
+      buffer.position(20) // Skip the native frame header and NONE codec.
+      assert(buffer.getInt() == -1) // IPC continuation marker.
+      val schemaLength = buffer.getInt()
+      val schemaStart = buffer.position()
+      val schemaEnd = schemaStart + schemaLength
+      val message = Message.getRootAsMessage(buffer)
+      assert(message.headerType() == MessageHeader.Schema)
+      val schema = message.header(new IpcSchema).asInstanceOf[IpcSchema]
+      assert(schema.fieldsLength() == 1)
+      val field = schema.fields(0)
+      assert(field.typeType() == IpcType.Int)
+      val intType = field.`type`(new IpcInt).asInstanceOf[IpcInt]
+      assert(intType.bitWidth() == 32 && intType.isSigned())
+      val mutable = field.`type`(new MutableIpcInt).asInstanceOf[MutableIpcInt]
+      val signednessPosition = mutable.clearSignedness()
+      assert(!intType.isSigned())
+      assert(signednessPosition >= schemaStart && signednessPosition < schemaEnd)
+      // Only the logical type changes: frame lengths, column count, and all batch buffers survive.
+      assert(
+        corrupted.indices.filter(index => corrupted(index) != pristine(index)) ==
+          Seq(signednessPosition))
+
+      val attributes = Seq(AttributeReference("value", IntegerType)())
+      val (rows, failure, reports) = readRemoteFrame(corrupted, attributes, raw)
+      assert(rows.isEmpty)
+      assert(failure.exists(_.toLowerCase(java.util.Locale.ROOT).contains("type mismatch")))
+      assert(reports == 1)
+    }
+  }
+
+  test("reader attempt identities match writer packing and reject wrapped attempt numbers") {
+    assert(CelebornRawPartitionReader.encodeAttemptNumber(0, 0) == 0)
+    assert(CelebornRawPartitionReader.encodeAttemptNumber(1, 7) == 65543)
+    assert(CelebornRawPartitionReader.encodeAttemptNumber(32767, 65535) == Int.MaxValue)
+
+    Seq((-1, 0), (32768, 0), (0, -1), (0, 65536)).foreach { case (stageAttempt, taskAttempt) =>
+      intercept[IllegalArgumentException] {
+        CelebornRawPartitionReader.encodeAttemptNumber(stageAttempt, taskAttempt)
+      }
+    }
+  }
+
+  test("both remote consumption paths validate Arrow offsets before exposing decoded arrays") {
+    val allocator = new RootAllocator(Long.MaxValue)
+    val strings = new VarCharVector("value", allocator)
+    val root = VectorSchemaRoot.of(strings)
+    val payload =
+      try {
+        strings.allocateNew()
+        strings.setSafe(0, Array[Byte](97, 98, 99))
+        strings.setSafe(1, Array[Byte](100, 101, 102))
+        strings.setValueCount(2)
+        root.setRowCount(2)
+        val output = new ByteArrayOutputStream()
+        val writer = new ArrowStreamWriter(root, null, Channels.newChannel(output))
+        try {
+          writer.start()
+          writer.writeBatch()
+          writer.end()
+          output.toByteArray
+        } finally writer.close()
+      } finally {
+        root.close()
+        allocator.close()
+      }
+    val offsets = ByteBuffer
+      .allocate(12)
+      .order(ByteOrder.LITTLE_ENDIAN)
+      .putInt(0)
+      .putInt(3)
+      .putInt(6)
+      .array()
+    val positions = payload
+      .sliding(offsets.length)
+      .zipWithIndex
+      .collect {
+        case (bytes, position) if bytes.sameElements(offsets) => position
+      }
+      .toSeq
+    assert(positions.size == 1)
+    ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN).putInt(positions.head + 8, 2)
+    val frame = frameBytes(payload: _*)
+    ByteBuffer.wrap(frame).order(ByteOrder.LITTLE_ENDIAN).putLong(8, 1L)
+    val attributes = Seq(AttributeReference("value", StringType)())
+
+    val context = TaskContext.empty()
+    val client = new RecordingCelebornRawClient
+    client.fileGroups.partitionGroups.put(0, location("worker"))
+    client.streams.put(0, new ByteArrayInputStream(frame))
+    val failure = intercept[FetchFailedException] {
+      reader(simpleDependency(1, attributes), client, context).read().hasNext
+    }
+    assert(failure.getCause.getMessage.toLowerCase(java.util.Locale.ROOT).contains("offset"))
+    assert(client.failureReports == 1)
+    context.markTaskCompleted(None)
+
+    assertNativeDecodeFailure(frame, "offset", attributes)
+  }
+
+  test("empty reducers are skipped and null mapper-attempt metadata fails closed") {
+    val emptyContext = TaskContext.empty()
+    val emptyClient = new RecordingCelebornRawClient
+    assert(rawReader(emptyClient, emptyContext).openPartitions().read() == -1)
+    assert(emptyClient.requests.isEmpty)
+
+    val brokenContext = TaskContext.empty()
+    val brokenClient = new RecordingCelebornRawClient
+    brokenClient.fileGroups.mapAttempts = null
+    val failure = intercept[IllegalStateException] {
+      rawReader(brokenClient, brokenContext).openPartitions().read()
+    }
+    assert(failure.getMessage.contains("mapper-attempt"))
+    assert(brokenClient.requests.isEmpty)
+  }
+
+  test("native ShuffleScan consumes real remote shuffle frames without decompression") {
+    withNativeFrame { (dependency, frame) =>
+      val context = TaskContext.empty()
+      val client = new RecordingCelebornRawClient
+      client.fileGroups.partitionGroups.put(0, location("worker"))
+      client.streams.put(0, new ByteArrayInputStream(frame))
+      val iterator =
+        new CometShuffleBlockIterator(reader(dependency, client, context).readAsRawStream())
+
+      val expectedLength = ByteBuffer.wrap(frame).order(ByteOrder.LITTLE_ENDIAN).getLong.toInt - 8
+      assert(iterator.hasNext() == expectedLength)
+      val actual = new Array[Byte](expectedLength)
+      val buffer = iterator.getBuffer.duplicate()
+      buffer.position(0)
+      buffer.get(actual)
+      assert(actual.toSeq == frame.slice(16, 16 + expectedLength).toSeq)
+      assert(iterator.hasNext() == -1)
+      assert(!client.requests.get(0).needDecompress)
+      context.markTaskCompleted(None)
+    }
+  }
+
+  test("remote validation is explicit and preserves the existing local decoder JNI entry point") {
+    val parameters = Array[Class[_]](
+      classOf[ByteBuffer],
+      java.lang.Integer.TYPE,
+      classOf[Array[Long]],
+      classOf[Array[Long]],
+      java.lang.Boolean.TYPE)
+    assert(
+      classOf[Native]
+        .getDeclaredMethod("decodeShuffleBlock", parameters: _*)
+        .getReturnType == java.lang.Long.TYPE)
+    assert(
+      classOf[Native]
+        .getDeclaredMethod(
+          "decodeShuffleBlockWithValidation",
+          (parameters :+ classOf[Array[Byte]]): _*)
+        .getReturnType == java.lang.Long.TYPE)
+
+    val local = new CometShuffleBlockIterator(new ByteArrayInputStream(Array.empty[Byte]))
+    assert(!local.requiresValidation())
+    local.close()
+
+    val context = TaskContext.empty()
+    val client = new RecordingCelebornRawClient
+    val remote =
+      new CometShuffleBlockIterator(reader(simpleDependency(), client, context).readAsRawStream())
+    assert(remote.requiresValidation())
+    assert(client.updateFileGroupCalls == 0)
+    remote.close()
+    context.markTaskCompleted(None)
+  }
+
+  test("JVM consumers decode real remote shuffle frames and count rows") {
+    withNativeFrame { (dependency, frame) =>
+      val context = TaskContext.empty()
+      val client = new RecordingCelebornRawClient
+      client.fileGroups.partitionGroups.put(0, location("worker"))
+      client.streams.put(0, new ByteArrayInputStream(frame))
+
+      val batches = reader(dependency, client, context).read()
+      var rows = 0
+      while (batches.hasNext) {
+        rows += batches.next()._2.numRows()
+      }
+
+      assert(rows > 0)
+      assert(context.taskMetrics.shuffleReadMetrics.recordsRead == rows)
+      assert(!client.requests.get(0).needDecompress)
+      context.markTaskCompleted(None)
+    }
+  }
+
+  test("a remote shuffle reader cannot be consumed through both paths") {
+    val context = TaskContext.empty()
+    val client = new RecordingCelebornRawClient
+    val remote = reader(simpleDependency(), client, context)
+    remote.readAsRawStream()
+
+    val failure = intercept[IllegalStateException](remote.readAsRawStream())
+    assert(failure.getMessage.contains("only be consumed once"))
+    context.markTaskCompleted(None)
+  }
+
+  test("decoder cleanup releases a prefetched batch that was not consumed") {
+    NativeBatchDecoderIteratorLifecycleChecks.closesPrefetchedBatch()
+  }
+
+  test("decoder cleanup releases its delivered batch exactly once") {
+    NativeBatchDecoderIteratorLifecycleChecks.closesDeliveredBatch()
+  }
+
+  test("decoder cleanup releases remaining resources and preserves suppressed failures") {
+    NativeBatchDecoderIteratorLifecycleChecks.preservesCleanupFailures()
+  }
+
+  test(
+    "decoder reports data errors but does not invalidate shuffle generations on cleanup errors") {
+    NativeBatchDecoderIteratorLifecycleChecks.forwardsDecodeFailuresButNotCleanup()
+  }
+
+  test("decoder does not invalidate persisted shuffle data on allocation or import failures") {
+    NativeBatchDecoderIteratorLifecycleChecks.doesNotReportAllocationOrImportFailures()
+  }
+
+  test("decoder propagates input EOF exceptions without reclassifying stream cleanup failures") {
+    NativeBatchDecoderIteratorLifecycleChecks.propagatesHeaderAndEofCleanupFailures()
+  }
+
+  test("decoder validates remote Arrow payloads without changing the local decode path") {
+    NativeBatchDecoderIteratorLifecycleChecks.selectsValidationOnlyForRemoteStreams()
+  }
+
+  test("decoder rejects a missing remote schema before consuming or reporting persisted data") {
+    NativeBatchDecoderIteratorLifecycleChecks.rejectsRemoteStreamsWithoutExpectedSchema()
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/comet/execution/shuffle/NativeBatchDecoderIteratorLifecycleChecks.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/execution/shuffle/NativeBatchDecoderIteratorLifecycleChecks.scala
@@ -1,0 +1,375 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet.execution.shuffle
+
+import java.io.{ByteArrayInputStream, EOFException, IOException}
+import java.nio.{ByteBuffer, ByteOrder}
+
+import org.apache.arrow.memory.OutOfMemoryException
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+
+import org.apache.comet.{CometShuffleReadFailureHandler, Native}
+import org.apache.comet.serde.{OperatorOuterClass, QueryPlanSerde}
+import org.apache.comet.vector.NativeUtil
+
+/** Exercises the decoder's ownership independently of the native codec implementation. */
+private[shuffle] object NativeBatchDecoderIteratorLifecycleChecks {
+
+  private final class TrackingBatch(failure: Option[Throwable] = None)
+      extends ColumnarBatch(Array.empty[ColumnVector], 1) {
+    var closeCalls = 0
+
+    override def close(): Unit = {
+      closeCalls += 1
+      super.close()
+      failure.foreach(throw _)
+    }
+  }
+
+  private val frame = ByteBuffer
+    .allocate(20)
+    .order(ByteOrder.LITTLE_ENDIAN)
+    .putLong(12L)
+    .putLong(0L)
+    .putInt(0)
+    .array()
+
+  private def withDecoder(batch: TrackingBatch, closeFailure: Option[Throwable] = None)(
+      check: (NativeBatchDecoderIterator, () => Int) => Unit): Unit = {
+    var closeCalls = 0
+    val input = new ByteArrayInputStream(frame) {
+      override def close(): Unit = {
+        closeCalls += 1
+        super.close()
+        closeFailure.foreach(throw _)
+      }
+    }
+    val util = new NativeUtil {
+      override def getNextBatch(
+          numOutputCols: Int,
+          decode: (Array[Long], Array[Long]) => Long): Option[ColumnarBatch] = Some(batch)
+    }
+    try {
+      val decoder = NativeBatchDecoderIterator(
+        input,
+        new SQLMetric("nsTiming", 0L),
+        null,
+        util,
+        tracingEnabled = false)
+      check(decoder, () => closeCalls)
+    } finally {
+      util.close()
+    }
+  }
+
+  def closesPrefetchedBatch(): Unit = {
+    val batch = new TrackingBatch()
+    withDecoder(batch) { (decoder, inputCloseCalls) =>
+      assert(decoder.hasNext)
+      decoder.close()
+      decoder.close()
+      assert(batch.closeCalls == 1)
+      assert(inputCloseCalls() == 1)
+      assert(!decoder.hasNext)
+    }
+  }
+
+  def closesDeliveredBatch(): Unit = {
+    val batch = new TrackingBatch()
+    withDecoder(batch) { (decoder, inputCloseCalls) =>
+      assert(decoder.next() eq batch)
+      decoder.close()
+      decoder.close()
+      assert(batch.closeCalls == 1)
+      assert(inputCloseCalls() == 1)
+      assert(!decoder.hasNext)
+    }
+  }
+
+  def preservesCleanupFailures(): Unit = {
+    Seq(false, true).foreach { delivered =>
+      val batchFailure = new IOException("batch release failed")
+      val streamFailure = new IOException("stream release failed")
+      val batch = new TrackingBatch(Some(batchFailure))
+      withDecoder(batch, Some(streamFailure)) { (decoder, inputCloseCalls) =>
+        assert(decoder.hasNext)
+        if (delivered) assert(decoder.next() eq batch)
+        val caught =
+          try {
+            decoder.close()
+            throw new AssertionError("Expected the batch release failure")
+          } catch {
+            case failure: IOException => failure
+          }
+        assert(caught eq batchFailure)
+        assert(caught.getSuppressed.toSeq == Seq(streamFailure))
+        decoder.close()
+        assert(batch.closeCalls == 1)
+        assert(inputCloseCalls() == 1)
+        assert(!decoder.hasNext)
+      }
+    }
+  }
+
+  def forwardsDecodeFailuresButNotCleanup(): Unit = {
+    val decodeFailure = new IOException("native decode failed")
+    val reportedFailure = new IOException("remote fetch failed", decodeFailure)
+    val closeFailure = new IOException("stream close failed")
+    var reports = 0
+    val input = new ByteArrayInputStream(frame) with CometShuffleReadFailureHandler {
+      override def onShuffleReadFailure(failure: Throwable): Unit = {
+        assert(failure eq decodeFailure)
+        reports += 1
+        throw reportedFailure
+      }
+
+      override def close(): Unit = throw closeFailure
+    }
+    val util = new NativeUtil {
+      override def getNextBatch(
+          numOutputCols: Int,
+          decode: (Array[Long], Array[Long]) => Long): Option[ColumnarBatch] = {
+        decode(Array.empty[Long], Array.empty[Long])
+        throw new AssertionError("Expected native decoding to fail")
+      }
+    }
+    val nativeLib = new Native {
+      override def decodeShuffleBlockWithValidation(
+          block: ByteBuffer,
+          length: Int,
+          arrays: Array[Long],
+          schemas: Array[Long],
+          tracing: Boolean,
+          expectedSchema: Array[Byte]): Long = throw decodeFailure
+    }
+    val decoder = NativeBatchDecoderIterator(
+      input,
+      new SQLMetric("nsTiming", 0L),
+      nativeLib,
+      util,
+      tracingEnabled = false,
+      expectedSchema = Some(Array.empty[Byte]))
+    try {
+      val readError =
+        try {
+          decoder.hasNext
+          throw new AssertionError("Expected the remote fetch failure")
+        } catch {
+          case failure: IOException => failure
+        }
+      assert(readError eq reportedFailure)
+      val closeError =
+        try {
+          decoder.close()
+          throw new AssertionError("Expected the stream close failure")
+        } catch {
+          case failure: IOException => failure
+        }
+      assert(closeError eq closeFailure)
+      assert(reports == 1)
+    } finally {
+      util.close()
+    }
+  }
+
+  def selectsValidationOnlyForRemoteStreams(): Unit = {
+    val intSchema = OperatorOuterClass.ShuffleScan
+      .newBuilder()
+      .addFields(QueryPlanSerde.serializeDataType(IntegerType).get)
+      .build()
+      .toByteArray
+    Seq(None, Some(Array.empty[Byte]), Some(intSchema)).foreach { expectedSchema =>
+      val remote = expectedSchema.isDefined
+      var localCalls = 0
+      var validatedCalls = 0
+      val input =
+        if (remote) {
+          new ByteArrayInputStream(frame) with CometShuffleReadFailureHandler {
+            override def onShuffleReadFailure(failure: Throwable): Unit = throw failure
+          }
+        } else {
+          new ByteArrayInputStream(frame)
+        }
+      val batch = new TrackingBatch()
+      val util = new NativeUtil {
+        override def getNextBatch(
+            numOutputCols: Int,
+            decode: (Array[Long], Array[Long]) => Long): Option[ColumnarBatch] = {
+          assert(decode(Array.empty[Long], Array.empty[Long]) == 1L)
+          Some(batch)
+        }
+      }
+      val nativeLib = new Native {
+        override def decodeShuffleBlock(
+            block: ByteBuffer,
+            length: Int,
+            arrays: Array[Long],
+            schemas: Array[Long],
+            tracing: Boolean): Long = {
+          localCalls += 1
+          1L
+        }
+
+        override def decodeShuffleBlockWithValidation(
+            block: ByteBuffer,
+            length: Int,
+            arrays: Array[Long],
+            schemas: Array[Long],
+            tracing: Boolean,
+            schema: Array[Byte]): Long = {
+          assert(expectedSchema.exists(_.sameElements(schema)))
+          validatedCalls += 1
+          1L
+        }
+      }
+      val decoder = NativeBatchDecoderIterator(
+        input,
+        new SQLMetric("nsTiming", 0L),
+        nativeLib,
+        util,
+        tracingEnabled = false,
+        expectedSchema = expectedSchema)
+      try {
+        assert(decoder.hasNext)
+        assert(localCalls == (if (remote) 0 else 1))
+        assert(validatedCalls == (if (remote) 1 else 0))
+      } finally {
+        decoder.close()
+        util.close()
+      }
+      assert(batch.closeCalls == 1)
+    }
+  }
+
+  def rejectsRemoteStreamsWithoutExpectedSchema(): Unit = {
+    Seq(None, Some(null)).foreach { expectedSchema =>
+      var reads = 0
+      var reports = 0
+      val input = new ByteArrayInputStream(frame) with CometShuffleReadFailureHandler {
+        override def read(buffer: Array[Byte], offset: Int, length: Int): Int = {
+          reads += 1
+          super.read(buffer, offset, length)
+        }
+
+        override def onShuffleReadFailure(failure: Throwable): Unit = { reports += 1 }
+      }
+      try {
+        val failure =
+          try {
+            NativeBatchDecoderIterator(
+              input,
+              new SQLMetric("nsTiming", 0L),
+              null,
+              null,
+              tracingEnabled = false,
+              expectedSchema = expectedSchema)
+            throw new AssertionError("Expected the missing remote schema to fail")
+          } catch {
+            case failure: IllegalArgumentException => failure
+          }
+        assert(failure.getMessage.contains("expected Spark schema"))
+        assert(reads == 0)
+        assert(reports == 0)
+      } finally {
+        input.close()
+      }
+    }
+  }
+
+  def doesNotReportAllocationOrImportFailures(): Unit = {
+    Seq(
+      new OutOfMemoryException("Arrow allocator exhausted"),
+      new IllegalArgumentException("Arrow import failed")).foreach { expected =>
+      var reports = 0
+      val input = new ByteArrayInputStream(frame) with CometShuffleReadFailureHandler {
+        override def onShuffleReadFailure(failure: Throwable): Unit = { reports += 1 }
+      }
+      val util = new NativeUtil {
+        override def getNextBatch(
+            numOutputCols: Int,
+            decode: (Array[Long], Array[Long]) => Long): Option[ColumnarBatch] = throw expected
+      }
+      val decoder = NativeBatchDecoderIterator(
+        input,
+        new SQLMetric("nsTiming", 0L),
+        null,
+        util,
+        tracingEnabled = false,
+        expectedSchema = Some(Array.empty[Byte]))
+      try {
+        val actual =
+          try {
+            decoder.hasNext
+            throw new AssertionError("Expected the allocation/import failure")
+          } catch {
+            case failure: RuntimeException => failure
+          }
+        assert(actual eq expected)
+        assert(reports == 0)
+      } finally {
+        decoder.close()
+        util.close()
+      }
+    }
+  }
+
+  def propagatesHeaderAndEofCleanupFailures(): Unit = {
+    Seq(false, true).foreach { closeAtEof =>
+      val expected =
+        if (closeAtEof) new IOException("EOF stream close failed")
+        else new EOFException("remote reducer ended during the frame header")
+      var reports = 0
+      val input = new ByteArrayInputStream(Array.empty[Byte])
+        with CometShuffleReadFailureHandler {
+        override def read(buffer: Array[Byte], offset: Int, length: Int): Int = {
+          if (closeAtEof) -1 else throw expected
+        }
+
+        override def close(): Unit = {
+          if (closeAtEof) throw expected
+        }
+
+        override def onShuffleReadFailure(failure: Throwable): Unit = { reports += 1 }
+      }
+      val decoder = NativeBatchDecoderIterator(
+        input,
+        new SQLMetric("nsTiming", 0L),
+        null,
+        null,
+        tracingEnabled = false,
+        expectedSchema = Some(Array.empty[Byte]))
+      try {
+        val actual =
+          try {
+            decoder.hasNext
+            throw new AssertionError("Expected the header/cleanup failure")
+          } catch {
+            case failure: IOException => failure
+          }
+        assert(actual eq expected)
+        assert(reports == 0)
+      } finally {
+        decoder.close()
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Which issue does this PR close?

Part of #5352. This is the seventh foundational PR and does not close the issue.

Previous PRs:

- https://github.com/apache/datafusion-comet/pull/5473
- https://github.com/apache/datafusion-comet/pull/5476
- https://github.com/apache/datafusion-comet/pull/5481
- https://github.com/apache/datafusion-comet/pull/5491
- https://github.com/apache/datafusion-comet/pull/5501
- https://github.com/apache/datafusion-comet/pull/5513

## Rationale for this change

The preceding PRs added native Celeborn map-side shuffle writes. Comet also needs a reduce-side reader that consumes native frames without Celeborn's row decompression, preserves AQE read ranges, and participates in Spark's fetch-failure recovery.

## What changes are included in this PR?

- Add a shared local/remote reader interface and route native Celeborn handles through the application-owned client.
- Read reducers lazily using one file-group snapshot, preserving shuffle generations, mapper ranges, attempt identities, and shuffle metrics. Support the stock Celeborn 0.6/0.7 raw-reader API and the newer coalesced-metadata overload without adding a Celeborn dependency.
- Validate frame boundaries before concatenating reducers and preserve `FetchFailedException` across native codec/IPC decoding. Keep metadata timeouts, cancellation, and cleanup failures distinct from corrupt shuffle data.
- Validate Arrow payloads on the remote path while retaining the existing local decoder entry point and fast path.
- Release prefetched batches and unconsumed Arrow structures on early termination, EOF, and failure, preserving suppressed cleanup errors.

Planner enablement remains for 8/n; this PR does not enable end-to-end Celeborn query planning.

## How are these changes tested?

- 177 JVM tests passed across the Celeborn reader/pusher/manager/writer, native shuffle, configuration, and Arrow utility suites (Spark 4.1.3 / Scala 2.13).
- 299 Rust unit tests passed across the core, shuffle, and JNI bridge crates. Four existing HDFS-dependent tests remain ignored.
- Added regressions using real native frames and Arrow IPC for reducer boundaries, corrupt offsets, schema mismatches, JNI fetch-failure propagation, cancellation, and cleanup.
- Seven isolated compatibility probes passed using published Celeborn 0.6.3/0.7.0 binaries. Reader/decoder source was also type-checked against Spark 3.4.3/3.5.9 and Scala 2.12 APIs; these probes are not complete legacy Maven builds or live Celeborn cluster tests.
- Spotless, Scalastyle, Rust formatting, workspace/all-target Clippy with warnings denied, and Scala 2.12 parsing passed.
- Three independent review passes completed with no outstanding P1/P2 findings.
