### PR TITLE
fix: skip codegen dispatcher null short-circuit when a foldable subtree can raise

### DIFF
--- a/spark/src/main/scala/org/apache/comet/codegen/CometBatchKernelCodegen.scala
+++ b/spark/src/main/scala/org/apache/comet/codegen/CometBatchKernelCodegen.scala
@@ -437,10 +437,13 @@ object CometBatchKernelCodegen extends Logging with CometExprTraitShim with Come
    *   - The root is `NullIntolerant`, so a null input really does mean a null result.
    *   - Every node in the tree is null-propagating ([[allNullIntolerant]]); a `Coalesce` / `If` /
    *     `CaseWhen` anywhere would break the chain.
+   *   - No node other than a `Literal` is foldable ([[noSurvivingFoldableSubtree]]); a foldable
+   *     subtree that `ConstantFolding` left in place is one that threw while folding, and Spark
+   *     may evaluate it -- and raise -- ahead of an input's null check.
    *   - Either the tree reads exactly one ordinal, or every direct child of the root is a leaf
    *     ([[rootChildrenAreLeaves]]). Both shapes make the short-circuit exact:
-   *     - One ordinal: there is nothing left for Spark to evaluate ahead of that ordinal's own
-   *       null check.
+   *     - One ordinal: with no surviving foldable subtree, there is nothing left for Spark to
+   *       evaluate ahead of that ordinal's own null check.
    *     - Leaf-only children: the tree is one level deep, so the only code Spark runs ahead of
    *       its null checks is `BoundReference` / `Literal` reads, which cannot raise. Any error
    *       comes from the root's own logic, which runs only once every input is known non-null --
@@ -457,7 +460,33 @@ object CometBatchKernelCodegen extends Logging with CometExprTraitShim with Come
    */
   private def canShortCircuitNulls(expr: Expression, inputOrdinals: Seq[Int]): Boolean =
     inputOrdinals.nonEmpty && isNullIntolerant(expr) && allNullIntolerant(expr) &&
+      noSurvivingFoldableSubtree(expr) &&
       (inputOrdinals.size == 1 || rootChildrenAreLeaves(expr))
+
+  /**
+   * True iff no node in the tree other than a `Literal` is foldable. One of the conditions on
+   * [[canShortCircuitNulls]], and what closes the single-ordinal hole in #5218 (see #5608).
+   *
+   * A single input ordinal does not by itself mean Spark has nothing to evaluate ahead of that
+   * ordinal's null check: a literal-only subtree between the root and the ordinal can still
+   * raise. `ConstantFolding` normally folds such a subtree away, but it deliberately leaves it in
+   * place when evaluating it throws and it sits inside a conditional branch (it tags the node
+   * `FAILED_TO_EVALUATE` and moves on), so the throwing expression survives into the physical
+   * plan. `IF(flag, upper(substring('abc', CAST(1L DIV 0L AS INT), n)), NULL)` is a witness:
+   * `TernaryExpression.nullSafeCodeGen` emits `Substring`'s `pos` code -- the division -- before
+   * it tests `len`'s null, so Spark raises `DIVIDE_BY_ZERO` on a row where `n` is null while the
+   * short-circuit would return null.
+   *
+   * By the time the dispatcher sees the tree `ConstantFolding` has already run, so a surviving
+   * foldable non-`Literal` node is precisely one that threw during folding -- exactly the
+   * dangerous case. `Literal`s are foldable by definition and must be exempt, or the fast path
+   * would be lost for the common shapes (`upper(substring(s, 1, 2))`, `conv(a, b, c)`, ...).
+   */
+  private def noSurvivingFoldableSubtree(expr: Expression): Boolean =
+    !expr.exists {
+      case _: Literal => false
+      case other => other.foldable
+    }
 
   /**
    * True iff every direct child of the root is a leaf (`BoundReference` or `Literal`), i.e. the

--- a/spark/src/main/scala/org/apache/comet/codegen/CometBatchKernelCodegen.scala
+++ b/spark/src/main/scala/org/apache/comet/codegen/CometBatchKernelCodegen.scala
@@ -465,22 +465,14 @@ object CometBatchKernelCodegen extends Logging with CometExprTraitShim with Come
 
   /**
    * True iff no node in the tree other than a `Literal` is foldable. One of the conditions on
-   * [[canShortCircuitNulls]], and what closes the single-ordinal hole in #5218 (see #5608).
+   * [[canShortCircuitNulls]], and what closes the single-ordinal hole left by #5218 (see #5608).
    *
-   * A single input ordinal does not by itself mean Spark has nothing to evaluate ahead of that
-   * ordinal's null check: a literal-only subtree between the root and the ordinal can still
-   * raise. `ConstantFolding` normally folds such a subtree away, but it deliberately leaves it in
-   * place when evaluating it throws and it sits inside a conditional branch (it tags the node
-   * `FAILED_TO_EVALUATE` and moves on), so the throwing expression survives into the physical
-   * plan. `IF(flag, upper(substring('abc', CAST(1L DIV 0L AS INT), n)), NULL)` is a witness:
-   * `TernaryExpression.nullSafeCodeGen` emits `Substring`'s `pos` code -- the division -- before
-   * it tests `len`'s null, so Spark raises `DIVIDE_BY_ZERO` on a row where `n` is null while the
-   * short-circuit would return null.
-   *
-   * By the time the dispatcher sees the tree `ConstantFolding` has already run, so a surviving
-   * foldable non-`Literal` node is precisely one that threw during folding -- exactly the
-   * dangerous case. `Literal`s are foldable by definition and must be exempt, or the fast path
-   * would be lost for the common shapes (`upper(substring(s, 1, 2))`, `conv(a, b, c)`, ...).
+   * `ConstantFolding` has already run by the time the dispatcher sees the tree, so a surviving
+   * foldable non-`Literal` node is precisely one that threw while folding: the rule tags such a
+   * node `FAILED_TO_EVALUATE` and leaves it in place rather than folding it. That is exactly the
+   * subtree Spark may evaluate -- and raise from -- ahead of an input's null check. `Literal`s
+   * are foldable by definition and must be exempt, or the fast path would be lost for the common
+   * shapes (`upper(substring(s, 1, 2))`, `conv(a, b, c)`, ...).
    */
   private def noSurvivingFoldableSubtree(expr: Expression): Boolean =
     !expr.exists {

--- a/spark/src/test/scala/org/apache/comet/CometCodegenSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCodegenSourceSuite.scala
@@ -24,7 +24,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.apache.spark.SparkConf
 import org.apache.spark.serializer.JavaSerializer
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Add, AddMonths, BoundReference, Cast, Coalesce, Concat, CreateArray, CreateMap, DateFormatClass, ElementAt, Expression, GetStructField, LeafExpression, Length, Literal, MakeTimestamp, MicrosToTimestamp, MillisToTimestamp, MonthsBetween, Nondeterministic, Rand, Size, ToUnixTimestamp, Unevaluable, UnixMicros, UnixMillis, UnixSeconds, Upper}
+import org.apache.spark.sql.catalyst.expressions.{Add, AddMonths, BoundReference, Cast, Coalesce, Concat, CreateArray, CreateMap, DateFormatClass, ElementAt, Expression, GetStructField, IntegralDivide, LeafExpression, Length, Literal, MakeTimestamp, MicrosToTimestamp, MillisToTimestamp, MonthsBetween, Nondeterministic, Rand, Size, Substring, ToUnixTimestamp, Unevaluable, UnixMicros, UnixMillis, UnixSeconds, Upper}
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodeFormatter, CodegenContext, CodegenFallback, ExprCode}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
@@ -195,6 +195,43 @@ class CometCodegenSourceSuite extends AnyFunSuite {
     assert(
       !src.contains("if (this.col0.isNull(i))") && !src.contains("if (this.col1.isNullAt(i))"),
       s"expected no pre-eval input-null short-circuit at all for this shape; got:\n$src")
+  }
+
+  test("NullIntolerant short-circuit skipped when a foldable subtree can raise (#5608)") {
+    // The residual hole left by #5218: the single-ordinal branch was unguarded, on the reasoning
+    // that one input ordinal leaves Spark nothing to evaluate ahead of that ordinal's null check.
+    // A foldable subtree between the root and the ordinal breaks that. `ConstantFolding` normally
+    // folds such a subtree away, but it deliberately leaves it in place when evaluating it throws
+    // and it sits inside a conditional branch, so the throwing expression survives into the
+    // physical plan. Here `TernaryExpression.nullSafeCodeGen` emits `Substring`'s `pos` code --
+    // the division -- before it tests `len`'s null, so Spark raises DIVIDE_BY_ZERO on a row where
+    // col0 is null while the short-circuit would return NULL. See CometCodegenSuite for the
+    // end-to-end witness.
+    val intCol = ArrowColumnSpec(
+      CometBatchKernelCodegen.vectorClassBySimpleName("IntVector"),
+      nullable = true)
+    val expr = Upper(
+      Substring(
+        Literal(UTF8String.fromString("abc"), StringType),
+        Cast(IntegralDivide(Literal(1L), Literal(0L)), IntegerType, ansiEnabled = true),
+        BoundReference(0, IntegerType, nullable = true)))
+    assert(expr.children.head.children.head.foldable, "the throwing subtree must be foldable")
+    val src = gen(expr, intCol)
+    assert(
+      !src.contains("if (this.col0.isNullAt(i))"),
+      s"expected no short-circuit when a foldable subtree under the root can raise; got:\n$src")
+  }
+
+  test("NullIntolerant short-circuit kept when the only foldable nodes are Literals (#5608)") {
+    // Counterpart to the test above, guarding against over-correcting #5608. `Literal` arguments
+    // are foldable by definition and must not disqualify the short-circuit, or the fast path
+    // would be lost for the common `upper(substring(s, 1, 2))` shape.
+    val expr =
+      Upper(Substring(BoundReference(0, StringType, nullable = true), Literal(1), Literal(2)))
+    val src = gen(expr, nullableString)
+    assert(
+      src.contains("if (this.col0.isNull(i))"),
+      s"expected the single-ordinal short-circuit to survive a Literal-only argument list; got:\n$src")
   }
 
   test("NullIntolerant short-circuit kept for a multi-input leaf-only tree (#5218)") {

--- a/spark/src/test/scala/org/apache/comet/CometCodegenSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCodegenSourceSuite.scala
@@ -210,12 +210,16 @@ class CometCodegenSourceSuite extends AnyFunSuite {
     val intCol = ArrowColumnSpec(
       CometBatchKernelCodegen.vectorClassBySimpleName("IntVector"),
       nullable = true)
+    // Bound out so the premise is asserted on the throwing node itself: it must be foldable, or
+    // `noSurvivingFoldableSubtree` has nothing to catch and the test would pass vacuously.
+    val throwingPos =
+      Cast(IntegralDivide(Literal(1L), Literal(0L)), IntegerType, ansiEnabled = true)
+    assert(throwingPos.foldable, "the subtree ConstantFolding leaves in place must be foldable")
     val expr = Upper(
       Substring(
         Literal(UTF8String.fromString("abc"), StringType),
-        Cast(IntegralDivide(Literal(1L), Literal(0L)), IntegerType, ansiEnabled = true),
+        throwingPos,
         BoundReference(0, IntegerType, nullable = true)))
-    assert(expr.children.head.children.head.foldable, "the throwing subtree must be foldable")
     val src = gen(expr, intCol)
     assert(
       !src.contains("if (this.col0.isNullAt(i))"),

--- a/spark/src/test/scala/org/apache/comet/CometCodegenSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCodegenSuite.scala
@@ -1485,6 +1485,39 @@ class CometCodegenSuite
     }
   }
 
+  test(
+    "single-input short-circuit does not swallow an ANSI error from a foldable subtree (#5608)") {
+    // The residual hole left by #5218: `canShortCircuitNulls` assumed a single input ordinal
+    // leaves Spark nothing to evaluate ahead of that ordinal's null check. Not true when a
+    // foldable subtree sits between the root and the ordinal. `ConstantFolding` refuses to fold
+    // `1L DIV 0L` because evaluating it throws and it sits under an `If` branch, so the throwing
+    // expression survives into the physical plan. `TernaryExpression.nullSafeCodeGen` then emits
+    // `Substring`'s `pos` code -- the division -- before it tests `len`'s null, so Spark raises
+    // DIVIDE_BY_ZERO on the (true, NULL) row while the short-circuit returned NULL.
+    withTable("t") {
+      sql("CREATE TABLE t (flag BOOLEAN, n INT) USING parquet")
+      sql("INSERT INTO t VALUES (true, NULL), (false, NULL)")
+      withSQLConf("spark.sql.ansi.enabled" -> "true") {
+        CometScalaUDFCodegen.resetStats()
+        val (sparkErr, cometErr) = checkSparkAnswerMaybeThrows(
+          sql("SELECT IF(flag, upper(substring('abc', CAST(1L DIV 0L AS INT), n)), NULL) FROM t"))
+        val stats = CometScalaUDFCodegen.stats()
+        assert(
+          stats.compileCount + stats.cacheHitCount >= 1,
+          s"expected the codegen dispatcher to run for this query, got $stats")
+        assert(
+          sparkErr.isDefined,
+          "expected Spark to raise DIVIDE_BY_ZERO; the test row is no longer a witness")
+        assert(
+          cometErr.isDefined,
+          "Comet returned a value where Spark raised: the null short-circuit swallowed the error")
+        assert(
+          cometErr.get.getMessage.contains("DIVIDE_BY_ZERO"),
+          s"expected the same DIVIDE_BY_ZERO error Spark raises, got: ${cometErr.get}")
+      }
+    }
+  }
+
   test("multi-input leaf-only NullIntolerant tree short-circuits nulls correctly (#5218)") {
     // The leaf-only-children shape keeps the union-of-ordinals short-circuit, because the only
     // code Spark runs ahead of its own null checks is `BoundReference` reads. Exercises every


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5608.

## Rationale for this change

`CometBatchKernelCodegen.canShortCircuitNulls` allows the pre-`ev.code` null short-circuit whenever the dispatched tree reads exactly one input ordinal, on the reasoning that a single ordinal leaves Spark nothing to evaluate ahead of that ordinal's own null check.

That is not true. A literal-only subtree between the root and the ordinal can still raise. `ConstantFolding` normally folds such a subtree away, but it deliberately leaves it in place when evaluating it throws and it sits inside a conditional branch (it tags the node `FAILED_TO_EVALUATE` and moves on), so the throwing expression survives into the physical plan. The kernel then writes NULL before `ev.code` runs, and an ANSI error Spark raises is silently swallowed:

```sql
CREATE TABLE t (flag BOOLEAN, n INT) USING parquet;
INSERT INTO t VALUES (true, NULL), (false, NULL);

SELECT IF(flag, upper(substring('abc', CAST(1L DIV 0L AS INT), n)), NULL) FROM t;
```

Spark raises `[DIVIDE_BY_ZERO]`; Comet returned a row. Three ordinary things line up: `ConstantFolding` refuses to fold `1L DIV 0L` under the `If` branch, `TernaryExpression.nullSafeCodeGen` emits `Substring`'s `pos` code before it tests `len`'s null, and `Upper` / `Substring` / `Cast` / `IntegralDivide` are all null-intolerant over a single ordinal.

This is the residual hole in #5218: that fix added `rootChildrenAreLeaves` for the multi-ordinal case but left the single-ordinal branch unguarded. `upper` is just a convenient witness; any dispatched null-intolerant root with a throwing foldable subtree between it and its single input reproduces it.

## What changes are included in this PR?

Adds a `noSurvivingFoldableSubtree` condition to `canShortCircuitNulls`: no node in the tree other than a `Literal` may be foldable. By the time the dispatcher sees the tree `ConstantFolding` has already run, so a surviving foldable non-`Literal` node is precisely one that threw during folding, which is exactly the dangerous case.

`Literal`s are exempt, so the existing fast paths are untouched: none of `upper(substring(s, 1, 2))`, `pmod(a, b)`, `a + b`, `conv(a, b, c)` or `make_timestamp(...)` contains a foldable non-`Literal` node. The scaladoc on `canShortCircuitNulls` is updated to record the new condition.

## How are these changes tested?

- `CometCodegenSuite`: a new end-to-end test asserting Comet raises the same `DIVIDE_BY_ZERO` Spark does for the query above, and that the codegen dispatcher actually ran for it. Verified to fail on `main` (`cometErr.isDefined was false`) and pass with the fix, on the `spark-3.4`, `spark-3.5`, `spark-4.0` and `spark-4.1` profiles.
- `CometCodegenSourceSuite`: two generated-source tests, one asserting the short-circuit is not emitted for a single-ordinal tree carrying a throwing foldable subtree, and a counterpart asserting it *is* still emitted when the only foldable nodes are `Literal`s, so the fix is not over-corrected.
- Full `CometCodegenSuite`, `CometCodegenSourceSuite`, `CometCodegenFuzzSuite` and `CometSpecializedGettersDispatchSuite` pass (177 tests).

The `length` / `bit_length` / `octet_length` witnesses listed in the issue are left out here because they only apply once #5607 lands.
