### PR TITLE
test: enable native path in lower/upper_enabled sql fixtures

### DIFF
--- a/spark/src/test/resources/sql-tests/expressions/string/lower_enabled.sql
+++ b/spark/src/test/resources/sql-tests/expressions/string/lower_enabled.sql
@@ -15,8 +15,9 @@
 -- specific language governing permissions and limitations
 -- under the License.
 
--- Test lower() with the standard allowIncompatible opt-in (happy path)
--- Config: spark.comet.expression.Lower.allowIncompatible=true
+-- Covers the native case-conversion path for lower(), not the codegen
+-- dispatcher used by lower.sql. ASCII inputs only.
+-- Config: spark.comet.caseConversion.enabled=true
 
 statement
 CREATE TABLE test_lower_enabled(s string) USING parquet

--- a/spark/src/test/resources/sql-tests/expressions/string/upper_enabled.sql
+++ b/spark/src/test/resources/sql-tests/expressions/string/upper_enabled.sql
@@ -15,8 +15,9 @@
 -- specific language governing permissions and limitations
 -- under the License.
 
--- Test upper() with the standard allowIncompatible opt-in (happy path)
--- Config: spark.comet.expression.Upper.allowIncompatible=true
+-- Covers the native case-conversion path for upper(), not the codegen
+-- dispatcher used by upper.sql. ASCII inputs only.
+-- Config: spark.comet.caseConversion.enabled=true
 
 statement
 CREATE TABLE test_upper_enabled(s string) USING parquet


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5611.

## Rationale for this change

`lower_enabled.sql` and `upper_enabled.sql` were meant to cover the native case-conversion path, but they set the no-op config `spark.comet.expression.Lower/Upper.allowIncompatible`. The native path is gated by `spark.comet.caseConversion.enabled`, so these fixtures currently exercise the same codegen dispatcher path as plain `lower.sql` / `upper.sql`.

## What changes are included in this PR?

- Point both `_enabled` fixtures at `spark.comet.caseConversion.enabled=true`
- Update header comments to describe the native path (ASCII inputs unchanged)
- Do **not** add `expect_native(...)` yet — that depends on open #5610

## Are these changes tested?

Yes. After `make core` (Spark 4.1):

```
./mvnw test -Dsuites="org.apache.comet.CometSqlFileTestSuite lower_enabled" -Dtest=none
./mvnw test -Dsuites="org.apache.comet.CometSqlFileTestSuite upper_enabled" -Dtest=none
```

Both passed (1 test each, 0 failures).

## Are there any user-facing changes?

No.