### PR TITLE
feat: route `round` on float/double through the codegen dispatcher

### DIFF
--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -465,7 +465,7 @@ The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `deci
 | `random` | ✅ | Native | Alias for `rand` (Spark 4.0+); seed must be a literal |
 | `randstr` | ✅ | Native | Random string (Spark 4.0+); length and seed must be literals |
 | `rint` | ✅ | Native |  |
-| `round` | ✅ | Native | Float/double inputs fall back |
+| `round` | ✅ | Hybrid | Float/double inputs route through the JVM codegen dispatcher; other types run natively |
 | `sec` | ✅ | Native |  |
 | `shiftleft` | ✅ | Native |  |
 | `sign` | ✅ | Native |  |

--- a/native/spark-expr/src/math_funcs/round.rs
+++ b/native/spark-expr/src/math_funcs/round.rs
@@ -19,12 +19,9 @@ use crate::arithmetic_overflow_error;
 use crate::math_funcs::utils::{get_precision_scale, make_decimal_array, make_decimal_scalar};
 use arrow::array::{Array, ArrowNativeTypeOp};
 use arrow::array::{Int16Array, Int32Array, Int64Array, Int8Array};
-use arrow::datatypes::{DataType, Field};
+use arrow::datatypes::DataType;
 use arrow::error::ArrowError;
-use datafusion::common::config::ConfigOptions;
 use datafusion::common::{exec_err, internal_err, DataFusionError, ScalarValue};
-use datafusion::functions::math::round::RoundFunc;
-use datafusion::logical_expr::{ScalarFunctionArgs, ScalarUDFImpl};
 use datafusion::physical_plan::ColumnarValue;
 use std::{cmp::min, sync::Arc};
 
@@ -156,6 +153,11 @@ macro_rules! round_integer_scalar {
 }
 
 /// `round` function that simulates Spark `round` expression
+///
+/// Float and double are deliberately absent: Spark rounds them through a `BigDecimal` built from
+/// `java.lang.Double.toString()`, which no native kernel reproduces, so `CometRound` reports those
+/// inputs as `Unsupported` and routes them to the JVM codegen dispatcher instead. They never reach
+/// this function, and fall through to the catch-all error below if they somehow do.
 pub fn spark_round(
     args: &[ColumnarValue],
     data_type: &DataType,
@@ -166,8 +168,6 @@ pub fn spark_round(
     let ColumnarValue::Scalar(ScalarValue::Int64(Some(point))) = point else {
         return internal_err!("Invalid point argument for Round(): {:#?}", point);
     };
-    // DataFusion's RoundFunc expects Int32 for decimal_places
-    let point_i32 = ColumnarValue::Scalar(ScalarValue::Int32(Some(*point as i32)));
     match value {
         ColumnarValue::Array(array) => match array.data_type() {
             DataType::Int64 if *point < 0 => {
@@ -186,18 +186,6 @@ pub fn spark_round(
                 let f = decimal_round_f(scale, point);
                 let (precision, scale) = get_precision_scale(data_type);
                 make_decimal_array(array, precision, scale, &f)
-            }
-            DataType::Float32 | DataType::Float64 => {
-                let round_udf = RoundFunc::new();
-                let return_field = Arc::new(Field::new("round", array.data_type().clone(), true));
-                let args_for_round = ScalarFunctionArgs {
-                    args: vec![ColumnarValue::Array(Arc::clone(array)), point_i32.clone()],
-                    number_rows: array.len(),
-                    return_field,
-                    arg_fields: vec![],
-                    config_options: Arc::new(ConfigOptions::default()),
-                };
-                round_udf.invoke_with_args(args_for_round)
             }
             dt => exec_err!("Not supported datatype for ROUND: {dt}"),
         },
@@ -218,19 +206,6 @@ pub fn spark_round(
                 let f = decimal_round_f(scale, point);
                 let (precision, scale) = get_precision_scale(data_type);
                 make_decimal_scalar(a, precision, scale, &f)
-            }
-            ScalarValue::Float32(_) | ScalarValue::Float64(_) => {
-                let round_udf = RoundFunc::new();
-                let data_type = a.data_type();
-                let return_field = Arc::new(Field::new("round", data_type, true));
-                let args_for_round = ScalarFunctionArgs {
-                    args: vec![ColumnarValue::Scalar(a.clone()), point_i32.clone()],
-                    number_rows: 1,
-                    return_field,
-                    arg_fields: vec![],
-                    config_options: Arc::new(ConfigOptions::default()),
-                };
-                round_udf.invoke_with_args(args_for_round)
             }
             dt => exec_err!("Not supported datatype for ROUND: {dt}"),
         },
@@ -263,79 +238,11 @@ mod test {
 
     use crate::spark_round;
 
-    use arrow::array::{Float32Array, Float64Array, Int64Array};
+    use arrow::array::Int64Array;
     use arrow::datatypes::DataType;
-    use datafusion::common::cast::{as_float32_array, as_float64_array, as_int64_array};
+    use datafusion::common::cast::as_int64_array;
     use datafusion::common::{Result, ScalarValue};
     use datafusion::physical_plan::ColumnarValue;
-
-    #[test]
-    #[cfg_attr(miri, ignore)] // rounding does not work when miri enabled
-    fn test_round_f32_array() -> Result<()> {
-        let args = vec![
-            ColumnarValue::Array(Arc::new(Float32Array::from(vec![
-                125.2345, 15.3455, 0.1234, 0.125, 0.785, 123.123,
-            ]))),
-            ColumnarValue::Scalar(ScalarValue::Int64(Some(2))),
-        ];
-        let ColumnarValue::Array(result) = spark_round(&args, &DataType::Float32, false)? else {
-            unreachable!()
-        };
-        let floats = as_float32_array(&result)?;
-        let expected = Float32Array::from(vec![125.23, 15.35, 0.12, 0.13, 0.79, 123.12]);
-        assert_eq!(floats, &expected);
-        Ok(())
-    }
-
-    #[test]
-    #[cfg_attr(miri, ignore)] // rounding does not work when miri enabled
-    fn test_round_f64_array() -> Result<()> {
-        let args = vec![
-            ColumnarValue::Array(Arc::new(Float64Array::from(vec![
-                125.2345, 15.3455, 0.1234, 0.125, 0.785, 123.123,
-            ]))),
-            ColumnarValue::Scalar(ScalarValue::Int64(Some(2))),
-        ];
-        let ColumnarValue::Array(result) = spark_round(&args, &DataType::Float64, false)? else {
-            unreachable!()
-        };
-        let floats = as_float64_array(&result)?;
-        let expected = Float64Array::from(vec![125.23, 15.35, 0.12, 0.13, 0.79, 123.12]);
-        assert_eq!(floats, &expected);
-        Ok(())
-    }
-
-    #[test]
-    #[cfg_attr(miri, ignore)] // rounding does not work when miri enabled
-    fn test_round_f32_scalar() -> Result<()> {
-        let args = vec![
-            ColumnarValue::Scalar(ScalarValue::Float32(Some(125.2345))),
-            ColumnarValue::Scalar(ScalarValue::Int64(Some(2))),
-        ];
-        let ColumnarValue::Scalar(ScalarValue::Float32(Some(result))) =
-            spark_round(&args, &DataType::Float32, false)?
-        else {
-            unreachable!()
-        };
-        assert_eq!(result, 125.23);
-        Ok(())
-    }
-
-    #[test]
-    #[cfg_attr(miri, ignore)] // rounding does not work when miri enabled
-    fn test_round_f64_scalar() -> Result<()> {
-        let args = vec![
-            ColumnarValue::Scalar(ScalarValue::Float64(Some(125.2345))),
-            ColumnarValue::Scalar(ScalarValue::Int64(Some(2))),
-        ];
-        let ColumnarValue::Scalar(ScalarValue::Float64(Some(result))) =
-            spark_round(&args, &DataType::Float64, false)?
-        else {
-            unreachable!()
-        };
-        assert_eq!(result, 125.23);
-        Ok(())
-    }
 
     // Regression tests for https://github.com/apache/datafusion-comet/issues/5070:
     // round(Int64, scale) where `10^(-scale)` does not fit in i64. For scale=-19,

--- a/spark/src/main/scala/org/apache/comet/serde/arithmetic.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arithmetic.scala
@@ -367,11 +367,29 @@ object CometRemainder extends CometExpressionSerde[Remainder] with MathBase {
   }
 }
 
-object CometRound extends CometExpressionSerde[Round] {
+/**
+ * `round` lowers to the native `round` kernel for integral and non-negative-scale decimal inputs.
+ * The cases below have no native implementation; `CodegenDispatchFallback` keeps them in the
+ * Comet pipeline by running Spark's own `RoundBase.doGenCode` in the JVM codegen dispatcher,
+ * which matches Spark exactly.
+ */
+object CometRound extends CometExpressionSerde[Round] with CodegenDispatchFallback {
+
+  private val negativeScaleReason =
+    "Negative-scale decimal inputs, which are only creatable with " +
+      "spark.sql.legacy.allowNegativeScaleOfDecimal=true"
+
+  private val floatingPointReason =
+    "Float and double inputs. Spark rounds them through a BigDecimal built from " +
+      "`java.lang.Double.toString()` rather than from the exact binary value, and that " +
+      "shortened decimal string can round differently than the value it came from"
+
+  override def getUnsupportedReasons(): Seq[String] =
+    Seq(floatingPointReason, negativeScaleReason)
 
   override def getSupportLevel(expr: Round): SupportLevel = expr.child.dataType match {
     case t: DecimalType if t.scale < 0 => // Spark disallows negative scale SPARK-30252
-      Unsupported(Some("Decimal type has negative scale"))
+      Unsupported(Some(negativeScaleReason))
     case _: FloatType | DoubleType =>
       // We cannot properly match with the Spark behavior for floating-point numbers.
       // Spark uses BigDecimal for rounding float/double, and BigDecimal fist converts a
@@ -387,7 +405,7 @@ object CometRound extends CometExpressionSerde[Round] {
       // I.e. 6.13171162472835E18 == 6.1317116247283497E18. However, toString() does not.
       // That results in round(6.1317116247283497E18, -5) == 6.1317116247282995E18 instead
       // of 6.1317116247283999E18.
-      Unsupported(Some("Comet does not support Spark's BigDecimal rounding"))
+      Unsupported(Some(floatingPointReason))
     case _ =>
       Compatible()
   }

--- a/spark/src/test/resources/sql-tests/expressions/math/round.sql
+++ b/spark/src/test/resources/sql-tests/expressions/math/round.sql
@@ -15,24 +15,60 @@
 -- specific language governing permissions and limitations
 -- under the License.
 
-statement
-CREATE TABLE test_round(d double, i int) USING parquet
+-- Integral and non-negative-scale decimal inputs round natively. Float and double inputs have no
+-- native implementation (Spark rounds them through BigDecimal built from Double.toString), so they
+-- route through the codegen dispatcher and must match Spark exactly.
 
 statement
-INSERT INTO test_round VALUES (2.5, 0), (3.5, 0), (-2.5, 0), (123.456, 2), (123.456, -1), (NULL, 0), (cast('NaN' as double), 0), (cast('Infinity' as double), 0), (0.0, 0)
+CREATE TABLE test_round(d double, f float, dec decimal(10,4), i int, l bigint) USING parquet
 
-query expect_fallback(BigDecimal rounding)
-SELECT round(d, 0) FROM test_round WHERE i = 0
+statement
+INSERT INTO test_round VALUES
+ (2.5, 2.5, 2.5, 25, 25),
+ (3.5, 3.5, 3.5, 35, 35),
+ (-2.5, -2.5, -2.5, -25, -25),
+ (123.456, 123.456, 123.456, 123, 123),
+ (0.0, 0.0, 0.0, 0, 0),
+ (-0.0D, -0.0F, 0.0, 0, 0),
+ (NULL, NULL, NULL, NULL, NULL),
+ (cast('NaN' as double), cast('NaN' as float), 0.0, 0, 0),
+ (cast('Infinity' as double), cast('Infinity' as float), 0.0, 0, 0),
+ (cast('-Infinity' as double), cast('-Infinity' as float), 0.0, 0, 0)
 
-query expect_fallback(BigDecimal rounding)
-SELECT round(d, 2) FROM test_round WHERE i = 2
+query
+SELECT d, round(d), round(d, 0), round(d, 2), round(d, -1) FROM test_round
 
-query expect_fallback(BigDecimal rounding)
-SELECT round(d, -1) FROM test_round WHERE i = -1
+query
+SELECT f, round(f), round(f, 0), round(f, 2), round(f, -1) FROM test_round
 
-query expect_fallback(BigDecimal rounding)
-SELECT round(d) FROM test_round
+-- Null scale makes the whole result null without evaluating the child.
+query
+SELECT round(d, NULL), round(f, NULL) FROM test_round
+
+-- Decimal and integral inputs stay on the native path.
+query
+SELECT dec, round(dec), round(dec, 2), round(dec, -1) FROM test_round
+
+query
+SELECT i, round(i, 0), round(i, -1), round(l, -1) FROM test_round
+
+-- Doubles whose shortest decimal representation rounds differently than the exact binary value.
+-- -5.81855622136895E8 is exactly -581855622.13689494132995605468750, but Double.toString gives
+-- -5.81855622136895E8, so Spark rounds the 5th fractional digit up. 6.1317116247283497E18 is
+-- exactly 6131711624728349696, which Double.toString does not round up. Both cases are why there
+-- is no native float/double path.
+statement
+CREATE TABLE test_round_repr(d double) USING parquet
+
+statement
+INSERT INTO test_round_repr VALUES (-5.81855622136895E8), (6.1317116247283497E18)
+
+query
+SELECT d, round(d, 5), round(d, -5) FROM test_round_repr
 
 -- literal + literal
-query expect_fallback(BigDecimal rounding)
+query
 SELECT round(123.456, 2), round(2.5, 0), round(3.5, 0), round(-2.5, 0), round(NULL, 0)
+
+query
+SELECT round(2.5D, 0), round(3.5D, 0), round(-2.5D, 0), round(2.5F, 0), round(-2.5F, 0)

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q78/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q78/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+-  Project [COMET: Comet does not support Spark's BigDecimal rounding]
-   +- CometColumnarToRow
+CometColumnarToRow
++-  CometTakeOrderedAndProject [COMET-INFO: JVM codegen dispatcher: round]
+   +-  CometProject [COMET-INFO: JVM codegen dispatcher: round]
       +- CometSortMergeJoin
          :- CometProject
          :  +- CometSortMergeJoin
@@ -76,4 +76,4 @@ TakeOrderedAndProject
                                  +- CometFilter
                                     +- CometNativeScan parquet spark_catalog.default.date_dim
 
-Comet accelerated 72 out of 74 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet. Accelerated expressions: 10 native, 0 codegen dispatch.
+Comet accelerated 74 out of 74 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet. Accelerated expressions: 12 native, 1 codegen dispatch.

--- a/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78/extended.txt
+++ b/spark/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78/extended.txt
@@ -1,6 +1,6 @@
-TakeOrderedAndProject
-+-  Project [COMET: Comet does not support Spark's BigDecimal rounding]
-   +- CometColumnarToRow
+CometColumnarToRow
++- CometTakeOrderedAndProject
+   +-  CometProject [COMET-INFO: JVM codegen dispatcher: round]
       +- CometSortMergeJoin
          :- CometProject
          :  +- CometSortMergeJoin
@@ -76,4 +76,4 @@ TakeOrderedAndProject
                                  +- CometFilter
                                     +- CometNativeScan parquet spark_catalog.default.date_dim
 
-Comet accelerated 72 out of 74 eligible operators (97%). Final plan contains 1 transitions between Spark and Comet. Accelerated expressions: 10 native, 0 codegen dispatch.
+Comet accelerated 74 out of 74 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet. Accelerated expressions: 12 native, 1 codegen dispatch.

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -3139,6 +3139,23 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("round on negative-scale decimal") {
+    // Negative-scale decimals only exist with spark.sql.legacy.allowNegativeScaleOfDecimal=true
+    // and cannot be spelled in the SQL type syntax, so build the column with an explicit cast in
+    // the DataFrame API. There is no native round for them; CometRound reports the case as
+    // Unsupported and CodegenDispatchFallback routes it through the JVM codegen dispatcher, so it
+    // stays in the Comet pipeline and matches Spark exactly.
+    withSQLConf("spark.sql.legacy.allowNegativeScaleOfDecimal" -> "true") {
+      val data = Seq(12345.6789, -12345.6789, 0.0, 55555.0, -0.0).map(Tuple1.apply)
+      withParquetTable(data, "tbl") {
+        val df = spark.table("tbl").select(col("_1").cast(DecimalType(10, -2)).as("d"))
+        Seq(-3, -2, -1, 0, 2).foreach { scale =>
+          checkSparkAnswerAndOperator(df.select(round(col("d"), scale)))
+        }
+      }
+    }
+  }
+
   test("test integral divide overflow for decimal") {
     // All inserted values produce a quotient > Decimal(38,0).max (~1e38), so they overflow
     // the intermediate decimal result type.  In legacy/try mode both Spark and Comet return


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5576.

## Rationale for this change

`round` on a float or double fell the whole projection back to Spark:

```scala
case _: FloatType | DoubleType =>
  Unsupported(Some("Comet does not support Spark's BigDecimal rounding"))
```

The reasoning behind that is sound — Spark rounds floating point through a `BigDecimal` built from `java.lang.Double.toString()`, and no native kernel reproduces that. But "we can't do this natively" is precisely what the JVM codegen dispatcher is for: running Spark's own `RoundBase.doGenCode` inside the Comet pipeline gives that behavior byte for byte. `bround` — the sibling function with the *same* `doGenCode` — already dispatches, so the two behaved completely differently for no principled reason.

`round(double_col, n)` is everyday analytics SQL. TPC-DS q78 is a concrete example: it goes from **72/74 eligible operators (97%) to 74/74 (100%)**, and `10 native, 0 codegen dispatch` to `12 native, 1 codegen dispatch` — the projection that used to fall back was also carrying two other expressions that could have run natively.

## What changes are included in this PR?

- `CometRound` mixes in `CodegenDispatchFallback`, adds `getUnsupportedReasons()`, and reuses those reason strings in `getSupportLevel`. Integral and non-negative-scale decimal inputs are unaffected and still take the native path.
- The issue suggested leaving the negative-scale decimal arm alone. It turns out to dispatch cleanly — `canHandle` admits it and the result matches Spark — so both `Unsupported` arms now stay in the Comet pipeline rather than falling back. There is a test pinning that.
- Removes the `Float32`/`Float64` arms of the native `spark_round`. They were unreachable: `CometRound.convert` is the only thing that emits the `round` scalar function and it never emits it for those types. Their unit tests go with them.
- `expressions.md`: `round` is now `Hybrid` rather than `Native`, and the note says where float/double actually run.
- Regenerated the two q78 plan-stability goldens.

## How are these changes tested?

`round.sql` previously marked every query `expect_fallback(BigDecimal rounding)`. Those are now plain `query` records, i.e. `checkSparkAnswerAndOperator`, which fails if anything falls back. The fixture is also extended with a float column, NaN / ±Infinity, null scale, the one-arg form, and the two pathological doubles named in the source comment — `-5.81855622136895E8` and `6.1317116247283497E18` — whose shortest decimal representation rounds differently than the exact binary value. Those are the cases a native implementation would get wrong, so they are the ones worth pinning.

New `CometExpressionSuite` test for negative-scale decimals under `spark.sql.legacy.allowNegativeScaleOfDecimal=true` (built via the DataFrame API, since the type cannot be spelled in SQL syntax).

Run locally:

- `CometSqlFileTestSuite` round fixture and the three `CometExpressionSuite` round tests, on Spark 4.1 and 3.4.
- Both plan-stability suites in check mode on Spark 3.4 and 4.2; goldens regenerated across 3.4 / 3.5 / 4.0 / 4.1 / 4.2, and only the two base q78 files changed — the version-specific directories pruned as duplicates, so every supported version produces the same plan.
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and the `spark-expr` round unit tests; `spotless:check` and `scalastyle:check`.