### PR TITLE
fix: Bump iceberg-rust so native Iceberg writes URL-escape partition paths

### DIFF
--- a/docs/source/user-guide/latest/iceberg-writes.md
+++ b/docs/source/user-guide/latest/iceberg-writes.md
@@ -156,7 +156,7 @@ A write is eligible only when ALL of the following hold:
 | `write.spark.fanout.enabled`                                                                                                                | any value (the native writer implements both clustered and fanout modes)                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `write.target-file-size-bytes`                                                                                                              | any value (file rolling cadence differs; see accepted divergences)                                                                                                                                                                                                                                                                                                                                                                                                              |
 | data location URI scheme                                                                                                                    | `file`, `memory`, `s3`, `s3a`, `gs`                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| partition spec                                                                                                                              | any (but see partition paths under accepted divergences)                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| partition spec                                                                                                                              | any                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | column types                                                                                                                                | any except `uuid` (Spark plans it as a string; no Arrow cast reaches `fixed(16)`)                                                                                                                                                                                                                                                                                                                                                                                               |
 
 Within the namespaces that shape data-file bytes — `write.parquet.*` and `parquet.*` —
@@ -279,15 +279,6 @@ iceberg-java's _writer-tracked_ state would have recorded, and both are analyzed
   parquet footer), while iceberg-java's writer-tracked counts do not. Both counts inflate by
   the same amount, so the derived null ratios and `IS NULL` / `IS NOT NULL` pruning decisions
   are unaffected.
-
-### Operational caveat
-
-- Partition paths are not URL-escaped: iceberg-java percent-encodes partition directory names
-  and values (`region=a%2Fb`), iceberg-rust writes them raw (`region=a/b`). Readers resolve
-  files through manifest metadata, not paths, so query results are unaffected — but the
-  directory layout differs from iceberg-java's, and partition values containing characters
-  that are invalid in a URI (`:`, `#`, newline) may produce paths that `HadoopFileIO`-based
-  readers cannot open.
 
 All content not listed above — the logical data, encodings for non-FLBA columns, statistics
 values, and manifest metadata — must match iceberg-java exactly, or the write falls back.

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -3507,7 +3507,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/apache/iceberg-rust?rev=3d84c81353b1b23b6e4ae8eea8f8a021cc6927a7#3d84c81353b1b23b6e4ae8eea8f8a021cc6927a7"
+source = "git+https://github.com/apache/iceberg-rust?rev=8adaa872f31549dd5ad8255848715758228038bc#8adaa872f31549dd5ad8255848715758228038bc"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3533,6 +3533,7 @@ dependencies = [
  "fastnum",
  "flate2",
  "fnv",
+ "form_urlencoded",
  "futures",
  "itertools 0.13.0",
  "moka",
@@ -3563,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.10.0"
-source = "git+https://github.com/apache/iceberg-rust?rev=3d84c81353b1b23b6e4ae8eea8f8a021cc6927a7#3d84c81353b1b23b6e4ae8eea8f8a021cc6927a7"
+source = "git+https://github.com/apache/iceberg-rust?rev=8adaa872f31549dd5ad8255848715758228038bc#8adaa872f31549dd5ad8255848715758228038bc"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -62,8 +62,8 @@ object_store = { version = "0.13.2", features = ["gcp", "azure", "aws", "http"] 
 url = "2.2"
 aws-config = "1.8.18"
 aws-credential-types = "1.2.13"
-iceberg = { git = "https://github.com/apache/iceberg-rust", rev = "3d84c81353b1b23b6e4ae8eea8f8a021cc6927a7" }
-iceberg-storage-opendal = { git = "https://github.com/apache/iceberg-rust", rev = "3d84c81353b1b23b6e4ae8eea8f8a021cc6927a7", features = ["opendal-memory", "opendal-fs", "opendal-s3", "opendal-gcs", "opendal-oss", "opendal-azdls"] }
+iceberg = { git = "https://github.com/apache/iceberg-rust", rev = "8adaa872f31549dd5ad8255848715758228038bc" }
+iceberg-storage-opendal = { git = "https://github.com/apache/iceberg-rust", rev = "8adaa872f31549dd5ad8255848715758228038bc", features = ["opendal-memory", "opendal-fs", "opendal-s3", "opendal-gcs", "opendal-oss", "opendal-azdls"] }
 reqsign-core = "3"
 
 [profile.release]

--- a/spark/src/test/scala/org/apache/comet/CometIcebergWriteActionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergWriteActionSuite.scala
@@ -1172,6 +1172,59 @@ class CometIcebergWriteActionSuite
     }
   }
 
+  // iceberg-java's `PartitionSpec.partitionToPath` runs every partition name and value through
+  // `URLEncoder.encode`, and iceberg-rust's `partition_to_path` uses the same
+  // application/x-www-form-urlencoded table (apache/iceberg-rust#2875). Readers resolve files
+  // through manifest metadata rather than paths, but the committed location still has to be one
+  // every FileIO can open: an unescaped `#` in an S3 key is a fragment delimiter to `S3FileIO`.
+  test("native acceleration: partition paths are URL-escaped like iceberg-java") {
+    assumeNativeAcceleration()
+    withIcebergCatalog { warehouseDir =>
+      createTable(warehouseDir, "escaped_native", partitionSpec = "PARTITIONED BY (region)")
+      createTable(warehouseDir, "escaped_jvm", partitionSpec = "PARTITIONED BY (region)")
+      val regions = Seq("a/b", "c#d", "e?f", "g h", "i=j", "k%l", "m+n", "*-._", "日本", "")
+      val values = regions.zipWithIndex
+        .map { case (region, i) => s"($i, '$region', $i.5)" }
+        .mkString(", ")
+
+      spark.sql(s"INSERT INTO $catalog.$ns.escaped_native VALUES $values")
+      withSQLConf(CometConf.COMET_ICEBERG_WRITE_SPLIT_OPERATOR_ENABLED.key -> "false") {
+        spark.sql(s"INSERT INTO $catalog.$ns.escaped_jvm VALUES $values")
+      }
+
+      // Every partition directory the native writer produced exists in the JVM writer's layout
+      // and vice versa, so the two tables are byte-for-byte compatible in their data locations.
+      def partitionDirs(table: String): Set[String] = {
+        val location = warehouseDir.toURI.toString.stripSuffix("/")
+        spark
+          .sql(s"SELECT file_path FROM $catalog.$ns.$table.files")
+          .collect()
+          .map(_.getString(0))
+          .map { path =>
+            val relative = path.stripPrefix(location).split("/data/", 2)(1)
+            relative.substring(0, relative.lastIndexOf('/'))
+          }
+          .toSet
+      }
+      val nativeDirs = partitionDirs("escaped_native")
+      assert(nativeDirs == partitionDirs("escaped_jvm"), s"native layout: $nativeDirs")
+      assert(nativeDirs.contains("region=a%2Fb") && nativeDirs.contains("region=c%23d"))
+      assert(nativeDirs.contains("region=g+h") && nativeDirs.contains("region=*-._"))
+
+      // Both Comet's native scan and iceberg-java's reader open the escaped locations.
+      val expected = regions.zipWithIndex.map { case (region, i) => Row(i, region, i + 0.5) }
+      Seq("true", "false").foreach { cometEnabled =>
+        withSQLConf(CometConf.COMET_ENABLED.key -> cometEnabled) {
+          val rows = spark
+            .sql(s"SELECT id, region, amount FROM $catalog.$ns.escaped_native ORDER BY id")
+            .collect()
+            .toSeq
+          assert(rows == expected, s"comet=$cometEnabled: $rows")
+        }
+      }
+    }
+  }
+
   test("native acceleration: wide primitive types keep JVM-parity values and manifest metrics") {
     assumeNativeAcceleration()
     withIcebergCatalog { _ =>

--- a/spark/src/test/scala/org/apache/comet/CometIcebergWriteActionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergWriteActionSuite.scala
@@ -1187,10 +1187,10 @@ class CometIcebergWriteActionSuite
         .map { case (region, i) => s"($i, '$region', $i.5)" }
         .mkString(", ")
 
-      spark.sql(s"INSERT INTO $catalog.$ns.escaped_native VALUES $values")
-      withSQLConf(CometConf.COMET_ICEBERG_WRITE_SPLIT_OPERATOR_ENABLED.key -> "false") {
-        spark.sql(s"INSERT INTO $catalog.$ns.escaped_jvm VALUES $values")
+      assertNativeWriteEngages("escaped_native", regions.indices) {
+        spark.sql(s"INSERT INTO $catalog.$ns.escaped_native VALUES $values")
       }
+      spark.sql(s"INSERT INTO $catalog.$ns.escaped_jvm VALUES $values")
 
       // Every partition directory the native writer produced exists in the JVM writer's layout
       // and vice versa, so the two tables are byte-for-byte compatible in their data locations.


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5636. Closes #5641.

## Rationale for this change

The native Iceberg writer pins iceberg-rust at `3d84c81` (2026-07-29), one day before apache/iceberg-rust#2875 merged. That fix makes `PartitionSpec::partition_to_path` form-urlencode partition field names and values, which is what iceberg-java's `PartitionSpec.partitionToPath` has always done through `URLEncoder.encode`. Without it the native writer commits raw partition directories: a value containing `#` or `?` lands in the manifest as a location that iceberg-java's `S3FileIO` parses as a URI fragment or query, so a table written by Comet resolves to a different object key when read back through the standard Java path. This is the first phase-1 item of the native Iceberg writes epic (#5649).

## What changes are included in this PR?

- `native/Cargo.toml` pins `iceberg` and `iceberg-storage-opendal` to `8adaa872f31549dd5ad8255848715758228038bc`, the merge commit of apache/iceberg-rust#2875. That revision has the same arrow (58.4), parquet (58.4), DataFusion (54.1), and opendal (0.57) versions as the current pin, so the lockfile change is confined to the two iceberg crates and no Comet code needed to change. The v0.10.1 release was considered and rejected: it sits on a release branch that does not contain the fix and pins DataFusion 53.
- `iceberg-writes.md` drops the "partition paths are not URL-escaped" operational caveat and the eligibility table's cross-reference to it; the layouts now match.

Both encoders use the application/x-www-form-urlencoded table: alphanumerics and `*-._` unescaped, space as `+`, everything else percent-encoded as UTF-8, and `null` for a null value. The commits between this revision and iceberg-rust `main` (opendal 0.58, `ObjectStorageLocationGenerator`, a GCS host fix, additional parquet writer settings) are left for the pin policy in #5645 so this change stays a targeted correctness fix.

## How are these changes tested?

A new test in `CometIcebergWriteActionSuite`, "partition paths are URL-escaped like iceberg-java", writes the same rows through the native writer and the JVM writer into two tables partitioned by a string column whose values contain `/`, `#`, `?`, space, `=`, `%`, `+`, the unescaped set `*-._`, multi-byte characters, and the empty string. It asserts that the set of partition directories under each table's data location is identical, that the expected encodings (`region=a%2Fb`, `region=c%23d`, `region=g+h`, `region=*-._`) are present, and that the natively written table reads back correctly through both Comet's native scan and iceberg-java's reader.

The existing Iceberg suites (native scan, write action, write detection, rewrite actions, fuzz, reflection, proto translation) were run locally against the new pin on the default Spark profile.
