### PR TITLE
feat: support native concat_ws with string arrays

### DIFF
--- a/docs/source/contributor-guide/expression-audits/string_funcs.md
+++ b/docs/source/contributor-guide/expression-audits/string_funcs.md
@@ -66,9 +66,10 @@
 
 ## concat_ws
 
-- Spark 3.4.3 (audited 2026-05-27): identical to 3.5.8.
-- Spark 3.5.8 (audited 2026-05-27): baseline. `Seq[Expression] -> StringType`; NULL separator yields NULL, NULL element values are skipped, children can be `StringType` or `ArrayType(StringType)`. Comet serde rewrites a NULL-literal separator to a NULL of the result type and bails out on all-foldable inputs so Spark's `ConstantFolding` handles them; otherwise delegates to DataFusion `concat_ws`.
-- Spark 4.0.1 (audited 2026-05-27): `inputTypes` widened to `StringTypeWithCollation` / `AbstractArrayType`; `dataType` becomes `children.head.dataType` (collation-derived). Semantics unchanged for `UTF8_BINARY`. Non-default collations not honoured by Comet ([#4496](https://github.com/apache/datafusion-comet/issues/4496)).
+- Spark 3.4.3 (audited 2026-09-06): identical to 3.5.8.
+- Spark 3.5.8 (audited 2026-09-06): accepts ordered mixtures of strings and string arrays, skips null arguments and array elements, and returns NULL for a NULL separator. Comet uses DataFusion Spark's `SparkConcatWs`, with native column coverage for multiple arrays, empty arrays, nulls, empty strings, Unicode, and varying separators. The existing all-foldable codegen fallback remains because the upstream kernel assumes a column input for multirow batches.
+- Spark 4.0.1 (audited 2026-09-06): collation-aware input and result types; concatenation still uses `UTF8String.concatWs` without collation-dependent comparisons.
+- Spark 4.1.1 (audited 2026-09-06): same concatenation and null semantics as 4.0.1.
 
 ## contains
 

--- a/docs/source/contributor-guide/expression-audits/string_funcs.md
+++ b/docs/source/contributor-guide/expression-audits/string_funcs.md
@@ -67,7 +67,7 @@
 ## concat_ws
 
 - Spark 3.4.3 (audited 2026-09-06): identical to 3.5.8.
-- Spark 3.5.8 (audited 2026-09-06): accepts ordered mixtures of strings and string arrays, skips null arguments and array elements, and returns NULL for a NULL separator. Comet uses DataFusion Spark's `SparkConcatWs`, with native column coverage for multiple arrays, empty arrays, nulls, empty strings, Unicode, and varying separators. The existing all-foldable codegen fallback remains because the upstream kernel assumes a column input for multirow batches.
+- Spark 3.5.8 (audited 2026-09-06): accepts ordered mixtures of strings and string arrays, skips null arguments and array elements, and returns NULL for a NULL separator. Comet retains DataFusion's string kernel and uses DataFusion Spark's `SparkConcatWs` for arrays and separator-only inputs, with native column coverage for multiple arrays, empty arrays, nulls, empty strings, Unicode, and varying separators. The existing all-foldable codegen fallback remains. A native adapter evaluates runtime scalars once and returns a scalar for broadcasting, including non-foldable scalar subqueries.
 - Spark 4.0.1 (audited 2026-09-06): collation-aware input and result types; concatenation still uses `UTF8String.concatWs` without collation-dependent comparisons.
 - Spark 4.1.1 (audited 2026-09-06): same concatenation and null semantics as 4.0.1.
 

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -561,7 +561,7 @@ The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `deci
 | `chr` | ✅ | Native |  |
 | `collate` | 🔜 | — | Spark collation (umbrella [#2190](https://github.com/apache/datafusion-comet/issues/2190)) |
 | `collation` | ✅ | — | Constant-folded to a literal (Spark 4.0+) |
-| `concat_ws` | ✅ | Hybrid | Array arguments route through the JVM codegen dispatcher; string arguments run natively ([details](compatibility/expressions/string.md)) |
+| `concat_ws` | ✅ | Hybrid | Mixed string and array arguments run natively; all-foldable arguments use codegen dispatch |
 | `contains` | ✅ | — |  |
 | `decode` | ✅ | — |  |
 | `elt` | ✅ | Codegen dispatch |  |

--- a/native/spark-expr/src/comet_scalar_funcs.rs
+++ b/native/spark-expr/src/comet_scalar_funcs.rs
@@ -118,6 +118,9 @@ pub fn create_comet_physical_fun_with_eval_mode(
 ) -> Result<Arc<ScalarUDF>, DataFusionError> {
     let fail_on_error = fail_on_error.unwrap_or(false);
     match fun_name {
+        "concat_ws" => Ok(Arc::new(ScalarUDF::new_from_impl(
+            datafusion_spark::function::string::concat_ws::SparkConcatWs::new(),
+        ))),
         "ceil" => {
             make_comet_scalar_udf!("ceil", spark_ceil, data_type)
         }

--- a/native/spark-expr/src/comet_scalar_funcs.rs
+++ b/native/spark-expr/src/comet_scalar_funcs.rs
@@ -118,8 +118,8 @@ pub fn create_comet_physical_fun_with_eval_mode(
 ) -> Result<Arc<ScalarUDF>, DataFusionError> {
     let fail_on_error = fail_on_error.unwrap_or(false);
     match fun_name {
-        "concat_ws" => Ok(Arc::new(ScalarUDF::new_from_impl(
-            datafusion_spark::function::string::concat_ws::SparkConcatWs::new(),
+        "spark_concat_ws" => Ok(Arc::new(ScalarUDF::new_from_impl(
+            crate::string_funcs::CometConcatWs::default(),
         ))),
         "ceil" => {
             make_comet_scalar_udf!("ceil", spark_ceil, data_type)

--- a/native/spark-expr/src/string_funcs/concat_ws.rs
+++ b/native/spark-expr/src/string_funcs/concat_ws.rs
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::datatypes::DataType;
+use datafusion::common::{exec_err, Result, ScalarValue};
+use datafusion::logical_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature};
+use datafusion_spark::function::string::concat_ws::SparkConcatWs;
+
+/// Adapt SparkConcatWs to runtime scalars, including non-foldable scalar subqueries.
+#[derive(Debug, Default, PartialEq, Eq, Hash)]
+pub struct CometConcatWs(SparkConcatWs);
+
+impl ScalarUDFImpl for CometConcatWs {
+    fn name(&self) -> &str {
+        self.0.name()
+    }
+
+    fn signature(&self) -> &Signature {
+        self.0.signature()
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        self.0.return_type(arg_types)
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        self.0.coerce_types(arg_types)
+    }
+
+    fn invoke_with_args(&self, mut args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        if args.args.is_empty() {
+            return exec_err!("concat_ws requires a separator");
+        }
+        let all_scalar = args
+            .args
+            .iter()
+            .all(|arg| matches!(arg, ColumnarValue::Scalar(_)));
+        // The upstream kernel expands scalars to one row, independently of number_rows.
+        // Evaluate once and let DataFusion broadcast the scalar to the enclosing batch.
+        if all_scalar {
+            args.number_rows = 1;
+        }
+        match (all_scalar, self.0.invoke_with_args(args)?) {
+            (true, ColumnarValue::Array(array)) => Ok(ColumnarValue::Scalar(
+                ScalarValue::try_from_array(&array, 0)?,
+            )),
+            (_, result) => Ok(result),
+        }
+    }
+}

--- a/native/spark-expr/src/string_funcs/mod.rs
+++ b/native/spark-expr/src/string_funcs/mod.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 mod base64;
+mod concat_ws;
 mod contains;
 mod get_json_object;
 mod levenshtein;
@@ -26,6 +27,7 @@ mod split;
 mod unbase64;
 
 pub use base64::spark_base64;
+pub use concat_ws::CometConcatWs;
 pub use contains::SparkContains;
 pub use get_json_object::spark_get_json_object;
 pub use levenshtein::spark_levenshtein;

--- a/native/spark-expr/tests/spark_expr_reg.rs
+++ b/native/spark-expr/tests/spark_expr_reg.rs
@@ -25,13 +25,57 @@ mod tests {
     use datafusion_comet_spark_expr::create_comet_physical_fun;
     use datafusion_comet_spark_expr::register_all_comet_functions;
 
+    #[test]
+    fn test_concat_ws_runtime_scalars() -> Result<()> {
+        use arrow::datatypes::Field;
+        use datafusion::common::{config::ConfigOptions, ScalarValue};
+        use datafusion::logical_expr::{ColumnarValue, ScalarFunctionArgs};
+        use std::sync::Arc;
+
+        let state = SessionStateBuilder::new().build();
+        let udf = create_comet_physical_fun("spark_concat_ws", DataType::Utf8, &state, None)?;
+        let value = ScalarValue::Utf8(Some("a".into()));
+        let list = ScalarValue::List(ScalarValue::new_list(
+            &[
+                value.clone(),
+                ScalarValue::Utf8(None),
+                ScalarValue::Utf8(Some("".into())),
+            ],
+            &DataType::Utf8,
+            true,
+        ));
+        for (input, expected) in [(value, "a"), (list, "a,")] {
+            for number_rows in [8, 1, 0] {
+                for separator in [Some(",".to_string()), None] {
+                    let expected =
+                        ScalarValue::Utf8(separator.as_ref().map(|_| expected.to_string()));
+                    let result = udf.invoke_with_args(ScalarFunctionArgs {
+                        args: vec![
+                            ColumnarValue::Scalar(ScalarValue::Utf8(separator)),
+                            ColumnarValue::Scalar(input.clone()),
+                        ],
+                        arg_fields: vec![],
+                        number_rows,
+                        return_field: Arc::new(Field::new("result", DataType::Utf8, true)),
+                        config_options: Arc::new(ConfigOptions::default()),
+                    })?;
+                    let ColumnarValue::Scalar(result) = result else {
+                        panic!("expected scalar output");
+                    };
+                    assert_eq!(result, expected);
+                }
+            }
+        }
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_concat_ws_array_arguments() -> Result<()> {
         use arrow::array::{AsArray, StringArray};
 
         let ctx = SessionContext::new();
         let state = ctx.state();
-        let udf = create_comet_physical_fun("concat_ws", DataType::Utf8, &state, None)?;
+        let udf = create_comet_physical_fun("spark_concat_ws", DataType::Utf8, &state, None)?;
         ctx.register_udf(udf.as_ref().clone());
         let results = ctx
             .sql(

--- a/native/spark-expr/tests/spark_expr_reg.rs
+++ b/native/spark-expr/tests/spark_expr_reg.rs
@@ -26,6 +26,31 @@ mod tests {
     use datafusion_comet_spark_expr::register_all_comet_functions;
 
     #[tokio::test]
+    async fn test_concat_ws_array_arguments() -> Result<()> {
+        use arrow::array::{AsArray, StringArray};
+
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+        let udf = create_comet_physical_fun("concat_ws", DataType::Utf8, &state, None)?;
+        ctx.register_udf(udf.as_ref().clone());
+        let results = ctx
+            .sql(
+                "SELECT concat_ws(sep, make_array(a, NULL, b), 'tail', make_array(b, a))
+                 FROM (VALUES ('|', '', 'é'), ('', NULL, 'x'), (NULL, 'a', 'b'))
+                 AS t(sep, a, b)",
+            )
+            .await?
+            .collect()
+            .await?;
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].column(0).as_string::<i32>(),
+            &StringArray::from(vec![Some("|é|tail|é|"), Some("xtailx"), None])
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_udf_registration() -> Result<()> {
         // 1. Setup session with UDF registration of existing Spark-compatible expression
         let mut session_state = SessionStateBuilder::new().build();

--- a/spark/src/main/scala/org/apache/comet/serde/strings.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/strings.scala
@@ -292,8 +292,8 @@ object CometConcatWs extends CometExpressionSerde[ConcatWs] with CodegenDispatch
   override def getSupportLevel(expr: ConcatWs): SupportLevel = expr.children.headOption match {
     case Some(Literal(null, _)) => Compatible()
     case _ if expr.children.forall(_.foldable) =>
-      // The upstream kernel expands scalar arguments to one row but iterates over the batch
-      // length. Keep codegen dispatch for this shape until it supports all-scalar batches.
+      // Preserve the existing ConstantFolding/codegen behavior for foldable expressions.
+      // Non-foldable runtime scalars are handled by the native adapter.
       Unsupported(Some("all arguments are foldable"))
     case _ => Compatible()
   }
@@ -302,10 +302,17 @@ object CometConcatWs extends CometExpressionSerde[ConcatWs] with CodegenDispatch
     expr.children.headOption match {
       case Some(Literal(null, _)) =>
         exprToProtoInternal(Literal.create(null, expr.dataType), inputs, binding)
-      case _ =>
+      case _
+          if expr.children.length == 1 ||
+            expr.children.exists(_.dataType.isInstanceOf[ArrayType]) =>
         val childExprs = expr.children.map(exprToProtoInternal(_, inputs, binding))
-        // Bypass DataFusion's string-only concat_ws signature.
-        scalarFunctionExprToProtoWithReturnType("concat_ws", expr.dataType, false, childExprs: _*)
+        scalarFunctionExprToProtoWithReturnType(
+          "spark_concat_ws",
+          expr.dataType,
+          false,
+          childExprs: _*)
+      case _ =>
+        CometScalarFunction[ConcatWs]("concat_ws").convert(expr, inputs, binding)
     }
   }
 }

--- a/spark/src/main/scala/org/apache/comet/serde/strings.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/strings.scala
@@ -287,44 +287,25 @@ object CometConcat
 }
 
 object CometConcatWs extends CometExpressionSerde[ConcatWs] with CodegenDispatchFallback {
-
-  // Spark's ConcatWs accepts `array<string>` arguments after the separator and flattens their
-  // elements into the list of strings to join (null elements are skipped, like null strings).
-  // DataFusion's `concat_ws` accepts only string arguments and fails at execution time when it is
-  // handed a list, so these calls have no native path. Because this serde mixes in
-  // `CodegenDispatchFallback`, they run through the JVM codegen dispatcher (Spark's own
-  // `ConcatWs.doGenCode` inside the Comet pipeline) instead, and fall back to Spark only when the
-  // dispatcher is disabled. See https://github.com/apache/datafusion-comet/issues/5675.
-  private val arrayArgumentReason =
-    "`concat_ws` with `array<string>` arguments: Spark flattens the array elements into the " +
-      "strings to join, which DataFusion's `concat_ws` does not support " +
-      "(https://github.com/apache/datafusion-comet/issues/5675)"
-
-  override def getUnsupportedReasons(): Seq[String] = Seq(arrayArgumentReason)
+  override def getUnsupportedReasons(): Seq[String] = Seq("all arguments are foldable")
 
   override def getSupportLevel(expr: ConcatWs): SupportLevel = expr.children.headOption match {
-    // A NULL separator converts directly to a NULL result, so it stays supported.
     case Some(Literal(null, _)) => Compatible()
-    case _ if expr.children.exists(_.dataType.isInstanceOf[ArrayType]) =>
-      Unsupported(Some(arrayArgumentReason))
-    // Decline all-literal args so that Spark's ConstantFolding handles them (it normally folds
-    // them before they reach Comet). With the dispatcher enabled they run through Spark's own
-    // generated code in-pipeline; otherwise the projection falls back to Spark.
     case _ if expr.children.forall(_.foldable) =>
+      // The upstream kernel expands scalar arguments to one row but iterates over the batch
+      // length. Keep codegen dispatch for this shape until it supports all-scalar batches.
       Unsupported(Some("all arguments are foldable"))
     case _ => Compatible()
   }
 
   override def convert(expr: ConcatWs, inputs: Seq[Attribute], binding: Boolean): Option[Expr] = {
     expr.children.headOption match {
-      // Match Spark behavior: when the separator is NULL, the result of concat_ws is NULL.
       case Some(Literal(null, _)) =>
-        val nullLiteral = Literal.create(null, expr.dataType)
-        exprToProtoInternal(nullLiteral, inputs, binding)
-
+        exprToProtoInternal(Literal.create(null, expr.dataType), inputs, binding)
       case _ =>
-        // For all other cases, use the generic scalar function implementation.
-        CometScalarFunction[ConcatWs]("concat_ws").convert(expr, inputs, binding)
+        val childExprs = expr.children.map(exprToProtoInternal(_, inputs, binding))
+        // Bypass DataFusion's string-only concat_ws signature.
+        scalarFunctionExprToProtoWithReturnType("concat_ws", expr.dataType, false, childExprs: _*)
     }
   }
 }

--- a/spark/src/test/resources/sql-tests/expressions/string/concat_ws.sql
+++ b/spark/src/test/resources/sql-tests/expressions/string/concat_ws.sql
@@ -40,17 +40,11 @@ INSERT INTO names VALUES(1, 'James', 'B', 'Taylor'), (2, 'Smith', 'C', 'Davis'),
 query
 SELECT concat_ws(' ', first_name, middle_initial, last_name) FROM names
 
--- literal + literal + literal (declined natively when all args are foldable; routed through the
--- JVM codegen dispatcher, or falls back to Spark when the dispatcher is disabled)
+-- All-scalar inputs retain codegen dispatch.
 query spark_answer_only
 SELECT concat_ws(',', 'hello', 'world'), concat_ws(',', '', ''), concat_ws(',', NULL, 'b', 'c'), concat_ws(NULL, 'a', 'b')
 
--- https://github.com/apache/datafusion-comet/issues/5675
--- Spark accepts array<string> arguments after the separator and flattens their elements into the
--- strings to join (skipping null elements). DataFusion's concat_ws rejects list arguments, so
--- ConcatWs mixes in CodegenDispatchFallback: these calls route through the JVM codegen dispatcher
--- (Spark's own ConcatWs.doGenCode inside the Comet pipeline) and stay native while matching Spark
--- exactly.
+-- Mixed string and array arguments execute natively.
 statement
 CREATE TABLE test_concat_ws_array(arr array<string>, s string) USING parquet
 
@@ -85,3 +79,14 @@ SELECT concat_ws(NULL, arr, s) FROM test_concat_ws_array
 -- literal array arguments
 query
 SELECT concat_ws(',', array('a', 'b'), 'c'), concat_ws(',', array('x', NULL, 'y')), concat_ws(',', CAST(array() AS array<string>), 'w')
+
+-- Non-foldable separators, including empty strings and NULL.
+query
+SELECT concat_ws(s, arr, 'tail', arr), concat_ws(s) FROM test_concat_ws_array
+
+-- Empty strings count as elements; null strings, arrays, and elements do not.
+query
+SELECT concat_ws(',', array('', NULL, 'é'), s, CAST(NULL AS array<string>), array(NULL, '', '世界')) FROM test_concat_ws_array
+
+query
+SELECT concat_ws(','), concat_ws(NULL), concat_ws(',', array(NULL, NULL)), concat_ws(',', CAST(NULL AS array<string>))

--- a/spark/src/test/scala/org/apache/comet/CometStringExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometStringExpressionSuite.scala
@@ -725,6 +725,23 @@ class CometStringExpressionSuite extends CometTestBase with CometCodegenAssertio
     // scalastyle:on
   }
 
+  test("concat_ws with scalar subqueries over a multi-row batch") {
+    withSQLConf(CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "false") {
+      withParquetTable((1 to 32).map(i => (i, "row")), "fact") {
+        withParquetTable(Seq(Tuple1("a"), Tuple1("b")), "lookup") {
+          for (subquery <- Seq(
+              "(SELECT max(_1) FROM lookup)",
+              "(SELECT max(_1) FROM lookup WHERE _1 = 'missing')")) {
+            checkSparkAnswerAndOperator(s"SELECT _1, concat_ws($subquery) FROM fact")
+            checkSparkAnswerAndOperator(s"SELECT _1, concat_ws(',', $subquery) FROM fact")
+            checkSparkAnswerAndOperator(
+              s"SELECT _1, concat_ws(',', array('x', NULL, ''), $subquery) FROM fact")
+          }
+        }
+      }
+    }
+  }
+
   test("concat_ws with array<string> arguments") {
     val data: Seq[(Seq[String], String)] = Seq(
       (Seq("a", "b"), "c d"),

--- a/spark/src/test/scala/org/apache/comet/CometStringExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometStringExpressionSuite.scala
@@ -726,17 +726,16 @@ class CometStringExpressionSuite extends CometTestBase with CometCodegenAssertio
   }
 
   test("concat_ws with array<string> arguments") {
-    // https://github.com/apache/datafusion-comet/issues/5675
-    // Spark flattens array<string> arguments into the strings to join (skipping null elements).
-    // DataFusion's concat_ws rejects list arguments, so these calls run through the JVM codegen
-    // dispatcher (Spark's own doGenCode inside the Comet pipeline) instead of the native path.
     val data: Seq[(Seq[String], String)] = Seq(
       (Seq("a", "b"), "c d"),
       (Seq("x", null, "y"), "z"),
       (Seq("only"), ""),
       (Seq.empty[String], "w"),
       (null, "v"),
-      (Seq("p", "q"), null))
+      (Seq("p", "q"), null),
+      (Seq(null, "", "\u00e9"), "|"),
+      (Seq(null, null), ""),
+      (null, null))
     withParquetTable(data, "tbl") {
       val arrayArgQueries = Seq(
         "SELECT concat_ws(',', _1, _2) FROM tbl",
@@ -744,18 +743,16 @@ class CometStringExpressionSuite extends CometTestBase with CometCodegenAssertio
         "SELECT concat_ws(',', _1) FROM tbl",
         "SELECT concat_ws('-', _1, _2, _1) FROM tbl",
         "SELECT concat_ws(',', split(_2, ' ')) FROM tbl",
-        "SELECT concat_ws(',', split(_2, ' '), _1) FROM tbl")
-      for (query <- arrayArgQueries) {
-        // Spark's answer, the whole plan stays in Comet, and the codegen dispatcher actually ran.
-        assertCodegenRan {
-          checkSparkAnswerAndOperator(query)
-        }
-      }
-      // With the dispatcher disabled there is no in-pipeline path, so the projection falls back
-      // to Spark with the serde's reason instead of failing at native execution.
-      withSQLConf(CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "false") {
+        "SELECT concat_ws(',', split(_2, ' '), _1) FROM tbl",
+        "SELECT concat_ws(_2, _1, 'tail', _1) FROM tbl",
+        "SELECT concat_ws('', _1, _2, array('x', NULL, 'y')) FROM tbl",
+        "SELECT concat_ws(NULL, _1, _2) FROM tbl",
+        "SELECT concat_ws(_2) FROM tbl")
+      withSQLConf(
+        CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "false",
+        "spark.comet.expression.StringSplit.allowIncompatible" -> "true") {
         for (query <- arrayArgQueries) {
-          checkSparkAnswerAndFallbackReason(query, "`concat_ws` with `array<string>` arguments")
+          checkSparkAnswerAndOperator(query)
         }
       }
       // A NULL separator produces NULL regardless of the argument types and stays native.

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometConcatWsBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometConcatWsBenchmark.scala
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.benchmark
+
+import org.apache.spark.sql.execution.WholeStageCodegenExec
+import org.apache.spark.sql.internal.SQLConf
+
+import org.apache.comet.CometConf
+
+/**
+ * Matched Parquet inputs for native concat_ws versus Spark whole-stage codegen. Pass `strings` to
+ * run only the previously supported string cases against an older native library.
+ */
+object CometConcatWsBenchmark extends CometBenchmarkBase {
+  override def runCometBenchmark(mainArgs: Array[String]): Unit = {
+    val rows = 65536
+    val stringsOnly = mainArgs.contains("strings")
+    val nativeConfigs = Map(
+      CometConf.COMET_ENABLED.key -> "true",
+      CometConf.COMET_EXEC_ENABLED.key -> "true",
+      CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "false")
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.PARQUET_VECTORIZED_READER_BATCH_SIZE.key -> "8192",
+      CometConf.COMET_BATCH_SIZE.key -> "8192") {
+      for (width <- Seq(8, 128); arrayLength <- Seq(2, 8, 32)
+        if !stringsOnly || arrayLength == 8) {
+        withTempPath { dir =>
+          withTempTable("concat_inputs") {
+            withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
+              spark
+                .sql(s"""WITH strings AS (
+                  | SELECT id, CASE WHEN id % 13 = 0 THEN NULL
+                  | ELSE lpad(CAST(id AS STRING), $width, 'x') END AS c1
+                  | FROM range($rows)), arrays AS (
+                  | SELECT *, CASE WHEN id % 11 = 0 THEN NULL ELSE
+                  | transform(sequence(1, CAST(id % $arrayLength + 1 AS INT)),
+                  | j -> CASE WHEN j % 5 = 0 THEN NULL
+                  | ELSE concat(c1, CAST(j AS STRING)) END) END AS a1
+                  | FROM strings)
+                  | SELECT c1, a1, reverse(a1) AS a2,
+                  | CASE WHEN id % 17 = 0 THEN NULL WHEN id % 2 = 0 THEN '|'
+                  | ELSE '--' END AS sep FROM arrays""".stripMargin)
+                .coalesce(1)
+                .write
+                .parquet(dir.getCanonicalPath)
+            }
+            spark.read.parquet(dir.getCanonicalPath).createOrReplaceTempView("concat_inputs")
+            val expressions =
+              (if (arrayLength == 8) Seq("strings" -> "c1, c1") else Seq.empty) ++
+                (if (stringsOnly) Seq.empty else Seq("mixed" -> "a1, c1, a2, 'tail'"))
+            for ((shape, args) <- expressions; separator <- Seq("' '", "sep")) {
+              val query = s"SELECT concat_ws($separator, $args) FROM concat_inputs"
+              val name = s"concat_ws $shape width=$width arrayLength=$arrayLength sep=$separator"
+              withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
+                val plan = spark.sql(query).queryExecution.executedPlan
+                require(plan.find(_.isInstanceOf[WholeStageCodegenExec]).nonEmpty)
+                require(plan.toString.contains("concat_ws"))
+                // scalastyle:off println
+                println(s"$name Spark plan:\n$plan")
+                // scalastyle:on println
+              }
+              withSQLConf(nativeConfigs.toSeq: _*) {
+                val df = spark.sql(query)
+                df.noop()
+                val plan = df.queryExecution.executedPlan
+                require(findFirstNonCometOperator(plan).isEmpty, plan.toString)
+                // scalastyle:off println
+                println(s"$name Comet plan (codegen dispatch disabled):\n$plan")
+                // scalastyle:on println
+              }
+              runBenchmark(name) {
+                runExpressionBenchmark(name, rows, query, nativeConfigs)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometConcatWsBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometConcatWsBenchmark.scala
@@ -23,25 +23,31 @@ import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.internal.SQLConf
 
 import org.apache.comet.CometConf
+import org.apache.comet.udf.codegen.CometScalaUDFCodegen
 
 /**
  * Matched Parquet inputs for native concat_ws versus Spark whole-stage codegen. Pass `strings` to
- * run only the previously supported string cases against an older native library.
+ * run only the previously supported string cases against an older native library. `long-arrays`
+ * selects width 128 and lengths up to 32. `dispatch` requires the pre-native concat_ws serde on
+ * the classpath and verifies that the old default dispatcher actually ran.
  */
 object CometConcatWsBenchmark extends CometBenchmarkBase {
   override def runCometBenchmark(mainArgs: Array[String]): Unit = {
     val rows = 65536
     val stringsOnly = mainArgs.contains("strings")
-    val nativeConfigs = Map(
+    val longArraysOnly = mainArgs.contains("long-arrays")
+    val dispatch = mainArgs.contains("dispatch")
+    val cometConfigs = Map(
       CometConf.COMET_ENABLED.key -> "true",
       CometConf.COMET_EXEC_ENABLED.key -> "true",
-      CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> "false")
+      CometConf.COMET_SCALA_UDF_CODEGEN_ENABLED.key -> dispatch.toString)
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
       SQLConf.PARQUET_VECTORIZED_READER_BATCH_SIZE.key -> "8192",
       CometConf.COMET_BATCH_SIZE.key -> "8192") {
       for (width <- Seq(8, 128); arrayLength <- Seq(2, 8, 32)
-        if !stringsOnly || arrayLength == 8) {
+        if (!stringsOnly || arrayLength == 8) &&
+          (!longArraysOnly || (width == 128 && arrayLength == 32))) {
         withTempPath { dir =>
           withTempTable("concat_inputs") {
             withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
@@ -77,17 +83,22 @@ object CometConcatWsBenchmark extends CometBenchmarkBase {
                 println(s"$name Spark plan:\n$plan")
                 // scalastyle:on println
               }
-              withSQLConf(nativeConfigs.toSeq: _*) {
+              withSQLConf(cometConfigs.toSeq: _*) {
+                CometScalaUDFCodegen.resetStats()
                 val df = spark.sql(query)
                 df.noop()
+                val stats = CometScalaUDFCodegen.stats()
+                require(
+                  (stats.compileCount + stats.cacheHitCount > 0) == dispatch,
+                  stats.toString)
                 val plan = df.queryExecution.executedPlan
                 require(findFirstNonCometOperator(plan).isEmpty, plan.toString)
                 // scalastyle:off println
-                println(s"$name Comet plan (codegen dispatch disabled):\n$plan")
+                println(s"$name Comet plan (dispatch=$dispatch, stats=$stats):\n$plan")
                 // scalastyle:on println
               }
               runBenchmark(name) {
-                runExpressionBenchmark(name, rows, query, nativeConfigs)
+                runExpressionBenchmark(name, rows, query, cometConfigs)
               }
             }
           }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5687.

## Rationale for this change

Expressions such as `concat_ws(',', array_col, string_col)` currently run through Comet's JVM codegen dispatcher, or fall back to Spark when dispatch is disabled. This PR adds native execution using the `SparkConcatWs` implementation in DataFusion Spark 55.

## What changes are included in this PR?

Array arguments and calls containing only a separator use a `spark_concat_ws` adapter with Spark's analyzed return type. When every argument is a runtime scalar, the adapter evaluates one row and returns a scalar for DataFusion to broadcast. This handles non-foldable scalar subqueries without the upstream kernel indexing past a one-row array. Ordinary string arguments use DataFusion's string kernel.

The PR adds Rust and Spark regressions, updates expression documentation, and adds a benchmark comparing native execution, the existing JVM dispatcher and pure Spark. The `implement-comet-expression` skill was used to scaffold the implementation workflow.

## How are these changes tested?

Both Rust regressions and all three focused Spark 4.0.4 tests pass. Coverage includes mixed strings and arrays, argument order, multiple arrays, nulls, empty values, Unicode, column separators and scalar subqueries across a batch. The SQL-file test contains 16 queries. The Scala regressions disable codegen dispatch to verify native execution, and the runtime-scalar regression reproduced the panic before the fix.

Debug and release native builds, workspace Clippy with `-D warnings`, JVM compilation, Spotless and Spark 4.0 semantic Scalafix pass. The benchmark verifies physical plans and dispatcher activity.

Native array routing is the proposed default because the comparison with the existing dispatcher favors it: mean times are 3–7% lower with a literal separator and 18–23% lower with a column separator. The literal results have substantial variance, so confidence in that small improvement is limited. Native took 11–21% longer than pure Spark in the longest-array literal cases in the earlier matrix. String-only comparisons show no consistent regression.

The table below uses 65,536 rows, 128-character strings and two arrays varying from 1–32 elements. Times are mean ± standard deviation in milliseconds. Each JVM includes its own pure-Spark control; run order is dispatch-1, native-1, native-2, dispatch-2.

| Pair | Separator | Spark in dispatch JVM | Old Comet dispatcher | Spark in native JVM | Native Comet | Native mean reduction vs dispatcher |
|---:|---|---:|---:|---:|---:|---:|
| 1 | literal | 123 ± 4 | 176 ± 2 | 136 ± 8 | 171 ± 75 | 2.8% |
| 1 | column | 117 ± 1 | 173 ± 3 | 119 ± 5 | 133 ± 9 | 23.1% |
| 2 | literal | 128 ± 7 | 185 ± 5 | 151 ± 38 | 172 ± 11 | 7.0% |
| 2 | column | 122 ± 4 | 170 ± 3 | 122 ± 7 | 140 ± 3 | 17.6% |

The plan for the remaining gap to pure Spark is to profile allocation and copying, then test an upstream output capacity estimate against the current 16-byte-per-row reservation. The estimate would account for string/list buffers, nulls, separators and repeated scalar arguments. Both short and long inputs must benefit after including the sizing cost. If reallocations do not explain the gap, scalar expansion and list-row slicing are the next areas to profile. The cause has not yet been established.

<details>
<summary>Benchmark setup and reproduction</summary>

Measurements used an Apple M4 with 24 GiB RAM, macOS 26.6.2, Zulu JDK 21.0.6 and Spark 4.0.4. Each fresh JVM used a 4 GiB heap, `local[1]`, one Comet worker, AQE disabled and 8,192-row batches for both readers. Cargo release builds used the same flags without `target-cpu=native`. Timing includes Parquet scanning, projection and the noop sink. Background desktop applications contribute to the reported variance.

Inputs are deterministic and stored in one Parquet file. Every 13th string and 11th array is NULL; every fifth array element is NULL. The column separator alternates `|` and `--`, with NULL every 17th row. The expressions are `concat_ws(separator, a1, c1, a2, 'tail')` and `concat_ws(separator, c1, c1)`.

The dispatcher comparison uses the same release library and JVM classes for both Comet paths, with only `CometConcatWs` overridden by the serializer compiled from parent `75fdddc9285ec61c0cd326977c61dd41fca39a8b`. Spark plans contain `WholeStageCodegenExec` and `concat_ws`; Comet plans contain `CometProject` over `CometNativeScan`. Dispatcher checks report `DispatcherStats(1,7,1)` for literal separators and `DispatcherStats(1,7,2)` for column separators. Native checks report `DispatcherStats(0,0,0)`. All four JVMs completed through the same launcher, which calls `System.exit(0)` after benchmark main returns to release an attached native worker.

Run the suite with:

```sh
make benchmark-org.apache.spark.sql.benchmark.CometConcatWsBenchmark PROFILES=-Pspark-4.0 BENCH_HEAP=4g
```

Pass `strings` for the string-only cases or `long-arrays` for the long-array fixture. For the old default, compile the parent's unmodified `strings.scala` with the Spark 4.0 reactor profile, save `CometConcatWs.class` and `CometConcatWs$.class`, then restore and compile the PR sources. Put the saved classes first on the classpath and pass `long-arrays dispatch`. The benchmark asserts that the dispatcher ran.

The reported runs launch the benchmark directly with the reactor test classpath, an explicit `java.library.path`, and JVM options from `make print-benchmark-args`. The normal make target adds `target-cpu=native`; use identical build flags when repeating comparisons.

Artifact SHA-256 values:

| Artifact | SHA-256 |
|---|---|
| Release library used by both dispatcher and native comparisons | `3dad10e0a2d7d51ef67bec0b01ede096e771f91c79be6b1fc441e4fedc0f7d67` |
| Parent release library used by string-only controls | `ffe3b864c56bbfa2620250d1591380965d06733b7fc0b9581f8c64f1c9d346dd` |
| Parent serializer module | `cb7f43f323bd591893e571124fe506052f982475466c791351f6c249de1ba5e1` |

</details>

<details>
<summary>Full native-versus-Spark matrix and string-only controls</summary>

The array matrix covers string widths of 8 and 128 and maximum array lengths of 2, 8 and 32. Both runs use native execution with dispatch disabled. Times are mean ± standard deviation in milliseconds; the ratio is Spark mean / Comet mean.

| Run | Width | Maximum array length | Separator | Spark (ms) | Comet (ms) | Ratio |
|---:|---:|---:|---|---:|---:|---:|
| 1 | 8 | 2 | literal | 35 ± 5 | 25 ± 4 | 1.40x |
| 1 | 8 | 2 | column | 48 ± 12 | 30 ± 8 | 1.60x |
| 1 | 8 | 8 | literal | 63 ± 42 | 47 ± 66 | 1.34x |
| 1 | 8 | 8 | column | 82 ± 76 | 39 ± 8 | 2.10x |
| 1 | 8 | 32 | literal | 113 ± 37 | 71 ± 12 | 1.59x |
| 1 | 8 | 32 | column | 106 ± 11 | 59 ± 6 | 1.80x |
| 1 | 128 | 2 | literal | 33 ± 2 | 25 ± 2 | 1.32x |
| 1 | 128 | 2 | column | 34 ± 4 | 25 ± 2 | 1.36x |
| 1 | 128 | 8 | literal | 51 ± 5 | 61 ± 17 | 0.84x |
| 1 | 128 | 8 | column | 61 ± 11 | 61 ± 33 | 1.00x |
| 1 | 128 | 32 | literal | 126 ± 7 | 153 ± 11 | 0.82x |
| 1 | 128 | 32 | column | 137 ± 12 | 143 ± 7 | 0.96x |
| 2 | 8 | 2 | literal | 28 ± 2 | 23 ± 5 | 1.22x |
| 2 | 8 | 2 | column | 26 ± 1 | 22 ± 3 | 1.18x |
| 2 | 8 | 8 | literal | 39 ± 6 | 25 ± 1 | 1.56x |
| 2 | 8 | 8 | column | 35 ± 2 | 25 ± 2 | 1.40x |
| 2 | 8 | 32 | literal | 75 ± 5 | 49 ± 2 | 1.53x |
| 2 | 8 | 32 | column | 72 ± 2 | 50 ± 2 | 1.44x |
| 2 | 128 | 2 | literal | 28 ± 1 | 22 ± 3 | 1.27x |
| 2 | 128 | 2 | column | 27 ± 2 | 22 ± 4 | 1.23x |
| 2 | 128 | 8 | literal | 47 ± 4 | 44 ± 2 | 1.07x |
| 2 | 128 | 8 | column | 47 ± 4 | 46 ± 7 | 1.02x |
| 2 | 128 | 32 | literal | 114 ± 6 | 126 ± 5 | 0.90x |
| 2 | 128 | 32 | column | 114 ± 5 | 116 ± 4 | 0.98x |

For string-only controls, “before” uses the native factory from parent `75fdddc9285ec61c0cd326977c61dd41fca39a8b`, and “after” uses this PR. Each run uses the same benchmark and inputs in a fresh JVM. Order: before-1, after-1, before-2, after-2, matrix-1, matrix-2.

| Run | Width | Separator | Spark before (ms) | Comet before (ms) | Spark after (ms) | Comet after (ms) |
|---:|---:|---|---:|---:|---:|---:|
| 1 | 8 | literal | 31 ± 22 | 15 ± 2 | 22 ± 3 | 14 ± 2 |
| 1 | 8 | column | 19 ± 2 | 13 ± 2 | 19 ± 3 | 12 ± 1 |
| 1 | 128 | literal | 25 ± 13 | 13 ± 2 | 22 ± 18 | 12 ± 1 |
| 1 | 128 | column | 18 ± 1 | 12 ± 2 | 18 ± 1 | 11 ± 1 |
| 2 | 8 | literal | 22 ± 2 | 13 ± 1 | 21 ± 2 | 13 ± 2 |
| 2 | 8 | column | 26 ± 7 | 14 ± 2 | 18 ± 2 | 12 ± 1 |
| 2 | 128 | literal | 28 ± 7 | 19 ± 4 | 18 ± 2 | 19 ± 13 |
| 2 | 128 | column | 26 ± 10 | 14 ± 3 | 21 ± 4 | 12 ± 1 |

</details>
