### PR TITLE
fix(celeborn): reject unsafe native push completion tracking

### DIFF
--- a/docs/source/user-guide/latest/tuning.md
+++ b/docs/source/user-guide/latest/tuning.md
@@ -254,8 +254,14 @@ even when both its parent and child are non-Comet operators.
 
 ### Remote Shuffle with Celeborn
 
-Applications using Apache Celeborn can opt into Comet's native shuffle writer and reader with
-the composite shuffle manager:
+Applications using Apache Celeborn can use Comet's composite shuffle manager to retain ordinary
+Spark/Celeborn shuffle while accelerating other operators with Comet.
+
+Native shuffle requires reliable completion tracking for in-flight payloads. Released Celeborn
+0.6.0 and 0.7.0 clients do not provide the required guarantee, so these versions retain ordinary
+Spark/Celeborn shuffle even when `spark.comet.shuffle.mode=native`. Native shuffle support for
+these clients requires a safe Celeborn push-completion API. The following settings request
+native shuffle when the client passes Comet's compatibility checks:
 
 ```properties
 spark.shuffle.manager=org.apache.spark.sql.comet.execution.shuffle.CometCelebornShuffleManager

--- a/spark/src/main/java/org/apache/comet/shuffle/CelebornShufflePartitionPusher.java
+++ b/spark/src/main/java/org/apache/comet/shuffle/CelebornShufflePartitionPusher.java
@@ -234,6 +234,13 @@ public final class CelebornShufflePartitionPusher implements ShufflePartitionPus
           "Celeborn in-flight byte limit must fit all copies of one Comet frame");
     }
 
+    String unavailable = nativePushCompletionUnavailableReason(shuffleClient.getClass());
+    if (unavailable != null) {
+      // Do not silently use PushState counters: callbacks, retries and timed-out writes can
+      // still retain payloads after those counters report completion.
+      throw new UnsupportedOperationException(unavailable);
+    }
+
     final Method pushMethod;
     try {
       pushMethod =
@@ -345,8 +352,8 @@ public final class CelebornShufflePartitionPusher implements ShufflePartitionPus
         // Wrappers need not provide the optional side-effect-free state lookup.
       }
     } catch (NoSuchMethodException missing) {
-      // Compatibility-only clients can still push synchronously. Stock Celeborn 0.6 and 0.7
-      // expose getPushState and use completion-backed admission.
+      // Compatibility-only clients can still push synchronously. Asynchronous clients must
+      // expose getPushState in addition to safely published transport hooks.
       pushStateMethod = null;
       pushStatesField = null;
       trackerField = null;
@@ -382,6 +389,11 @@ public final class CelebornShufflePartitionPusher implements ShufflePartitionPus
     this.maxFrameBytes =
         Math.min(Math.min(configuredMaxFrameBytes, MAX_JVM_ARRAY_BYTES), maxReservationBytes / 3);
     this.partitionLengths = new AtomicLongArray(numPartitions);
+  }
+
+  /** Returns the reason an optional client cannot safely track native push completion, or null. */
+  public static String nativePushCompletionUnavailableReason(Class<?> shuffleClientClass) {
+    return CelebornTransportCallbackTracker.unavailableReason(shuffleClientClass);
   }
 
   private static Method optionalLifecycleMethod(

--- a/spark/src/main/java/org/apache/comet/shuffle/CelebornTransportCallbackTracker.java
+++ b/spark/src/main/java/org/apache/comet/shuffle/CelebornTransportCallbackTracker.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
@@ -50,7 +51,7 @@ import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Tracks payload ownership across stock Celeborn transport callbacks and retry tasks. */
+/** Tracks payload ownership only for clients that safely publish replaceable transport fields. */
 final class CelebornTransportCallbackTracker {
   private static final Logger LOG = LoggerFactory.getLogger(CelebornTransportCallbackTracker.class);
 
@@ -66,12 +67,49 @@ final class CelebornTransportCallbackTracker {
   }
 
   static CelebornTransportCallbackTracker tryCreate(Object shuffleClient) {
+    String unavailable = unavailableReason(shuffleClient.getClass());
+    if (unavailable != null) {
+      throw new UnsupportedOperationException(unavailable);
+    }
     try {
       return new CelebornTransportCallbackTracker(
           shuffleClient, shuffleClient.getClass().getMethod("getDataClientFactory"));
     } catch (NoSuchMethodException ignored) {
       // Compatibility clients without a transport factory retain their own completion tracking.
       return null;
+    }
+  }
+
+  static String unavailableReason(Class<?> clientClass) {
+    final Method factoryMethod;
+    try {
+      factoryMethod = clientClass.getMethod("getDataClientFactory");
+    } catch (NoSuchMethodException absent) {
+      // Synchronous compatibility clients do not install transport hooks.
+      return null;
+    }
+    try {
+      Class<?> factoryClass = factoryMethod.getReturnType();
+      Field bootstraps = replaceableField(factoryClass, "clientBootstraps");
+      replaceableField(clientClass, "pushDataRetryPool");
+      Class<?> bootstrapClass = bootstrapInterface(bootstraps, factoryClass);
+      Method bootstrapMethod = null;
+      for (Method method : bootstrapClass.getMethods()) {
+        if (method.getName().equals("doBootstrap") && method.getParameterCount() == 1) {
+          bootstrapMethod = method;
+          break;
+        }
+      }
+      if (bootstrapMethod == null) {
+        throw new NoSuchMethodException("Celeborn transport bootstrap has no client parameter");
+      }
+      Class<?> transportClass = bootstrapMethod.getParameterTypes()[0];
+      replaceableField(transportClass, "channel");
+      replaceableField(transportClass.getMethod("getHandler").getReturnType(), "outstandingPushes");
+      return null;
+    } catch (ReflectiveOperationException | RuntimeException failure) {
+      return "Native Celeborn shuffle requires safely published transport completion tracking: "
+          + failure.getMessage();
     }
   }
 
@@ -103,7 +141,7 @@ final class CelebornTransportCallbackTracker {
         throw new IOException("Celeborn returned a null data transport factory");
       }
       synchronized (factory) {
-        Field bootstrapsField = field(factory.getClass(), "clientBootstraps");
+        Field bootstrapsField = replaceableField(factory.getClass(), "clientBootstraps");
         Object bootstrapValue = bootstrapsField.get(factory);
         if (!(bootstrapValue instanceof List<?>)) {
           throw new IOException("Celeborn transport factory has no bootstrap list");
@@ -116,7 +154,7 @@ final class CelebornTransportCallbackTracker {
           addBootstrap = true;
         }
         if (hook == null) {
-          Class<?> bootstrapInterface = bootstrapInterface(bootstrapsField, factory);
+          Class<?> bootstrapInterface = bootstrapInterface(bootstrapsField, factory.getClass());
           hook = new FactoryHook(factory, bootstrapsField);
           hook.bootstrap =
               Proxy.newProxyInstance(
@@ -227,7 +265,7 @@ final class CelebornTransportCallbackTracker {
     }
   }
 
-  private static Class<?> bootstrapInterface(Field bootstrapsField, Object factory)
+  private static Class<?> bootstrapInterface(Field bootstrapsField, Class<?> factoryClass)
       throws ReflectiveOperationException {
     Type genericType = bootstrapsField.getGenericType();
     if (genericType instanceof ParameterizedType) {
@@ -239,7 +277,22 @@ final class CelebornTransportCallbackTracker {
     return Class.forName(
         "org.apache.celeborn.common.network.client.TransportClientBootstrap",
         false,
-        factory.getClass().getClassLoader());
+        factoryClass.getClassLoader());
+  }
+
+  private static Field replaceableField(Class<?> type, String name) throws NoSuchFieldException {
+    Field result = field(type, name);
+    int modifiers = result.getModifiers();
+    // A monitor used only by Comet cannot publish replacements to Celeborn's readers. In
+    // particular, reflective writes to a final field may never be observed by those readers.
+    // A plain mutable field also lacks the required happens-before edge.
+    if (Modifier.isStatic(modifiers)
+        || Modifier.isFinal(modifiers)
+        || !Modifier.isVolatile(modifiers)) {
+      throw new IllegalArgumentException(
+          type.getName() + "." + name + " must be a volatile instance field");
+    }
+    return result;
   }
 
   private static Field field(Class<?> type, String name) throws NoSuchFieldException {
@@ -544,7 +597,7 @@ final class CelebornTransportCallbackTracker {
     private void installRetryPool(Object shuffleClient)
         throws ReflectiveOperationException, IOException {
       synchronized (shuffleClient) {
-        Field poolField = field(shuffleClient.getClass(), "pushDataRetryPool");
+        Field poolField = replaceableField(shuffleClient.getClass(), "pushDataRetryPool");
         Object pool = poolField.get(shuffleClient);
         if (pool instanceof TrackingRetryExecutor) {
           if (((TrackingRetryExecutor) pool).hook != this) {
@@ -596,7 +649,7 @@ final class CelebornTransportCallbackTracker {
       }
       synchronized (handler) {
         installChannel(client);
-        Field requestsField = field(handler.getClass(), "outstandingPushes");
+        Field requestsField = replaceableField(handler.getClass(), "outstandingPushes");
         Object requests = requestsField.get(handler);
         if (requests instanceof CallbackTrackingRequests) {
           if (((CallbackTrackingRequests) requests).hook != this) {
@@ -615,7 +668,7 @@ final class CelebornTransportCallbackTracker {
     }
 
     private void installChannel(Object client) throws ReflectiveOperationException, IOException {
-      Field channelField = field(client.getClass(), "channel");
+      Field channelField = replaceableField(client.getClass(), "channel");
       Object channel = channelField.get(client);
       if (channel == null || !channelField.getType().isInterface()) {
         throw new IOException("Celeborn transport client has no compatible channel interface");

--- a/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometCelebornShuffleManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/execution/shuffle/CometCelebornShuffleManager.scala
@@ -442,13 +442,21 @@ private[shuffle] object CometCelebornShuffleManager {
 
   private[shuffle] def nativeShufflePlanningSupport(
       conf: SparkConf,
-      loadCelebornConf: SparkConf => AnyRef = reflectedCelebornConf)
+      loadCelebornConf: SparkConf => AnyRef = reflectedCelebornConf,
+      pushCompletionUnavailableReason: () => Option[String] = () =>
+        Option(
+          CelebornShufflePartitionPusher.nativePushCompletionUnavailableReason(
+            ClassLoaders.loadClass("org.apache.celeborn.client.ShuffleClientImpl"))))
       : CelebornNativeShufflePlanningSupport = {
     if (conf.getBoolean("spark.io.encryption.enabled", false)) {
       return CelebornNativeShufflePlanningSupport(
         Some("Native Celeborn shuffle does not support spark.io.encryption.enabled=true"))
     }
     try {
+      val completionUnavailable = pushCompletionUnavailableReason()
+      if (completionUnavailable.nonEmpty) {
+        return CelebornNativeShufflePlanningSupport(completionUnavailable)
+      }
       // Use Celeborn's effective settings to preserve its defaults, aliases, JVM properties and
       // legacy force-fallback precedence without depending on a particular client version.
       val settings = loadCelebornConf(conf)

--- a/spark/src/test/celeborn-reflection-compatibility/org/apache/comet/shuffle/CelebornReflectionCompatibilitySuite.scala
+++ b/spark/src/test/celeborn-reflection-compatibility/org/apache/comet/shuffle/CelebornReflectionCompatibilitySuite.scala
@@ -169,6 +169,24 @@ class CelebornReflectionCompatibilitySuite extends AnyFunSuite {
     })
   }
 
+  test("reject native shuffle for released clients with final completion-tracking fields") {
+    val completionFields = Seq(
+      declaredField(transportClientFactory, "clientBootstraps"),
+      declaredField(transportClient, "channel"),
+      declaredField(transportResponseHandler, "outstandingPushes"),
+      declaredField(shuffleClient, "pushDataRetryPool"))
+    completionFields.foreach { field =>
+      assert(Modifier.isFinal(field.getModifiers), s"$field must remain final in Celeborn")
+      assert(!Modifier.isVolatile(field.getModifiers), s"$field must not be volatile in Celeborn")
+    }
+
+    val reason =
+      CelebornShufflePartitionPusher.nativePushCompletionUnavailableReason(shuffleClient)
+    assert(reason != null, s"Celeborn $celebornVersion must not use native push admission")
+    assert(reason.contains("completion"), reason)
+    assert(reason.contains("volatile"), reason)
+  }
+
   private def load(name: String): Class[_] = Class.forName(name, false, classLoader)
 
   private def instanceField(owner: Class[_], name: String, expectedType: Class[_]): Field = {

--- a/spark/src/test/java/org/apache/comet/shuffle/CelebornTransportOwnershipTestHelper.java
+++ b/spark/src/test/java/org/apache/comet/shuffle/CelebornTransportOwnershipTestHelper.java
@@ -514,12 +514,12 @@ public final class CelebornTransportOwnershipTestHelper {
   }
 
   public static final class ResponseHandler {
-    private final ConcurrentHashMap<Long, Request> outstandingPushes = new ConcurrentHashMap<>();
+    private volatile ConcurrentHashMap<Long, Request> outstandingPushes = new ConcurrentHashMap<>();
   }
 
   public static final class Client {
     private final HoldingChannel underlying = new HoldingChannel();
-    private final Channel channel;
+    private volatile Channel channel;
     private final ResponseHandler handler = new ResponseHandler();
     private Error handlerFailure;
     private CountDownLatch handlerEntered;
@@ -562,7 +562,7 @@ public final class CelebornTransportOwnershipTestHelper {
   }
 
   public static final class Factory {
-    private final List<Bootstrap> clientBootstraps = new ArrayList<>();
+    private volatile List<Bootstrap> clientBootstraps = new ArrayList<>();
     private final ConcurrentHashMap<String, Pool> connectionPool = new ConcurrentHashMap<>();
 
     private Client createClient() {
@@ -584,7 +584,7 @@ public final class CelebornTransportOwnershipTestHelper {
 
   public static final class ShuffleClient {
     private final Factory factory;
-    private final ExecutorService pushDataRetryPool;
+    private volatile ExecutorService pushDataRetryPool;
 
     private ShuffleClient() {
       this(new Factory(), Executors.newSingleThreadExecutor());

--- a/spark/src/test/scala/org/apache/comet/shuffle/CelebornShufflePartitionPusherSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/shuffle/CelebornShufflePartitionPusherSuite.scala
@@ -363,6 +363,46 @@ class CelebornShufflePartitionPusherSuite extends AnyFunSuite {
     assert(wrongReturnType.getMessage.contains("returning an int"))
   }
 
+  test("final transport fields are rejected before client setup or raw submission") {
+    val client = new FinalFieldsRecordingCelebornPushClient
+    val originalBootstraps = client.factory.clientBootstraps
+    val originalRetryPool = client.pushDataRetryPool
+    val readerStarted = new CountDownLatch(1)
+    val checkReferences = new CountDownLatch(1)
+    val readerFailure = new AtomicReference[Throwable]()
+    val reader = new Thread(() => {
+      try {
+        // A Celeborn thread may keep these references indefinitely after final-field reads.
+        val bootstraps = client.factory.clientBootstraps
+        val retryPool = client.pushDataRetryPool
+        readerStarted.countDown()
+        assert(checkReferences.await(5, TimeUnit.SECONDS))
+        assert(client.factory.clientBootstraps eq bootstraps)
+        assert(client.pushDataRetryPool eq retryPool)
+        assert(bootstraps.isEmpty)
+      } catch {
+        case failure: Throwable => readerFailure.set(failure)
+      }
+    })
+    reader.start()
+    try {
+      assert(readerStarted.await(5, TimeUnit.SECONDS))
+      val failure = intercept[UnsupportedOperationException](pusher(client))
+      assert(failure.getMessage.contains("completion"))
+      assert(failure.getMessage.contains("volatile"))
+      intercept[UnsupportedOperationException](CelebornTransportCallbackTracker.tryCreate(client))
+      assert(client.factoryCalls.get() == 0)
+      assert(client.pushCount == 0)
+      assert(client.factory.clientBootstraps eq originalBootstraps)
+      assert(client.pushDataRetryPool eq originalRetryPool)
+    } finally {
+      checkReferences.countDown()
+      reader.join(5000)
+    }
+    assert(!reader.isAlive)
+    assert(readerFailure.get() == null)
+  }
+
   test("adapter rejects invalid shuffle, map-attempt, mapper, and partition metadata") {
     val client = new RecordingCelebornPushClient
     val invalidMetadata = Seq(
@@ -1717,12 +1757,29 @@ class AsyncRecordingCelebornPushClient extends RecordingCelebornPushClient {
   }
 }
 
-/** Reproduces stock Celeborn's client-factory, handler, and callback completion boundaries. */
+/** Models the final references in released clients without starting Celeborn network services. */
+final class FinalFieldsRecordingCelebornPushClient extends RecordingCelebornPushClient {
+  val factory = new FinalFieldsRecordingCelebornFactory
+  val pushDataRetryPool: ExecutorService = new RecordingCelebornRetryExecutor
+  val factoryCalls = new AtomicInteger()
+
+  def getDataClientFactory: FinalFieldsRecordingCelebornFactory = {
+    factoryCalls.incrementAndGet()
+    factory
+  }
+}
+
+final class FinalFieldsRecordingCelebornFactory {
+  val clientBootstraps: JList[RecordingCelebornTransportClientBootstrap] =
+    new JArrayList[RecordingCelebornTransportClientBootstrap]()
+}
+
+/** Models completion boundaries with safely published hooks, unlike stock Celeborn 0.6/0.7. */
 final class TransportRecordingCelebornPushClient extends AsyncRecordingCelebornPushClient {
   val dataClientFactory: RecordingCelebornTransportClientFactory =
     new RecordingCelebornTransportClientFactory
   val retryExecutor = new RecordingCelebornRetryExecutor
-  val pushDataRetryPool: ExecutorService = retryExecutor
+  @volatile var pushDataRetryPool: ExecutorService = retryExecutor
 
   def getDataClientFactory: RecordingCelebornTransportClientFactory = dataClientFactory
 
@@ -1833,7 +1890,7 @@ final class RecordingCelebornRetryExecutor extends AbstractExecutorService {
 final class RecordingCelebornTransportClientFactory {
   var handler: RecordingCelebornTransportResponseHandler =
     new RecordingCelebornTransportResponseHandler
-  val clientBootstraps: JList[RecordingCelebornTransportClientBootstrap] =
+  @volatile var clientBootstraps: JList[RecordingCelebornTransportClientBootstrap] =
     new JArrayList[RecordingCelebornTransportClientBootstrap]()
   val connectionPool: ConcurrentHashMap[String, RecordingCelebornTransportClientPool] =
     new ConcurrentHashMap[String, RecordingCelebornTransportClientPool]()
@@ -1872,14 +1929,15 @@ final class RecordingCelebornTransportClientPool(
 
 final class RecordingCelebornTransportClient(
     handler: RecordingCelebornTransportResponseHandler,
-    val channel: io.netty.channel.Channel) {
+    @volatile var channel: io.netty.channel.Channel) {
   def getChannel: io.netty.channel.Channel = channel
   def getHandler: RecordingCelebornTransportResponseHandler = handler
 }
 
 final class RecordingCelebornTransportResponseHandler {
   private val nextRequestId = new AtomicLong()
-  val outstandingPushes: ConcurrentHashMap[java.lang.Long, RecordingCelebornTransportRequest] =
+  @volatile var outstandingPushes
+      : ConcurrentHashMap[java.lang.Long, RecordingCelebornTransportRequest] =
     new ConcurrentHashMap[java.lang.Long, RecordingCelebornTransportRequest]()
 
   def add(pushState: RecordingCelebornPushState): Unit =

--- a/spark/src/test/scala/org/apache/spark/sql/comet/execution/shuffle/CometCelebornShuffleManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/execution/shuffle/CometCelebornShuffleManagerSuite.scala
@@ -395,7 +395,10 @@ class CometCelebornShuffleManagerSuite extends AnyFunSuite {
         loads += 1
         assert(!(actualConf eq conf))
         assert(actualConf.get("spark.app.name") == "native-celeborn-planning")
-        CometCelebornShuffleManager.nativeShufflePlanningSupport(actualConf, _ => effectiveConf)
+        CometCelebornShuffleManager.nativeShufflePlanningSupport(
+          actualConf,
+          _ => effectiveConf,
+          () => None)
       })
 
     // Mutating settings after manager construction cannot change its native capabilities.
@@ -419,7 +422,8 @@ class CometCelebornShuffleManagerSuite extends AnyFunSuite {
       _ => {
         loads += 1
         new ReflectedPlanningConf
-      })
+      },
+      () => fail("Encrypted applications must not probe push completion"))
 
     assert(support.fallbackReason(1).exists(_.contains("encryption")))
     assert(loads == 0)
@@ -433,17 +437,57 @@ class CometCelebornShuffleManagerSuite extends AnyFunSuite {
       .set("spark.celeborn.client.spark.fetch.throwsFetchFailure", "true")
     val support = CometCelebornShuffleManager.nativeShufflePlanningSupport(
       conf,
-      _ => new ReflectedPlanningConf(stageReruns = false))
+      _ => new ReflectedPlanningConf(stageReruns = false),
+      () => None)
 
     assert(support.fallbackReason(1).nonEmpty)
     assert(support.fallbackReason(100).nonEmpty)
+  }
+
+  test("unavailable push completion preserves ordinary delegated shuffle") {
+    val backend = new RecordingShuffleManager
+    val reason = "Celeborn client cannot safely observe native push completion"
+    var completionProbes = 0
+    var configurationLoads = 0
+    val composite = new CometCelebornShuffleManager(
+      new SparkConf(false),
+      false,
+      (_, _) => backend,
+      planningSupportFactory = conf =>
+        CometCelebornShuffleManager.nativeShufflePlanningSupport(
+          conf,
+          _ => {
+            configurationLoads += 1
+            new ReflectedPlanningConf(policy = "NEVER")
+          },
+          () => {
+            completionProbes += 1
+            Some(reason)
+          }))
+    try {
+      assert(composite.nativeShuffleFallbackReason(1).contains(reason))
+      assert(composite.nativeShuffleFallbackReason(Int.MaxValue).contains(reason))
+      assert(completionProbes == 1)
+      assert(configurationLoads == 0)
+
+      val handle = composite.registerShuffle[Any, Any, Any](31, null)
+      assert(handle eq backend.returnedHandle)
+      assert(composite.getWriter[Any, Any](handle, 12L, null, null) == null)
+      assert(composite.getReader[Any, Any](handle, 0, 2, null, null) == null)
+      assert(backend.writerCall.contains((handle, 12L)))
+      assert(backend.rangedReaderCall.contains((handle, 0, Int.MaxValue, 0, 2)))
+    } finally {
+      composite.stop()
+    }
+    assert(backend.stopped)
   }
 
   test("native planning honors the effective fallback policy and partition threshold") {
     Seq("AUTO", "auto").foreach { policy =>
       val support = CometCelebornShuffleManager.nativeShufflePlanningSupport(
         new SparkConf(false),
-        _ => new ReflectedPlanningConf(policy = policy, partitionThreshold = 4L))
+        _ => new ReflectedPlanningConf(policy = policy, partitionThreshold = 4L),
+        () => None)
       assert(support.fallbackReason(1).isEmpty)
       assert(support.fallbackReason(3).isEmpty)
       assert(support.fallbackReason(4).nonEmpty)
@@ -452,14 +496,16 @@ class CometCelebornShuffleManagerSuite extends AnyFunSuite {
 
     val always = CometCelebornShuffleManager.nativeShufflePlanningSupport(
       new SparkConf(false),
-      _ => new ReflectedPlanningConf(policy = "ALWAYS", partitionThreshold = Long.MaxValue))
+      _ => new ReflectedPlanningConf(policy = "ALWAYS", partitionThreshold = Long.MaxValue),
+      () => None)
     assert(always.fallbackReason(1).nonEmpty)
 
     // Celeborn's explicit NEVER policy takes precedence over the deprecated force-fallback flag.
     val never = CometCelebornShuffleManager.nativeShufflePlanningSupport(
       new SparkConf(false)
         .set("spark.celeborn.client.spark.shuffle.forceFallback.enabled", "true"),
-      _ => new ReflectedPlanningConf(policy = "NEVER", partitionThreshold = 1L))
+      _ => new ReflectedPlanningConf(policy = "NEVER", partitionThreshold = 1L),
+      () => None)
     assert(never.fallbackReason(1).isEmpty)
     assert(never.fallbackReason(4).isEmpty)
   }
@@ -467,13 +513,15 @@ class CometCelebornShuffleManagerSuite extends AnyFunSuite {
   test("native planning retains the Celeborn partition threshold's full Long range") {
     val largeThreshold = CometCelebornShuffleManager.nativeShufflePlanningSupport(
       new SparkConf(false),
-      _ => new ReflectedPlanningConf(partitionThreshold = Int.MaxValue.toLong + 1L))
+      _ => new ReflectedPlanningConf(partitionThreshold = Int.MaxValue.toLong + 1L),
+      () => None)
     assert(largeThreshold.fallbackReason(Int.MaxValue).isEmpty)
 
     Seq(0L, -1L).foreach { threshold =>
       val support = CometCelebornShuffleManager.nativeShufflePlanningSupport(
         new SparkConf(false),
-        _ => new ReflectedPlanningConf(partitionThreshold = threshold))
+        _ => new ReflectedPlanningConf(partitionThreshold = threshold),
+        () => None)
       assert(support.fallbackReason(1).nonEmpty)
     }
   }
@@ -493,7 +541,10 @@ class CometCelebornShuffleManagerSuite extends AnyFunSuite {
 
     loaders.foreach { loader =>
       val support =
-        CometCelebornShuffleManager.nativeShufflePlanningSupport(new SparkConf(false), loader)
+        CometCelebornShuffleManager.nativeShufflePlanningSupport(
+          new SparkConf(false),
+          loader,
+          () => None)
       assert(support.fallbackReason(1).nonEmpty)
     }
   }
@@ -507,7 +558,8 @@ class CometCelebornShuffleManagerSuite extends AnyFunSuite {
       planningSupportFactory = conf =>
         CometCelebornShuffleManager.nativeShufflePlanningSupport(
           conf,
-          _ => throw new ClassNotFoundException("native planning API is unavailable")))
+          _ => throw new ClassNotFoundException("native planning API is unavailable"),
+          () => None))
     val handle = composite.registerShuffle[Any, Any, Any](31, null)
 
     assert(composite.nativeShuffleFallbackReason(1).nonEmpty)

--- a/spark/src/test/scala/org/apache/spark/sql/comet/execution/shuffle/CometCelebornShufflePlanningSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/execution/shuffle/CometCelebornShufflePlanningSuite.scala
@@ -638,6 +638,43 @@ class CometCelebornShufflePlanningSuite extends CometTestBase {
       }
     }
 
+    test(s"unavailable push completion executes Spark shuffles with AQE=$adaptive") {
+      val reason = "Celeborn client cannot safely observe native push completion"
+      manager.withPlanningSupport(
+        CelebornNativeShufflePlanningSupport(unavailableReason = Some(reason))) {
+        withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString,
+          CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+          assertNativeExecutionLoaded()
+          assert(!isCometShuffleEnabled(spark.sessionState.conf))
+          val exchange = ShuffleExchangeExec(SinglePartition, nativeChild())
+          assert(CometShuffleExchangeExec.shuffleSupported(exchange).isEmpty)
+          assert(reasons(exchange).contains(reason))
+          assertSpecialSupport(expected = false)
+
+          val nativeRegistrations = manager.nativeRegistrations.get()
+          val sparkRegistrations = manager.sparkRegistrations.get()
+          val repartitioned = input.repartition(2, col("value"))
+          assertSparkExchange(repartitioned.queryExecution.executedPlan)
+          checkAnswer(repartitioned, (1L to 32L).map(Row(_)))
+
+          val limit = input.limit(3)
+          val topK = input.orderBy(col("value").desc).limit(3)
+          assert(collect(limit.queryExecution.executedPlan) { case op: CometCollectLimitExec =>
+            op
+          }.isEmpty)
+          assert(collect(topK.queryExecution.executedPlan) {
+            case op: CometTakeOrderedAndProjectExec => op
+          }.isEmpty)
+          checkAnswer(limit, Seq(Row(1L), Row(2L), Row(3L)))
+          checkAnswer(topK, Seq(Row(32L), Row(31L), Row(30L)))
+          assert(cometExchanges(repartitioned.queryExecution.executedPlan).isEmpty)
+          assert(manager.nativeRegistrations.get() == nativeRegistrations)
+          assert(manager.sparkRegistrations.get() > sparkRegistrations)
+        }
+      }
+    }
+
     test(s"QueryExecution protects hidden limit and topK shuffles with AQE=$adaptive") {
       withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString) {
         withSQLConf(CometConf.COMET_SHUFFLE_MODE.key -> "native") {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5528.

## Rationale for this change

Replacing final fields on live Celeborn clients does not guarantee that transport and retry threads observe Comet's ownership hooks. Admission can then be released while payloads remain in flight. Push-state counters alone do not prove that callbacks, retries, and timed-out writes have released those payloads.

## What changes are included in this PR?

- Require volatile instance fields for shared transport hook replacements, and reject incompatible clients before native submission or admission registration.
- Keep unsupported clients on ordinary Spark/Celeborn shuffle during planning, including collect-limit and top-K. Released Celeborn 0.6.0 and 0.7.0 now take this path even when native shuffle is requested; preserving native support requires a safe completion API.
- Add rejection and fallback regressions, model safely published fields in the ownership test doubles, and document the limitation.

## How are these changes tested?

- 135 tests passed across `CelebornShufflePartitionPusherSuite`, `CometCelebornShuffleManagerSuite`, and `CometCelebornShufflePlanningSuite` in a root reactor build with Spark 4.1.3 / Scala 2.13.17. Coverage includes retained references on another thread and Spark fallback queries with AQE enabled and disabled.
- `CelebornReflectionCompatibilitySuite` passed all 5 tests against each released 0.6.0 and 0.7.0 JAR. These suites were compiled and run separately, including production Java compilation with `--release 11`.
- Native build, root Maven packaging for Spark 4.1, Spotless formatting/checks, and `git diff --check` passed.
