### PR TITLE
feat: route unrecognized StaticInvoke and Invoke through the codegen dispatcher

### DIFF
--- a/docs/source/contributor-guide/expression-audits/string_funcs.md
+++ b/docs/source/contributor-guide/expression-audits/string_funcs.md
@@ -137,7 +137,7 @@
 - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.
 - Spark 3.5.8 (audited 2026-05-27): baseline. `StringLPad(str, len, pad) -> StringType`; `len <= 0` returns the empty string, empty `pad` returns `str` unchanged, NULL inputs propagate. Comet serde requires `str` to be a column and `pad` to be a literal; otherwise falls back.
 - Spark 4.0.1 (audited 2026-05-27): `NullIntolerant` trait replaced by `override def nullIntolerant: Boolean = true`; `inputTypes` widened to `StringTypeWithCollation(supportsTrimCollation = true)`. Semantics unchanged for `UTF8_BINARY`. Non-default collations not honoured by Comet ([#4496](https://github.com/apache/datafusion-comet/issues/4496)).
-- Known limitation: `lpad(<binary>, ...)` is rewritten by Spark to `BinaryPad / StaticInvoke(ByteArray.lpad)` before serde runs and always falls back to Spark.
+- `lpad(<binary>, ...)` is rewritten by Spark to `BinaryPad / StaticInvoke(ByteArray.lpad)` before serde runs. There is no native path, so `CometStaticInvoke` routes it through the JVM codegen dispatcher and the projection stays in the Comet pipeline; it falls back to Spark only when the dispatcher is disabled.
 
 ## ltrim
 
@@ -182,7 +182,7 @@
 - Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.
 - Spark 3.5.8 (audited 2026-05-27): baseline. `StringRPad(str, len, pad) -> StringType`; same edge-case behaviour as `lpad` (negative len, empty pad, NULL propagation). Comet serde requires column `str` and literal `pad`.
 - Spark 4.0.1 (audited 2026-05-27): same evolution as `lpad`; default-pad literal type tightened; semantics unchanged for `UTF8_BINARY`. Non-default collations not honoured by Comet ([#4496](https://github.com/apache/datafusion-comet/issues/4496)).
-- Known limitation: same `BinaryPad / StaticInvoke` rewrite as `lpad` causes `rpad(<binary>, ...)` to fall back.
+- Same `BinaryPad / StaticInvoke` rewrite as `lpad`, so `rpad(<binary>, ...)` also runs through the codegen dispatcher rather than falling back.
 
 ## rtrim
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -565,7 +565,7 @@ The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `deci
 | `contains` | ✅ | — |  |
 | `decode` | ✅ | — |  |
 | `elt` | ✅ | Codegen dispatch |  |
-| `encode` | 🔜 | — | Lowers to `StaticInvoke(encode)` (not allowlisted); falls back |
+| `encode` | ✅ | — | Spark 4.0+ lowers to `StaticInvoke(Encode.encode)`, which runs via codegen dispatch; on Spark 3.x it falls back |
 | `endswith` | ✅ | — |  |
 | `find_in_set` | ✅ | Codegen dispatch |  |
 | `format_number` | ✅ | Codegen dispatch |  |
@@ -606,7 +606,7 @@ The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `deci
 | `substr` | ✅ | Native |  |
 | `substring` | ✅ | Native |  |
 | `substring_index` | ✅ | Native |  |
-| `to_binary` | ✅ | — | Hex form accelerated; other formats fall back |
+| `to_binary` | ✅ | — | Hex and base64 forms accelerated natively; the `utf-8` form rewrites to `encode` and runs via codegen dispatch on Spark 4.0+ |
 | `to_char` | ✅ | Codegen dispatch |  |
 | `to_number` | ✅ | Codegen dispatch |  |
 | `to_varchar` | ✅ | Codegen dispatch |  |

--- a/spark/src/main/scala/org/apache/comet/serde/CometScalaUDF.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/CometScalaUDF.scala
@@ -19,6 +19,8 @@
 
 package org.apache.comet.serde
 
+import scala.util.control.NonFatal
+
 import org.apache.spark.SparkEnv
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSeq, BindReferences, Expression, Literal, RuntimeReplaceable, ScalaUDF}
 import org.apache.spark.sql.types.BinaryType
@@ -63,9 +65,9 @@ object CometScalaUDF extends CometExpressionSerde[ScalaUDF] {
    * batch kernel on first invocation per task.
    *
    * Returns `None` (with `withFallbackReason` tagging the reason) when the dispatcher is disabled
-   * via [[CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED]] or when
-   * [[CometBatchKernelCodegen.canHandle]] refuses the expression tree. Callers should treat
-   * `None` as a clean Spark-fallback signal.
+   * via [[CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED]], when [[CometBatchKernelCodegen.canHandle]]
+   * refuses the expression tree, or when the bound tree cannot be closure-serialized. Callers
+   * should treat `None` as a clean Spark-fallback signal; this method never throws.
    */
   def emitJvmCodegenDispatch(
       expr: Expression,
@@ -108,10 +110,31 @@ object CometScalaUDF extends CometExpressionSerde[ScalaUDF] {
     // UDF jars are visible) and matches Spark's wire format. The bytes become arg 0 of the
     // JvmScalarUdf proto and self-describe the expression so this works in cluster mode without
     // executor-side driver registry state.
-    val serializer = SparkEnv.get.closureSerializer.newInstance()
-    val buffer = serializer.serialize(boundExpr)
-    val bytes = new Array[Byte](buffer.remaining())
-    buffer.get(bytes)
+    //
+    // Guarded because this is the one step in this method that can throw rather than degrade: a
+    // tree can hold a reference the closure serializer refuses, such as a `Literal` wrapping a
+    // non-serializable evaluator or a UDF closure capturing an open resource. An escape here
+    // fails planning, which is a much worse outcome than falling the operator back to Spark.
+    // `CometStaticInvoke` / `CometInvoke` route unrecognized nodes here as a catch-all, so the
+    // trees reaching this point are arbitrary.
+    val bytes =
+      try {
+        val serializer = SparkEnv.get.closureSerializer.newInstance()
+        val buffer = serializer.serialize(boundExpr)
+        val serialized = new Array[Byte](buffer.remaining())
+        buffer.get(serialized)
+        serialized
+      } catch {
+        // `NonFatal` rather than `NotSerializableException`: Java serialization reports an
+        // unserializable object graph as one of several exception types depending on where in
+        // the graph it trips, and a custom `writeObject` can throw anything.
+        case NonFatal(e) =>
+          withFallbackReason(
+            expr,
+            s"$exprName: codegen dispatch: expression could not be closure-serialized " +
+              s"(${e.getClass.getSimpleName}: ${e.getMessage})")
+          return None
+      }
     val exprArg = exprToProtoInternal(Literal(bytes, BinaryType), inputs, binding).getOrElse {
       withFallbackReason(
         expr,

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -28,7 +28,7 @@ import scala.jdk.CollectionConverters._
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
-import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
+import org.apache.spark.sql.catalyst.expressions.objects.{Invoke, StaticInvoke}
 import org.apache.spark.sql.catalyst.expressions.xml.{XPathBoolean, XPathDouble, XPathFloat, XPathInt, XPathList, XPathLong, XPathShort, XPathString}
 import org.apache.spark.sql.comet.DecimalPrecision
 import org.apache.spark.sql.execution.{ScalarSubquery, SparkPlan}
@@ -365,6 +365,7 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
       classOf[BloomFilterMightContain] -> CometBloomFilterMightContain,
       classOf[CheckOverflow] -> CometCheckOverflow,
       classOf[Coalesce] -> CometCoalesce,
+      classOf[Invoke] -> CometInvoke,
       classOf[KnownFloatingPointNormalized] -> CometKnownFloatingPointNormalized,
       classOf[KnownNotNull] -> CometKnownNotNull,
       classOf[KnownNullable] -> CometKnownNullable,

--- a/spark/src/main/scala/org/apache/comet/serde/statics.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/statics.scala
@@ -20,7 +20,7 @@
 package org.apache.comet.serde
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Base64, ExpressionImplUtils, Literal, StringDecode, TryEval, UrlCodec}
-import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
+import org.apache.spark.sql.catalyst.expressions.objects.{Invoke, StaticInvoke}
 import org.apache.spark.sql.catalyst.util.CharVarcharCodegenUtils
 import org.apache.spark.sql.types.StringType
 
@@ -59,6 +59,23 @@ object CometStaticInvoke extends CometExpressionSerde[StaticInvoke] {
   private def handlerFor(expr: StaticInvoke): Option[CometExpressionSerde[StaticInvoke]] =
     staticInvokeExpressions.get((expr.functionName, expr.staticObject.getName))
 
+  /** Every Iceberg system function is named `invoke`, so name the declaring class too. */
+  private def noNativePathNote(expr: StaticInvoke): String =
+    s"Static invoke expression: ${expr.functionName} has no native implementation and the " +
+      s"codegen dispatcher declined it (declared on ${expr.staticObject.getName})"
+
+  /**
+   * A `StaticInvoke` outside the allowlist reports `Compatible` and is handled in [[convert]],
+   * which routes it through the codegen dispatcher. Deliberately not `Unsupported` +
+   * [[CodegenDispatchFallback]]: that would also route a *handler's* `Unsupported` through the
+   * dispatcher, and at least one of those is not dispatchable. `CometIcebergTruncate` declines a
+   * decimal because Iceberg's `truncate` can return a value wider than the column's declared
+   * precision, which Spark nulls only when the row is materialized; the dispatcher writes into an
+   * Arrow `Decimal128(precision, scale)` vector just like a native kernel does, so it produces
+   * the out-of-range value instead of a null. The mixin's contract ("the case must be something
+   * `doGenCode` can compile") does not cover a limit that lives at the Arrow output boundary, so
+   * enrollment stays with the individual handlers.
+   */
   override def getSupportLevel(expr: StaticInvoke): SupportLevel =
     handlerFor(expr).map(_.getSupportLevel(expr)).getOrElse(Compatible())
 
@@ -78,15 +95,37 @@ object CometStaticInvoke extends CometExpressionSerde[StaticInvoke] {
       case Some(handler) =>
         handler.convert(expr, inputs, binding)
       case None =>
-        // Every Iceberg system function is named `invoke`, so name the declaring class too.
-        withFallbackReason(
-          expr,
-          s"Static invoke expression: ${expr.functionName} is not supported " +
-            s"(declared on ${expr.staticObject.getName})")
-        None
+        // Nothing in the allowlist covers this lowering, so run Spark's own implementation inside
+        // the Comet pipeline rather than failing the whole operator back to Spark.
+        // `StaticInvoke.doGenCode` emits a static method call, so the kernel matches Spark by
+        // construction. Spark 4.x keeps lowering more `RuntimeReplaceable` functions this way
+        // (`encode`, `is_valid_utf8`, the `TIME` family, ...) and `lpad` / `rpad` on binary has
+        // lowered to `StaticInvoke(ByteArray, ...)` since Spark 3.4.
+        //
+        // The encoder and deserializer trees that make up most `StaticInvoke` usage in typed
+        // Dataset operations are unaffected: their arguments are `ObjectType`, which
+        // `CometBatchKernelCodegen.isSupportedDataType` rejects, so the dispatcher declines them
+        // and they fall back exactly as before.
+        CometStaticInvokeCodegenDispatch.convert(expr, inputs, binding).orElse {
+          // The dispatcher tags its own reason, but not which static invoke it was.
+          withFallbackReason(expr, noNativePathNote(expr))
+          None
+        }
     }
   }
 }
+
+/**
+ * Catch-all for `Invoke`, which has no allowlist at all. Spark 4.x lowers a growing number of
+ * `RuntimeReplaceable` expressions to evaluator-backed `Invoke` nodes; the Spark 4.x shim
+ * reconstructs the handful it recognizes and everything else lands here. `Invoke.doGenCode` emits
+ * a method call on the target object, so the dispatcher runs Spark's own implementation inside
+ * the Comet pipeline rather than failing the operator back to Spark.
+ *
+ * As with [[CometStaticInvoke]], the object-typed `Invoke` nodes in encoder / deserializer trees
+ * are rejected by `CometBatchKernelCodegen.canHandle` and fall back as before.
+ */
+object CometInvoke extends CometCodegenDispatch[Invoke]
 
 object CometUrlEncodeStaticInvoke extends CometExpressionSerde[StaticInvoke] {
   override def convert(

--- a/spark/src/test/resources/sql-tests/expressions/datetime/to_time.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/to_time.sql
@@ -319,8 +319,9 @@ SELECT to_time(concat('1:00:00 PM', pad))
 FROM test_to_time_trim
 WHERE name = 'd_tab_0x09'
 
--- to_time with format pattern falls back to Spark (not supported natively)
-query expect_fallback(invoke is not supported)
+-- to_time with a format pattern has no native path; Spark 4.1 lowers it to an evaluator-backed
+-- Invoke, which runs in the Comet pipeline through the JVM codegen dispatcher.
+query
 SELECT to_time('12:30:45', 'HH:mm:ss')
 
 statement
@@ -331,7 +332,6 @@ INSERT INTO test_to_time_col_fmt VALUES
   ('14.30.00', 'HH.mm.ss'),
   ('1230', 'HHmm')
 
--- A non-foldable format column should fall back to Spark because Comet does
--- not implement the format-pattern variant of to_time.
-query expect_fallback(invoke is not supported)
+-- A non-foldable format column takes the same codegen-dispatch path as the literal form above.
+query
 SELECT to_time(s, f) FROM test_to_time_col_fmt

--- a/spark/src/test/scala/org/apache/comet/CometCodegenSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCodegenSuite.scala
@@ -25,7 +25,8 @@ import org.apache.arrow.vector._
 import org.apache.spark.{SparkConf, SparkEnv, TaskContext}
 import org.apache.spark.sql.CometTestBase
 import org.apache.spark.sql.api.java.UDF1
-import org.apache.spark.sql.catalyst.expressions.{BoundReference, CreateArray, CreateMap, CreateNamedStruct, Expression, Literal, MapConcat}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, BoundReference, CreateArray, CreateMap, CreateNamedStruct, Expression, Literal, MapConcat}
+import org.apache.spark.sql.catalyst.expressions.objects.Invoke
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -34,6 +35,7 @@ import org.apache.spark.unsafe.types.UTF8String
 import org.apache.comet.CometSparkSessionExtensions.isSpark41Plus
 import org.apache.comet.codegen.CometBatchKernelCodegen
 import org.apache.comet.codegen.CometBatchKernelCodegen.ArrowColumnSpec
+import org.apache.comet.serde.{CometScalaUDF, QueryPlanSerde}
 import org.apache.comet.udf.codegen.CometScalaUDFCodegen
 import org.apache.comet.vector.CometVector
 
@@ -1786,6 +1788,83 @@ class CometCodegenSuite
         }
       }
     }
+  }
+
+  test("dispatch falls back cleanly when the bound tree cannot be closure-serialized (#5573)") {
+    val attr = AttributeReference("s", StringType)()
+    val expr = Invoke(
+      Literal(
+        new CometCodegenSuite.NotSerializableTarget,
+        ObjectType(classOf[CometCodegenSuite.NotSerializableTarget])),
+      "twice",
+      StringType,
+      Seq(attr))
+    // `canHandle` greenlights this tree -- string in, string out, nothing unevaluable -- so the
+    // closure serializer is the step that refuses it. Every other failure mode in
+    // `emitJvmCodegenDispatch` already degraded to a Spark fallback; without the guard this one
+    // throws during planning instead, which is a much worse outcome.
+    assert(CometScalaUDF.emitJvmCodegenDispatch(expr, Seq(attr), binding = true).isEmpty)
+    val reasons = expr.getTagValue(CometExplainInfo.FALLBACK_REASONS).getOrElse(Set.empty)
+    assert(
+      reasons.exists(_.contains("could not be closure-serialized")),
+      s"unexpected fallback reasons: $reasons")
+  }
+
+  test(
+    "unrecognized StaticInvoke routes through the dispatcher instead of falling back (#5575)") {
+    withTable("t") {
+      sql("CREATE TABLE t (b BINARY) USING parquet")
+      sql("INSERT INTO t VALUES (unhex('CAFE')), (unhex('')), (NULL)")
+      // `lpad` on binary input lowers to `StaticInvoke(ByteArray, "lpad", ...)` on every supported
+      // Spark version, and is not in `CometStaticInvoke`'s allowlist. It has no native path, so
+      // before #5575 it failed the whole projection back to Spark.
+      val query = "SELECT lpad(b, 8, unhex('FF')) FROM t"
+      assertCodegenRan {
+        checkSparkAnswerAndOperator(sql(query))
+      }
+      // With the dispatcher off there is nowhere left to run it, so the operator falls back and
+      // says why.
+      withSQLConf(CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "false") {
+        checkSparkAnswerAndFallbackReason(
+          query,
+          "expression has no native path so the plan falls back to Spark")
+      }
+    }
+  }
+
+  test("Invoke routes through the codegen dispatcher (#5575)") {
+    val target = Literal(
+      new CometCodegenSuite.SerializableTarget,
+      ObjectType(classOf[CometCodegenSuite.SerializableTarget]))
+    // `Invoke` has no serde of its own beyond the catch-all, so this also pins the registration:
+    // reaching a `JvmScalarUdf` proto means `QueryPlanSerde` resolved `CometInvoke`.
+    val attr = AttributeReference("s", StringType)()
+    val proto =
+      QueryPlanSerde.exprToProto(Invoke(target, "twice", StringType, Seq(attr)), Seq(attr))
+    assert(proto.exists(_.hasJvmScalarUdf), s"expected a codegen-dispatch proto, got $proto")
+    // ...and the emitted method call compiles and evaluates.
+    val folded =
+      Invoke(target, "twice", StringType, Seq(Literal(UTF8String.fromString("ab"), StringType)))
+    assert(runKernel(folded, 1)(_.getUTF8String(0).toString) === "abab")
+  }
+}
+
+/**
+ * Targets for the `Invoke` tests. Declared inside the companion object so they are static nested
+ * classes with no reference to the enclosing suite -- otherwise closure-serializing a tree that
+ * holds one would drag the whole suite in and the serialization outcome would say nothing about
+ * the target itself.
+ */
+object CometCodegenSuite {
+
+  /** Public and `Serializable`, so the dispatcher accepts a tree holding an instance. */
+  class SerializableTarget extends Serializable {
+    def twice(s: UTF8String): UTF8String = UTF8String.fromString(s.toString + s.toString)
+  }
+
+  /** Deliberately not `Serializable`, to make the closure serializer refuse the bound tree. */
+  class NotSerializableTarget {
+    def twice(s: UTF8String): UTF8String = UTF8String.fromString(s.toString + s.toString)
   }
 }
 

--- a/spark/src/test/scala/org/apache/comet/CometIcebergSystemFunctionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergSystemFunctionSuite.scala
@@ -140,6 +140,12 @@ class CometIcebergSystemFunctionSuite
       // Spark nulls only on materialization and a `Decimal128(p, s)` array cannot represent at
       // all; the expression stays with Spark rather than null early. `bucket` on the same columns
       // is unaffected and is covered by the bucket test above.
+      //
+      // This is also why `CometStaticInvoke` routes only *unrecognized* functions through the
+      // codegen dispatcher instead of mixing in `CodegenDispatchFallback` (see #5572): the
+      // dispatcher writes into the same Arrow `Decimal128(p, s)` vector, so rescuing this
+      // `Unsupported` produces the out-of-range value where Spark produces a null. Measured: the
+      // rescued plan returns `-100000000000000.0000` for a row Spark nulls.
       decimalColumns.foreach { column =>
         checkSparkAnswerAndFallbackReason(
           s"SELECT $catalog.system.truncate(10, $column) FROM $source",
@@ -329,20 +335,34 @@ class CometIcebergSystemFunctionSuite
         Unsupported(Some(CometIcebergTruncate.DecimalNote)))
   }
 
-  test("fallback reason for an unlisted static invoke names the declaring class") {
-    val expr = StaticInvoke(
-      classOf[java.lang.Math],
-      IntegerType,
-      "abs",
-      Seq(AttributeReference("v", IntegerType)()),
-      propagateNull = false)
-    assert(CometStaticInvoke.convert(expr, Seq.empty, binding = false).isEmpty)
-    val reasons = expr.getTagValue(CometExplainInfo.FALLBACK_REASONS).getOrElse(Set.empty)
+  test("an unlisted static invoke routes through the codegen dispatcher") {
+    val attr = AttributeReference("v", IntegerType)()
+    val expr =
+      StaticInvoke(classOf[java.lang.Math], IntegerType, "abs", Seq(attr), propagateNull = false)
+    // Nothing in the allowlist matches, so the dispatcher takes it: `StaticInvoke.doGenCode` emits
+    // a static method call, and both the argument and the result are types the kernel handles.
+    val proto = CometStaticInvoke.convert(expr, Seq(attr), binding = true)
     assert(
-      reasons.exists(r =>
-        r.contains("Static invoke expression: abs is not supported") &&
-          r.contains("java.lang.Math")),
-      s"unexpected fallback reasons: $reasons")
+      proto.exists(_.hasJvmScalarUdf),
+      s"expected a codegen-dispatch proto for an unlisted static invoke, got $proto")
+
+    // When the dispatcher is off there is nowhere left to run it, and the fallback reason has to
+    // name both the function and the declaring class -- every Iceberg system function is named
+    // `invoke`, so the function name alone is ambiguous.
+    withSQLConf(CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "false") {
+      val fresh =
+        StaticInvoke(
+          classOf[java.lang.Math],
+          IntegerType,
+          "abs",
+          Seq(attr),
+          propagateNull = false)
+      assert(CometStaticInvoke.convert(fresh, Seq(attr), binding = true).isEmpty)
+      val reasons = fresh.getTagValue(CometExplainInfo.FALLBACK_REASONS).getOrElse(Set.empty)
+      assert(
+        reasons.exists(r => r.contains("abs") && r.contains("java.lang.Math")),
+        s"unexpected fallback reasons: $reasons")
+    }
   }
 
   /** Runs `f` with the Iceberg catalog registered and the source parquet table in scope. */

--- a/spark/src/test/scala/org/apache/comet/CometStringExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometStringExpressionSuite.scala
@@ -128,21 +128,12 @@ class CometStringExpressionSuite extends CometTestBase {
               s"SELECT $str, $len, $expr($str, $len) FROM t1 ORDER BY str, len, pad"
           }
 
-          val isLiteralStr = str != "str"
-          val isLiteralLen = !len.contains("len")
-          val isLiteralPad = !pad.contains("pad")
-
-          if (isLiteralStr && isLiteralLen && isLiteralPad) {
-            // all arguments are literal, so Spark constant folding will kick in
-            // and pad function will not be evaluated by Comet
-            checkSparkAnswerAndOperator(sql)
-          } else {
-            // Comet will fall back to Spark because the plan contains a staticinvoke instruction
-            // which is not supported
-            checkSparkAnswerAndFallbackReason(
-              sql,
-              s"Static invoke expression: $expr is not supported")
-          }
+          // `lpad` / `rpad` on binary input lowers to `StaticInvoke(ByteArray, funcName, ...)`,
+          // which has no native path and is not in `CometStaticInvoke`'s allowlist, so it routes
+          // through the JVM codegen dispatcher and the projection stays in the Comet pipeline.
+          // When every argument is a literal, Spark's constant folding evaluates the call before
+          // Comet ever sees it.
+          checkSparkAnswerAndOperator(sql)
         }
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometCodegenDispatchBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometCodegenDispatchBenchmark.scala
@@ -1,0 +1,407 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.benchmark
+
+import java.nio.charset.StandardCharsets
+
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.optimizer.ConstantFolding
+import org.apache.spark.sql.internal.SQLConf
+
+import org.apache.comet.CometConf
+import org.apache.comet.CometSparkSessionExtensions.{isSpark40Plus, isSpark41Plus}
+import org.apache.comet.udf.codegen.CometScalaUDFCodegen
+
+/**
+ * Benchmark of the expressions that the JVM codegen dispatcher picks up when no native handler
+ * exists: `StaticInvoke` outside `CometStaticInvoke`'s allowlist, and `Invoke`, which has no
+ * allowlist at all. Every case here fell the whole projection back to Spark before that catch-all
+ * existed, so the interesting comparison is not Comet against Spark but
+ *
+ *   - `codegen dispatch` -- the expression runs as a Janino-compiled kernel reading and writing
+ *     Arrow vectors inside the Comet pipeline, and
+ *   - `dispatch off` -- `spark.comet.exec.scalaUDF.codegen.enabled=false`, which is exactly the
+ *     behaviour that shipped before: the enclosing projection falls back to Spark, so the plan
+ *     pays a columnar-to-row conversion and runs every other expression in the projection under
+ *     whole-stage codegen.
+ *
+ * Both arms run Spark's own implementation of the function itself -- the dispatcher compiles
+ * `Expression.doGenCode` -- so the difference between them is the cost of the bridge (expression
+ * transport, per-batch argument binding, Arrow output allocation) set against the cost of losing
+ * the operator to Spark. A pure Spark case is included as a third reference point.
+ *
+ * A `dispatch off (repeat)` case repeats the baseline at the end of every table. It measures the
+ * same work as the first row, so the spread between the two is this machine's noise floor for
+ * that table; ignore any difference between the other rows that is smaller than that spread.
+ *
+ * Compilation is a one-time cost, and the steady-state tables warm up before timing, so it does
+ * not appear there. The `first use` table at the top measures it directly: the same query run
+ * twice back to back on a cold kernel, after the dispatcher itself has been warmed on an
+ * unrelated expression.
+ *
+ * Before timing anything, every case is run through all three arms and the rows are compared, so
+ * a timing cannot come from an arm that computed something else.
+ *
+ * To run this benchmark:
+ * {{{
+ *   SPARK_GENERATE_BENCHMARK_FILES=1 make benchmark-org.apache.spark.sql.benchmark.CometCodegenDispatchBenchmark
+ * }}}
+ * Results will be written to "spark/benchmarks/CometCodegenDispatchBenchmark-**results.txt".
+ */
+object CometCodegenDispatchBenchmark extends CometBenchmarkBase {
+
+  /** Fewer rows than one Comet batch, so the query is a single batch of real work. */
+  private val SmallRows = 1024
+
+  /** ~128 batches at the default `spark.comet.batchSize`. */
+  private val LargeRows = 1024 * 1024
+
+  /**
+   * @param name
+   *   Case name, as it appears in the results table.
+   * @param query
+   *   The query to time. Every argument is a column so that the expression is evaluated per row.
+   * @param available
+   *   False when the Spark version under test does not lower this function to a `StaticInvoke` /
+   *   `Invoke`, in which case there is nothing for the dispatcher to pick up.
+   * @param extraConfigs
+   *   Applied to all three arms, so they never account for a difference between them.
+   */
+  private case class DispatchCase(
+      name: String,
+      query: String,
+      available: Boolean = true,
+      extraConfigs: Seq[(String, String)] = Nil)
+
+  private def cases: Seq[DispatchCase] = Seq(
+    // `lpad` / `rpad` on binary input lowers to `StaticInvoke(ByteArray, funcName, ...)` on every
+    // supported Spark version.
+    DispatchCase("lpad(binary)", "select lpad(c_bin, 24, c_pad) from parquetV1Table"),
+    DispatchCase("rpad(binary)", "select rpad(c_bin, 24, c_pad) from parquetV1Table"),
+    // Spark 4.0+ lowers `encode`, and the `utf-8` form of `to_binary`, to
+    // `StaticInvoke(Encode, "encode", ...)`. On 3.x they are ordinary expressions.
+    DispatchCase(
+      "encode(utf-8)",
+      "select encode(c_str, 'utf-8') from parquetV1Table",
+      isSpark40Plus),
+    DispatchCase(
+      "to_binary(utf-8)",
+      "select to_binary(c_str, 'utf-8') from parquetV1Table",
+      isSpark40Plus),
+    // Spark 4.1's `to_time` with a format lowers to an evaluator-backed `Invoke`, the receiver
+    // call the `Invoke` half of the catch-all exists for. `spark.sql.timeType.enabled` defaults
+    // to `Utils.isTesting`, so a benchmark JVM has to opt in the way Spark's own test runs do,
+    // or `ToTime.checkInputDataTypes` rejects the call during analysis.
+    DispatchCase(
+      "to_time(fmt)",
+      "select to_time(c_time, 'HH:mm:ss') from parquetV1Table",
+      isSpark41Plus,
+      Seq("spark.sql.timeType.enabled" -> "true")),
+    // The case the catch-all is really about: one unhandled expression used to cost the whole
+    // projection, including the three expressions next to it that do have native kernels.
+    DispatchCase(
+      "mixed projection",
+      "select length(c_str), c_long + 1, substring(c_str, 1, 4), lpad(c_bin, 24, c_pad) " +
+        "from parquetV1Table"),
+    // ...and the same thing one operator further out. With the projection gone the aggregate
+    // above it has a row-based child, so the partial aggregate, the exchange and the final
+    // aggregate all leave the Comet pipeline with it. `c_pad` has 100 distinct values, so the
+    // grouping is cheap and the per-row call is still what dominates. AQE is off and the
+    // shuffle is one partition so that both arms plan the same shape every iteration, and so
+    // that the plan check is not looking at `AQEShuffleRead`.
+    DispatchCase(
+      "group by dispatch",
+      "select lpad(c_pad, 8, c_pad) as k, count(*) from parquetV1Table group by 1",
+      available = true,
+      Seq(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+        SQLConf.SHUFFLE_PARTITIONS.key -> "1")))
+    .filter(_.available)
+
+  private def noConstantFolding: (String, String) =
+    SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> excludedRulesWith(ConstantFolding.ruleName)
+
+  private def sparkConfigs(c: DispatchCase): Seq[(String, String)] =
+    Seq(noConstantFolding, CometConf.COMET_ENABLED.key -> "false") ++ c.extraConfigs
+
+  /** Comet on, dispatcher on: the behaviour this benchmark is validating. */
+  private def dispatchConfigs(c: DispatchCase): Seq[(String, String)] =
+    cometConfigs(c, dispatch = true)
+
+  /** Comet on, dispatcher off: the behaviour that shipped before the catch-all. */
+  private def fallbackConfigs(c: DispatchCase): Seq[(String, String)] =
+    cometConfigs(c, dispatch = false)
+
+  private def cometConfigs(c: DispatchCase, dispatch: Boolean): Seq[(String, String)] = Seq(
+    noConstantFolding,
+    CometConf.COMET_ENABLED.key -> "true",
+    CometConf.COMET_EXEC_ENABLED.key -> "true",
+    CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> dispatch.toString) ++ c.extraConfigs
+
+  private val DispatchCaseName = "Comet, codegen dispatch"
+  private val FallbackCaseName = "Comet, dispatch off (Spark fallback)"
+  private val SparkCaseName = "Spark (Comet disabled)"
+
+  override def runCometBenchmark(mainArgs: Array[String]): Unit = {
+    val selected = cases
+    runBenchmark("Codegen dispatch: environment") {
+      emitEnvironment(selected)
+    }
+    if (selected.isEmpty) {
+      return
+    }
+
+    // The kernels must be uncompiled when `runFirstUse` starts, so it runs before anything else
+    // executes these queries: `CodeGenerator.compile` caches on the generated source JVM-wide,
+    // and a single earlier execution would make every "first use" number a cache hit.
+    withCorpus(SmallRows) {
+      runBenchmark(s"Codegen dispatch: first use, $SmallRows rows") {
+        runFirstUse(selected)
+      }
+      selected.foreach(verifyArmsAgree(_, SmallRows))
+      selected.foreach(runSteadyState(_, SmallRows))
+    }
+    withCorpus(LargeRows) {
+      selected.foreach(verifyArmsAgree(_, LargeRows))
+      selected.foreach(runSteadyState(_, LargeRows))
+    }
+  }
+
+  /**
+   * The reader of a results file cannot see the confs the numbers were produced under, and for
+   * this benchmark the batch size and the dispatcher conf are the whole point.
+   */
+  private def emitEnvironment(selected: Seq[DispatchCase]): Unit = {
+    emit(s"Spark version: ${spark.version}")
+    emit(
+      s"Java version: ${System.getProperty("java.version")} " +
+        s"(${System.getProperty("java.vm.name")})")
+    emit(s"Scala version: ${scala.util.Properties.versionNumberString}")
+    emit(s"spark.master: ${spark.conf.get("spark.master", "<unset>")}")
+    emit(
+      s"${CometConf.COMET_BATCH_SIZE.key}: " +
+        CometConf.COMET_BATCH_SIZE.get(spark.sessionState.conf))
+    emit(
+      s"${SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key}: " +
+        spark.conf.get(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key))
+    emit(s"Dispatcher conf: ${CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key}")
+    emit("Steady-state tables: Spark's Benchmark defaults -- 2s of untimed warmup per case, then")
+    emit(
+      "  at least 2 iterations and at least 2s of timed iterations; the table reports best and")
+    emit("  average of the timed iterations.")
+    emit(s"Row counts: $SmallRows (sub-batch) and $LargeRows (multi-batch).")
+    val skipped =
+      Seq("encode(utf-8) / to_binary(utf-8)" -> isSpark40Plus, "to_time(fmt)" -> isSpark41Plus)
+        .collect { case (name, false) => name }
+    if (skipped.nonEmpty) {
+      emit(
+        s"Not lowered to StaticInvoke/Invoke on this Spark version, skipped: " +
+          skipped.mkString(", "))
+    }
+    emit(s"Cases: ${selected.map(_.name).mkString(", ")}")
+  }
+
+  /**
+   * Cost of the first execution of a query whose kernel has never been compiled, against the
+   * second execution of the same query.
+   *
+   * The dispatcher is warmed on an expression that is not in the case list first, so that Janino,
+   * `CodeGenerator`, the Arrow bridge and the FFI boundary are all loaded and JIT-warm before the
+   * first case runs and the difference is dominated by compiling that one kernel. It is still an
+   * upper bound on the compile: the first case in the list absorbs whatever class loading the
+   * warmup missed, and any case that reaches machinery no earlier case did -- the grouped case is
+   * the first to shuffle -- pays for that here too.
+   */
+  private def runFirstUse(selected: Seq[DispatchCase]): Unit = {
+    // `rlike` routes through the same dispatcher and is not one of the cases below.
+    val warmup = DispatchCase("warmup", "select c_str rlike '[0-9]+' from parquetV1Table")
+    (0 until 5).foreach(_ => runQuery(warmup.query, dispatchConfigs(warmup)))
+
+    emit(
+      f"${"case"}%-24s  ${"1st run (ms)"}%14s  ${"2nd run (ms)"}%14s  " +
+        f"${"one-time (ms)"}%14s  ${"compiles"}%9s")
+    emit("-" * 84)
+    selected.foreach { c =>
+      CometScalaUDFCodegen.resetStats()
+      val cold = timeMillis(runQuery(c.query, dispatchConfigs(c)))
+      val compiles = CometScalaUDFCodegen.stats().compileCount
+      val warm = timeMillis(runQuery(c.query, dispatchConfigs(c)))
+      emit(f"${c.name}%-24s  $cold%14.1f  $warm%14.1f  ${cold - warm}%14.1f  $compiles%9d")
+    }
+    emit("")
+    emit("`compiles` counts dispatcher cache misses, which is one per task. The Janino work")
+    emit("itself is deduplicated JVM-wide by Spark's CodeGenerator source cache, so only the")
+    emit("first task to reach a given kernel source pays for it -- and a case whose bound tree")
+    emit("matches an earlier case's, as `to_binary(utf-8)` matches `encode(utf-8)`, is a hit on")
+    emit("that cache and reports a one-time cost near zero.")
+  }
+
+  /**
+   * Fails if the three arms disagree on `query`. Rows are compared as a sorted multiset rather
+   * than positionally, because the grouped case shuffles and its output order is a property of
+   * the plan, which is the one thing that differs between the arms.
+   */
+  private def verifyArmsAgree(c: DispatchCase, rows: Int): Unit = {
+    def collect(configs: Seq[(String, String)]): Array[String] = {
+      // Assigned to a local rather than returned from the block: Spark 3.4 and 3.5 declare
+      // `SQLHelper.withSQLConf` as returning `Unit`; only Spark 4 has the result-returning form.
+      var collected: Array[Row] = Array.empty
+      withSQLConf(configs: _*) {
+        collected = spark.sql(c.query).collect()
+      }
+      // `Row.equals` compares binary columns by reference, so normalize before comparing.
+      collected
+        .map(
+          _.toSeq
+            .map {
+              case bytes: Array[Byte] => bytes.mkString("[", ",", "]")
+              case other => String.valueOf(other)
+            }
+            .mkString("|"))
+        .sorted
+    }
+
+    val expected = collect(sparkConfigs(c))
+    Seq(DispatchCaseName -> dispatchConfigs(c), FallbackCaseName -> fallbackConfigs(c)).foreach {
+      case (armName, configs) =>
+        val actual = collect(configs)
+        assert(
+          expected.length == actual.length,
+          s"${c.name} @ $rows rows: Spark produced ${expected.length} rows, " +
+            s"$armName ${actual.length}")
+        expected.indices.find(i => expected(i) != actual(i)).foreach { i =>
+          throw new AssertionError(
+            s"${c.name} @ $rows rows: row $i differs -- Spark ${expected(i)}, " +
+              s"$armName ${actual(i)}")
+        }
+    }
+  }
+
+  private def runSteadyState(c: DispatchCase, rows: Int): Unit = {
+    runBenchmark(s"${c.name} -- $rows rows") {
+      val benchmark = new Benchmark(s"${c.name} -- $rows rows", rows, output = output)
+      checkPlans(benchmark, c)
+      // The dispatch-off arm goes first so the `Relative` column reads as the speedup this
+      // change buys over the behaviour that shipped before it.
+      benchmark.addCase(FallbackCaseName)(_ => runQuery(c.query, fallbackConfigs(c)))
+      benchmark.addCase(DispatchCaseName)(_ => runQuery(c.query, dispatchConfigs(c)))
+      benchmark.addCase(SparkCaseName)(_ => runQuery(c.query, sparkConfigs(c)))
+      benchmark.addCase(s"$FallbackCaseName (repeat)")(_ => runQuery(c.query, fallbackConfigs(c)))
+      benchmark.run()
+    }
+  }
+
+  /**
+   * Warns rather than fails, so one Spark version lowering a function differently degrades the
+   * table to a note instead of aborting the run. A case where the dispatch arm is not fully
+   * native, or where the dispatch-off arm is, is not measuring what its name says.
+   */
+  private def checkPlans(benchmark: Benchmark, c: DispatchCase): Unit = {
+    var dispatchNonComet: Option[String] = None
+    var fallbackIsFullyComet = false
+    var dispatcherRan = false
+    withSQLConf(dispatchConfigs(c): _*) {
+      CometScalaUDFCodegen.resetStats()
+      val df = spark.sql(c.query)
+      df.noop()
+      val stats = CometScalaUDFCodegen.stats()
+      dispatcherRan = stats.compileCount + stats.cacheHitCount > 0
+      dispatchNonComet =
+        findFirstNonCometOperator(stripAQEPlan(df.queryExecution.executedPlan)).map(_.nodeName)
+    }
+    withSQLConf(fallbackConfigs(c): _*) {
+      val df = spark.sql(c.query)
+      df.noop()
+      fallbackIsFullyComet =
+        findFirstNonCometOperator(stripAQEPlan(df.queryExecution.executedPlan)).isEmpty
+    }
+    dispatchNonComet.foreach(op =>
+      warn(
+        benchmark,
+        s"WARNING: the codegen-dispatch plan is not fully Comet native (first " +
+          s"non-Comet operator: $op), so that case is partly measuring Spark."))
+    if (!dispatcherRan) {
+      warn(
+        benchmark,
+        "WARNING: the codegen dispatcher did not run for this query, so the two " +
+          "Comet cases below are measuring the same plan.")
+    }
+    if (fallbackIsFullyComet) {
+      warn(
+        benchmark,
+        "WARNING: the dispatch-off plan is fully Comet native, so this case is " +
+          "not exercising the operator fallback it is meant to be compared against.")
+    }
+  }
+
+  private def runQuery(query: String, configs: Seq[(String, String)]): Unit =
+    withSQLConf(configs: _*) {
+      spark.sql(query).noop()
+    }
+
+  private def timeMillis(f: => Unit): Double = {
+    val start = System.nanoTime()
+    f
+    (System.nanoTime() - start) / 1e6
+  }
+
+  /** Builds `parquetV1Table` with `rows` rows of the corpus and drops it afterwards. */
+  private def withCorpus(rows: Int)(f: => Unit): Unit = {
+    withTempPath { dir =>
+      withTempTable(tbl, "parquetV1Table") {
+        spark.range(rows).createOrReplaceTempView(tbl)
+        prepareTable(dir, spark.sql(corpusQuery))
+        f
+      }
+    }
+  }
+
+  /**
+   * Every column varies per row, so no argument to a benchmarked expression is loop-invariant and
+   * neither engine can hoist the call out of the row loop.
+   */
+  private def corpusQuery: String = {
+    val columns = Seq(
+      "c_str" -> "REPEAT(CAST(id AS STRING), 4)",
+      "c_bin" -> "CAST(REPEAT(CAST(id AS STRING), 4) AS BINARY)",
+      // Short, so `lpad` / `rpad` have padding to do on most rows.
+      "c_pad" -> "CAST(CAST(PMOD(id, 100) AS STRING) AS BINARY)",
+      "c_long" -> "id",
+      "c_time" -> ("CONCAT(LPAD(CAST(PMOD(id, 24) AS STRING), 2, '0'), ':', " +
+        "LPAD(CAST(PMOD(id, 60) AS STRING), 2, '0'), ':', " +
+        "LPAD(CAST(PMOD(id * 7, 60) AS STRING), 2, '0'))"))
+    s"SELECT ${columns.map { case (name, expr) => s"$expr AS $name" }.mkString(", ")} FROM $tbl"
+  }
+
+  /** Writes a warning to the results file as well as the console, ordered against the table. */
+  private def warn(benchmark: Benchmark, message: String): Unit = {
+    val border = "=" * 80
+    benchmark.out.println(s"\n$border\n$message\n$border")
+  }
+
+  /** [[Benchmark]] tees console and results file; this benchmark's own tables need the same. */
+  private def emit(line: String): Unit = {
+    // scalastyle:off println
+    println(line)
+    // scalastyle:on println
+    output.foreach(_.write(s"$line\n".getBytes(StandardCharsets.UTF_8)))
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometCodegenDispatchBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometCodegenDispatchBenchmark.scala
@@ -213,7 +213,7 @@ object CometCodegenDispatchBenchmark extends CometBenchmarkBase {
         .collect { case (name, false) => name }
     if (skipped.nonEmpty) {
       emit(
-        s"Not lowered to StaticInvoke/Invoke on this Spark version, skipped: " +
+        "Not lowered to StaticInvoke/Invoke on this Spark version, skipped: " +
           skipped.mkString(", "))
     }
     emit(s"Cases: ${selected.map(_.name).mkString(", ")}")
@@ -336,7 +336,7 @@ object CometCodegenDispatchBenchmark extends CometBenchmarkBase {
     dispatchNonComet.foreach(op =>
       warn(
         benchmark,
-        s"WARNING: the codegen-dispatch plan is not fully Comet native (first " +
+        "WARNING: the codegen-dispatch plan is not fully Comet native (first " +
           s"non-Comet operator: $op), so that case is partly measuring Spark."))
     if (!dispatcherRan) {
       warn(


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5573.
Closes #5575.

Both are children of the codegen-dispatch coverage audit, #5572.

## Rationale for this change

`CometStaticInvoke` dispatches on an allowlist of `(functionName, staticObject)` pairs and fails the whole operator back to Spark for anything else. `Invoke` has no entry in the serde map at all. Both nodes are codegen-friendly — `StaticInvoke.doGenCode` emits a static method call, `Invoke.doGenCode` emits a method call on the target object — so routing them through the JVM codegen dispatcher runs Spark's own implementation inside the Comet pipeline and matches Spark by construction, instead of losing the whole projection for every lowering nobody has allowlisted yet.

Spark keeps adding these. Three concrete cases that were fallbacks before this PR:

- `lpad` / `rpad` on **binary** input lower to `StaticInvoke(ByteArray, funcName, ...)` on every supported Spark version (3.4 through 4.1).
- Spark 4.1's `to_time(str, fmt)` lowers to an evaluator-backed `Invoke`.
- `encode`, and the `utf-8` form of `to_binary`, lower to `StaticInvoke(Encode.encode, ...)` on Spark 4.0+. The compatibility guide already recorded both as falling back for exactly this reason.

#5573 is the prerequisite: the closure-serialize in `emitJvmCodegenDispatch` was the one failure mode in that method that threw during planning rather than degrading to a Spark fallback, and a catch-all is what starts handing the dispatcher arbitrary trees.

## What changes are included in this PR?

**#5573** — `CometScalaUDF.emitJvmCodegenDispatch` wraps the closure-serialize in `try` / `catch NonFatal`, tags a fallback reason and returns `None`, matching the shape of every other check around it. `NonFatal` rather than `NotSerializableException` because Java serialization reports an unserializable object graph as one of several exception types depending on where it trips, and a custom `writeObject` can throw anything. The scaladoc now states that the method never throws.

**#5575** — `CometStaticInvoke.convert`'s `case None` routes to `CometStaticInvokeCodegenDispatch`; if the dispatcher declines (config off, or `canHandle` refuses the tree), it still tags a fallback reason naming the function and the declaring class, so the diagnostic that existed before is preserved. New `CometInvoke extends CometCodegenDispatch[Invoke]`, registered as `classOf[Invoke]` in `QueryPlanSerde.miscExpressions`.

**Docs** — `expressions.md` rows for `encode` and `to_binary`, and the `lpad` / `rpad` known-limitation notes in the string expression audit.

### One deliberate deviation from #5572

#5572 frames these items as "add the `CodegenDispatchFallback` mixin". I implemented that variant first for `CometStaticInvoke` and it **produces wrong answers**, so this PR scopes the catch-all to functions with no handler at all.

The mixin also rescues a *handler's* `Unsupported`. `CometIcebergTruncate` declines a decimal because Iceberg's `truncate` can return a value wider than the column's declared precision, which Spark turns into null only when the row is materialized. The dispatcher writes into the same Arrow `Decimal128(p, s)` vector a native kernel would, so the rescued plan returned `-100000000000000.0000` for a row Spark nulls, in `CometIcebergSystemFunctionSuite`'s "truncate on a decimal falls back to Spark".

The mixin's stated contract is that the case "must be something `Expression.doGenCode` can compile". That does not cover a limit living at the **Arrow output boundary**, which the dispatcher and a native kernel share. Worth checking each remaining child issue's `Unsupported` reason against that distinction. The reasoning is recorded in `CometStaticInvoke`'s scaladoc and in the Iceberg test so it is not re-litigated.

### Residual risk, not addressed here

The dispatcher Janino-compiles at execute time with no recovery, so a `StaticInvoke` whose target class is not public would fail the task where Spark's whole-stage codegen falls back to interpreted evaluation. I could not exhibit one — Spark's own lowerings all use public utility classes, and the DSv2 magic-method contract effectively requires a public class since Spark's own WSCG emits the same call. A plan-time guard would have to replicate `StaticInvoke.doGenCode`'s name mangling, and getting that approximation wrong would reject valid dispatches, which is the worse failure. Flagging it rather than guessing.

Encoder and deserializer trees — which are most `StaticInvoke` / `Invoke` usage in typed Dataset operations — are unaffected either way: their arguments are `ObjectType`, which `CometBatchKernelCodegen.isSupportedDataType` rejects, so `canHandle` declines them and they fall back exactly as before.

## How are these changes tested?

New tests in `CometCodegenSuite`:

- `dispatch falls back cleanly when the bound tree cannot be closure-serialized (#5573)` — an `Invoke` holding a deliberately non-`Serializable` target. `canHandle` greenlights the tree (string in, string out), so the serializer is the step that refuses, and the assertion is on the fallback reason rather than on an escaping exception.
- `unrecognized StaticInvoke routes through the dispatcher instead of falling back (#5575)` — `lpad` on a binary column: asserts the dispatcher ran and the operator stayed native, then asserts a clean fallback with the dispatcher disabled.
- `Invoke routes through the codegen dispatcher (#5575)` — pins the serde-map registration by going through `QueryPlanSerde.exprToProto`, then runs the compiled kernel to check the emitted method call evaluates.

Existing tests updated to the new behaviour:

- `CometStringExpressionSuite`'s binary `lpad` / `rpad` flip from `checkSparkAnswerAndFallbackReason` to `checkSparkAnswerAndOperator`.
- `expressions/datetime/to_time.sql` flips two `expect_fallback(invoke is not supported)` blocks to plain `query`.
- `CometIcebergSystemFunctionSuite`'s unlisted-static-invoke test now asserts the dispatch proto, and that the declaring-class diagnostic survives when the dispatcher is off.

Regression runs, all on this branch:

| Scope | Result |
| --- | --- |
| `CometExpressionSuite`, `CometCodegenFuzzSuite`, `CometSqlFileTestSuite`, `CometExecSuite` (4.1) | 782 passed |
| `CometCodegenSuite`, `CometStringExpressionSuite`, `CometIcebergSystemFunctionSuite`, `CometSqlFileTestSuite` (4.1) | 602 passed |
| `CometStringExpressionSuite`, `CometCodegenSuite` (3.4 and 3.5) | 121 passed each |
| `CometStringExpressionSuite`, `CometCodegenSuite`, `CometSqlFileTestSuite` (4.0) | 590 passed |

### Benchmark

`CometCodegenDispatchBenchmark` (added in response to review) times every case this PR newly dispatches against the operator fallback it replaces: three arms per case (codegen dispatch, `spark.comet.exec.scalaUDF.codegen.enabled=false`, Comet off), at 1024 and 1,048,576 rows, with the rows compared across all three arms before anything is timed and a repeat of the baseline closing each table as a noise floor. First-use compilation gets its own table so it does not contaminate the steady-state numbers.

At 1M rows a projection containing nothing but the dispatched call runs between parity and ~20% slower than falling the projection back (`lpad` 51 -> 61 ms is the worst); a projection that mixes it with native expressions is 1.4x (137 -> 101 ms), and a grouped aggregate over it is 1.1x (73 -> 65 ms) because the exchange and both aggregates stay native. At 1024 rows every arm is inside the noise floor. Full numbers are in the review thread.

Cross-compiled against Spark 3.4 / 3.5 / 4.0 / 4.1; spotless and scalastyle clean; `mvn package` regenerates the docs with no churn beyond the note edits above.

