### PR TITLE
feat: fuse the typed Dataset map sandwich into a Comet projection

### DIFF
--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -471,6 +471,7 @@ jobs:
               org.apache.comet.CometUuidExpressionSuite
               org.apache.comet.serde.CometScalarFunctionSuite
               org.apache.comet.CometFallbackInvarianceSuite
+              org.apache.comet.CometTypedDatasetSuite
       fail-fast: false
     name: ${{ matrix.profile.name }} [${{ matrix.suite.name }}]
     runs-on: ubuntu-24.04

--- a/.github/workflows/pr_build_macos.yml
+++ b/.github/workflows/pr_build_macos.yml
@@ -244,6 +244,7 @@ jobs:
               org.apache.comet.CometUuidExpressionSuite
               org.apache.comet.serde.CometScalarFunctionSuite
               org.apache.comet.CometFallbackInvarianceSuite
+              org.apache.comet.CometTypedDatasetSuite
 
       fail-fast: false
     name: ${{ matrix.os }}/${{ matrix.profile.name }} [${{ matrix.suite.name }}]

--- a/docs/source/user-guide/latest/operators.md
+++ b/docs/source/user-guide/latest/operators.md
@@ -120,6 +120,23 @@ omitted from the tables below and may be reconsidered based on demand:
 | ------------------------ | ------ | ----------------------------------------------------------------- |
 | `DataWritingCommandExec` | ⚠️     | Experimental native Parquet writes, disabled by default (opt-in). |
 
+## Typed Dataset operations
+
+Typed `Dataset` operations bracket a JVM object in a `DeserializeToObject` / `SerializeFromObject`
+pair. Neither operator can run natively on its own, because its input or output is a raw JVM object
+reference that has no Arrow representation. What Comet can do is fuse a whole sandwich back into a
+projection when everything between the pair is per-row, so the typed operation no longer forces a
+Spark fallback island in the middle of an otherwise native plan. The user closure still runs on the
+JVM, once per row, inside Comet's codegen dispatcher, so results match Spark exactly.
+
+| Operator                                                                     | Status | Notes                                                                                                                                                                                                                                                               |
+| ---------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SerializeFromObjectExec` + `MapElementsExec` + `DeserializeToObjectExec`    | ⚠️     | The `ds.map(f)` sandwich is fused into a projection when `spark.comet.exec.typedDatasetMap.enabled=true` (off by default). Worth enabling when the typed operation sits between native operators ([#5710](https://github.com/apache/datafusion-comet/issues/5710)). |
+| `MapPartitionsExec`, `FlatMapGroupsExec`, `CoGroupExec`, `AppendColumnsExec` | 🔜     | These consume iterators or groups rather than rows, so there is no per-row expression to fuse. `AppendColumnsExec` is per-row but widens the schema and is not handled yet.                                                                                         |
+
+Typed filters (`ds.filter(func)`) do not produce this sandwich at all: Catalyst lowers them to an
+ordinary `FilterExec` whose condition is an `Invoke` of the closure, which Comet already dispatches.
+
 ## Python and UDF
 
 | Operator                                                                                | Status | Notes                                                                                                                        |

--- a/spark/src/main/scala/org/apache/comet/CometConf.scala
+++ b/spark/src/main/scala/org/apache/comet/CometConf.scala
@@ -396,6 +396,20 @@ object CometConf extends ShimCometConf {
       .booleanConf
       .createWithDefault(true)
 
+  val COMET_EXEC_TYPED_DATASET_MAP_ENABLED: ConfigEntry[Boolean] =
+    conf("spark.comet.exec.typedDatasetMap.enabled")
+      .category(CATEGORY_EXEC)
+      .doc("Experimental. Whether to fuse the `SerializeFromObject` / `MapElements` / " +
+        "`DeserializeToObject` operator sandwich that a typed `Dataset.map` produces into a " +
+        "Comet projection, so the typed operation no longer forces a Spark fallback island in " +
+        "the middle of an otherwise native plan. The user closure still runs on the JVM, once " +
+        "per row, inside Comet's Arrow-direct codegen dispatcher, so results match Spark. Off " +
+        "by default: the rewrite only pays off when the typed operation sits between native " +
+        "operators, and can cost a little when it is at the top of the plan. Requires " +
+        s"${COMET_SCALA_UDF_CODEGEN_ENABLED.key}=true.")
+      .booleanConf
+      .createWithDefault(false)
+
   val COMET_SHUFFLE_NATIVE_HASH_PARTITIONING_ENABLED: ConfigEntry[Boolean] =
     conf("spark.comet.shuffle.native.partitioning.hash.enabled")
       .withAlternative("spark.comet.native.shuffle.partitioning.hash.enabled")

--- a/spark/src/main/scala/org/apache/comet/codegen/CometBatchKernelCodegen.scala
+++ b/spark/src/main/scala/org/apache/comet/codegen/CometBatchKernelCodegen.scala
@@ -124,9 +124,22 @@ object CometBatchKernelCodegen extends Logging with CometExprTraitShim with Come
     // typed input field count, the typed-getter switch, and the constant pool. Refuse here so the
     // operator falls back to Spark cleanly rather than tripping a Janino compile failure
     // mid-execution (Comet has no recovery for that).
+    //
+    // Count each input ordinal once. WSCG gates on the operator's *schema*
+    // (`plan.schema.map(_.dataType).map(numOfNestedFields).sum`), so a column read more than once
+    // contributes once; the kernel likewise emits one typed field and one getter per ordinal, not
+    // per occurrence. Counting occurrences instead would scale with how often the tree happens to
+    // repeat a column, which is what `RewriteTypedDatasetMap` does deliberately: it puts the same
+    // shared subtree in every struct field so subexpression elimination can collapse it. A
+    // 12-column typed map reads 12 ordinals in each of 12 fields, which counted per occurrence
+    // came to 156 and refused a kernel that is really 24 fields wide.
     val maxFields = SQLConf.get.wholeStageMaxNumFields
-    val totalFields = numOfNestedFields(boundExpr.dataType) +
-      boundExpr.collect { case b: BoundReference => numOfNestedFields(b.dataType) }.sum
+    val inputFields = boundExpr
+      .collect { case b: BoundReference => b.ordinal -> b.dataType }
+      .distinct
+      .map { case (_, dt) => numOfNestedFields(dt) }
+      .sum
+    val totalFields = numOfNestedFields(boundExpr.dataType) + inputFields
     if (totalFields > maxFields) {
       return Some(
         s"codegen dispatch: too many nested fields ($totalFields > " +

--- a/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
@@ -707,13 +707,26 @@ case class CometExecRule(session: SparkSession)
         normalizedPlan
       }
 
+      // Collapse the SerializeFromObject / MapElements / DeserializeToObject sandwich that a typed
+      // `Dataset.map` produces into a projection, before the bottom-up conversion sees the
+      // individual operators. `transform()` visits children first, so by the time it reached
+      // `DeserializeToObjectExec` the island would already have fallen back.
+      val planWithTypedMapFused =
+        if (CometConf.COMET_EXEC_TYPED_DATASET_MAP_ENABLED.get(conf)) {
+          planWithJoinRewritten.transformUp { case p =>
+            RewriteTypedDatasetMap.rewrite(p)
+          }
+        } else {
+          planWithJoinRewritten
+        }
+
       // Tag Partial aggregates that must not be converted to Comet because a
       // corresponding Final or PartialMerge cannot be converted and the intermediate buffer
       // formats are incompatible. This runs before transform() so the tags are checked
       // during the bottom-up conversion. Tags persist through AQE stage creation.
-      tagUnsafePartialAggregates(planWithJoinRewritten)
+      tagUnsafePartialAggregates(planWithTypedMapFused)
 
-      var newPlan = transform(planWithJoinRewritten)
+      var newPlan = transform(planWithTypedMapFused)
 
       // if the plan cannot be run fully natively then explain why (when appropriate
       // config is enabled)

--- a/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/CometExecRule.scala
@@ -697,7 +697,29 @@ case class CometExecRule(session: SparkSession)
         plan
       }
     } else {
-      val normalizedPlan = normalizePlan(plan)
+      // Collapse the SerializeFromObject / MapElements / DeserializeToObject sandwich that a typed
+      // `Dataset.map` produces into a projection. Runs before `normalizePlan` so the projections it
+      // synthesizes get the same NaN / -0.0 normalization every other `ProjectExec` in the plan
+      // gets; encoder serializer trees contain no comparison operators today, so this is
+      // future-proofing rather than a live fix.
+      //
+      // A pre-pass rather than a `convertNode` case for now. Note that `convertNode` *could* do it:
+      // the bottom-up walk only tags `DeserializeToObjectExec` with a fallback reason, it never
+      // replaces it, so the sandwich is still structurally intact when the walk reaches
+      // `SerializeFromObjectExec`. Doing it there would additionally let the rule see whether the
+      // deserializer's child converted to a `CometNativeExec` and decline when it did not, which is
+      // the profitability signal this rewrite currently lacks. See
+      // https://github.com/apache/datafusion-comet/issues/5710.
+      val planWithTypedMapFused =
+        if (CometConf.COMET_EXEC_TYPED_DATASET_MAP_ENABLED.get(conf)) {
+          plan.transformUp { case p =>
+            RewriteTypedDatasetMap.rewrite(p)
+          }
+        } else {
+          plan
+        }
+
+      val normalizedPlan = normalizePlan(planWithTypedMapFused)
 
       val planWithJoinRewritten = if (CometConf.COMET_FORCE_SHJ.get()) {
         normalizedPlan.transformUp { case p =>
@@ -707,26 +729,13 @@ case class CometExecRule(session: SparkSession)
         normalizedPlan
       }
 
-      // Collapse the SerializeFromObject / MapElements / DeserializeToObject sandwich that a typed
-      // `Dataset.map` produces into a projection, before the bottom-up conversion sees the
-      // individual operators. `transform()` visits children first, so by the time it reached
-      // `DeserializeToObjectExec` the island would already have fallen back.
-      val planWithTypedMapFused =
-        if (CometConf.COMET_EXEC_TYPED_DATASET_MAP_ENABLED.get(conf)) {
-          planWithJoinRewritten.transformUp { case p =>
-            RewriteTypedDatasetMap.rewrite(p)
-          }
-        } else {
-          planWithJoinRewritten
-        }
-
       // Tag Partial aggregates that must not be converted to Comet because a
       // corresponding Final or PartialMerge cannot be converted and the intermediate buffer
       // formats are incompatible. This runs before transform() so the tags are checked
       // during the bottom-up conversion. Tags persist through AQE stage creation.
-      tagUnsafePartialAggregates(planWithTypedMapFused)
+      tagUnsafePartialAggregates(planWithJoinRewritten)
 
-      var newPlan = transform(planWithTypedMapFused)
+      var newPlan = transform(planWithJoinRewritten)
 
       // if the plan cannot be run fully natively then explain why (when appropriate
       // config is enabled)

--- a/spark/src/main/scala/org/apache/comet/rules/RewriteTypedDatasetMap.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/RewriteTypedDatasetMap.scala
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet.rules
+
+import org.apache.spark.api.java.function.MapFunction
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, AttributeSeq, AttributeSet, BindReferences, BoundReference, CreateNamedStruct, Expression, GetStructField, Literal, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.objects.Invoke
+import org.apache.spark.sql.catalyst.plans.logical.FunctionUtils
+import org.apache.spark.sql.execution.{DeserializeToObjectExec, MapElementsExec, ProjectExec, SerializeFromObjectExec, SparkPlan}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.ObjectType
+
+import org.apache.comet.CometConf
+import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
+import org.apache.comet.codegen.CometBatchKernelCodegen
+import org.apache.comet.serde.CometScalaUDF
+
+/**
+ * Collapses the three-operator island that a typed `Dataset.map` produces
+ *
+ * {{{
+ *   SerializeFromObject [serializer...]
+ *   +- MapElements <closure>, obj: T
+ *      +- DeserializeToObject <deserializer>, obj: T
+ *         +- child
+ * }}}
+ *
+ * into a projection over `child` whose expressions are the fused
+ * serializer(closure(deserializer(child))) trees. The projection then converts through the
+ * ordinary `CometProjectExec` path, and the fused tree routes through the JVM codegen dispatcher,
+ * so the whole thing stays inside the Comet pipeline. No proto or native change is involved.
+ *
+ * '''Why the operators cannot be handled individually.''' `DeserializeToObjectExec` outputs a
+ * single `ObjectType` attribute and `SerializeFromObjectExec` consumes one. `ObjectType` is
+ * outside `QueryPlanSerde.supportedDataType` and outside
+ * `CometBatchKernelCodegen.isSupportedDataType`, because a JVM object reference cannot live in an
+ * Arrow vector. Fusing works because `CometBatchKernelCodegen.canHandle` only type-checks the
+ * root and the bound references, so the object may exist strictly ''inside'' the tree. See
+ * https://github.com/apache/datafusion-comet/issues/5710.
+ *
+ * '''Why the expression is safe to rebuild.''' Spark already constructs it. This rule mirrors
+ * `MapElementsExec.doConsume` (the `Invoke` on the closure literal),
+ * `DeserializeToObjectExec.doConsume` and `SerializeFromObjectExec.doConsume`, which whole-stage
+ * codegen chains to produce exactly the same fused tree.
+ *
+ * '''Shape of the output.''' With one output column the projection is a single fused expression.
+ * With N > 1 the rule emits two stacked projections: an inner one producing a single
+ * `CreateNamedStruct` column, and an outer one extracting the N fields with `GetStructField`. The
+ * struct matters for correctness, not tidiness: N separate projection expressions would each
+ * carry their own copy of the closure `Invoke` and each become its own dispatch kernel, calling
+ * the user closure N times per row where Spark calls it once. The inner struct is tagged
+ * `CometScalaUDF.FORCE_DISPATCH` so it compiles into one kernel, and subexpression elimination
+ * inside that kernel collapses the shared `Invoke` back to a single call per row.
+ *
+ * Only `MapElementsExec` is fusable. `MapPartitionsExec`, `FlatMapGroupsExec` and `CoGroupExec`
+ * consume iterators or groups rather than rows, so no per-row expression exists for them. A chain
+ * of adjacent `MapElementsExec` nodes is fused as a whole, because `ds.map(f).map(g)` leaves both
+ * under a single Serialize/Deserialize pair.
+ */
+object RewriteTypedDatasetMap extends Logging {
+
+  /** Name of the single intermediate struct column when there is more than one output column. */
+  private val FUSED_COLUMN = "comet_fused_object"
+
+  def rewrite(plan: SparkPlan): SparkPlan = plan match {
+    case serialize: SerializeFromObjectExec =>
+      // `ds.map(f).map(g)` leaves two adjacent `MapElements` under one Serialize/Deserialize pair,
+      // so walk the whole chain rather than expecting exactly one.
+      val chain = mapElementsChain(serialize.child)
+      chain.lastOption.map(_.child) match {
+        case Some(deserialize: DeserializeToObjectExec) =>
+          fuse(serialize, chain, deserialize).getOrElse(plan)
+        case _ => plan
+      }
+    case _ => plan
+  }
+
+  /** Consecutive `MapElementsExec` nodes, outermost first. */
+  private def mapElementsChain(plan: SparkPlan): Seq[MapElementsExec] = plan match {
+    case m: MapElementsExec => m +: mapElementsChain(m.child)
+    case _ => Nil
+  }
+
+  private def fuse(
+      serialize: SerializeFromObjectExec,
+      chain: Seq[MapElementsExec],
+      deserialize: DeserializeToObjectExec): Option[SparkPlan] = {
+    val child = deserialize.child
+    val serializer = serialize.serializer
+    val objType = chain.head.outputObjectType
+
+    // Every serializer element is an `Alias` for encoder-generated serializers. The outer
+    // projection rebuilds them with `withNewChildren`, which needs exactly one child, and that
+    // is also what preserves `exprId` / qualifier / metadata across the rewrite.
+    if (!serializer.forall(_.isInstanceOf[Alias])) {
+      return declineQuietly(
+        serialize,
+        "serializer contains a non-Alias element: " +
+          serializer
+            .filterNot(_.isInstanceOf[Alias])
+            .map(_.getClass.getSimpleName)
+            .mkString(", "))
+    }
+
+    // The serializer reads the object through `BoundReference(0, objType)`. Anything else means a
+    // shape this rule has not been reasoned about, so leave it alone rather than guess.
+    val badRefs = serializer.flatMap(_.collect {
+      case b: BoundReference if b.ordinal != 0 || b.dataType != objType => b
+    })
+    if (badRefs.nonEmpty) {
+      return declineQuietly(
+        serialize,
+        s"serializer reads unexpected bound references: ${badRefs.mkString(", ")}")
+    }
+
+    // Compose the chain innermost-first, so `ds.map(f).map(g)` becomes g(f(deserializer)). Each
+    // step mirrors `MapElementsExec.doConsume`, including how it picks the specialized
+    // `Function1.apply$mc..$sp` name from the operator's own input and output object types.
+    val callFunc = chain.reverse.foldLeft(deserialize.deserializer) { (arg, m) =>
+      val (funcClass, funcName) = m.func match {
+        case _: MapFunction[_, _] => classOf[MapFunction[_, _]] -> "call"
+        case _ =>
+          FunctionUtils.getFunctionOneName(m.outputObjectType, m.child.output.head.dataType)
+      }
+      Invoke(
+        Literal.create(m.func, ObjectType(funcClass)),
+        funcName,
+        m.outputObjectType,
+        arg :: Nil,
+        propagateNull = false)
+    }
+
+    // Substitute the closure call for the object the serializer reads. `transform` on an `Alias`
+    // preserves `exprId`, qualifier and metadata via `otherCopyArgs`, so the rewritten projection
+    // keeps `SerializeFromObjectExec`'s exact output attributes and parents stay valid.
+    val fused = serializer.map { ne =>
+      ne.transform { case _: BoundReference => callFunc }.asInstanceOf[NamedExpression]
+    }
+
+    // A projection may only reference its child's output. The deserializer reads `child.output`
+    // and the object reference is gone, so this should hold; check rather than assume.
+    val childOutput = AttributeSet(child.output)
+    val dangling = fused.flatMap(f => (f.references -- childOutput).toSeq)
+    if (dangling.nonEmpty) {
+      return declineQuietly(
+        serialize,
+        s"fused expression references attributes outside the child: ${dangling.mkString(", ")}")
+    }
+
+    if (fused.length == 1) {
+      // Single output column: the fused expression is already one dispatch kernel, so there is
+      // nothing for the struct wrapper to deduplicate.
+      val single = fused.head
+      val value = single.children.head
+      dispatchable(value).map { _ =>
+        value.setTagValue(CometScalaUDF.FORCE_DISPATCH, ())
+        ProjectExec(fused, child)
+      }
+    } else {
+      // Without subexpression elimination the single kernel would still evaluate the shared
+      // `Invoke` once per struct field, so the closure would run N times per row. Spark runs it
+      // once; decline rather than change how many times user code executes.
+      if (!SQLConf.get.subexpressionEliminationEnabled) {
+        return declineQuietly(
+          serialize,
+          s"${serializer.length} output columns require subexpression elimination to keep the " +
+            "closure to one call per row, but " +
+            s"${SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key}=false")
+      }
+
+      val structExpr =
+        CreateNamedStruct(fused.flatMap(ne => Seq(Literal(ne.name), ne.children.head)))
+      dispatchable(structExpr).map { _ =>
+        structExpr.setTagValue(CometScalaUDF.FORCE_DISPATCH, ())
+        val structAlias = Alias(structExpr, FUSED_COLUMN)()
+        val inner = ProjectExec(Seq(structAlias), child)
+        val structAttr = structAlias.toAttribute
+        // `CreateNamedStruct` is never null and copies each field's nullability, so
+        // `GetStructField(structAttr, i).nullable` equals the original expression's nullability.
+        // The rewritten output attributes therefore match `SerializeFromObjectExec.output` exactly.
+        val outer = fused.zipWithIndex.map { case (ne, i) =>
+          ne.withNewChildren(Seq(GetStructField(structAttr, i, Some(ne.name))))
+            .asInstanceOf[NamedExpression]
+        }
+        ProjectExec(outer, inner)
+      }
+    }
+  }
+
+  /**
+   * Plan-time gate. The rewrite is only worth making if the fused tree can actually reach the
+   * dispatcher; otherwise the resulting projection would fall back to Spark anyway, and we would
+   * have replaced a whole-stage-fused island with an unfused one. Binds the same way
+   * `CometScalaUDF.emitJvmCodegenDispatch` does so `canHandle` sees the tree it will really get.
+   */
+  private def dispatchable(fusedValue: Expression): Option[Unit] = {
+    if (!CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.get()) {
+      logDebug(
+        "RewriteTypedDatasetMap: not rewriting because " +
+          s"${CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key}=false")
+      return None
+    }
+    // Same binding as `emitJvmCodegenDispatch`, so `canHandle` sees the tree it will really get.
+    val attrs = fusedValue.collect { case a: AttributeReference => a }.distinct
+    val bound = BindReferences.bindReference(fusedValue, AttributeSeq(attrs))
+    CometBatchKernelCodegen.canHandle(bound) match {
+      case Some(reason) =>
+        logDebug(s"RewriteTypedDatasetMap: not rewriting because $reason")
+        None
+      case None => Some(())
+    }
+  }
+
+  /**
+   * Leave the sandwich alone and record why on the operator, so `EXPLAIN` shows the reason the
+   * typed operation stayed on Spark rather than the bare "not supported" the un-rewritten
+   * operators would otherwise produce.
+   */
+  private def declineQuietly(
+      serialize: SerializeFromObjectExec,
+      reason: String): Option[SparkPlan] = {
+    withFallbackReason(serialize, s"Cannot fuse typed Dataset map: $reason")
+    None
+  }
+}

--- a/spark/src/main/scala/org/apache/comet/rules/RewriteTypedDatasetMap.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/RewriteTypedDatasetMap.scala
@@ -21,7 +21,7 @@ package org.apache.comet.rules
 
 import org.apache.spark.api.java.function.MapFunction
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, AttributeSeq, AttributeSet, BindReferences, BoundReference, CreateNamedStruct, Expression, GetStructField, Literal, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeSet, BoundReference, CreateNamedStruct, Expression, GetStructField, Literal, NamedExpression}
 import org.apache.spark.sql.catalyst.expressions.objects.Invoke
 import org.apache.spark.sql.catalyst.plans.logical.FunctionUtils
 import org.apache.spark.sql.execution.{DeserializeToObjectExec, MapElementsExec, ProjectExec, SerializeFromObjectExec, SparkPlan}
@@ -30,8 +30,7 @@ import org.apache.spark.sql.types.ObjectType
 
 import org.apache.comet.CometConf
 import org.apache.comet.CometSparkSessionExtensions.withFallbackReason
-import org.apache.comet.codegen.CometBatchKernelCodegen
-import org.apache.comet.serde.CometScalaUDF
+import org.apache.comet.serde.{CometScalaUDF, QueryPlanSerde}
 
 /**
  * Collapses the three-operator island that a typed `Dataset.map` produces
@@ -85,11 +84,11 @@ object RewriteTypedDatasetMap extends Logging {
       // `ds.map(f).map(g)` leaves two adjacent `MapElements` under one Serialize/Deserialize pair,
       // so walk the whole chain rather than expecting exactly one.
       val chain = mapElementsChain(serialize.child)
-      chain.lastOption.map(_.child) match {
-        case Some(deserialize: DeserializeToObjectExec) =>
-          fuse(serialize, chain, deserialize).getOrElse(plan)
-        case _ => plan
-      }
+      chain.lastOption
+        .map(_.child)
+        .collect { case deserialize: DeserializeToObjectExec => deserialize }
+        .flatMap(fuse(serialize, chain, _))
+        .getOrElse(plan)
     case _ => plan
   }
 
@@ -107,26 +106,36 @@ object RewriteTypedDatasetMap extends Logging {
     val serializer = serialize.serializer
     val objType = chain.head.outputObjectType
 
-    // Every serializer element is an `Alias` for encoder-generated serializers. The outer
-    // projection rebuilds them with `withNewChildren`, which needs exactly one child, and that
-    // is also what preserves `exprId` / qualifier / metadata across the rewrite.
-    if (!serializer.forall(_.isInstanceOf[Alias])) {
-      return declineQuietly(
+    // Cheapest precondition first: a config that cannot change mid-plan.
+    if (!CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.get()) {
+      return decline(
         serialize,
-        "serializer contains a non-Alias element: " +
-          serializer
-            .filterNot(_.isInstanceOf[Alias])
-            .map(_.getClass.getSimpleName)
-            .mkString(", "))
+        s"${CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key}=false, so there is no dispatcher to " +
+          "fuse into")
     }
 
-    // The serializer reads the object through `BoundReference(0, objType)`. Anything else means a
-    // shape this rule has not been reasoned about, so leave it alone rather than guess.
+    // Every serializer element is an `Alias` for encoder-generated serializers -- Spark builds them
+    // via `ExpressionEncoder.namedExpressions`, which aliases every field of the flattened
+    // `CreateNamedStruct`. The outer projection relies on that: it rebuilds each element with
+    // `withNewChildren`, which needs exactly one child, and that is what preserves `exprId` /
+    // qualifier / metadata across the rewrite.
+    val nonAliases = serializer.filterNot(_.isInstanceOf[Alias])
+    if (nonAliases.nonEmpty) {
+      return decline(
+        serialize,
+        "serializer contains a non-Alias element: " +
+          nonAliases.map(_.getClass.getSimpleName).mkString(", "))
+    }
+
+    // The serializer reads the object through `BoundReference(0, objType)` -- Spark asserts as much
+    // in `ExpressionEncoder` ("all serializer expressions must use the same BoundReference") and
+    // `ScalaReflection.serializerFor` builds it at ordinal 0. Anything else is a shape this rule
+    // has not been reasoned about, so leave it alone rather than guess.
     val badRefs = serializer.flatMap(_.collect {
       case b: BoundReference if b.ordinal != 0 || b.dataType != objType => b
     })
     if (badRefs.nonEmpty) {
-      return declineQuietly(
+      return decline(
         serialize,
         s"serializer reads unexpected bound references: ${badRefs.mkString(", ")}")
     }
@@ -148,95 +157,87 @@ object RewriteTypedDatasetMap extends Logging {
         propagateNull = false)
     }
 
-    // Substitute the closure call for the object the serializer reads. `transform` on an `Alias`
-    // preserves `exprId`, qualifier and metadata via `otherCopyArgs`, so the rewritten projection
-    // keeps `SerializeFromObjectExec`'s exact output attributes and parents stay valid.
+    // Substitute the closure call for the object the serializer reads. The guard above proved every
+    // `BoundReference` here is that object, and the pattern restates it so the substitution cannot
+    // outlive its precondition. `transform` on an `Alias` preserves `exprId`, qualifier and
+    // metadata via `otherCopyArgs`, so the rewritten projection keeps
+    // `SerializeFromObjectExec`'s exact output attributes and parents stay valid.
     val fused = serializer.map { ne =>
-      ne.transform { case _: BoundReference => callFunc }.asInstanceOf[NamedExpression]
+      ne.transform {
+        case b: BoundReference if b.ordinal == 0 && b.dataType == objType => callFunc
+      }.asInstanceOf[NamedExpression]
     }
 
-    // A projection may only reference its child's output. The deserializer reads `child.output`
-    // and the object reference is gone, so this should hold; check rather than assume.
-    val childOutput = AttributeSet(child.output)
-    val dangling = fused.flatMap(f => (f.references -- childOutput).toSeq)
+    // A projection may only reference its child's output. Spark asserts the serializer itself has
+    // no free references (`ExpressionEncoder`), and the substituted tree bottoms out in the
+    // deserializer, which reads `child.output` -- so this should hold; check rather than assume.
+    val dangling = AttributeSet(fused) -- child.outputSet
     if (dangling.nonEmpty) {
-      return declineQuietly(
+      return decline(
         serialize,
         s"fused expression references attributes outside the child: ${dangling.mkString(", ")}")
     }
 
-    if (fused.length == 1) {
-      // Single output column: the fused expression is already one dispatch kernel, so there is
-      // nothing for the struct wrapper to deduplicate.
-      val single = fused.head
-      val value = single.children.head
-      dispatchable(value).map { _ =>
-        value.setTagValue(CometScalaUDF.FORCE_DISPATCH, ())
-        ProjectExec(fused, child)
-      }
-    } else {
-      // Without subexpression elimination the single kernel would still evaluate the shared
-      // `Invoke` once per struct field, so the closure would run N times per row. Spark runs it
-      // once; decline rather than change how many times user code executes.
-      if (!SQLConf.get.subexpressionEliminationEnabled) {
-        return declineQuietly(
-          serialize,
-          s"${serializer.length} output columns require subexpression elimination to keep the " +
-            "closure to one call per row, but " +
-            s"${SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key}=false")
-      }
+    // Without subexpression elimination the single kernel would evaluate the shared `Invoke` once
+    // per struct field, so the closure would run N times per row. Spark runs it once; decline
+    // rather than change how many times user code executes. One output column has nothing to
+    // deduplicate, so it does not need CSE.
+    if (fused.length > 1 && !SQLConf.get.subexpressionEliminationEnabled) {
+      return decline(
+        serialize,
+        s"${fused.length} output columns require subexpression elimination to keep the closure " +
+          s"to one call per row, but ${SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key}=false")
+    }
 
-      val structExpr =
-        CreateNamedStruct(fused.flatMap(ne => Seq(Literal(ne.name), ne.children.head)))
-      dispatchable(structExpr).map { _ =>
-        structExpr.setTagValue(CometScalaUDF.FORCE_DISPATCH, ())
-        val structAlias = Alias(structExpr, FUSED_COLUMN)()
-        val inner = ProjectExec(Seq(structAlias), child)
-        val structAttr = structAlias.toAttribute
-        // `CreateNamedStruct` is never null and copies each field's nullability, so
-        // `GetStructField(structAttr, i).nullable` equals the original expression's nullability.
-        // The rewritten output attributes therefore match `SerializeFromObjectExec.output` exactly.
-        val outer = fused.zipWithIndex.map { case (ne, i) =>
-          ne.withNewChildren(Seq(GetStructField(structAttr, i, Some(ne.name))))
-            .asInstanceOf[NamedExpression]
+    fused match {
+      // One output column is already one kernel; the struct wrapper would have nothing to dedupe.
+      case Seq(only) =>
+        forceDispatch(only.children.head).map(_ => ProjectExec(fused, child))
+
+      case _ =>
+        forceDispatch(
+          CreateNamedStruct(fused.flatMap(ne => Seq(Literal(ne.name), ne.children.head)))).map {
+          structExpr =>
+            val structAlias = Alias(structExpr, FUSED_COLUMN)()
+            val inner = ProjectExec(Seq(structAlias), child)
+            val structAttr = structAlias.toAttribute
+            // `CreateNamedStruct` is never null and copies each field's nullability, so
+            // `GetStructField(structAttr, i).nullable` equals the original expression's
+            // nullability. The rewritten output attributes therefore match
+            // `SerializeFromObjectExec.output` exactly.
+            val outer = fused.zipWithIndex.map { case (ne, i) =>
+              ne.withNewChildren(Seq(GetStructField(structAttr, i, Some(ne.name))))
+                .asInstanceOf[NamedExpression]
+            }
+            ProjectExec(outer, inner)
         }
-        ProjectExec(outer, inner)
-      }
     }
   }
 
   /**
-   * Plan-time gate. The rewrite is only worth making if the fused tree can actually reach the
-   * dispatcher; otherwise the resulting projection would fall back to Spark anyway, and we would
-   * have replaced a whole-stage-fused island with an unfused one. Binds the same way
-   * `CometScalaUDF.emitJvmCodegenDispatch` does so `canHandle` sees the tree it will really get.
+   * Tag `expr` to compile into a single kernel, or `None` when the dispatcher would refuse it.
+   *
+   * The gate matters: if the fused tree cannot reach the dispatcher, the projection this rule
+   * builds would fall back to Spark anyway, and we would have traded a whole-stage-fused island
+   * for an unfused one. Delegating to [[CometScalaUDF.canDispatch]] rather than re-deriving the
+   * binding is what keeps the prediction identical to what the serde will really do.
    */
-  private def dispatchable(fusedValue: Expression): Option[Unit] = {
-    if (!CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.get()) {
-      logDebug(
-        "RewriteTypedDatasetMap: not rewriting because " +
-          s"${CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key}=false")
-      return None
-    }
-    // Same binding as `emitJvmCodegenDispatch`, so `canHandle` sees the tree it will really get.
-    val attrs = fusedValue.collect { case a: AttributeReference => a }.distinct
-    val bound = BindReferences.bindReference(fusedValue, AttributeSeq(attrs))
-    CometBatchKernelCodegen.canHandle(bound) match {
+  private def forceDispatch[T <: Expression](expr: T): Option[T] =
+    CometScalaUDF.canDispatch(expr) match {
       case Some(reason) =>
         logDebug(s"RewriteTypedDatasetMap: not rewriting because $reason")
         None
-      case None => Some(())
+      case None =>
+        expr.setTagValue(QueryPlanSerde.FORCE_DISPATCH, ())
+        Some(expr)
     }
-  }
 
   /**
    * Leave the sandwich alone and record why on the operator, so `EXPLAIN` shows the reason the
    * typed operation stayed on Spark rather than the bare "not supported" the un-rewritten
    * operators would otherwise produce.
    */
-  private def declineQuietly(
-      serialize: SerializeFromObjectExec,
-      reason: String): Option[SparkPlan] = {
+  private def decline(serialize: SerializeFromObjectExec, reason: String): Option[SparkPlan] = {
     withFallbackReason(serialize, s"Cannot fuse typed Dataset map: $reason")
     None
   }

--- a/spark/src/main/scala/org/apache/comet/serde/CometScalaUDF.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/CometScalaUDF.scala
@@ -21,7 +21,6 @@ package org.apache.comet.serde
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSeq, BindReferences, Expression, Literal, RuntimeReplaceable, ScalaUDF}
-import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.types.BinaryType
 
 import org.apache.comet.CometConf
@@ -54,26 +53,47 @@ import org.apache.comet.udf.codegen.CometScalaUDFCodegen
  */
 object CometScalaUDF extends CometExpressionSerde[ScalaUDF] {
 
-  /**
-   * Marks a subtree as "dispatch this whole thing as one kernel", overriding the normal per-node
-   * serde lookup in `QueryPlanSerde.exprToProtoInternal`.
-   *
-   * Needed when a rewrite builds a tree whose root has a perfectly good native serde but whose
-   * children must not be converted independently. `RewriteTypedDatasetMap` is the motivating
-   * case: it fuses a typed `Dataset.map` into a `CreateNamedStruct` over N serializer expressions
-   * that all share one `Invoke` of the user closure. Letting `CometCreateNamedStruct` convert
-   * each field separately would emit N dispatch protos and call the closure N times per row.
-   * Tagging the root produces one kernel instead, and subexpression elimination inside it
-   * collapses the shared `Invoke` to a single call per row.
-   *
-   * A tag rather than a Comet-specific `Expression` subclass on purpose: the rewritten plan stays
-   * built entirely from stock Spark expressions, so it still executes correctly if the enclosing
-   * operator ends up falling back to Spark for an unrelated reason.
-   */
-  val FORCE_DISPATCH: TreeNodeTag[Unit] = TreeNodeTag[Unit]("comet.forceCodegenDispatch")
-
   override def convert(expr: ScalaUDF, inputs: Seq[Attribute], binding: Boolean): Option[Expr] =
     emitJvmCodegenDispatch(expr, inputs, binding)
+
+  /**
+   * Bind `expr` the way [[emitJvmCodegenDispatch]] will, returning the attributes it reads in
+   * ordinal order alongside the bound tree.
+   *
+   * Callers that only need to know whether a tree is dispatchable should use [[canDispatch]]
+   * rather than repeating this.
+   */
+  private def bindForDispatch(expr: Expression): (Seq[AttributeReference], Expression) = {
+    // `RuntimeReplaceable` expressions (e.g. Spark 4's `StructsToJson`) have a `doGenCode` that
+    // always throws "Cannot generate code for expression". Catalyst's `ReplaceExpressions` rule
+    // normally rewrites them to their `replacement` form before codegen runs. Comet's serde
+    // sometimes works with the pre-rewrite form (via shim reconstruction) for matching purposes,
+    // so unwrap to the replacement here before binding so the kernel compiles.
+    val target = expr match {
+      case rr: RuntimeReplaceable => rr.replacement
+      case other => other
+    }
+    // Bind against only the AttributeReferences the tree actually reads, so ordinals align with
+    // the data args we ship.
+    val attrs = target.collect { case a: AttributeReference => a }.distinct
+    (attrs, BindReferences.bindReference(target, AttributeSeq(attrs)))
+  }
+
+  /**
+   * Plan-time gate: `None` if the dispatcher would accept `expr`, `Some(reason)` otherwise.
+   *
+   * Exposed so a rule that decides whether to rewrite a plan into a dispatchable shape predicts
+   * the same answer [[emitJvmCodegenDispatch]] will give it later. Do not re-derive the binding
+   * at the call site -- the two would drift, and a stale prediction commits a plan neither side
+   * wants.
+   */
+  def canDispatch(expr: Expression): Option[String] = {
+    if (!CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.get()) {
+      return Some(
+        s"${CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key}=false; expression has no native path")
+    }
+    CometBatchKernelCodegen.canHandle(bindForDispatch(expr)._2)
+  }
 
   /**
    * Bind `expr`, closure-serialize it, and emit a `JvmScalarUdf` proto routed through
@@ -104,15 +124,7 @@ object CometScalaUDF extends CometExpressionSerde[ScalaUDF] {
     // normally rewrites them to their `replacement` form before codegen runs. Comet's serde
     // sometimes works with the pre-rewrite form (via shim reconstruction) for matching purposes,
     // so unwrap to the replacement here before binding so the kernel compiles.
-    val target = expr match {
-      case rr: RuntimeReplaceable => rr.replacement
-      case other => other
-    }
-
-    // Bind against only the AttributeReferences the tree actually reads, so ordinals align with
-    // the data args we ship.
-    val attrs = target.collect { case a: AttributeReference => a }.distinct
-    val boundExpr = BindReferences.bindReference(target, AttributeSeq(attrs))
+    val (attrs, boundExpr) = bindForDispatch(expr)
 
     // Gate at plan time. Surface the reason via withFallbackReason rather than crashing Janino
     // at execute.

--- a/spark/src/main/scala/org/apache/comet/serde/CometScalaUDF.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/CometScalaUDF.scala
@@ -21,6 +21,7 @@ package org.apache.comet.serde
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSeq, BindReferences, Expression, Literal, RuntimeReplaceable, ScalaUDF}
+import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.types.BinaryType
 
 import org.apache.comet.CometConf
@@ -52,6 +53,24 @@ import org.apache.comet.udf.codegen.CometScalaUDFCodegen
  * lowering is viable. See [[CometDateFormat]] for an example.
  */
 object CometScalaUDF extends CometExpressionSerde[ScalaUDF] {
+
+  /**
+   * Marks a subtree as "dispatch this whole thing as one kernel", overriding the normal per-node
+   * serde lookup in `QueryPlanSerde.exprToProtoInternal`.
+   *
+   * Needed when a rewrite builds a tree whose root has a perfectly good native serde but whose
+   * children must not be converted independently. `RewriteTypedDatasetMap` is the motivating
+   * case: it fuses a typed `Dataset.map` into a `CreateNamedStruct` over N serializer expressions
+   * that all share one `Invoke` of the user closure. Letting `CometCreateNamedStruct` convert
+   * each field separately would emit N dispatch protos and call the closure N times per row.
+   * Tagging the root produces one kernel instead, and subexpression elimination inside it
+   * collapses the shared `Invoke` to a single call per row.
+   *
+   * A tag rather than a Comet-specific `Expression` subclass on purpose: the rewritten plan stays
+   * built entirely from stock Spark expressions, so it still executes correctly if the enclosing
+   * operator ends up falling back to Spark for an unrelated reason.
+   */
+  val FORCE_DISPATCH: TreeNodeTag[Unit] = TreeNodeTag[Unit]("comet.forceCodegenDispatch")
 
   override def convert(expr: ScalaUDF, inputs: Seq[Attribute], binding: Boolean): Option[Expr] =
     emitJvmCodegenDispatch(expr, inputs, binding)

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.expressions.xml.{XPathBoolean, XPathDouble, XPathFloat, XPathInt, XPathList, XPathLong, XPathShort, XPathString}
+import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.comet.DecimalPrecision
 import org.apache.spark.sql.execution.{ScalarSubquery, SparkPlan}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetUtils
@@ -51,6 +52,31 @@ import org.apache.comet.shims.{CometExprShim, CometTypeShim}
  * An utility object for query plan and expression serialization.
  */
 object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
+
+  /**
+   * Marks a subtree as "dispatch this whole thing as one kernel", overriding the normal per-node
+   * serde lookup in [[exprToProtoInternal]].
+   *
+   * Needed when a rewrite builds a tree whose root has a perfectly good native serde but whose
+   * children must not be converted independently. `RewriteTypedDatasetMap` is the motivating
+   * case: it fuses a typed `Dataset.map` into a `CreateNamedStruct` over N serializer expressions
+   * that all share one `Invoke` of the user closure. Letting `CometCreateNamedStruct` convert
+   * each field separately would emit N dispatch protos and call the closure N times per row.
+   * Tagging the root produces one kernel instead, and subexpression elimination inside it
+   * collapses the shared `Invoke` to a single call per row.
+   *
+   * A tag rather than a Comet-specific `Expression` subclass on purpose: the rewritten plan stays
+   * built entirely from stock Spark expressions, so it still executes correctly if the enclosing
+   * operator ends up falling back to Spark for an unrelated reason. (Comet has no `Expression`
+   * subclasses at all, and its whole expression story is serdes over stock Spark nodes.)
+   *
+   * Caveat for future callers: the tag routes straight to `CometScalaUDF.emitJvmCodegenDispatch`,
+   * bypassing the per-expression policy layer in `exprToProtoInternal`'s `convert` helper -- so
+   * `CometConf.isExprEnabled`, `getSupportLevel` and `allowIncompatible` are *not* consulted for
+   * a tagged node. Only tag trees you have already decided are dispatchable, via
+   * [[CometScalaUDF.canDispatch]].
+   */
+  val FORCE_DISPATCH: TreeNodeTag[Unit] = TreeNodeTag[Unit]("comet.forceCodegenDispatch")
 
   private[comet] val arrayExpressions: Map[Class[_ <: Expression], CometExpressionSerde[_]] = Map(
     // ArrayAppend is a concrete expression only on Spark 3.x. Spark 4.0+ marks it
@@ -998,13 +1024,18 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
       }
     }
 
+    // A rewrite rule asked for this whole subtree to compile into one kernel rather than letting
+    // each child pick its own serde. Checked ahead of the version shim so the override is
+    // unconditional: the shim pattern-matches on `Invoke`/`StaticInvoke`, which is exactly the
+    // shape `RewriteTypedDatasetMap` synthesizes. See `FORCE_DISPATCH`.
+    if (expr.getTagValue(FORCE_DISPATCH).isDefined) {
+      return CometScalaUDF
+        .emitJvmCodegenDispatch(expr, inputs, binding)
+        .map(attachExprIdAndContext(expr, _))
+    }
+
     sparkVersionSpecificExprToProtoInternal(expr, inputs, binding)
       .orElse(expr match {
-
-        case _ if expr.getTagValue(CometScalaUDF.FORCE_DISPATCH).isDefined =>
-          // A rewrite rule asked for this whole subtree to compile into one kernel rather than
-          // letting each child pick its own serde. See `CometScalaUDF.FORCE_DISPATCH`.
-          CometScalaUDF.emitJvmCodegenDispatch(expr, inputs, binding)
 
         case UnaryExpression(child) if expr.prettyName == "promote_precision" =>
           // `UnaryExpression` includes `PromotePrecision` for Spark 3.3

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -1001,6 +1001,11 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
     sparkVersionSpecificExprToProtoInternal(expr, inputs, binding)
       .orElse(expr match {
 
+        case _ if expr.getTagValue(CometScalaUDF.FORCE_DISPATCH).isDefined =>
+          // A rewrite rule asked for this whole subtree to compile into one kernel rather than
+          // letting each child pick its own serde. See `CometScalaUDF.FORCE_DISPATCH`.
+          CometScalaUDF.emitJvmCodegenDispatch(expr, inputs, binding)
+
         case UnaryExpression(child) if expr.prettyName == "promote_precision" =>
           // `UnaryExpression` includes `PromotePrecision` for Spark 3.3
           // `PromotePrecision` is just a wrapper, don't need to serialize it.

--- a/spark/src/test/scala/org/apache/comet/CometTypedDatasetSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometTypedDatasetSuite.scala
@@ -22,11 +22,9 @@ package org.apache.comet
 import java.util.concurrent.atomic.AtomicLong
 
 import org.apache.spark.api.java.function.MapFunction
-import org.apache.spark.sql.CometTestBase
-import org.apache.spark.sql.Encoders
+import org.apache.spark.sql.{CometTestBase, DataFrame, Dataset, Encoders}
 import org.apache.spark.sql.comet.CometProjectExec
-import org.apache.spark.sql.execution.{DeserializeToObjectExec, MapElementsExec, MapPartitionsExec, SerializeFromObjectExec, SparkPlan}
-import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.{MapPartitionsExec, ObjectConsumerExec, ObjectProducerExec, SparkPlan}
 import org.apache.spark.sql.internal.SQLConf
 
 /** Top-level so `NewInstance` needs no outer pointer, which is the ordinary user shape. */
@@ -37,6 +35,21 @@ case class TypedWide(i: Int, s: String, d: java.math.BigDecimal, opt: Option[Lon
 case class TypedNested(id: Int, inner: TypedRec, tags: Seq[String])
 
 case class TypedDec(id: Int, d: java.math.BigDecimal)
+
+/** Twelve columns, to pin the `spark.sql.codegen.maxFields` accounting. */
+case class TypedWide12(
+    c1: Int,
+    c2: Int,
+    c3: Int,
+    c4: Int,
+    c5: Int,
+    c6: Int,
+    c7: Int,
+    c8: Int,
+    c9: Int,
+    c10: Int,
+    c11: Int,
+    c12: Int)
 
 /** JVM-static counter. Comet tests run in local mode, so driver and executor share this. */
 object TypedMapCounter {
@@ -50,7 +63,7 @@ object TypedMapCounter {
  * `SerializeFromObject` / `MapElements` / `DeserializeToObject` sandwich a typed `Dataset.map`
  * produces into a Comet projection. See https://github.com/apache/datafusion-comet/issues/5710.
  */
-class CometTypedDatasetSuite extends CometTestBase with AdaptiveSparkPlanHelper {
+class CometTypedDatasetSuite extends CometTestBase {
 
   import testImplicits._
 
@@ -60,24 +73,44 @@ class CometTypedDatasetSuite extends CometTestBase with AdaptiveSparkPlanHelper 
         CometConf.COMET_EXEC_TYPED_DATASET_MAP_ENABLED.key -> "true",
         CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "true") ++ pairs): _*)(f)
 
-  private def objectOperators(plan: SparkPlan): Seq[SparkPlan] =
-    collectWithSubqueries(plan) {
-      case p: SerializeFromObjectExec => p
-      case p: DeserializeToObjectExec => p
-      case p: MapElementsExec => p
-      case p: MapPartitionsExec => p
+  /** The common fixture: `rows` rows of `(a: Int, b: String)` via Parquet, read back typed. */
+  private def withTypedRecs(rows: Int = 100)(f: Dataset[TypedRec] => Unit): Unit =
+    withParquetTable((0 until rows).map(i => (i, i.toString)), "tbl") {
+      f(spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec])
     }
 
-  private def assertNoObjectOperators(plan: SparkPlan): Unit =
-    assert(
-      objectOperators(plan).isEmpty,
-      s"expected the typed sandwich to be fused away, but plan still has " +
-        s"${objectOperators(plan).map(_.nodeName).mkString(", ")}:\n$plan")
+  /**
+   * Round-trips `df` through Parquet and registers it as `tbl`. Needed rather than
+   * `withParquetTable(df, name)` because that registers the DataFrame directly, leaving a
+   * `LocalTableScanExec` that the native-plan assertions do not tolerate.
+   */
+  private def withParquetRoundTrip(df: => DataFrame)(f: => Unit): Unit =
+    withTempPath { path =>
+      df.write.parquet(path.toString)
+      withParquetTable(path.toString, "tbl")(f)
+    }
+
+  /**
+   * Every operator in the typed-Dataset family, via the two traits Spark uses to mark them. Wider
+   * than the `ds.map` sandwich on purpose: it also covers `FlatMapGroupsExec` /
+   * `AppendColumnsExec`, which this rule does not fuse, so a future change that starts fusing
+   * them is visible here.
+   */
+  private def objectOperators(plan: SparkPlan): Seq[SparkPlan] =
+    collectWithSubqueries(plan) { case p @ (_: ObjectConsumerExec | _: ObjectProducerExec) => p }
+
+  private def assertNoObjectOperators(plan: SparkPlan): Unit = {
+    val remaining = objectOperators(plan)
+    if (remaining.nonEmpty) {
+      fail(
+        "expected the typed sandwich to be fused away, but plan still has " +
+          s"${remaining.map(_.nodeName).mkString(", ")}:\n$plan")
+    }
+  }
 
   test("ds.map produces a fully native plan - single output column") {
     withFusion() {
-      withParquetTable((0 until 100).map(i => (i, i.toString)), "tbl") {
-        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+      withTypedRecs() { ds =>
         val (_, cometPlan) = checkSparkAnswerAndOperator(ds.map(_.a + 1).toDF())
         assertNoObjectOperators(cometPlan)
       }
@@ -86,8 +119,7 @@ class CometTypedDatasetSuite extends CometTestBase with AdaptiveSparkPlanHelper 
 
   test("ds.map produces a fully native plan - multiple output columns") {
     withFusion() {
-      withParquetTable((0 until 100).map(i => (i, i.toString)), "tbl") {
-        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+      withTypedRecs() { ds =>
         val (_, cometPlan) =
           checkSparkAnswerAndOperator(ds.map(r => TypedRec(r.a + 1, r.b + "!")).toDF())
         assertNoObjectOperators(cometPlan)
@@ -99,30 +131,35 @@ class CometTypedDatasetSuite extends CometTestBase with AdaptiveSparkPlanHelper 
     }
   }
 
-  test("output schema is unchanged by the rewrite") {
-    withParquetTable((0 until 20).map(i => (i, i.toString)), "tbl") {
-      // `withSQLConf` returns Unit on Spark 3.x, so capture rather than return from the block.
-      def schemaOf(fused: Boolean): String = {
-        var schema: String = null
+  test("executed-plan output attributes are unchanged by the rewrite") {
+    // `Dataset.schema` comes from the analyzed plan, which a physical rule cannot touch, so
+    // comparing it would be vacuous. The property that matters is that the rewritten projections
+    // reproduce `SerializeFromObjectExec.output` exactly -- names, types and nullability -- since
+    // parent operators reference those attributes.
+    withTypedRecs(20) { _ =>
+      def executedOutput(fused: Boolean): String = {
+        var out: String = null
         withSQLConf(CometConf.COMET_EXEC_TYPED_DATASET_MAP_ENABLED.key -> fused.toString) {
-          schema = spark
+          out = spark
             .sql("select _1 as a, _2 as b from tbl")
             .as[TypedRec]
             .map(r => TypedRec(r.a + 1, r.b))
             .toDF()
-            .schema
-            .treeString
+            .queryExecution
+            .executedPlan
+            .output
+            .map(a => s"${a.name}:${a.dataType.simpleString}:${a.nullable}")
+            .mkString(",")
         }
-        schema
+        out
       }
-      assert(schemaOf(fused = true) === schemaOf(fused = false))
+      assert(executedOutput(fused = true) === executedOutput(fused = false))
     }
   }
 
   test("closure runs exactly once per row with multiple output columns") {
     withFusion() {
-      withParquetTable((0 until 50).map(i => (i, i.toString)), "tbl") {
-        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+      withTypedRecs(50) { ds =>
         TypedMapCounter.reset()
         val fused = ds
           .map { r =>
@@ -136,6 +173,21 @@ class CometTypedDatasetSuite extends CometTestBase with AdaptiveSparkPlanHelper 
         assert(
           TypedMapCounter.calls.get() === 50,
           s"expected 50 closure calls for 50 rows, got ${TypedMapCounter.calls.get()}")
+      }
+    }
+  }
+
+  test("a 12-column record still fuses (maxFields counts each input ordinal once)") {
+    // Every struct field carries the whole deserializer, so counting BoundReference occurrences
+    // rather than distinct ordinals made this 12 + 12*12 = 156 fields against a default
+    // `spark.sql.codegen.maxFields` of 100, and the rule silently declined.
+    withFusion() {
+      val cols = (1 to 12).map(i => s"_1 + $i as c$i").mkString(", ")
+      withParquetTable((0 until 20).map(i => (i, i.toString)), "tbl") {
+        val ds = spark.sql(s"select $cols from tbl").as[TypedWide12]
+        val (_, cometPlan) =
+          checkSparkAnswerAndOperator(ds.map(r => r.copy(c1 = r.c1 + 1)).toDF())
+        assertNoObjectOperators(cometPlan)
       }
     }
   }
@@ -159,52 +211,39 @@ class CometTypedDatasetSuite extends CometTestBase with AdaptiveSparkPlanHelper 
           s"s$i",
           new java.math.BigDecimal(s"$i.25"),
           if (i % 3 == 0) null else Long.box(i * 10L)))
-      withTempPath { path =>
-        rows.toDF("i", "s", "d", "opt").write.parquet(path.toString)
-        withParquetTable(path.toString, "tbl") {
-          val ds = spark.table("tbl").as[TypedWide]
-          val (_, cometPlan) = checkSparkAnswerAndOperator(
-            ds.map(r => TypedWide(r.i + 1, r.s, r.d, r.opt.map(_ + 1))).toDF())
-          assertNoObjectOperators(cometPlan)
-        }
+      withParquetRoundTrip(rows.toDF("i", "s", "d", "opt")) {
+        val ds = spark.table("tbl").as[TypedWide]
+        val (_, cometPlan) = checkSparkAnswerAndOperator(
+          ds.map(r => TypedWide(r.i + 1, r.s, r.d, r.opt.map(_ + 1))).toDF())
+        assertNoObjectOperators(cometPlan)
       }
     }
   }
 
   test("nested struct and array fields round-trip") {
     withFusion() {
-      withTempPath { path =>
-        (1 to 30)
-          .map(i => (i, (i, s"n$i"), Seq(s"t$i", s"u$i")))
-          .toDF("id", "inner", "tags")
-          .selectExpr("id", "named_struct('a', inner._1, 'b', inner._2) as inner", "tags")
-          .write
-          .parquet(path.toString)
-        withParquetTable(path.toString, "tbl") {
-          val ds = spark.table("tbl").as[TypedNested]
-          val (_, cometPlan) = checkSparkAnswerAndOperator(
-            ds.map(r => TypedNested(r.id + 1, TypedRec(r.inner.a, r.inner.b), r.tags.reverse))
-              .toDF())
-          assertNoObjectOperators(cometPlan)
-        }
+      val nested = (1 to 30)
+        .map(i => (i, (i, s"n$i"), Seq(s"t$i", s"u$i")))
+        .toDF("id", "inner", "tags")
+        .selectExpr("id", "named_struct('a', inner._1, 'b', inner._2) as inner", "tags")
+      withParquetRoundTrip(nested) {
+        val ds = spark.table("tbl").as[TypedNested]
+        val (_, cometPlan) = checkSparkAnswerAndOperator(
+          ds.map(r => TypedNested(r.id + 1, TypedRec(r.inner.a, r.inner.b), r.tags.reverse))
+            .toDF())
+        assertNoObjectOperators(cometPlan)
       }
     }
   }
 
   test("null field values in the input and the output") {
     withFusion() {
-      withTempPath { path =>
-        (1 to 30)
-          .map(i => (i, if (i % 4 == 0) null else s"s$i"))
-          .toDF("a", "b")
-          .write
-          .parquet(path.toString)
-        withParquetTable(path.toString, "tbl") {
-          val ds = spark.table("tbl").as[TypedRec]
-          val (_, cometPlan) = checkSparkAnswerAndOperator(
-            ds.map(r => TypedRec(r.a, if (r.a % 5 == 0) null else r.b)).toDF())
-          assertNoObjectOperators(cometPlan)
-        }
+      val withNulls = (1 to 30).map(i => (i, if (i % 4 == 0) null else s"s$i")).toDF("a", "b")
+      withParquetRoundTrip(withNulls) {
+        val ds = spark.table("tbl").as[TypedRec]
+        val (_, cometPlan) = checkSparkAnswerAndOperator(
+          ds.map(r => TypedRec(r.a, if (r.a % 5 == 0) null else r.b)).toDF())
+        assertNoObjectOperators(cometPlan)
       }
     }
   }
@@ -213,8 +252,7 @@ class CometTypedDatasetSuite extends CometTestBase with AdaptiveSparkPlanHelper 
     // Returning null for a non-nullable top-level product is an error in Spark. The serializer's
     // `assertnotnull` has to survive the fuse, or Comet would silently emit a null row instead.
     withFusion() {
-      withParquetTable((0 until 20).map(i => (i, i.toString)), "tbl") {
-        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+      withTypedRecs(20) { ds =>
         val df = ds.map(r => if (r.a == 7) null else TypedRec(r.a, r.b)).toDF()
         assertNoObjectOperators(df.queryExecution.executedPlan)
         val err = intercept[Exception](df.collect())
@@ -261,8 +299,7 @@ class CometTypedDatasetSuite extends CometTestBase with AdaptiveSparkPlanHelper 
 
   test("Java MapFunction takes the same path as a Scala closure") {
     withFusion() {
-      withParquetTable((0 until 40).map(i => (i, i.toString)), "tbl") {
-        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+      withTypedRecs(40) { ds =>
         val fn = new MapFunction[TypedRec, TypedRec] {
           override def call(r: TypedRec): TypedRec = TypedRec(r.a + 100, r.b)
         }
@@ -275,8 +312,7 @@ class CometTypedDatasetSuite extends CometTestBase with AdaptiveSparkPlanHelper 
 
   test("chained maps fuse into one native pipeline") {
     withFusion() {
-      withParquetTable((0 until 40).map(i => (i, i.toString)), "tbl") {
-        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+      withTypedRecs(40) { ds =>
         val (_, cometPlan) = checkSparkAnswerAndOperator(
           ds.map(r => TypedRec(r.a + 1, r.b)).map(r => TypedRec(r.a * 2, r.b + "x")).toDF())
         assertNoObjectOperators(cometPlan)
@@ -285,8 +321,7 @@ class CometTypedDatasetSuite extends CometTestBase with AdaptiveSparkPlanHelper 
   }
 
   test("off by default") {
-    withParquetTable((0 until 20).map(i => (i, i.toString)), "tbl") {
-      val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+    withTypedRecs(20) { ds =>
       val df = ds.map(r => TypedRec(r.a + 1, r.b)).toDF()
       df.collect()
       assert(
@@ -299,13 +334,12 @@ class CometTypedDatasetSuite extends CometTestBase with AdaptiveSparkPlanHelper 
     withSQLConf(
       CometConf.COMET_EXEC_TYPED_DATASET_MAP_ENABLED.key -> "true",
       CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "false") {
-      withParquetTable((0 until 20).map(i => (i, i.toString)), "tbl") {
-        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
-        val df = ds.map(r => TypedRec(r.a + 1, r.b)).toDF()
-        checkSparkAnswer(df)
-        assert(
-          objectOperators(df.queryExecution.executedPlan).nonEmpty,
-          "without the dispatcher there is nothing to fuse into")
+      withTypedRecs(20) { ds =>
+        checkSparkAnswerAndFallbackReason(
+          ds.map(r => TypedRec(r.a + 1, r.b)).toDF(),
+          s"Cannot fuse typed Dataset map: " +
+            s"${CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key}=false, so there is no dispatcher " +
+            "to fuse into")
       }
     }
   }
@@ -314,21 +348,19 @@ class CometTypedDatasetSuite extends CometTestBase with AdaptiveSparkPlanHelper 
     // Without CSE the single kernel would evaluate the shared closure Invoke once per struct
     // field, so the rule must decline rather than change how many times user code runs.
     withFusion(SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key -> "false") {
-      withParquetTable((0 until 20).map(i => (i, i.toString)), "tbl") {
-        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
-        val df = ds.map(r => TypedRec(r.a + 1, r.b)).toDF()
-        checkSparkAnswer(df)
-        assert(
-          objectOperators(df.queryExecution.executedPlan).nonEmpty,
-          "multi-column fusion needs CSE to keep the closure to one call per row")
+      withTypedRecs(20) { ds =>
+        checkSparkAnswerAndFallbackReason(
+          ds.map(r => TypedRec(r.a + 1, r.b)).toDF(),
+          "Cannot fuse typed Dataset map: 2 output columns require subexpression elimination " +
+            "to keep the closure to one call per row, but " +
+            s"${SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key}=false")
       }
     }
   }
 
   test("mapPartitions is not fused") {
     withFusion() {
-      withParquetTable((0 until 20).map(i => (i, i.toString)), "tbl") {
-        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+      withTypedRecs(20) { ds =>
         val df = ds.mapPartitions(it => it.map(r => TypedRec(r.a + 1, r.b))).toDF()
         checkSparkAnswer(df)
         assert(

--- a/spark/src/test/scala/org/apache/comet/CometTypedDatasetSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometTypedDatasetSuite.scala
@@ -1,0 +1,342 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.comet
+
+import java.util.concurrent.atomic.AtomicLong
+
+import org.apache.spark.api.java.function.MapFunction
+import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.Encoders
+import org.apache.spark.sql.comet.CometProjectExec
+import org.apache.spark.sql.execution.{DeserializeToObjectExec, MapElementsExec, MapPartitionsExec, SerializeFromObjectExec, SparkPlan}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.internal.SQLConf
+
+/** Top-level so `NewInstance` needs no outer pointer, which is the ordinary user shape. */
+case class TypedRec(a: Int, b: String)
+
+case class TypedWide(i: Int, s: String, d: java.math.BigDecimal, opt: Option[Long])
+
+case class TypedNested(id: Int, inner: TypedRec, tags: Seq[String])
+
+case class TypedDec(id: Int, d: java.math.BigDecimal)
+
+/** JVM-static counter. Comet tests run in local mode, so driver and executor share this. */
+object TypedMapCounter {
+  val calls = new AtomicLong(0)
+
+  def reset(): Unit = calls.set(0)
+}
+
+/**
+ * Tests for [[org.apache.comet.rules.RewriteTypedDatasetMap]], which fuses the
+ * `SerializeFromObject` / `MapElements` / `DeserializeToObject` sandwich a typed `Dataset.map`
+ * produces into a Comet projection. See https://github.com/apache/datafusion-comet/issues/5710.
+ */
+class CometTypedDatasetSuite extends CometTestBase with AdaptiveSparkPlanHelper {
+
+  import testImplicits._
+
+  private def withFusion(pairs: (String, String)*)(f: => Unit): Unit =
+    withSQLConf(
+      (Seq(
+        CometConf.COMET_EXEC_TYPED_DATASET_MAP_ENABLED.key -> "true",
+        CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "true") ++ pairs): _*)(f)
+
+  private def objectOperators(plan: SparkPlan): Seq[SparkPlan] =
+    collectWithSubqueries(plan) {
+      case p: SerializeFromObjectExec => p
+      case p: DeserializeToObjectExec => p
+      case p: MapElementsExec => p
+      case p: MapPartitionsExec => p
+    }
+
+  private def assertNoObjectOperators(plan: SparkPlan): Unit =
+    assert(
+      objectOperators(plan).isEmpty,
+      s"expected the typed sandwich to be fused away, but plan still has " +
+        s"${objectOperators(plan).map(_.nodeName).mkString(", ")}:\n$plan")
+
+  test("ds.map produces a fully native plan - single output column") {
+    withFusion() {
+      withParquetTable((0 until 100).map(i => (i, i.toString)), "tbl") {
+        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+        val (_, cometPlan) = checkSparkAnswerAndOperator(ds.map(_.a + 1).toDF())
+        assertNoObjectOperators(cometPlan)
+      }
+    }
+  }
+
+  test("ds.map produces a fully native plan - multiple output columns") {
+    withFusion() {
+      withParquetTable((0 until 100).map(i => (i, i.toString)), "tbl") {
+        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+        val (_, cometPlan) =
+          checkSparkAnswerAndOperator(ds.map(r => TypedRec(r.a + 1, r.b + "!")).toDF())
+        assertNoObjectOperators(cometPlan)
+        // Inner projection builds the struct, outer one unpacks it.
+        assert(
+          collectWithSubqueries(cometPlan) { case p: CometProjectExec => p }.size >= 2,
+          s"expected stacked projections for the struct fuse:\n$cometPlan")
+      }
+    }
+  }
+
+  test("output schema is unchanged by the rewrite") {
+    withParquetTable((0 until 20).map(i => (i, i.toString)), "tbl") {
+      // `withSQLConf` returns Unit on Spark 3.x, so capture rather than return from the block.
+      def schemaOf(fused: Boolean): String = {
+        var schema: String = null
+        withSQLConf(CometConf.COMET_EXEC_TYPED_DATASET_MAP_ENABLED.key -> fused.toString) {
+          schema = spark
+            .sql("select _1 as a, _2 as b from tbl")
+            .as[TypedRec]
+            .map(r => TypedRec(r.a + 1, r.b))
+            .toDF()
+            .schema
+            .treeString
+        }
+        schema
+      }
+      assert(schemaOf(fused = true) === schemaOf(fused = false))
+    }
+  }
+
+  test("closure runs exactly once per row with multiple output columns") {
+    withFusion() {
+      withParquetTable((0 until 50).map(i => (i, i.toString)), "tbl") {
+        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+        TypedMapCounter.reset()
+        val fused = ds
+          .map { r =>
+            TypedMapCounter.calls.incrementAndGet()
+            TypedRec(r.a * 2, r.b)
+          }
+          .toDF()
+        assertNoObjectOperators(fused.queryExecution.executedPlan)
+        assert(fused.collect().length === 50)
+        // The whole point of the struct wrapper: N output columns must not mean N closure calls.
+        assert(
+          TypedMapCounter.calls.get() === 50,
+          s"expected 50 closure calls for 50 rows, got ${TypedMapCounter.calls.get()}")
+      }
+    }
+  }
+
+  test("fusion unblocks the aggregate and shuffle above it") {
+    withFusion() {
+      withParquetTable((0 until 100).map(i => (i, (i % 7).toString)), "tbl") {
+        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+        val (_, cometPlan) =
+          checkSparkAnswerAndOperator(ds.map(r => TypedRec(r.a + 1, r.b)).groupBy("b").count())
+        assertNoObjectOperators(cometPlan)
+      }
+    }
+  }
+
+  test("wide record with decimal, string and Option fields") {
+    withFusion() {
+      val rows = (1 to 40).map(i =>
+        (
+          i,
+          s"s$i",
+          new java.math.BigDecimal(s"$i.25"),
+          if (i % 3 == 0) null else Long.box(i * 10L)))
+      withTempPath { path =>
+        rows.toDF("i", "s", "d", "opt").write.parquet(path.toString)
+        withParquetTable(path.toString, "tbl") {
+          val ds = spark.table("tbl").as[TypedWide]
+          val (_, cometPlan) = checkSparkAnswerAndOperator(
+            ds.map(r => TypedWide(r.i + 1, r.s, r.d, r.opt.map(_ + 1))).toDF())
+          assertNoObjectOperators(cometPlan)
+        }
+      }
+    }
+  }
+
+  test("nested struct and array fields round-trip") {
+    withFusion() {
+      withTempPath { path =>
+        (1 to 30)
+          .map(i => (i, (i, s"n$i"), Seq(s"t$i", s"u$i")))
+          .toDF("id", "inner", "tags")
+          .selectExpr("id", "named_struct('a', inner._1, 'b', inner._2) as inner", "tags")
+          .write
+          .parquet(path.toString)
+        withParquetTable(path.toString, "tbl") {
+          val ds = spark.table("tbl").as[TypedNested]
+          val (_, cometPlan) = checkSparkAnswerAndOperator(
+            ds.map(r => TypedNested(r.id + 1, TypedRec(r.inner.a, r.inner.b), r.tags.reverse))
+              .toDF())
+          assertNoObjectOperators(cometPlan)
+        }
+      }
+    }
+  }
+
+  test("null field values in the input and the output") {
+    withFusion() {
+      withTempPath { path =>
+        (1 to 30)
+          .map(i => (i, if (i % 4 == 0) null else s"s$i"))
+          .toDF("a", "b")
+          .write
+          .parquet(path.toString)
+        withParquetTable(path.toString, "tbl") {
+          val ds = spark.table("tbl").as[TypedRec]
+          val (_, cometPlan) = checkSparkAnswerAndOperator(
+            ds.map(r => TypedRec(r.a, if (r.a % 5 == 0) null else r.b)).toDF())
+          assertNoObjectOperators(cometPlan)
+        }
+      }
+    }
+  }
+
+  test("AssertNotNull inside the fused kernel still raises like Spark") {
+    // Returning null for a non-nullable top-level product is an error in Spark. The serializer's
+    // `assertnotnull` has to survive the fuse, or Comet would silently emit a null row instead.
+    withFusion() {
+      withParquetTable((0 until 20).map(i => (i, i.toString)), "tbl") {
+        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+        val df = ds.map(r => if (r.a == 7) null else TypedRec(r.a, r.b)).toDF()
+        assertNoObjectOperators(df.queryExecution.executedPlan)
+        val err = intercept[Exception](df.collect())
+        // Spark 3.x raises NullPointerException("Null value appeared ..."), Spark 4.x raises
+        // SparkRuntimeException("[NOT_NULL_ASSERT_VIOLATION] NULL value appeared ..."). Match the
+        // part they share.
+        assert(
+          Option(err.getMessage).exists(
+            _.toLowerCase.contains("value appeared in non-nullable field")),
+          s"expected a not-null assertion failure, got: ${err.getMessage}")
+      }
+    }
+  }
+
+  test("decimal overflow in the serializer is caught before the Arrow write") {
+    // The concern on #5710 was that an encoder-declared decimal(38,18) could receive a wider
+    // value that Spark nulls at row materialization but the kernel's Arrow DecimalVector write
+    // would not -- the shape of the Iceberg truncate(w, decimal) bug from #5575. It does not
+    // apply: the encoder's serializer already wraps the value in `CheckOverflow`, so the fused
+    // tree raises (ANSI) or nulls (non-ANSI) exactly where Spark does, ahead of the write.
+    withFusion() {
+      withParquetTable((1 to 5).map(i => (i, new java.math.BigDecimal(s"$i.5"))), "tbl") {
+        val ds = spark.sql("select _1 as id, _2 as d from tbl").as[TypedDec]
+        def overflowed =
+          ds.map(r => TypedDec(r.id, r.d.multiply(new java.math.BigDecimal("1" + "0" * 30))))
+            .toDF()
+
+        assertNoObjectOperators(overflowed.queryExecution.executedPlan)
+
+        withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+          val err = intercept[Exception](overflowed.collect())
+          assert(
+            err.getMessage.contains("cannot be represented as Decimal(38, 18)"),
+            s"expected an ANSI overflow error, got: ${err.getMessage}")
+        }
+        withSQLConf(SQLConf.ANSI_ENABLED.key -> "false") {
+          // Non-ANSI nulls the overflowing value; Comet must produce the same nulls as Spark.
+          val (_, cometPlan) = checkSparkAnswerAndOperator(overflowed)
+          assertNoObjectOperators(cometPlan)
+        }
+      }
+    }
+  }
+
+  test("Java MapFunction takes the same path as a Scala closure") {
+    withFusion() {
+      withParquetTable((0 until 40).map(i => (i, i.toString)), "tbl") {
+        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+        val fn = new MapFunction[TypedRec, TypedRec] {
+          override def call(r: TypedRec): TypedRec = TypedRec(r.a + 100, r.b)
+        }
+        val (_, cometPlan) =
+          checkSparkAnswerAndOperator(ds.map(fn, Encoders.product[TypedRec]).toDF())
+        assertNoObjectOperators(cometPlan)
+      }
+    }
+  }
+
+  test("chained maps fuse into one native pipeline") {
+    withFusion() {
+      withParquetTable((0 until 40).map(i => (i, i.toString)), "tbl") {
+        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+        val (_, cometPlan) = checkSparkAnswerAndOperator(
+          ds.map(r => TypedRec(r.a + 1, r.b)).map(r => TypedRec(r.a * 2, r.b + "x")).toDF())
+        assertNoObjectOperators(cometPlan)
+      }
+    }
+  }
+
+  test("off by default") {
+    withParquetTable((0 until 20).map(i => (i, i.toString)), "tbl") {
+      val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+      val df = ds.map(r => TypedRec(r.a + 1, r.b)).toDF()
+      df.collect()
+      assert(
+        objectOperators(df.queryExecution.executedPlan).nonEmpty,
+        "rewrite must not apply unless it is explicitly enabled")
+    }
+  }
+
+  test("declines when the codegen dispatcher is disabled") {
+    withSQLConf(
+      CometConf.COMET_EXEC_TYPED_DATASET_MAP_ENABLED.key -> "true",
+      CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "false") {
+      withParquetTable((0 until 20).map(i => (i, i.toString)), "tbl") {
+        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+        val df = ds.map(r => TypedRec(r.a + 1, r.b)).toDF()
+        checkSparkAnswer(df)
+        assert(
+          objectOperators(df.queryExecution.executedPlan).nonEmpty,
+          "without the dispatcher there is nothing to fuse into")
+      }
+    }
+  }
+
+  test("declines multi-column fusion when subexpression elimination is off") {
+    // Without CSE the single kernel would evaluate the shared closure Invoke once per struct
+    // field, so the rule must decline rather than change how many times user code runs.
+    withFusion(SQLConf.SUBEXPRESSION_ELIMINATION_ENABLED.key -> "false") {
+      withParquetTable((0 until 20).map(i => (i, i.toString)), "tbl") {
+        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+        val df = ds.map(r => TypedRec(r.a + 1, r.b)).toDF()
+        checkSparkAnswer(df)
+        assert(
+          objectOperators(df.queryExecution.executedPlan).nonEmpty,
+          "multi-column fusion needs CSE to keep the closure to one call per row")
+      }
+    }
+  }
+
+  test("mapPartitions is not fused") {
+    withFusion() {
+      withParquetTable((0 until 20).map(i => (i, i.toString)), "tbl") {
+        val ds = spark.sql("select _1 as a, _2 as b from tbl").as[TypedRec]
+        val df = ds.mapPartitions(it => it.map(r => TypedRec(r.a + 1, r.b))).toDF()
+        checkSparkAnswer(df)
+        assert(
+          collectWithSubqueries(df.queryExecution.executedPlan) { case p: MapPartitionsExec =>
+            p
+          }.nonEmpty,
+          "mapPartitions is iterator-shaped and must be left alone")
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5710. Part of #5572.

## Rationale for this change

`ds.map(f)` drops a three-operator island into the middle of an otherwise native plan, and every operator in it falls back:

```
*(1) SerializeFromObject [invoke(knownnotnull(assertnotnull(input[0, TypedRec, true])).a()) AS a#21, ...]
+- *(1) MapElements <lambda>, obj#18: TypedRec
   +- *(1) DeserializeToObject newInstance(class TypedRec), obj#15: TypedRec
      +- *(1) CometColumnarToRow
         +- CometProject [a#4, b#5], [_1#2 AS a#4, _2#3 AS b#5]
            +- CometNativeScan parquet [_1#2,_2#3]
```

It cascades past the island. `ds.map(f).groupBy("b").count()` loses the aggregate and the exchange too — 2 of 8 eligible operators accelerated.

Neither object operator can be handled on its own. `DeserializeToObjectExec` outputs a single `ObjectType` attribute and `SerializeFromObjectExec` consumes one; `ObjectType` is outside `QueryPlanSerde.supportedDataType` and outside `CometBatchKernelCodegen.isSupportedDataType`, because a JVM object reference cannot live in an Arrow vector. `CodegenDispatchFallback`'s self-type is `CometExpressionSerde[_]`, so there is no operator-level dispatch hook to mix in either.

Fusing the sandwich works, though, for two reasons. `canHandle` only type-checks the **root** `dataType` and every **`BoundReference`** — intermediate nodes are never inspected — so the object may exist strictly _inside_ the tree while the outer boundary stays ordinary SQL data. And Spark already builds the fused expression: `MapElementsExec.doConsume` constructs `Invoke(Literal.create(func, ObjectType(funcClass)), funcName, outputObjectType, child.output, propagateNull = false)`, so the closure has a first-class Catalyst representation. The rule just does statically what whole-stage codegen does by chaining the three `doConsume`s.

## What changes are included in this PR?

`RewriteTypedDatasetMap` (new), run as a pre-pass in `CometExecRule._apply` before `transform`, since the bottom-up conversion would otherwise reach `DeserializeToObjectExec` and fall the island back before anything could fuse it. It rewrites the sandwich into a projection over the deserializer's child. The projection then converts through the ordinary `CometProjectExec` path and the fused tree routes through the JVM codegen dispatcher — **no proto change and no native change**.

**Multiple output columns.** `emitJvmCodegenDispatch` emits one `JvmScalarUdf` per expression and gets one Arrow vector back, but `SerializeFromObject` has N serializers that all share one `Invoke`. Converting them separately would produce N kernels and call the user closure N times per row where Spark calls it once — a real behavioural difference for a side-effecting closure, not just a slowdown. So for N > 1 the rule emits two stacked projections: an inner one producing a single `CreateNamedStruct`, and an outer one extracting the fields with `GetStructField`. Both node types already have serdes, and `CometBatchKernelCodegenOutput` already maps `StructType` to `StructVector`.

**`CometScalaUDF.FORCE_DISPATCH`.** The struct needs to compile into _one_ kernel, but `CreateNamedStruct` has a perfectly good native serde that would convert each field independently and put us back at N kernels. A `TreeNodeTag` checked at the top of `exprToProtoInternal` forces whole-subtree dispatch. I used a tag rather than a Comet-specific `Expression` subclass deliberately: the rewritten plan stays built entirely from stock Spark expressions, so it still executes correctly if the enclosing operator falls back to Spark for an unrelated reason.

**Scope.** Only `MapElementsExec`, including a chain of them (`ds.map(f).map(g)` leaves two adjacent `MapElements` under one Serialize/Deserialize pair). `MapPartitionsExec`, `FlatMapGroupsExec` and `CoGroupExec` consume iterators or groups, so no per-row expression exists. `AppendColumnsExec` is per-row but widens the schema; left for a follow-up. Typed filters never produce this sandwich — Catalyst lowers them to a `FilterExec` over an `Invoke`, which #5692 already dispatches.

**Declines rather than guesses** when the serializer has a non-`Alias` element, reads an unexpected bound reference, produces a dangling attribute reference, `canHandle` refuses the tree, the dispatcher is disabled, or (for N > 1) subexpression elimination is off. Each records a fallback reason so `EXPLAIN` says why instead of showing the bare "not supported".

**Off by default** (`spark.comet.exec.typedDatasetMap.enabled`). The rewrite pays off when the typed operation sits between native operators; when it is at the top of the plan (`ds.map(f).collect()`) the gain is roughly nil and could be slightly negative, since the kernel writes into Arrow only for something to read rows straight back out. Flipping the default needs benchmarks, and it is worth checking whether `RevertNativeForTransitionHeavyStages` already covers that shape.

## How are these changes tested?

New `CometTypedDatasetSuite`, 16 tests, registered in both `pr_build_linux.yml` and `pr_build_macos.yml`. Green on the default profile and on `-Pspark-3.5`; main and test code compile on `spark-3.4`, `spark-3.5`, `spark-4.0` and the default. No regressions in `CometCodegenSuite` (86), `CometCodegenSourceSuite` (60), `CometExpressionSuite` (141), `CometExecRuleSuite` (29) or `CometCoverageStatsSuite`.

Beyond `checkSparkAnswerAndOperator` on single-column, multi-column, wide (decimal / string / `Option`), nested-struct-and-array, chained-map and Java `MapFunction` shapes, the tests that carry the most weight:

- **`closure runs exactly once per row with multiple output columns`** — a JVM-static counter asserts 50 calls for 50 rows. This is the test that would catch the N-kernel regression the struct wrapper exists to prevent.
- **`fusion unblocks the aggregate and shuffle above it`** — asserts the `groupBy().count()` case is fully native, i.e. the cascade is actually fixed.
- **`output schema is unchanged by the rewrite`** — compares the schema tree with the flag on and off, guarding the nullability reasoning behind `GetStructField` over a non-nullable `CreateNamedStruct`.
- **`AssertNotNull inside the fused kernel still raises like Spark`** — returning null for a non-nullable product is an error in Spark; the serializer's `assertnotnull` has to survive the fuse or Comet would silently emit a null row. The stack trace confirms it fires from `SpecificCometBatchKernel.subExpr_0$`, which incidentally also confirms CSE hoisted the shared `Invoke`.
- **`decimal overflow in the serializer is caught before the Arrow write`** — I raised this on #5710 as the #5575-shaped risk: an encoder-declared `decimal(38,18)` receiving a wider value that Spark nulls at row materialization but the kernel's `DecimalVector` write might not. **It does not apply.** The encoder's serializer already wraps the value in `CheckOverflow`, so the fused tree raises under ANSI and nulls under non-ANSI exactly where Spark does, ahead of the write. The test pins both directions. I verified the same is true on the pre-existing plain-`ScalaUDF` decimal path.
- Negative tests for each decline path: off by default, dispatcher disabled, CSE disabled, and `mapPartitions` left alone.

Not covered, and worth a reviewer's attention: no benchmark numbers yet, which is why the flag is off. Nested (non-top-level) case classes carry a `NewInstance` `outerPointer` closure over the enclosing instance that closure serialization would drag along — `ScalaUDF` has the same exposure, but I have not written a test for it.
