### PR TITLE
fix: accept UTC timezone aliases in Python Arrow input

### DIFF
--- a/spark/src/main/spark-4.x/org/apache/spark/sql/execution/python/CometArrowPythonRunnerBase.scala
+++ b/spark/src/main/spark-4.x/org/apache/spark/sql/execution/python/CometArrowPythonRunnerBase.scala
@@ -334,7 +334,7 @@ private[python] object CometArrowPythonRunnerBase {
     ArrowType.ExtensionType.EXTENSION_METADATA_KEY_NAME,
     ArrowType.ExtensionType.EXTENSION_METADATA_KEY_METADATA)
 
-  private def hasCompatibleType(expected: ArrowType, actual: ArrowType): Boolean = {
+  private def areArrowTypesCompatible(expected: ArrowType, actual: ArrowType): Boolean = {
     if (expected == actual) {
       true
     } else {
@@ -353,7 +353,7 @@ private[python] object CometArrowPythonRunnerBase {
   /** Names, nullability and ordinary field metadata do not change the IPC buffer layout. */
   private[python] def hasCompatibleSchema(expected: Seq[Field], actual: Seq[Field]): Boolean = {
     expected.size == actual.size && expected.zip(actual).forall { case (left, right) =>
-      hasCompatibleType(left.getType, right.getType) &&
+      areArrowTypesCompatible(left.getType, right.getType) &&
       left.getDictionary == right.getDictionary &&
       extensionMetadataKeys.forall(key =>
         left.getMetadata.get(key) == right.getMetadata.get(key)) &&

--- a/spark/src/main/spark-4.x/org/apache/spark/sql/execution/python/CometArrowPythonRunnerBase.scala
+++ b/spark/src/main/spark-4.x/org/apache/spark/sql/execution/python/CometArrowPythonRunnerBase.scala
@@ -334,10 +334,26 @@ private[python] object CometArrowPythonRunnerBase {
     ArrowType.ExtensionType.EXTENSION_METADATA_KEY_NAME,
     ArrowType.ExtensionType.EXTENSION_METADATA_KEY_METADATA)
 
+  private def hasCompatibleType(expected: ArrowType, actual: ArrowType): Boolean = {
+    if (expected == actual) {
+      true
+    } else {
+      (expected, actual) match {
+        case (left: ArrowType.Timestamp, right: ArrowType.Timestamp) =>
+          // Native scans use UTC, while date_trunc can retain the equivalent Etc/UTC session
+          // zone. Both interpret the same instants, so preserve the stream schema and buffers.
+          left.getUnit == right.getUnit &&
+          ((left.getTimezone == "UTC" && right.getTimezone == "Etc/UTC") ||
+            (left.getTimezone == "Etc/UTC" && right.getTimezone == "UTC"))
+        case _ => false
+      }
+    }
+  }
+
   /** Names, nullability and ordinary field metadata do not change the IPC buffer layout. */
   private[python] def hasCompatibleSchema(expected: Seq[Field], actual: Seq[Field]): Boolean = {
     expected.size == actual.size && expected.zip(actual).forall { case (left, right) =>
-      left.getType == right.getType &&
+      hasCompatibleType(left.getType, right.getType) &&
       left.getDictionary == right.getDictionary &&
       extensionMetadataKeys.forall(key =>
         left.getMetadata.get(key) == right.getMetadata.get(key)) &&

--- a/spark/src/test/resources/pyspark/test_pyarrow_udf.py
+++ b/spark/src/test/resources/pyspark/test_pyarrow_udf.py
@@ -653,6 +653,59 @@ def test_map_in_batch_union_with_compatible_nested_fields(
 
 
 @pytest.mark.parametrize("api", ["mapInArrow", "mapInPandas"])
+@pytest.mark.parametrize("timezone", ["UTC", "Etc/UTC"])
+@pytest.mark.parametrize(
+    "truncated_first", [False, True], ids=["scan-first", "truncation-first"]
+)
+def test_map_in_batch_union_with_utc_timezone_alias(
+    spark, tmp_path, accelerated, api, timezone, truncated_first
+):
+    """Native scans use UTC, while date_trunc preserves the equivalent Etc/UTC alias."""
+    previous_timezone = spark.conf.get("spark.sql.session.timeZone")
+    spark.conf.set("spark.sql.session.timeZone", timezone)
+    try:
+        schema = T.StructType(
+            [
+                T.StructField("id", T.LongType()),
+                T.StructField("ts", T.TimestampType()),
+            ]
+        )
+        rows = [
+            (0, None),
+            (1, dt.datetime(2024, 1, 2, 3, 4, 5, 123456)),
+            (2, dt.datetime(2024, 1, 2, 23, 59, 59, 999999)),
+            (3, dt.datetime(2024, 1, 3)),
+        ]
+        src = str(tmp_path / "union_timestamp_timezones.parquet")
+        spark.createDataFrame(rows, schema).coalesce(1).write.parquet(src)
+        source = spark.read.parquet(src)
+        truncated = source.selectExpr("id", "date_trunc('day', ts) AS ts")
+        left, right = (truncated, source) if truncated_first else (source, truncated)
+        # Put both source schemas in one worker's input stream, in either order.
+        combined = left.union(right).coalesce(1)
+        expected = Counter(tuple(row) for row in combined.collect())
+        assert sum(expected.values()) == 2 * len(rows)
+        assert expected[(0, None)] == 2
+
+        def passthrough(iterator):
+            yield from iterator
+
+        result = getattr(combined, api)(passthrough, combined.schema)
+        plan = _executed_plan(result)
+        _assert_plan_matches_mode(
+            plan,
+            accelerated,
+            vanilla_node="MapInArrow" if api == "mapInArrow" else "MapInPandas",
+        )
+        assert "CometUnion" in plan
+        assert "CometCoalesce" in plan
+        assert "CometProject" in plan
+        assert Counter(tuple(row) for row in result.collect()) == expected
+    finally:
+        spark.conf.set("spark.sql.session.timeZone", previous_timezone)
+
+
+@pytest.mark.parametrize("api", ["mapInArrow", "mapInPandas"])
 def test_map_in_batch_union_with_different_field_metadata(
     spark, tmp_path, accelerated, api
 ):

--- a/spark/src/test/spark-4.x/org/apache/spark/sql/execution/python/CometArrowPythonRunnerSuite.scala
+++ b/spark/src/test/spark-4.x/org/apache/spark/sql/execution/python/CometArrowPythonRunnerSuite.scala
@@ -34,6 +34,7 @@ import org.apache.arrow.memory.{BufferAllocator, RootAllocator}
 import org.apache.arrow.vector.{FieldVector, IntVector, NullVector, VarCharVector, VectorSchemaRoot}
 import org.apache.arrow.vector.complex.{ListVector, MapVector, StructVector}
 import org.apache.arrow.vector.ipc.{ArrowStreamReader, ArrowStreamWriter, WriteChannel}
+import org.apache.arrow.vector.types.TimeUnit
 import org.apache.arrow.vector.types.pojo.{ArrowType, DictionaryEncoding, Field, FieldType, Schema}
 import org.apache.spark.sql.execution.python.CometArrowPythonRunnerBase.{hasCompatibleSchema, serializeBatch}
 
@@ -122,6 +123,76 @@ class CometArrowPythonRunnerSuite extends AnyFunSuite with Matchers {
     hasCompatibleSchema(
       fields(dictionary = dictionary),
       fields(dictionary = new DictionaryEncoding(2L, false, intType))) shouldBe false
+  }
+
+  test("input schema compatibility accepts UTC timestamp aliases with matching units") {
+    def fields(unit: TimeUnit, timezone: String): Seq[Field] =
+      Seq(new Field("ts", FieldType.nullable(new ArrowType.Timestamp(unit, timezone)), null))
+    def nested(children: Seq[Field]): Seq[Field] =
+      Seq(new Field("outer", FieldType.nullable(ArrowType.Struct.INSTANCE), children.asJava))
+
+    for (unit <- TimeUnit.values()) {
+      val utc = fields(unit, "UTC")
+      val alias = fields(unit, "Etc/UTC")
+      hasCompatibleSchema(utc, alias) shouldBe true
+      hasCompatibleSchema(alias, utc) shouldBe true
+      hasCompatibleSchema(nested(utc), nested(alias)) shouldBe true
+      hasCompatibleSchema(nested(alias), nested(utc)) shouldBe true
+    }
+
+    for {
+      expectedUnit <- TimeUnit.values()
+      actualUnit <- TimeUnit.values()
+      if expectedUnit != actualUnit
+    } {
+      hasCompatibleSchema(
+        fields(expectedUnit, "UTC"),
+        fields(actualUnit, "Etc/UTC")) shouldBe false
+      hasCompatibleSchema(
+        fields(expectedUnit, "Etc/UTC"),
+        fields(actualUnit, "UTC")) shouldBe false
+    }
+  }
+
+  test("UTC timestamp aliases preserve timezone, dictionary and extension constraints") {
+    def fields(
+        timezone: String,
+        metadata: Map[String, String] = Map.empty,
+        dictionary: DictionaryEncoding = null): Seq[Field] = Seq(
+      new Field(
+        "ts",
+        new FieldType(
+          true,
+          new ArrowType.Timestamp(TimeUnit.MICROSECOND, timezone),
+          dictionary,
+          metadata.asJava),
+        null))
+
+    for {
+      utc <- Seq("UTC", "Etc/UTC")
+      other <- Seq(null, "", "GMT", "+00:00", "America/Los_Angeles")
+    } {
+      hasCompatibleSchema(fields(utc), fields(other)) shouldBe false
+      hasCompatibleSchema(fields(other), fields(utc)) shouldBe false
+    }
+    hasCompatibleSchema(fields(null), fields(null)) shouldBe true
+    hasCompatibleSchema(
+      fields("America/Los_Angeles"),
+      fields("America/Los_Angeles")) shouldBe true
+
+    val dictionary = new DictionaryEncoding(1L, false, new ArrowType.Int(32, true))
+    val otherDictionary = new DictionaryEncoding(2L, false, dictionary.getIndexType)
+    hasCompatibleSchema(fields("UTC", dictionary = dictionary), fields("Etc/UTC")) shouldBe false
+    hasCompatibleSchema(
+      fields("UTC", dictionary = dictionary),
+      fields("Etc/UTC", dictionary = otherDictionary)) shouldBe false
+    Seq(
+      ArrowType.ExtensionType.EXTENSION_METADATA_KEY_NAME,
+      ArrowType.ExtensionType.EXTENSION_METADATA_KEY_METADATA).foreach { key =>
+      hasCompatibleSchema(
+        fields("UTC", Map(key -> "before")),
+        fields("Etc/UTC", Map(key -> "after"))) shouldBe false
+    }
   }
 
   test("direct batches retain borrowed buffers without copying them into the writer allocator") {


### PR DESCRIPTION
## Which issue does this PR close?

Follow-up to #5368. No separate issue.

## Rationale for this change

The schema check added in #5368 rejects valid timestamp batches when native producers use the equivalent timezone labels `UTC` and `Etc/UTC`.

With `spark.sql.session.timeZone=Etc/UTC`, a native Parquet scan produces `Timestamp(MICROSECOND, UTC)`, while native `date_trunc` preserves `Etc/UTC`. Unioning those branches and coalescing them into one partition makes `mapInArrow` and `mapInPandas` fail with `Arrow input schema changed between batches` when the second schema reaches the same Python input stream.

Confirmed on the merged commit `e0fa3ccb16d4c9b3a03a38b09af6ed0fb242e027`, in both branch orders.

## What changes are included in this PR?

- Accept `UTC` and `Etc/UTC` timestamp types interchangeably only when their units match, including in nested fields.
- Preserve the first batch's stream schema and existing buffers. Keep all other type, dictionary, extension-metadata, and child-layout checks unchanged.
- Add positive and negative Arrow compatibility tests and a 16-case Python regression covering both APIs, timezone labels, branch orders, and accelerated/fallback modes, with nulls and fractional timestamps.

## How are these changes tested?

- Merged-code control: the 16 new Python cases produced **4 failures and 12 passes**. The failures were exactly the accelerated `Etc/UTC` cases for both APIs and branch orders.
- Fixed code: the full `test_pyarrow_udf.py` suite passed **133/133**, including all 16 new cases, with no skips. This used Spark 4.1.3, real native execution, and real Python workers; accelerated cases assert the native Python, union, coalesce, and projection plan nodes.
- `CometArrowPythonRunnerSuite`: **11/11 passed**, including Arrow C Data JNI ownership/cleanup checks. Running the same tests on the merged control gives the expected single alias-compatibility failure.
- Full Spark 4.1 Spotless check and `git diff --check` passed.

Local execution used all production JVM sources compiled into an isolated unshaded test jar and a native library built from the exact merged commit. Standard Maven packaging could not finish because the inherited Maven mirror timed out; shaded packaging and the Spark 4.0 matrix remain for CI.
