### PR TITLE
fix: prevent memory leak after failed Arrow vector import

### DIFF
--- a/spark/src/main/java/org/apache/arrow/c/ArrowImporter.java
+++ b/spark/src/main/java/org/apache/arrow/c/ArrowImporter.java
@@ -50,10 +50,32 @@ public class ArrowImporter {
 
   public FieldVector importVector(
       ArrowArray array, ArrowSchema schema, CDataDictionaryProvider provider) {
-    Field field = importField(schema, provider);
-    FieldVector vector = field.createVector(allocator);
-    ArrayImporter importer = new ArrayImporter(allocator, vector, provider);
-    importer.importArray(array);
-    return vector;
+    FieldVector vector = null;
+    try {
+      Field field = importField(schema, provider);
+      vector = field.createVector(allocator);
+      ArrayImporter importer = new ArrayImporter(allocator, vector, provider);
+      importer.importArray(array);
+      return vector;
+    } catch (RuntimeException | Error failure) {
+      if (vector != null) {
+        runCleanup(failure, vector::close);
+      }
+      if (!array.isClosed()) {
+        runCleanup(failure, array::release);
+        runCleanup(failure, array::close);
+      }
+      throw failure;
+    }
+  }
+
+  private static void runCleanup(Throwable failure, Runnable cleanup) {
+    try {
+      cleanup.run();
+    } catch (Throwable cleanupFailure) {
+      if (cleanupFailure != failure) {
+        failure.addSuppressed(cleanupFailure);
+      }
+    }
   }
 }

--- a/spark/src/main/java/org/apache/arrow/c/ArrowImporter.java
+++ b/spark/src/main/java/org/apache/arrow/c/ArrowImporter.java
@@ -22,6 +22,8 @@ package org.apache.arrow.c;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.dictionary.Dictionary;
+import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
 import org.apache.arrow.vector.types.pojo.Field;
 
 /**
@@ -51,9 +53,10 @@ public class ArrowImporter {
 
   public FieldVector importVector(
       ArrowArray array, ArrowSchema schema, CDataDictionaryProvider provider) {
+    Field field = null;
     FieldVector vector = null;
     try {
-      Field field = importField(schema, provider);
+      field = importField(schema, provider);
       vector = field.createVector(allocator);
       ArrayImporter importer = new ArrayImporter(allocator, vector, provider);
       importer.importArray(array);
@@ -62,10 +65,40 @@ public class ArrowImporter {
       if (vector != null) {
         AutoCloseables.close(failure, vector);
       }
+      if (field != null) {
+        closeDictionaries(field, provider, failure);
+      }
+      // ArrayImporter.importArray moves the array into a copy it owns and closes the source
+      // before doImport can fail, so a closed array means the importer already took it and
+      // releasing it again would be a double release.
       if (!array.isClosed()) {
         AutoCloseables.close(failure, array::release, array);
       }
       throw failure;
+    }
+  }
+
+  /**
+   * Closes the dictionary vectors registered in {@code provider} for {@code field} and its
+   * children.
+   *
+   * <p>{@code ArrayImporter.doImport} loads a column's dictionary values before its main data, and
+   * both sets of buffers hold references on the same imported C array. Those values live in the
+   * provider rather than in the column's own vector, so closing the column alone leaves the C array
+   * alive until the provider is closed at the end of the task. Each import assigns a fresh
+   * dictionary id, so no other column can be using the entries this one created.
+   */
+  public static void closeDictionaries(
+      Field field, CDataDictionaryProvider provider, Throwable failure) {
+    DictionaryEncoding encoding = field.getDictionary();
+    if (encoding != null) {
+      Dictionary dictionary = provider.lookup(encoding.getId());
+      if (dictionary != null) {
+        AutoCloseables.close(failure, dictionary.getVector());
+      }
+    }
+    for (Field child : field.getChildren()) {
+      closeDictionaries(child, provider, failure);
     }
   }
 }

--- a/spark/src/main/java/org/apache/arrow/c/ArrowImporter.java
+++ b/spark/src/main/java/org/apache/arrow/c/ArrowImporter.java
@@ -20,6 +20,7 @@
 package org.apache.arrow.c;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.types.pojo.Field;
 
@@ -59,23 +60,12 @@ public class ArrowImporter {
       return vector;
     } catch (RuntimeException | Error failure) {
       if (vector != null) {
-        runCleanup(failure, vector::close);
+        AutoCloseables.close(failure, vector);
       }
       if (!array.isClosed()) {
-        runCleanup(failure, array::release);
-        runCleanup(failure, array::close);
+        AutoCloseables.close(failure, array::release, array);
       }
       throw failure;
-    }
-  }
-
-  private static void runCleanup(Throwable failure, Runnable cleanup) {
-    try {
-      cleanup.run();
-    } catch (Throwable cleanupFailure) {
-      if (cleanupFailure != failure) {
-        failure.addSuppressed(cleanupFailure);
-      }
     }
   }
 }

--- a/spark/src/main/scala/org/apache/comet/vector/NativeUtil.scala
+++ b/spark/src/main/scala/org/apache/comet/vector/NativeUtil.scala
@@ -245,6 +245,10 @@ class NativeUtil extends AutoCloseable {
   /**
    * Imports a list of Arrow addresses from native execution, and return a list of Comet vectors.
    *
+   * On failure this releases everything it was given, both the arrays and schemas it has not
+   * imported yet and the vectors it has already imported, so callers must not add cleanup of
+   * their own.
+   *
    * @param arrays
    *   a list of Arrow array
    * @param schemas
@@ -261,18 +265,23 @@ class NativeUtil extends AutoCloseable {
         val arrowSchema = schemas(i)
         val arrowArray = arrays(i)
 
+        // importField's finally consumes the schema. ArrayImporter takes the array normally, while
+        // ArrowImporter's catch releases it if the import fails before that transfer.
         firstUnconsumed = i + 1
         val arrowVector = importer.importVector(arrowArray, arrowSchema, dictionaryProvider)
-        var cometVector: CometVector = null
-        try {
-          cometVector = CometVector.getVector(arrowVector, dictionaryProvider)
-          arrayVectors += cometVector
-        } catch {
-          case failure: Throwable =>
-            val rollback = if (cometVector == null) arrowVector else cometVector
-            AutoCloseables.close(failure, rollback)
-            throw failure
-        }
+        val cometVector =
+          try CometVector.getVector(arrowVector, dictionaryProvider)
+          catch {
+            case failure: Throwable =>
+              // Nothing took ownership of the column, so release both halves: the vector and the
+              // dictionary values the import left in the provider. Read the field before closing,
+              // so the walk never depends on metadata read back from a closed vector.
+              val field = arrowVector.getField
+              AutoCloseables.close(failure, arrowVector: AutoCloseable)
+              ArrowImporter.closeDictionaries(field, dictionaryProvider, failure)
+              throw failure
+          }
+        arrayVectors += cometVector
       }
       arrayVectors.toSeq
     } catch {

--- a/spark/src/main/scala/org/apache/comet/vector/NativeUtil.scala
+++ b/spark/src/main/scala/org/apache/comet/vector/NativeUtil.scala
@@ -254,15 +254,29 @@ class NativeUtil {
   def importVector(arrays: Array[ArrowArray], schemas: Array[ArrowSchema]): Seq[CometVector] = {
     val arrayVectors = mutable.ArrayBuffer.empty[CometVector]
 
-    (0 until arrays.length).foreach { i =>
-      val arrowSchema = schemas(i)
-      val arrowArray = arrays(i)
+    try {
+      (0 until arrays.length).foreach { i =>
+        val arrowSchema = schemas(i)
+        val arrowArray = arrays(i)
 
-      arrayVectors += CometVector.getVector(
-        importer.importVector(arrowArray, arrowSchema, dictionaryProvider),
-        dictionaryProvider)
+        arrayVectors += CometVector.getVector(
+          importer.importVector(arrowArray, arrowSchema, dictionaryProvider),
+          dictionaryProvider)
+      }
+      arrayVectors.toSeq
+    } catch {
+      case failure: Throwable =>
+        val firstUnconsumed = arrayVectors.length
+        arrayVectors.foreach { vector =>
+          try vector.close()
+          catch {
+            case closeFailure: Throwable =>
+              if (closeFailure ne failure) failure.addSuppressed(closeFailure)
+          }
+        }
+        releaseArrowStructs(arrays.drop(firstUnconsumed), schemas.drop(firstUnconsumed), failure)
+        throw failure
     }
-    arrayVectors.toSeq
   }
 
   /**

--- a/spark/src/main/scala/org/apache/comet/vector/NativeUtil.scala
+++ b/spark/src/main/scala/org/apache/comet/vector/NativeUtil.scala
@@ -22,6 +22,7 @@ package org.apache.comet.vector
 import scala.collection.mutable
 
 import org.apache.arrow.c.{ArrowArray, ArrowImporter, ArrowSchema, CDataDictionaryProvider, Data}
+import org.apache.arrow.util.AutoCloseables
 import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.arrow.vector.dictionary.DictionaryProvider
 import org.apache.spark.SparkException
@@ -43,7 +44,7 @@ import org.apache.comet.CometArrowAllocator
  *
  * NativeUtil must be closed after use to release resources in the dictionary provider.
  */
-class NativeUtil {
+class NativeUtil extends AutoCloseable {
   import Utils._
 
   /** Use the global allocator */
@@ -269,24 +270,14 @@ class NativeUtil {
         } catch {
           case failure: Throwable =>
             val rollback = if (cometVector == null) arrowVector else cometVector
-            try rollback.close()
-            catch {
-              case closeFailure: Throwable =>
-                if (closeFailure ne failure) failure.addSuppressed(closeFailure)
-            }
+            AutoCloseables.close(failure, rollback)
             throw failure
         }
       }
       arrayVectors.toSeq
     } catch {
       case failure: Throwable =>
-        arrayVectors.foreach { vector =>
-          try vector.close()
-          catch {
-            case closeFailure: Throwable =>
-              if (closeFailure ne failure) failure.addSuppressed(closeFailure)
-          }
-        }
+        AutoCloseables.close(failure, arrayVectors.toSeq: _*)
         releaseArrowStructs(arrays.drop(firstUnconsumed), schemas.drop(firstUnconsumed), failure)
         throw failure
     }
@@ -315,7 +306,7 @@ class NativeUtil {
     new ColumnarBatch(arrayVectors.toArray, maxNumRows)
   }
 
-  def close(): Unit = {
+  override def close(): Unit = {
     // closing the dictionary provider also closes the dictionary arrays
     dictionaryProvider.close()
   }

--- a/spark/src/main/scala/org/apache/comet/vector/NativeUtil.scala
+++ b/spark/src/main/scala/org/apache/comet/vector/NativeUtil.scala
@@ -253,20 +253,33 @@ class NativeUtil {
    */
   def importVector(arrays: Array[ArrowArray], schemas: Array[ArrowSchema]): Seq[CometVector] = {
     val arrayVectors = mutable.ArrayBuffer.empty[CometVector]
+    var firstUnconsumed = 0
 
     try {
       (0 until arrays.length).foreach { i =>
         val arrowSchema = schemas(i)
         val arrowArray = arrays(i)
 
-        arrayVectors += CometVector.getVector(
-          importer.importVector(arrowArray, arrowSchema, dictionaryProvider),
-          dictionaryProvider)
+        firstUnconsumed = i + 1
+        val arrowVector = importer.importVector(arrowArray, arrowSchema, dictionaryProvider)
+        var cometVector: CometVector = null
+        try {
+          cometVector = CometVector.getVector(arrowVector, dictionaryProvider)
+          arrayVectors += cometVector
+        } catch {
+          case failure: Throwable =>
+            val rollback = if (cometVector == null) arrowVector else cometVector
+            try rollback.close()
+            catch {
+              case closeFailure: Throwable =>
+                if (closeFailure ne failure) failure.addSuppressed(closeFailure)
+            }
+            throw failure
+        }
       }
       arrayVectors.toSeq
     } catch {
       case failure: Throwable =>
-        val firstUnconsumed = arrayVectors.length
         arrayVectors.foreach { vector =>
           try vector.close()
           catch {

--- a/spark/src/test/scala/org/apache/comet/vector/NativeUtilSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/vector/NativeUtilSuite.scala
@@ -99,6 +99,35 @@ class NativeUtilSuite extends CometTestBase {
     }
   }
 
+  test("getNextBatch releases imported vectors and Arrow structs when vector import fails") {
+    withIsolatedStructAllocator { (nativeUtil, allocator, _) =>
+      val vector = new IntVector("value", allocator)
+      vector.allocateNew(4)
+      vector.setSafe(0, 42)
+      vector.setValueCount(1)
+      try {
+        val failure = intercept[IllegalStateException] {
+          nativeUtil.getNextBatch(
+            2,
+            (arrays, schemas) => {
+              Data.exportVector(
+                allocator,
+                vector,
+                null,
+                ArrowArray.wrap(arrays(0)),
+                ArrowSchema.wrap(schemas(0)))
+              vector.close()
+              1L
+            })
+        }
+        assert(failure.getMessage == "Cannot import released ArrowSchema")
+        assert(allocator.getAllocatedMemory == 0)
+      } finally {
+        vector.close()
+      }
+    }
+  }
+
   test("getNextBatch preserves a native failure and attempts all remaining struct cleanup") {
     withIsolatedStructAllocator { (nativeUtil, allocator, arrays) =>
       val expected = new IOException("native decode failed")

--- a/spark/src/test/scala/org/apache/comet/vector/NativeUtilSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/vector/NativeUtilSuite.scala
@@ -21,6 +21,8 @@ package org.apache.comet.vector
 
 import java.io.IOException
 
+import scala.util.Using
+
 import org.apache.arrow.c.{ArrowArray, ArrowSchema, Data}
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.{IntVector, UInt4Vector, VarCharVector}
@@ -103,11 +105,10 @@ class NativeUtilSuite extends CometTestBase {
 
   test("getNextBatch releases imported vectors and Arrow structs when vector import fails") {
     withIsolatedStructAllocator { (nativeUtil, allocator, _) =>
-      val vector = new IntVector("value", allocator)
-      vector.allocateNew(4)
-      vector.setSafe(0, 42)
-      vector.setValueCount(1)
-      try {
+      Using.resource(new IntVector("value", allocator)) { vector =>
+        vector.allocateNew(4)
+        vector.setSafe(0, 42)
+        vector.setValueCount(1)
         val failure = intercept[IllegalStateException] {
           nativeUtil.getNextBatch(
             2,
@@ -125,19 +126,16 @@ class NativeUtilSuite extends CometTestBase {
         assert(failure.getMessage == "Cannot import released ArrowSchema")
         assert(failure.getSuppressed.isEmpty)
         assert(allocator.getAllocatedMemory == 0)
-      } finally {
-        vector.close()
       }
     }
   }
 
   test("getNextBatch releases an imported vector when its Comet wrapper rejects the type") {
     withIsolatedStructAllocator { (nativeUtil, allocator, _) =>
-      val vector = new UInt4Vector("value", allocator)
-      vector.allocateNew(1)
-      vector.setSafe(0, 42)
-      vector.setValueCount(1)
-      try {
+      Using.resource(new UInt4Vector("value", allocator)) { vector =>
+        vector.allocateNew(1)
+        vector.setSafe(0, 42)
+        vector.setValueCount(1)
         val failure = intercept[UnsupportedOperationException] {
           nativeUtil.getNextBatch(
             2,
@@ -154,8 +152,6 @@ class NativeUtilSuite extends CometTestBase {
         }
         assert(failure.getSuppressed.isEmpty)
         assert(allocator.getAllocatedMemory == 0)
-      } finally {
-        vector.close()
       }
     }
   }

--- a/spark/src/test/scala/org/apache/comet/vector/NativeUtilSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/vector/NativeUtilSuite.scala
@@ -23,7 +23,9 @@ import java.io.IOException
 
 import org.apache.arrow.c.{ArrowArray, ArrowSchema, Data}
 import org.apache.arrow.memory.RootAllocator
-import org.apache.arrow.vector.IntVector
+import org.apache.arrow.vector.{IntVector, UInt4Vector, VarCharVector}
+import org.apache.arrow.vector.complex.StructVector
+import org.apache.arrow.vector.types.pojo.{ArrowType, FieldType}
 import org.apache.spark.sql.CometTestBase
 import org.apache.spark.sql.execution.vectorized.ConstantColumnVector
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
@@ -121,10 +123,80 @@ class NativeUtilSuite extends CometTestBase {
             })
         }
         assert(failure.getMessage == "Cannot import released ArrowSchema")
+        assert(failure.getSuppressed.isEmpty)
         assert(allocator.getAllocatedMemory == 0)
       } finally {
         vector.close()
       }
+    }
+  }
+
+  test("getNextBatch releases an imported vector when its Comet wrapper rejects the type") {
+    withIsolatedStructAllocator { (nativeUtil, allocator, _) =>
+      val vector = new UInt4Vector("value", allocator)
+      vector.allocateNew(1)
+      vector.setSafe(0, 42)
+      vector.setValueCount(1)
+      try {
+        val failure = intercept[UnsupportedOperationException] {
+          nativeUtil.getNextBatch(
+            2,
+            (arrays, schemas) => {
+              Data.exportVector(
+                allocator,
+                vector,
+                null,
+                ArrowArray.wrap(arrays(0)),
+                ArrowSchema.wrap(schemas(0)))
+              vector.close()
+              1L
+            })
+        }
+        assert(failure.getSuppressed.isEmpty)
+        assert(allocator.getAllocatedMemory == 0)
+      } finally {
+        vector.close()
+      }
+    }
+  }
+
+  test("importVector releases partially imported vectors when Arrow array import fails") {
+    withIsolatedStructAllocator { (nativeUtil, allocator, _) =>
+      val intType = FieldType.nullable(new ArrowType.Int(32, true))
+      val stringType = FieldType.nullable(new ArrowType.Utf8())
+      val intStruct = StructVector.empty("int_struct", allocator)
+      val firstInt = intStruct.addOrGet("first", intType, classOf[IntVector])
+      val secondInt = intStruct.addOrGet("second", intType, classOf[IntVector])
+      intStruct.allocateNew()
+      intStruct.setIndexDefined(0)
+      firstInt.setSafe(0, 1)
+      secondInt.setSafe(0, 2)
+      intStruct.setValueCount(1)
+
+      val stringStruct = StructVector.empty("string_struct", allocator)
+      stringStruct.addOrGet("first", intType, classOf[IntVector])
+      stringStruct.addOrGet("second", stringType, classOf[VarCharVector])
+      stringStruct.allocateNew()
+      stringStruct.setValueCount(1)
+
+      val (arrays, schemas) = nativeUtil.allocateArrowStructs(2)
+      Data.exportVector(allocator, intStruct, null, arrays(0), schemas(0))
+      Data.exportVector(allocator, stringStruct, null, arrays(1), schemas(1))
+      intStruct.close()
+      stringStruct.close()
+
+      try {
+        val failure = intercept[IllegalArgumentException] {
+          nativeUtil.importVector(Array(arrays(0)), Array(schemas(1)))
+        }
+        assert(failure.getSuppressed.isEmpty)
+      } finally {
+        arrays(1).release()
+        arrays(1).close()
+        schemas(0).release()
+        schemas(0).close()
+      }
+      assert(allocator.getAllocatedMemory == 0)
     }
   }
 

--- a/spark/src/test/scala/org/apache/comet/vector/NativeUtilSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/vector/NativeUtilSuite.scala
@@ -20,6 +20,7 @@
 package org.apache.comet.vector
 
 import java.io.IOException
+import java.nio.charset.StandardCharsets
 
 import scala.util.Using
 
@@ -27,7 +28,9 @@ import org.apache.arrow.c.{ArrowArray, ArrowSchema, Data}
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.{IntVector, UInt4Vector, VarCharVector}
 import org.apache.arrow.vector.complex.StructVector
-import org.apache.arrow.vector.types.pojo.{ArrowType, FieldType}
+import org.apache.arrow.vector.dictionary.Dictionary
+import org.apache.arrow.vector.dictionary.DictionaryProvider.MapDictionaryProvider
+import org.apache.arrow.vector.types.pojo.{ArrowType, DictionaryEncoding, Field, FieldType}
 import org.apache.spark.sql.CometTestBase
 import org.apache.spark.sql.execution.vectorized.ConstantColumnVector
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
@@ -160,27 +163,29 @@ class NativeUtilSuite extends CometTestBase {
     withIsolatedStructAllocator { (nativeUtil, allocator, _) =>
       val intType = FieldType.nullable(new ArrowType.Int(32, true))
       val stringType = FieldType.nullable(new ArrowType.Utf8())
-      val intStruct = StructVector.empty("int_struct", allocator)
-      val firstInt = intStruct.addOrGet("first", intType, classOf[IntVector])
-      val secondInt = intStruct.addOrGet("second", intType, classOf[IntVector])
-      intStruct.allocateNew()
-      intStruct.setIndexDefined(0)
-      firstInt.setSafe(0, 1)
-      secondInt.setSafe(0, 2)
-      intStruct.setValueCount(1)
-
-      val stringStruct = StructVector.empty("string_struct", allocator)
-      stringStruct.addOrGet("first", intType, classOf[IntVector])
-      stringStruct.addOrGet("second", stringType, classOf[VarCharVector])
-      stringStruct.allocateNew()
-      stringStruct.setValueCount(1)
-
       val (arrays, schemas) = nativeUtil.allocateArrowStructs(2)
-      Data.exportVector(allocator, intStruct, null, arrays(0), schemas(0))
-      Data.exportVector(allocator, stringStruct, null, arrays(1), schemas(1))
-      intStruct.close()
-      stringStruct.close()
 
+      Using.resources(
+        StructVector.empty("int_struct", allocator),
+        StructVector.empty("string_struct", allocator)) { (intStruct, stringStruct) =>
+        val firstInt = intStruct.addOrGet("first", intType, classOf[IntVector])
+        val secondInt = intStruct.addOrGet("second", intType, classOf[IntVector])
+        intStruct.allocateNew()
+        intStruct.setIndexDefined(0)
+        firstInt.setSafe(0, 1)
+        secondInt.setSafe(0, 2)
+        intStruct.setValueCount(1)
+
+        stringStruct.addOrGet("first", intType, classOf[IntVector])
+        stringStruct.addOrGet("second", stringType, classOf[VarCharVector])
+        stringStruct.allocateNew()
+        stringStruct.setValueCount(1)
+
+        Data.exportVector(allocator, intStruct, null, arrays(0), schemas(0))
+        Data.exportVector(allocator, stringStruct, null, arrays(1), schemas(1))
+      }
+
+      // Both structs are closed now, so only the exported C data retains their buffers.
       try {
         val failure = intercept[IllegalArgumentException] {
           nativeUtil.importVector(Array(arrays(0)), Array(schemas(1)))
@@ -192,6 +197,90 @@ class NativeUtilSuite extends CometTestBase {
         schemas(0).release()
         schemas(0).close()
       }
+      assert(allocator.getAllocatedMemory == 0)
+    }
+  }
+
+  test("importVector releases dictionary values when a later column of the array fails") {
+    withIsolatedStructAllocator { (nativeUtil, allocator, _) =>
+      val indexType = new ArrowType.Int(32, true)
+      val encoding = new DictionaryEncoding(0L, false, indexType)
+      val encodedType = new FieldType(true, indexType, encoding)
+      val intType = FieldType.nullable(indexType)
+      val stringType = FieldType.nullable(new ArrowType.Utf8())
+      val (arrays, schemas) = nativeUtil.allocateArrowStructs(2)
+
+      Using.resources(
+        new VarCharVector("dictionary", allocator),
+        StructVector.empty("int_struct", allocator),
+        StructVector.empty("string_struct", allocator)) { (values, intStruct, stringStruct) =>
+        values.allocateNew(1)
+        values.setSafe(0, "a".getBytes(StandardCharsets.UTF_8))
+        values.setValueCount(1)
+        val provider = new MapDictionaryProvider(new Dictionary(values, encoding))
+
+        val encoded = intStruct.addOrGet("encoded", encodedType, classOf[IntVector])
+        val secondInt = intStruct.addOrGet("second", intType, classOf[IntVector])
+        intStruct.allocateNew()
+        intStruct.setIndexDefined(0)
+        encoded.setSafe(0, 0)
+        secondInt.setSafe(0, 2)
+        intStruct.setValueCount(1)
+
+        stringStruct.addOrGet("encoded", encodedType, classOf[IntVector])
+        stringStruct.addOrGet("second", stringType, classOf[VarCharVector])
+        stringStruct.allocateNew()
+        stringStruct.setValueCount(1)
+
+        Data.exportVector(allocator, intStruct, provider, arrays(0), schemas(0))
+        Data.exportVector(allocator, stringStruct, provider, arrays(1), schemas(1))
+      }
+
+      // The second column is an int in the array and a string in the schema, so the import gets
+      // as far as loading the first column's dictionary values into the provider and then fails.
+      // Once the struct vector is closed, those values hold the only remaining references on the
+      // imported C array.
+      try {
+        val failure = intercept[IllegalArgumentException] {
+          nativeUtil.importVector(Array(arrays(0)), Array(schemas(1)))
+        }
+        assert(failure.getSuppressed.isEmpty)
+      } finally {
+        arrays(1).release()
+        arrays(1).close()
+        schemas(0).release()
+        schemas(0).close()
+      }
+      assert(allocator.getAllocatedMemory == 0)
+    }
+  }
+
+  test("importVector releases dictionary values when its Comet wrapper rejects the value type") {
+    withIsolatedStructAllocator { (nativeUtil, allocator, _) =>
+      val indexType = new ArrowType.Int(32, true)
+      val encoding = new DictionaryEncoding(0L, false, indexType)
+      val indexField = new Field("encoded", new FieldType(true, indexType, encoding), null)
+      val (arrays, schemas) = nativeUtil.allocateArrowStructs(1)
+
+      Using.resources(
+        new UInt4Vector("dictionary", allocator),
+        new IntVector(indexField, allocator)) { (values, indices) =>
+        values.allocateNew(1)
+        values.setSafe(0, 42)
+        values.setValueCount(1)
+        indices.allocateNew(1)
+        indices.setSafe(0, 0)
+        indices.setValueCount(1)
+        val provider = new MapDictionaryProvider(new Dictionary(values, encoding))
+        Data.exportVector(allocator, indices, provider, arrays(0), schemas(0))
+      }
+
+      // UInt4 has no Spark equivalent, so the column imports cleanly and only its Comet wrapper
+      // fails, by which point the dictionary values are already in the provider.
+      val failure = intercept[UnsupportedOperationException] {
+        nativeUtil.importVector(Array(arrays(0)), Array(schemas(0)))
+      }
+      assert(failure.getSuppressed.isEmpty)
       assert(allocator.getAllocatedMemory == 0)
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?

Closes https://github.com/apache/datafusion-comet/issues/5534.

## Rationale for this change

Failed Arrow imports retain native buffers in Comet executors. The allocator
then reports errors such as `Memory was leaked by query. Memory leaked: (176)`,
which adds pressure while the query is already failing.

## What changes are included in this PR?

`ArrowImporter` keeps each new `FieldVector` rollback-owned until array import
succeeds. `NativeUtil.importVector` keeps that ownership through Comet wrapping
and publication, then closes earlier vectors and untouched C Data structs when
a later column fails.

Dictionary values live in the provider rather than in the failed column vector.
The rollback now closes those vectors too, so their native buffers are released
at the failure instead of task shutdown. Cleanup failures remain suppressed on
the original exception.

## How are these changes tested?

Current upstream leaves allocator memory charged on every covered failure path.
The branch preserves each original error and returns the allocator to zero under
Spark 3.5 and Spark 4.1.

<details>
<summary>Raw test output</summary>

```console
$ BASE=/tmp/comet-base
$ TEST=spark/src/test/scala/org/apache/comet/vector/NativeUtilSuite.scala
$ git worktree add --detach "$BASE" e0fa3ccb16d4c9b3a03a38b09af6ed0fb242e027
$ git archive 21ae48db7da56d1a0c172205a02d6f4c8722e97e "$TEST" | tar -x -C "$BASE"
$ cd "$BASE"
$ JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -Prelease -Pspark-4.1 test \
    -Dtest=none -Dsuites=org.apache.comet.vector.NativeUtilSuite
Memory was leaked by query. Memory leaked: (176)
Memory was leaked by query. Memory leaked: (288)
Memory was leaked by query. Memory leaked: (33592)
Memory was leaked by query. Memory leaked: (66536)
Memory was leaked by query. Memory leaked: (192)
Tests: succeeded 4, failed 5, canceled 0, ignored 0, pending 0
BUILD FAILURE

$ GREEN=/tmp/comet-green
$ git worktree add --detach "$GREEN" 21ae48db7da56d1a0c172205a02d6f4c8722e97e
$ cd "$GREEN"
$ JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -Prelease -Pspark-4.1 test \
    -Dtest=none -Dsuites=org.apache.comet.vector.NativeUtilSuite
Tests: succeeded 9, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
BUILD SUCCESS
```

</details>
