### PR TITLE
fix: disable conflicting IfBraceChecker

### DIFF
--- a/dev/scalastyle-config.xml
+++ b/dev/scalastyle-config.xml
@@ -91,7 +91,8 @@ This file is divided into 3 sections:
 
   <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
 
-  <check level="error" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
+  <!-- Disabled because Scalafmt can wrap brace-less if/else expressions across multiple lines. -->
+  <check level="error" class="org.scalastyle.scalariform.IfBraceChecker" enabled="false">
     <parameters>
       <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
       <parameter name="doubleLineAllowed"><![CDATA[true]]></parameter>


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5711

## Rationale for this change

`make format` uses Scalafmt, which can wrap long brace-less `if`/`else` expressions across multiple lines without adding braces. Scalastyle's `IfBraceChecker` then rejects the formatted code.

Since Scalafmt is the canonical formatter and cannot automatically add braces, the `IfBraceChecker` rule can conflict with the formatter and leave code that fails Scalastyle after formatting.

## What changes are included in this PR?

- Disabled `IfBraceChecker` in `dev/scalastyle-config.xml`.
- No Scala source files were changed.

## How are these changes tested?

- Ran Scalastyle directly against the Spark Scala sources:
  `mvnw.cmd scalastyle:check -pl spark -Dscalastyle.failOnViolation=true -Dscalastyle.verbose=true`
- Scalastyle scanned 153 Scala source files and reported no `IfBraceChecker` violations.
- The check still reports an unrelated existing `Class.forName` violation in `spark/src/main/scala/org/apache/spark/sql/comet/util/Utils.scala:131`.
- A full `test-compile` could not complete locally because of unrelated missing generated protobuf/dependency classes.