### PR TITLE
fix: align Spark 4.2 Python worker configuration

### DIFF
--- a/.github/workflows/pyarrow_udf_test.yml
+++ b/.github/workflows/pyarrow_udf_test.yml
@@ -38,6 +38,9 @@ on:
       - "spark/src/main/spark-4.0/org/apache/spark/sql/comet/shims/ShimCometMapInBatch.scala"
       - "spark/src/main/spark-4.1/org/apache/spark/sql/comet/shims/ShimCometMapInBatch.scala"
       - "spark/src/main/spark-4.2/org/apache/spark/sql/comet/shims/ShimCometMapInBatch.scala"
+      - "spark/src/main/spark-4.0/org/apache/spark/sql/execution/python/CometArrowPythonRunner.scala"
+      - "spark/src/main/spark-4.1/org/apache/spark/sql/execution/python/CometArrowPythonRunner.scala"
+      - "spark/src/main/spark-4.2/org/apache/spark/sql/execution/python/CometArrowPythonRunner.scala"
       - "spark/src/main/spark-4.x/org/apache/spark/sql/comet/shims/Spark4xMapInBatchSupport.scala"
       - "spark/src/main/spark-4.x/org/apache/spark/sql/execution/python/CometArrowPythonRunnerBase.scala"
       - "spark/src/test/resources/pyspark/conftest.py"
@@ -66,16 +69,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Run a real Python worker against each 4.x runner. The 4.0 and 4.1 subclasses differ in
-          # constructor shape and `writeUDF` arity, so both need worker-level coverage; a wiring
-          # divergence in one would otherwise slip through. (4.2 is a preview with no released
-          # pyspark, so it stays compile-only via the pr_build matrix.)
+          # Run a real Python worker against each 4.x runner. Their constructor, command framing,
+          # and `writeUDF` shapes differ, so a wiring divergence would otherwise slip through.
           - name: Spark 4.0
             maven_profiles: "-Pspark-4.0 -Pscala-2.13"
             pyspark: "4.0.4"
           - name: Spark 4.1
             maven_profiles: "-Pspark-4.1"
             pyspark: "4.1.3"
+          - name: Spark 4.2
+            maven_profiles: "-Pspark-4.2"
+            pyspark: "4.2.0"
     container:
       # Pinned to the Debian 12 (bookworm) base so the system `python3` is 3.11. The default
       # `amd64/rust` image is Debian 13 (trixie) which ships Python 3.13 and no python3.11 apt

--- a/spark/src/main/spark-4.2/org/apache/spark/sql/execution/python/CometArrowPythonRunner.scala
+++ b/spark/src/main/spark-4.2/org/apache/spark/sql/execution/python/CometArrowPythonRunner.scala
@@ -50,6 +50,13 @@ class CometArrowPythonRunner(
 
   override protected def workerConf: Map[String, String] = pythonRunnerConf
 
+  // Spark 4.2 writes runnerConf and evalConf before writeCommand. Pass Comet's settings through the
+  // native slot and do not emit the legacy map inside the command, which the worker would interpret
+  // as the number of UDFs.
+  override protected def runnerConf: Map[String, String] = super.runnerConf ++ workerConf
+
+  override protected def writeWorkerConf(dataOut: DataOutputStream): Unit = ()
+
   override protected def writeUDF(dataOut: DataOutputStream): Unit =
     PythonUDFRunner.writeUDFs(dataOut, funcs, argOffsets)
 }

--- a/spark/src/main/spark-4.x/org/apache/spark/sql/execution/python/CometArrowPythonRunnerBase.scala
+++ b/spark/src/main/spark-4.x/org/apache/spark/sql/execution/python/CometArrowPythonRunnerBase.scala
@@ -77,6 +77,19 @@ private[python] trait CometArrowPythonRunnerBase
   protected def writeUDF(dataOut: DataOutputStream): Unit
 
   /**
+   * Write the worker configuration where Spark 4.0 and 4.1 workers expect it. Spark 4.2 moved
+   * this map into [[BasePythonRunner.runnerConf]], so its subclass overrides this hook with a
+   * no-op.
+   */
+  protected def writeWorkerConf(dataOut: DataOutputStream): Unit = {
+    dataOut.writeInt(workerConf.size)
+    for ((key, value) <- workerConf) {
+      PythonRDD.writeUTF(key, dataOut)
+      PythonRDD.writeUTF(value, dataOut)
+    }
+  }
+
+  /**
    * Input schema as Comet hands it to the runner: a single non-nullable struct named "struct"
    * whose children are the user's input columns. Comet's FFI-imported vectors carry Arrow
    * `Field`s with null names (Comet uses positional schema), so these names are the source of
@@ -126,11 +139,7 @@ private[python] trait CometArrowPythonRunnerBase
 
       protected override def writeCommand(dataOut: DataOutputStream): Unit = {
         // handleMetadataBeforeExec: write the worker config as key/value string pairs.
-        dataOut.writeInt(workerConf.size)
-        for ((k, v) <- workerConf) {
-          PythonRDD.writeUTF(k, dataOut)
-          PythonRDD.writeUTF(v, dataOut)
-        }
+        writeWorkerConf(dataOut)
         writeUDF(dataOut)
       }
 


### PR DESCRIPTION
## Which issue does this PR close?

Extracted from #5557 while addressing #5555.

## Rationale for this change

Spark 4.2 changed the Python worker command protocol. `BasePythonRunner` now writes `runnerConf` and `evalConf` before `writeCommand`, but Comet still writes its legacy configuration map inside `writeCommand`. The Python worker interprets that extra map size as the number of UDFs, so accelerated `mapInArrow` / `mapInPandas` execution fails before it can read the command.

The problem is independent of large Arrow offsets and was previously missed because the real-worker PyArrow workflow covered Spark 4.0 and 4.1 but not Spark 4.2.

## What changes are included in this PR?

The shared runner extracts its legacy configuration serialization into a hook. Spark 4.0 and 4.1 keep writing that frame in the command exactly as before. The Spark 4.2 subclass instead contributes Comet's worker settings through Spark's native `runnerConf` slot and suppresses the legacy frame.

The PyArrow workflow now watches all three version-specific runner files and runs the existing real-worker suite on released PySpark 4.2.0 in addition to Spark 4.0 and 4.1. This makes protocol drift observable at the worker boundary rather than through compilation alone.

## How are these changes tested?

Native code was built before the JVM checks; this PR does not change native code.

- Spark 4.0 / Scala 2.13 root-reactor package build: **14/14 focused JVM tests passed**, verifying that the shared hook preserves the 4.0 command path.
- The Spark 4.2 subclass compiled against the released Spark 4.2 artifacts, and Spark 4.2 Spotless checked all 447 Scala files.
- Workflow YAML parsing, matrix assertions for Spark 4.0 / 4.1 / 4.2, Scala formatting/style, and `git diff --check` passed.
- The same three-file protocol change passed the Spark 4.2 real-worker job on #5557. This PR's new matrix job will validate the isolated head again.

The configured local Maven mirror stalled while resolving `jackson-bom:2.21.2` for a full Spark 4.2 reactor package, so that local scope remains unverified. The mirror configuration was left unchanged.
