### PR TITLE
fix: accept dictionary encodings in remote shuffle

### DIFF
--- a/native/core/src/execution/jni_api.rs
+++ b/native/core/src/execution/jni_api.rs
@@ -100,7 +100,7 @@ use tokio::sync::mpsc;
 use crate::execution::memory_pools::{create_memory_pool, parse_memory_pool_config};
 use crate::execution::operators::{ScanExec, ShuffleScanExec};
 use crate::execution::shuffle::{
-    read_ipc_compressed, read_ipc_compressed_validated, validate_remote_schema, CompressionCodec,
+    decode_remote_shuffle_batch, read_ipc_compressed, CompressionCodec,
 };
 use crate::execution::spark_plan::SparkPlan;
 
@@ -1297,11 +1297,9 @@ fn decode_shuffle_block(
     let length = length as usize;
     let slice: &[u8] = unsafe { std::slice::from_raw_parts(raw_pointer, length) };
     let batch = if let Some(expected_types) = expected_types {
-        let batch = read_ipc_compressed_validated(slice)?;
-        // Reject incompatible remote schemas before exporting arrays to the JVM. Casting or
-        // importing first can silently change values or bypass remote fetch-failure reporting.
-        validate_remote_schema(&batch, expected_types)?;
-        batch
+        // Reject incompatible logical types, then decode dictionaries before JVM import. The
+        // JVM importer supports fewer dictionary key/value layouts than the shuffle writer.
+        decode_remote_shuffle_batch(slice, expected_types)?
     } else {
         read_ipc_compressed(slice)?
     };

--- a/native/core/src/execution/operators/shuffle_scan.rs
+++ b/native/core/src/execution/operators/shuffle_scan.rs
@@ -20,7 +20,7 @@ use crate::{
     execution::{
         operators::ExecutionError,
         planner::TEST_EXEC_CONTEXT_ID,
-        shuffle::{read_ipc_compressed, read_ipc_compressed_validated, validate_remote_schema},
+        shuffle::{decode_remote_shuffle_batch, read_ipc_compressed},
     },
     jvm_bridge::{jni_call, JVMClasses},
 };
@@ -230,11 +230,9 @@ fn decode_shuffle_batch(
     requires_validation: bool,
 ) -> DataFusionResult<RecordBatch> {
     if requires_validation {
-        let batch = read_ipc_compressed_validated(bytes)?;
-        // Validate before unpack_dictionary or cast_and_stamp_schema can hide an incompatible
-        // wire type by changing values. Keep failures inside get_next's recovery callback.
-        validate_remote_schema(&batch, expected_types)?;
-        Ok(batch)
+        // Validate logical types before decoding dictionaries or normalizing nested fields.
+        // Keep both validation and normalization failures inside get_next's recovery callback.
+        decode_remote_shuffle_batch(bytes, expected_types)
     } else {
         check_column_count(read_ipc_compressed(bytes)?, expected_types.len())
     }
@@ -452,7 +450,7 @@ mod tests {
         };
         payload[signed_flag] = 0;
 
-        let decoded = super::read_ipc_compressed_validated(&payload).unwrap();
+        let decoded = crate::execution::shuffle::read_ipc_compressed_validated(&payload).unwrap();
         assert_eq!(decoded.num_columns(), 1);
         assert_eq!(decoded.column(0).data_type(), &DataType::UInt32);
         assert_eq!(
@@ -568,13 +566,13 @@ mod tests {
     fn test_dictionary_encoded_shuffle_block_is_unpacked() {
         use super::*;
         use arrow::array::StringDictionaryBuilder;
-        use arrow::datatypes::Int32Type;
+        use arrow::datatypes::Int8Type;
         use datafusion::physical_plan::ExecutionPlan;
         use futures::StreamExt;
 
         // Build a batch with a dictionary-encoded string column (simulating what
         // the native shuffle writer produces for string columns).
-        let mut dict_builder = StringDictionaryBuilder::<Int32Type>::new();
+        let mut dict_builder = StringDictionaryBuilder::<Int8Type>::new();
         dict_builder.append_value("hello");
         dict_builder.append_value("world");
         dict_builder.append_value("hello"); // repeated value, good for dictionary
@@ -585,7 +583,7 @@ mod tests {
             Field::new("id", DataType::Int32, false),
             Field::new(
                 "name",
-                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
                 true,
             ),
         ]));
@@ -614,14 +612,17 @@ mod tests {
         let bytes = buf.into_inner();
         let body = &bytes[16..];
 
-        // Remote schema validation must preserve the writer's dictionary representation.
+        // Local decoding preserves the wire encoding for get_next to unpack. Remote decoding
+        // validates and unpacks first, so the same result can also be safely imported by the JVM.
+        let local =
+            super::decode_shuffle_batch(body, &[DataType::Int32, DataType::Utf8], false).unwrap();
+        assert!(matches!(
+            local.column(1).data_type(),
+            DataType::Dictionary(_, _)
+        ));
         let decoded =
             super::decode_shuffle_batch(body, &[DataType::Int32, DataType::Utf8], true).unwrap();
-        assert!(
-            matches!(decoded.column(1).data_type(), DataType::Dictionary(_, _)),
-            "Expected dictionary-encoded column from IPC, got {:?}",
-            decoded.column(1).data_type()
-        );
+        assert_eq!(decoded.column(1).data_type(), &DataType::Utf8);
 
         // Create ShuffleScanExec with value types (Utf8, not Dictionary) — this is
         // what the protobuf schema provides.

--- a/native/shuffle/src/lib.rs
+++ b/native/shuffle/src/lib.rs
@@ -21,6 +21,8 @@ pub(crate) mod metrics;
 pub(crate) mod partitioners;
 mod remote_schema;
 #[cfg(test)]
+mod remote_schema_tests;
+#[cfg(test)]
 mod rss_execution_tests;
 mod schema_align;
 mod shuffle_writer;
@@ -30,7 +32,7 @@ pub(crate) mod writers;
 
 pub use comet_partitioning::CometPartitioning;
 pub use ipc::{read_ipc_compressed, read_ipc_compressed_validated};
-pub use remote_schema::validate_remote_schema;
+pub use remote_schema::{decode_remote_shuffle_batch, validate_remote_schema};
 pub use schema_align::SchemaAlignExec;
 pub use shuffle_writer::{ShuffleWriterDestination, ShuffleWriterExec};
 pub use writers::{CompressionCodec, ShuffleBlockWriter};

--- a/native/shuffle/src/remote_schema.rs
+++ b/native/shuffle/src/remote_schema.rs
@@ -16,18 +16,73 @@
 // under the License.
 
 use arrow::array::RecordBatch;
-use arrow::datatypes::DataType;
+use arrow::datatypes::{DataType, Schema};
 use datafusion::common::DataFusionError;
 use datafusion::error::Result;
+use datafusion_comet_common::cast_and_stamp_schema;
+use std::sync::Arc;
+
+/// Decode a remote shuffle batch and reconcile its encoding with Spark's declared logical types.
+/// Validate buffers and logical types before casting, so a corrupt frame cannot be made to look
+/// compatible by a value-changing cast. Dictionary keys are an encoding detail, including inside
+/// containers: decode them here before either native execution or the JVM Arrow importer sees them.
+pub fn decode_remote_shuffle_batch(
+    bytes: &[u8],
+    expected_types: &[DataType],
+) -> Result<RecordBatch> {
+    let batch = crate::read_ipc_compressed_validated(bytes)?;
+    validate_remote_schema(&batch, expected_types)?;
+    if batch
+        .columns()
+        .iter()
+        .zip(expected_types)
+        .all(|(column, expected)| column.data_type() == expected)
+    {
+        return Ok(batch);
+    }
+
+    let fields: Vec<_> = batch
+        .schema()
+        .fields()
+        .iter()
+        .zip(expected_types)
+        .map(|(field, expected)| {
+            // Non-null dictionary keys can reference null values. The declared types do not
+            // constrain top-level nullability; match ShuffleScanExec's nullable output fields.
+            field
+                .as_ref()
+                .clone()
+                .with_data_type(expected.clone())
+                .with_nullable(true)
+        })
+        .collect();
+    let schema = Arc::new(Schema::new_with_metadata(
+        fields,
+        batch.schema().metadata().clone(),
+    ));
+    // Match the local reader's unpack-then-normalize order. Taking the dictionary keys first
+    // removes unused values, which may contain nulls that cannot satisfy the expected nested
+    // nullability even though every referenced value does.
+    let columns = batch
+        .columns()
+        .iter()
+        .map(|column| match column.data_type() {
+            DataType::Dictionary(_, values) => {
+                arrow::compute::cast(column, values).map_err(DataFusionError::from)
+            }
+            _ => Ok(Arc::clone(column)),
+        })
+        .collect::<Result<Vec<_>>>()?;
+    cast_and_stamp_schema("Remote shuffle reader", &schema, columns, batch.num_rows())
+}
 
 /// Check a remotely fetched batch against the logical types declared by Spark before any cast
 /// or JVM Arrow import. Arrow buffer validation alone cannot detect a valid but incorrect IPC
 /// type, and a general cast can silently change values or turn them into nulls.
 ///
-/// Native shuffle writers align their input with Spark's types before partitioning; row writers
-/// build those types directly. Row writers may use top-level Int32-keyed string/binary
-/// dictionaries, but disable dictionaries inside containers. Do not accept other dictionary
-/// layouts just because Arrow can cast them: the JVM importer does not support all of them.
+/// Dictionary encoding does not change the logical value type, regardless of key width or nesting.
+/// Callers must decode accepted dictionaries before JVM import; use [`decode_remote_shuffle_batch`]
+/// to keep buffer validation, logical validation, and normalization in that order.
 ///
 /// Nested nullability and metadata are normalized separately. List element and map entries names
 /// are synthetic (for example, Rust uses `item` while the JVM uses `element`), but struct member
@@ -44,16 +99,7 @@ pub fn validate_remote_schema(batch: &RecordBatch, expected_types: &[DataType]) 
 
     for (index, (column, expected)) in batch.columns().iter().zip(expected_types).enumerate() {
         let actual = column.data_type();
-        let value_type = match actual {
-            DataType::Dictionary(keys, values)
-                if keys.as_ref() == &DataType::Int32
-                    && matches!(values.as_ref(), DataType::Utf8 | DataType::Binary) =>
-            {
-                values.as_ref()
-            }
-            _ => actual,
-        };
-        if !same_logical_type(value_type, expected) {
+        if !same_logical_type(actual, expected) {
             return Err(DataFusionError::Execution(format!(
                 "Shuffle block type mismatch at column {index}: got {actual} but expected {expected}"
             )));
@@ -64,6 +110,7 @@ pub fn validate_remote_schema(batch: &RecordBatch, expected_types: &[DataType]) 
 
 fn same_logical_type(actual: &DataType, expected: &DataType) -> bool {
     match (actual, expected) {
+        (DataType::Dictionary(_, values), _) => same_logical_type(values, expected),
         (DataType::List(a), DataType::List(e))
         | (DataType::LargeList(a), DataType::LargeList(e)) => {
             same_logical_type(a.data_type(), e.data_type())
@@ -100,7 +147,7 @@ mod tests {
         TimestampMicrosecondArray,
     };
     use arrow::buffer::OffsetBuffer;
-    use arrow::datatypes::{DataType, Field, Fields, Int32Type, IntervalUnit, Schema, TimeUnit};
+    use arrow::datatypes::{DataType, Field, Fields, Int32Type, Schema, TimeUnit};
     use arrow::ipc::writer::StreamWriter;
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -263,22 +310,16 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_or_wrongly_typed_dictionaries_are_rejected() {
+    fn dictionaries_with_wrong_logical_types_are_rejected() {
         use DataType::*;
         for (actual, expected) in [
             (dictionary(Int32, UInt32), Int32),
             (dictionary(Int32, Utf8), Int32),
-            (dictionary(Int32, Int32), Int32),
-            (dictionary(Int32, Null), Null),
-            (
-                dictionary(Int32, Interval(IntervalUnit::MonthDayNano)),
-                Interval(IntervalUnit::MonthDayNano),
-            ),
-            (dictionary(Int8, Utf8), Utf8),
-            (dictionary(UInt32, Utf8), Utf8),
-            (dictionary(Int32, list(Utf8)), list(Utf8)),
-            (dictionary(Int32, dictionary(Int32, Utf8)), Utf8),
-            (list(dictionary(Int32, Utf8)), list(Utf8)),
+            (dictionary(Int8, Utf8), Binary),
+            (dictionary(UInt32, Int64), Int32),
+            (dictionary(Int32, list(Utf8)), list(Binary)),
+            (dictionary(Int32, dictionary(Int8, UInt32)), Int32),
+            (list(dictionary(Int32, Utf8)), list(Binary)),
         ] {
             let error = validate_remote_schema(&batch_of_type(actual), &[expected])
                 .unwrap_err()

--- a/native/shuffle/src/remote_schema.rs
+++ b/native/shuffle/src/remote_schema.rs
@@ -15,8 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::RecordBatch;
-use arrow::datatypes::{DataType, Schema};
+use arrow::array::{
+    Array, ArrayRef, AsArray, FixedSizeListArray, GenericListArray, MapArray, OffsetSizeTrait,
+    RecordBatch, StructArray,
+};
+use arrow::datatypes::{DataType, FieldRef, Schema};
 use datafusion::common::DataFusionError;
 use datafusion::error::Result;
 use datafusion_comet_common::cast_and_stamp_schema;
@@ -60,20 +63,125 @@ pub fn decode_remote_shuffle_batch(
         fields,
         batch.schema().metadata().clone(),
     ));
-    // Match the local reader's unpack-then-normalize order. Taking the dictionary keys first
-    // removes unused values, which may contain nulls that cannot satisfy the expected nested
-    // nullability even though every referenced value does.
+    // Select dictionary values at every nesting level before narrowing nullability. Unused
+    // values may contain nulls even when every referenced value satisfies the expected schema.
     let columns = batch
         .columns()
         .iter()
-        .map(|column| match column.data_type() {
-            DataType::Dictionary(_, values) => {
-                arrow::compute::cast(column, values).map_err(DataFusionError::from)
-            }
-            _ => Ok(Arc::clone(column)),
-        })
+        .map(unpack_dictionaries)
         .collect::<Result<Vec<_>>>()?;
     cast_and_stamp_schema("Remote shuffle reader", &schema, columns, batch.num_rows())
+}
+
+/// Decode dictionary rows before visiting their children or reconciling field nullability.
+/// Casting to a dictionary's value type is not equivalent: Arrow can cast the entire values
+/// table before selecting keys, or reinterpret the outer keys as a nested dictionary's key type.
+fn unpack_dictionaries(array: &ArrayRef) -> Result<ArrayRef> {
+    if let Some(dictionary) = array.as_any_dictionary_opt() {
+        let values = arrow::compute::take(dictionary.values().as_ref(), dictionary.keys(), None)?;
+        return unpack_dictionaries(&values);
+    }
+
+    match array.data_type() {
+        DataType::List(field) => unpack_list_dictionaries::<i32>(array, field),
+        DataType::LargeList(field) => unpack_list_dictionaries::<i64>(array, field),
+        DataType::FixedSizeList(field, size) => {
+            let list = array.as_fixed_size_list();
+            let values = unpack_dictionaries(list.values())?;
+            if Arc::ptr_eq(&values, list.values()) {
+                return Ok(Arc::clone(array));
+            }
+            let field = Arc::new(
+                field
+                    .as_ref()
+                    .clone()
+                    .with_data_type(values.data_type().clone()),
+            );
+            Ok(Arc::new(FixedSizeListArray::try_new_with_length(
+                field,
+                *size,
+                values,
+                list.nulls().cloned(),
+                list.len(),
+            )?))
+        }
+        DataType::Struct(fields) => {
+            let structure = array.as_struct();
+            let columns = structure
+                .columns()
+                .iter()
+                .map(unpack_dictionaries)
+                .collect::<Result<Vec<_>>>()?;
+            if columns
+                .iter()
+                .zip(structure.columns())
+                .all(|(decoded, original)| Arc::ptr_eq(decoded, original))
+            {
+                return Ok(Arc::clone(array));
+            }
+            let fields = fields
+                .iter()
+                .zip(&columns)
+                .map(|(field, column)| {
+                    field
+                        .as_ref()
+                        .clone()
+                        .with_data_type(column.data_type().clone())
+                })
+                .collect();
+            Ok(Arc::new(StructArray::try_new_with_length(
+                fields,
+                columns,
+                structure.nulls().cloned(),
+                structure.len(),
+            )?))
+        }
+        DataType::Map(field, ordered) => {
+            let map = array.as_map();
+            let original_entries: ArrayRef = Arc::new(map.entries().clone());
+            let entries = unpack_dictionaries(&original_entries)?;
+            if Arc::ptr_eq(&entries, &original_entries) {
+                return Ok(Arc::clone(array));
+            }
+            let field = Arc::new(
+                field
+                    .as_ref()
+                    .clone()
+                    .with_data_type(entries.data_type().clone()),
+            );
+            Ok(Arc::new(MapArray::try_new(
+                field,
+                map.offsets().clone(),
+                entries.as_struct().clone(),
+                map.nulls().cloned(),
+                *ordered,
+            )?))
+        }
+        _ => Ok(Arc::clone(array)),
+    }
+}
+
+fn unpack_list_dictionaries<O: OffsetSizeTrait>(
+    array: &ArrayRef,
+    field: &FieldRef,
+) -> Result<ArrayRef> {
+    let list = array.as_list::<O>();
+    let values = unpack_dictionaries(list.values())?;
+    if Arc::ptr_eq(&values, list.values()) {
+        return Ok(Arc::clone(array));
+    }
+    let field = Arc::new(
+        field
+            .as_ref()
+            .clone()
+            .with_data_type(values.data_type().clone()),
+    );
+    Ok(Arc::new(GenericListArray::<O>::try_new(
+        field,
+        list.offsets().clone(),
+        values,
+        list.nulls().cloned(),
+    )?))
 }
 
 /// Check a remotely fetched batch against the logical types declared by Spark before any cast
@@ -139,7 +247,7 @@ fn same_logical_type(actual: &DataType, expected: &DataType) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_remote_schema;
+    use super::{unpack_dictionaries, validate_remote_schema};
     use crate::read_ipc_compressed_validated;
     use arrow::array::{
         Array, ArrayRef, BinaryArray, BinaryDictionaryBuilder, Decimal128Array, Int32Array,
@@ -151,6 +259,37 @@ mod tests {
     use arrow::ipc::writer::StreamWriter;
     use std::collections::HashMap;
     use std::sync::Arc;
+
+    #[test]
+    fn unpacking_nested_dictionaries_preserves_each_key_type() {
+        use arrow::array::{DictionaryArray, Int8Array, UInt16Array};
+        use arrow::datatypes::{Int8Type, UInt16Type};
+
+        // IPC has only one dictionary encoding per field. Exercise the array-level helper
+        // directly to ensure it gathers outer keys rather than casting them to the inner type.
+        let mut inner_keys = vec![Some(0); 129];
+        inner_keys[1] = None;
+        inner_keys[128] = Some(1);
+        let inner = Arc::new(
+            DictionaryArray::<Int8Type>::try_new(
+                Int8Array::from(inner_keys),
+                Arc::new(Int32Array::from(vec![7, 42])),
+            )
+            .unwrap(),
+        );
+        let outer: ArrayRef = Arc::new(
+            DictionaryArray::<UInt16Type>::try_new(
+                UInt16Array::from(vec![Some(128), None, Some(1), Some(0)]),
+                inner,
+            )
+            .unwrap(),
+        );
+        let decoded = unpack_dictionaries(&outer).unwrap();
+        assert_eq!(
+            decoded.to_data(),
+            Int32Array::from(vec![Some(42), None, None, Some(7)]).to_data()
+        );
+    }
 
     fn batch_of_type(data_type: DataType) -> RecordBatch {
         RecordBatch::new_empty(Arc::new(Schema::new(vec![Field::new(

--- a/native/shuffle/src/remote_schema_tests.rs
+++ b/native/shuffle/src/remote_schema_tests.rs
@@ -330,6 +330,166 @@ fn unused_dictionary_values_do_not_prevent_nested_nullability_narrowing() {
     assert_eq!(decoded.column(0).to_data(), expected.to_data());
 }
 
+fn struct_dictionary_values(encoded: bool, reference_null: bool) -> ArrayRef {
+    if encoded {
+        Arc::new(
+            DictionaryArray::<Int32Type>::try_new(
+                Int32Array::from(vec![0, i32::from(reference_null)]),
+                Arc::new(StructArray::new(
+                    Fields::from(vec![Field::new("value", DataType::Int32, true)]),
+                    vec![Arc::new(Int32Array::from(vec![Some(7), None]))],
+                    None,
+                )),
+            )
+            .unwrap(),
+        )
+    } else {
+        Arc::new(StructArray::new(
+            Fields::from(vec![Field::new("value", DataType::Int32, false)]),
+            vec![Arc::new(Int32Array::from(vec![7, 7]))],
+            None,
+        ))
+    }
+}
+
+fn nested_struct_dictionary_columns(encoded: bool, reference_null: bool) -> Vec<ArrayRef> {
+    let values = struct_dictionary_values(encoded, reference_null);
+    let item = Arc::new(Field::new("element", values.data_type().clone(), true));
+    let nulls = Some(NullBuffer::from(vec![false, true]));
+    let map_fields = Fields::from(vec![
+        Field::new("key", DataType::Int32, false),
+        Field::new("value", values.data_type().clone(), true),
+    ]);
+    vec![
+        Arc::new(ListArray::new(
+            Arc::clone(&item),
+            OffsetBuffer::new(vec![0, 1, 2].into()),
+            Arc::clone(&values),
+            nulls.clone(),
+        )),
+        Arc::new(LargeListArray::new(
+            Arc::clone(&item),
+            OffsetBuffer::new(vec![0_i64, 1, 2].into()),
+            Arc::clone(&values),
+            nulls.clone(),
+        )),
+        Arc::new(FixedSizeListArray::new(
+            item,
+            1,
+            Arc::clone(&values),
+            nulls.clone(),
+        )),
+        Arc::new(StructArray::new(
+            Fields::from(vec![Field::new(
+                "payload",
+                values.data_type().clone(),
+                true,
+            )]),
+            vec![Arc::clone(&values)],
+            nulls.clone(),
+        )),
+        Arc::new(MapArray::new(
+            Arc::new(Field::new(
+                "entries",
+                DataType::Struct(map_fields.clone()),
+                false,
+            )),
+            OffsetBuffer::new(vec![0, 1, 2].into()),
+            StructArray::new(
+                map_fields,
+                vec![Arc::new(Int32Array::from(vec![1, 2])), values],
+                None,
+            ),
+            nulls,
+            false,
+        )),
+    ]
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn nested_dictionary_values_are_selected_before_nullability_narrowing() {
+    let list = |values: ArrayRef| -> ArrayRef {
+        Arc::new(ListArray::new(
+            Arc::new(Field::new("element", values.data_type().clone(), true)),
+            OffsetBuffer::new(vec![0, 2].into()),
+            values,
+            None,
+        ))
+    };
+    // Regression: List<Dictionary<Int32, Struct<value: nullable Int32>>> must decode
+    // to List<Struct<value: non-null Int32>> when neither key references the null value.
+    assert_roundtrip(
+        vec![list(struct_dictionary_values(true, false))],
+        vec![list(struct_dictionary_values(false, false))],
+    );
+    for (actual, expected) in nested_struct_dictionary_columns(true, false)
+        .into_iter()
+        .zip(nested_struct_dictionary_columns(false, false))
+    {
+        // Keep a null parent and a non-null parent, then separately exercise a nonzero slice.
+        // The unreferenced dictionary value contains a null, but both keys reference {value: 7}.
+        assert_roundtrip(vec![actual.slice(1, 1)], vec![expected.slice(1, 1)]);
+        assert_roundtrip(vec![actual], vec![expected]);
+    }
+}
+
+#[test]
+fn referenced_null_dictionary_values_cannot_satisfy_non_null_nested_fields() {
+    for (actual, expected) in nested_struct_dictionary_columns(true, true)
+        .into_iter()
+        .zip(nested_struct_dictionary_columns(false, false))
+    {
+        for rss in [false, true] {
+            let bytes = encoded_batch(
+                &batch(vec![Arc::clone(&actual)]),
+                CompressionCodec::None,
+                rss,
+            );
+            let error = decode_remote_shuffle_batch(&bytes, &[expected.data_type().clone()])
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("null"), "{error}");
+        }
+    }
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn dictionary_value_nulls_masked_by_parent_nulls_remain_valid() {
+    let dictionary: ArrayRef = Arc::new(
+        DictionaryArray::<Int32Type>::try_new(
+            Int32Array::from(vec![0, 1]),
+            Arc::new(Int32Array::from(vec![Some(7), None])),
+        )
+        .unwrap(),
+    );
+    let expected: ArrayRef = Arc::new(Int32Array::from(vec![Some(7), None]));
+    let nulls = Some(NullBuffer::from(vec![true, false]));
+    let structure = |values: ArrayRef| -> ArrayRef {
+        Arc::new(StructArray::new(
+            Fields::from(vec![Field::new("value", values.data_type().clone(), false)]),
+            vec![values],
+            nulls.clone(),
+        ))
+    };
+    let fixed_size_list = |values: ArrayRef| -> ArrayRef {
+        Arc::new(FixedSizeListArray::new(
+            Arc::new(Field::new("element", values.data_type().clone(), false)),
+            1,
+            values,
+            nulls.clone(),
+        ))
+    };
+    assert_roundtrip(
+        vec![
+            structure(Arc::clone(&dictionary)),
+            fixed_size_list(dictionary),
+        ],
+        vec![structure(Arc::clone(&expected)), fixed_size_list(expected)],
+    );
+}
+
 #[test]
 fn dictionary_decoding_does_not_allow_logical_type_or_container_shape_changes() {
     let numeric = numbers(true);

--- a/native/shuffle/src/remote_schema_tests.rs
+++ b/native/shuffle/src/remote_schema_tests.rs
@@ -1,0 +1,412 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::{decode_remote_shuffle_batch, CompressionCodec, ShuffleBlockWriter};
+use arrow::array::{
+    Array, ArrayRef, BinaryArray, BinaryDictionaryBuilder, DictionaryArray, FixedSizeListArray,
+    Int16Array, Int32Array, LargeListArray, ListArray, MapArray, PrimitiveDictionaryBuilder,
+    RecordBatch, RecordBatchOptions, StringArray, StringDictionaryBuilder, StructArray,
+    UInt16Array,
+};
+use arrow::buffer::{NullBuffer, OffsetBuffer};
+use arrow::datatypes::{
+    ArrowDictionaryKeyType, DataType, Field, Fields, Int16Type, Int32Type, Int64Type, Int8Type,
+    Schema, UInt16Type, UInt32Type, UInt64Type, UInt8Type,
+};
+use arrow::ipc::writer::CompressionContext;
+use datafusion::physical_plan::metrics::Time;
+use std::io::Cursor;
+use std::sync::Arc;
+
+fn encoded_batch(batch: &RecordBatch, codec: CompressionCodec, rss: bool) -> Vec<u8> {
+    let writer = if rss {
+        ShuffleBlockWriter::try_new_rss(batch.schema(), codec)
+    } else {
+        ShuffleBlockWriter::try_new(batch.schema().as_ref(), codec)
+    }
+    .unwrap();
+    let mut output = Cursor::new(Vec::new());
+    let mut context = CompressionContext::default();
+    if rss {
+        writer
+            .write_rss_batch(batch, &mut output, &mut context, &Time::default())
+            .unwrap();
+    } else {
+        writer
+            .write_batch(batch, &mut output, &mut context, &Time::default())
+            .unwrap();
+    }
+    // The transport consumes the u64 block length and column count before the codec and IPC.
+    output.into_inner()[16..].to_vec()
+}
+
+fn batch(columns: Vec<ArrayRef>) -> RecordBatch {
+    RecordBatch::try_from_iter(
+        columns
+            .into_iter()
+            .enumerate()
+            .map(|(index, column)| (format!("column_{index}"), column)),
+    )
+    .unwrap()
+}
+
+fn assert_roundtrip(actual: Vec<ArrayRef>, expected: Vec<ArrayRef>) {
+    let batch = batch(actual);
+    let types: Vec<_> = expected
+        .iter()
+        .map(|array| array.data_type().clone())
+        .collect();
+    for codec in [
+        CompressionCodec::None,
+        CompressionCodec::Lz4Frame,
+        CompressionCodec::Snappy,
+        CompressionCodec::Zstd(1),
+    ] {
+        for rss in [false, true] {
+            let bytes = encoded_batch(&batch, codec.clone(), rss);
+            let decoded = decode_remote_shuffle_batch(&bytes, &types).unwrap();
+            assert_eq!(decoded.num_rows(), batch.num_rows());
+            for (actual, expected) in decoded.columns().iter().zip(&expected) {
+                assert_eq!(actual.to_data(), expected.to_data());
+            }
+        }
+    }
+}
+
+fn check_dictionary_key_type<K: ArrowDictionaryKeyType>() {
+    let mut numbers = PrimitiveDictionaryBuilder::<K, Int32Type>::new();
+    let mut strings = StringDictionaryBuilder::<K>::new();
+    let mut binaries = BinaryDictionaryBuilder::<K>::new();
+    for value in [Some(-7), None, Some(42), Some(-7)] {
+        match value {
+            Some(value) => {
+                numbers.append(value).unwrap();
+                strings
+                    .append(if value < 0 { "first" } else { "second" })
+                    .unwrap();
+                binaries
+                    .append(if value < 0 {
+                        &b"\0\xff"[..]
+                    } else {
+                        &b"second"[..]
+                    })
+                    .unwrap();
+            }
+            None => {
+                numbers.append_null();
+                strings.append_null();
+                binaries.append_null();
+            }
+        }
+    }
+    assert_roundtrip(
+        vec![
+            Arc::new(numbers.finish()),
+            Arc::new(strings.finish()),
+            Arc::new(binaries.finish()),
+        ],
+        vec![
+            Arc::new(Int32Array::from(vec![Some(-7), None, Some(42), Some(-7)])),
+            Arc::new(StringArray::from(vec![
+                Some("first"),
+                None,
+                Some("second"),
+                Some("first"),
+            ])),
+            Arc::new(BinaryArray::from(vec![
+                Some(&b"\0\xff"[..]),
+                None,
+                Some(&b"second"[..]),
+                Some(&b"\0\xff"[..]),
+            ])),
+        ],
+    );
+}
+
+#[test]
+#[cfg_attr(miri, ignore)] // The codec matrix calls ZSTD_createCCtx.
+fn integer_key_dictionary_values_survive_remote_shuffle() {
+    check_dictionary_key_type::<Int8Type>();
+    check_dictionary_key_type::<Int16Type>();
+    check_dictionary_key_type::<Int32Type>();
+    check_dictionary_key_type::<Int64Type>();
+    check_dictionary_key_type::<UInt8Type>();
+    check_dictionary_key_type::<UInt16Type>();
+    check_dictionary_key_type::<UInt32Type>();
+    check_dictionary_key_type::<UInt64Type>();
+}
+
+fn numbers(encoded: bool) -> ArrayRef {
+    if encoded {
+        Arc::new(
+            DictionaryArray::<Int16Type>::try_new(
+                Int16Array::from(vec![Some(1), None, Some(0), Some(1)]),
+                Arc::new(Int32Array::from(vec![7, -42])),
+            )
+            .unwrap(),
+        )
+    } else {
+        Arc::new(Int32Array::from(vec![Some(-42), None, Some(7), Some(-42)]))
+    }
+}
+
+fn nested_columns(encoded: bool) -> Vec<ArrayRef> {
+    let values = numbers(encoded);
+    let item = Arc::new(Field::new(
+        if encoded { "wire_item" } else { "element" },
+        values.data_type().clone(),
+        true,
+    ));
+    let validity = Some(NullBuffer::from(vec![true, false, true]));
+    vec![
+        Arc::new(ListArray::new(
+            Arc::clone(&item),
+            OffsetBuffer::new(vec![0, 2, 2, 4].into()),
+            Arc::clone(&values),
+            validity.clone(),
+        )),
+        Arc::new(LargeListArray::new(
+            Arc::clone(&item),
+            OffsetBuffer::new(vec![0_i64, 2, 2, 4].into()),
+            Arc::clone(&values),
+            validity,
+        )),
+        Arc::new(FixedSizeListArray::new(
+            item,
+            2,
+            Arc::clone(&values),
+            Some(NullBuffer::from(vec![true, false])),
+        )),
+        Arc::new(StructArray::new(
+            Fields::from(vec![Field::new(
+                "payload",
+                values.data_type().clone(),
+                true,
+            )]),
+            vec![values],
+            Some(NullBuffer::from(vec![true, true, false, true])),
+        )),
+    ]
+}
+
+fn dictionary_map(encoded: bool) -> ArrayRef {
+    let keys: ArrayRef = if encoded {
+        Arc::new(
+            DictionaryArray::<UInt16Type>::try_new(
+                UInt16Array::from(vec![0, 1, 0]),
+                Arc::new(StringArray::from(vec!["one", "two"])),
+            )
+            .unwrap(),
+        )
+    } else {
+        Arc::new(StringArray::from(vec!["one", "two", "one"]))
+    };
+    let values: ArrayRef = if encoded {
+        Arc::new(
+            DictionaryArray::<Int32Type>::try_new(
+                Int32Array::from(vec![Some(0), None, Some(1)]),
+                Arc::new(Int32Array::from(vec![7, -42])),
+            )
+            .unwrap(),
+        )
+    } else {
+        Arc::new(Int32Array::from(vec![Some(7), None, Some(-42)]))
+    };
+    let fields = Fields::from(vec![
+        Field::new("key", keys.data_type().clone(), false),
+        Field::new("value", values.data_type().clone(), true),
+    ]);
+    Arc::new(MapArray::new(
+        Arc::new(Field::new(
+            if encoded { "wire_entries" } else { "entries" },
+            DataType::Struct(fields.clone()),
+            false,
+        )),
+        OffsetBuffer::new(vec![0, 2, 2, 3].into()),
+        StructArray::new(fields, vec![keys, values], None),
+        Some(NullBuffer::from(vec![true, false, true])),
+        false,
+    ))
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn dictionaries_inside_containers_survive_remote_shuffle() {
+    for (actual, expected) in nested_columns(true).into_iter().zip(nested_columns(false)) {
+        assert_roundtrip(vec![actual], vec![expected]);
+    }
+    assert_roundtrip(vec![dictionary_map(true)], vec![dictionary_map(false)]);
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn dictionaries_wrapping_lists_and_nested_dictionaries_survive_remote_shuffle() {
+    let inner = Arc::new(
+        DictionaryArray::<Int16Type>::try_new(
+            Int16Array::from(vec![0, 1, 0]),
+            Arc::new(Int32Array::from(vec![7, -42])),
+        )
+        .unwrap(),
+    );
+    let values = Arc::new(ListArray::new(
+        Arc::new(Field::new("wire_item", inner.data_type().clone(), true)),
+        OffsetBuffer::new(vec![0, 2, 3].into()),
+        inner,
+        None,
+    ));
+    let dictionary = Arc::new(
+        DictionaryArray::<UInt16Type>::try_new(
+            UInt16Array::from(vec![Some(1), None, Some(0), Some(1)]),
+            values,
+        )
+        .unwrap(),
+    );
+    let expected = Arc::new(ListArray::new(
+        Arc::new(Field::new("element", DataType::Int32, true)),
+        OffsetBuffer::new(vec![0, 1, 1, 3, 4].into()),
+        Arc::new(Int32Array::from(vec![7, 7, -42, 7])),
+        Some(NullBuffer::from(vec![true, false, true, true])),
+    ));
+    assert_roundtrip(vec![dictionary], vec![expected]);
+}
+
+#[test]
+fn non_null_dictionary_keys_can_reference_null_values() {
+    let dictionary = Arc::new(
+        DictionaryArray::<Int32Type>::try_new(
+            Int32Array::from(vec![0, 1]),
+            Arc::new(Int32Array::from(vec![Some(7), None])),
+        )
+        .unwrap(),
+    );
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new(
+            "wire",
+            dictionary.data_type().clone(),
+            false,
+        )])),
+        vec![dictionary],
+    )
+    .unwrap();
+    let bytes = encoded_batch(&batch, CompressionCodec::None, true);
+    let decoded = decode_remote_shuffle_batch(&bytes, &[DataType::Int32]).unwrap();
+    assert_eq!(
+        decoded.column(0).to_data(),
+        Int32Array::from(vec![Some(7), None]).to_data()
+    );
+}
+
+#[test]
+fn unused_dictionary_values_do_not_prevent_nested_nullability_narrowing() {
+    let values = Arc::new(StructArray::new(
+        Fields::from(vec![Field::new("value", DataType::Int32, true)]),
+        vec![Arc::new(Int32Array::from(vec![Some(7), None]))],
+        None,
+    ));
+    let dictionary = Arc::new(
+        DictionaryArray::<Int32Type>::try_new(Int32Array::from(vec![0, 0]), values).unwrap(),
+    );
+    let expected = Arc::new(StructArray::new(
+        Fields::from(vec![Field::new("value", DataType::Int32, false)]),
+        vec![Arc::new(Int32Array::from(vec![7, 7]))],
+        None,
+    ));
+    let bytes = encoded_batch(&batch(vec![dictionary]), CompressionCodec::None, true);
+    let decoded = decode_remote_shuffle_batch(&bytes, &[expected.data_type().clone()]).unwrap();
+    assert_eq!(decoded.column(0).to_data(), expected.to_data());
+}
+
+#[test]
+fn dictionary_decoding_does_not_allow_logical_type_or_container_shape_changes() {
+    let numeric = numbers(true);
+    let expected_nested = nested_columns(false);
+    let actual_nested = nested_columns(true);
+    let mut cases = vec![
+        (Arc::clone(&numeric), DataType::Int64),
+        (Arc::clone(&numeric), DataType::UInt32),
+        (numeric, DataType::Float32),
+        (
+            Arc::clone(&actual_nested[0]),
+            DataType::List(Arc::new(Field::new("element", DataType::UInt32, true))),
+        ),
+        (
+            Arc::clone(&actual_nested[0]),
+            expected_nested[1].data_type().clone(),
+        ),
+        (
+            Arc::clone(&actual_nested[2]),
+            DataType::FixedSizeList(Arc::new(Field::new("element", DataType::Int32, true)), 3),
+        ),
+        (
+            Arc::clone(&actual_nested[3]),
+            DataType::Struct(Fields::from(vec![Field::new(
+                "renamed",
+                DataType::Int32,
+                true,
+            )])),
+        ),
+    ];
+    let strings: ArrayRef = Arc::new(
+        DictionaryArray::<UInt16Type>::try_new(
+            UInt16Array::from(vec![0]),
+            Arc::new(StringArray::from(vec!["text"])),
+        )
+        .unwrap(),
+    );
+    cases.push((strings, DataType::Binary));
+    let map = dictionary_map(true);
+    let DataType::Map(entries, _) = dictionary_map(false).data_type().clone() else {
+        unreachable!()
+    };
+    cases.push((map, DataType::Map(entries, true)));
+    let structure: ArrayRef = Arc::new(StructArray::new(
+        Fields::from(vec![
+            Field::new("left", DataType::Int32, false),
+            Field::new("right", DataType::Int32, false),
+        ]),
+        vec![
+            Arc::new(Int32Array::from(vec![1])),
+            Arc::new(Int32Array::from(vec![2])),
+        ],
+        None,
+    ));
+    cases.push((
+        structure,
+        DataType::Struct(Fields::from(vec![
+            Field::new("right", DataType::Int32, true),
+            Field::new("left", DataType::Int32, true),
+        ])),
+    ));
+    for (column, expected) in cases {
+        let bytes = encoded_batch(&batch(vec![column]), CompressionCodec::None, true);
+        let error = decode_remote_shuffle_batch(&bytes, &[expected])
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("type mismatch"), "{error}");
+    }
+}
+
+#[test]
+fn remote_shuffle_preserves_row_count_without_columns() {
+    let options = RecordBatchOptions::new().with_row_count(Some(3));
+    let batch =
+        RecordBatch::try_new_with_options(Arc::new(Schema::empty()), vec![], &options).unwrap();
+    let bytes = encoded_batch(&batch, CompressionCodec::None, true);
+    let decoded = decode_remote_shuffle_batch(&bytes, &[]).unwrap();
+    assert_eq!(decoded.num_columns(), 0);
+    assert_eq!(decoded.num_rows(), 3);
+}


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5536.

Follow-up to #5352, discovered during post-merge review of #5531.

## Rationale for this change

The remote shuffle validator rejects dictionary encodings that `ShuffleBlockWriter` can emit and the local reader can consume, including numeric dictionaries, alternate key widths, and dictionaries inside containers.

The current Spark pipeline normally strips these encodings before writing, but a future change could expose this mismatch and cause repeated fetch failures. Relaxing validation alone is insufficient because the JVM Arrow importer supports fewer dictionary layouts.

## What changes are included in this PR?

- Compare dictionary value types recursively while retaining strict checks for logical types, struct field identity, and container shape.
- Share remote batch decoding between native shuffle scans and JNI, validating buffers and logical types before normalizing dictionary encodings.
- Preserve null values, nested nullability reconciliation, and zero-column batch row counts.
- Add writer-to-reader regression coverage for supported dictionary layouts.

## How are these changes tested?

- All 99 shuffle crate tests pass.
- All 7 native shuffle-scan tests pass.
- Writer round trips cover all eight integer dictionary key types, numeric/string/binary values, nested containers, both writer modes, and all four compression codecs.
- Negative tests verify that logical-type and container-shape mismatches remain rejected.
- Clippy passes for both affected crates' libraries and tests with warnings denied.
- `cargo fmt --all -- --check` and `git diff --check` pass.
