### PR TITLE
feat: route next_day and levenshtein collated input through the codegen dispatcher

### DIFF
--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -287,7 +287,7 @@ The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `deci
 | `month` | ✅ | Native |  |
 | `monthname` | ✅ | — | Abbreviated month name (Spark 4.0+) |
 | `months_between` | ✅ | Codegen dispatch |  |
-| `next_day` | ✅ | Native |  |
+| `next_day` | ✅ | Hybrid | Non-UTF8_BINARY collated `dayOfWeek` routes through the JVM codegen dispatcher; other input runs natively |
 | `now` | ✅ | — | Constant-folded to a literal (alias of `current_timestamp`) |
 | `quarter` | ✅ | Native |  |
 | `second` | ✅ | Native |  |
@@ -576,7 +576,7 @@ The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `deci
 | `left` | ✅ | Native |  |
 | `len` | ✅ | Native |  |
 | `length` | ✅ | Native |  |
-| `levenshtein` | ✅ | Native |  |
+| `levenshtein` | ✅ | Hybrid | Non-UTF8_BINARY collated input routes through the JVM codegen dispatcher; other input runs natively |
 | `locate` | ✅ | Codegen dispatch |  |
 | `lower` | ✅ | Hybrid |  |
 | `lpad` | ✅ | — |  |

--- a/docs/source/user-guide/latest/understanding-comet-plans.md
+++ b/docs/source/user-guide/latest/understanding-comet-plans.md
@@ -122,7 +122,7 @@ natively in DataFusion" from "runs Spark's generated code inside a Comet
 kernel". The annotation only appears for expressions Comet actually routed
 through the dispatcher on this plan — either because no native DataFusion
 implementation exists (`CometCodegenDispatch` serdes such as `hypot`,
-`levenshtein`, `pmod`), or because a native path exists but declined this
+`pmod`, `months_between`), or because a native path exists but declined this
 specific input (`CodegenDispatchFallback` mixins). It is not a general "this
 expression ran here" marker.
 
@@ -132,7 +132,7 @@ Example:
 spark.conf.set("spark.comet.exec.scalaUDF.codegen.enabled", "true")
 spark.conf.set("spark.comet.explain.codegen.enabled", "true")
 
-val df = spark.sql("SELECT hypot(a, b), levenshtein(s1, s2) FROM t")
+val df = spark.sql("SELECT hypot(a, b), pmod(a, b) FROM t")
 println(new org.apache.comet.ExtendedExplainInfo()
   .generateExtendedInfo(df.queryExecution.executedPlan))
 ```
@@ -141,14 +141,14 @@ Output:
 
 ```
 CometColumnarToRow
-+- CometProject [COMET-INFO: JVM codegen dispatcher: hypot, levenshtein]
++- CometProject [COMET-INFO: JVM codegen dispatcher: hypot, pmod]
    +- CometNativeScan parquet spark_catalog.default.t
 
 Comet accelerated 2 out of 2 eligible operators (100%). Final plan contains 1 transitions between Spark and Comet. Accelerated expressions: 0 native, 2 codegen dispatch.
 ```
 
 Note that the operator is still `CometProject` (Comet-accelerated); only the
-per-expression evaluation for `hypot` and `levenshtein` takes the JVM codegen
+per-expression evaluation for `hypot` and `pmod` takes the JVM codegen
 path.
 
 ### `spark.comet.explain.format`

--- a/spark/src/main/scala/org/apache/comet/serde/datetime.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/datetime.scala
@@ -433,13 +433,16 @@ object CometConvertTimezone
   }
 }
 
-object CometNextDay extends CometExpressionSerde[NextDay] {
+/**
+ * The native `next_day` kernel reads its `dayOfWeek` argument as raw bytes, so a non-UTF8_BINARY
+ * collation is reported as `Incompatible` and `CodegenDispatchFallback` routes it through the JVM
+ * codegen dispatcher instead of failing the projection back to Spark. Dispatching is not only the
+ * compatible answer here, it is also the faster one: over 1M rows a collated `next_day` measured
+ * 70ms dispatched against 89ms for Spark. See
+ * https://github.com/apache/datafusion-comet/issues/5591.
+ */
+object CometNextDay extends CometExpressionSerde[NextDay] with CodegenDispatchFallback {
 
-  /**
-   * `failOnError` mirrors `spark.sql.ansi.enabled`: under ANSI, Spark throws on a malformed
-   * `dayOfWeek` rather than returning NULL. The resolved flag is passed to native via the
-   * `ScalarFunc.fail_on_error` field.
-   */
   private val collationReason = DatetimeCollation.reason("next_day")
 
   override def getIncompatibleReasons(): Seq[String] =
@@ -452,6 +455,12 @@ object CometNextDay extends CometExpressionSerde[NextDay] {
       Compatible()
     }
   }
+
+  /**
+   * `failOnError` mirrors `spark.sql.ansi.enabled`: under ANSI, Spark throws on a malformed
+   * `dayOfWeek` rather than returning NULL. The resolved flag is passed to native via the
+   * `ScalarFunc.fail_on_error` field.
+   */
   override def convert(expr: NextDay, inputs: Seq[Attribute], binding: Boolean): Option[Expr] = {
     val childExpr = expr.children.map(exprToProtoInternal(_, inputs, binding))
     val optExpr = scalarFunctionExprToProtoWithReturnType(

--- a/spark/src/main/scala/org/apache/comet/serde/strings.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/strings.scala
@@ -120,14 +120,24 @@ object CometStringTranslate extends CometScalarFunction[StringTranslate]("transl
     Some(incompatReason))
 }
 
-object CometLevenshtein extends CometExpressionSerde[Levenshtein] {
+/**
+ * The native `levenshtein` kernel compares raw bytes, so a non-UTF8_BINARY collation is reported
+ * as `Unsupported` and `CodegenDispatchFallback` routes it through the JVM codegen dispatcher
+ * instead of failing the projection back to Spark. Dispatching is not only the compatible answer
+ * here, it is also the faster one: over 1M rows a collated `levenshtein` measured 341ms
+ * dispatched against 378ms for Spark. See https://github.com/apache/datafusion-comet/issues/5591.
+ */
+object CometLevenshtein extends CometExpressionSerde[Levenshtein] with CodegenDispatchFallback {
 
-  override def getUnsupportedReasons(): Seq[String] = Seq(
-    "Non-default collation (non-UTF8_BINARY) is not supported")
+  private val collationReason =
+    "Non-default (non-UTF8_BINARY) collated input. The native kernel compares raw bytes, so " +
+      "collation-aware comparison has no native path."
+
+  override def getUnsupportedReasons(): Seq[String] = Seq(collationReason)
 
   override def getSupportLevel(expr: Levenshtein): SupportLevel =
     if (expr.children.exists(child => QueryPlanSerde.isStringCollationType(child.dataType))) {
-      Unsupported(Some("Levenshtein with non-default collation is not supported"))
+      Unsupported(Some(collationReason))
     } else {
       Compatible()
     }

--- a/spark/src/test/resources/sql-tests/expressions/datetime/next_day_ansi_collation.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/next_day_ansi_collation.sql
@@ -1,0 +1,41 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- MinSparkVersion: 4.0
+-- Config: spark.sql.ansi.enabled=true
+
+-- ANSI mode with a collated dayOfWeek. A collated next_day runs through the JVM codegen
+-- dispatcher (see next_day_collation.sql for why), which evaluates Spark's own generated code, so
+-- the ANSI error must surface from the Comet pipeline rather than from a Spark fallback.
+
+-- Sentinel: a recognised collated day name must still execute inside the Comet pipeline under
+-- ANSI, through the dispatcher rather than natively. Without it the expect_error queries below
+-- would pass vacuously if next_day fell back to Spark, which raises the same error.
+query
+SELECT next_day(date('2024-01-01'), 'Monday' COLLATE UTF8_LCASE)
+
+-- Case-insensitive collation does not make an unrecognised name recognised.
+query expect_error(Illegal input for day of week)
+SELECT next_day(date('2024-01-01'), 'NOT_A_DAY' COLLATE UTF8_LCASE)
+
+query expect_error(Illegal input for day of week)
+SELECT next_day(date('2024-01-01'), 'NOT_A_DAY' COLLATE UNICODE_CI)
+
+-- An RTRIM collation does not trim the day name before matching, so a padded value throws under
+-- ANSI rather than resolving to MONDAY.
+query expect_error(Illegal input for day of week)
+SELECT next_day(date('2024-01-01'), 'MON ' COLLATE UTF8_LCASE_RTRIM)

--- a/spark/src/test/resources/sql-tests/expressions/datetime/next_day_collation.sql
+++ b/spark/src/test/resources/sql-tests/expressions/datetime/next_day_collation.sql
@@ -1,0 +1,91 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- MinSparkVersion: 4.0
+
+-- Spark 4.0+ widens NextDay's dayOfWeek argument to collated strings, but NextDay resolves it
+-- through DateTimeUtils.getDayOfWeekFromString, which upper-cases with Locale.ROOT and matches a
+-- fixed literal set. That match takes no collation and the result is a DateType, so collation
+-- cannot change the answer. The native kernel reads the argument as raw bytes though, so a
+-- collated dayOfWeek is reported as Incompatible and routed through the JVM codegen dispatcher,
+-- which runs Spark's own doGenCode inside the Comet pipeline. That keeps the projection in Comet
+-- and is measurably faster than the native path: 70ms against 89ms for Spark over 1M rows. See
+-- https://github.com/apache/datafusion-comet/issues/5591.
+
+-- This harness disables ConstantFolding, so `x COLLATE ...` survives as a `Collate` node rather
+-- than folding into a collated literal. Comet has no serde for `Collate`, but that does not matter
+-- here: the dispatcher compiles the whole bound subtree with Spark's own doGenCode, `Collate`
+-- included. That is one reason dispatching covers every spelling of a collated argument.
+
+statement
+CREATE TABLE test_next_day_collated(d date, dow string) USING parquet
+
+statement
+INSERT INTO test_next_day_collated VALUES
+ (date('2023-01-01'), 'Monday'),
+ (date('2024-02-29'), 'MON'),
+ (date('1969-12-31'), 'mo'),
+ (date('2024-06-15'), 'notaday'),
+ (date('2024-01-01'), NULL),
+ (NULL, 'Monday')
+
+-- collated column argument: proves a collated column reaches the Comet operator at all
+query
+SELECT d, next_day(d, dow COLLATE UTF8_LCASE) FROM test_next_day_collated
+
+-- collated literal argument
+query
+SELECT d, next_day(d, 'Monday' COLLATE UTF8_LCASE) FROM test_next_day_collated
+
+-- Spark upper-cases the day name before matching, so all three spellings must agree under a
+-- case-insensitive collation exactly as they do under UTF8_BINARY.
+query
+SELECT next_day(d, 'monday' COLLATE UTF8_LCASE), next_day(d, 'MoNdAy' COLLATE UTF8_LCASE), next_day(d, 'mO' COLLATE UTF8_LCASE) FROM test_next_day_collated
+
+-- a second ICU collation, to show the guard is not UTF8_LCASE-only
+query
+SELECT d, next_day(d, dow COLLATE UNICODE_CI) FROM test_next_day_collated
+
+query
+SELECT next_day(d, 'Monday' COLLATE UNICODE_CI) FROM test_next_day_collated
+
+-- unrecognised day name returns NULL outside ANSI mode (ANSI is covered by next_day_ansi.sql)
+query
+SELECT next_day(date('2024-01-01'), 'notaday' COLLATE UTF8_LCASE)
+
+-- Collation does not introduce trimming: getDayOfWeekFromString matches character for character,
+-- so a padded value is still NULL. Mirrors the whitespace case in next_day.sql.
+query
+SELECT next_day(date('2024-01-01'), ' MO ' COLLATE UTF8_LCASE), next_day(date('2024-01-01'), 'MO ' COLLATE UTF8_LCASE)
+
+-- RTRIM collations are the case where trimming looks plausible: NextDay's inputTypes accept them
+-- (StringTypeWithCollation(supportsTrimCollation = true)), and CollationFactory right-trims when
+-- building a *collation key*. getDayOfWeekFromString never builds one, so a padded day name is
+-- still unmatched and the answer is still NULL, exactly as under UTF8_BINARY.
+query
+SELECT next_day(date('2024-01-01'), 'MON' COLLATE UTF8_BINARY_RTRIM), next_day(date('2024-01-01'), 'MON ' COLLATE UTF8_BINARY_RTRIM)
+
+query
+SELECT next_day(date('2024-01-01'), 'mon' COLLATE UTF8_LCASE_RTRIM), next_day(date('2024-01-01'), 'mon ' COLLATE UTF8_LCASE_RTRIM)
+
+-- literal + literal
+query
+SELECT next_day(date('2023-01-01'), 'Monday' COLLATE UTF8_LCASE), next_day(date('2023-01-01'), 'Sun' COLLATE UNICODE_CI)
+
+-- A NULL-literal dayOfWeek is omitted: NextDay is nullIntolerant, so NullPropagation folds the
+-- whole call to a NULL literal before Comet sees it. The NULL rows in the table above cover
+-- NULL-in-data for both arguments.

--- a/spark/src/test/resources/sql-tests/expressions/string/collation.sql
+++ b/spark/src/test/resources/sql-tests/expressions/string/collation.sql
@@ -52,6 +52,15 @@ SELECT concat('Hello' COLLATE UNICODE_CI, 'World' COLLATE UNICODE_CI)
 query
 SELECT reverse('Hello' COLLATE UNICODE_CI)
 
+-- next_day and levenshtein join the same pattern: their native kernels read the argument as raw
+-- bytes, so a collated argument is dispatched rather than run natively. Full coverage lives in
+-- datetime/next_day_collation.sql and string/levenshtein_collation.sql.
+query
+SELECT next_day(date('2024-01-01'), 'Monday' COLLATE UTF8_LCASE), next_day(date('2024-01-01'), 'mo' COLLATE UNICODE_CI)
+
+query
+SELECT levenshtein('HELLO' COLLATE UTF8_LCASE, 'hello' COLLATE UTF8_LCASE), levenshtein('kitten' COLLATE UNICODE_CI, 'sitting' COLLATE UNICODE_CI)
+
 -- ============================================================================
 -- Collated predicate operands route through the JVM codegen dispatcher.
 -- The predicate serdes mark collated cases `Unsupported`; `CodegenDispatchFallback` runs

--- a/spark/src/test/resources/sql-tests/expressions/string/levenshtein_collation.sql
+++ b/spark/src/test/resources/sql-tests/expressions/string/levenshtein_collation.sql
@@ -1,0 +1,86 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- MinSparkVersion: 4.0
+
+-- Spark 4.0+ widens Levenshtein's arguments to collated strings, but Levenshtein computes the
+-- distance with UTF8String.levenshteinDistance, which walks UTF-8 code points and takes no
+-- collation. The result is an IntegerType, so collation cannot change the answer. The native
+-- kernel compares raw bytes though, so a collated argument is reported as Unsupported and routed
+-- through the JVM codegen dispatcher, which runs Spark's own doGenCode inside the Comet pipeline.
+-- That keeps the projection in Comet and is measurably faster than the native path: 341ms against
+-- 378ms for Spark over 1M rows. See https://github.com/apache/datafusion-comet/issues/5591.
+
+-- This harness disables ConstantFolding, so `x COLLATE ...` survives as a `Collate` node rather
+-- than folding into a collated literal. Comet has no serde for `Collate`, but that does not matter
+-- here: the dispatcher compiles the whole bound subtree with Spark's own doGenCode, `Collate`
+-- included. That is one reason dispatching covers every spelling of a collated argument.
+
+statement
+CREATE TABLE test_levenshtein_collated(s1 string, s2 string) USING parquet
+
+statement
+INSERT INTO test_levenshtein_collated VALUES ('kitten', 'sitting'), ('frog', 'fog'), ('HELLO', 'hello'), ('abc', 'abc'), ('', 'hello'), (NULL, 'test'), ('hello', NULL), (NULL, NULL)
+
+-- both arguments collated, column form
+query
+SELECT s1, s2, levenshtein(s1 COLLATE UTF8_LCASE, s2 COLLATE UTF8_LCASE) FROM test_levenshtein_collated
+
+-- The load-bearing case. Spark's levenshtein is NOT collation-aware: under UTF8_LCASE the two
+-- values still differ in all five characters, so the answer is 5 and not 0. This is why the
+-- byte-oriented native kernel already matches Spark.
+query
+SELECT levenshtein('HELLO' COLLATE UTF8_LCASE, 'hello' COLLATE UTF8_LCASE)
+
+-- only one side collated; the other is implicitly cast to the collated type
+query
+SELECT levenshtein(s1 COLLATE UTF8_LCASE, s2) FROM test_levenshtein_collated
+
+query
+SELECT levenshtein(s1, s2 COLLATE UTF8_LCASE) FROM test_levenshtein_collated
+
+-- three-argument form takes Levenshtein's other codegen branch (genCodeWithThreshold)
+query
+SELECT levenshtein(s1 COLLATE UTF8_LCASE, s2 COLLATE UTF8_LCASE, 2) FROM test_levenshtein_collated
+
+query
+SELECT levenshtein('kitten' COLLATE UTF8_LCASE, 'sitting' COLLATE UTF8_LCASE, 1)
+
+-- a second ICU collation, to show the guard is not UTF8_LCASE-only
+query
+SELECT levenshtein(s1 COLLATE UNICODE_CI, s2 COLLATE UNICODE_CI) FROM test_levenshtein_collated
+
+query
+SELECT levenshtein('HELLO' COLLATE UNICODE_CI, 'hello' COLLATE UNICODE_CI)
+
+-- non-ASCII input under a collation, mirroring the unicode case in levenshtein.sql
+query
+SELECT levenshtein('café' COLLATE UTF8_LCASE, 'cafe' COLLATE UTF8_LCASE), levenshtein('你好' COLLATE UTF8_LCASE, '你坏' COLLATE UTF8_LCASE)
+
+-- RTRIM collations are the case where trimming looks plausible: Levenshtein's inputTypes accept
+-- them (StringTypeWithCollation(supportsTrimCollation = true)), and CollationFactory right-trims
+-- when building a *collation key*. UTF8String.levenshteinDistance never builds one, so the
+-- trailing space still counts as an edit and the distance is 1, not 0.
+query
+SELECT levenshtein('abc ' COLLATE UTF8_BINARY_RTRIM, 'abc' COLLATE UTF8_BINARY_RTRIM)
+
+query
+SELECT levenshtein('ABC ' COLLATE UTF8_LCASE_RTRIM, 'abc' COLLATE UTF8_LCASE_RTRIM)
+
+-- A NULL-literal argument is omitted: Levenshtein is nullIntolerant, so NullPropagation folds the
+-- whole call to a NULL literal before Comet sees it. The NULL rows in the table above cover
+-- NULL-in-data for both arguments.

--- a/spark/src/test/scala/org/apache/comet/CometStringExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometStringExpressionSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.{CometTestBase, DataFrame}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
 
+import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
 import org.apache.comet.testing.{DataGenOptions, FuzzDataGenerator}
 import org.apache.comet.udf.codegen.CometScalaUDFCodegen
 
@@ -766,6 +767,27 @@ class CometStringExpressionSuite extends CometTestBase with CometCodegenAssertio
       assert(
         CometScalaUDFCodegen.stats().totalLookups == 0,
         "expected the native concat_ws path for string arguments, not codegen dispatch")
+    }
+  }
+
+  test("levenshtein routes collated strings through the codegen dispatcher (issue #5591)") {
+    assume(isSpark40Plus, "COLLATE requires Spark 4.0")
+    // The native levenshtein kernel compares raw bytes, so CometLevenshtein reports a collated
+    // argument as Unsupported and CodegenDispatchFallback runs Spark's own doGenCode inside the
+    // Comet pipeline. checkSparkAnswerAndOperator alone would also pass if the projection fell
+    // back to Spark on a shape this test did not intend, so assertCodegenRan pins that the
+    // dispatcher is what kept it native. Answer coverage, including the three-argument form and
+    // RTRIM collations, lives in sql-tests/expressions/string/levenshtein_collation.sql.
+    val data = Seq(("kitten", "sitting"), ("HELLO", "hello"), ("frog", "fog"), (null, "test"))
+    withParquetTable(data, "tbl") {
+      assertCodegenRan {
+        checkSparkAnswerAndOperator(
+          "SELECT levenshtein(_1 COLLATE utf8_lcase, _2 COLLATE utf8_lcase) FROM tbl")
+        checkSparkAnswerAndOperator(
+          "SELECT levenshtein(_1 COLLATE unicode_ci, _2 COLLATE unicode_ci) FROM tbl")
+        checkSparkAnswerAndOperator(
+          "SELECT levenshtein(_1 COLLATE utf8_lcase, _2 COLLATE utf8_lcase, 2) FROM tbl")
+      }
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometDatetimeExpressionBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometDatetimeExpressionBenchmark.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone
 import org.apache.spark.sql.internal.SQLConf
 
 import org.apache.comet.CometConf
+import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
 
 // spotless:off
 /**
@@ -182,6 +183,43 @@ object CometDatetimeExpressionBenchmark extends CometBenchmarkBase {
     }
   }
 
+  /**
+   * `next_day` over a default-collation and, on Spark 4.0+, a collated `dayOfWeek`. The native
+   * kernel reads the argument as raw bytes, so CometNextDay reports a collated argument as
+   * Incompatible and CodegenDispatchFallback runs it through the JVM codegen dispatcher. The
+   * collated case therefore measures the dispatcher rather than the native kernel. See
+   * https://github.com/apache/datafusion-comet/issues/5591.
+   */
+  def nextDayExprBenchmark(values: Int): Unit = {
+    withTempPath { dir =>
+      withTempTable("parquetV1Table") {
+        prepareTable(
+          dir,
+          spark.sql(s"""
+            SELECT
+              date_from_unix_date(CAST(PMOD(value, 3650) AS INT)) AS dt,
+              CASE CAST(PMOD(value, 7) AS INT)
+                WHEN 0 THEN 'MON'
+                WHEN 1 THEN 'TUE'
+                WHEN 2 THEN 'WED'
+                WHEN 3 THEN 'THU'
+                WHEN 4 THEN 'FRI'
+                WHEN 5 THEN 'SAT'
+                ELSE 'SUN'
+              END AS dow
+            FROM $tbl
+          """))
+        runExpressionBenchmark("NextDay", values, "select next_day(dt, dow) from parquetV1Table")
+        if (isSpark40Plus) {
+          runExpressionBenchmark(
+            "NextDay - collated dayOfWeek",
+            values,
+            "select next_day(dt, dow collate utf8_lcase) from parquetV1Table")
+        }
+      }
+    }
+  }
+
   override def runCometBenchmark(mainArgs: Array[String]): Unit = {
     val values = 1024 * 1024;
 
@@ -221,6 +259,10 @@ object CometDatetimeExpressionBenchmark extends CometBenchmarkBase {
 
     runBenchmarkWithTable("MakeInterval", values) { v =>
       makeIntervalBenchmark(v)
+    }
+
+    runBenchmarkWithTable("NextDay", values) { v =>
+      nextDayExprBenchmark(v)
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometStringExpressionBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometStringExpressionBenchmark.scala
@@ -20,6 +20,7 @@
 package org.apache.spark.sql.benchmark
 
 import org.apache.comet.CometConf
+import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
 
 /**
  * Configuration for a string expression benchmark.
@@ -86,6 +87,25 @@ object CometStringExpressionBenchmark extends CometBenchmarkBase {
     StringExprConfig("trim", "select trim(c1) from parquetV1Table"),
     StringExprConfig("upper", "select upper(c1) from parquetV1Table"))
 
+  // Collated cases are Spark 4.0+ only, since the COLLATE syntax does not parse on 3.4 and 3.5.
+  // CometLevenshtein reports collated input as Unsupported and CodegenDispatchFallback runs it
+  // through the JVM codegen dispatcher, so these measure the dispatcher rather than the native
+  // kernel. See https://github.com/apache/datafusion-comet/issues/5591.
+  private val collatedStringExpressions =
+    if (isSpark40Plus) {
+      List(
+        StringExprConfig(
+          "levenshtein_collated",
+          "select levenshtein(c1 collate utf8_lcase, 'test' collate utf8_lcase)" +
+            " from parquetV1Table"),
+        StringExprConfig(
+          "levenshtein_threshold_collated",
+          "select levenshtein(c1 collate utf8_lcase, 'test' collate utf8_lcase, 3)" +
+            " from parquetV1Table"))
+    } else {
+      List.empty
+    }
+
   override def runCometBenchmark(mainArgs: Array[String]): Unit = {
     runBenchmarkWithTable("String expressions", 1024) { v =>
       withTempPath { dir =>
@@ -104,7 +124,7 @@ object CometStringExpressionBenchmark extends CometBenchmarkBase {
             CometConf.getExprAllowIncompatConfigKey("Lower") -> "true",
             CometConf.getExprAllowIncompatConfigKey("InitCap") -> "true")
 
-          stringExpressions.foreach { config =>
+          (stringExpressions ++ collatedStringExpressions).foreach { config =>
             val allConfigs = extraConfigs ++ config.extraCometConfigs
             runBenchmark(config.name) {
               runExpressionBenchmark(config.name, v, config.query, allConfigs)

--- a/spark/src/test/spark-4.0/org/apache/spark/sql/CometCollationSuite.scala
+++ b/spark/src/test/spark-4.0/org/apache/spark/sql/CometCollationSuite.scala
@@ -252,11 +252,12 @@ class CometCollationSuite extends CometTestBase {
   //
   // Comet's native datetime functions use string arguments (format patterns, timezones,
   // day-of-week) as raw bytes, so non-default collations on those arguments must not reach
-  // the native path silently. Expressions without a codegen-dispatcher fallback (next_day,
-  // unix_timestamp) fall back to Spark entirely. Expressions with CodegenDispatchFallback
-  // (trunc, date_trunc, date_format, from_unixtime, make_timestamp, to_unix_timestamp,
-  // convert_timezone) fall back to Spark when COMET_SCALA_UDF_CODEGEN_ENABLED is false
-  // or route through Spark codegen inside the Comet pipeline when it is true.
+  // the native path silently. `unix_timestamp` has no codegen-dispatcher fallback and falls
+  // back to Spark entirely. Expressions with CodegenDispatchFallback
+  // (next_day, trunc, date_trunc, date_format, from_unixtime, make_timestamp,
+  // to_unix_timestamp, convert_timezone) fall back to Spark when
+  // COMET_SCALA_UDF_CODEGEN_ENABLED is false or route through Spark codegen inside the Comet
+  // pipeline when it is true.
 
   private def withDatetimeCollationTable(f: => Unit): Unit = {
     withParquetTable(
@@ -354,6 +355,23 @@ class CometCollationSuite extends CometTestBase {
       "date_format does not support non-UTF8_BINARY collations")
   }
 
+  test("next_day uses native path with collated dayOfWeek when allowIncompatible is enabled") {
+    // With allowIncompatible the collated case takes the native kernel instead of the dispatcher.
+    // That kernel reads dayOfWeek as raw bytes, which matches Spark because
+    // DateTimeUtils.getDayOfWeekFromString upper-cases with Locale.ROOT and matches a fixed
+    // literal set, taking no collation. This test is what pins that claim, since every other
+    // collated next_day test exercises the dispatcher rather than the native kernel.
+    withDatetimeCollationTable {
+      withSQLConf(
+        CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "false",
+        "spark.comet.expression.NextDay.allowIncompatible" -> "true") {
+        checkSparkAnswerAndOperator(
+          "SELECT next_day(CAST(_1 AS DATE), 'MON' COLLATE utf8_lcase) " +
+            "FROM datetime_collation_tbl")
+      }
+    }
+  }
+
   test("date_format uses native path with collated format when allowIncompatible is enabled") {
     withDatetimeCollationTable {
       withSQLConf(
@@ -381,6 +399,14 @@ class CometCollationSuite extends CometTestBase {
     checkDatetimeDispatcher(
       "SELECT date_format(CAST(_2 AS TIMESTAMP), _6 COLLATE utf8_lcase) " +
         "FROM datetime_collation_tbl")
+  }
+
+  test("next_day routes collated dayOfWeek through codegen dispatcher (issue #5591)") {
+    // Dispatching is both the compatible answer and the faster one: over 1M rows a collated
+    // next_day measured 70ms dispatched against 89ms for Spark. Answer coverage lives in
+    // sql-tests/expressions/datetime/next_day_collation.sql.
+    checkDatetimeDispatcher(
+      "SELECT next_day(CAST(_1 AS DATE), _5 COLLATE utf8_lcase) FROM datetime_collation_tbl")
   }
 
   test("datetime expressions still run with default UTF8_BINARY collation (issue #4646)") {

--- a/spark/src/test/spark-4.1/org/apache/spark/sql/CometCollationSuite.scala
+++ b/spark/src/test/spark-4.1/org/apache/spark/sql/CometCollationSuite.scala
@@ -73,11 +73,12 @@ class CometCollationSuite extends CometTestBase {
   //
   // Comet's native datetime functions use string arguments (format patterns, timezones,
   // day-of-week) as raw bytes, so non-default collations on those arguments must not reach
-  // the native path silently. Expressions without a codegen-dispatcher fallback (next_day,
-  // unix_timestamp) fall back to Spark entirely. Expressions with CodegenDispatchFallback
-  // (trunc, date_trunc, date_format, from_unixtime, make_timestamp, to_unix_timestamp,
-  // convert_timezone) fall back to Spark when COMET_SCALA_UDF_CODEGEN_ENABLED is false
-  // or route through Spark codegen inside the Comet pipeline when it is true.
+  // the native path silently. `unix_timestamp` has no codegen-dispatcher fallback and falls
+  // back to Spark entirely. Expressions with CodegenDispatchFallback
+  // (next_day, trunc, date_trunc, date_format, from_unixtime, make_timestamp,
+  // to_unix_timestamp, convert_timezone) fall back to Spark when
+  // COMET_SCALA_UDF_CODEGEN_ENABLED is false or route through Spark codegen inside the Comet
+  // pipeline when it is true.
 
   private def withDatetimeCollationTable(f: => Unit): Unit = {
     withParquetTable(
@@ -175,6 +176,23 @@ class CometCollationSuite extends CometTestBase {
       "date_format does not support non-UTF8_BINARY collations")
   }
 
+  test("next_day uses native path with collated dayOfWeek when allowIncompatible is enabled") {
+    // With allowIncompatible the collated case takes the native kernel instead of the dispatcher.
+    // That kernel reads dayOfWeek as raw bytes, which matches Spark because
+    // DateTimeUtils.getDayOfWeekFromString upper-cases with Locale.ROOT and matches a fixed
+    // literal set, taking no collation. This test is what pins that claim, since every other
+    // collated next_day test exercises the dispatcher rather than the native kernel.
+    withDatetimeCollationTable {
+      withSQLConf(
+        CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "false",
+        "spark.comet.expression.NextDay.allowIncompatible" -> "true") {
+        checkSparkAnswerAndOperator(
+          "SELECT next_day(CAST(_1 AS DATE), 'MON' COLLATE utf8_lcase) " +
+            "FROM datetime_collation_tbl")
+      }
+    }
+  }
+
   test("date_format uses native path with collated format when allowIncompatible is enabled") {
     withDatetimeCollationTable {
       withSQLConf(
@@ -202,6 +220,14 @@ class CometCollationSuite extends CometTestBase {
     checkDatetimeDispatcher(
       "SELECT date_format(CAST(_2 AS TIMESTAMP), _6 COLLATE utf8_lcase) " +
         "FROM datetime_collation_tbl")
+  }
+
+  test("next_day routes collated dayOfWeek through codegen dispatcher (issue #5591)") {
+    // Dispatching is both the compatible answer and the faster one: over 1M rows a collated
+    // next_day measured 70ms dispatched against 89ms for Spark. Answer coverage lives in
+    // sql-tests/expressions/datetime/next_day_collation.sql.
+    checkDatetimeDispatcher(
+      "SELECT next_day(CAST(_1 AS DATE), _5 COLLATE utf8_lcase) FROM datetime_collation_tbl")
   }
 
   test("datetime expressions still run with default UTF8_BINARY collation (issue #4646)") {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5591. Part of #5572.

## Rationale for this change

`CometNextDay` and `CometLevenshtein` decline non-UTF8_BINARY collated arguments but do not mix in `CodegenDispatchFallback`, so a collated argument fails the whole projection back to Spark. Both are ordinary codegen expressions, so the dispatcher can run Spark's own `doGenCode` inside the Comet pipeline instead.

Collated values do reach Comet operators, but only from the query text (`col COLLATE x` or `CAST(col AS STRING COLLATE UTF8_LCASE)`). A table schema that declares a collated column is rejected at scan (`Unsupported schema ... StringType(UTF8_LCASE)`). The guards are live.

Neither Spark implementation consults collation (`getDayOfWeekFromString` / `UTF8String.levenshteinDistance` take no collation id on 4.0.1 or 4.1.1, neither appears in `CollationSupport`). That suggested dropping the guards and running the native kernels. I implemented that variant and benchmarked it. It lost on every axis, so this PR does what the issue originally proposed.

## What changes are included in this PR?

- Mix `CodegenDispatchFallback` into `CometNextDay` and `CometLevenshtein`.
- Collapse `CometLevenshtein`'s two collation reason strings into one `private val`, reworded so it does not contradict the `GenerateDocs` "runs in the JVM" header for mixin serdes.
- `expressions.md`: both rows `Native` → `Hybrid`.
- `understanding-comet-plans.md`: `levenshtein` was wrongly listed as `CometCodegenDispatch` with no native kernel. The example now uses `pmod`.
- Collated cases on `CometStringExpressionBenchmark` and `CometDatetimeExpressionBenchmark` (`isSpark40Plus`; `COLLATE` does not parse on 3.4/3.5). `next_day` had no benchmark at all, so the default-collation case is added too.

## Benchmark
1,048,576 rows, `spark-4.0`, `local[1]`. "guard removed" is the native-path alternative above; it is not in this PR.

| Case | Spark | guard removed | this PR |
| --- | --- | --- | --- |
| `next_day`, UTF8_LCASE | 89 ms | 125 ms (0.7X) | **70 ms (1.3X)** |
| `levenshtein`, UTF8_LCASE | 378 ms | 489 ms (0.8X) | **341 ms (1.1X)** |
| `next_day`, default (control) | 90 ms | 104 ms | 104 ms |
| `levenshtein`, default (control) | 380 ms | 439 ms | 435 ms |

Controls match between variants, so only the collated path differs. Dispatching is also the only variant that covers `col COLLATE x`: `Collate` has no serde, and a `Compatible` expression never reaches the dispatcher.

Added benchmark cases on a second profile / data shape: collated `next_day` 1.4X on `spark-4.1`; collated `levenshtein` 2.6X / 3.2X on `spark-4.0`. Default-collation `next_day` is 1.0X.

## How are these changes tested?

New Spark 4.0+ SQL fixtures:

- `datetime/next_day_collation.sql`, `datetime/next_day_ansi_collation.sql`
- `string/levenshtein_collation.sql`

Column and literal arguments, `UTF8_LCASE` / `UNICODE_CI` / RTRIM collations, non-ASCII, bad day names, ANSI errors, three-argument `levenshtein`, and NULL in data. NULL literals are omitted:
both expressions are `nullIntolerant`, so `NullPropagation` folds them before Comet sees them.

The load-bearing case is `levenshtein('HELLO' COLLATE UTF8_LCASE, 'hello' COLLATE UTF8_LCASE)` returning 5, not 0. That query fails first if Spark ever makes `levenshtein` collation-aware.

`CometCollationSuite` (4.0 and 4.1) adds a `next_day` dispatcher test and an `allowIncompatible=true` native-path test, matching `date_format`. The latter is the only coverage of the native kernel on collated input. `CometStringExpressionSuite` asserts the `levenshtein` path through `assertCodegenRan`.

Local runs, no style checks skipped: `spark-4.0` 566/0/0, `spark-4.1` 561/0/0, `spark-3.5` 539/0/1 (`assume(isSpark40Plus)` skip). Suites: `CometCollationSuite`, `CometSqlFileTestSuite`, `CometTemporalExpressionSuite`, `CometStringExpressionSuite`.

## Known gap
`col COLLATE utf8_lcase` works here only because the dispatcher compiles the whole bound subtree, including `Collate`. Comet has no serde for `Collate` (`QueryPlanSerde.scala:1009`), so any `Compatible()` expression over a `Collate` child still fails the projection, e.g.`length(s COLLATE utf8_lcase)`. That is wider than this issue and predates this PR.