### PR TITLE
fix: route translate through codegen dispatcher by default

### DIFF
--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -610,7 +610,7 @@ The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `deci
 | `to_char` | ✅ | Codegen dispatch |  |
 | `to_number` | ✅ | Codegen dispatch |  |
 | `to_varchar` | ✅ | Codegen dispatch |  |
-| `translate` | ✅ | Native | DataFusion's `translate` iterates over Unicode graphemes (Spark uses code points) and substitutes U+0000 instead of treating it as a deletion sentinel, so the native path is opt-in via allowIncompatible |
+| `translate` | ✅ | Hybrid | Routes through the JVM codegen dispatcher by default; the native path (which iterates Unicode graphemes rather than code points and substitutes U+0000 instead of a deletion sentinel) is opt-in via allowIncompatible |
 | `trim` | ✅ | Native |  |
 | `try_to_binary` | ✅ | — | Runs natively (rewrites to `try_eval(to_binary(...))`) |
 | `try_to_number` | ✅ | Codegen dispatch | Routed through the JVM codegen dispatcher |

--- a/spark/src/main/scala/org/apache/comet/serde/strings.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/strings.scala
@@ -109,15 +109,37 @@ object CometOctetLength extends CometScalarFunction[OctetLength]("octet_length")
   }
 }
 
-object CometStringTranslate extends CometScalarFunction[StringTranslate]("translate") {
+object CometStringTranslate
+    extends CometScalarFunction[StringTranslate]("translate")
+    with NativeOptInAvailable {
   private val incompatReason =
     "DataFusion's translate iterates over Unicode graphemes (Spark uses code points) and" +
       " substitutes U+0000 instead of treating it as a deletion sentinel"
 
   override def getIncompatibleReasons(): Seq[String] = Seq(incompatReason)
 
-  override def getSupportLevel(expr: StringTranslate): SupportLevel = Incompatible(
-    Some(incompatReason))
+  override def getSupportLevel(expr: StringTranslate): SupportLevel =
+    if (!CometConf.isExprAllowIncompat(getExprConfigName(expr))) {
+      Compatible(nativeOptIn =
+        Some(NativeOptIn(CometConf.getExprAllowIncompatConfigKey(getExprConfigName(expr)))))
+    } else {
+      Compatible()
+    }
+
+  override def convert(
+      expr: StringTranslate,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[Expr] = {
+    if (CometConf.isExprAllowIncompat(getExprConfigName(expr))) {
+      // Native path: faster but iterates Unicode graphemes and substitutes U+0000 rather than
+      // treating it as a deletion sentinel, so it is only used when incompatibility is allowed.
+      super.convert(expr, inputs, binding)
+    } else {
+      // Default: run Spark's own generated code inside the Comet pipeline for exact
+      // compatibility. Falls back to Spark when the codegen dispatcher is disabled.
+      CometScalaUDF.emitJvmCodegenDispatch(expr, inputs, binding)
+    }
+  }
 }
 
 object CometLevenshtein extends CometExpressionSerde[Levenshtein] {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5585.

## Rationale for this change

`CometStringTranslate` reported itself as `Incompatible` unconditionally, forcing whole projections to fall back to Spark unless `spark.comet.expression.StringTranslate.allowIncompatible=true` was set. Comparable string functions (`CometInitCap`, `CometStringReplace`) instead run natively by default through the JVM codegen dispatcher and treat their semantic differences as an opt-in caveat.

## What changes are included in this PR?

- `CometStringTranslate` mixes in `NativeOptInAvailable`: default is `Compatible` and routes through the codegen dispatcher (Spark-compatible); the incompatible native DataFusion path is opt-in via `allowIncompatible`.
- Docs: `translate` updated from `Native` to `Hybrid`.

## How are these changes tested?

Ran the affected suites against Spark 4.1 (`-Dtest=none -Dsuites=...`):

- `CometFallbackInvarianceSuite` — `pass=25 fail=0 excused=0 vacuous=0` (translate is now a real native-vs-fallback parity pass rather than the previous SKIPPED-VACUOUS case).
- `CometStringExpressionSuite` — 39 tests succeeded, 0 failed.
