### PR TITLE
test: cover struct data columns in native shuffle

### DIFF
--- a/spark/src/test/scala/org/apache/comet/exec/CometNativeShuffleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometNativeShuffleSuite.scala
@@ -616,6 +616,63 @@ class CometNativeShuffleSuite extends CometTestBase with AdaptiveSparkPlanHelper
     }
   }
 
+  test("native shuffle on struct data column") {
+    // The native shuffle type gate (CometShuffleExchangeExec.supportedSerializableDataType)
+    // allows struct data columns, but nothing exercised them: struct columns can only reach
+    // native shuffle as DATA, since supportedHashPartitioningDataType rejects them as a
+    // hash key. So partition on a primitive and carry the struct along.
+    Seq(10, 201).foreach { numPartitions =>
+      withParquetTable((0 until 50).map(i => (i, (i + 1, (i + 2).toString), i + 3)), "tbl") {
+        val df = sql("SELECT * FROM tbl")
+          .filter($"_3" > 10)
+          .repartition(numPartitions, $"_1")
+          .sortWithinPartitions($"_1")
+
+        checkShuffleAnswer(df, 1)
+      }
+    }
+  }
+
+  test("native shuffle on struct data column including nulls") {
+    Seq(10, 201).foreach { numPartitions =>
+      val data: Seq[(Int, (Int, String))] =
+        Seq((1, (0, "1")), (2, (3, "3")), (3, null), (4, (5, null)))
+      withParquetTable(data, "tbl") {
+        val df = sql("SELECT * FROM tbl")
+          .repartition(numPartitions, $"_1")
+          .sortWithinPartitions($"_1")
+
+        checkShuffleAnswer(df, 1)
+      }
+    }
+  }
+
+  test("native shuffle on deeply nested data columns") {
+    // struct<array<...>> and array<struct<...>>: the recursive branches of the type gate.
+    Seq(10, 201).foreach { numPartitions =>
+      withParquetTable(
+        (0 until 50).map(i =>
+          (i, (Seq(i + 1, i + 2), (i + 3).toString), Seq((i + 4, (i + 5).toString)))),
+        "tbl") {
+        val df = sql("SELECT * FROM tbl")
+          .repartition(numPartitions, $"_1")
+          .sortWithinPartitions($"_1")
+
+        checkShuffleAnswer(df, 1)
+      }
+    }
+  }
+
+  test("native shuffle on struct data column with map field") {
+    withSQLConf(CometConf.COMET_EXEC_LOCAL_TABLE_SCAN_ENABLED.key -> "true") {
+      val df = spark.sql(
+        "SELECT id, named_struct('m', map(id, id + 1), 's', cast(id AS STRING)) AS st " +
+          "FROM VALUES (1), (2), (3) AS t(id)")
+      val shuffled = df.repartition(2, $"id")
+      checkShuffleAnswer(shuffled, 1)
+    }
+  }
+
   test("fix: Comet native shuffle with binary data") {
     withParquetTable((0 until 5).map(i => (i, (i + 1).toLong)), "tbl") {
       val df = sql("SELECT cast(cast(_1 as STRING) as BINARY) as binary, _2 FROM tbl")


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5563.

## Rationale for this change

`CometShuffleExchangeExec.supportedSerializableDataType` allows struct data
columns in native shuffle, but `CometNativeShuffleSuite` never exercised one --
the only nested coverage was `array<array<int>>` and `map<int, null>`, and the
word `struct` did not appear in the suite at all. `CometColumnarShuffleSuite`
has extensive nested coverage, so the gap was specific to native shuffle.

Nested types in shuffle have been a real source of bugs (e.g. cd4d0e25d, #5137,
on nested field nullability in `ShuffleScanExec`), so a behavior the type gate
explicitly claims to support deserves an end-to-end test rather than relying on
it not regressing.

## What changes are included in this PR?

Test-only. Four tests added to `CometNativeShuffleSuite`:

- `native shuffle on struct data column` -- a plain `struct<int, string>`
- `native shuffle on struct data column including nulls` -- a null struct and a
  null field inside a struct
- `native shuffle on deeply nested data columns` -- `struct<array<int>, string>`
  and `array<struct<int, string>>`, covering the recursive branches of the gate
- `native shuffle on struct data column with map field`

All of them partition on a primitive column and carry the struct as a data
column, because `supportedHashPartitioningDataType` rejects nested types as a
hash key -- a struct can only reach native shuffle as data. The first test
carries a comment explaining this, so the arrangement is not mistaken for an
oversight.

No product code is changed.

## How are these changes tested?

This PR is the tests. `CometNativeShuffleSuite` passes locally: 40 tests,
40 succeeded, 0 failed (36 pre-existing + 4 new).

I also mutation-tested them to confirm they are not vacuous: temporarily
changing the native gate's `case StructType(...)` to `false` makes exactly these
4 tests fail while the other 36 keep passing, so they really do assert that
struct data columns go through native shuffle, rather than passing because the
plan silently fell back to Spark.
