### PR TITLE
chore: move dead and defensive serde guards out of convert

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/CometScalarSubquery.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/CometScalarSubquery.scala
@@ -26,28 +26,35 @@ import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
 import org.apache.comet.serde.QueryPlanSerde.{serializeDataType, supportedDataType}
 
 object CometScalarSubquery extends CometExpressionSerde[ScalarSubquery] {
+
+  override def getUnsupportedReasons(): Seq[String] = Seq(
+    "Not all data types are supported for scalar subquery results")
+
+  override def getSupportLevel(expr: ScalarSubquery): SupportLevel =
+    if (supportedDataType(expr.dataType)) {
+      Compatible()
+    } else {
+      Unsupported(Some(s"Unsupported data type: ${expr.dataType}"))
+    }
+
   override def convert(
       expr: ScalarSubquery,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    if (supportedDataType(expr.dataType)) {
-      val dataType = serializeDataType(expr.dataType)
-      if (dataType.isEmpty) {
-        withFallbackReason(
-          expr,
-          s"Failed to serialize datatype ${expr.dataType} for scalar subquery")
-        return None
-      }
-
-      val builder = ExprOuterClass.Subquery
-        .newBuilder()
-        .setId(expr.exprId.id)
-        .setDatatype(dataType.get)
-      Some(ExprOuterClass.Expr.newBuilder().setSubquery(builder).build())
-    } else {
-      withFallbackReason(expr, s"Unsupported data type: ${expr.dataType}")
-      None
+    // getSupportLevel has already screened the data type with `supportedDataType`. That is a
+    // different predicate from `serializeDataType`, which can still decline, so keep this check.
+    val dataType = serializeDataType(expr.dataType)
+    if (dataType.isEmpty) {
+      withFallbackReason(
+        expr,
+        s"Failed to serialize datatype ${expr.dataType} for scalar subquery")
+      return None
     }
 
+    val builder = ExprOuterClass.Subquery
+      .newBuilder()
+      .setId(expr.exprId.id)
+      .setDatatype(dataType.get)
+    Some(ExprOuterClass.Expr.newBuilder().setSubquery(builder).build())
   }
 }

--- a/spark/src/main/scala/org/apache/comet/serde/collectionOperations.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/collectionOperations.scala
@@ -22,7 +22,6 @@ package org.apache.comet.serde
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Reverse, Shuffle}
 import org.apache.spark.sql.types.ArrayType
 
-import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
 import org.apache.comet.serde.ExprOuterClass.Expr
 import org.apache.comet.serde.QueryPlanSerde.exprToProtoInternal
 import org.apache.comet.shims.CometTypeShim
@@ -63,28 +62,35 @@ object CometReverse
 
 object CometShuffle extends CometExpressionSerde[Shuffle] with ArraysBase {
 
+  private val unresolvedSeedReason = "shuffle requires a resolved random seed"
+
+  override def getUnsupportedReasons(): Seq[String] = Seq(unresolvedSeedReason)
+
   // Comet reproduces Spark's random permutation exactly: the resolved seed is combined with the
   // partition index and drives the same MersenneTwister-based inside-out Fisher-Yates shuffle as
   // org.apache.spark.sql.catalyst.util.RandomIndicesGenerator, so results match Spark bit for bit.
-  override def getSupportLevel(expr: Shuffle): SupportLevel = childTypesSupportLevel(expr)
+  override def getSupportLevel(expr: Shuffle): SupportLevel = {
+    // In a resolved plan `randomSeed` is always defined (resolution requires it). Guard anyway,
+    // here rather than in `convert`, so the decline goes through the normal support-level path.
+    if (expr.randomSeed.isEmpty) {
+      Unsupported(Some(unresolvedSeedReason))
+    } else {
+      childTypesSupportLevel(expr)
+    }
+  }
 
   override def convert(expr: Shuffle, inputs: Seq[Attribute], binding: Boolean): Option[Expr] = {
-    // In a resolved plan `randomSeed` is always defined (resolution requires it). Guard anyway.
-    expr.randomSeed match {
-      case Some(seed) =>
-        exprToProtoInternal(expr.child, inputs, binding).map { child =>
-          ExprOuterClass.Expr
+    // getSupportLevel has already verified the seed is resolved.
+    val seed = expr.randomSeed.get
+    exprToProtoInternal(expr.child, inputs, binding).map { child =>
+      ExprOuterClass.Expr
+        .newBuilder()
+        .setShuffle(
+          ExprOuterClass.Shuffle
             .newBuilder()
-            .setShuffle(
-              ExprOuterClass.Shuffle
-                .newBuilder()
-                .setChild(child)
-                .setSeed(seed))
-            .build()
-        }
-      case None =>
-        withFallbackReason(expr, "shuffle requires a resolved random seed")
-        None
+            .setChild(child)
+            .setSeed(seed))
+        .build()
     }
   }
 }

--- a/spark/src/main/scala/org/apache/comet/serde/datetime.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/datetime.scala
@@ -309,13 +309,18 @@ object CometUnixTimestamp extends CometExpressionSerde[UnixTimestamp] {
   }
 
   override def getSupportLevel(expr: UnixTimestamp): SupportLevel = {
-    if (DatetimeCollation.hasNonDefaultCollation(expr)) {
-      Incompatible(Some(collationReason))
-    } else if (isSupportedInputType(expr)) {
-      Compatible()
-    } else {
+    // The input type is screened ahead of the collation check on purpose. A non-date/timestamp
+    // input has no native path at all, so it must report `Unsupported` rather than
+    // `Incompatible`: the latter is waved straight through to `convert` when
+    // `spark.comet.expression.UnixTimestamp.allowIncompatible=true`, and the native kernel then
+    // raises an execution error on the string child instead of falling back to Spark.
+    if (!isSupportedInputType(expr)) {
       val inputType = expr.children.head.dataType
       Unsupported(Some(s"unix_timestamp does not support input type: $inputType"))
+    } else if (DatetimeCollation.hasNonDefaultCollation(expr)) {
+      Incompatible(Some(collationReason))
+    } else {
+      Compatible()
     }
   }
 

--- a/spark/src/main/scala/org/apache/comet/serde/datetime.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/datetime.scala
@@ -27,7 +27,6 @@ import org.apache.spark.sql.types.{CalendarIntervalType, DataType, DateType, Dou
 import org.apache.spark.unsafe.types.UTF8String
 
 import org.apache.comet.CometConf
-import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
 import org.apache.comet.expressions.{CometCast, CometEvalMode}
 import org.apache.comet.serde.CometGetDateField.CometGetDateField
 import org.apache.comet.serde.ExprOuterClass.Expr
@@ -324,12 +323,7 @@ object CometUnixTimestamp extends CometExpressionSerde[UnixTimestamp] {
       expr: UnixTimestamp,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    if (!isSupportedInputType(expr)) {
-      val inputType = expr.children.head.dataType
-      withFallbackReason(expr, s"unix_timestamp does not support input type: $inputType")
-      return None
-    }
-
+    // getSupportLevel reports an unsupported input type before reaching here, so no re-check.
     val childExpr = exprToProtoInternal(expr.children.head, inputs, binding)
 
     if (childExpr.isDefined) {

--- a/spark/src/main/scala/org/apache/comet/serde/nondetermenistic.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/nondetermenistic.scala
@@ -21,8 +21,6 @@ package org.apache.comet.serde
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, Literal, MonotonicallyIncreasingID, Rand, Randn, SparkPartitionID, Uuid}
 
-import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
-
 object CometSparkPartitionId extends CometExpressionSerde[SparkPartitionID] {
   override def convert(
       expr: SparkPartitionID,
@@ -72,6 +70,15 @@ sealed abstract class CometRandCommonSerde[T <: Expression] extends CometExpress
 
 object CometUuid extends CometExpressionSerde[Uuid] {
 
+  private val unresolvedSeedReason = "uuid requires a resolved random seed"
+
+  override def getUnsupportedReasons(): Seq[String] = Seq(unresolvedSeedReason)
+
+  // In a resolved plan `randomSeed` is always defined (resolution requires it). Guard anyway,
+  // here rather than in `convert`, so the decline goes through the normal support-level path.
+  override def getSupportLevel(expr: Uuid): SupportLevel =
+    if (expr.randomSeed.isEmpty) Unsupported(Some(unresolvedSeedReason)) else Compatible()
+
   // Comet reproduces Spark's UUIDs exactly: the resolved seed is combined with the partition index
   // and seeds the same Commons Math3 MersenneTwister that drives
   // org.apache.spark.sql.catalyst.util.RandomUUIDGenerator, so results match Spark bit for bit.
@@ -79,18 +86,12 @@ object CometUuid extends CometExpressionSerde[Uuid] {
       expr: Uuid,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
-    // In a resolved plan `randomSeed` is always defined (resolution requires it). Guard anyway.
-    expr.randomSeed match {
-      case Some(seed) =>
-        Some(
-          ExprOuterClass.Expr
-            .newBuilder()
-            .setUuid(ExprOuterClass.Uuid.newBuilder().setSeed(seed))
-            .build())
-      case None =>
-        withFallbackReason(expr, "uuid requires a resolved random seed")
-        None
-    }
+    // getSupportLevel has already verified the seed is resolved.
+    Some(
+      ExprOuterClass.Expr
+        .newBuilder()
+        .setUuid(ExprOuterClass.Uuid.newBuilder().setSeed(expr.randomSeed.get))
+        .build())
   }
 }
 

--- a/spark/src/main/scala/org/apache/comet/serde/unixtime.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/unixtime.scala
@@ -22,7 +22,6 @@ package org.apache.comet.serde
 import org.apache.spark.sql.catalyst.expressions.{Attribute, FromUnixTime, Literal}
 import org.apache.spark.sql.catalyst.util.TimestampFormatter
 
-import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
 import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, scalarFunctionExprToProto}
 
 // TODO: DataFusion supports only -8334601211038 <= sec <= 8210266876799
@@ -65,6 +64,8 @@ object CometFromUnixTime extends CometExpressionSerde[FromUnixTime] with Codegen
       expr: FromUnixTime,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
+    // getSupportLevel reports a non-default format as `Unsupported`, so it is routed to the
+    // codegen dispatcher (or falls back) before reaching here; only the default pattern arrives.
     val secExpr = exprToProtoInternal(expr.sec, inputs, binding)
     // TODO: DataFusion toChar does not support Spark datetime pattern format
     // https://github.com/apache/datafusion/issues/16577
@@ -73,10 +74,7 @@ object CometFromUnixTime extends CometExpressionSerde[FromUnixTime] with Codegen
     val formatExpr = exprToProtoInternal(Literal("%Y-%m-%d %H:%M:%S"), inputs, binding)
     val timeZone = exprToProtoInternal(Literal(expr.timeZoneId.orNull), inputs, binding)
 
-    if (expr.format != Literal(TimestampFormatter.defaultPattern())) {
-      withFallbackReason(expr, formatReason)
-      None
-    } else if (secExpr.isDefined && formatExpr.isDefined) {
+    if (secExpr.isDefined && formatExpr.isDefined) {
       val timestampExpr =
         scalarFunctionExprToProto("from_unixtime", Seq(secExpr, timeZone): _*)
       val optExpr = scalarFunctionExprToProto("to_char", Seq(timestampExpr, formatExpr): _*)

--- a/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometTemporalExpressionSuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
 
+import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
 import org.apache.comet.serde.{CometDateFormat, CometTruncDate, CometTruncTimestamp}
 import org.apache.comet.testing.{DataGenOptions, FuzzDataGenerator}
 
@@ -402,6 +403,28 @@ class CometTemporalExpressionSuite extends CometTestBase with AdaptiveSparkPlanH
       checkSparkAnswerAndFallbackReason(
         "SELECT ts_str, unix_timestamp(ts_str, 'yyyy-MM-dd HH:mm:ss') from string_tbl",
         "unix_timestamp does not support input type: StringType")
+    }
+  }
+
+  test("unix_timestamp - string input falls back even when a collated format opts into native") {
+    assume(isSpark40Plus, "string collation requires Spark 4.0+")
+    withTempView("string_tbl") {
+      val schema = StructType(Seq(StructField("ts_str", DataTypes.StringType, true)))
+      val data = Seq(Row("2020-01-01 00:00:00"), Row("2021-06-15 12:30:45"), Row(null))
+      spark
+        .createDataFrame(spark.sparkContext.parallelize(data), schema)
+        .createOrReplaceTempView("string_tbl")
+
+      // A collated format argument makes the expression `Incompatible`, which
+      // `allowIncompatible=true` waves straight through to `convert`. The input type has to be
+      // rejected ahead of that opt-in: the native kernel accepts only date/timestamp input, so
+      // serializing a string child raises an execution error instead of falling back to Spark.
+      withSQLConf(CometConf.getExprAllowIncompatConfigKey("UnixTimestamp") -> "true") {
+        checkSparkAnswerAndFallbackReason(
+          "SELECT ts_str, unix_timestamp(ts_str, 'yyyy-MM-dd HH:mm:ss' COLLATE UTF8_LCASE) " +
+            "from string_tbl order by ts_str",
+          "unix_timestamp does not support input type: StringType")
+      }
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

Part of #5574. First of a few small PRs moving `convert`-side declines into `getSupportLevel`; this one is deliberately the zero-risk slice.

## Rationale for this change

A serde that reports `Compatible` from `getSupportLevel` and then returns `None` from `convert` breaks the serde invariant, and it is also the one shape the codegen dispatcher cannot see — `dispatchIfFallback` is reached only from the `Unsupported` and `Incompatible` arms of `exprToProtoInternal` (`QueryPlanSerde.scala:941` and `:968`), so a decline from inside `convert` always costs a whole-operator Spark fallback.

Auditing all 35 `convert`-side declines, five are node-local *and* had no user-visible effect, because each guard was already dead or unreachable. Those are worth moving first: the change is provably behavior-preserving, and it shrinks the surface the harder follow-ups have to reason about.

## What changes are included in this PR?

- **`CometFromUnixTime`** (`unixtime.scala`) and **`CometUnixTimestamp`** (`datetime.scala`) re-checked in `convert` exactly what `getSupportLevel` had already reported as `Unsupported`. `CometFromUnixTime` additionally mixes in `CodegenDispatchFallback`, so the `Unsupported` result is either dispatched or fails before `convert`; either way the declining input never reached the duplicated check. Removed.
- **`CometShuffle`** (`collectionOperations.scala`) and **`CometUuid`** (`nondetermenistic.scala`) guarded a `randomSeed` that their own comments note is always defined in a resolved plan. Moved to `getSupportLevel`; `convert` now reads the seed directly, matching the existing pattern in `CometKnownFloatingPointNormalized` and `CometRandStr`.
- **`CometScalarSubquery`** screened the data type in `convert`. Moved to `getSupportLevel`. The `serializeDataType` backstop stays — that is a genuinely different predicate from `supportedDataType`, as the scaladoc on `serializeDataType` spells out.

Also drops four `withFallbackReason` imports that became unused.

**Deliberately not included:** `CometLiteral`. Its `convert` guards look like the same pattern but are reachable, not dead — `supportedDataType` admits `CalendarIntervalType` while the literal value match has no arm for it, so a non-null calendar-interval literal really does fall through to `case dt =>`. Left as-is.

## How are these changes tested?

No new tests, because there is no new behavior — the point of this slice is that the removed guards were unreachable. Covered by existing suites:

- `CometTemporalExpressionSuite`, `CometUuidExpressionSuite`, `CometArrayExpressionSuite` — 92 tests
- `CometSqlFileTestSuite` (includes `from_unix_time_enabled.sql`, `to_unix_timestamp_time_parser_policy.sql`, `to_unix_timestamp_time_parser_policy_corrected.sql`) and `CometExpressionSuite` — 607 tests

All green on Spark 4.1.
