### PR TITLE
fix: distinguish "nothing spilled" from a spill backend with no local path

### DIFF
--- a/native/shuffle/src/shuffle_writer.rs
+++ b/native/shuffle/src/shuffle_writer.rs
@@ -856,7 +856,7 @@ mod test {
             .partition_writer()
             .get_spill_writers()
             .iter()
-            .filter_map(|writer| writer.path())
+            .filter_map(|writer| writer.path().unwrap())
             .map(|path| usize::try_from(std::fs::metadata(path).unwrap().len()).unwrap())
             .sum();
         assert_eq!(

--- a/native/shuffle/src/writers/local/local_partition_writer.rs
+++ b/native/shuffle/src/writers/local/local_partition_writer.rs
@@ -240,7 +240,7 @@ impl PartitionWriter for LocalPartitionWriter {
                 // if we wrote a spill file for this partition then copy the
                 // contents into the shuffle file
                 if let Some(writer) = spill_writers.get(pid) {
-                    if let Some(spill_path) = writer.path() {
+                    if let Some(spill_path) = writer.path()? {
                         // Use raw File handle (not BufReader) so that std::io::copy
                         // can use copy_file_range/sendfile for zero-copy on Linux.
                         let mut spill_file = File::open(spill_path)?;
@@ -330,25 +330,30 @@ impl PartitionWriter for LocalPartitionWriter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::writers::local::spill::pathless_backend;
     use crate::CompressionCodec;
     use arrow::array::Int64Array;
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 
-    /// A partition whose batch iterator fails after a batch was already encoded must hand
-    /// back a drained scratch; leftover bytes would land in the next partition's block.
-    #[test]
-    fn finish_partition_error_drains_recycled_buffer() {
+    fn test_batch() -> RecordBatch {
         let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
-        let batch = RecordBatch::try_new(
+        RecordBatch::try_new(
             Arc::clone(&schema),
             vec![Arc::new(Int64Array::from_iter_values(0..100))],
         )
-        .unwrap();
+        .unwrap()
+    }
+
+    fn partition_writer(
+        batch: &RecordBatch,
+        dir: &tempfile::TempDir,
+        runtime: Arc<RuntimeEnv>,
+    ) -> LocalPartitionWriter {
         let block_writer =
-            ShuffleBlockWriter::try_new(schema.as_ref(), CompressionCodec::None).unwrap();
-        let dir = tempfile::tempdir().unwrap();
-        let mut writer = LocalPartitionWriter::try_new(
+            ShuffleBlockWriter::try_new(batch.schema_ref().as_ref(), CompressionCodec::None)
+                .unwrap();
+        LocalPartitionWriter::try_new(
             dir.path().join("data.out").to_str().unwrap().to_string(),
             dir.path().join("index.out").to_str().unwrap().to_string(),
             block_writer,
@@ -356,9 +361,18 @@ mod tests {
             // batch_size below the row count so the write serializes into the scratch.
             10,
             1 << 20,
-            Arc::new(RuntimeEnv::default()),
+            runtime,
         )
-        .unwrap();
+        .unwrap()
+    }
+
+    /// A partition whose batch iterator fails after a batch was already encoded must hand
+    /// back a drained scratch; leftover bytes would land in the next partition's block.
+    #[test]
+    fn finish_partition_error_drains_recycled_buffer() {
+        let batch = test_batch();
+        let dir = tempfile::tempdir().unwrap();
+        let mut writer = partition_writer(&batch, &dir, Arc::new(RuntimeEnv::default()));
 
         let metrics = ShufflePartitionerMetrics::new(&ExecutionPlanMetricsSet::new(), 0);
         let mut iter = vec![
@@ -378,5 +392,28 @@ mod tests {
             ),
             DataOutput::Single { .. } => unreachable!("two partitions use the multi output"),
         }
+    }
+
+    /// Spilled bytes the writer cannot reach must fail the task. Skipping the copy the way
+    /// an unspilled partition is skipped would leave the offsets claiming bytes that were
+    /// never written, so the reader would decode the next partition's block as this one's.
+    #[test]
+    fn finish_partition_fails_when_spill_has_no_local_path() {
+        let batch = test_batch();
+        let dir = tempfile::tempdir().unwrap();
+        let mut writer = partition_writer(&batch, &dir, Arc::new(pathless_backend::runtime()));
+        let metrics = ShufflePartitionerMetrics::new(&ExecutionPlanMetricsSet::new(), 0);
+
+        writer
+            .write(0, &mut vec![Ok(batch)].into_iter(), &metrics)
+            .unwrap();
+
+        let err = writer
+            .finish_partition(0, &mut std::iter::empty(), &metrics)
+            .expect_err("unreachable spilled data must fail rather than truncate the partition");
+        assert!(
+            err.to_string().contains("no local path"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/native/shuffle/src/writers/local/spill.rs
+++ b/native/shuffle/src/writers/local/spill.rs
@@ -123,15 +123,113 @@ impl SpillWriter {
         Ok(())
     }
 
-    pub(crate) fn path(&self) -> Option<&std::path::Path> {
-        self.spill_file
-            .as_ref()
-            .and_then(|spill_file| spill_file.temp_file.path())
+    /// Local filesystem path holding this partition's spilled bytes.
+    ///
+    /// * `Ok(None)` — nothing was spilled for this partition.
+    /// * `Ok(Some(path))` — the spilled bytes live at `path`.
+    /// * `Err(..)` — bytes were spilled but the backend exposes no local path.
+    ///
+    /// The last case must stay distinct from `Ok(None)`: a caller that treated it as
+    /// "nothing to copy" would drop the spilled bytes while still recording the
+    /// partition offsets, silently truncating the partition in the shuffle file.
+    pub(crate) fn path(&self) -> datafusion::common::Result<Option<&std::path::Path>> {
+        match self.spill_file.as_ref() {
+            None => Ok(None),
+            Some(spill_file) => match spill_file.temp_file.path() {
+                Some(path) => Ok(Some(path)),
+                None => Err(DataFusionError::Execution(
+                    "Shuffle spill file has no local path; the shuffle writer requires a \
+                     spill backend backed by local files."
+                        .to_string(),
+                )),
+            },
+        }
     }
 
     #[cfg(test)]
     pub(crate) fn has_spill_file(&self) -> bool {
         self.spill_file.is_some()
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod pathless_backend {
+    //! A spill backend that stores bytes somewhere other than the local filesystem, so
+    //! `SpillFile::path()` returns `None`. `DiskManager`'s default backend always has a
+    //! local path, but `TempFileFactory` is pluggable, so the shuffle writer has to cope
+    //! with a backend that does not.
+
+    use bytes::Bytes;
+    use datafusion::common::DataFusionError;
+    use datafusion::execution::disk_manager::DiskManagerBuilder;
+    use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
+    use datafusion::execution::{SpillFile, SpillWriter, TempFileFactory};
+    use futures::Stream;
+    use std::pin::Pin;
+    use std::sync::Arc;
+
+    /// A [`RuntimeEnv`] whose spill files report no local path.
+    pub(crate) fn runtime() -> RuntimeEnv {
+        RuntimeEnvBuilder::new()
+            .with_disk_manager_builder(
+                DiskManagerBuilder::default().with_temp_file_factory(Arc::new(PathlessFactory)),
+            )
+            .build()
+            .unwrap()
+    }
+
+    struct PathlessFactory;
+
+    impl TempFileFactory for PathlessFactory {
+        fn create_temp_file(
+            &self,
+            _description: &str,
+        ) -> datafusion::common::Result<Arc<dyn SpillFile>> {
+            Ok(Arc::new(PathlessSpillFile))
+        }
+    }
+
+    struct PathlessSpillFile;
+
+    impl SpillFile for PathlessSpillFile {
+        // `path()` is left at the trait default, which returns `None`.
+
+        fn size(&self) -> Option<u64> {
+            None
+        }
+
+        fn read_stream(
+            &self,
+        ) -> datafusion::common::Result<
+            Pin<Box<dyn Stream<Item = datafusion::common::Result<Bytes>> + Send>>,
+        > {
+            Err(DataFusionError::NotImplemented(
+                "PathlessSpillFile::read_stream".to_string(),
+            ))
+        }
+
+        fn open_writer(&self) -> datafusion::common::Result<Box<dyn SpillWriter>> {
+            Ok(Box::new(SinkWriter))
+        }
+    }
+
+    /// Accepts and discards every byte, standing in for a backend that writes elsewhere.
+    struct SinkWriter;
+
+    impl std::io::Write for SinkWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl SpillWriter for SinkWriter {
+        fn finish(&mut self) -> datafusion::common::Result<()> {
+            Ok(())
+        }
     }
 }
 
@@ -144,20 +242,29 @@ mod tests {
     use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
     use std::sync::Arc;
 
+    fn test_batch() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+        RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from_iter_values(0..100))],
+        )
+        .unwrap()
+    }
+
+    fn spill_writer(batch: &RecordBatch, batch_size: usize) -> SpillWriter {
+        let block_writer =
+            ShuffleBlockWriter::try_new(batch.schema_ref().as_ref(), CompressionCodec::None)
+                .unwrap();
+        SpillWriter::try_new(block_writer, 1 << 20, batch_size).unwrap()
+    }
+
     /// A spill whose batch iterator fails after a batch was already encoded must hand
     /// back a drained scratch; leftover bytes would land in the next partition's block.
     #[test]
     fn write_error_drains_recycled_buffer() {
-        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![Arc::new(Int64Array::from_iter_values(0..100))],
-        )
-        .unwrap();
-        let block_writer =
-            ShuffleBlockWriter::try_new(schema.as_ref(), CompressionCodec::None).unwrap();
+        let batch = test_batch();
         // batch_size below the row count so the first write serializes into the scratch.
-        let mut spill = SpillWriter::try_new(block_writer, 1 << 20, 10).unwrap();
+        let mut spill = spill_writer(&batch, 10);
         let runtime = RuntimeEnv::default();
         let metrics = ShufflePartitionerMetrics::new(&ExecutionPlanMetricsSet::new(), 0);
         let mut recycled = Vec::new();
@@ -174,6 +281,40 @@ mod tests {
             recycled.is_empty(),
             "errored spill left {} bytes in the recycled buffer",
             recycled.len()
+        );
+    }
+
+    /// A partition that never spilled has no path, and that is not an error.
+    #[test]
+    fn path_is_none_when_nothing_spilled() {
+        let batch = test_batch();
+        let spill = spill_writer(&batch, 10);
+        assert!(!spill.has_spill_file());
+        assert_eq!(spill.path().unwrap(), None);
+    }
+
+    /// Spilling to a backend with no local path must report an error rather than the
+    /// `None` that means "nothing spilled" — see `path`'s doc comment.
+    #[test]
+    fn path_errors_when_backend_has_no_local_path() {
+        let batch = test_batch();
+        let mut spill = spill_writer(&batch, 10);
+        let runtime = pathless_backend::runtime();
+        let metrics = ShufflePartitionerMetrics::new(&ExecutionPlanMetricsSet::new(), 0);
+        let mut recycled = Vec::new();
+        let mut iter = vec![Ok(batch)].into_iter();
+
+        spill
+            .write(&mut iter, &runtime, &metrics, &mut recycled)
+            .unwrap();
+        assert!(spill.has_spill_file());
+
+        let err = spill
+            .path()
+            .expect_err("a spill file with no local path must not look like an empty partition");
+        assert!(
+            err.to_string().contains("no local path"),
+            "unexpected error: {err}"
         );
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5705.

## Rationale for this change

`SpillWriter::path()` returned `Option<&Path>`, which folds two different situations into `None`:

- nothing was spilled for this partition (`spill_file` is `None`), and
- a spill file exists but its backend exposes no local path (`SpillFile::path()` is `None`).

`LocalPartitionWriter::finish_partition` reads `None` as "nothing to copy" and moves on, but `self.offsets[pid]` and the trailing total length keep advancing. A pathless backend would therefore write an index claiming bytes that never landed in the data file, so the reader would decode the next partition's block as this one's — a corrupt shuffle file rather than an error.

This is not reachable today: the default `DiskManager` backend always hands back a spill file with a local path. But `TempFileFactory` is pluggable, so a future or custom backend could return `None`, and this should fail loudly rather than silently truncate.

## What changes are included in this PR?

- `SpillWriter::path()` now returns `datafusion::common::Result<Option<&Path>>`, keeping the three outcomes distinct: `Ok(None)` for nothing spilled, `Ok(Some(path))` for reachable spilled bytes, and `Err(..)` for spilled-but-pathless.
- The `finish_partition` call site becomes `writer.path()?`, so an unreachable spill file fails the shuffle task instead of skipping the copy.

## How are these changes tested?

Three new unit tests, plus a test-only spill backend (`pathless_backend`) that installs a `TempFileFactory` whose `SpillFile` leaves `path()` at the trait default and sinks its bytes, via `DiskManagerBuilder::with_temp_file_factory`:

- `path_is_none_when_nothing_spilled` — the benign case stays benign.
- `path_errors_when_backend_has_no_local_path` — asserts `has_spill_file()` before checking the error, so the test cannot pass vacuously by simply never spilling.
- `finish_partition_fails_when_spill_has_no_local_path` — covers the corruption path end to end through `LocalPartitionWriter`.

I checked the end-to-end test is not vacuous by temporarily swapping `writer.path()?` back to a lenient `unwrap_or(None)`: the test fails there and passes again once the `?` is restored.

`cargo test -p datafusion-comet-shuffle` passes (124 tests), and `cargo clippy -p datafusion-comet-shuffle --all-targets -- -D warnings` is clean.