### PR TITLE
fix: Delete data files left by a failed native Iceberg write task

### DIFF
--- a/docs/source/user-guide/latest/iceberg-writes.md
+++ b/docs/source/user-guide/latest/iceberg-writes.md
@@ -209,12 +209,18 @@ attempt id is embedded in its data file names.
 
 Partial results are never committed. The commit set is exactly the commit messages returned by
 successful tasks — a failed task contributes none — and if the job fails, the driver-side
-commit operator aborts without committing anything. Data files already finalized by a failed
-task attempt are not deleted by that task (iceberg-java's writer abort deletes them; the
-native path has no abort hook yet — tracked in
-[#5618](https://github.com/apache/datafusion-comet/issues/5618)): they are invisible to every
-reader, since readers resolve files through committed manifests only, and are reclaimed by
-Iceberg's normal `remove_orphan_files` maintenance.
+commit operator aborts without committing anything. A failed task attempt also deletes the
+data files it created, as iceberg-java's writer abort does. The native writer records every
+location it hands to a file writer, and exactly one side owns deleting them at any moment: the
+native writer owns them until its output batch reaches the JVM (so it cleans up a failed write,
+a task torn down before the write completed — for example because the operator feeding it threw
+— and a failure encoding the manifest or building that batch), and the JVM owns them from then
+on through a task failure listener. The handoff does not depend on decoding the manifest: the
+native side reports the locations in the output batch alongside it, and the listener is handed
+them before the manifest is decoded, so a failure in that decode still cleans up. Both
+deletions are best-effort and never mask the original failure; anything they miss is invisible
+to every reader, since readers resolve files through committed manifests only, and is reclaimed
+by Iceberg's normal `remove_orphan_files` maintenance.
 
 A failure during the driver-side commit itself behaves exactly as on the stock path: the
 commit messages carry genuine `SparkWrite$TaskCommit` objects, so Iceberg's own

--- a/native/core/src/execution/operators/iceberg_write.rs
+++ b/native/core/src/execution/operators/iceberg_write.rs
@@ -152,9 +152,16 @@ impl AbortOnDrop {
     /// Delete the tracked files, awaiting completion, and give up ownership. Preferred over the
     /// `Drop` path wherever the failure is observed inside the task's own future, so the deletes
     /// finish before the task reports its error rather than racing the runtime's shutdown.
+    ///
+    /// Ownership is given up only after the deletes have finished. Clearing `armed` first would
+    /// remove the cancellation fallback while deletion is still in progress: if this future is
+    /// dropped after one delete has yielded, `Drop` would see a disarmed guard, return
+    /// immediately, and leave the remaining files with no owner. Re-deleting a file that the
+    /// cancelled run already removed is harmless, since `delete_task_files` is best effort and
+    /// logs rather than fails.
     async fn abort(&mut self) {
-        self.armed = false;
         delete_task_files(&self.file_io, self.generator.locations()).await;
+        self.armed = false;
     }
 }
 
@@ -2128,6 +2135,83 @@ mod tests {
                 data_files[0].file_path()
             );
         }
+    }
+
+    /// Cancelling `abort()` part way through must leave the guard armed, so `Drop` still owns
+    /// the files the cancelled run did not reach. Clearing `armed` before the await made `Drop`
+    /// return immediately and orphaned the remainder.
+    ///
+    /// This uses the filesystem `FileIO` rather than the in-memory one on purpose: the memory
+    /// backend completes every delete inside a single poll (measured: one poll, zero pendings),
+    /// so a mid-deletion cancellation cannot be constructed against it.
+    #[tokio::test]
+    async fn cancelling_abort_keeps_the_guard_armed() {
+        use std::future::Future;
+        use std::task::Context;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file_io = FileIOBuilder::new(Arc::new(OpenDalStorageFactory::Fs)).build();
+        let generator = tracking_generator(&format!("file://{}", dir.path().display()));
+        let mut locations = Vec::new();
+        for i in 0..4 {
+            let location = generator.generate_location(None, &format!("{i}.parquet"));
+            file_io
+                .new_output(&location)
+                .unwrap()
+                .write(bytes::Bytes::from_static(b"parquet"))
+                .await
+                .unwrap();
+            locations.push(location);
+        }
+
+        let mut guard = AbortOnDrop {
+            file_io: file_io.clone(),
+            generator,
+            armed: true,
+        };
+        {
+            // A no-op waker means nothing ever wakes the future, so the first delete that yields
+            // strands it. Dropping it there is the cancellation.
+            let waker = futures::task::noop_waker();
+            let mut cx = Context::from_waker(&waker);
+            let mut fut = Box::pin(guard.abort());
+            assert!(
+                fut.as_mut().poll(&mut cx).is_pending(),
+                "expected the deletes to yield so the abort can be cancelled mid-flight"
+            );
+        }
+
+        assert!(
+            guard.armed,
+            "a cancelled abort must not have given up ownership of the remaining files"
+        );
+        let mut survived = Vec::new();
+        for location in &locations {
+            if file_io.exists(location).await.unwrap() {
+                survived.push(location.clone());
+            }
+        }
+        assert!(
+            !survived.is_empty(),
+            "the cancellation left nothing behind, so this test would pass either way"
+        );
+
+        // The guard is still the owner, so its `Drop` has to finish the job. Inside a runtime it
+        // spawns the delete, hence the bounded wait rather than an immediate assertion.
+        drop(guard);
+        for _ in 0..200 {
+            let mut remaining = 0;
+            for location in &locations {
+                if file_io.exists(location).await.unwrap() {
+                    remaining += 1;
+                }
+            }
+            if remaining == 0 {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        panic!("dropping the still-armed guard did not delete {survived:?}");
     }
 }
 

--- a/native/core/src/execution/operators/iceberg_write.rs
+++ b/native/core/src/execution/operators/iceberg_write.rs
@@ -25,7 +25,7 @@
 //! decodes the bytes with `ManifestFiles.read(...)` to recover the `DataFile`s for commit.
 
 use std::fmt;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use arrow::array::{ArrayRef, BinaryArray, RecordBatch, UInt32Array};
 use arrow::datatypes::{DataType, Field, Schema as ArrowSchema, SchemaRef};
@@ -46,13 +46,16 @@ use futures::TryStreamExt;
 use iceberg::arrow::{
     arrow_struct_to_literal, PartitionValueCalculator, RecordBatchPartitionSplitter,
 };
+use iceberg::io::FileIO;
 use iceberg::spec::{
     DataFile, DataFileFormat, Literal, ManifestWriterBuilder, PartitionKey, PartitionSpec,
     PartitionSpecRef, Schema as IcebergSchema, SchemaRef as IcebergSchemaRef,
     Struct as IcebergStruct, StructType,
 };
 use iceberg::writer::base_writer::data_file_writer::DataFileWriterBuilder;
-use iceberg::writer::file_writer::location_generator::DefaultFileNameGenerator;
+use iceberg::writer::file_writer::location_generator::{
+    DefaultFileNameGenerator, LocationGenerator,
+};
 use iceberg::writer::file_writer::rolling_writer::RollingFileWriterBuilder;
 use iceberg::writer::file_writer::ParquetWriterBuilder;
 use iceberg::writer::partitioning::clustered_writer::ClusteredWriter;
@@ -77,8 +80,139 @@ use crate::execution::operators::iceberg_partition_path::{
 };
 
 /// Builder chain instantiated once per task and handed to the partitioning wrapper.
-type IcebergDataFileWriterBuilder =
-    DataFileWriterBuilder<ParquetWriterBuilder, CometLocationGenerator, DefaultFileNameGenerator>;
+type IcebergDataFileWriterBuilder = DataFileWriterBuilder<
+    ParquetWriterBuilder,
+    TrackingLocationGenerator,
+    DefaultFileNameGenerator,
+>;
+
+/// [`CometLocationGenerator`] that records every location it hands to a file writer.
+///
+/// iceberg-rust's writers keep the `DataFile`s they have finalized private until `close`, and
+/// have no abort hook, so when a task fails partway through there is no other way to learn which
+/// files it created. The recorded locations let `delete_task_files` clean up after a failure the
+/// way iceberg-java's `DataWriter.abort()` does.
+#[derive(Clone, Debug)]
+struct TrackingLocationGenerator {
+    inner: CometLocationGenerator,
+    locations: Arc<Mutex<Vec<String>>>,
+}
+
+impl TrackingLocationGenerator {
+    fn new(inner: CometLocationGenerator) -> Self {
+        Self {
+            inner,
+            locations: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn locations(&self) -> Vec<String> {
+        self.locations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+}
+
+impl LocationGenerator for TrackingLocationGenerator {
+    fn generate_location(&self, partition_key: Option<&PartitionKey>, file_name: &str) -> String {
+        let location = self.inner.generate_location(partition_key, file_name);
+        self.locations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(location.clone());
+        location
+    }
+}
+
+/// Deletes the tracked files if the write task is dropped before it finished.
+///
+/// A task can end without its future ever observing an error: when the JVM-side input iterator
+/// throws, `executePlan` returns that error straight from the JNI batch pull and the JVM then
+/// releases the plan, dropping this future mid-flight. The guard turns that drop into the same
+/// cleanup the explicit error path performs. It stays armed until the task's output batch has
+/// been handed to the JVM, which is the point where the JVM takes over cleanup ownership.
+struct AbortOnDrop {
+    file_io: FileIO,
+    generator: TrackingLocationGenerator,
+    armed: bool,
+}
+
+impl AbortOnDrop {
+    /// Every location the task's writers were handed, in the order they were generated.
+    fn locations(&self) -> Vec<String> {
+        self.generator.locations()
+    }
+
+    /// Give up ownership without deleting: the files are now someone else's responsibility.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+
+    /// Delete the tracked files, awaiting completion, and give up ownership. Preferred over the
+    /// `Drop` path wherever the failure is observed inside the task's own future, so the deletes
+    /// finish before the task reports its error rather than racing the runtime's shutdown.
+    async fn abort(&mut self) {
+        self.armed = false;
+        delete_task_files(&self.file_io, self.generator.locations()).await;
+    }
+}
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let locations = self.generator.locations();
+        if locations.is_empty() {
+            return;
+        }
+        let file_io = self.file_io.clone();
+        match tokio::runtime::Handle::try_current() {
+            // Dropped from inside a runtime (the stream was dropped while being polled): the
+            // delete cannot block here, so hand it to the runtime.
+            Ok(handle) => {
+                handle.spawn(async move { delete_task_files(&file_io, locations).await });
+            }
+            // Dropped from a plain JVM thread (`releasePlan`): run the delete to completion so the
+            // files are gone before the task reports its failure.
+            Err(_) => match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime.block_on(delete_task_files(&file_io, locations)),
+                Err(e) => log::warn!(
+                    "Could not build a runtime to delete {} data file(s) left by a failed \
+                     Iceberg write task: {e}",
+                    locations.len()
+                ),
+            },
+        }
+    }
+}
+
+/// Best-effort deletion of every file a failed task attempt created, the native counterpart of
+/// iceberg-java's `SparkCleanupUtil.deleteTaskFiles`. Failures are logged rather than returned:
+/// the original task failure must stay the one Spark reports, and anything left behind is still
+/// invisible to readers and reclaimed by `remove_orphan_files`.
+async fn delete_task_files(file_io: &FileIO, locations: Vec<String>) {
+    if locations.is_empty() {
+        return;
+    }
+    let mut deleted = 0usize;
+    for location in &locations {
+        match file_io.delete(location).await {
+            Ok(()) => deleted += 1,
+            Err(e) => log::warn!(
+                "Failed to delete data file {location} left by a failed Iceberg write task: {e}"
+            ),
+        }
+    }
+    log::info!(
+        "Deleted {deleted} of {} data file(s) left by a failed Iceberg write task",
+        locations.len()
+    );
+}
 
 /// Native Iceberg write operator. Owns the parsed Iceberg schema/spec and the parquet writer
 /// properties; at task execution it builds the iceberg-rust writer stack, drains the upstream
@@ -218,7 +352,7 @@ impl ExecutionPlan for IcebergWriteExec {
         let output_schema = Arc::clone(&self.output_schema);
 
         let task = async move {
-            let data_files = run_write_task(
+            let (data_files, mut abort_guard) = run_write_task(
                 input_stream,
                 Arc::clone(&common),
                 Arc::clone(&iceberg_schema),
@@ -230,17 +364,35 @@ impl ExecutionPlan for IcebergWriteExec {
                 write_time,
             )
             .await?;
-            let manifest_bytes = encode_data_files_as_manifest(
-                data_files,
-                iceberg_schema,
-                partition_spec,
-                partition_id,
-                task_attempt_id,
-                &common.operation_id,
-            )
-            .await?;
-            let batch = build_output_batch(manifest_bytes, &output_schema)?;
-            Ok::<_, DataFusionError>(futures::stream::iter(vec![Ok(batch)]))
+            // The guard is still armed: until the output batch reaches the JVM nothing else knows
+            // which files this attempt created, so a failure while packaging it has to delete
+            // them here.
+            let locations = abort_guard.locations();
+            let packaged = async {
+                let manifest_bytes = encode_data_files_as_manifest(
+                    data_files,
+                    iceberg_schema,
+                    partition_spec,
+                    partition_id,
+                    task_attempt_id,
+                    &common.operation_id,
+                )
+                .await?;
+                build_output_batch(manifest_bytes, &locations, &output_schema)
+            }
+            .await;
+            match packaged {
+                // The batch carries the locations, and the JVM takes cleanup ownership of them
+                // before it decodes the manifest, so the guard's job is done.
+                Ok(batch) => {
+                    abort_guard.disarm();
+                    Ok::<_, DataFusionError>(futures::stream::iter(vec![Ok(batch)]))
+                }
+                Err(e) => {
+                    abort_guard.abort().await;
+                    Err(e)
+                }
+            }
         };
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
@@ -281,6 +433,9 @@ impl DisplayAs for IcebergWriteExec {
 /// batch with `PARQUET_FIELD_ID_META_KEY` metadata so iceberg-rust can match Arrow columns to
 /// Iceberg field IDs, and routes through `UnpartitionedWriter`/`FanoutWriter`/`ClusteredWriter`
 /// depending on `writer_mode`.
+///
+/// On success the still-armed [`AbortOnDrop`] is returned along with the data files: the caller
+/// owns cleanup until the output batch has been handed to the JVM.
 #[allow(clippy::too_many_arguments)]
 async fn run_write_task(
     mut input: SendableRecordBatchStream,
@@ -292,7 +447,7 @@ async fn run_write_task(
     partition_id: Option<i32>,
     task_attempt_id: Option<i64>,
     write_time: Time,
-) -> DFResult<Vec<DataFile>> {
+) -> DFResult<(Vec<DataFile>, AbortOnDrop)> {
     // The JVM exec wrapper stamps both ids per task; a missing id means the plan template was
     // executed directly, and defaulting would make every task collide on the same file names.
     let partition_id = partition_id.ok_or_else(|| {
@@ -316,12 +471,14 @@ async fn run_write_task(
     // Resolves the write's partition type once per task, before any data is written, so a spec the
     // location generator could not render fails the task cleanly rather than panicking inside the
     // infallible `LocationGenerator::generate_location`.
-    let location_generator = CometLocationGenerator::try_new(
-        common.data_location.clone(),
-        &partition_spec,
-        &iceberg_schema,
-    )
-    .map_err(iceberg_err)?;
+    let location_generator = TrackingLocationGenerator::new(
+        CometLocationGenerator::try_new(
+            common.data_location.clone(),
+            &partition_spec,
+            &iceberg_schema,
+        )
+        .map_err(iceberg_err)?,
+    );
     let file_name_generator = DefaultFileNameGenerator::new(
         file_name_prefix(partition_id, task_attempt_id, &common.operation_id),
         None,
@@ -331,11 +488,16 @@ async fn run_write_task(
     let rolling_builder = RollingFileWriterBuilder::new(
         parquet_builder,
         common.target_file_size_bytes as usize,
-        file_io,
-        location_generator,
+        file_io.clone(),
+        location_generator.clone(),
         file_name_generator,
     );
     let data_file_builder = DataFileWriterBuilder::new(rolling_builder);
+    let mut abort_guard = AbortOnDrop {
+        file_io,
+        generator: location_generator,
+        armed: true,
+    };
 
     let unpartitioned = partition_spec.is_unpartitioned();
     let mut writer = match (unpartitioned, writer_mode) {
@@ -377,19 +539,35 @@ async fn run_write_task(
     // Build the field-id-decorated target schema once per task; every batch is cast against it.
     let target_schema =
         Arc::new(iceberg::arrow::schema_to_arrow_schema(&iceberg_schema).map_err(iceberg_err)?);
-    while let Some(batch) = input.try_next().await? {
-        let decorated = decorate_batch_with_field_ids(batch, &target_schema)?;
+    let outcome = async move {
+        while let Some(batch) = input.try_next().await? {
+            let decorated = decorate_batch_with_field_ids(batch, &target_schema)?;
+            let _timer = write_time.timer();
+            writer
+                .write(
+                    decorated,
+                    fanout_splitter.as_ref(),
+                    clustered_splitter.as_ref(),
+                )
+                .await?;
+        }
         let _timer = write_time.timer();
-        writer
-            .write(
-                decorated,
-                fanout_splitter.as_ref(),
-                clustered_splitter.as_ref(),
-            )
-            .await?;
+        writer.close().await
     }
-    let _timer = write_time.timer();
-    writer.close().await
+    .await;
+    match outcome {
+        // Hand the still-armed guard to the caller: manifest encoding and output-batch
+        // construction can still fail, and until the batch reaches the JVM nothing else knows
+        // which files this attempt created.
+        Ok(data_files) => Ok((data_files, abort_guard)),
+        // Whether the input stream, a write, or the close failed, every file this attempt created
+        // is orphaned from here on: nothing will commit it, and the retry uses attempt-unique
+        // names.
+        Err(e) => {
+            abort_guard.abort().await;
+            Err(e)
+        }
+    }
 }
 
 /// Enum-based dispatch over the three iceberg-rust partitioning writers. Each variant takes the
@@ -537,12 +715,19 @@ fn format_partition_spec(spec: &PartitionSpec) -> String {
     }
 }
 
+/// The per-task output: the V2 data manifest the JVM decodes into `DataFile`s, plus the plain
+/// list of locations the task's writers were handed.
+///
+/// The locations are redundant with the manifest, and deliberately so: they let the JVM take
+/// cleanup ownership of the written files with a `ByteBuffer` walk, before it runs the far more
+/// allocation-hungry Avro decode that recovers the `DataFile`s. A failure in that decode would
+/// otherwise leave files that only the failed decode could have named. See `decodeLocations` and
+/// `WrittenFileCleanup` on the JVM side (`CometIcebergWriteExec`).
 fn build_output_schema() -> SchemaRef {
-    Arc::new(ArrowSchema::new(vec![Field::new(
-        "iceberg_manifest",
-        DataType::Binary,
-        false,
-    )]))
+    Arc::new(ArrowSchema::new(vec![
+        Field::new("iceberg_manifest", DataType::Binary, false),
+        Field::new("written_file_locations", DataType::Binary, false),
+    ]))
 }
 
 /// Align an input batch with the field-id-decorated target schema by casting each column. The
@@ -758,9 +943,31 @@ fn manifest_partition_spec(partition_spec: &PartitionSpecRef) -> PartitionSpec {
     }
 }
 
-fn build_output_batch(manifest_bytes: Vec<u8>, output_schema: &SchemaRef) -> DFResult<RecordBatch> {
-    let array: ArrayRef = Arc::new(BinaryArray::from(vec![manifest_bytes.as_slice()]));
-    RecordBatch::try_new(Arc::clone(output_schema), vec![array]).map_err(DataFusionError::from)
+/// Frame the written-file locations for the `written_file_locations` column: a big-endian `i32`
+/// count, then a big-endian `i32` byte length and the UTF-8 bytes for each location. Explicit
+/// lengths rather than a separator so a path is never re-interpreted, whatever it contains.
+fn encode_locations(locations: &[String]) -> Vec<u8> {
+    let mut encoded = Vec::with_capacity(
+        4 + locations.len() * 4 + locations.iter().map(|l| l.len()).sum::<usize>(),
+    );
+    encoded.extend_from_slice(&(locations.len() as i32).to_be_bytes());
+    for location in locations {
+        encoded.extend_from_slice(&(location.len() as i32).to_be_bytes());
+        encoded.extend_from_slice(location.as_bytes());
+    }
+    encoded
+}
+
+fn build_output_batch(
+    manifest_bytes: Vec<u8>,
+    locations: &[String],
+    output_schema: &SchemaRef,
+) -> DFResult<RecordBatch> {
+    let manifest: ArrayRef = Arc::new(BinaryArray::from(vec![manifest_bytes.as_slice()]));
+    let encoded_locations = encode_locations(locations);
+    let locations: ArrayRef = Arc::new(BinaryArray::from(vec![encoded_locations.as_slice()]));
+    RecordBatch::try_new(Arc::clone(output_schema), vec![manifest, locations])
+        .map_err(DataFusionError::from)
 }
 
 /// Translate `IcebergParquetWriteSettings` into parquet-rs `WriterProperties`.
@@ -834,6 +1041,109 @@ fn compression_from_proto(codec: i32, level: Option<i32>) -> DFResult<Compressio
 #[cfg(test)]
 mod tests {
     use super::*;
+    use iceberg::io::FileIOBuilder;
+    use iceberg::spec::{NestedField, PrimitiveType, Type};
+    use iceberg_storage_opendal::OpenDalStorageFactory;
+
+    /// Tracking generator over an unpartitioned spec, the layout every tracking test writes to.
+    fn tracking_generator(data_location: &str) -> TrackingLocationGenerator {
+        let schema = Arc::new(
+            IcebergSchema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![NestedField::required(
+                    1,
+                    "id",
+                    Type::Primitive(PrimitiveType::Int),
+                )
+                .into()])
+                .build()
+                .unwrap(),
+        );
+        let spec = PartitionSpec::builder(Arc::clone(&schema)).build().unwrap();
+        TrackingLocationGenerator::new(
+            CometLocationGenerator::try_new(data_location.to_string(), &spec, &schema).unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn failed_task_deletes_every_tracked_location() {
+        let file_io = FileIOBuilder::new(Arc::new(OpenDalStorageFactory::Memory)).build();
+        let generator = tracking_generator("memory:/warehouse/data");
+        // Two files the writer "created", plus one location that was handed out but never
+        // written (the file open at the time of the failure): deleting it must not fail.
+        let first = generator.generate_location(None, "00000-00001-op-00001.parquet");
+        let second = generator.generate_location(None, "00000-00001-op-00002.parquet");
+        let never_written = generator.generate_location(None, "00000-00001-op-00003.parquet");
+        for location in [&first, &second] {
+            file_io
+                .new_output(location)
+                .unwrap()
+                .write(bytes::Bytes::from_static(b"parquet"))
+                .await
+                .unwrap();
+        }
+        assert_eq!(
+            generator.locations(),
+            vec![first.clone(), second.clone(), never_written.clone()]
+        );
+        assert!(file_io.exists(&first).await.unwrap());
+
+        delete_task_files(&file_io, generator.locations()).await;
+
+        assert!(!file_io.exists(&first).await.unwrap());
+        assert!(!file_io.exists(&second).await.unwrap());
+        assert!(!file_io.exists(&never_written).await.unwrap());
+    }
+
+    #[test]
+    fn dropping_an_armed_guard_outside_a_runtime_deletes_the_files() {
+        let file_io = FileIOBuilder::new(Arc::new(OpenDalStorageFactory::Memory)).build();
+        let generator = tracking_generator("memory:/warehouse/data");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let armed = generator.generate_location(None, "armed.parquet");
+        let disarmed = generator.generate_location(None, "disarmed.parquet");
+        runtime.block_on(async {
+            for location in [&armed, &disarmed] {
+                file_io
+                    .new_output(location)
+                    .unwrap()
+                    .write(bytes::Bytes::from_static(b"parquet"))
+                    .await
+                    .unwrap();
+            }
+        });
+
+        // Disarmed: the task completed, nothing may be deleted.
+        let mut guard = AbortOnDrop {
+            file_io: file_io.clone(),
+            generator: generator.clone(),
+            armed: true,
+        };
+        guard.disarm();
+        drop(guard);
+        assert!(runtime.block_on(file_io.exists(&armed)).unwrap());
+
+        // Armed and dropped from a thread without a runtime, as `releasePlan` does: the delete
+        // runs to completion before `drop` returns.
+        drop(AbortOnDrop {
+            file_io: file_io.clone(),
+            generator,
+            armed: true,
+        });
+        assert!(!runtime.block_on(file_io.exists(&armed)).unwrap());
+        assert!(!runtime.block_on(file_io.exists(&disarmed)).unwrap());
+    }
+
+    #[test]
+    fn tracked_locations_follow_the_default_layout() {
+        let generator = tracking_generator("s3://bucket/table/data");
+        let location = generator.generate_location(None, "f.parquet");
+        assert_eq!(location, "s3://bucket/table/data/f.parquet");
+        assert_eq!(generator.locations(), vec![location]);
+    }
     use datafusion_comet_proto::spark_operator::CompressionCodec as ProtoCodec;
 
     fn base_settings() -> IcebergParquetWriteSettings {
@@ -942,11 +1252,40 @@ mod tests {
     }
 
     #[test]
-    fn build_output_schema_has_single_binary_column() {
+    fn build_output_schema_carries_the_manifest_and_the_written_locations() {
         let schema = build_output_schema();
-        assert_eq!(schema.fields().len(), 1);
+        assert_eq!(schema.fields().len(), 2);
         assert_eq!(schema.field(0).name(), "iceberg_manifest");
         assert_eq!(schema.field(0).data_type(), &DataType::Binary);
+        assert_eq!(schema.field(1).name(), "written_file_locations");
+        assert_eq!(schema.field(1).data_type(), &DataType::Binary);
+    }
+
+    #[test]
+    fn encoded_locations_round_trip_through_the_jvm_framing() {
+        // Mirrors `CometIcebergWriteExec.decodeLocations`; a path containing a newline is decoded
+        // as one location rather than two.
+        fn decode(encoded: &[u8]) -> Vec<String> {
+            let mut out = Vec::new();
+            let count = i32::from_be_bytes(encoded[0..4].try_into().unwrap());
+            let mut at = 4usize;
+            for _ in 0..count {
+                let len = i32::from_be_bytes(encoded[at..at + 4].try_into().unwrap()) as usize;
+                at += 4;
+                out.push(String::from_utf8(encoded[at..at + len].to_vec()).unwrap());
+                at += len;
+            }
+            assert_eq!(at, encoded.len());
+            out
+        }
+        let locations = vec![
+            "s3://bucket/table/data/00000-00001-op-00001.parquet".to_string(),
+            "file:/tmp/t/data/region=a%2Fb/00000-00001-op-00002.parquet".to_string(),
+            "file:/tmp/t/data/odd\nname.parquet".to_string(),
+            "file:/tmp/t/data/日本.parquet".to_string(),
+        ];
+        assert_eq!(decode(&encode_locations(&locations)), locations);
+        assert_eq!(decode(&encode_locations(&[])), Vec::<String>::new());
     }
 
     #[test]
@@ -972,6 +1311,7 @@ mod tests {
         };
         use parquet::file::properties::WriterProperties;
         use std::collections::HashMap;
+        use std::path::PathBuf;
         use std::sync::Arc;
         use tempfile::TempDir;
 
@@ -1055,7 +1395,7 @@ mod tests {
             writer_mode: ProtoIcebergWriterMode,
             batches: Vec<RecordBatch>,
         ) -> DFResult<Vec<DataFile>> {
-            run_write_task(
+            let (data_files, mut abort_guard) = run_write_task(
                 input_stream(batches),
                 common,
                 Arc::new(schema),
@@ -1066,7 +1406,11 @@ mod tests {
                 Some(0),
                 Time::default(),
             )
-            .await
+            .await?;
+            // These tests assert on the written files, so they stand in for the JVM taking
+            // ownership of them.
+            abort_guard.disarm();
+            Ok(data_files)
         }
 
         #[tokio::test]
@@ -1100,6 +1444,56 @@ mod tests {
                 .file_path()
                 .contains(temp_dir.path().to_str().unwrap()));
             assert!(data_files[0].file_path().ends_with(".parquet"));
+        }
+
+        // Manifest encoding and output-batch construction run after the writer has closed and can
+        // still fail. `run_write_task` therefore hands its caller a guard that is still armed, so
+        // the files a successful writer produced are deleted if packaging them fails.
+        #[tokio::test]
+        async fn a_successful_write_returns_an_armed_guard_that_can_still_delete_its_files() {
+            let temp_dir = TempDir::new().unwrap();
+            let data_location = format!("file://{}", temp_dir.path().display());
+            let schema = iceberg_user_schema();
+            let spec = PartitionSpec::builder(Arc::new(schema.clone()))
+                .build()
+                .unwrap();
+            let common = common(
+                data_location,
+                serde_json::to_string(&spec).unwrap(),
+                serde_json::to_string(&schema).unwrap(),
+                ProtoIcebergWriterMode::IcebergWriterUnpartitioned,
+            );
+
+            let (data_files, mut abort_guard) = run_write_task(
+                input_stream(vec![batch(&[1, 2, 3], &["us", "eu", "us"])]),
+                common,
+                Arc::new(schema),
+                Arc::new(spec),
+                ProtoIcebergWriterMode::IcebergWriterUnpartitioned,
+                WriterProperties::builder().build(),
+                Some(0),
+                Some(0),
+                Time::default(),
+            )
+            .await
+            .unwrap();
+
+            assert!(
+                abort_guard.armed,
+                "the caller owns cleanup until the JVM does"
+            );
+            let written: Vec<PathBuf> = data_files
+                .iter()
+                .map(|f| PathBuf::from(f.file_path().trim_start_matches("file:")))
+                .collect();
+            assert!(written.iter().all(|p| p.exists()), "{written:?}");
+            assert_eq!(abort_guard.locations().len(), written.len());
+
+            // What the outer task does when `encode_data_files_as_manifest` or
+            // `build_output_batch` fails.
+            abort_guard.abort().await;
+            assert!(written.iter().all(|p| !p.exists()), "{written:?}");
+            assert!(!abort_guard.armed, "aborting also gives up ownership");
         }
 
         #[tokio::test]
@@ -1422,7 +1816,7 @@ mod tests {
 
             let schema_arc = Arc::new(schema);
             let spec_arc = Arc::new(spec);
-            let data_files = run_write_task(
+            let (data_files, mut abort_guard) = run_write_task(
                 input_stream(vec![batch(&[10, 20], &["x", "y"])]),
                 Arc::clone(&common),
                 Arc::clone(&schema_arc),
@@ -1435,6 +1829,8 @@ mod tests {
             )
             .await
             .unwrap();
+            let locations = abort_guard.locations();
+            abort_guard.disarm();
 
             let manifest_bytes = encode_data_files_as_manifest(
                 data_files.clone(),
@@ -1447,8 +1843,18 @@ mod tests {
             .await
             .unwrap();
             let output_schema = build_output_schema();
-            let batch = build_output_batch(manifest_bytes.clone(), &output_schema).unwrap();
+            let batch =
+                build_output_batch(manifest_bytes.clone(), &locations, &output_schema).unwrap();
             assert_eq!(batch.num_rows(), 1);
+            // The locations column names every file the manifest does, so the JVM can clean up
+            // without decoding the manifest.
+            assert_eq!(
+                locations,
+                data_files
+                    .iter()
+                    .map(|f| f.file_path().to_string())
+                    .collect::<Vec<_>>()
+            );
 
             let manifest = Manifest::parse_avro(&manifest_bytes).unwrap();
             let entries = manifest.entries();
@@ -1538,7 +1944,7 @@ mod tests {
 
             let schema_arc = Arc::new(schema);
             let spec_arc = Arc::new(spec);
-            let data_files = run_write_task(
+            let (data_files, mut abort_guard) = run_write_task(
                 input_stream(vec![batch(&[1, 2], &["us", "eu"])]),
                 Arc::clone(&common),
                 Arc::clone(&schema_arc),
@@ -1551,6 +1957,8 @@ mod tests {
             )
             .await
             .unwrap();
+            // The write succeeded, so the guard must not delete what it produced.
+            abort_guard.disarm();
             assert_eq!(data_files.len(), 1);
             // No partition directory, matching iceberg-java's `UnpartitionedDataWriter`: the file
             // sits directly under the data location.
@@ -1603,7 +2011,7 @@ mod tests {
 
             let schema_arc = Arc::new(schema);
             let spec_arc = Arc::new(spec);
-            let data_files = run_write_task(
+            let (data_files, mut abort_guard) = run_write_task(
                 input_stream(vec![batch(&[1], &["us"])]),
                 Arc::clone(&common),
                 Arc::clone(&schema_arc),
@@ -1616,6 +2024,8 @@ mod tests {
             )
             .await
             .unwrap();
+            // The write succeeded, so the guard must not delete what it produced.
+            abort_guard.disarm();
             let manifest_bytes = encode_data_files_as_manifest(
                 data_files,
                 schema_arc,
@@ -1690,7 +2100,7 @@ mod tests {
             )
             .unwrap();
 
-            let data_files = run_write_task(
+            let (data_files, mut abort_guard) = run_write_task(
                 Box::pin(RecordBatchStreamAdapter::new(
                     arrow_schema,
                     futures::stream::iter(vec![Ok::<_, DataFusionError>(batch)]),
@@ -1706,6 +2116,8 @@ mod tests {
             )
             .await
             .unwrap();
+            // The write succeeded, so the guard must not delete what it produced.
+            abort_guard.disarm();
 
             assert_eq!(data_files.len(), 1);
             assert!(

--- a/spark/src/main/scala/org/apache/comet/iceberg/IcebergReflection.scala
+++ b/spark/src/main/scala/org/apache/comet/iceberg/IcebergReflection.scala
@@ -1736,6 +1736,51 @@ object IcebergReflection extends Logging {
     }
   }
 
+  /**
+   * Best-effort deletion of `locations` through the table's `FileIO`, for a task that failed
+   * after iceberg-rust had already written them (the JVM-side counterpart of iceberg-java's
+   * `SparkCleanupUtil.deleteTaskFiles`). Uses `SupportsBulkOperations.deleteFiles` when the
+   * `FileIO` offers it and `FileIO.deleteFile(String)` per path otherwise. Never throws: the
+   * original task failure must stay the one Spark reports. Returns the number of locations
+   * deleted, or handed to the bulk delete. `context` identifies the task in the log lines.
+   */
+  def deleteFilesQuietly(io: AnyRef, locations: Seq[String], context: String): Int = {
+    import scala.jdk.CollectionConverters._
+    if (locations.isEmpty) return 0
+    val deleted = findMethod(io.getClass, "deleteFiles", classOf[java.lang.Iterable[_]]) match {
+      case Some(bulkDelete) =>
+        try {
+          bulkDelete.invoke(io, locations.asJava)
+          locations.size
+        } catch {
+          case NonFatal(e) =>
+            logWarning(s"Bulk delete of ${locations.size} data file(s) failed ($context)", e)
+            0
+        }
+      case None =>
+        findMethod(io.getClass, "deleteFile", classOf[String]) match {
+          case None =>
+            logWarning(
+              s"FileIO ${io.getClass.getName} has no deleteFile(String); leaving " +
+                s"${locations.size} data file(s) for remove_orphan_files ($context)")
+            0
+          case Some(deleteFile) =>
+            locations.count { location =>
+              try {
+                deleteFile.invoke(io, location)
+                true
+              } catch {
+                case NonFatal(e) =>
+                  logWarning(s"Failed to delete data file $location ($context)", e)
+                  false
+              }
+            }
+        }
+    }
+    logInfo(s"Deleted $deleted of ${locations.size} data file(s) ($context)")
+    deleted
+  }
+
   /** The table's `FileIO` (`table.io()`). Iceberg requires `FileIO` to be `Serializable`. */
   def getTableIO(table: Any): Option[AnyRef] =
     findMethodInHierarchy(table.getClass, "io").map(_.invoke(table))

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometIcebergWriteExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometIcebergWriteExec.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.types.BinaryType
 import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.TaskFailureListener
 
 import com.google.protobuf.CodedOutputStream
 
@@ -171,10 +172,10 @@ case class CometIcebergWriteExec(
       .getOrElse(
         throw new IllegalStateException(s"Native Iceberg write: no sort order id=$sortOrderId"))
     columnarRdd.mapPartitionsInternal { batches =>
-      // Per-task: drain the native output (single-row Binary column carrying one V2 data
-      // manifest), decode it via Iceberg's `ManifestFiles.read` to recover `DataFile`s, rebuild
-      // each file's metrics into the ones iceberg-java's own writer would have committed
-      // (re-derived from the written parquet footer through the version-matched
+      // Per-task: drain the native output (one row carrying one V2 data manifest and the locations
+      // the task wrote), decode the manifest via Iceberg's `ManifestFiles.read` to recover
+      // `DataFile`s, rebuild each file's metrics into the ones iceberg-java's own writer would
+      // have committed (re-derived from the written parquet footer through the version-matched
       // `ParquetUtil.footerMetrics` + `MetricsConfig`, with float/double NaN counts and bounds
       // carried over from the rust writer) while re-applying the write's `SortOrder` (which
       // iceberg-rust doesn't stamp), wrap them in `SparkWrite$TaskCommit` via reflection
@@ -182,7 +183,17 @@ case class CometIcebergWriteExec(
       // `IcebergCommitExec` consumes it identically to the JVM-path output. Empty manifests
       // (zero data files written) are still committed; the surrounding
       // `BatchWrite.commit(messages)` handles the no-op case correctly.
-      val manifestBytes = drainAvroPayload(batches)
+      //
+      // Cleanup ownership crosses the native boundary here. The listener is registered before the
+      // native payload is pulled and starts with nothing to delete; `drainNativePayload` hands it
+      // the written-file locations off the payload's locations column, which the native side fills
+      // in for exactly this purpose, before anything expensive runs. From that point a failure in
+      // the manifest decode, the metrics rebuild, `TaskCommit` construction, or serialization
+      // deletes the files the way iceberg-java's `DataWriter.abort()` would; failures inside the
+      // native writer, or before its output reaches us, are cleaned up on the native side.
+      val cleanup = new CometIcebergWriteExec.WrittenFileCleanup(tableIO)
+      Option(TaskContext.get()).foreach(_.addTaskFailureListener(cleanup))
+      val manifestBytes = drainNativePayload(batches, cleanup)
       val proj = UnsafeProjection.create(schemaTypes)
       val decoded =
         if (manifestBytes.isEmpty) new java.util.ArrayList[AnyRef]()
@@ -223,8 +234,9 @@ case class CometIcebergWriteExec(
     }
 
     val numPartitions = childRDD.getNumPartitions
-    // Native side emits a single Binary column carrying the per-task Avro `DataFile` blob.
-    val numOutputCols = 1
+    // Native side emits the per-task Avro `DataFile` blob and the locations it wrote, one Binary
+    // column each (see `build_output_schema` in `iceberg_write.rs`).
+    val numOutputCols = 2
     val capturedNativeOp = nativeOp
 
     childRDD.mapPartitionsInternal { iter =>
@@ -273,10 +285,16 @@ case class CometIcebergWriteExec(
 
   /**
    * Drain a partition's columnar output. `iceberg_write.rs` always emits exactly one batch with
-   * one `BINARY` row carrying the per-task V2 data manifest (possibly empty bytes when no data
-   * files were written). The asserts guard against a future native-side change.
+   * one row: a `BINARY` per-task V2 data manifest (possibly empty bytes when no data files were
+   * written) and a `BINARY` framing of the locations the task's writers were handed. The asserts
+   * guard against a future native-side change.
+   *
+   * `cleanup` takes ownership of those locations before the manifest bytes are copied out of the
+   * off-heap batch, so neither that copy nor anything after it can orphan the written files.
    */
-  private def drainAvroPayload(batches: Iterator[ColumnarBatch]): Array[Byte] = {
+  private def drainNativePayload(
+      batches: Iterator[ColumnarBatch],
+      cleanup: CometIcebergWriteExec.WrittenFileCleanup): Array[Byte] = {
     require(batches.hasNext, "iceberg_write produced no output batch for this task")
     val batch = batches.next()
     val payload =
@@ -284,11 +302,78 @@ case class CometIcebergWriteExec(
         require(
           batch.numRows() == 1,
           s"iceberg_write expected exactly 1 row per task, got ${batch.numRows()}")
+        require(
+          batch.numCols() == 2,
+          s"iceberg_write expected 2 output columns per task, got ${batch.numCols()}")
+        cleanup.own(CometIcebergWriteExec.decodeLocations(batch.column(1).getBinary(0)))
         batch.column(0).getBinary(0)
       } finally {
         batch.close()
       }
     require(!batches.hasNext, "iceberg_write produced more than one batch for this task")
     payload
+  }
+}
+
+object CometIcebergWriteExec {
+
+  /**
+   * Decode the `written_file_locations` column written by `encode_locations` in
+   * `iceberg_write.rs`: a big-endian `int` count, then a big-endian `int` byte length and the
+   * UTF-8 bytes for each location. Kept free of Iceberg and of the Avro decoder so cleanup
+   * ownership never depends on decoding the manifest that the task may have failed to decode.
+   *
+   * Strict about consuming the whole column: every native write decodes it, so a framing
+   * divergence between the two sides fails loudly here rather than silently handing cleanup a
+   * truncated list of the files to delete.
+   */
+  def decodeLocations(encoded: Array[Byte]): Seq[String] = {
+    if (encoded.isEmpty) return Nil
+    val buffer = java.nio.ByteBuffer.wrap(encoded)
+    val count = buffer.getInt
+    val locations = new Array[String](count)
+    var i = 0
+    while (i < count) {
+      val bytes = new Array[Byte](buffer.getInt)
+      buffer.get(bytes)
+      locations(i) = new String(bytes, java.nio.charset.StandardCharsets.UTF_8)
+      i += 1
+    }
+    require(
+      !buffer.hasRemaining,
+      s"iceberg_write locations column has ${buffer.remaining()} trailing byte(s) after " +
+        s"$count location(s)")
+    locations.toSeq
+  }
+
+  /**
+   * Deletes the data files a failed native Iceberg write task had already written, the
+   * counterpart of iceberg-java's `DataWriter.abort()` / `SparkCleanupUtil.deleteTaskFiles`.
+   *
+   * Registered before the task consumes the native output and left registered for the rest of the
+   * task: a task that fails at any point after the write never contributes a commit message, so
+   * every file it created is an orphan. It starts owning nothing and takes ownership of the
+   * locations the native writer reported as soon as they are read off the payload, which is why a
+   * failure in the manifest decode -- the step the locations would otherwise have to be recovered
+   * from -- is covered. Deletion is best-effort and never throws, so the failure Spark reports
+   * stays the real one.
+   *
+   * @param io
+   *   the table's `FileIO`, resolved on the driver and shipped in the task closure.
+   */
+  class WrittenFileCleanup(io: AnyRef) extends TaskFailureListener {
+    // Captured at construction (executor-side, inside the task) rather than read from the
+    // listener argument, so the log line is identical however the cleanup is triggered.
+    private val describeTask = Option(TaskContext.get())
+      .map(tc => s"failed Iceberg write task ${tc.partitionId()} (attempt ${tc.attemptNumber()})")
+      .getOrElse("failed Iceberg write task")
+
+    @volatile private var locations: Seq[String] = Nil
+
+    /** Take ownership of the locations the native writer reported. */
+    def own(written: Seq[String]): Unit = locations = written
+
+    override def onTaskFailure(context: TaskContext, error: Throwable): Unit =
+      IcebergReflection.deleteFilesQuietly(io, locations, describeTask)
   }
 }

--- a/spark/src/test/scala/org/apache/comet/CometIcebergTestBase.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergTestBase.scala
@@ -160,4 +160,30 @@ trait CometIcebergTestBase {
     }
     captured.toSeq
   }
+
+  /**
+   * The executed plan of every query that fails while `action` runs, and the failure `action`
+   * itself raised (`None` if it unexpectedly succeeded).
+   */
+  protected def captureFailedPlans(spark: SparkSession)(
+      action: => Unit): (Seq[SparkPlan], Option[Exception]) = {
+    val captured = mutable.Buffer.empty[SparkPlan]
+    val listener = new QueryExecutionListener {
+      override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = ()
+      override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit =
+        captured += qe.executedPlan
+    }
+    spark.listenerManager.register(listener)
+    try {
+      val error =
+        try {
+          action
+          None
+        } catch { case e: Exception => Some(e) }
+      CometListenerBusUtils.waitUntilEmpty(spark.sparkContext)
+      (captured.toSeq, error)
+    } finally {
+      spark.listenerManager.unregister(listener)
+    }
+  }
 }

--- a/spark/src/test/scala/org/apache/comet/CometIcebergWriteActionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergWriteActionSuite.scala
@@ -27,6 +27,7 @@ import scala.collection.mutable
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters._
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.CometTestBase
@@ -40,6 +41,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DoubleType, IntegerType, StringType, StructField, StructType}
 
 import org.apache.comet.CometSparkSessionExtensions.{isSpark35Plus, isSpark41Plus}
+import org.apache.comet.iceberg.IcebergReflection
 
 private case class WriteSnapshot(snapshotDelta: Long, plans: Seq[SparkPlan])
 
@@ -1598,6 +1600,165 @@ class CometIcebergWriteActionSuite
     }
   }
 
+  // A one-byte target file size makes the rolling writer finalize a file per batch, and a two-row
+  // Comet batch size means the task has handed several batches to the writer before the UDF
+  // throws on id 7. iceberg-java's writer abort deletes such files; the native path must too.
+  test("native acceleration: a failed task deletes the data files it already finalized") {
+    assumeNativeAcceleration()
+    withIcebergCatalog { warehouseDir =>
+      val session = spark
+      import session.implicits._
+      (1 to 10)
+        .map(i => (i, s"r$i", i.toDouble))
+        .toDF("id", "region", "amount")
+        .coalesce(1)
+        .createOrReplaceTempView("cleanup_src")
+      spark.udf.register(
+        "boom_on_seven_cleanup",
+        (id: Int) => {
+          if (id == 7) throw new RuntimeException("boom")
+          id
+        })
+      val rollingProps = Some("'write.target-file-size-bytes'='1'")
+
+      withNativeEnabled(withSQLConf(CometConf.COMET_BATCH_SIZE.key -> "2") {
+        // Control: the same source and settings without the failure roll into several files, so
+        // the failing run below really does have finalized files to clean up.
+        createTable(
+          warehouseDir,
+          "cleanup_control",
+          partitionSpec = "",
+          properties = rollingProps)
+        val controlPlans = capturePlans(spark) {
+          spark.sql(
+            s"INSERT INTO $catalog.$ns.cleanup_control SELECT id, region, amount FROM cleanup_src")
+        }
+        assert(
+          controlPlans.exists(p =>
+            collectWithSubqueries(p) { case w: CometIcebergWriteExec => w }.nonEmpty),
+          "control write did not run natively")
+        val controlFiles = parquetFiles(dataDir("cleanup_control"))
+        assert(controlFiles.size >= 3, s"expected the writer to roll files, got $controlFiles")
+
+        createTable(warehouseDir, "cleanup_target", partitionSpec = "", properties = rollingProps)
+        coalesceInsert("cleanup_target", Seq((0, "seed", 0.0)))
+        val committed = parquetFiles(dataDir("cleanup_target"))
+        assert(committed.size == 1)
+        val before = countSnapshots("cleanup_target")
+
+        val (failedPlans, error) = captureFailedPlans(spark) {
+          spark.sql(s"INSERT INTO $catalog.$ns.cleanup_target " +
+            "SELECT boom_on_seven_cleanup(id), region, amount FROM cleanup_src")
+        }
+        assert(
+          error.toSeq
+            .flatMap(exceptionChain)
+            .exists(t => Option(t.getMessage).exists(_.contains("boom"))),
+          s"expected the injected task failure to surface, got $error")
+        assert(
+          failedPlans.exists(p =>
+            collectWithSubqueries(p) { case w: CometIcebergWriteExec => w }.nonEmpty),
+          s"failed write did not run natively:\n${failedPlans.mkString("\n--\n")}")
+        assert(countSnapshots("cleanup_target") == before, "failed write must not commit")
+        val remaining = parquetFiles(dataDir("cleanup_target"))
+        assert(
+          remaining == committed,
+          s"the failed task left data files behind: ${remaining -- committed}")
+        assertRows("cleanup_target", expectedIds = Seq(0))
+      })
+    }
+  }
+
+  test("deleteFilesQuietly removes data files through the table FileIO and never throws") {
+    assumeNativeAcceleration()
+    withIcebergCatalog { warehouseDir =>
+      createTable(warehouseDir, "delete_quietly", partitionSpec = "PARTITIONED BY (region)")
+      spark.sql(s"INSERT INTO $catalog.$ns.delete_quietly VALUES (1, 'us', 1.0), (2, 'eu', 2.0)")
+      val locations = spark
+        .sql(s"SELECT file_path FROM $catalog.$ns.delete_quietly.files")
+        .collect()
+        .map(_.getString(0))
+        .toSeq
+      assert(locations.size == 2)
+      val io = IcebergReflection
+        .getTableIO(loadIcebergTable(spark, catalog, ns, "delete_quietly"))
+        .getOrElse(fail("table.io() unavailable"))
+
+      val deleted = IcebergReflection.deleteFilesQuietly(
+        io,
+        locations :+ s"${locations.head}.missing",
+        "test")
+      assert(deleted == locations.size + 1, s"deleted=$deleted")
+      assert(parquetFiles(dataDir("delete_quietly")).isEmpty)
+      // Deleting the same paths again is a no-op rather than an error.
+      IcebergReflection.deleteFilesQuietly(io, locations, "test")
+    }
+  }
+
+  // The gap this closes: the locations the cleanup listener works from come off the native
+  // payload's own locations column, not out of the manifest, so a failure decoding that manifest
+  // -- the step the locations would otherwise have to be recovered from -- is still covered.
+  test("the write cleanup listener deletes the locations the native writer reported") {
+    assumeNativeAcceleration()
+    withIcebergCatalog { warehouseDir =>
+      createTable(warehouseDir, "listener_cleanup", partitionSpec = "PARTITIONED BY (region)")
+      spark.sql(
+        s"INSERT INTO $catalog.$ns.listener_cleanup VALUES (1, 'us', 1.0), (2, 'eu', 2.0)")
+      val locations = spark
+        .sql(s"SELECT file_path FROM $catalog.$ns.listener_cleanup.files")
+        .collect()
+        .map(_.getString(0))
+        .toSeq
+      assert(locations.size == 2)
+      val io = IcebergReflection
+        .getTableIO(loadIcebergTable(spark, catalog, ns, "listener_cleanup"))
+        .getOrElse(fail("table.io() unavailable"))
+
+      // The listener identifies its task from the context captured at construction, so its
+      // argument goes unused; it is registered before the native payload arrives, and until it
+      // has been handed the locations it owns nothing and must leave the table alone.
+      val cleanup = new CometIcebergWriteExec.WrittenFileCleanup(io)
+      cleanup.onTaskFailure(null, new RuntimeException("boom"))
+      assert(parquetFiles(dataDir("listener_cleanup")).size == 2)
+
+      cleanup.own(locations)
+      cleanup.onTaskFailure(null, new RuntimeException("boom"))
+      assert(parquetFiles(dataDir("listener_cleanup")).isEmpty)
+    }
+  }
+
+  test("the written-file locations column round-trips the native framing") {
+    // Mirrors `encode_locations` in `iceberg_write.rs`.
+    def encode(locations: Seq[String]): Array[Byte] = {
+      val bytes = new java.io.ByteArrayOutputStream()
+      val out = new java.io.DataOutputStream(bytes)
+      out.writeInt(locations.size)
+      locations.foreach { location =>
+        val utf8 = location.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        out.writeInt(utf8.length)
+        out.write(utf8)
+      }
+      bytes.toByteArray
+    }
+    // Explicit lengths rather than a separator, so a path is decoded as one location whatever it
+    // contains: an escaped partition path, a newline, non-ASCII.
+    val locations = Seq(
+      "s3://bucket/t/data/00000-00001-op-00001.parquet",
+      "file:/tmp/t/data/region=a%2Fb/00000-00001-op-00002.parquet",
+      "file:/tmp/t/data/odd\nname.parquet",
+      "file:/tmp/t/data/日本.parquet")
+    assert(CometIcebergWriteExec.decodeLocations(encode(locations)) == locations)
+    assert(CometIcebergWriteExec.decodeLocations(encode(Nil)) == Nil)
+    assert(CometIcebergWriteExec.decodeLocations(Array.emptyByteArray) == Nil)
+    // A framing divergence between the two sides has to fail loudly rather than hand cleanup a
+    // truncated list of files to delete.
+    val trailing = encode(locations) :+ 0.toByte
+    assert(
+      intercept[IllegalArgumentException](
+        CometIcebergWriteExec.decodeLocations(trailing)).getMessage
+        .contains("trailing byte"))
+  }
+
   test("native acceleration: wide primitive types keep JVM-parity values and manifest metrics") {
     assumeNativeAcceleration()
     withIcebergCatalog { _ =>
@@ -2039,6 +2200,34 @@ class CometIcebergWriteActionSuite
     // pass is a whole class of bug (issue #5689) and the check is free once the plans are here.
     plans.foreach(assertColumnarContract)
     WriteSnapshot(countSnapshots(tableName) - before, plans)
+  }
+
+  /**
+   * The table's `data` directory, resolved from `Table.location()` rather than from the warehouse
+   * conf: Spark caches the catalog instance per session, so a later test's warehouse setting does
+   * not necessarily govern where its tables are created.
+   */
+  private def dataDir(tableName: String): File = {
+    val table = loadIcebergTable(spark, catalog, ns, tableName)
+    val location = table.getClass.getMethod("location").invoke(table).toString
+    val uri = new java.net.URI(location)
+    val root = if (uri.getScheme == null) new File(location) else new File(uri)
+    new File(root, "data")
+  }
+
+  /** Relative paths of every parquet file under `dir`, or empty when it does not exist yet. */
+  private def parquetFiles(dir: File): Set[String] = {
+    if (!dir.exists()) return Set.empty
+    val root = dir.toPath
+    val stream = java.nio.file.Files.walk(root)
+    try {
+      stream
+        .iterator()
+        .asScala
+        .filter(p => p.toString.endsWith(".parquet"))
+        .map(p => root.relativize(p).toString)
+        .toSet
+    } finally stream.close()
   }
 
   private def countSnapshots(tableName: String): Long =


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5618.

## Rationale for this change

When a native Iceberg write task fails partway through, the data files it had already finalized stay in the table's data location. They are invisible to readers and `remove_orphan_files` eventually reclaims them, but iceberg-java deletes them synchronously (`DataWriter.abort()` calls `SparkCleanupUtil.deleteTaskFiles`), so on spot-heavy or preemption-prone clusters the native path silently accumulates orphans that the JVM path does not. This is the first phase-2 item of the native Iceberg writes epic (#5649).

## What changes are included in this PR?

The native writer records every location it hands to a file writer, and exactly one side owns deleting those files at any moment: the native writer until its output batch reaches the JVM, the JVM from then on. The handoff is explicit and does not depend on decoding the manifest.

**Inside the native writer.** iceberg-rust's writers keep the `DataFile`s they have finalized private until `close` and have no abort hook, so the task cannot ask a failed writer what it wrote. Instead, the `RollingFileWriterBuilder` is given a `TrackingLocationGenerator`, a wrapper around `DefaultLocationGenerator` that records every location it hands out. If the input stream, a write, or the final close fails, the task deletes every recorded location through its `FileIO` before propagating the original error.

That explicit path is not enough on its own, and the end-to-end test proved it: when the JVM-side input iterator throws (a UDF failure upstream of the write, the most common shape), `executePlan` returns the error straight from its JNI batch pull and the JVM releases the plan, so the write task's future is dropped without ever seeing an error. An `AbortOnDrop` guard covers that case. If it is dropped while still armed it deletes the tracked files, synchronously on a throwaway current-thread runtime when dropped from a plain JVM thread (`releasePlan`), or spawned onto the current runtime when dropped from inside one.

The guard is not disarmed when the writer closes: `run_write_task` returns it, still armed, alongside the `DataFile`s, and the outer task disarms it only once `build_output_batch` has produced the batch. `encode_data_files_as_manifest` and `build_output_batch` are both fallible and run after the files exist, so a failure there awaits the guard's abort (delete, then disarm) rather than leaving the files for nobody.

**Across the JNI boundary.** Once the batch reaches the JVM, the native side is out of the picture, but the locations must not be recoverable only by decoding the manifest — the manifest decode is itself a step that can fail, and does so under heap pressure (a valid 864 KB manifest from 4,096 files raised `OutOfMemoryError` inside Iceberg's Avro reader in a 128 MiB JVM). So the native operator emits the locations as a second Binary column next to the manifest, framed as a big-endian `i32` count, then a big-endian `i32` byte length and the UTF-8 bytes for each location. Explicit lengths rather than a separator, so a path is never re-interpreted whatever it contains.

`CometIcebergWriteExec.doExecute` registers a `WrittenFileCleanup` task failure listener *before* pulling the native payload, owning nothing at first, and `drainNativePayload` hands it the decoded locations before it copies the manifest bytes out of the off-heap batch. Everything after that point — the manifest `Array[Byte]` copy, the Avro decode, the metrics rebuild, `TaskCommit` construction, serialization — happens with the listener already owning the files. The decode is strict about consuming the whole column, so a framing divergence between the two sides fails loudly on every native write rather than silently handing cleanup a truncated list.

`IcebergReflection.deleteFilesQuietly` prefers `SupportsBulkOperations.deleteFiles` and falls back to `FileIO.deleteFile(String)` per path. Deletion is best-effort on both sides: failures are logged, never returned, so the task failure Spark reports is still the real one. The location that was open at the time of a failure is included; deleting a path that was never materialized is a no-op.

One window remains open and is worth stating plainly: if building the location list is itself what exhausts the heap, nothing deletes. That is a few thousand short strings against the Avro decoder's full `DataFile` objects plus metrics maps, so it is a much smaller target, but it is not zero.

The "Failure handling" section of `iceberg-writes.md` is updated to describe the ownership handoff and drop the reference to this issue.

## How are these changes tested?

Rust:

- The tracking generator (layout unchanged, every location recorded).
- Cleanup against an in-memory `FileIO`, including a recorded location that was never written.
- The drop guard: a disarmed guard deletes nothing; an armed guard dropped outside a runtime deletes synchronously.
- `run_write_task` hands back an armed guard after a successful write whose locations match the files on disk, and aborting it removes them — the packaging-failure path.
- The locations framing round-trips through a decoder mirroring the JVM's, including a path with a newline and a non-ASCII path.
- The manifest round-trip test also asserts the locations column names exactly the files the manifest does.

JVM (`CometIcebergWriteActionSuite`):

- A failure-injection test writes a single-task source with a two-row Comet batch size into a table with a one-byte `write.target-file-size-bytes`, so the rolling writer finalizes a file per batch, and a UDF throws on the seventh row. A control run with the same source and settings first proves the writer rolls into several files; the failing run then asserts the write planned natively (`CometIcebergWriteExec` in the failed plan), no snapshot was created, the pre-existing data file is untouched, and no other parquet file remains under the table's data location.
- `WrittenFileCleanup` leaves the table alone before it has been handed any locations, and deletes them all once it has, through a real table's `HadoopFileIO`.
- The locations framing round-trips, an empty column decodes to nothing, and a trailing byte fails loudly.
- `deleteFilesQuietly` through a real table's `HadoopFileIO`: written files are removed, a nonexistent path is tolerated, and a second call is a no-op.

The full Iceberg suite set was run locally on the default Spark profile (253 tests, all passing), and the tree cross-compiles against `spark-3.5`/`scala-2.12` and `spark-4.0`.

Every native write in the suite now decodes the locations column with the strict framing check, so the two sides' framing is exercised on each of them.
