### PR TITLE
feat: support large Arrow inputs for accelerated Python UDFs

### DIFF
--- a/docs/source/user-guide/latest/pyarrow-udfs.md
+++ b/docs/source/user-guide/latest/pyarrow-udfs.md
@@ -202,15 +202,15 @@ on the unoptimized path.
   `mapInPandas` UDF that strips the tz and treats the value as naive local time): under a non-UTC
   session time zone such a UDF can diverge from the unoptimized path. Set
   `spark.comet.exec.pyarrowUDF.enabled=false` for those UDFs.
-- `spark.sql.execution.arrow.useLargeVarTypes=true` is not supported. With this conf enabled,
-  Spark supplies `large_string` and `large_binary` input columns with 8-byte offsets. Native
-  Comet vectors use 4-byte offsets, and direct serialization advertises their matching `string`
-  and `binary` types. This produces a valid IPC stream, but does not preserve the input types
-  requested by the configuration. `EliminateRedundantTransitions` therefore skips the rewrite
-  and vanilla Spark handles the operation. Comet can read `large_string` and `large_binary`
-  columns returned by a Python worker; that output support does not widen the input vectors.
-- Comet writes input Arrow IPC record batches directly from its existing vector buffers. The
-  only additional Arrow buffer is the validity bitmap for the non-null struct that wraps the
-  input columns. Writing the IPC bytes to the Python worker's pipe still requires one copy;
-  that copy is inherent to Spark's process-based Python transport. This path does not transfer
-  buffers between Arrow allocators or change their ownership.
+- `spark.sql.execution.arrow.useLargeVarTypes=true` is supported by the accelerated path.
+  Comet supplies `large_string` and `large_binary` input fields, including nested fields, by
+  widening ordinary 4-byte offsets to 8-byte offsets. The value and validity buffers remain
+  shared with the source batch, and inputs that already have large offsets are reused directly.
+  This conversion does not remove the 32-bit size limits of native producers that construct
+  ordinary string or binary arrays before the Python boundary.
+- Comet writes input Arrow IPC record batches directly from its existing vector buffers. With
+  the default `useLargeVarTypes=false`, the only additional Arrow buffer is the validity bitmap
+  for the non-null struct that wraps the input columns. Enabling large variable types also
+  allocates temporary widened offset buffers. Writing the IPC bytes to the Python worker's pipe
+  still requires one copy; that copy is inherent to Spark's process-based Python transport.
+  This path does not transfer buffers between Arrow allocators or change their ownership.

--- a/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
@@ -32,7 +32,6 @@ import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.comet.CometConf
 import org.apache.comet.CometSparkSessionExtensions.withInfo
 import org.apache.comet.serde.NativeOptIn
-import org.apache.comet.shims.ShimSQLConf
 
 // This rule is responsible for eliminating redundant transitions between row-based and
 // columnar-based operators for Comet. Currently, three potential redundant transitions are:
@@ -57,8 +56,7 @@ import org.apache.comet.shims.ShimSQLConf
 // be removed.
 case class EliminateRedundantTransitions(session: SparkSession)
     extends Rule[SparkPlan]
-    with ShimCometMapInBatch
-    with ShimSQLConf {
+    with ShimCometMapInBatch {
 
   private lazy val showTransformations = CometConf.COMET_EXPLAIN_TRANSFORMATIONS.get()
 
@@ -110,12 +108,6 @@ case class EliminateRedundantTransitions(session: SparkSession)
       // UnsafeProjection copies and keeping the stage columnar. The matchers are
       // version-shimmed: Spark 3.4 / 3.5 return None (they lack the required APIs) and Spark
       // 4.1+ matches the renamed `MapInArrowExec`.
-      //
-      // Falls back to vanilla Spark when `spark.sql.execution.arrow.useLargeVarTypes` is enabled:
-      // Native Comet string/binary vectors use 4-byte offsets. The IPC schema follows these
-      // vectors, so the stream is internally consistent, but the worker would receive string /
-      // binary instead of the large_string / large_binary input types requested by this conf.
-      // Keep the fallback to preserve Spark's input type contract.
       //
       // `EligibleMapInBatch` matches whenever the operator would run natively if the feature were
       // enabled. When it is disabled (the default) we leave the vanilla Spark operator in place
@@ -194,20 +186,15 @@ case class EliminateRedundantTransitions(session: SparkSession)
    * that flag to decide between rewriting the operator and merely annotating it with an opt-in
    * hint. Single extractor so the matchers run once per visited plan. Returns `(info,
    * columnarChild)` where `columnarChild` is the Comet columnar producer that
-   * `CometMapInBatchExec` will consume directly. Returns `None` (and the arm misses) when
-   * `useLargeVarTypes` forces the fallback, when the plan is not one of the version-shimmed
-   * MapInArrow / MapInPandas operators, or when the child is not a Comet columnar-to-row
-   * transition we can strip.
+   * `CometMapInBatchExec` will consume directly. Returns `None` (and the arm misses) when the
+   * plan is not one of the version-shimmed MapInArrow / MapInPandas operators, or when the child
+   * is not a Comet columnar-to-row transition we can strip.
    */
   private object EligibleMapInBatch {
     def unapply(plan: SparkPlan): Option[(MapInBatchInfo, SparkPlan)] = {
-      if (arrowUseLargeVarTypes(plan.conf)) {
-        None
-      } else {
-        matchMapInArrow(plan)
-          .orElse(matchMapInPandas(plan))
-          .flatMap(info => extractColumnarChild(info.child).map(child => (info, child)))
-      }
+      matchMapInArrow(plan)
+        .orElse(matchMapInPandas(plan))
+        .flatMap(info => extractColumnarChild(info.child).map(child => (info, child)))
     }
   }
 

--- a/spark/src/main/spark-3.4/org/apache/comet/shims/ShimSQLConf.scala
+++ b/spark/src/main/spark-3.4/org/apache/comet/shims/ShimSQLConf.scala
@@ -19,18 +19,10 @@
 
 package org.apache.comet.shims
 
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
 
 trait ShimSQLConf {
   protected val LEGACY = LegacyBehaviorPolicy.LEGACY
   protected val CORRECTED = LegacyBehaviorPolicy.CORRECTED
 
-  /**
-   * Reads `spark.sql.execution.arrow.useLargeVarTypes`. Spark 3.4 has no typed accessor for this
-   * conf, so read by raw key. The conf only governs the destination Arrow IPC root width on Spark
-   * 4.x, so the value returned here matters only to callers that look it up explicitly.
-   */
-  protected def arrowUseLargeVarTypes(conf: SQLConf): Boolean =
-    conf.getConfString("spark.sql.execution.arrow.useLargeVarTypes", "false").toBoolean
 }

--- a/spark/src/main/spark-3.4/org/apache/comet/shims/ShimSQLConf.scala
+++ b/spark/src/main/spark-3.4/org/apache/comet/shims/ShimSQLConf.scala
@@ -24,5 +24,4 @@ import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
 trait ShimSQLConf {
   protected val LEGACY = LegacyBehaviorPolicy.LEGACY
   protected val CORRECTED = LegacyBehaviorPolicy.CORRECTED
-
 }

--- a/spark/src/main/spark-3.5/org/apache/comet/shims/ShimSQLConf.scala
+++ b/spark/src/main/spark-3.5/org/apache/comet/shims/ShimSQLConf.scala
@@ -19,15 +19,10 @@
 
 package org.apache.comet.shims
 
-import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
+import org.apache.spark.sql.internal.LegacyBehaviorPolicy
 
 trait ShimSQLConf {
   protected val LEGACY = LegacyBehaviorPolicy.LEGACY
   protected val CORRECTED = LegacyBehaviorPolicy.CORRECTED
 
-  /**
-   * Reads `spark.sql.execution.arrow.useLargeVarTypes`. Spark 3.5 has the typed accessor; forward
-   * to it.
-   */
-  protected def arrowUseLargeVarTypes(conf: SQLConf): Boolean = conf.arrowUseLargeVarTypes
 }

--- a/spark/src/main/spark-3.5/org/apache/comet/shims/ShimSQLConf.scala
+++ b/spark/src/main/spark-3.5/org/apache/comet/shims/ShimSQLConf.scala
@@ -24,5 +24,4 @@ import org.apache.spark.sql.internal.LegacyBehaviorPolicy
 trait ShimSQLConf {
   protected val LEGACY = LegacyBehaviorPolicy.LEGACY
   protected val CORRECTED = LegacyBehaviorPolicy.CORRECTED
-
 }

--- a/spark/src/main/spark-3.x/org/apache/spark/sql/comet/shims/ShimCometMapInBatch.scala
+++ b/spark/src/main/spark-3.x/org/apache/spark/sql/comet/shims/ShimCometMapInBatch.scala
@@ -36,10 +36,9 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  * always return `None`. 3.x support can be added later if there is user demand.
  *
  * Shared across spark-3.4 and spark-3.5 because both are identical: 3.4 lacks the modern
- * `ArrowPythonRunner` constructor and `arrowUseLargeVarTypes`, and 3.5's `PythonArrowInput` trait
- * has a different contract (`writeIteratorToArrowStream` one-shot vs 4.x's
- * `writeNextBatchToArrowStream` batch-at-a-time), so neither version can host the columnar input
- * implementation without a separate rewrite.
+ * `ArrowPythonRunner` constructor, and 3.5's `PythonArrowInput` trait has a different contract
+ * (`writeIteratorToArrowStream` one-shot vs 4.x's `writeNextBatchToArrowStream` batch-at-a-time),
+ * so neither version can host the columnar input implementation without a separate rewrite.
  */
 trait ShimCometMapInBatch {
 

--- a/spark/src/main/spark-4.x/org/apache/comet/shims/ShimSQLConf.scala
+++ b/spark/src/main/spark-4.x/org/apache/comet/shims/ShimSQLConf.scala
@@ -24,5 +24,4 @@ import org.apache.spark.sql.internal.LegacyBehaviorPolicy
 trait ShimSQLConf {
   protected val LEGACY = LegacyBehaviorPolicy.LEGACY
   protected val CORRECTED = LegacyBehaviorPolicy.CORRECTED
-
 }

--- a/spark/src/main/spark-4.x/org/apache/comet/shims/ShimSQLConf.scala
+++ b/spark/src/main/spark-4.x/org/apache/comet/shims/ShimSQLConf.scala
@@ -19,17 +19,10 @@
 
 package org.apache.comet.shims
 
-import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
+import org.apache.spark.sql.internal.LegacyBehaviorPolicy
 
 trait ShimSQLConf {
   protected val LEGACY = LegacyBehaviorPolicy.LEGACY
   protected val CORRECTED = LegacyBehaviorPolicy.CORRECTED
 
-  /**
-   * Reads `spark.sql.execution.arrow.useLargeVarTypes`. Spark 4.x exposes a typed accessor; 3.4
-   * lacks it (a 3.5 backport added it, but Comet's 3.x shim collapses both into a single string
-   * fallback). Forward to the accessor here so callers do not depend on which version they're
-   * compiled against.
-   */
-  protected def arrowUseLargeVarTypes(conf: SQLConf): Boolean = conf.arrowUseLargeVarTypes
 }

--- a/spark/src/main/spark-4.x/org/apache/spark/sql/execution/python/CometArrowPythonRunnerBase.scala
+++ b/spark/src/main/spark-4.x/org/apache/spark/sql/execution/python/CometArrowPythonRunnerBase.scala
@@ -112,6 +112,13 @@ private[python] trait CometArrowPythonRunnerBase
       private var arrowWriter: ArrowStreamWriter = _
       private var writeRoot: VectorSchemaRoot = _
       private var streamFields: Seq[Field] = _
+      // This map is captured on the driver; do not resolve SQLConf from the task closure.
+      private val useLargeVarTypes = workerConf
+        .getOrElse(SQLConf.ARROW_EXECUTION_USE_LARGE_VAR_TYPES.key, "false")
+        .toBoolean
+
+      private def inputField(field: Field): Field =
+        if (useLargeVarTypes) CometArrowPythonRunnerBase.withLargeVarTypes(field) else field
 
       // The runner's input schema is a single struct column ("struct") whose children are the
       // user's input columns (see `schema` above). Cast once here rather than at each use site.
@@ -158,7 +165,7 @@ private[python] trait CometArrowPythonRunnerBase
               // no sample batch, so derive the schema from the Spark input schema. The timezone is
               // irrelevant here because no rows are exchanged.
               val childFields = inputStructType.fields.toSeq.map(f =>
-                Utils.toArrowField(f.name, f.dataType, nullable = true, "UTC"))
+                inputField(Utils.toArrowField(f.name, f.dataType, nullable = true, "UTC")))
               startWriter(childFields, dataOut)
             }
             arrowWriter.end()
@@ -176,15 +183,15 @@ private[python] trait CometArrowPythonRunnerBase
             .getValueVector
             .asInstanceOf[FieldVector]
         }
-        val batchFields = sourceVectors.map(_.getField)
+        val batchFields = sourceVectors.map(vector => inputField(vector.getField))
 
         if (arrowWriter == null) {
           // Build the schema-only struct root once from the first batch's child fields.
           // mapInArrow/mapInPandas exchange the columns under a single non-nullable struct.
           // Comet's FFI-imported vectors leave the Arrow Field name null, so restore the real
           // column names from the input schema (the worker reads columns by name, and shaded
-          // Arrow rejects a null field name). Keep the field types and child structure as-is so
-          // the advertised schema matches the source buffers. Keeping the type as-is also means
+          // Arrow rejects a null field name). Apart from optional string/binary offset widening,
+          // keep the field types and child structure consistent with the source buffers. This means
           // a TimestampType reaches the worker with Comet's UTC time zone
           // rather than the session zone vanilla Spark would label it with; this is a documented
           // limitation (see pyarrow-udfs.md), not a value difference, since the stored instant is
@@ -206,7 +213,8 @@ private[python] trait CometArrowPythonRunnerBase
           new WriteChannel(Channels.newChannel(dataOut)),
           sourceVectors,
           cometBatch.numRows(),
-          allocator)
+          allocator,
+          useLargeVarTypes)
 
         pythonMetrics("pythonDataSent") += dataOut.size() - startData
         true
@@ -329,6 +337,24 @@ private[python] trait CometArrowPythonRunnerBase
 
 private[python] object CometArrowPythonRunnerBase {
 
+  /** Match Spark's large string/binary input types, including fields nested in containers. */
+  private[python] def withLargeVarTypes(field: Field): Field = {
+    val fieldType = field.getFieldType
+    val dataType = fieldType.getType match {
+      case ArrowType.Utf8.INSTANCE => ArrowType.LargeUtf8.INSTANCE
+      case ArrowType.Binary.INSTANCE => ArrowType.LargeBinary.INSTANCE
+      case other => other
+    }
+    new Field(
+      field.getName,
+      new FieldType(
+        fieldType.isNullable,
+        dataType,
+        fieldType.getDictionary,
+        fieldType.getMetadata),
+      field.getChildren.asScala.map(withLargeVarTypes).asJava)
+  }
+
   // Extensions can change interpretation even when their underlying storage types match.
   private val extensionMetadataKeys = Seq(
     ArrowType.ExtensionType.EXTENSION_METADATA_KEY_NAME,
@@ -350,7 +376,8 @@ private[python] object CometArrowPythonRunnerBase {
    *
    * VectorUnloader recursively retains the source buffers without moving them between allocators.
    * The wrapping record batch takes its own references, so closing both temporary batches
-   * restores the original reference counts after the synchronous pipe write. The borrowed
+   * restores the original reference counts after the synchronous pipe write. Large variable types
+   * replace only the offset buffers and release those allocations after the write. The borrowed
    * VectorSchemaRoot must never be closed because its vectors are owned by the input
    * ColumnarBatch.
    */
@@ -358,7 +385,8 @@ private[python] object CometArrowPythonRunnerBase {
       writeChannel: WriteChannel,
       sourceVectors: Seq[FieldVector],
       numRows: Int,
-      allocator: BufferAllocator): Unit = {
+      allocator: BufferAllocator,
+      useLargeVarTypes: Boolean = false): Unit = {
     val sourceRoot =
       new VectorSchemaRoot(sourceVectors.map(_.getField).asJava, sourceVectors.asJava, numRows)
     val sourceBatch = new VectorUnloader(sourceRoot).getRecordBatch
@@ -379,17 +407,27 @@ private[python] object CometArrowPythonRunnerBase {
         buffers.add(structValidity)
         buffers.addAll(sourceBatch.getBuffers)
 
-        val wrappedBatch = new ArrowRecordBatch(
-          numRows,
-          nodes,
-          buffers,
-          sourceBatch.getBodyCompression,
-          sourceBatch.getVariadicBufferCounts,
-          true)
+        val widenedOffsets = if (useLargeVarTypes) new ArrayList[ArrowBuf]() else null
         try {
-          MessageSerializer.serialize(writeChannel, wrappedBatch)
+          if (useLargeVarTypes) {
+            widenOffsets(sourceVectors, buffers, widenedOffsets, allocator)
+          }
+          val wrappedBatch = new ArrowRecordBatch(
+            numRows,
+            nodes,
+            buffers,
+            sourceBatch.getBodyCompression,
+            sourceBatch.getVariadicBufferCounts,
+            true)
+          try {
+            MessageSerializer.serialize(writeChannel, wrappedBatch)
+          } finally {
+            wrappedBatch.close()
+          }
         } finally {
-          wrappedBatch.close()
+          if (widenedOffsets != null) {
+            widenedOffsets.asScala.foreach(_.close())
+          }
         }
       } finally {
         structValidity.close()
@@ -397,5 +435,42 @@ private[python] object CometArrowPythonRunnerBase {
     } finally {
       sourceBatch.close()
     }
+  }
+
+  /**
+   * Replace only 32-bit offsets; validity and payload buffers remain borrowed from the source.
+   */
+  private def widenOffsets(
+      sourceVectors: Seq[FieldVector],
+      buffers: ArrayList[ArrowBuf],
+      widenedOffsets: ArrayList[ArrowBuf],
+      allocator: BufferAllocator): Unit = {
+    // Skip the wrapping struct's validity buffer, then follow VectorUnloader's depth-first order.
+    var bufferIndex = 1
+    def visit(vector: FieldVector): Unit = {
+      vector.getField.getType match {
+        case ArrowType.Utf8.INSTANCE | ArrowType.Binary.INSTANCE =>
+          val source = buffers.get(bufferIndex + 1)
+          val count = vector.getValueCount.toLong + 1L
+          val offsets = allocator.buffer(count * 8L)
+          // Register each allocation before populating it so partial conversion failures clean up.
+          widenedOffsets.add(offsets)
+          if (vector.getValueCount == 0 && source.readableBytes() == 0L) {
+            offsets.setLong(0L, 0L)
+          } else {
+            var i = 0L
+            while (i < count) {
+              offsets.setLong(i * 8L, source.getInt(i * 4L).toLong)
+              i += 1L
+            }
+          }
+          offsets.writerIndex(count * 8L)
+          buffers.set(bufferIndex + 1, offsets)
+        case _ =>
+      }
+      bufferIndex += vector.getFieldBuffers.size()
+      vector.getChildrenFromFields.asScala.foreach(visit)
+    }
+    sourceVectors.foreach(visit)
   }
 }

--- a/spark/src/main/spark-4.x/org/apache/spark/sql/execution/python/CometArrowPythonRunnerBase.scala
+++ b/spark/src/main/spark-4.x/org/apache/spark/sql/execution/python/CometArrowPythonRunnerBase.scala
@@ -386,7 +386,7 @@ private[python] object CometArrowPythonRunnerBase {
       sourceVectors: Seq[FieldVector],
       numRows: Int,
       allocator: BufferAllocator,
-      useLargeVarTypes: Boolean = false): Unit = {
+      useLargeVarTypes: Boolean): Unit = {
     val sourceRoot =
       new VectorSchemaRoot(sourceVectors.map(_.getField).asJava, sourceVectors.asJava, numRows)
     val sourceBatch = new VectorUnloader(sourceRoot).getRecordBatch
@@ -407,7 +407,7 @@ private[python] object CometArrowPythonRunnerBase {
         buffers.add(structValidity)
         buffers.addAll(sourceBatch.getBuffers)
 
-        val widenedOffsets = if (useLargeVarTypes) new ArrayList[ArrowBuf]() else null
+        val widenedOffsets = new ArrayList[ArrowBuf]()
         try {
           if (useLargeVarTypes) {
             widenOffsets(sourceVectors, buffers, widenedOffsets, allocator)
@@ -425,9 +425,7 @@ private[python] object CometArrowPythonRunnerBase {
             wrappedBatch.close()
           }
         } finally {
-          if (widenedOffsets != null) {
-            widenedOffsets.asScala.foreach(_.close())
-          }
+          widenedOffsets.asScala.foreach(_.close())
         }
       } finally {
         structValidity.close()

--- a/spark/src/test/resources/pyspark/benchmark_pyarrow_udf.py
+++ b/spark/src/test/resources/pyspark/benchmark_pyarrow_udf.py
@@ -32,7 +32,8 @@ optimization actually changes for users:
               (per-row InternalRow.getXXX() loop inside ArrowWriter.write)
   * optimized: CometScan -> CometMapInBatchExec -> CometArrowPythonRunner
               (Arrow IPC serialization directly from Comet's source vectors;
-              no row materialization or intermediate vector-buffer copy)
+              no row materialization or intermediate payload-buffer copy;
+              large variable types widen offsets when requested)
 
 Results are wall-clock seconds, so they include Python interpreter,
 Arrow IPC, and downstream count() costs. That's intentional: the
@@ -58,6 +59,7 @@ Override defaults via environment variables:
     BENCHMARK_ROWS=2000000                rows per run
     BENCHMARK_WARMUP=2                    warmup iterations per case
     BENCHMARK_ITERS=5                     measured iterations per case
+    BENCHMARK_LARGE_VAR_TYPES=true        request large Arrow strings/binary (default false)
 """
 
 import contextlib
@@ -84,6 +86,10 @@ def _build_spark() -> SparkSession:
         .config("spark.plugins", "org.apache.spark.CometPlugin")
         .config("spark.comet.enabled", "true")
         .config("spark.comet.exec.enabled", "true")
+        .config(
+            "spark.sql.execution.arrow.useLargeVarTypes",
+            os.environ.get("BENCHMARK_LARGE_VAR_TYPES", "false"),
+        )
         .config(
             "spark.shuffle.manager",
             "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager",
@@ -180,6 +186,8 @@ def main() -> None:
 
     print(f"\nrows per run: {rows:,}")
     print(f"warmup iters: {warmup}, measured iters: {iters}")
+    large_types = spark.conf.get("spark.sql.execution.arrow.useLargeVarTypes")
+    print(f"useLargeVarTypes: {large_types}")
     print(f"jar: {resolve_comet_jar()}\n")
 
     header = "  {:<14} {:<10} {:>10} {:>10} {:>10} {:>13} {:>9}".format(

--- a/spark/src/test/resources/pyspark/test_pyarrow_udf.py
+++ b/spark/src/test/resources/pyspark/test_pyarrow_udf.py
@@ -89,6 +89,26 @@ def accelerated(request, spark) -> bool:
     return request.param
 
 
+@pytest.fixture
+def large_var_types(spark):
+    settings = {
+        "spark.sql.execution.arrow.useLargeVarTypes": "true",
+        "spark.comet.batchSize": "7",
+        "spark.sql.execution.arrow.maxRecordsPerBatch": "7",
+    }
+    previous = {key: spark.conf.get(key, None) for key in settings}
+    for key, value in settings.items():
+        spark.conf.set(key, value)
+    try:
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                spark.conf.unset(key)
+            else:
+                spark.conf.set(key, value)
+
+
 def _executed_plan(df) -> str:
     return df._jdf.queryExecution().executedPlan().toString()
 
@@ -1158,50 +1178,132 @@ def test_map_in_arrow_deeply_nested(spark, tmp_path, accelerated):
     assert out == expected
 
 
-def test_map_in_arrow_falls_back_when_use_large_var_types(spark, tmp_path):
-    """
-    `spark.sql.execution.arrow.useLargeVarTypes=true` widens StringType / BinaryType to
-    LargeUtf8 / LargeBinary in Spark's input IPC schema (8-byte offsets). Native Comet
-    vectors use 4-byte offsets; direct serialization advertises their matching types,
-    producing a valid stream but not the large input types requested by the configuration.
-    EliminateRedundantTransitions must skip the rewrite in that case so vanilla Spark
-    handles the operation. This test does not use the `accelerated` fixture: it sets
-    pyarrowUDF.enabled=true AND useLargeVarTypes=true and asserts the plan still falls
-    back to vanilla MapInArrow.
-    """
-    schema_in = T.StructType(
-        [
-            T.StructField("id", T.LongType()),
-            T.StructField("name", T.StringType()),
-        ]
+@pytest.mark.parametrize("api", ["mapInArrow", "mapInPandas"])
+@pytest.mark.parametrize("union_input", [False, True])
+def test_large_var_types_nested_batches_and_chained_udfs(
+    spark, tmp_path, accelerated, large_var_types, api, union_input
+):
+    """Widen native offsets, then reuse already-large output in the next Python runner."""
+    schema = (
+        "id int, text string, data binary, nested struct<text:string,data:binary>, "
+        "texts array<string>, binaries array<binary>, "
+        "mapping map<string,struct<text:string,data:binary>>"
     )
-    rows = [(i, f"name_{i}") for i in range(20)]
-    src = str(tmp_path / "src.parquet")
-    spark.createDataFrame(rows, schema_in).write.parquet(src)
+    rows = []
+    for index in range(37):
+        text = None if index % 4 == 0 else f"λ中文-{index}"
+        data = None if index % 5 == 0 else bytearray([0, index, 255])
+        rows.append(
+            (
+                index,
+                text,
+                data,
+                None if index % 3 == 0 else (text, data),
+                [text, "", None],
+                [data, bytearray(), None],
+                {f"key-{index}": (text, data), "missing": None},
+            )
+        )
+    path = str(tmp_path / "large_types.parquet")
+    spark.createDataFrame(rows, schema).coalesce(1).write.parquet(path)
+    source = spark.read.parquet(path)
+    if union_input:
+        other = source.selectExpr(
+            "id + 37 AS id",
+            "text",
+            "data",
+            "named_struct('renamed_text', nested.text, 'renamed_data', nested.data) AS nested",
+            "texts",
+            "binaries",
+            "mapping",
+        )
+        source = source.union(other).coalesce(1)
+    expected = sorted(source.collect(), key=lambda row: row.id)
 
-    def passthrough(iterator):
+    def check_arrow_batch(batch):
+        assert batch.num_rows <= 7
+        fields = batch.schema
+        assert pa.types.is_large_string(fields.field("text").type)
+        assert pa.types.is_large_binary(fields.field("data").type)
+        nested = fields.field("nested").type
+        assert pa.types.is_large_string(nested.field("text").type)
+        assert pa.types.is_large_binary(nested.field("data").type)
+        assert pa.types.is_large_string(fields.field("texts").type.value_type)
+        assert pa.types.is_large_binary(fields.field("binaries").type.value_type)
+        mapping = fields.field("mapping").type
+        assert pa.types.is_large_string(mapping.key_type)
+        assert not mapping.key_field.nullable
+        assert pa.types.is_large_string(mapping.item_type.field("text").type)
+        assert pa.types.is_large_binary(mapping.item_type.field("data").type)
+
+    def first(iterator):
         for batch in iterator:
+            if api == "mapInArrow":
+                check_arrow_batch(batch)
+                yield batch.slice(0, 0)
+            else:
+                yield batch.iloc[:0]
             yield batch
 
-    prev_pyarrow = spark.conf.get("spark.comet.exec.pyarrowUDF.enabled", "false")
-    prev_large = spark.conf.get("spark.sql.execution.arrow.useLargeVarTypes", "false")
-    spark.conf.set("spark.comet.exec.pyarrowUDF.enabled", "true")
-    spark.conf.set("spark.sql.execution.arrow.useLargeVarTypes", "true")
-    try:
-        result_df = spark.read.parquet(src).mapInArrow(passthrough, schema_in)
-        plan = _executed_plan(result_df)
-        assert "CometMapInBatch" not in plan, (
-            f"useLargeVarTypes=true should force fallback, but plan has "
-            f"CometMapInBatch:\n{plan}"
+    def second(iterator):
+        for batch in iterator:
+            check_arrow_batch(batch)
+            yield batch
+
+    result = getattr(source, api)(first, source.schema).mapInArrow(
+        second, source.schema
+    )
+    plan = _executed_plan(result)
+    _assert_plan_matches_mode(plan, accelerated)
+    if accelerated:
+        assert plan.count("CometMapInBatch") == 2
+        if union_input:
+            assert "CometUnion" in plan
+    assert sorted(result.collect(), key=lambda row: row.id) == expected
+
+
+@pytest.mark.parametrize("api", ["mapInArrow", "mapInPandas"])
+def test_large_var_types_with_no_input_batches(
+    spark, tmp_path, accelerated, large_var_types, api
+):
+    path = str(tmp_path / "empty_large_types.parquet")
+    spark.createDataFrame(
+        [(1, "a", bytearray(b"x"))], "id int, text string, data binary"
+    ).coalesce(1).write.parquet(path)
+    source = spark.read.parquet(path).where("id < 0")
+
+    def emit_without_input(iterator):
+        assert (
+            sum(
+                batch.num_rows if api == "mapInArrow" else len(batch)
+                for batch in iterator
+            )
+            == 0
         )
-        assert "MapInArrow" in plan, (
-            f"expected vanilla MapInArrow in fallback plan, got:\n{plan}"
-        )
-        out = sorted((r["id"], r["name"]) for r in result_df.collect())
-        assert out == sorted(rows)
-    finally:
-        spark.conf.set("spark.comet.exec.pyarrowUDF.enabled", prev_pyarrow)
-        spark.conf.set("spark.sql.execution.arrow.useLargeVarTypes", prev_large)
+        if api == "mapInArrow":
+            yield pa.RecordBatch.from_arrays(
+                [
+                    pa.array(["empty"], type=pa.large_string()),
+                    pa.array([b""], type=pa.large_binary()),
+                ],
+                names=["text", "data"],
+            )
+        else:
+            import pandas as pd
+
+            yield pd.DataFrame(
+                {"text": pd.Series(["empty"], dtype=object), "data": [b""]}
+            )
+
+    result = getattr(source, api)(emit_without_input, "text string, data binary")
+    _assert_plan_matches_mode(
+        _executed_plan(result),
+        accelerated,
+        vanilla_node="MapInArrow" if api == "mapInArrow" else "MapInPandas",
+    )
+    assert [(row.text, row.data) for row in result.collect()] == [
+        ("empty", bytearray())
+    ]
 
 
 def test_map_in_arrow_after_shuffle(spark, tmp_path, accelerated):

--- a/spark/src/test/spark-4.x/org/apache/spark/sql/comet/CometMapInBatchSuite.scala
+++ b/spark/src/test/spark-4.x/org/apache/spark/sql/comet/CometMapInBatchSuite.scala
@@ -87,12 +87,16 @@ class CometMapInBatchSuite extends CometTestBase {
       profile = None)
   }
 
-  test("rule rewrites MapInArrowExec over Comet to CometMapInBatchExec") {
-    withSQLConf(CometConf.COMET_PYARROW_UDF_ENABLED.key -> "true") {
-      val rewritten = EliminateRedundantTransitions(spark).apply(buildPlan())
-      assert(
-        rewritten.exists(_.isInstanceOf[CometMapInBatchExec]),
-        s"expected CometMapInBatchExec in rewritten plan:\n$rewritten")
+  for (useLargeVarTypes <- Seq(false, true)) {
+    test(s"rule rewrites MapInArrowExec over Comet (large variable types: $useLargeVarTypes)") {
+      withSQLConf(
+        CometConf.COMET_PYARROW_UDF_ENABLED.key -> "true",
+        "spark.sql.execution.arrow.useLargeVarTypes" -> useLargeVarTypes.toString) {
+        val rewritten = EliminateRedundantTransitions(spark).apply(buildPlan())
+        assert(
+          rewritten.exists(_.isInstanceOf[CometMapInBatchExec]),
+          s"expected CometMapInBatchExec in rewritten plan:\n$rewritten")
+      }
     }
   }
 

--- a/spark/src/test/spark-4.x/org/apache/spark/sql/execution/python/CometArrowPythonRunnerSuite.scala
+++ b/spark/src/test/spark-4.x/org/apache/spark/sql/execution/python/CometArrowPythonRunnerSuite.scala
@@ -30,8 +30,8 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 import org.apache.arrow.c.{ArrowArray, ArrowSchema, Data}
-import org.apache.arrow.memory.{BufferAllocator, OutOfMemoryException, RootAllocator}
-import org.apache.arrow.vector.{FieldVector, IntVector, LargeVarBinaryVector, LargeVarCharVector, NullVector, VarBinaryVector, VarCharVector, VectorSchemaRoot}
+import org.apache.arrow.memory.{ArrowBuf, BufferAllocator, OutOfMemoryException, RootAllocator}
+import org.apache.arrow.vector.{FieldVector, FixedSizeBinaryVector, IntVector, LargeVarBinaryVector, LargeVarCharVector, NullVector, VarBinaryVector, VarCharVector, VectorSchemaRoot}
 import org.apache.arrow.vector.complex.{ListVector, MapVector, StructVector}
 import org.apache.arrow.vector.ipc.{ArrowStreamReader, ArrowStreamWriter, WriteChannel}
 import org.apache.arrow.vector.types.pojo.{ArrowType, DictionaryEncoding, Field, FieldType, Schema}
@@ -143,7 +143,12 @@ class CometArrowPythonRunnerSuite extends AnyFunSuite with Matchers {
 
       withWriter(Seq(field), writerAllocator, Channels.newChannel(output)) { channel =>
         val originalWriterAllocation = writerAllocator.getAllocatedMemory
-        serializeBatch(new WriteChannel(channel), Seq(vector), 2, writerAllocator)
+        serializeBatch(
+          new WriteChannel(channel),
+          Seq(vector),
+          2,
+          writerAllocator,
+          useLargeVarTypes = false)
 
         writerAllocator.getAllocatedMemory shouldBe originalWriterAllocation
         buffers.map(_.refCnt()) shouldBe originalReferenceCounts
@@ -452,102 +457,193 @@ class CometArrowPythonRunnerSuite extends AnyFunSuite with Matchers {
     }
   }
 
-  test("direct batches preserve nested list, struct, map, and null field layouts") {
-    val sourceAllocator = new RootAllocator(Long.MaxValue)
-    val writerAllocator = new RootAllocator(Long.MaxValue)
-    val list = ListVector.empty("items", sourceAllocator)
-    val struct = StructVector.empty("details", sourceAllocator)
-    val map = MapVector.empty("mapping", sourceAllocator, false)
-    val nulls = new NullVector("nulls", 3)
-    val output = new ByteArrayOutputStream()
-    try {
-      val listWriter = list.getWriter
-      listWriter.setPosition(0)
-      listWriter.startList()
-      listWriter.integer().writeInt(11)
-      listWriter.integer().writeInt(12)
-      listWriter.endList()
-      listWriter.setPosition(1)
-      listWriter.writeNull()
-      listWriter.setPosition(2)
-      listWriter.startList()
-      listWriter.integer().writeInt(13)
-      listWriter.endList()
-      listWriter.setValueCount(3)
+  for (useLargeVarTypes <- Seq(false, true)) {
+    test(s"direct batches preserve mixed nested layouts (large: $useLargeVarTypes)") {
+      val sourceAllocator = new RootAllocator(Long.MaxValue)
+      val writerAllocator = new RootAllocator(Long.MaxValue)
+      val details = StructVector.empty("details", sourceAllocator)
+      val texts = ListVector.empty("texts", sourceAllocator)
+      val mapping = MapVector.empty("mapping", sourceAllocator, false)
+      val records = ListVector.empty("records", sourceAllocator)
+      val nulls = new NullVector("nulls", 3)
+      val fixed = new FixedSizeBinaryVector("fixed", sourceAllocator, 4)
+      val trailing = new VarCharVector("trailing", sourceAllocator)
+      val output = new ByteArrayOutputStream()
+      try {
+        val detailsWriter = details.getWriter
+        detailsWriter.setPosition(0)
+        detailsWriter.start()
+        detailsWriter.varChar("text").writeVarChar("alpha")
+        detailsWriter.integer("count").writeInt(21)
+        detailsWriter.varBinary("data").writeVarBinary(Array[Byte](1, 2))
+        detailsWriter.end()
+        detailsWriter.setPosition(1)
+        detailsWriter.writeNull()
+        detailsWriter.setPosition(2)
+        detailsWriter.start()
+        detailsWriter.varChar("text").writeVarChar("")
+        detailsWriter.integer("count").writeNull()
+        detailsWriter.varBinary("data").writeVarBinary(Array[Byte](3, 4))
+        detailsWriter.end()
+        detailsWriter.setValueCount(3)
 
-      val structWriter = struct.getWriter
-      structWriter.setPosition(0)
-      structWriter.start()
-      structWriter.integer("count").writeInt(21)
-      structWriter.end()
-      structWriter.setPosition(1)
-      structWriter.writeNull()
-      structWriter.setPosition(2)
-      structWriter.start()
-      structWriter.integer("count").writeNull()
-      structWriter.end()
-      structWriter.setValueCount(3)
+        val textsWriter = texts.getWriter
+        textsWriter.setPosition(0)
+        textsWriter.startList()
+        textsWriter.varChar().writeVarChar("one")
+        textsWriter.varChar().writeVarChar("")
+        textsWriter.endList()
+        textsWriter.setPosition(1)
+        textsWriter.writeNull()
+        textsWriter.setPosition(2)
+        textsWriter.startList()
+        textsWriter.varChar().writeVarChar("three")
+        textsWriter.endList()
+        textsWriter.setValueCount(3)
 
-      val mapWriter = map.getWriter
-      mapWriter.setPosition(0)
-      mapWriter.startMap()
-      mapWriter.startEntry()
-      mapWriter.key().integer().writeInt(31)
-      mapWriter.value().integer().writeInt(32)
-      mapWriter.endEntry()
-      mapWriter.endMap()
-      mapWriter.setPosition(1)
-      mapWriter.writeNull()
-      mapWriter.setPosition(2)
-      mapWriter.startMap()
-      mapWriter.startEntry()
-      mapWriter.key().integer().writeInt(33)
-      mapWriter.value().integer().writeNull()
-      mapWriter.endEntry()
-      mapWriter.endMap()
-      mapWriter.setValueCount(3)
+        val mapWriter = mapping.getWriter
+        mapWriter.setPosition(0)
+        mapWriter.startMap()
+        mapWriter.startEntry()
+        mapWriter.key().varChar().writeVarChar("key-0")
+        mapWriter.value().varChar().writeVarChar("value-0")
+        mapWriter.endEntry()
+        mapWriter.endMap()
+        mapWriter.setPosition(1)
+        mapWriter.writeNull()
+        mapWriter.setPosition(2)
+        mapWriter.startMap()
+        mapWriter.startEntry()
+        mapWriter.key().varChar().writeVarChar("key-2")
+        mapWriter.value().varChar().writeVarChar("value-2")
+        mapWriter.endEntry()
+        mapWriter.endMap()
+        mapWriter.setValueCount(3)
 
-      val vectors = Seq[FieldVector](list, struct, map, nulls)
-      withWriter(vectors.map(_.getField), writerAllocator, Channels.newChannel(output)) {
-        channel =>
-          serializeBatch(new WriteChannel(channel), vectors, 3, writerAllocator)
+        val recordsWriter = records.getWriter
+        val recordWriter = recordsWriter.struct()
+        recordsWriter.setPosition(0)
+        recordsWriter.startList()
+        recordWriter.start()
+        recordWriter.varChar("text").writeVarChar("record-0")
+        recordWriter.end()
+        recordsWriter.endList()
+        recordsWriter.setPosition(1)
+        recordsWriter.writeNull()
+        recordsWriter.setPosition(2)
+        recordsWriter.startList()
+        recordWriter.start()
+        recordWriter.varChar("text").writeVarChar("record-2")
+        recordWriter.end()
+        recordsWriter.endList()
+        recordsWriter.setValueCount(3)
+
+        fixed.allocateNew()
+        fixed.setSafe(0, Array[Byte](5, 6, 7, 8))
+        fixed.setNull(1)
+        fixed.setSafe(2, Array[Byte](9, 10, 11, 12))
+        fixed.setValueCount(3)
+
+        trailing.allocateNew()
+        trailing.setSafe(0, "tail-0".getBytes("UTF-8"))
+        trailing.setNull(1)
+        trailing.setSafe(2, "tail-2".getBytes("UTF-8"))
+        trailing.setValueCount(3)
+
+        val vectors = Seq[FieldVector](details, texts, mapping, records, nulls, fixed, trailing)
+        def buffers(vector: FieldVector): Seq[ArrowBuf] =
+          vector.getFieldBuffers.asScala.toSeq ++
+            vector.getChildrenFromFields.asScala.toSeq.flatMap(buffers)
+        val sourceBuffers = vectors.flatMap(buffers)
+        val sourceRefs = sourceBuffers.map(_.refCnt())
+        val sourceBytes = sourceAllocator.getAllocatedMemory
+        val streamFields = vectors.map { vector =>
+          if (useLargeVarTypes) withLargeVarTypes(vector.getField) else vector.getField
+        }
+
+        withWriter(streamFields, writerAllocator, Channels.newChannel(output)) { channel =>
+          serializeBatch(new WriteChannel(channel), vectors, 3, writerAllocator, useLargeVarTypes)
+          writerAllocator.getAllocatedMemory shouldBe 0L
+          sourceAllocator.getAllocatedMemory shouldBe sourceBytes
+          sourceBuffers.map(_.refCnt()) shouldBe sourceRefs
+        }
+
+        withReader(output.toByteArray) { reader =>
+          reader.loadNextBatch() shouldBe true
+          val result = reader.getVectorSchemaRoot.getVector(0).asInstanceOf[StructVector]
+          result.getNullCount shouldBe 0
+          val expectedUtf8 =
+            if (useLargeVarTypes) ArrowType.LargeUtf8.INSTANCE else ArrowType.Utf8.INSTANCE
+          val expectedBinary =
+            if (useLargeVarTypes) ArrowType.LargeBinary.INSTANCE else ArrowType.Binary.INSTANCE
+
+          val resultDetails = result.getChild("details").asInstanceOf[StructVector]
+          val detailText = resultDetails.getChild("text")
+          val detailCount = resultDetails.getChild("count").asInstanceOf[IntVector]
+          val detailData = resultDetails.getChild("data")
+          detailText.getField.getType shouldBe expectedUtf8
+          detailData.getField.getType shouldBe expectedBinary
+          detailText.getObject(0).toString shouldBe "alpha"
+          detailCount.get(0) shouldBe 21
+          detailData.getObject(0).asInstanceOf[Array[Byte]] shouldBe Array[Byte](1, 2)
+          resultDetails.isNull(1) shouldBe true
+          detailText.getObject(2).toString shouldBe ""
+          detailCount.isNull(2) shouldBe true
+          detailData.getObject(2).asInstanceOf[Array[Byte]] shouldBe Array[Byte](3, 4)
+
+          val resultTexts = result.getChild("texts").asInstanceOf[ListVector]
+          resultTexts.getDataVector.getField.getType shouldBe expectedUtf8
+          resultTexts.getObject(0).asScala.map(_.toString).toSeq shouldBe Seq("one", "")
+          resultTexts.isNull(1) shouldBe true
+          resultTexts.getObject(2).asScala.map(_.toString).toSeq shouldBe Seq("three")
+
+          val resultMap = result.getChild("mapping").asInstanceOf[MapVector]
+          val entries = resultMap.getDataVector.asInstanceOf[StructVector]
+          val keys = entries.getChildByOrdinal(0)
+          val values = entries.getChildByOrdinal(1)
+          keys.getField.getName shouldBe MapVector.KEY_NAME
+          values.getField.getName shouldBe MapVector.VALUE_NAME
+          keys.getField.getType shouldBe expectedUtf8
+          values.getField.getType shouldBe expectedUtf8
+          keys.getObject(0).toString shouldBe "key-0"
+          values.getObject(0).toString shouldBe "value-0"
+          resultMap.isNull(1) shouldBe true
+          keys.getObject(1).toString shouldBe "key-2"
+          values.getObject(1).toString shouldBe "value-2"
+
+          val resultRecords = result.getChild("records").asInstanceOf[ListVector]
+          val recordStruct = resultRecords.getDataVector.asInstanceOf[StructVector]
+          val recordText = recordStruct.getChild("text")
+          recordText.getField.getType shouldBe expectedUtf8
+          resultRecords.getObject(0).size() shouldBe 1
+          recordText.getObject(0).toString shouldBe "record-0"
+          resultRecords.isNull(1) shouldBe true
+          resultRecords.getObject(2).size() shouldBe 1
+          recordText.getObject(1).toString shouldBe "record-2"
+
+          result.getChild("nulls").asInstanceOf[NullVector].getNullCount shouldBe 3
+          val resultFixed = result.getChild("fixed").asInstanceOf[FixedSizeBinaryVector]
+          resultFixed.get(0) shouldBe Array[Byte](5, 6, 7, 8)
+          resultFixed.isNull(1) shouldBe true
+          resultFixed.get(2) shouldBe Array[Byte](9, 10, 11, 12)
+          val resultTrailing = result.getChild("trailing")
+          resultTrailing.getField.getType shouldBe expectedUtf8
+          resultTrailing.getObject(0).toString shouldBe "tail-0"
+          resultTrailing.isNull(1) shouldBe true
+          resultTrailing.getObject(2).toString shouldBe "tail-2"
+          reader.loadNextBatch() shouldBe false
+        }
+      } finally {
+        trailing.close()
+        fixed.close()
+        nulls.close()
+        records.close()
+        mapping.close()
+        texts.close()
+        details.close()
+        writerAllocator.close()
+        sourceAllocator.close()
       }
-
-      withReader(output.toByteArray) { reader =>
-        reader.loadNextBatch() shouldBe true
-        val result = reader.getVectorSchemaRoot.getVector(0).asInstanceOf[StructVector]
-        result.getNullCount shouldBe 0
-
-        val resultList = result.getChild("items").asInstanceOf[ListVector]
-        resultList.getObject(0).asScala.toSeq shouldBe Seq(11, 12)
-        resultList.isNull(1) shouldBe true
-        resultList.getObject(2).asScala.toSeq shouldBe Seq(13)
-
-        val resultStruct = result.getChild("details").asInstanceOf[StructVector]
-        resultStruct.getChild("count").asInstanceOf[IntVector].get(0) shouldBe 21
-        resultStruct.isNull(1) shouldBe true
-        resultStruct.getChild("count").isNull(2) shouldBe true
-
-        val resultMap = result.getChild("mapping").asInstanceOf[MapVector]
-        val entries = resultMap.getDataVector.asInstanceOf[StructVector]
-        entries.getChildByOrdinal(0).getField.getName shouldBe MapVector.KEY_NAME
-        entries.getChildByOrdinal(1).getField.getName shouldBe MapVector.VALUE_NAME
-        entries.getChildByOrdinal(0).asInstanceOf[IntVector].get(0) shouldBe 31
-        entries.getChildByOrdinal(1).asInstanceOf[IntVector].get(0) shouldBe 32
-        resultMap.isNull(1) shouldBe true
-        entries.getChildByOrdinal(1).isNull(1) shouldBe true
-
-        val resultNulls = result.getChild("nulls").asInstanceOf[NullVector]
-        resultNulls.getNullCount shouldBe 3
-        reader.loadNextBatch() shouldBe false
-      }
-    } finally {
-      nulls.close()
-      map.close()
-      struct.close()
-      list.close()
-      writerAllocator.close()
-      sourceAllocator.close()
     }
   }
 
@@ -569,9 +665,24 @@ class CometArrowPythonRunnerSuite extends AnyFunSuite with Matchers {
       last.setValueCount(1)
 
       withWriter(Seq(first.getField), writerAllocator, Channels.newChannel(output)) { channel =>
-        serializeBatch(new WriteChannel(channel), Seq(first), 2, writerAllocator)
-        serializeBatch(new WriteChannel(channel), Seq(empty), 0, writerAllocator)
-        serializeBatch(new WriteChannel(channel), Seq(last), 1, writerAllocator)
+        serializeBatch(
+          new WriteChannel(channel),
+          Seq(first),
+          2,
+          writerAllocator,
+          useLargeVarTypes = false)
+        serializeBatch(
+          new WriteChannel(channel),
+          Seq(empty),
+          0,
+          writerAllocator,
+          useLargeVarTypes = false)
+        serializeBatch(
+          new WriteChannel(channel),
+          Seq(last),
+          1,
+          writerAllocator,
+          useLargeVarTypes = false)
       }
 
       withReader(output.toByteArray) { reader =>
@@ -599,7 +710,12 @@ class CometArrowPythonRunnerSuite extends AnyFunSuite with Matchers {
     val output = new ByteArrayOutputStream()
     try {
       withWriter(Seq.empty, allocator, Channels.newChannel(output)) { channel =>
-        serializeBatch(new WriteChannel(channel), Seq.empty, 3, allocator)
+        serializeBatch(
+          new WriteChannel(channel),
+          Seq.empty,
+          3,
+          allocator,
+          useLargeVarTypes = false)
       }
 
       withReader(output.toByteArray) { reader =>
@@ -649,7 +765,12 @@ class CometArrowPythonRunnerSuite extends AnyFunSuite with Matchers {
         failWrites = true
         try {
           val error = intercept[IOException] {
-            serializeBatch(new WriteChannel(channel), Seq(source), 1, writerAllocator)
+            serializeBatch(
+              new WriteChannel(channel),
+              Seq(source),
+              1,
+              writerAllocator,
+              useLargeVarTypes = false)
           }
           error.getMessage shouldBe "injected Arrow IPC write failure"
         } finally {

--- a/spark/src/test/spark-4.x/org/apache/spark/sql/execution/python/CometArrowPythonRunnerSuite.scala
+++ b/spark/src/test/spark-4.x/org/apache/spark/sql/execution/python/CometArrowPythonRunnerSuite.scala
@@ -30,12 +30,12 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 import org.apache.arrow.c.{ArrowArray, ArrowSchema, Data}
-import org.apache.arrow.memory.{BufferAllocator, RootAllocator}
-import org.apache.arrow.vector.{FieldVector, IntVector, NullVector, VarCharVector, VectorSchemaRoot}
+import org.apache.arrow.memory.{BufferAllocator, OutOfMemoryException, RootAllocator}
+import org.apache.arrow.vector.{FieldVector, IntVector, LargeVarBinaryVector, LargeVarCharVector, NullVector, VarBinaryVector, VarCharVector, VectorSchemaRoot}
 import org.apache.arrow.vector.complex.{ListVector, MapVector, StructVector}
 import org.apache.arrow.vector.ipc.{ArrowStreamReader, ArrowStreamWriter, WriteChannel}
 import org.apache.arrow.vector.types.pojo.{ArrowType, DictionaryEncoding, Field, FieldType, Schema}
-import org.apache.spark.sql.execution.python.CometArrowPythonRunnerBase.{hasCompatibleSchema, serializeBatch}
+import org.apache.spark.sql.execution.python.CometArrowPythonRunnerBase.{hasCompatibleSchema, serializeBatch, withLargeVarTypes}
 
 class CometArrowPythonRunnerSuite extends AnyFunSuite with Matchers {
 
@@ -169,8 +169,12 @@ class CometArrowPythonRunnerSuite extends AnyFunSuite with Matchers {
     }
   }
 
-  for (failSerialization <- Seq(false, true)) {
-    test(s"direct FFI batches release temporary references (write failure: $failSerialization)") {
+  for {
+    failSerialization <- Seq(false, true)
+    useLargeVarTypes <- Seq(false, true)
+  } {
+    test(
+      s"direct FFI batches release references (failure: $failSerialization, large: $useLargeVarTypes)") {
       // Arrow's JNI loader extracts its library here; Maven's target/tmp may not exist yet.
       Files.createDirectories(Paths.get(System.getProperty("java.io.tmpdir")))
       val sourceAllocator = new RootAllocator(Long.MaxValue)
@@ -209,38 +213,50 @@ class CometArrowPythonRunnerSuite extends AnyFunSuite with Matchers {
         val originalSourceAllocation = sourceAllocator.getAllocatedMemory
         originalSourceAllocation should be > 0L
 
-        withWriter(Seq(imported.getField), writerAllocator, Channels.newChannel(output)) {
-          channel =>
-            val originalWriterAllocation = writerAllocator.getAllocatedMemory
-            failWrites = failSerialization
-            try {
-              if (failSerialization) {
-                val error = intercept[IOException] {
-                  serializeBatch(new WriteChannel(channel), Seq(imported), 2, writerAllocator)
-                }
-                error.getMessage shouldBe "injected Arrow IPC write failure"
-              } else {
-                serializeBatch(new WriteChannel(channel), Seq(imported), 2, writerAllocator)
+        val field =
+          if (useLargeVarTypes) withLargeVarTypes(imported.getField) else imported.getField
+        withWriter(Seq(field), writerAllocator, Channels.newChannel(output)) { channel =>
+          val originalWriterAllocation = writerAllocator.getAllocatedMemory
+          failWrites = failSerialization
+          try {
+            if (failSerialization) {
+              val error = intercept[IOException] {
+                serializeBatch(
+                  new WriteChannel(channel),
+                  Seq(imported),
+                  2,
+                  writerAllocator,
+                  useLargeVarTypes)
               }
-            } finally {
-              failWrites = false
+              error.getMessage shouldBe "injected Arrow IPC write failure"
+            } else {
+              serializeBatch(
+                new WriteChannel(channel),
+                Seq(imported),
+                2,
+                writerAllocator,
+                useLargeVarTypes)
             }
+          } finally {
+            failWrites = false
+          }
 
-            buffers.map(_.refCnt()) shouldBe originalReferenceCounts
-            importAllocator.getAllocatedMemory shouldBe originalImportAllocation
-            sourceAllocator.getAllocatedMemory shouldBe originalSourceAllocation
-            writerAllocator.getAllocatedMemory shouldBe originalWriterAllocation
-            imported.getValueCount shouldBe 2
-            imported.get(0) shouldBe payload
-            imported.isNull(1) shouldBe true
+          buffers.map(_.refCnt()) shouldBe originalReferenceCounts
+          importAllocator.getAllocatedMemory shouldBe originalImportAllocation
+          sourceAllocator.getAllocatedMemory shouldBe originalSourceAllocation
+          writerAllocator.getAllocatedMemory shouldBe originalWriterAllocation
+          imported.getValueCount shouldBe 2
+          imported.get(0) shouldBe payload
+          imported.isNull(1) shouldBe true
         }
 
         if (!failSerialization) {
           withReader(output.toByteArray) { reader =>
             reader.loadNextBatch() shouldBe true
             val struct = reader.getVectorSchemaRoot.getVector(0).asInstanceOf[StructVector]
-            val result = struct.getChild("payload").asInstanceOf[VarCharVector]
-            result.get(0) shouldBe payload
+            val result = struct.getChild("payload")
+            result.getField.getType shouldBe field.getType
+            result.getObject(0).toString shouldBe new String(payload, "UTF-8")
             result.isNull(1) shouldBe true
             reader.loadNextBatch() shouldBe false
           }
@@ -262,6 +278,177 @@ class CometArrowPythonRunnerSuite extends AnyFunSuite with Matchers {
         importAllocator.close()
         sourceAllocator.close()
       }
+    }
+  }
+
+  test("large input types widen offsets without copying string or binary payloads") {
+    val sourceAllocator = new RootAllocator(Long.MaxValue)
+    val writerAllocator = new RootAllocator(1024)
+    val text = new VarCharVector("text", sourceAllocator)
+    val binary = new VarBinaryVector("binary", sourceAllocator)
+    val output = new ByteArrayOutputStream()
+    try {
+      val strings = Seq(
+        Array.fill[Byte](16 * 1024)('x'.toByte),
+        Array.emptyByteArray,
+        "λ中文".getBytes("UTF-8"))
+      val bytes =
+        Seq(Array.fill[Byte](16 * 1024)(0xff.toByte), Array.emptyByteArray, Array[Byte](0, 1, -1))
+      text.allocateNew()
+      binary.allocateNew()
+      Seq(0, 2, 3).zipWithIndex.foreach { case (row, i) =>
+        text.setSafe(row, strings(i))
+        binary.setSafe(row, bytes(i))
+      }
+      text.setNull(1)
+      binary.setNull(1)
+      text.setValueCount(4)
+      binary.setValueCount(4)
+      val vectors = Seq[FieldVector](text, binary)
+      val buffers = vectors.flatMap(_.getFieldBuffers.asScala)
+      val refs = buffers.map(_.refCnt())
+      val sourceBytes = sourceAllocator.getAllocatedMemory
+
+      withWriter(
+        vectors.map(v => withLargeVarTypes(v.getField)),
+        writerAllocator,
+        Channels.newChannel(output)) { channel =>
+        serializeBatch(
+          new WriteChannel(channel),
+          vectors,
+          4,
+          writerAllocator,
+          useLargeVarTypes = true)
+        writerAllocator.getAllocatedMemory shouldBe 0L
+        sourceAllocator.getAllocatedMemory shouldBe sourceBytes
+        buffers.map(_.refCnt()) shouldBe refs
+        text.getLastSet shouldBe 3
+        binary.getLastSet shouldBe 3
+        text.get(3) shouldBe strings(2)
+        binary.get(3) shouldBe bytes(2)
+      }
+      withReader(output.toByteArray) { reader =>
+        reader.loadNextBatch() shouldBe true
+        val struct = reader.getVectorSchemaRoot.getVector(0).asInstanceOf[StructVector]
+        val resultText = struct.getChild("text").asInstanceOf[LargeVarCharVector]
+        val resultBinary = struct.getChild("binary").asInstanceOf[LargeVarBinaryVector]
+        Seq(0, 2, 3).zipWithIndex.foreach { case (row, i) =>
+          resultText.get(row) shouldBe strings(i)
+          resultBinary.get(row) shouldBe bytes(i)
+        }
+        resultText.isNull(1) shouldBe true
+        resultBinary.isNull(1) shouldBe true
+        reader.loadNextBatch() shouldBe false
+      }
+    } finally {
+      binary.close()
+      text.close()
+      writerAllocator.close()
+      sourceAllocator.close()
+    }
+  }
+
+  test("large input types preserve empty batches and reuse already-large offsets") {
+    val sourceAllocator = new RootAllocator(Long.MaxValue)
+    val writerAllocator = new RootAllocator(64)
+    val first = new VarCharVector("value", sourceAllocator)
+    val empty = new VarCharVector("value", sourceAllocator)
+    val last = new LargeVarCharVector("value", sourceAllocator)
+    val output = new ByteArrayOutputStream()
+    try {
+      first.allocateNew()
+      first.setSafe(0, "first".getBytes("UTF-8"))
+      first.setValueCount(1)
+      last.allocateNew()
+      last.setSafe(0, "last".getBytes("UTF-8"))
+      last.setValueCount(1)
+      val largeBuffers = last.getFieldBuffers.asScala.toSeq
+      val largeRefs = largeBuffers.map(_.refCnt())
+      val largeField = withLargeVarTypes(first.getField)
+      hasCompatibleSchema(Seq(largeField), Seq(withLargeVarTypes(last.getField))) shouldBe true
+
+      withWriter(Seq(largeField), writerAllocator, Channels.newChannel(output)) { channel =>
+        serializeBatch(
+          new WriteChannel(channel),
+          Seq(first),
+          1,
+          writerAllocator,
+          useLargeVarTypes = true)
+        serializeBatch(
+          new WriteChannel(channel),
+          Seq(empty),
+          0,
+          writerAllocator,
+          useLargeVarTypes = true)
+        // Only the wrapping bitmap fits: an already-large input must not allocate new offsets.
+        writerAllocator.setLimit(8L)
+        serializeBatch(
+          new WriteChannel(channel),
+          Seq(last),
+          1,
+          writerAllocator,
+          useLargeVarTypes = true)
+        largeBuffers.map(_.refCnt()) shouldBe largeRefs
+        writerAllocator.getAllocatedMemory shouldBe 0L
+      }
+      withReader(output.toByteArray) { reader =>
+        Seq(Some("first"), None, Some("last")).foreach { expected =>
+          reader.loadNextBatch() shouldBe true
+          reader.getVectorSchemaRoot.getRowCount shouldBe expected.size
+          val struct = reader.getVectorSchemaRoot.getVector(0).asInstanceOf[StructVector]
+          val value = struct.getChild("value").asInstanceOf[LargeVarCharVector]
+          expected.foreach(v => value.getObject(0).toString shouldBe v)
+        }
+        reader.loadNextBatch() shouldBe false
+      }
+    } finally {
+      last.close()
+      empty.close()
+      first.close()
+      writerAllocator.close()
+      sourceAllocator.close()
+    }
+  }
+
+  test("large input conversion releases earlier offsets when a later allocation fails") {
+    val sourceAllocator = new RootAllocator(Long.MaxValue)
+    // The wrapping bitmap and one 32-byte offset buffer fit, but the second offset buffer cannot.
+    val writerAllocator = new RootAllocator(40)
+    val vectors = Seq(
+      new VarCharVector("first", sourceAllocator),
+      new VarCharVector("second", sourceAllocator))
+    val output = new ByteArrayOutputStream()
+    try {
+      vectors.foreach { vector =>
+        vector.allocateNew()
+        (0 until 3).foreach(i => vector.setSafe(i, s"value-$i".getBytes("UTF-8")))
+        vector.setValueCount(3)
+      }
+      val buffers = vectors.flatMap(_.getFieldBuffers.asScala)
+      val refs = buffers.map(_.refCnt())
+      val sourceBytes = sourceAllocator.getAllocatedMemory
+      withWriter(
+        vectors.map(v => withLargeVarTypes(v.getField)),
+        writerAllocator,
+        Channels.newChannel(output)) { channel =>
+        intercept[OutOfMemoryException] {
+          serializeBatch(
+            new WriteChannel(channel),
+            vectors,
+            3,
+            writerAllocator,
+            useLargeVarTypes = true)
+        }
+        writerAllocator.getPeakMemoryAllocation should be > 8L
+        writerAllocator.getAllocatedMemory shouldBe 0L
+        buffers.map(_.refCnt()) shouldBe refs
+        sourceAllocator.getAllocatedMemory shouldBe sourceBytes
+        vectors.foreach(_.getObject(2).toString shouldBe "value-2")
+      }
+    } finally {
+      vectors.foreach(_.close())
+      writerAllocator.close()
+      sourceAllocator.close()
     }
   }
 


### PR DESCRIPTION
> **Draft / merge order:** this feature depends on #5560 (dictionary shuffle input) and #5561 (Spark 4.2 worker framing). After both fixes merge, this branch will be rebased onto `main`, the integrated validation will be rerun, and the PR can return to ready-for-review state.

## Which issue does this PR close?

Closes #5555.

## Rationale for this change

Setting `spark.sql.execution.arrow.useLargeVarTypes=true` currently disables Comet's accelerated `mapInArrow` / `mapInPandas` path, even for a small batch that is already columnar. For example, a Parquet batch containing strings and binary values falls back through `CometColumnarToRow` and Spark's Arrow writer so that Python receives `large_string` and `large_binary`. This preserves Spark's requested types but reintroduces the row conversion that the accelerated path avoids.

This PR keeps eligible operations accelerated while supplying real 64-bit offset buffers. Changing the IPC schema alone would be incorrect because ordinary Comet string and binary vectors have 32-bit offsets.

## What changes are included in this PR?

The Python runner reads the setting from the driver-captured worker configuration and recursively advertises large string and binary fields, including fields inside structs, arrays, and maps. Serialization widens only ordinary string and binary offset buffers; value and validity buffers remain borrowed, already-large offsets are reused, and temporary offsets are released after the synchronous write. Empty inputs also advertise the configured types, and compatible batches with different field names, nullability, or descriptive metadata can share the stream schema.

The planner's unconditional large-type fallback and its now-unused SQLConf shim accessors are removed. Spark 3.x retains its existing unsupported-API fallback. The three shim copies remain separate, with the stale blank lines left by the removed accessor cleaned up.

The widening cleanup always owns temporary offset buffers through one list instead of using a null sentinel, and `serializeBatch` now requires callers to choose the offset mode explicitly. A mixed-layout JVM regression test drives the depth-first buffer walk through `struct<string,int,binary>`, `list<string>`, `map<string,string>`, `list<struct<string>>`, a zero-buffer null vector, fixed-size binary, and a trailing string in both offset modes. It checks values, types, source reference counts, and writer allocator cleanup.

The documentation describes the remaining limit: widening at the Python boundary does **not** remove the 32-bit size limits of native producers that first construct ordinary arrays. This is input support; it does not claim to resolve the separate output serialization issue #5488. The end-to-end benchmark supports `BENCHMARK_LARGE_VAR_TYPES=true` to exercise the new path.

Dictionary decoding and Spark 4.2 command framing are intentionally excluded from this diff and live in #5560 and #5561.

## How are these changes tested?

Native code was built before the JVM and Python checks; this PR does not change native code.

- Spark 4.0 / Scala 2.13 root-reactor package build: **21/21 focused JVM tests passed** (15 Arrow runner tests and 6 planner tests). Coverage includes regular and large offsets, nested buffer traversal, already-large offsets, empty batches, cross-allocator FFI ownership, source refcounts, writer cleanup, and partial allocation failure.
- PySpark 4.0.4 / JDK 17 / PyArrow 25.0.1 / pandas 3.0.5: **all 128 real-worker integration tests passed** on this narrow head.
- Spark 3.5 compatibility validation from the feature commit passed **28 tests**, with one expected Spark-4-only case canceled.
- Scala formatting/style, Python syntax/lint for the changed code, suite-registration checks, and `git diff --check` passed.

An isolated JVM harness called the production serializer with 8,192 rows, alternating string and binary columns containing 32-byte values and one null per seven rows. After warmup, it took the median of seven samples while alternating measurement order. The output channel discarded bytes, so these measurements isolate serializer work and exclude Python, transport copies, dictionary decoding, and end-to-end query costs:

| Variable-width columns | Default offsets | Large offsets | Added time per batch | Peak writer allocation, default / large |
| --- | ---: | ---: | ---: | ---: |
| 2 | 3.0 us | 51.8 us | 48.7 us | 1 KiB / 257 KiB |
| 16 | 12.8 us | 398.8 us | 386.0 us | 1 KiB / 2,049 KiB |

Writer allocation returned to zero after serialization. These local measurements describe the cost of offset widening for plain vectors, not a claimed query speedup.
