### PR TITLE
fix: bound native explode output batch size

### DIFF
--- a/native/core/src/execution/operators/batch_split.rs
+++ b/native/core/src/execution/operators/batch_split.rs
@@ -1,0 +1,154 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt::Formatter;
+use std::sync::Arc;
+
+use datafusion::common::{internal_err, Result};
+use datafusion::execution::TaskContext;
+use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet, SplitMetrics};
+use datafusion::physical_plan::stream::BatchSplitStream;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
+};
+
+/// Splits oversized batches emitted by an input plan using the runtime batch size.
+///
+/// DataFusion 54.1.0's `UnnestExec` can emit more rows than the configured batch size. This
+/// wrapper is a temporary downstream boundary for Comet's explode path until Comet upgrades to a
+/// DataFusion version containing https://github.com/apache/datafusion/pull/24384.
+#[derive(Debug)]
+pub struct BatchSplitExec {
+    input: Arc<dyn ExecutionPlan>,
+    cache: Arc<PlanProperties>,
+    metrics: ExecutionPlanMetricsSet,
+}
+
+impl BatchSplitExec {
+    pub fn new(input: Arc<dyn ExecutionPlan>) -> Self {
+        Self {
+            cache: Arc::clone(input.properties()),
+            input,
+            metrics: ExecutionPlanMetricsSet::new(),
+        }
+    }
+}
+
+impl DisplayAs for BatchSplitExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(f, "CometBatchSplitExec")
+            }
+            DisplayFormatType::TreeRender => unimplemented!(),
+        }
+    }
+}
+
+impl ExecutionPlan for BatchSplitExec {
+    fn name(&self) -> &str {
+        "CometBatchSplitExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.cache
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return internal_err!(
+                "CometBatchSplitExec expects one child, got {}",
+                children.len()
+            );
+        }
+        Ok(Arc::new(Self::new(Arc::clone(&children[0]))))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let batch_size = context.session_config().batch_size();
+        let input = self.input.execute(partition, context)?;
+        Ok(Box::pin(BatchSplitStream::new(
+            input,
+            batch_size,
+            SplitMetrics::new(&self.metrics, partition),
+        )))
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![true]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use arrow::array::{AsArray, Int32Array, RecordBatch};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::datasource::source::DataSourceExec;
+    use datafusion::execution::SessionStateBuilder;
+    use datafusion::prelude::{SessionConfig, SessionContext};
+    use futures::StreamExt;
+
+    #[tokio::test]
+    async fn splits_batches_at_the_runtime_batch_size_and_preserves_order() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        let input_batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from_iter_values(0..10))],
+        )
+        .unwrap();
+        let source = MemorySourceConfig::try_new(&[vec![input_batch]], schema, None).unwrap();
+        let input: Arc<dyn ExecutionPlan> = Arc::new(DataSourceExec::new(Arc::new(source)));
+        let split = BatchSplitExec::new(input);
+
+        let config = SessionConfig::new().with_batch_size(4);
+        let state = SessionStateBuilder::new().with_config(config).build();
+        let context = SessionContext::new_with_state(state);
+        let mut stream = split.execute(0, context.task_ctx()).unwrap();
+
+        let mut batch_sizes = vec![];
+        let mut values = vec![];
+        while let Some(batch) = stream.next().await {
+            let batch = batch.unwrap();
+            batch_sizes.push(batch.num_rows());
+            let column = batch
+                .column(0)
+                .as_primitive::<arrow::datatypes::Int32Type>();
+            values.extend(column.values().iter().copied());
+        }
+
+        assert_eq!(batch_sizes, vec![4, 4, 2]);
+        assert_eq!(values, (0..10).collect::<Vec<_>>());
+    }
+}

--- a/native/core/src/execution/operators/batch_split.rs
+++ b/native/core/src/execution/operators/batch_split.rs
@@ -125,12 +125,83 @@ mod tests {
 
     use arrow::array::{AsArray, Int32Array, RecordBatch};
     use arrow::datatypes::{DataType, Field, Schema};
-    use datafusion::datasource::memory::MemorySourceConfig;
-    use datafusion::datasource::source::DataSourceExec;
     use datafusion::execution::SessionStateBuilder;
+    use datafusion::physical_expr::EquivalenceProperties;
+    use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
     use datafusion::physical_plan::limit::GlobalLimitExec;
+    use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+    use datafusion::physical_plan::Partitioning;
     use datafusion::prelude::{SessionConfig, SessionContext};
     use futures::StreamExt;
+
+    /// Emits one batch regardless of the session `batch_size`. MemorySource/DataSourceExec
+    /// would split first, so BatchSplitExec would only pass through and `batches_split`
+    /// would stay 0.
+    #[derive(Debug)]
+    struct SingleBatchExec {
+        batch: RecordBatch,
+        cache: Arc<PlanProperties>,
+    }
+
+    impl SingleBatchExec {
+        fn new(batch: RecordBatch) -> Self {
+            let cache = Arc::new(PlanProperties::new(
+                EquivalenceProperties::new(batch.schema()),
+                Partitioning::UnknownPartitioning(1),
+                EmissionType::Incremental,
+                Boundedness::Bounded,
+            ));
+            Self { batch, cache }
+        }
+    }
+
+    impl DisplayAs for SingleBatchExec {
+        fn fmt_as(&self, t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+            match t {
+                DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                    write!(f, "SingleBatchExec")
+                }
+                DisplayFormatType::TreeRender => unimplemented!(),
+            }
+        }
+    }
+
+    impl ExecutionPlan for SingleBatchExec {
+        fn name(&self) -> &str {
+            "SingleBatchExec"
+        }
+
+        fn properties(&self) -> &Arc<PlanProperties> {
+            &self.cache
+        }
+
+        fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+            vec![]
+        }
+
+        fn with_new_children(
+            self: Arc<Self>,
+            children: Vec<Arc<dyn ExecutionPlan>>,
+        ) -> Result<Arc<dyn ExecutionPlan>> {
+            if !children.is_empty() {
+                return internal_err!("SingleBatchExec expects no children");
+            }
+            Ok(self)
+        }
+
+        fn execute(
+            &self,
+            _partition: usize,
+            _context: Arc<TaskContext>,
+        ) -> Result<SendableRecordBatchStream> {
+            let batch = self.batch.clone();
+            let schema = batch.schema();
+            Ok(Box::pin(RecordBatchStreamAdapter::new(
+                schema,
+                futures::stream::once(async move { Ok(batch) }),
+            )))
+        }
+    }
 
     #[tokio::test]
     async fn splits_batches_at_the_runtime_batch_size_and_preserves_order() {
@@ -140,9 +211,12 @@ mod tests {
             vec![Arc::new(Int32Array::from_iter_values(0..10))],
         )
         .unwrap();
-        let source = MemorySourceConfig::try_new(&[vec![input_batch]], schema, None).unwrap();
-        let source: Arc<dyn ExecutionPlan> = Arc::new(DataSourceExec::new(Arc::new(source)));
-        let input: Arc<dyn ExecutionPlan> = Arc::new(GlobalLimitExec::new(source, 0, None));
+        // Limit records output_rows on the wrapped child so forwarding can be checked.
+        let input: Arc<dyn ExecutionPlan> = Arc::new(GlobalLimitExec::new(
+            Arc::new(SingleBatchExec::new(input_batch)),
+            0,
+            None,
+        ));
         let split = BatchSplitExec::new(input);
 
         let config = SessionConfig::new().with_batch_size(4);
@@ -170,5 +244,11 @@ mod tests {
             .find(|metric| metric.value().name() == "output_rows")
             .expect("wrapped input output_rows metric should be forwarded");
         assert_eq!(output_rows.value().as_usize(), 10);
+
+        let batches_split = metrics
+            .iter()
+            .find(|metric| metric.value().name() == "batches_split")
+            .expect("batches_split metric should be present");
+        assert_eq!(batches_split.value().as_usize(), 3);
     }
 }

--- a/native/core/src/execution/operators/batch_split.rs
+++ b/native/core/src/execution/operators/batch_split.rs
@@ -100,7 +100,18 @@ impl ExecutionPlan for BatchSplitExec {
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
-        Some(self.metrics.clone_inner())
+        let mut metrics = self.metrics.clone_inner();
+
+        // BatchSplitExec is a transparent execution wrapper. Preserve metrics produced by the
+        // wrapped UnnestExec so the Spark explode node can continue reporting its original SQL
+        // metrics.
+        if let Some(input_metrics) = self.input.metrics() {
+            for metric in input_metrics.iter() {
+                metrics.push(metric.to_owned());
+            }
+        }
+
+        Some(metrics)
     }
 
     fn maintains_input_order(&self) -> Vec<bool> {
@@ -117,6 +128,7 @@ mod tests {
     use datafusion::datasource::memory::MemorySourceConfig;
     use datafusion::datasource::source::DataSourceExec;
     use datafusion::execution::SessionStateBuilder;
+    use datafusion::physical_plan::limit::GlobalLimitExec;
     use datafusion::prelude::{SessionConfig, SessionContext};
     use futures::StreamExt;
 
@@ -129,7 +141,8 @@ mod tests {
         )
         .unwrap();
         let source = MemorySourceConfig::try_new(&[vec![input_batch]], schema, None).unwrap();
-        let input: Arc<dyn ExecutionPlan> = Arc::new(DataSourceExec::new(Arc::new(source)));
+        let source: Arc<dyn ExecutionPlan> = Arc::new(DataSourceExec::new(Arc::new(source)));
+        let input: Arc<dyn ExecutionPlan> = Arc::new(GlobalLimitExec::new(source, 0, None));
         let split = BatchSplitExec::new(input);
 
         let config = SessionConfig::new().with_batch_size(4);
@@ -150,5 +163,12 @@ mod tests {
 
         assert_eq!(batch_sizes, vec![4, 4, 2]);
         assert_eq!(values, (0..10).collect::<Vec<_>>());
+
+        let metrics = split.metrics().unwrap().aggregate_by_name();
+        let output_rows = metrics
+            .iter()
+            .find(|metric| metric.value().name() == "output_rows")
+            .expect("wrapped input output_rows metric should be forwarded");
+        assert_eq!(output_rows.value().as_usize(), 10);
     }
 }

--- a/native/core/src/execution/operators/mod.rs
+++ b/native/core/src/execution/operators/mod.rs
@@ -20,11 +20,13 @@
 pub use crate::errors::ExecutionError;
 
 pub use aligned_stream_reader::*;
+pub use batch_split::BatchSplitExec;
 pub use copy::*;
 pub use iceberg_scan::*;
 pub use scan::*;
 
 mod aligned_stream_reader;
+mod batch_split;
 mod copy;
 mod expand;
 pub use expand::ExpandExec;

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -39,8 +39,8 @@ use crate::execution::{
     expressions::list_positions::ListPositionsExpr,
     expressions::subquery::Subquery,
     operators::{
-        ExecutionError, ExpandExec, ParquetCompression, ParquetWriterExec, SampleExec, ScanExec,
-        ShuffleScanExec,
+        BatchSplitExec, ExecutionError, ExpandExec, ParquetCompression, ParquetWriterExec,
+        SampleExec, ScanExec, ShuffleScanExec,
     },
     planner::expression_registry::ExpressionRegistry,
     planner::operator_registry::OperatorRegistry,
@@ -2170,11 +2170,20 @@ impl PhysicalPlanner {
                     output_schema,
                     unnest_options,
                 )?);
+                // DataFusion 54.1.0's UnnestExec can emit more than the runtime batch size.
+                // Bound batches before downstream native projections until Comet upgrades to a
+                // DataFusion version containing https://github.com/apache/datafusion/pull/24384.
+                let bounded_unnest: Arc<dyn ExecutionPlan> =
+                    Arc::new(BatchSplitExec::new(unnest_exec));
 
                 Ok((
                     scans,
                     shuffle_scans,
-                    Arc::new(SparkPlan::new(spark_plan.plan_id, unnest_exec, vec![child])),
+                    Arc::new(SparkPlan::new(
+                        spark_plan.plan_id,
+                        bounded_unnest,
+                        vec![child],
+                    )),
                 ))
             }
             OpStruct::SortMergeJoin(join) => {

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -1545,7 +1545,10 @@ case class CometExplodeExec(
       Map(
         "input_batches" -> SQLMetrics.createMetric(sparkContext, "number of input batches"),
         "input_rows" -> SQLMetrics.createMetric(sparkContext, "number of input rows"),
-        "output_batches" -> SQLMetrics.createMetric(sparkContext, "number of output batches"))
+        "output_batches" -> SQLMetrics.createMetric(sparkContext, "number of output batches"),
+        "batches_split" -> SQLMetrics.createMetric(
+          sparkContext,
+          "number of output batches produced from oversized input batches"))
 }
 
 object CometUnionExec extends CometSink[UnionExec] {

--- a/spark/src/test/scala/org/apache/comet/exec/CometGenerateExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometGenerateExecSuite.scala
@@ -20,6 +20,7 @@
 package org.apache.comet.exec
 
 import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.comet.CometExplodeExec
 import org.apache.spark.sql.functions.col
 
 import org.apache.comet.CometConf
@@ -574,6 +575,39 @@ class CometGenerateExecSuite extends CometTestBase {
         .toDF("id", "arr")
         .selectExpr("id", "explode(arr) as value")
       checkSparkAnswerAndOperator(df)
+    }
+  }
+
+  // N rows each expanding by 2 can exceed spark.comet.batchSize even when no single
+  // array is larger than the batch. Distinct from "explode single row exceeds batch
+  // size" above. leafNodeDefaultParallelism=1 keeps the input in one partition so
+  // UnnestExec can emit one oversized batch for BatchSplitExec to slice.
+  test("native explode splits oversized output batches") {
+    withSQLConf(
+      CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_EXPLODE_ENABLED.key -> "true",
+      CometConf.COMET_BATCH_SIZE.key -> "8",
+      "spark.sql.leafNodeDefaultParallelism" -> "1") {
+      val df = (0 until 16)
+        .map(i => if (i % 2 == 0) "a" else "b")
+        .toDF("s")
+        .selectExpr("explode(array(s, s)) as e")
+      val (_, cometPlan) =
+        checkSparkAnswerAndOperator(df, includeClasses = Seq(classOf[CometExplodeExec]))
+
+      val explode = find(cometPlan) {
+        case _: CometExplodeExec => true
+        case _ => false
+      }.get
+
+      val metrics = explode.metrics
+      assert(metrics.contains("input_rows"))
+      assert(metrics.contains("output_rows"))
+      assert(metrics.contains("batches_split"))
+
+      assert(metrics("input_rows").value == 16L)
+      assert(metrics("output_rows").value == 32L)
+      assert(metrics("batches_split").value > 0L)
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

Related to #5409 and #5354.

## Rationale for this change

DataFusion 54.1.0's `UnnestExec` can emit batches containing more rows than `spark.comet.batchSize`. This violates the runtime batch-size boundary expected by downstream native operators. In particular, a downstream projection that broadcasts a scalar into an Arrow `Utf8` array can overflow its 32-bit offsets.

This PR wraps native `UnnestExec` with `BatchSplitExec`, which splits oversized output batches according to the runtime `TaskContext` batch size before passing them downstream.

This is a temporary workaround until Comet upgrades to a DataFusion version containing [datafusion#24384](https://github.com/apache/datafusion/pull/24384). The change was split out of #5409 so that the broader explode runtime behavior can be reviewed independently.

## What changes are included in this PR?

- Add `BatchSplitExec` after native `UnnestExec`.
- Preserve row order while splitting oversized batches.
- Forward the existing `UnnestExec` metrics through the wrapper.
- Expose `batches_split` on `CometExplodeExec`. DataFusion increments this counter once for each output slice produced from an oversized input batch.
- Keep `output_batches` as the original `UnnestExec` output-batch count from before splitting, rather than changing the meaning of the existing metric.

## Limitations

- This bounds the batch size observed by downstream operators. It does not reduce peak memory while `UnnestExec` constructs the expanded batch.
- `elapsed_compute` remains the `UnnestExec` compute time and does not include the wrapper's slicing cost.
- `batches_split` exposes split activity, but not the time spent slicing.
- The wrapper should be removed after upgrading to a DataFusion version containing datafusion#24384.

## Performance

Measured using a release native build (`-Ctarget-cpu=native`) with 5 warm-up runs and 10 measured runs. Values below are medians in ns per input row.

| Case     | Without wrapper | With wrapper | Difference(with − without)  |
| -------- | --------------: | -----------: | ---------: |
| No split |      389 ns/row |   395 ns/row |  +6 ns/row |
| Split    |      487 ns/row |   444 ns/row | −43 ns/row |

Environment:

- Queries against temp view `src` = `spark.range(131072)`, `spark.sql.leafNodeDefaultParallelism=1`
  - No split: `SELECT explode(array(id)) AS e FROM src` (array size 1)
  - Split: `SELECT explode(array(id, id)) AS e FROM src` (array size 2)
- Rows: 131072 input rows
- `spark.comet.batchSize`: 8192
- Spark 4.1.3, JDK 21.0.12, DataFusion 54.1.0
- Hardware: Apple M4
- Timed against `076c092a4`. Later commit `db10f73db` does not change the explode execution path.

Both arms used the same source revision and release build settings. For the without-wrapper arm, the planner was changed locally to return the original `UnnestExec` directly; no other code was changed.

The observed no-split pass-through overhead was approximately 6 ns per input row (about 1.5%). The split arm was 43 ns per input row faster in this end-to-end measurement, possibly because downstream `collect()` received smaller batches. This result does not establish that splitting itself improves performance. No regression was observed in this workload.

## How are these changes tested?

The Rust unit test verifies that:

- a 10-row batch with a runtime batch size of 4 becomes `[4, 4, 2]`;
- row order is preserved;
- the wrapped plan's `output_rows` metric is forwarded; and
- `batches_split == 3`.

The Spark integration test verifies that:

- a single-partition 16-row input expands to 32 rows through native
  `explode`;
- the plan contains `CometExplodeExec`;
- results match Spark;
- `input_rows == 16`;
- `output_rows == 32`; and
- `batches_split > 0` is exposed through the Spark SQL metric map.

```bash
(cd native && \
  cargo test -p datafusion-comet \
  splits_batches_at_the_runtime_batch_size_and_preserves_order)

./mvnw test -Dtest=none \
  -Dsuites="org.apache.comet.exec.CometGenerateExecSuite native explode splits"
```