### PR TITLE
feat: enable native-only Celeborn shuffle planning (8/n)

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -331,6 +331,7 @@ jobs:
               org.apache.spark.sql.comet.execution.shuffle.CometCelebornShuffleManagerSuite
               org.apache.spark.sql.comet.execution.shuffle.CometCelebornNativeShuffleWriterSuite
               org.apache.spark.sql.comet.execution.shuffle.CometCelebornShuffleReaderSuite
+              org.apache.spark.sql.comet.execution.shuffle.CometCelebornShufflePlanningSuite
               org.apache.spark.sql.comet.execution.shuffle.CometNativeShuffleInputRDDSuite
               org.apache.comet.exec.CometShuffleEncryptionSuite
               org.apache.comet.exec.CometShuffleManagerSuite

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -147,6 +147,7 @@ jobs:
               org.apache.spark.sql.comet.execution.shuffle.CometCelebornShuffleManagerSuite
               org.apache.spark.sql.comet.execution.shuffle.CometCelebornNativeShuffleWriterSuite
               org.apache.spark.sql.comet.execution.shuffle.CometCelebornShuffleReaderSuite
+              org.apache.spark.sql.comet.execution.shuffle.CometCelebornShufflePlanningSuite
               org.apache.spark.sql.comet.execution.shuffle.CometNativeShuffleInputRDDSuite
               org.apache.comet.exec.CometShuffleEncryptionSuite
               org.apache.comet.exec.CometShuffleManagerSuite

--- a/docs/source/user-guide/latest/tuning.md
+++ b/docs/source/user-guide/latest/tuning.md
@@ -206,7 +206,8 @@ spark.comet.shuffle.enabled=true
 `spark.shuffle.manager` is a Spark static configuration which cannot be changed at runtime.
 It must be set before the Spark context is created. You can enable or disable Comet shuffle
 at runtime by setting `spark.comet.shuffle.enabled` to `true` or `false`.
-Once it is disabled, Comet will fall back to the default Spark shuffle manager.
+Once it is disabled, the configured shuffle manager handles ordinary Spark shuffle dependencies
+without Comet's shuffle implementation.
 
 ### Shuffle Implementations
 
@@ -250,6 +251,55 @@ Each revert is logged at `INFO` level on the driver as `Reverting Comet columnar
 This optimization is enabled by default and can be disabled by setting
 `spark.comet.shuffle.revertRedundantColumnar.enabled=false`, in which case Comet will keep the columnar shuffle
 even when both its parent and child are non-Comet operators.
+
+### Remote Shuffle with Celeborn
+
+Applications using Apache Celeborn can opt into Comet's native shuffle writer and reader with
+the composite shuffle manager:
+
+```properties
+spark.shuffle.manager=org.apache.spark.sql.comet.execution.shuffle.CometCelebornShuffleManager
+spark.comet.exec.enabled=true
+spark.comet.shuffle.enabled=true
+spark.comet.shuffle.mode=native
+spark.celeborn.client.spark.stageRerun.enabled=true
+```
+
+Set the shuffle manager and Celeborn configuration before creating the Spark context. Celeborn is
+an optional application dependency, not bundled with Comet: provide a compatible Celeborn Spark
+client matching the application's Spark and Scala versions on both the driver and executors,
+alongside the Comet JAR. Keep the application's existing Celeborn service configuration.
+
+Native Celeborn shuffle requires explicit `spark.comet.shuffle.mode=native`. The default `auto`
+mode and `jvm` mode retain ordinary Spark shuffle through the delegated Celeborn manager; they do
+not select Comet's JVM columnar shuffle. Comet execution can still accelerate other operators.
+With native mode enabled, exchanges with unsupported children, data types, or partitioning also
+retain the ordinary Spark/Celeborn shuffle path. The local `CometShuffleManager` keeps its existing
+native-to-columnar fallback behavior.
+
+Stage reruns must remain enabled so failed or ambiguous map attempts can recover through a new
+Celeborn shuffle generation. Native RSS does not support `spark.io.encryption.enabled=true`;
+encrypted applications retain ordinary Spark/Celeborn shuffle instead. Do not disable encryption
+required by the application to enable native RSS. Eligibility uses the manager's application-time
+configuration, including Celeborn's effective defaults and legacy aliases, rather than later SQL
+session overrides.
+
+Celeborn's fallback policy remains application-owned. An effective
+`spark.celeborn.client.spark.shuffle.fallback.policy=ALWAYS`, or an `AUTO` partition-count
+threshold that the exchange reaches, keeps the exchange on Spark. Worker availability and quota
+can still cause Celeborn to choose local fallback during registration. Once an exchange has been
+planned as native, Comet rejects that local handle and fails the registration: native Arrow frames
+cannot be passed to Spark's ordinary local shuffle writer. Set
+`spark.celeborn.client.spark.shuffle.fallback.policy=NEVER` only if the application also wants
+Celeborn to prohibit local fallback for ordinary Spark shuffles.
+
+Native frames retain Comet's configured compression; the raw Celeborn client path bypasses
+Celeborn's additional row compression and decompression. Use
+`spark.comet.shuffle.rss.maxFrameBytes` and `spark.comet.shuffle.rss.maxInFlightBytes` to bound
+encoded frame size and executor-side push admission. These limits include framing and overlapping
+native/JNI/client copies; a frame that cannot fit is rejected rather than split across requests.
+AQE reducer coalescing and mapper-range reads are supported, but Celeborn physical-skew chunk reads
+are not.
 
 ### Shuffle Compression
 

--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -328,9 +328,11 @@ object CometConf extends ShimCometConf {
       .withAlternative(s"$COMET_EXEC_CONFIG_PREFIX.shuffle.enabled")
       .category(CATEGORY_SHUFFLE)
       .doc(
-        "Whether to enable Comet native shuffle. " +
+        "Whether to enable Comet shuffle. " +
           "Note that this requires setting `spark.shuffle.manager` to " +
-          "`org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager`. " +
+          "`org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager` or " +
+          "`org.apache.spark.sql.comet.execution.shuffle.CometCelebornShuffleManager`. " +
+          "Celeborn requires explicit native mode and compatible application settings. " +
           "`spark.shuffle.manager` must be set before starting the Spark application and " +
           "cannot be changed during the application.")
       .booleanConf
@@ -351,11 +353,10 @@ object CometConf extends ShimCometConf {
   val COMET_SHUFFLE_MODE: ConfigEntry[String] = conf("spark.comet.shuffle.mode")
     .withAlternative(s"$COMET_EXEC_CONFIG_PREFIX.shuffle.mode")
     .category(CATEGORY_SHUFFLE)
-    .doc(
-      "This is test config to allow tests to force a particular shuffle implementation to be " +
-        "used. Valid values are `jvm` for Columnar Shuffle, `native` for Native Shuffle, " +
-        s"and `auto` to pick the best supported option (`native` has priority). $TUNING_GUIDE.")
-    .internal()
+    .doc("Select the Comet shuffle implementation: `jvm` for Columnar Shuffle, " +
+      "`native` for Native Shuffle, and `auto` to pick the best supported option " +
+      "(`native` has priority). With CometCelebornShuffleManager, only explicit `native` " +
+      s"mode enables Comet shuffle; `auto` and `jvm` retain Spark/Celeborn shuffle. $TUNING_GUIDE.")
     .stringConf
     .transform(_.toLowerCase(Locale.ROOT))
     .checkValues(Set("native", "jvm", "auto"))

--- a/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
+++ b/spark/src/main/scala/org/apache/comet/CometSparkSessionExtensions.scala
@@ -21,13 +21,14 @@ package org.apache.comet
 
 import java.nio.ByteOrder
 
-import org.apache.spark.SparkConf
+import org.apache.spark.{SparkConf, SparkEnv}
 import org.apache.spark.internal.Logging
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.{TreeNode, TreeNodeTag}
 import org.apache.spark.sql.comet._
+import org.apache.spark.sql.comet.execution.shuffle.{CometCelebornShuffleManager, CometShuffleManager}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.internal.SQLConf
 
@@ -120,6 +121,7 @@ class CometSparkSessionExtensions
 
 object CometSparkSessionExtensions extends Logging {
   lazy val isBigEndian: Boolean = ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN)
+  private val SHUFFLE_MANAGER_KEY = "spark.shuffle.manager"
 
   /**
    * Checks whether Comet extension should be loaded for Spark.
@@ -137,7 +139,8 @@ object CometSparkSessionExtensions extends Logging {
     if (COMET_SHUFFLE_ENABLED.get(conf) && !isCometShuffleManagerEnabled(conf)) {
       logWarning(
         "Comet extension is disabled because spark.shuffle.manager is not set to " +
-          "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager. " +
+          s"${classOf[CometShuffleManager].getName} or " +
+          s"${classOf[CometCelebornShuffleManager].getName}. " +
           "Comet provides limited benefit without its shuffle manager. " +
           s"Set ${COMET_SHUFFLE_ENABLED.key}=false to keep Comet enabled with " +
           "Spark's default shuffle manager.")
@@ -173,16 +176,55 @@ object CometSparkSessionExtensions extends Logging {
     }
   }
 
-  // Check whether Comet shuffle is enabled:
-  // 1. `COMET_SHUFFLE_ENABLED` is true
-  // 2. `spark.shuffle.manager` is set to `CometShuffleManager`
-  // 3. Off-heap memory is enabled || Spark/Comet unit testing
+  // The shared gate also protects CollectLimit and TakeOrdered, which create single-partition
+  // dependencies without passing through ordinary exchange selection. Celeborn requires explicit
+  // native opt-in and compatible application settings; local Comet shuffle keeps its behavior.
   def isCometShuffleEnabled(conf: SQLConf): Boolean =
-    COMET_SHUFFLE_ENABLED.get(conf) && isCometShuffleManagerEnabled(conf)
+    COMET_SHUFFLE_ENABLED.get(conf) && isCometShuffleManagerEnabled(conf) &&
+      cometCelebornShuffleFallbackReason(conf, numPartitions = 1).isEmpty
+
+  private def activeCelebornShuffleManager: Option[CometCelebornShuffleManager] =
+    Option(SparkEnv.get).flatMap(env => Option(env.shuffleManager)).collect {
+      case manager: CometCelebornShuffleManager => manager
+    }
+
+  def isCometCelebornShuffleManagerEnabled(conf: SQLConf): Boolean =
+    activeCelebornShuffleManager.isDefined ||
+      conf.getConfString(SHUFFLE_MANAGER_KEY, "") ==
+      classOf[CometCelebornShuffleManager].getName
 
   def isCometShuffleManagerEnabled(conf: SQLConf): Boolean = {
-    conf.contains("spark.shuffle.manager") && conf.getConfString("spark.shuffle.manager") ==
-      "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager"
+    conf.contains(SHUFFLE_MANAGER_KEY) && {
+      val manager = conf.getConfString(SHUFFLE_MANAGER_KEY)
+      manager == classOf[CometShuffleManager].getName ||
+      manager == classOf[CometCelebornShuffleManager].getName ||
+      activeCelebornShuffleManager.isDefined
+    }
+  }
+
+  /**
+   * Native mode and execution can be chosen per query. Encryption, stage recovery, and Celeborn
+   * fallback policy belong to the application manager, so session SET commands cannot override
+   * their effective values. Inspect the actual manager even if a session changed its class name.
+   */
+  def cometCelebornShuffleFallbackReason(conf: SQLConf, numPartitions: Int): Option[String] = {
+    if (!isCometCelebornShuffleManagerEnabled(conf)) {
+      None
+    } else if (!COMET_EXEC_ENABLED.get(conf)) {
+      Some("Celeborn-backed Comet shuffle requires Comet native execution to be enabled")
+    } else if (COMET_SHUFFLE_MODE.get(conf) == "jvm") {
+      Some("Celeborn-backed Comet shuffle does not support spark.comet.shuffle.mode=jvm")
+    } else if (COMET_SHUFFLE_MODE.get(conf) != "native") {
+      Some("Celeborn-backed Comet shuffle requires spark.comet.shuffle.mode=native")
+    } else {
+      activeCelebornShuffleManager match {
+        case Some(manager) => manager.nativeShuffleFallbackReason(numPartitions)
+        case None =>
+          Some(
+            "Celeborn-backed Comet shuffle requires the application's " +
+              "CometCelebornShuffleManager")
+      }
+    }
   }
 
   def isCometScan(op: SparkPlan): Boolean = {

--- a/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
@@ -23,7 +23,7 @@ import scala.collection.mutable.ListBuffer
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Divide, DoubleLiteral, EqualNullSafe, EqualTo, Expression, FloatLiteral, GreaterThan, GreaterThanOrEqual, KnownFloatingPointNormalized, LessThan, LessThanOrEqual, NamedExpression, Remainder}
-import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateMode, Final, Partial, PartialMerge}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateMode, Final, First, Last, Partial, PartialMerge}
 import org.apache.spark.sql.catalyst.optimizer.NormalizeNaNAndZero
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
@@ -33,7 +33,7 @@ import org.apache.spark.sql.comet.execution.arrow.ArrowCachedBatchSerializer
 import org.apache.spark.sql.comet.execution.shuffle.{CometColumnarShuffle, CometNativeShuffle, CometShuffleExchangeExec}
 import org.apache.spark.sql.comet.util.Utils
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AQEShuffleReadExec, BroadcastQueryStageExec, ShuffleQueryStageExec}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AQEShuffleReadExec, BroadcastQueryStageExec, QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, HashAggregateExec, ObjectHashAggregateExec}
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.command.{DataWritingCommandExec, ExecutedCommandExec}
@@ -45,7 +45,7 @@ import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, V2CommandEx
 import org.apache.spark.sql.execution.datasources.v2.csv.CSVScan
 import org.apache.spark.sql.execution.datasources.v2.json.JsonScan
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
-import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ReusedExchangeExec, ShuffleExchangeExec}
+import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, BroadcastExchangeLike, ReusedExchangeExec, ShuffleExchangeExec, ShuffleExchangeLike}
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec, ShuffledHashJoinExec, SortMergeJoinExec}
 import org.apache.spark.sql.execution.window.WindowExec
 import org.apache.spark.sql.internal.SQLConf
@@ -62,9 +62,9 @@ import org.apache.comet.shims.{ShimCometStreaming, ShimCometWindowGroupLimit, Sh
 object CometExecRule {
 
   /**
-   * Tag applied to Partial-mode aggregate operators that must NOT be converted to Comet because
-   * the corresponding Final-mode aggregate cannot be converted, and the aggregate functions have
-   * incompatible intermediate buffer formats between Spark and Comet.
+   * Tag applied to Partial-mode aggregate operators that must NOT be converted to Comet because a
+   * corresponding buffer-consuming aggregate cannot be converted, and the aggregate functions
+   * have incompatible intermediate buffer formats between Spark and Comet.
    */
   val COMET_UNSAFE_PARTIAL: TreeNodeTag[String] =
     TreeNodeTag[String]("comet.unsafePartialAgg")
@@ -204,6 +204,51 @@ case class CometExecRule(session: SparkSession)
   }
 
   private def isCometNative(op: SparkPlan): Boolean = op.isInstanceOf[CometNativeExec]
+
+  /**
+   * A Celeborn exchange can fall back after its child has been converted, for example because of
+   * the partition threshold or an unsupported hash key. Keep incompatible partial aggregate
+   * buffers on Spark too: an ordinary shuffle cannot connect a native partial to a native final.
+   * Run before AQE materializes the producer stage, and retain the tag on later rule passes.
+   */
+  private def preserveSparkAggregateBuffers(exchange: ShuffleExchangeExec): SparkPlan = {
+    if (!isCometCelebornShuffleManagerEnabled(exchange.conf)) return exchange
+
+    val reason = "Partial aggregate disabled: Celeborn exchange falls back to Spark " +
+      "and intermediate buffer formats are incompatible"
+
+    def restore(plan: SparkPlan): SparkPlan = plan match {
+      // Do not rewrite data that an earlier stage may already have materialized.
+      case _: QueryStageExec | _: ShuffleExchangeLike | _: BroadcastExchangeLike => plan
+      case agg: CometHashAggregateExec
+          if agg.modes == Seq(Partial) &&
+            !QueryPlanSerde.allAggsSupportMixedExecution(agg.aggregateExpressions) =>
+        val sparkAggregate = agg.originalPlan.withNewChildren(agg.children)
+        sparkAggregate.setTagValue(CometExecRule.COMET_UNSAFE_PARTIAL, reason)
+        withFallbackReason(sparkAggregate, reason)
+      // Final output is ordinary SQL data; any partial below it belongs to another aggregate.
+      case agg: CometHashAggregateExec if agg.modes.contains(Final) => agg
+      case agg: BaseAggregateExec if agg.aggregateExpressions.exists(_.mode == Final) => agg
+      case placeholder: CometSinkPlaceHolder =>
+        val child = restore(placeholder.child)
+        if (child eq placeholder.child) placeholder else child
+      case other =>
+        val children = other.children.map(restore)
+        if (children == other.children) {
+          other
+        } else {
+          other match {
+            // A native ancestor embeds its old child in nativeOp. Replacing only its SparkPlan
+            // child would leave the incompatible native partial in that serialized plan.
+            case comet: CometExec =>
+              withFallbackReason(comet.originalPlan.withNewChildren(children), reason)
+            case _ => other.withNewChildren(children)
+          }
+        }
+    }
+
+    exchange.withNewChildren(Seq(restore(exchange.child)))
+  }
 
   // spotless:off
 
@@ -409,10 +454,11 @@ case class CometExecRule(session: SparkSession)
         convertToComet(s, CometExchangeSink).getOrElse(s)
 
       case s: ShuffleExchangeExec if shouldSkipCometShuffle(s) =>
-        s
+        preserveSparkAggregateBuffers(s)
 
       case s: ShuffleExchangeExec =>
-        convertToComet(s, CometShuffleExchangeExec).getOrElse(s)
+        convertToComet(s, CometShuffleExchangeExec)
+          .getOrElse(preserveSparkAggregateBuffers(s))
 
       case op =>
         // if all children are native (or if this is a leaf node) then see if there is a
@@ -655,8 +701,8 @@ case class CometExecRule(session: SparkSession)
         normalizedPlan
       }
 
-      // Tag Partial aggregates that must not be converted to Comet because the
-      // corresponding Final aggregate cannot be converted and the intermediate buffer
+      // Tag Partial aggregates that must not be converted to Comet because a
+      // corresponding Final or PartialMerge cannot be converted and the intermediate buffer
       // formats are incompatible. This runs before transform() so the tags are checked
       // during the bottom-up conversion. Tags persist through AQE stage creation.
       tagUnsafePartialAggregates(planWithJoinRewritten)
@@ -1001,35 +1047,44 @@ case class CometExecRule(session: SparkSession)
   }
 
   /**
-   * Walk the plan to find Final-mode aggregates that cannot be converted to Comet. For each such
-   * Final, if the aggregate functions have incompatible intermediate buffer formats, tag the
-   * corresponding Partial-mode aggregate so it will also be skipped during conversion.
+   * Walk the plan to find buffer-consuming aggregates that cannot be converted to Comet. If the
+   * aggregate functions have incompatible intermediate buffer formats, tag the corresponding
+   * Partial-mode aggregate so it will also be skipped during conversion.
    *
    * This prevents the crash described in issue #1389 where a Comet Partial produces intermediate
-   * data in a format that the Spark Final cannot interpret.
+   * data in a format that the Spark consumer cannot interpret.
    */
   private def tagUnsafePartialAggregates(plan: SparkPlan): Unit = {
     plan.foreach {
       case agg: BaseAggregateExec =>
-        // A single-mode Final that consumes an incompatible intermediate buffer and cannot itself
-        // be converted to Comet must not sit above a Comet aggregate that produces that buffer,
-        // otherwise Spark's Final would try to read a Comet-encoded buffer and crash. Tagging the
+        // A Final or PartialMerge that consumes an incompatible buffer and cannot itself be
+        // converted must not sit above a Comet aggregate that produces that buffer, otherwise
+        // Spark would try to read a Comet-encoded buffer and crash. Tagging the
         // bottom Partial so it falls back is enough: once it is Spark, the missingCometProducer
         // guard in CometBaseAggregate.doConvert cascades the fallback up through any intermediate
         // PartialMerge stages of a distinct-aggregate rewrite. See issues #1389 and #4813.
         val modes = agg.aggregateExpressions.map(_.mode).distinct
-        if (modes == Seq(Final) &&
+        val consumesBuffers = modes == Seq(Final) || modes.contains(PartialMerge)
+        val consumerMode: AggregateMode =
+          if (modes.contains(PartialMerge)) PartialMerge else Final
+        if (consumesBuffers &&
           !QueryPlanSerde.allAggsSupportMixedExecution(agg.aggregateExpressions) &&
-          !canAggregateBeConverted(agg, Final)) {
+          !canAggregateBeConverted(agg, consumerMode)) {
+          // This pass deliberately records the consumer diagnostic. Once the Partial is tagged
+          // below, the consumer can be skipped because its child is no longer native and may not
+          // reach doConvert, which normally records the same reason.
+          unsupportedPartialMergeFallbackReason(agg).foreach(reason =>
+            withFallbackReason(agg, reason))
           findPartialAggInPlan(agg.child).foreach { partial =>
             // Only tag if the Partial would otherwise have been converted. If the Partial itself
             // cannot be converted (e.g. an incompatible input type or a map-typed grouping key),
             // there is no buffer-format mismatch to guard against, and tagging would mask the
             // natural, more specific fallback reason.
             if (canAggregateBeConverted(partial, Partial)) {
+              val consumer = if (consumerMode == Final) "final" else "partial-merge"
               partial.setTagValue(
                 CometExecRule.COMET_UNSAFE_PARTIAL,
-                "Partial aggregate disabled: corresponding final aggregate " +
+                s"Partial aggregate disabled: corresponding $consumer aggregate " +
                   "cannot be converted to Comet and intermediate buffer formats are incompatible")
             }
           }
@@ -1136,14 +1191,21 @@ case class CometExecRule(session: SparkSession)
     }
 
     val modes = aggregateExpressions.map(_.mode).distinct
-    if (modes.size != 1 || modes.head != expectedMode) return false
+    val mixedPartialMerge =
+      expectedMode == PartialMerge && modes.toSet == Set(Partial, PartialMerge)
+    if (!mixedPartialMerge && modes != Seq(expectedMode)) return false
 
-    // In Final mode, exprToProto resolves against the child's output; in Partial/non-Final mode
-    // it must bind to input attributes. This mirrors the `binding` calculation in
-    // `CometBaseAggregate.doConvert`.
-    val binding = expectedMode != Final
-    if (!aggregateExpressions.forall(e =>
-        QueryPlanSerde.aggExprToProto(e, agg.child.output, binding, agg.conf).isDefined)) {
+    // FIRST/LAST cannot merge native partial states in a distinct-aggregate rewrite. Predict
+    // this refusal before an earlier exchange materializes incompatible buffers for other
+    // functions in the same aggregate (for example percentile). Mirror doConvert's restriction.
+    if (unsupportedPartialMergeFallbackReason(agg).nonEmpty) return false
+
+    // Only Partial binds input attributes; Final and PartialMerge consume intermediate buffers.
+    // Mixed distinct-aggregate stages need the same per-expression binding as doConvert.
+    if (!aggregateExpressions.forall { e =>
+        val binding = e.mode != Final && e.mode != PartialMerge
+        QueryPlanSerde.aggExprToProto(e, agg.child.output, binding, agg.conf).isDefined
+      }) {
       return false
     }
 
@@ -1155,6 +1217,21 @@ case class CometExecRule(session: SparkSession)
       agg.resultExpressions.forall(e => QueryPlanSerde.exprToProto(e, attributes).isDefined)
     } else {
       true
+    }
+  }
+
+  private def unsupportedPartialMergeFallbackReason(agg: BaseAggregateExec): Option[String] = {
+    val unsupportedMerges = agg.aggregateExpressions.filter { expression =>
+      expression.mode == PartialMerge &&
+      (expression.aggregateFunction.isInstanceOf[First] ||
+        expression.aggregateFunction.isInstanceOf[Last])
+    }
+    if (unsupportedMerges.nonEmpty) {
+      Some(
+        "PartialMerge not supported for aggregates: " +
+          unsupportedMerges.map(_.aggregateFunction.prettyName).mkString(", "))
+    } else {
+      None
     }
   }
 

--- a/spark/src/main/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStages.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStages.scala
@@ -21,14 +21,16 @@ package org.apache.comet.rules
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.aggregate.{Final, Partial, PartialMerge}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.comet.{CometColumnarToRowExec, CometExec, CometNativeColumnarToRowExec, CometSparkToColumnarExec}
+import org.apache.spark.sql.comet.{CometColumnarToRowExec, CometExec, CometHashAggregateExec, CometNativeColumnarToRowExec, CometSparkToColumnarExec}
 import org.apache.spark.sql.execution.{ColumnarToRowExec, ColumnarToRowTransition, RowToColumnarExec, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.QueryStageExec
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeLike, ShuffleExchangeLike}
 
 import org.apache.comet.CometConf
 import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
+import org.apache.comet.serde.QueryPlanSerde
 
 /**
  * Reverts a query stage to Spark row-based execution when it has too many columnar-to-row (C2R)
@@ -85,6 +87,13 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
     val transitionCount = countTransitions(stagePlan)
     if (transitionCount <= maxTransitions) return None
 
+    // Reverting either side of a native aggregate boundary can make one engine consume the
+    // other's intermediate state. Typed imperative aggregates such as percentile expose a native
+    // array where Spark expects serialized binary; others, including COUNT, must remain in one
+    // engine for planner semantics even though their physical buffer types match. Keep both
+    // producer and consumer stages native when mixed execution is unsafe across a stage boundary.
+    if (hasUnsafeMixedAggregateAtStageBoundary(stagePlan)) return None
+
     val reason =
       s"Stage reverted: $transitionCount C2R transitions exceed threshold $maxTransitions"
 
@@ -103,6 +112,29 @@ case class RevertNativeForTransitionHeavyStages(session: SparkSession)
   private def isStageBoundary(plan: SparkPlan): Boolean = plan match {
     case _: QueryStageExec | _: ShuffleExchangeLike | _: BroadcastExchangeLike => true
     case _ => false
+  }
+
+  private def hasUnsafeMixedAggregateAtStageBoundary(stagePlan: SparkPlan): Boolean = {
+    def reachesBoundaryBeforeAggregate(plan: SparkPlan): Boolean = plan match {
+      case _ if isStageBoundary(plan) => true
+      case _: CometHashAggregateExec => false
+      case _ => plan.children.exists(reachesBoundaryBeforeAggregate)
+    }
+
+    def visit(plan: SparkPlan): Boolean = plan match {
+      case _ if isStageBoundary(plan) => false
+      case aggregate: CometHashAggregateExec
+          if !QueryPlanSerde.allAggsSupportMixedExecution(aggregate.aggregateExpressions) =>
+        val producesBuffer =
+          aggregate.modes.exists(mode => mode == Partial || mode == PartialMerge)
+        val consumesAcrossBoundary =
+          aggregate.modes.exists(mode => mode == Final || mode == PartialMerge) &&
+            reachesBoundaryBeforeAggregate(aggregate.child)
+        producesBuffer || consumesAcrossBoundary || aggregate.children.exists(visit)
+      case _ => plan.children.exists(visit)
+    }
+
+    visit(stagePlan)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometCelebornShuffleManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometCelebornShuffleManager.scala
@@ -20,10 +20,12 @@
 package org.apache.spark.sql.comet.execution.shuffle
 
 import java.lang.reflect.InvocationTargetException
+import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
 
 import org.apache.spark.{ShuffleDependency, SparkConf, SparkEnv, TaskContext}
 import org.apache.spark.rpc.{RpcCallContext, RpcEndpointRef, RpcEnv, ThreadSafeRpcEndpoint}
@@ -40,14 +42,16 @@ import org.apache.comet.util.ClassLoaders
  * binding native Comet map output to Celeborn's application-owned client.
  *
  * Celeborn is an optional, application-provided dependency, so its shuffle manager is loaded
- * reflectively. Native map and reduce paths are available, but planner enablement is separate;
- * JVM Comet shuffle remains unsupported.
+ * reflectively. Explicit native mode enables supported native map and reduce paths; other
+ * exchanges retain ordinary Spark/Celeborn shuffle. JVM Comet shuffle remains unsupported.
  */
 class CometCelebornShuffleManager private[shuffle] (
     conf: SparkConf,
     isDriver: Boolean,
     backendFactory: (SparkConf, Boolean) => ShuffleManager,
-    readerApi: CelebornRawPartitionReader.Api = CelebornRawPartitionReader.reflectedApi)
+    readerApi: CelebornRawPartitionReader.Api = CelebornRawPartitionReader.reflectedApi,
+    planningSupportFactory: SparkConf => CelebornNativeShufflePlanningSupport = conf =>
+      CometCelebornShuffleManager.nativeShufflePlanningSupport(conf))
     extends ShuffleManager {
 
   /** Constructor used by Spark on both the driver and executors. */
@@ -61,6 +65,13 @@ class CometCelebornShuffleManager private[shuffle] (
   private val backend = Option(backendFactory(conf, isDriver)).getOrElse {
     throw new IllegalStateException("Celeborn Spark shuffle manager factory returned null")
   }
+  // Capture effective application settings once, alongside backend construction. Re-reading
+  // SQLConf or JVM properties during planning could disagree with the already-created backend.
+  private val nativePlanningSupport = planningSupportFactory(conf.clone())
+
+  def nativeShuffleFallbackReason(numPartitions: Int): Option[String] =
+    nativePlanningSupport.fallbackReason(numPartitions)
+
   private val nativeShuffleClients =
     new ConcurrentHashMap[Int, ConcurrentHashMap[Int, AnyRef]]()
   private val ownedNativeClients = new ConcurrentHashMap[AnyRef, java.lang.Boolean]()
@@ -397,12 +408,70 @@ class CometCelebornShuffleManager private[shuffle] (
   }
 }
 
+private[shuffle] case class CelebornNativeShufflePlanningSupport(
+    unavailableReason: Option[String] = None,
+    fallbackPolicy: String = "AUTO",
+    fallbackPartitionThreshold: Long = Int.MaxValue.toLong) {
+
+  def fallbackReason(numPartitions: Int): Option[String] =
+    unavailableReason.orElse {
+      if (fallbackPolicy == "ALWAYS") {
+        Some("Celeborn fallback policy ALWAYS requires ordinary Spark shuffle")
+      } else if (fallbackPolicy == "AUTO" && numPartitions.toLong >= fallbackPartitionThreshold) {
+        Some(
+          s"Celeborn falls back to local shuffle at $fallbackPartitionThreshold partitions " +
+            s"(requested $numPartitions); native Comet shuffle requires a remote handle")
+      } else {
+        None
+      }
+    }
+}
+
 private[shuffle] object CometCelebornShuffleManager {
 
   private[shuffle] val GENERATION_COORDINATOR_ENDPOINT =
     "CometCelebornShuffleGenerationCoordinator"
   private val CELEBORN_MANAGER_CLASS = "org.apache.spark.shuffle.celeborn.SparkShuffleManager"
   private val CELEBORN_HANDLE_CLASS = "org.apache.spark.shuffle.celeborn.CelebornShuffleHandle"
+
+  private def reflectedCelebornConf(conf: SparkConf): AnyRef =
+    ClassLoaders
+      .loadClass("org.apache.spark.shuffle.celeborn.SparkUtils")
+      .getMethod("fromSparkConf", classOf[SparkConf])
+      .invoke(null, conf)
+
+  private[shuffle] def nativeShufflePlanningSupport(
+      conf: SparkConf,
+      loadCelebornConf: SparkConf => AnyRef = reflectedCelebornConf)
+      : CelebornNativeShufflePlanningSupport = {
+    if (conf.getBoolean("spark.io.encryption.enabled", false)) {
+      return CelebornNativeShufflePlanningSupport(
+        Some("Native Celeborn shuffle does not support spark.io.encryption.enabled=true"))
+    }
+    try {
+      // Use Celeborn's effective settings to preserve its defaults, aliases, JVM properties and
+      // legacy force-fallback precedence without depending on a particular client version.
+      val settings = loadCelebornConf(conf)
+      def value(name: String): AnyRef = settings.getClass.getMethod(name).invoke(settings)
+      if (!value("clientStageRerunEnabled").asInstanceOf[Boolean]) {
+        return CelebornNativeShufflePlanningSupport(
+          Some("Native Celeborn shuffle requires Celeborn stage reruns to be enabled"))
+      }
+      val policy = value("sparkShuffleFallbackPolicy").toString.toUpperCase(Locale.ROOT)
+      if (!Set("AUTO", "ALWAYS", "NEVER").contains(policy)) {
+        return CelebornNativeShufflePlanningSupport(
+          Some("Celeborn returned an unsupported shuffle fallback policy"))
+      }
+      val threshold = value("shuffleFallbackPartitionThreshold")
+        .asInstanceOf[java.lang.Number]
+        .longValue()
+      CelebornNativeShufflePlanningSupport(None, policy, threshold)
+    } catch {
+      case _: LinkageError | NonFatal(_) =>
+        CelebornNativeShufflePlanningSupport(Some(
+          "Celeborn client does not expose the required native shuffle planning configuration API"))
+    }
+  }
 
   private[shuffle] def maxNativeFrameBytes(
       configuredMaxFrameBytes: Int,

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometShuffleExchangeExec.scala
@@ -51,7 +51,7 @@ import com.google.common.base.Objects
 
 import org.apache.comet.{CometConf, CometExplainInfo}
 import org.apache.comet.CometConf.{COMET_SHUFFLE_ENABLED, COMET_SHUFFLE_MODE}
-import org.apache.comet.CometSparkSessionExtensions.{hasFallbackReason, isCometShuffleManagerEnabled, withFallbackReasons}
+import org.apache.comet.CometSparkSessionExtensions.{cometCelebornShuffleFallbackReason, hasFallbackReason, isCometCelebornShuffleManagerEnabled, isCometShuffleManagerEnabled, withFallbackReasons}
 import org.apache.comet.serde.{Compatible, OperatorOuterClass, QueryPlanSerde, SupportLevel, Unsupported}
 import org.apache.comet.serde.operator.CometSink
 import org.apache.comet.shims.{CometTypeShim, ShimCometShuffleExchangeExec}
@@ -347,12 +347,31 @@ object CometShuffleExchangeExec
       return None
     }
 
-    // Native path is only eligible when the child is already a Comet plan; otherwise skip it
-    // silently (no reason to surface) and let columnar take over.
+    val usesCelebornShuffleManager = isCometCelebornShuffleManagerEnabled(s.conf)
+
+    // Native createExec requires a CometNativeExec child. A previously unwrapped CometPlan is
+    // not sufficient, and Celeborn cannot fall back to a Comet JVM columnar dependency.
+    val nativeChild = if (usesCelebornShuffleManager) {
+      s.child.isInstanceOf[CometNativeExec]
+    } else {
+      isCometPlan(s.child)
+    }
     val nativeReasons: Seq[String] =
-      if (isCometPlan(s.child)) nativeShuffleFailureReasons(s) else Seq.empty
-    if (isCometPlan(s.child) && nativeReasons.isEmpty) {
+      if (nativeChild) nativeShuffleFailureReasons(s) else Seq.empty
+    if (nativeChild && nativeReasons.isEmpty) {
       return Some(CometNativeShuffle)
+    }
+
+    if (usesCelebornShuffleManager) {
+      val reasons = if (nativeChild) {
+        nativeReasons
+      } else {
+        Seq("Celeborn native shuffle requires a CometNativeExec child")
+      }
+      val columnarReason =
+        "Comet columnar shuffle is not supported by the Celeborn shuffle manager"
+      withFallbackReasons(s, (reasons :+ columnarReason).toSet)
+      return None
     }
 
     if (!isCometPlan(s.child) &&
@@ -676,9 +695,11 @@ object CometShuffleExchangeExec
     if (!COMET_SHUFFLE_ENABLED.get(op.conf)) {
       Some(s"Comet shuffle is not enabled: ${COMET_SHUFFLE_ENABLED.key} is not enabled")
     } else if (!isCometShuffleManagerEnabled(op.conf)) {
-      Some(s"spark.shuffle.manager is not set to ${classOf[CometShuffleManager].getName}")
+      Some(
+        s"spark.shuffle.manager is not set to ${classOf[CometShuffleManager].getName} or " +
+          classOf[CometCelebornShuffleManager].getName)
     } else {
-      None
+      cometCelebornShuffleFallbackReason(op.conf, op.outputPartitioning.numPartitions)
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/CometSparkSessionExtensionsSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometSparkSessionExtensionsSuite.scala
@@ -21,7 +21,16 @@ package org.apache.comet
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
+import org.apache.spark.sql.catalyst.plans.physical.{RoundRobinPartitioning, SinglePartition}
+import org.apache.spark.sql.comet.CometScanWrapper
+import org.apache.spark.sql.comet.execution.shuffle.{CometCelebornShuffleManager, CometColumnarShuffle, CometShuffleExchangeExec}
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.LongType
+
+import org.apache.comet.serde.OperatorOuterClass
 
 class CometSparkSessionExtensionsSuite extends CometTestBase {
 
@@ -70,6 +79,56 @@ class CometSparkSessionExtensionsSuite extends CometTestBase {
       "spark.shuffle.manager",
       "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
     assert(isCometLoaded(conf))
+  }
+
+  test("the composite manager is recognized without requiring the optional Celeborn client") {
+    val conf = new SQLConf
+    conf.setConfString(CometConf.COMET_ENABLED.key, "true")
+    conf.setConfString(CometConf.COMET_SHUFFLE_ENABLED.key, "true")
+    conf.setConfString(CometConf.COMET_SHUFFLE_MODE.key, "native")
+    conf.setConfString("spark.shuffle.manager", classOf[CometCelebornShuffleManager].getName)
+    assert(isCometShuffleManagerEnabled(conf))
+    assert(isCometLoaded(conf))
+    // A session-only setting must not replace this suite's actual local shuffle manager.
+    assert(!isCometShuffleEnabled(conf))
+  }
+
+  test("the stock Celeborn manager cannot accept Comet shuffle dependencies") {
+    val conf = new SQLConf
+    conf.setConfString(CometConf.COMET_ENABLED.key, "true")
+    conf.setConfString(CometConf.COMET_SHUFFLE_ENABLED.key, "true")
+    conf.setConfString(
+      "spark.shuffle.manager",
+      "org.apache.spark.shuffle.celeborn.SparkShuffleManager")
+    assert(!isCometShuffleManagerEnabled(conf))
+    assert(!isCometShuffleEnabled(conf))
+    assert(!isCometLoaded(conf))
+  }
+
+  test("local auto mode retains Comet columnar fallback for unsupported native partitioning") {
+    withSQLConf(
+      CometConf.COMET_SHUFFLE_MODE.key -> "auto",
+      CometConf.COMET_SHUFFLE_NATIVE_ROUND_ROBIN_PARTITIONING_ENABLED.key -> "false") {
+      val leaf = spark.sessionState.planner
+        .plan(LocalRelation(Seq(AttributeReference("value", LongType)())))
+        .next()
+      val child = CometScanWrapper(OperatorOuterClass.Operator.getDefaultInstance, leaf)
+      val exchange = ShuffleExchangeExec(RoundRobinPartitioning(2), child)
+      assert(CometShuffleExchangeExec.shuffleSupported(exchange).contains(CometColumnarShuffle))
+    }
+  }
+
+  test("local JVM shuffle remains available when native execution is disabled") {
+    withSQLConf(
+      CometConf.COMET_SHUFFLE_MODE.key -> "jvm",
+      CometConf.COMET_EXEC_ENABLED.key -> "false") {
+      val child = spark.sessionState.planner
+        .plan(LocalRelation(Seq(AttributeReference("value", LongType)())))
+        .next()
+      val exchange = ShuffleExchangeExec(SinglePartition, child)
+      assert(isCometShuffleEnabled(spark.sessionState.conf))
+      assert(CometShuffleExchangeExec.shuffleSupported(exchange).contains(CometColumnarShuffle))
+    }
   }
 
   test("Arrow properties") {

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.comet.CometHashAggregateExec
 import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
-import org.apache.spark.sql.functions.{avg, col, count_distinct, sum}
+import org.apache.spark.sql.functions.{avg, col, count_distinct, expr, sum}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
 
@@ -297,6 +297,33 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
           checkSparkAnswer(
             s"SELECT percentile_approx(_2, 0.5), count(DISTINCT _3) FROM tbl$groupBy")
         }
+      }
+    }
+  }
+
+  test("unsupported PartialMerge preserves percentile buffers with local Comet shuffle") {
+    for {
+      adaptive <- Seq(false, true)
+      percentile <- Seq("percentile", "percentile_approx")
+      mergeFunction <- Seq("first", "last")
+    } {
+      withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString,
+        SQLConf.SHUFFLE_PARTITIONS.key -> "4",
+        CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+        val query = spark
+          .range(0, 18, 1, 4)
+          .selectExpr("id % 3 AS grouping_key", "id % 5 AS value")
+          .groupBy("grouping_key")
+          .agg(
+            expr("count(DISTINCT value)").as("distinct_values"),
+            expr(s"$percentile(value, 0.5)").as("percentile_value"),
+            // The grouping key is constant within each group, so FIRST/LAST are deterministic.
+            expr(s"$mergeFunction(grouping_key)").as("group_value"))
+        val (_, executedPlan) = checkSparkAnswer(query)
+        assert(collect(executedPlan) { case aggregate: CometHashAggregateExec =>
+          aggregate
+        }.isEmpty)
       }
     }
   }

--- a/spark/src/test/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStagesSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/RevertNativeForTransitionHeavyStagesSuite.scala
@@ -20,9 +20,12 @@
 package org.apache.comet.rules
 
 import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.catalyst.expressions.aggregate.{Final, Partial}
 import org.apache.spark.sql.comet._
 import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.adaptive.QueryStageExec
+import org.apache.spark.sql.internal.SQLConf
 
 import org.apache.comet.CometConf
 
@@ -53,6 +56,18 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
 
   private def countC2RNodes(plan: SparkPlan): Int = {
     plan.collect { case _: ColumnarToRowTransition => true }.size
+  }
+
+  private def collectCometAggregates(plan: SparkPlan): Seq[CometHashAggregateExec] = {
+    val current = plan match {
+      case aggregate: CometHashAggregateExec => Seq(aggregate)
+      case _ => Seq.empty
+    }
+    val descendants = plan match {
+      case stage: QueryStageExec => collectCometAggregates(stage.plan)
+      case _ => plan.children.flatMap(collectCometAggregates)
+    }
+    current ++ descendants
   }
 
   /**
@@ -170,7 +185,7 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
   test("revert fires with unsupported UDF producing transitions") {
     withParquetTable((0 until 100).map(i => (i, i % 10, s"val_$i")), "tbl") {
       spark.udf.register("identity_udf", (x: Int) => x)
-      val query = "SELECT _2, identity_udf(_1), count(*) FROM tbl GROUP BY _2, identity_udf(_1)"
+      val query = "SELECT _2, identity_udf(_1), max(_1) FROM tbl GROUP BY _2, identity_udf(_1)"
 
       // Without revert, plan should have transitions due from UDF
       withSQLConf(CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "false") {
@@ -195,7 +210,7 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
 
   test("revert fires and produces correct results when transitions exceed threshold") {
     withParquetTable((0 until 100).map(i => (i, i % 10, s"val_$i")), "tbl") {
-      val query = "SELECT _2, count(*), sum(_1) FROM tbl GROUP BY _2"
+      val query = "SELECT _2, min(_1), sum(_1) FROM tbl GROUP BY _2"
 
       // Without revert, plan should have CometExec nodes with transitions
       withSQLConf(
@@ -276,6 +291,102 @@ class RevertNativeForTransitionHeavyStagesSuite extends CometTestBase {
           invalid.isEmpty,
           "rule.apply produced invalid columnar/row boundaries " +
             s"(${invalid.map(_.nodeName).mkString(", ")}):\n${result.treeString}")
+      }
+    }
+  }
+
+  for (adaptive <- Seq(false, true)) {
+    test(s"transition reversion preserves incompatible aggregate buffers with AQE=$adaptive") {
+      withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString,
+        SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
+        CometConf.COMET_SHUFFLE_MODE.key -> "native",
+        CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "true",
+        CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "0") {
+        withParquetTable((0 until 256).map(i => (i % 4, i.toDouble)), "tbl") {
+          val (_, plan) =
+            checkSparkAnswer("SELECT _1, percentile(_2, 0.5) FROM tbl GROUP BY _1 ORDER BY _1")
+          val executedPlan = stripAQEPlan(plan)
+          val aggregates = collectCometAggregates(executedPlan)
+          assert(aggregates.exists(_.modes == Seq(Partial)), s"$executedPlan")
+          assert(aggregates.exists(_.modes == Seq(Final)), s"$executedPlan")
+        }
+      }
+    }
+  }
+
+  test("transition reversion finds an incompatible aggregate below another aggregate") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
+      CometConf.COMET_SHUFFLE_MODE.key -> "native",
+      CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "0") {
+      withParquetTable((0 until 256).map(i => (i % 4, i.toDouble)), "tbl") {
+        val query =
+          """SELECT grouping_key, percentile(inner_percentile, 0.5)
+            |FROM (
+            |  SELECT _1 AS grouping_key, percentile(_2, 0.5) AS inner_percentile
+            |  FROM tbl
+            |  GROUP BY _1
+            |) inner_aggregate
+            |GROUP BY grouping_key""".stripMargin
+        val (_, plan) = checkSparkAnswer(query)
+        val executedPlan = stripAQEPlan(plan)
+        val aggregates = collectCometAggregates(executedPlan)
+        assert(
+          executedPlan.collect { case _: CometShuffleExchangeExec => true }.size == 1,
+          s"test requires one exchange below the nested aggregates:\n$executedPlan")
+        assert(aggregates.count(_.modes == Seq(Partial)) == 2, s"$executedPlan")
+        assert(aggregates.count(_.modes == Seq(Final)) == 2, s"$executedPlan")
+      }
+    }
+  }
+
+  for (adaptive <- Seq(false, true)) {
+    test(s"transition reversion does not split native COUNT stages with AQE=$adaptive") {
+      withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString,
+        SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
+        CometConf.COMET_SHUFFLE_MODE.key -> "native",
+        CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "true",
+        CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "0") {
+        withParquetTable((0 until 256).map(i => (i % 4, i)), "tbl") {
+          val (_, plan) = checkSparkAnswer("SELECT _1, count(*) FROM tbl GROUP BY _1 ORDER BY _1")
+          val executedPlan = stripAQEPlan(plan)
+          val aggregates = collectCometAggregates(executedPlan)
+          assert(aggregates.exists(_.modes == Seq(Partial)), s"$executedPlan")
+          assert(aggregates.exists(_.modes == Seq(Final)), s"$executedPlan")
+        }
+      }
+    }
+  }
+
+  test("transition reversion preserves an incompatible native partial producer") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      CometConf.COMET_SHUFFLE_MODE.key -> "native",
+      CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "false") {
+      withParquetTable((0 until 256).map(i => (i % 4, i.toDouble)), "tbl") {
+        val nativePlan =
+          sql("SELECT _1, percentile(_2, 0.5) FROM tbl GROUP BY _1").queryExecution.executedPlan
+        val partial = nativePlan
+          .collectFirst {
+            case aggregate: CometHashAggregateExec if aggregate.modes == Seq(Partial) => aggregate
+          }
+          .getOrElse(fail(s"expected a native partial aggregate:\n$nativePlan"))
+        val producerWithTransition = partial.withNewChildren(
+          Seq(CometSparkToColumnarExec(CometNativeColumnarToRowExec(partial.child))))
+        val reverter = RevertNativeForTransitionHeavyStages(spark)
+        assert(reverter.countTransitions(producerWithTransition) == 1)
+
+        var reverted: SparkPlan = null
+        withSQLConf(
+          CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "true",
+          CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "0") {
+          reverted = reverter(producerWithTransition)
+        }
+        assert(reverted eq producerWithTransition)
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/comet/execution/shuffle/CometCelebornShuffleManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/execution/shuffle/CometCelebornShuffleManagerSuite.scala
@@ -29,6 +29,21 @@ import org.apache.spark.shuffle.{BaseShuffleHandle, ShuffleBlockResolver, Shuffl
 
 class CometCelebornShuffleManagerSuite extends AnyFunSuite {
 
+  // Match the optional CelebornConf API, including its enum-valued policy and Long threshold.
+  // The policy deliberately is not a String: production must use the enum's textual value.
+  class ReflectedPlanningConf(
+      var stageReruns: Boolean = true,
+      var policy: String = "AUTO",
+      var partitionThreshold: Long = Int.MaxValue.toLong) {
+    def clientStageRerunEnabled(): Boolean = stageReruns
+
+    def sparkShuffleFallbackPolicy(): AnyRef = new Object {
+      override def toString: String = policy
+    }
+
+    def shuffleFallbackPartitionThreshold(): Long = partitionThreshold
+  }
+
   private class RecordingShuffleManager extends ShuffleManager {
 
     val returnedHandle: ShuffleHandle = new BaseShuffleHandle[Any, Any, Any](31, null)
@@ -363,6 +378,146 @@ class CometCelebornShuffleManagerSuite extends AnyFunSuite {
     assert(observedConf eq conf)
     assert(!observedIsDriver)
     assert(conf.get("spark.app.name") == "existing-celeborn-application")
+  }
+
+  test("native planning snapshots the effective Celeborn configuration once at construction") {
+    val conf = new SparkConf(false)
+      .set("spark.app.name", "native-celeborn-planning")
+      .set("spark.io.encryption.enabled", "false")
+    val effectiveConf = new ReflectedPlanningConf(partitionThreshold = 4L)
+    val backend = new RecordingShuffleManager
+    var loads = 0
+    val composite = new CometCelebornShuffleManager(
+      conf,
+      false,
+      (_, _) => backend,
+      planningSupportFactory = actualConf => {
+        loads += 1
+        assert(!(actualConf eq conf))
+        assert(actualConf.get("spark.app.name") == "native-celeborn-planning")
+        CometCelebornShuffleManager.nativeShufflePlanningSupport(actualConf, _ => effectiveConf)
+      })
+
+    // Mutating settings after manager construction cannot change its native capabilities.
+    assert(loads == 1)
+    conf.set("spark.io.encryption.enabled", "true")
+    effectiveConf.stageReruns = false
+    effectiveConf.policy = "ALWAYS"
+    effectiveConf.partitionThreshold = 1L
+
+    assert(composite.nativeShuffleFallbackReason(3).isEmpty)
+    assert(composite.nativeShuffleFallbackReason(4).nonEmpty)
+    assert(loads == 1)
+    assert(composite.registerShuffle[Any, Any, Any](31, null) eq backend.returnedHandle)
+  }
+
+  test("encrypted native planning falls back before loading the optional Celeborn API") {
+    val conf = new SparkConf(false).set("spark.io.encryption.enabled", "true")
+    var loads = 0
+    val support = CometCelebornShuffleManager.nativeShufflePlanningSupport(
+      conf,
+      _ => {
+        loads += 1
+        new ReflectedPlanningConf
+      })
+
+    assert(support.fallbackReason(1).exists(_.contains("encryption")))
+    assert(loads == 0)
+  }
+
+  test("native planning uses Celeborn's effective stage-rerun setting") {
+    // Celeborn resolves JVM properties and legacy aliases itself. Spark SQL settings must not
+    // override the resolved value used by the actual client and lifecycle manager.
+    val conf = new SparkConf(false)
+      .set("spark.celeborn.client.spark.stageRerun.enabled", "true")
+      .set("spark.celeborn.client.spark.fetch.throwsFetchFailure", "true")
+    val support = CometCelebornShuffleManager.nativeShufflePlanningSupport(
+      conf,
+      _ => new ReflectedPlanningConf(stageReruns = false))
+
+    assert(support.fallbackReason(1).nonEmpty)
+    assert(support.fallbackReason(100).nonEmpty)
+  }
+
+  test("native planning honors the effective fallback policy and partition threshold") {
+    Seq("AUTO", "auto").foreach { policy =>
+      val support = CometCelebornShuffleManager.nativeShufflePlanningSupport(
+        new SparkConf(false),
+        _ => new ReflectedPlanningConf(policy = policy, partitionThreshold = 4L))
+      assert(support.fallbackReason(1).isEmpty)
+      assert(support.fallbackReason(3).isEmpty)
+      assert(support.fallbackReason(4).nonEmpty)
+      assert(support.fallbackReason(5).nonEmpty)
+    }
+
+    val always = CometCelebornShuffleManager.nativeShufflePlanningSupport(
+      new SparkConf(false),
+      _ => new ReflectedPlanningConf(policy = "ALWAYS", partitionThreshold = Long.MaxValue))
+    assert(always.fallbackReason(1).nonEmpty)
+
+    // Celeborn's explicit NEVER policy takes precedence over the deprecated force-fallback flag.
+    val never = CometCelebornShuffleManager.nativeShufflePlanningSupport(
+      new SparkConf(false)
+        .set("spark.celeborn.client.spark.shuffle.forceFallback.enabled", "true"),
+      _ => new ReflectedPlanningConf(policy = "NEVER", partitionThreshold = 1L))
+    assert(never.fallbackReason(1).isEmpty)
+    assert(never.fallbackReason(4).isEmpty)
+  }
+
+  test("native planning retains the Celeborn partition threshold's full Long range") {
+    val largeThreshold = CometCelebornShuffleManager.nativeShufflePlanningSupport(
+      new SparkConf(false),
+      _ => new ReflectedPlanningConf(partitionThreshold = Int.MaxValue.toLong + 1L))
+    assert(largeThreshold.fallbackReason(Int.MaxValue).isEmpty)
+
+    Seq(0L, -1L).foreach { threshold =>
+      val support = CometCelebornShuffleManager.nativeShufflePlanningSupport(
+        new SparkConf(false),
+        _ => new ReflectedPlanningConf(partitionThreshold = threshold))
+      assert(support.fallbackReason(1).nonEmpty)
+    }
+  }
+
+  test("unavailable or incompatible optional planning APIs fail closed") {
+    val loaders: Seq[SparkConf => AnyRef] = Seq(
+      _ => throw new ClassNotFoundException("optional Celeborn configuration is unavailable"),
+      _ =>
+        throw new NoClassDefFoundError("optional Celeborn configuration dependency is missing"),
+      _ => new Object,
+      _ => new ReflectedPlanningConf(policy = "UNKNOWN"),
+      _ =>
+        new ReflectedPlanningConf {
+          override def clientStageRerunEnabled(): Boolean =
+            throw new IllegalStateException("effective Celeborn setting could not be read")
+        })
+
+    loaders.foreach { loader =>
+      val support =
+        CometCelebornShuffleManager.nativeShufflePlanningSupport(new SparkConf(false), loader)
+      assert(support.fallbackReason(1).nonEmpty)
+    }
+  }
+
+  test("an unavailable native planning API leaves ordinary delegated shuffle operational") {
+    val backend = new RecordingShuffleManager
+    val composite = new CometCelebornShuffleManager(
+      new SparkConf(false),
+      false,
+      (_, _) => backend,
+      planningSupportFactory = conf =>
+        CometCelebornShuffleManager.nativeShufflePlanningSupport(
+          conf,
+          _ => throw new ClassNotFoundException("native planning API is unavailable")))
+    val handle = composite.registerShuffle[Any, Any, Any](31, null)
+
+    assert(composite.nativeShuffleFallbackReason(1).nonEmpty)
+    assert(handle eq backend.returnedHandle)
+    assert(composite.getWriter[Any, Any](handle, 12L, null, null) == null)
+    assert(composite.getReader[Any, Any](handle, 0, 2, null, null) == null)
+    assert(backend.writerCall.contains((handle, 12L)))
+    assert(backend.rangedReaderCall.contains((handle, 0, Int.MaxValue, 0, 2)))
+    composite.stop()
+    assert(backend.stopped)
   }
 
   test("ordinary shuffle registration preserves the delegated manager's handle") {

--- a/spark/src/test/scala/org/apache/spark/sql/comet/execution/shuffle/CometCelebornShufflePlanningSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/execution/shuffle/CometCelebornShufflePlanningSuite.scala
@@ -1,0 +1,723 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet.execution.shuffle
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.apache.spark.{ShuffleDependency, SparkConf, SparkEnv}
+import org.apache.spark.shuffle.ShuffleHandle
+import org.apache.spark.shuffle.sort.SortShuffleManager
+import org.apache.spark.sql.{CometTestBase, DataFrame, Row}
+import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeReference, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{Final, Partial, PartialMerge}
+import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, RangePartitioning, RoundRobinPartitioning, SinglePartition}
+import org.apache.spark.sql.comet.{CometCollectLimitExec, CometHashAggregateExec, CometLocalTableScanExec, CometNativeExec, CometScanWrapper, CometSortExec, CometSparkToColumnarExec, CometTakeOrderedAndProjectExec}
+import org.apache.spark.sql.execution.{CollectLimitExec, ColumnarToRowTransition, LocalTableScanExec, SortExec, SparkPlan, TakeOrderedAndProjectExec}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
+import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+import org.apache.spark.sql.functions.{col, expr}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{ArrayType, IntegerType, LongType, ObjectType}
+
+import org.apache.comet.{CometConf, CometExplainInfo}
+import org.apache.comet.CometSparkSessionExtensions.{isCometShuffleEnabled, isCometShuffleManagerEnabled}
+import org.apache.comet.rules.{CometExecRule, RevertNativeForTransitionHeavyStages}
+import org.apache.comet.serde.{Compatible, OperatorOuterClass}
+
+/**
+ * Plans against the actual composite manager without requiring the optional Celeborn client. Only
+ * Spark-fallback queries execute: the local test backend must never receive a native dependency.
+ * Native plan assertions below are not transport or live-cluster integration tests.
+ */
+class CometCelebornShufflePlanningSuite extends CometTestBase {
+
+  override protected val shuffleManager: String =
+    classOf[CometCelebornPlanningTestShuffleManager].getName
+
+  override protected def sparkConf: SparkConf =
+    super.sparkConf
+      .set(CometConf.COMET_SHUFFLE_MODE.key, "auto")
+      .set(CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key, "false")
+      .set("spark.io.encryption.enabled", "false")
+      .set("spark.celeborn.client.spark.stageRerun.enabled", "true")
+
+  private def manager: CometCelebornPlanningTestShuffleManager =
+    SparkEnv.get.shuffleManager.asInstanceOf[CometCelebornPlanningTestShuffleManager]
+
+  private def nativeChild(
+      attributes: Seq[Attribute] = Seq(AttributeReference("value", LongType)()))
+      : CometNativeExec = {
+    val original = sparkLeaf(attributes)
+    CometScanWrapper(OperatorOuterClass.Operator.getDefaultInstance, original)
+  }
+
+  // Let Spark supply its version-specific LocalTableScanExec constructor arguments.
+  private def sparkLeaf(attributes: Seq[Attribute] = Seq(AttributeReference("value", LongType)()))
+      : LocalTableScanExec =
+    spark.sessionState.planner
+      .plan(LocalRelation(attributes))
+      .next()
+      .asInstanceOf[LocalTableScanExec]
+
+  private def reasons(plan: SparkPlan): Set[String] =
+    plan.getTagValue(CometExplainInfo.FALLBACK_REASONS).getOrElse(Set.empty[String])
+
+  private def cometExchanges(plan: SparkPlan): Seq[CometShuffleExchangeExec] =
+    collect(plan) { case exchange: CometShuffleExchangeExec => exchange }
+
+  private def assertSparkExchange(plan: SparkPlan): Unit = {
+    assert(cometExchanges(plan).isEmpty, s"unexpected Comet shuffle:\n$plan")
+    assert(
+      collect(plan) { case exchange: ShuffleExchangeExec => exchange }.nonEmpty,
+      s"expected a Spark shuffle:\n$plan")
+  }
+
+  private def input: DataFrame =
+    spark.range(0, 32, 1, 4).selectExpr("id + 1 AS value")
+
+  private def collectionAggregatePlan: SparkPlan =
+    input
+      .selectExpr("value % 3 AS grouping_key", "value")
+      .groupBy("grouping_key")
+      .agg(expr("collect_list(value)"))
+      .queryExecution
+      .executedPlan
+
+  private def assertNativeExecutionLoaded(): Unit = {
+    val plan = input.queryExecution.executedPlan
+    assert(collect(plan) { case op: CometNativeExec => op }.nonEmpty, s"$plan")
+  }
+
+  private def specialOperators(child: SparkPlan): (CollectLimitExec, TakeOrderedAndProjectExec) =
+    (
+      CollectLimitExec(3, child),
+      TakeOrderedAndProjectExec(
+        3,
+        Seq(SortOrder(child.output.head, Ascending)),
+        child.output,
+        child))
+
+  private def assertSpecialSupport(expected: Boolean): Unit = {
+    val (limit, topK) = specialOperators(nativeChild())
+    assert(CometCollectLimitExec.getSupportLevel(limit).isInstanceOf[Compatible] == expected)
+    assert(
+      CometTakeOrderedAndProjectExec.getSupportLevel(topK).isInstanceOf[Compatible] == expected)
+    val rule = CometExecRule(spark)
+    assert(rule(limit).isInstanceOf[CometCollectLimitExec] == expected)
+    assert(rule(topK).isInstanceOf[CometTakeOrderedAndProjectExec] == expected)
+  }
+
+  // Spark core configuration cannot be changed through RuntimeConfig. Deliberately modify the
+  // session's copy only, proving it cannot override the manager already owned by SparkEnv.
+  private def withSessionConfOverride(settings: (String, String)*)(f: => Unit): Unit = {
+    val conf = spark.sessionState.conf
+    val previous = settings.map { case (key, _) => key -> Option(conf.getConfString(key, null)) }
+    try {
+      settings.foreach { case (key, value) => conf.setConfString(key, value) }
+      f
+    } finally {
+      previous.foreach {
+        case (key, Some(value)) => conf.setConfString(key, value)
+        case (key, None) => conf.unsetConf(key)
+      }
+    }
+  }
+
+  test("the actual composite manager loads Comet and default auto preserves Spark shuffle") {
+    val conf = spark.sessionState.conf
+    assert(isCometShuffleManagerEnabled(conf))
+    assertNativeExecutionLoaded()
+    assert(CometConf.COMET_SHUFFLE_MODE.get(conf) == "auto")
+    assert(!isCometShuffleEnabled(conf))
+    assertSpecialSupport(expected = false)
+  }
+
+  test("native opt-in, execution, and shuffle flags gate exchanges and special producers") {
+    for {
+      mode <- Seq("auto", "jvm", "native")
+      nativeExecution <- Seq(false, true)
+      shuffleEnabled <- Seq(false, true)
+    } {
+      withSQLConf(
+        CometConf.COMET_SHUFFLE_MODE.key -> mode,
+        CometConf.COMET_EXEC_ENABLED.key -> nativeExecution.toString,
+        CometConf.COMET_SHUFFLE_ENABLED.key -> shuffleEnabled.toString) {
+        val expected = mode == "native" && nativeExecution && shuffleEnabled
+        assert(isCometShuffleEnabled(spark.sessionState.conf) == expected)
+        val exchange = ShuffleExchangeExec(SinglePartition, nativeChild())
+        assert(
+          CometShuffleExchangeExec.shuffleSupported(exchange).contains(CometNativeShuffle) ==
+            expected)
+        assertSpecialSupport(expected)
+      }
+    }
+  }
+
+  test("supported native partitionings never select JVM Comet shuffle") {
+    withSQLConf(
+      CometConf.COMET_SHUFFLE_MODE.key -> "native",
+      CometConf.COMET_SHUFFLE_NATIVE_RANGE_PARTITIONING_ENABLED.key -> "true",
+      CometConf.COMET_SHUFFLE_NATIVE_ROUND_ROBIN_PARTITIONING_ENABLED.key -> "true") {
+      val child = nativeChild()
+      val partitionings = Seq(
+        SinglePartition,
+        HashPartitioning(child.output, 2),
+        RangePartitioning(Seq(SortOrder(child.output.head, Ascending)), 2),
+        RoundRobinPartitioning(2))
+      partitionings.foreach { partitioning =>
+        val exchange = ShuffleExchangeExec(partitioning, child)
+        assert(CometShuffleExchangeExec.shuffleSupported(exchange).contains(CometNativeShuffle))
+        assert(reasons(exchange).isEmpty)
+      }
+    }
+  }
+
+  test("unsupported native partitioning falls back without trying Comet columnar shuffle") {
+    withSQLConf(
+      CometConf.COMET_SHUFFLE_MODE.key -> "native",
+      CometConf.COMET_SHUFFLE_NATIVE_HASH_PARTITIONING_ENABLED.key -> "false",
+      CometConf.COMET_SHUFFLE_NATIVE_RANGE_PARTITIONING_ENABLED.key -> "false",
+      CometConf.COMET_SHUFFLE_NATIVE_ROUND_ROBIN_PARTITIONING_ENABLED.key -> "false") {
+      val child = nativeChild()
+      val partitionings = Seq(
+        HashPartitioning(child.output, 2),
+        RangePartitioning(Seq(SortOrder(child.output.head, Ascending)), 2),
+        RoundRobinPartitioning(2))
+      partitionings.foreach { partitioning =>
+        val exchange = ShuffleExchangeExec(partitioning, child)
+        assert(CometShuffleExchangeExec.shuffleSupported(exchange).isEmpty)
+        assert(reasons(exchange).exists(_.contains("disabled")))
+        assert(reasons(exchange).exists(_.contains("columnar shuffle")))
+      }
+    }
+  }
+
+  test("unsupported output and hash-key types retain the Spark exchange") {
+    withSQLConf(CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+      val objectChild =
+        nativeChild(Seq(AttributeReference("value", ObjectType(classOf[String]))()))
+      val objectExchange = ShuffleExchangeExec(SinglePartition, objectChild)
+      assert(CometShuffleExchangeExec.shuffleSupported(objectExchange).isEmpty)
+      assert(reasons(objectExchange).exists(_.contains("unsupported shuffle data type")))
+
+      val arrayChild = nativeChild(Seq(AttributeReference("value", ArrayType(IntegerType))()))
+      val arrayExchange = ShuffleExchangeExec(HashPartitioning(arrayChild.output, 2), arrayChild)
+      assert(CometShuffleExchangeExec.shuffleSupported(arrayExchange).isEmpty)
+      assert(reasons(arrayExchange).exists(_.contains("unsupported hash partitioning data type")))
+    }
+  }
+
+  test("Spark and already-unwrapped Comet children do not enter the native createExec branch") {
+    withSQLConf(CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+      val leaf = sparkLeaf()
+      val children = Seq(
+        leaf,
+        CometSparkToColumnarExec(leaf),
+        CometLocalTableScanExec(leaf, Nil, leaf.output),
+        CometCollectLimitExec(CollectLimitExec(3, leaf), 3, 0, leaf))
+      children.foreach { child =>
+        val exchange = ShuffleExchangeExec(SinglePartition, child)
+        assert(CometShuffleExchangeExec.shuffleSupported(exchange).isEmpty)
+        assert(reasons(exchange).exists(_.contains("Comet")))
+        assert(CometExecRule(spark)(exchange).isInstanceOf[ShuffleExchangeExec])
+      }
+    }
+  }
+
+  test("fallback is sticky after AQE reshapes the child or native mode becomes available") {
+    val child = nativeChild()
+    val exchange = ShuffleExchangeExec(SinglePartition, child)
+    withSQLConf(CometConf.COMET_SHUFFLE_MODE.key -> "auto") {
+      assert(CometShuffleExchangeExec.shuffleSupported(exchange).isEmpty)
+      assert(reasons(exchange).nonEmpty)
+    }
+    withSQLConf(CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+      val reshaped =
+        exchange.withNewChildren(Seq(nativeChild())).asInstanceOf[ShuffleExchangeExec]
+      assert(CometShuffleExchangeExec.shuffleSupported(reshaped).isEmpty)
+      assert(CometExecRule(spark)(reshaped).isInstanceOf[ShuffleExchangeExec])
+      assert(
+        CometShuffleExchangeExec
+          .shuffleSupported(ShuffleExchangeExec(SinglePartition, child))
+          .contains(CometNativeShuffle))
+    }
+  }
+
+  test("a session manager override cannot enable unsupported JVM Comet shuffle") {
+    withSessionConfOverride("spark.shuffle.manager" -> classOf[CometShuffleManager].getName) {
+      Seq("auto", "jvm").foreach { mode =>
+        withSQLConf(CometConf.COMET_SHUFFLE_MODE.key -> mode) {
+          assert(!isCometShuffleEnabled(spark.sessionState.conf))
+          assert(
+            CometShuffleExchangeExec
+              .shuffleSupported(ShuffleExchangeExec(SinglePartition, nativeChild()))
+              .isEmpty)
+          assertSpecialSupport(expected = false)
+        }
+      }
+      withSQLConf(CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+        assert(isCometShuffleEnabled(spark.sessionState.conf))
+      }
+    }
+  }
+
+  test("runtime encryption and disabled stage reruns cannot be masked by session overrides") {
+    val runtimeConfigurations = Seq(
+      new SparkConf(false).set("spark.io.encryption.enabled", "true"),
+      new SparkConf(false).set("spark.celeborn.client.spark.stageRerun.enabled", "false"))
+    runtimeConfigurations.foreach { runtimeConf =>
+      val support = CometCelebornPlanningTestShuffleManager.planningSupport(runtimeConf)
+      manager.withPlanningSupport(support) {
+        withSessionConfOverride(
+          "spark.io.encryption.enabled" -> "false",
+          "spark.celeborn.client.spark.stageRerun.enabled" -> "true") {
+          withSQLConf(CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+            assertNativeExecutionLoaded()
+            assert(!isCometShuffleEnabled(spark.sessionState.conf))
+            assert(
+              CometShuffleExchangeExec
+                .shuffleSupported(ShuffleExchangeExec(SinglePartition, nativeChild()))
+                .isEmpty)
+            assertSpecialSupport(expected = false)
+          }
+        }
+      }
+    }
+  }
+
+  test("forced local fallback protects special operators as well as ordinary exchanges") {
+    manager.withPlanningSupport(CelebornNativeShufflePlanningSupport(fallbackPolicy = "ALWAYS")) {
+      withSQLConf(CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+        assert(!isCometShuffleEnabled(spark.sessionState.conf))
+        assert(
+          CometShuffleExchangeExec
+            .shuffleSupported(ShuffleExchangeExec(SinglePartition, nativeChild()))
+            .isEmpty)
+        assertSpecialSupport(expected = false)
+      }
+    }
+  }
+
+  test("fallback partition thresholds use the exchange's reducer count") {
+    manager.withPlanningSupport(
+      CelebornNativeShufflePlanningSupport(fallbackPartitionThreshold = 2L)) {
+      withSQLConf(CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+        val child = nativeChild()
+        assert(isCometShuffleEnabled(spark.sessionState.conf))
+        assertSpecialSupport(expected = true)
+        assert(
+          CometShuffleExchangeExec
+            .shuffleSupported(ShuffleExchangeExec(SinglePartition, child))
+            .contains(CometNativeShuffle))
+        val exchange = ShuffleExchangeExec(HashPartitioning(child.output, 2), child)
+        assert(CometShuffleExchangeExec.shuffleSupported(exchange).isEmpty)
+        assert(reasons(exchange).nonEmpty)
+      }
+    }
+  }
+
+  test("single-partition thresholds also block CollectLimit and TakeOrdered") {
+    manager.withPlanningSupport(
+      CelebornNativeShufflePlanningSupport(fallbackPartitionThreshold = 1L)) {
+      withSQLConf(CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+        assert(!isCometShuffleEnabled(spark.sessionState.conf))
+        assertSpecialSupport(expected = false)
+      }
+    }
+    manager.withPlanningSupport(
+      CelebornNativeShufflePlanningSupport(
+        fallbackPolicy = "NEVER",
+        fallbackPartitionThreshold = 1L)) {
+      withSQLConf(CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+        assert(isCometShuffleEnabled(spark.sessionState.conf))
+        assertSpecialSupport(expected = true)
+      }
+    }
+  }
+
+  for (skipShuffle <- Seq(false, true)) {
+    test(
+      s"aggregate fallback restores native ancestors and survives re-entry: skip=$skipShuffle") {
+      withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+        CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+        val partial = collect(collectionAggregatePlan) {
+          case aggregate: CometHashAggregateExec if aggregate.modes == Seq(Partial) => aggregate
+        }.head
+        val rule = CometExecRule(spark)
+        val sorted =
+          rule(SortExec(Seq(SortOrder(partial.output.head, Ascending)), false, partial))
+        assert(sorted.isInstanceOf[CometSortExec], s"$sorted")
+
+        val exchange = ShuffleExchangeExec(HashPartitioning(Seq(sorted.output.head), 4), sorted)
+        if (skipShuffle) {
+          exchange.setTagValue(CometExecRule.SKIP_COMET_SHUFFLE_TAG, ())
+        }
+        var restored: SparkPlan = exchange
+        manager.withPlanningSupport(
+          CelebornNativeShufflePlanningSupport(fallbackPartitionThreshold = 2L)) {
+          restored = rule(exchange)
+          assertSparkExchange(restored)
+          assert(restored.children.head.isInstanceOf[SortExec], s"$restored")
+          assert(collect(restored) { case aggregate: CometHashAggregateExec =>
+            aggregate
+          }.isEmpty)
+          val sparkPartial = collect(restored) { case aggregate: BaseAggregateExec =>
+            aggregate
+          }.head
+          assert(sparkPartial.getTagValue(CometExecRule.COMET_UNSAFE_PARTIAL).isDefined)
+        }
+
+        // Even if the runtime policy now permits native shuffle, AQE must not reconvert the
+        // producer after its exchange committed to Spark's intermediate buffer representation.
+        val reentered = rule(restored)
+        assertSparkExchange(reentered)
+        assert(reentered.children.head.isInstanceOf[SortExec], s"$reentered")
+        assert(collect(reentered) { case aggregate: CometHashAggregateExec => aggregate }.isEmpty)
+      }
+    }
+  }
+
+  test("an outer fallback exchange preserves completed native aggregate stages") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+      val finalAggregate = collect(collectionAggregatePlan) {
+        case aggregate: CometHashAggregateExec if aggregate.modes == Seq(Final) => aggregate
+      }.head
+      val originalAggregates = collect(finalAggregate) { case aggregate: CometHashAggregateExec =>
+        aggregate
+      }
+      assert(originalAggregates.exists(_.modes == Seq(Partial)))
+
+      manager.withPlanningSupport(
+        CelebornNativeShufflePlanningSupport(fallbackPartitionThreshold = 2L)) {
+        val exchange =
+          ShuffleExchangeExec(
+            HashPartitioning(Seq(finalAggregate.output.head), 4),
+            finalAggregate)
+        val restored = CometExecRule(spark)(exchange)
+        assert(restored.isInstanceOf[ShuffleExchangeExec])
+        val retainedAggregates = collect(restored) { case aggregate: CometHashAggregateExec =>
+          aggregate
+        }
+        assert(
+          retainedAggregates.map(aggregate => (aggregate.modes, aggregate.output)) ==
+            originalAggregates.map(aggregate => (aggregate.modes, aggregate.output)),
+          s"$restored")
+        assert(
+          retainedAggregates.forall(
+            _.originalPlan.getTagValue(CometExecRule.COMET_UNSAFE_PARTIAL).isEmpty))
+      }
+    }
+  }
+
+  test("transition reversion preserves native aggregate buffers across a Celeborn exchange") {
+    manager.withPlanningSupport(CelebornNativeShufflePlanningSupport()) {
+      withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+        SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
+        CometConf.COMET_SHUFFLE_MODE.key -> "native",
+        CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "false") {
+        val query = spark
+          .range(0, 256, 1, 4)
+          .selectExpr("id % 4 AS grouping_key", "CAST(id AS DOUBLE) AS value")
+          .groupBy("grouping_key")
+          .agg(expr("percentile(value, 0.5)").as("percentile_value"))
+        val nativePlan = query.queryExecution.executedPlan
+
+        assert(cometExchanges(nativePlan).nonEmpty, s"$nativePlan")
+        assert(
+          collect(nativePlan) {
+            case aggregate: CometHashAggregateExec if aggregate.modes == Seq(Final) => aggregate
+          }.nonEmpty,
+          s"expected a native final aggregate before transition reversion:\n$nativePlan")
+        assert(
+          collect(nativePlan) { case transition: ColumnarToRowTransition => transition }.nonEmpty,
+          s"test requires a result-stage transition:\n$nativePlan")
+
+        var reverted: SparkPlan = null
+        withSQLConf(
+          CometConf.COMET_EXEC_TRANSITION_REVERT_ENABLED.key -> "true",
+          CometConf.COMET_EXEC_TRANSITION_REVERT_MAX_TRANSITIONS.key -> "0") {
+          reverted = RevertNativeForTransitionHeavyStages(spark)(nativePlan)
+        }
+        assert(
+          collect(reverted) {
+            case aggregate: CometHashAggregateExec if aggregate.modes == Seq(Final) => aggregate
+          }.nonEmpty,
+          "transition reversion must not make Spark consume a native percentile buffer:\n" +
+            reverted)
+      }
+    }
+  }
+
+  for (adaptive <- Seq(false, true)) {
+    for {
+      percentile <- Seq("percentile", "percentile_approx")
+      mergeFunction <- Seq("first", "last")
+    } {
+      test(s"unsupported $mergeFunction merge preserves $percentile buffers with AQE=$adaptive") {
+        manager.withPlanningSupport(CelebornNativeShufflePlanningSupport()) {
+          withSQLConf(
+            SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString,
+            SQLConf.SHUFFLE_PARTITIONS.key -> "4",
+            CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+            // FIRST/LAST cannot merge natively. Tag the incompatible percentile producer
+            // before the first DISTINCT exchange is materialized, not just at the later
+            // exchange that falls back. Its grouping key makes FIRST/LAST deterministic.
+            val query = spark
+              .range(0, 18, 1, 4)
+              .selectExpr("id % 3 AS grouping_key", "id % 5 AS value")
+              .groupBy("grouping_key")
+              .agg(
+                expr("count(DISTINCT value)").as("distinct_values"),
+                expr(s"$percentile(value, 0.5)").as("percentile_value"),
+                expr(s"$mergeFunction(grouping_key)").as("merge_value"))
+            val nativeRegistrations = manager.nativeRegistrations.get()
+            val (_, executedPlan) = checkSparkAnswer(query)
+            assertSparkExchange(executedPlan)
+            assert(manager.nativeRegistrations.get() == nativeRegistrations)
+            assert(collect(executedPlan) { case aggregate: CometHashAggregateExec =>
+              aggregate
+            }.isEmpty)
+            assert(collect(executedPlan) {
+              case aggregate: BaseAggregateExec
+                  if aggregate.aggregateExpressions.exists(expression =>
+                    expression.mode == PartialMerge &&
+                      expression.aggregateFunction.prettyName == mergeFunction) =>
+                aggregate
+            }.nonEmpty)
+          }
+        }
+      }
+    }
+
+    test(s"fallback restores incompatible partial-merge ancestors with AQE=$adaptive") {
+      manager.withPlanningSupport(
+        CelebornNativeShufflePlanningSupport(fallbackPartitionThreshold = 2L)) {
+        withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString,
+          SQLConf.SHUFFLE_PARTITIONS.key -> "4",
+          "spark.sql.requireAllClusterKeysForDistribution" -> "false",
+          CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+          // Range's existing partitioning satisfies the initial DISTINCT-id distribution, so
+          // PartialMerge can convert above Partial before the later exchange falls back.
+          val query = spark
+            .range(0, 18, 1, 4)
+            .selectExpr("id % 3 AS grouping_key", "id", "id % 5 AS value")
+            .groupBy("grouping_key")
+            .agg(
+              expr("count(DISTINCT id)").as("distinct_ids"),
+              expr("percentile_approx(value, 0.5)").as("aggregate_value"))
+          val nativeRegistrations = manager.nativeRegistrations.get()
+          val (_, executedPlan) = checkSparkAnswer(query)
+          assertSparkExchange(executedPlan)
+          assert(manager.nativeRegistrations.get() == nativeRegistrations)
+          assert(collect(executedPlan) { case aggregate: CometHashAggregateExec =>
+            aggregate
+          }.isEmpty)
+          assert(collect(executedPlan) {
+            case aggregate: BaseAggregateExec
+                if aggregate.aggregateExpressions.exists(_.mode == PartialMerge) =>
+              aggregate
+          }.nonEmpty)
+        }
+      }
+    }
+
+    for {
+      fallback <- Seq("partition threshold", "unsupported array hash key")
+      function <- Seq("collect_list", "collect_set", "avg")
+    } {
+      test(s"native $fallback preserves $function aggregate buffers with AQE=$adaptive") {
+        val complexKey = fallback == "unsupported array hash key"
+        val support = if (complexKey) {
+          CelebornNativeShufflePlanningSupport()
+        } else {
+          CelebornNativeShufflePlanningSupport(fallbackPartitionThreshold = 2L)
+        }
+        manager.withPlanningSupport(support) {
+          withSQLConf(
+            SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString,
+            SQLConf.SHUFFLE_PARTITIONS.key -> "4",
+            CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+            val grouping = if (complexKey) "array(id % 3)" else "id % 3"
+            val aggregate =
+              if (function == "avg") "avg(value)" else s"sort_array($function(value))"
+            val query = spark
+              .range(0, 18, 1, 4)
+              .selectExpr(s"$grouping AS grouping_key", "id AS value")
+              .groupBy("grouping_key")
+              .agg(expr(aggregate).as("aggregate_value"))
+
+            val nativeRegistrations = manager.nativeRegistrations.get()
+            val (_, executedPlan) = checkSparkAnswer(query)
+            assertSparkExchange(executedPlan)
+            assert(manager.nativeRegistrations.get() == nativeRegistrations)
+
+            val nativeAggregates = collect(executedPlan) {
+              case aggregate: CometHashAggregateExec => aggregate
+            }
+            if (function == "avg") {
+              // AVG's intermediate state is Spark-compatible; native partials remain safe.
+              assert(nativeAggregates.nonEmpty, s"$executedPlan")
+            } else {
+              // A Spark final cannot deserialize Comet's ArrayType collect_list/collect_set
+              // state as its BinaryType buffer. Both halves must agree when the exchange falls
+              // back, not just when an aggregate operator itself is unsupported.
+              assert(nativeAggregates.isEmpty, s"$executedPlan")
+            }
+          }
+        }
+      }
+    }
+
+    test(
+      s"QueryExecution plans native Celeborn exchanges only with explicit opt-in: AQE=$adaptive") {
+      withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString,
+        CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+        val nativeRegistrations = manager.nativeRegistrations.get()
+        val plan = input.repartition(2, col("value")).queryExecution.executedPlan
+        assert(plan.isInstanceOf[AdaptiveSparkPlanExec] == adaptive)
+        val exchanges = cometExchanges(plan)
+        assert(exchanges.nonEmpty, s"expected native exchange:\n$plan")
+        assert(exchanges.forall(_.shuffleType == CometNativeShuffle))
+        assert(manager.nativeRegistrations.get() == nativeRegistrations)
+      }
+    }
+
+    for (mode <- Seq("auto", "jvm")) {
+      test(s"QueryExecution executes the Spark fallback in mode=$mode with AQE=$adaptive") {
+        withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString,
+          CometConf.COMET_SHUFFLE_MODE.key -> mode) {
+          val nativeRegistrations = manager.nativeRegistrations.get()
+          val sparkRegistrations = manager.sparkRegistrations.get()
+          val query = input.repartition(2, col("value"))
+          assertSparkExchange(query.queryExecution.executedPlan)
+          checkAnswer(query, (1L to 32L).map(Row(_)))
+          assert(cometExchanges(query.queryExecution.executedPlan).isEmpty)
+          assert(manager.nativeRegistrations.get() == nativeRegistrations)
+          assert(manager.sparkRegistrations.get() > sparkRegistrations)
+        }
+      }
+    }
+
+    test(s"unsupported native repartition executes Spark fallback with AQE=$adaptive") {
+      withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString,
+        CometConf.COMET_SHUFFLE_MODE.key -> "native",
+        CometConf.COMET_SHUFFLE_NATIVE_ROUND_ROBIN_PARTITIONING_ENABLED.key -> "false") {
+        val nativeRegistrations = manager.nativeRegistrations.get()
+        val query = input.repartition(2)
+        assertSparkExchange(query.queryExecution.executedPlan)
+        checkAnswer(query, (1L to 32L).map(Row(_)))
+        assert(cometExchanges(query.queryExecution.executedPlan).isEmpty)
+        assert(manager.nativeRegistrations.get() == nativeRegistrations)
+      }
+    }
+
+    test(s"QueryExecution protects hidden limit and topK shuffles with AQE=$adaptive") {
+      withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString) {
+        withSQLConf(CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+          val limit = input.limit(3).queryExecution.executedPlan
+          val topK = input.orderBy(col("value").desc).limit(3).queryExecution.executedPlan
+          assert(collect(limit) { case op: CometCollectLimitExec => op }.nonEmpty, s"$limit")
+          assert(
+            collect(topK) { case op: CometTakeOrderedAndProjectExec => op }.nonEmpty,
+            s"$topK")
+        }
+        withSQLConf(CometConf.COMET_SHUFFLE_MODE.key -> "auto") {
+          val limit = input.limit(3)
+          val topK = input.orderBy(col("value").desc).limit(3)
+          assert(collect(limit.queryExecution.executedPlan) { case op: CometCollectLimitExec =>
+            op
+          }.isEmpty)
+          assert(collect(topK.queryExecution.executedPlan) {
+            case op: CometTakeOrderedAndProjectExec => op
+          }.isEmpty)
+          checkAnswer(limit, Seq(Row(1L), Row(2L), Row(3L)))
+          checkAnswer(topK, Seq(Row(32L), Row(31L), Row(30L)))
+        }
+      }
+    }
+  }
+}
+
+/** Spark-reflective test constructor; no Celeborn classes or service are needed. */
+class CometCelebornPlanningTestShuffleManager(conf: SparkConf, isDriver: Boolean)
+    extends CometCelebornShuffleManager(
+      conf,
+      isDriver,
+      (sparkConf, _) => new SortShuffleManager(sparkConf),
+      planningSupportFactory = CometCelebornPlanningTestShuffleManager.planningSupport) {
+
+  val nativeRegistrations = new AtomicInteger()
+  val sparkRegistrations = new AtomicInteger()
+  @volatile private var supportOverride: Option[CelebornNativeShufflePlanningSupport] = None
+
+  // Test controls emulate policies captured when different applications start. They never mutate
+  // SparkEnv or a production manager, and every override is restored even if an assertion fails.
+  private[shuffle] def withPlanningSupport(support: CelebornNativeShufflePlanningSupport)(
+      f: => Unit): Unit = {
+    val previous = supportOverride
+    try {
+      supportOverride = Some(support)
+      f
+    } finally {
+      supportOverride = previous
+    }
+  }
+
+  override def nativeShuffleFallbackReason(numPartitions: Int): Option[String] =
+    supportOverride match {
+      case Some(support) => support.fallbackReason(numPartitions)
+      case None => super.nativeShuffleFallbackReason(numPartitions)
+    }
+
+  override def registerShuffle[K, V, C](
+      shuffleId: Int,
+      dependency: ShuffleDependency[K, V, C]): ShuffleHandle = {
+    dependency match {
+      case _: CometShuffleDependency[_, _, _] => nativeRegistrations.incrementAndGet()
+      case _ => sparkRegistrations.incrementAndGet()
+    }
+    super.registerShuffle(shuffleId, dependency)
+  }
+}
+
+private[shuffle] object CometCelebornPlanningTestShuffleManager {
+  // This fake captures application configuration just like the real manager. Reflection against
+  // the optional Celeborn client is covered separately; these tests exercise planner routing.
+  def planningSupport(conf: SparkConf): CelebornNativeShufflePlanningSupport = {
+    val unavailable = if (conf.getBoolean("spark.io.encryption.enabled", false)) {
+      Some("Native Celeborn shuffle does not support spark.io.encryption.enabled=true")
+    } else if (!conf.getBoolean("spark.celeborn.client.spark.stageRerun.enabled", true)) {
+      Some("Native Celeborn shuffle requires stage reruns")
+    } else {
+      None
+    }
+    CelebornNativeShufflePlanningSupport(unavailableReason = unavailable)
+  }
+}


### PR DESCRIPTION
## Which issue does this PR close?

Part of #5352. This is the eighth foundational PR and does not close the issue.

Previous PRs:

- https://github.com/apache/datafusion-comet/pull/5473
- https://github.com/apache/datafusion-comet/pull/5476
- https://github.com/apache/datafusion-comet/pull/5481
- https://github.com/apache/datafusion-comet/pull/5491
- https://github.com/apache/datafusion-comet/pull/5501
- https://github.com/apache/datafusion-comet/pull/5513
- https://github.com/apache/datafusion-comet/pull/5531

## Rationale for this change

The preceding PRs added the Celeborn-backed native shuffle writer, map-side lifecycle, and raw reader. This PR enables the planner to select that path through `CometCelebornShuffleManager` with explicit native opt-in.

Unsupported exchanges must retain ordinary Spark/Celeborn shuffle without selecting Comet's JVM columnar shuffle. Fallback must also keep aggregate producers and consumers on compatible intermediate buffer formats.

## What changes are included in this PR?

- Recognize the composite manager and require Comet execution, Comet shuffle, and explicit `spark.comet.shuffle.mode=native`. Default `auto` and `jvm` retain ordinary Spark/Celeborn shuffle.
- Snapshot effective application configuration through Celeborn's configuration API, preserving defaults, aliases, and fallback-policy precedence. Reject native planning for I/O encryption, disabled stage reruns, unsupported configuration APIs, and applicable local-fallback policies or partition thresholds. Session overrides cannot bypass these application-level restrictions.
- Require a native child and supported native partitioning/schema; preserve sticky AQE fallback and the existing local Comet shuffle behavior. Apply the shared guards to collect-limit and top-K shuffle producers as well.
- Keep incompatible aggregate buffers on Spark when an exchange or intermediate merge cannot run natively. Restore affected native ancestors, preserve completed/stage boundaries, and retain safe mixed execution such as non-decimal AVG.
- Make the shuffle-mode setting public, document configuration and limitations, and register the new planner suite in Linux and macOS CI.

## How are these changes tested?

New planner and manager tests cover the opt-in matrix, runtime versus session configuration, supported and unsupported exchanges, AQE, special shuffle producers, fallback-policy boundaries, optional API failures, and immutable configuration snapshots.

Executed Spark-reference comparisons cover fallback queries, collect-list/set buffer compatibility, and mixed DISTINCT/percentile/FIRST/LAST pipelines. Planner-only checks cover repeated rule application, native-ancestor rollback, and completed aggregate boundaries. The local Comet shuffle path has a matching aggregate regression.

Local validation:

- Final full-reactor Maven run on Spark 4.1.3 / Scala 2.13 / JDK 21: **116 tests passed**, including the corrected FIRST/LAST diagnostic assertion.
- Broader 13-suite shuffle, JNI, configuration, and aggregate run: **379/380 passed** before the final diagnostic correction; its sole failure passed in the final rerun.
- Rust core, shuffle, and JNI library tests: **312 passed**, with four existing HDFS tests ignored.
- Spotless, ScalaStyle, `cargo fmt --all --check`, and workspace Clippy with warnings denied passed.
- **63 configuration compatibility checks** passed against published Celeborn 0.6.3 and 0.7.0 clients. Scala 2.12 parsing and the corresponding reflected API signatures were also checked.

Native plan-selection tests use a delegated test manager without executing remote native dependencies. No live Celeborn cluster or complete legacy Spark build matrix was run locally.
