### PR TITLE
fix: make columnar-to-row benchmarks exercise Comet

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometColumnarToRowBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometColumnarToRowBenchmark.scala
@@ -19,10 +19,15 @@
 
 package org.apache.spark.sql.benchmark
 
+import scala.collection.mutable.ArrayBuffer
+
 import org.apache.spark.SparkConf
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.comet.{CometColumnarToRowExec, CometNativeColumnarToRowExec}
+import org.apache.spark.sql.execution.{ColumnarToRowExec, QueryExecution, SparkPlan}
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.util.QueryExecutionListener
 
 import org.apache.comet.{CometConf, CometSparkSessionExtensions}
 
@@ -46,6 +51,9 @@ object CometColumnarToRowBenchmark extends CometBenchmarkBase {
       .set("spark.master", "local[1]")
       .setIfMissing("spark.driver.memory", "3g")
       .setIfMissing("spark.executor.memory", "3g")
+      .set(
+        "spark.shuffle.manager",
+        "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager")
       .set("spark.memory.offHeap.enabled", "true")
       .set("spark.memory.offHeap.size", "2g")
 
@@ -61,6 +69,8 @@ object CometColumnarToRowBenchmark extends CometBenchmarkBase {
     sparkSession.conf.set(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key, "true")
     sparkSession.conf.set(CometConf.COMET_ENABLED.key, "false")
     sparkSession.conf.set(CometConf.COMET_EXEC_ENABLED.key, "false")
+    // These fixtures are written by Spark and contain no unsigned small integers.
+    sparkSession.conf.set(CometConf.COMET_PARQUET_UNSIGNED_SMALL_INT_CHECK.key, "false")
     // Disable dictionary encoding to ensure consistent data representation
     sparkSession.conf.set("parquet.enable.dictionary", "false")
 
@@ -72,29 +82,67 @@ object CometColumnarToRowBenchmark extends CometBenchmarkBase {
    * code duplication across benchmark methods.
    */
   private def addC2RBenchmarkCases(benchmark: Benchmark, query: String): Unit = {
-    benchmark.addCase("Spark (ColumnarToRowExec)") { _ =>
-      withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
-        spark.sql(query).noop()
+    def addCase(name: String, expected: Class[_ <: SparkPlan], conf: (String, String)*): Unit = {
+      withSQLConf(conf: _*) {
+        // Validate the actual noop write, whose plan can differ from the SELECT's plan.
+        // Keep execution and listener synchronization outside the timed benchmark cases.
+        val plans = ArrayBuffer.empty[SparkPlan]
+        val listener = new QueryExecutionListener {
+          override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
+            plans += qe.executedPlan
+          }
+
+          override def onFailure(
+              funcName: String,
+              qe: QueryExecution,
+              exception: Exception): Unit = ()
+        }
+        spark.sparkContext.listenerBus.waitUntilEmpty()
+        spark.listenerManager.register(listener)
+        try {
+          spark.sql(query).noop()
+          spark.sparkContext.listenerBus.waitUntilEmpty()
+        } finally {
+          spark.listenerManager.unregister(listener)
+        }
+        val conversions = plans.flatMap { plan =>
+          collect(plan) {
+            case c: ColumnarToRowExec => c
+            case c: CometColumnarToRowExec => c
+            case c: CometNativeColumnarToRowExec => c
+          }
+        }
+        require(
+          conversions.nonEmpty && conversions.forall(expected.isInstance),
+          s"$name did not execute the expected columnar-to-row conversion.\n" +
+            plans.mkString("\n"))
+        benchmark.out.println(s"Verified $name")
+      }
+      benchmark.addCase(name) { _ =>
+        withSQLConf(conf: _*) {
+          spark.sql(query).noop()
+        }
       }
     }
 
-    benchmark.addCase("Comet JVM (CometColumnarToRowExec)") { _ =>
-      withSQLConf(
-        CometConf.COMET_ENABLED.key -> "true",
-        CometConf.COMET_EXEC_ENABLED.key -> "true",
-        CometConf.COMET_NATIVE_COLUMNAR_TO_ROW_ENABLED.key -> "false") {
-        spark.sql(query).noop()
-      }
-    }
+    addCase(
+      "Spark (ColumnarToRowExec)",
+      classOf[ColumnarToRowExec],
+      CometConf.COMET_ENABLED.key -> "false")
 
-    benchmark.addCase("Comet Native (CometNativeColumnarToRowExec)") { _ =>
-      withSQLConf(
-        CometConf.COMET_ENABLED.key -> "true",
-        CometConf.COMET_EXEC_ENABLED.key -> "true",
-        CometConf.COMET_NATIVE_COLUMNAR_TO_ROW_ENABLED.key -> "true") {
-        spark.sql(query).noop()
-      }
-    }
+    addCase(
+      "Comet JVM (CometColumnarToRowExec)",
+      classOf[CometColumnarToRowExec],
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ENABLED.key -> "true",
+      CometConf.COMET_NATIVE_COLUMNAR_TO_ROW_ENABLED.key -> "false")
+
+    addCase(
+      "Comet Native (CometNativeColumnarToRowExec)",
+      classOf[CometNativeColumnarToRowExec],
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ENABLED.key -> "true",
+      CometConf.COMET_NATIVE_COLUMNAR_TO_ROW_ENABLED.key -> "true")
   }
 
   /**


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5624.

## Rationale for this change

`CometColumnarToRowBenchmark` overrides `getSparkSession` without setting `spark.shuffle.manager`. With Comet shuffle enabled by default, this disables the extension, so all three arms measure Spark's `ColumnarToRowExec` despite their labels. The fixed-width and primitive fixtures also contain small integers that trigger the scan safety check.

## What changes are included in this PR?

All changes are in `CometColumnarToRowBenchmark.scala`.

- Set `CometShuffleManager` before creating the Spark context.
- Disable the unsigned-small-integer safety check for these Spark-written fixtures, which contain no unsigned small integers.
- Run each arm once before timing and inspect the actual `.noop()` write plan through a query listener. Require the expected Spark, Comet JVM, or Comet native conversion, and write successful verification to the benchmark output.

The check fails before timing if an arm falls back or loses its conversion. Listener synchronization and plan checks are outside the timed cases.

## How are these changes tested?

Benchmarks are compiled and linted in CI; execution was checked locally with a temporary driver calling all 10 existing fixture methods with 16,384 rows each on Spark 4.1.3 / Scala 2.13.17 / Java 17. All 30 execution-path checks and benchmark cases completed.

Both fallback paths were checked separately: removing the shuffle-manager setting from a temporary compiled copy, and re-enabling the small-integer safety check for the fixed-width fixture. Each was rejected at the Comet JVM preflight with Spark's `ColumnarToRowExec` in the captured write plan.

[The fork CI run](https://github.com/rich7420/datafusion-comet/actions/runs/33977397812) passed preflight, Rust formatting/clippy, benchmark compilation, and Spark 4.0 Scala compilation/lint. Local Spotless, RAT, and whitespace checks also passed.