### PR TITLE
feat: Add Lance contrib build gate

### DIFF
--- a/contrib/lance/native/Cargo.toml
+++ b/contrib/lance/native/Cargo.toml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+name = "comet-contrib-lance"
+description = "Native Lance scan integration for Apache DataFusion Comet"
+version = "1.1.0"
+edition = "2021"
+rust-version = "1.94"
+publish = false
+license = "Apache-2.0"
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+datafusion = { version = "55.0.0", default-features = false }
+datafusion-comet-proto = { path = "../../../native/proto" }

--- a/contrib/lance/native/src/lib.rs
+++ b/contrib/lance/native/src/lib.rs
@@ -1,0 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+pub mod planner;

--- a/contrib/lance/native/src/planner.rs
+++ b/contrib/lance/native/src/planner.rs
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::error::DataFusionError;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion_comet_proto::spark_operator::{LanceScanCommon, LanceScanPartition};
+
+pub fn plan_lance_scan(
+    _common: &LanceScanCommon,
+    _partition: &LanceScanPartition,
+    _output_schema: &SchemaRef,
+) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    Err(DataFusionError::NotImplemented(
+        "contrib-lance native Lance read path is not yet implemented (build-gate stub)".to_string(),
+    ))
+}

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1481,6 +1481,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "comet-contrib-lance"
+version = "1.1.0"
+dependencies = [
+ "datafusion",
+ "datafusion-comet-proto",
+]
+
+[[package]]
 name = "comfy-table"
 version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1966,6 +1974,7 @@ dependencies = [
  "base64 0.23.1",
  "bytes",
  "comet-contrib-delta",
+ "comet-contrib-lance",
  "criterion",
  "datafusion",
  "datafusion-comet-common",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -18,9 +18,8 @@
 [workspace]
 default-members = ["core", "spark-expr", "common", "proto", "jni-bridge", "shuffle"]
 members = ["core", "spark-expr", "common", "proto", "jni-bridge", "shuffle"]
-# The contrib crate at ../contrib/delta/native is intentionally NOT a workspace member
-# (workspace members must live hierarchically under the workspace root). It's pulled in
-# as a path dep by `core/Cargo.toml` when the `contrib-delta` feature is enabled.
+# Crates under ../contrib are intentionally NOT workspace members. Core pulls them in as
+# optional path dependencies when their corresponding contrib feature is enabled.
 exclude = ["../contrib"]
 resolver = "2"
 

--- a/native/core/Cargo.toml
+++ b/native/core/Cargo.toml
@@ -72,6 +72,8 @@ parking_lot = "0.12.5"
 # Optional Delta Lake contrib (enabled by the `contrib-delta` feature). Source lives
 # under `contrib/delta/native/` so non-Delta committers can ignore it.
 comet-contrib-delta = { path = "../../contrib/delta/native", optional = true }
+# Optional Lance contrib. The native scan implementation lives outside core.
+comet-contrib-lance = { path = "../../contrib/lance/native", optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "http2"] }
 object_store_opendal = { version = "0.58.0", optional = true }
 hdfs-sys = {version = "0.3", optional = true, features = ["hdfs_3_3"]}
@@ -104,6 +106,7 @@ datafusion-functions-nested = { version = "55.1.0" }
 [features]
 backtrace = ["datafusion/backtrace"]
 default = ["hdfs-opendal"]
+contrib-lance = ["dep:comet-contrib-lance"]
 hdfs-opendal = ["opendal", "object_store_opendal", "hdfs-sys"]
 jemalloc = ["tikv-jemallocator", "tikv-jemalloc-ctl"]
 # Delta Lake integration. When enabled, links the `comet-contrib-delta` crate

--- a/native/core/src/execution/planner.rs
+++ b/native/core/src/execution/planner.rs
@@ -29,6 +29,8 @@ pub mod operator_registry;
 // and calls into that crate.
 #[cfg(feature = "contrib-delta")]
 mod delta_scan;
+#[cfg(feature = "contrib-lance")]
+mod lance_scan;
 
 use crate::execution::operators::init_csv_datasource_exec;
 use crate::execution::operators::AlignedArrowStreamReader;
@@ -1876,10 +1878,14 @@ impl PhysicalPlanner {
                 if let Some(result) = delta_scan::try_plan_contrib_scan(self, spark_plan, contrib) {
                     return result;
                 }
+                #[cfg(feature = "contrib-lance")]
+                if let Some(result) = lance_scan::try_plan_contrib_scan(self, spark_plan, contrib) {
+                    return result;
+                }
                 Err(GeneralError(format!(
                     "Received a contrib_scan operator (type_url: {}) but core was built without a \
-                     contrib that handles it. Rebuild with the matching contrib feature -- e.g. \
-                     `-Pcontrib-delta` (Maven) + `--features contrib-delta` (Cargo) for Delta Lake.",
+                     contrib that handles it. Rebuild with the matching Maven profile and Cargo \
+                     feature.",
                     contrib.type_url
                 )))
             }

--- a/native/core/src/execution/planner/lance_scan.rs
+++ b/native/core/src/execution/planner/lance_scan.rs
@@ -1,0 +1,66 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use datafusion_comet_proto::spark_operator::{ContribScan, LanceScan, Operator};
+use prost::Message;
+
+use crate::execution::operators::ExecutionError::GeneralError;
+use crate::execution::planner::{
+    convert_spark_types_to_arrow_schema, PhysicalPlanner, PlanCreationResult,
+};
+use crate::execution::spark_plan::SparkPlan;
+
+const LANCE_SCAN_TYPE_NAME: &str = "comet.contrib.lance.LanceScan";
+
+pub(crate) fn try_plan_contrib_scan(
+    _planner: &PhysicalPlanner,
+    spark_plan: &Operator,
+    contrib: &ContribScan,
+) -> Option<PlanCreationResult> {
+    if !contrib.type_url.ends_with(LANCE_SCAN_TYPE_NAME) {
+        return None;
+    }
+
+    Some(
+        LanceScan::decode(contrib.value.as_slice())
+            .map_err(|e| GeneralError(format!("Failed to decode LanceScan: {e}")))
+            .and_then(|scan| plan_lance_scan(spark_plan, &scan)),
+    )
+}
+
+fn plan_lance_scan(spark_plan: &Operator, scan: &LanceScan) -> PlanCreationResult {
+    let common = scan
+        .common
+        .as_ref()
+        .ok_or_else(|| GeneralError("LanceScan missing common data".into()))?;
+    let partition = scan
+        .partition
+        .as_ref()
+        .ok_or_else(|| GeneralError("LanceScan missing partition data".into()))?;
+    let output_schema = convert_spark_types_to_arrow_schema(common.projected_schema.as_slice());
+
+    let exec = comet_contrib_lance::planner::plan_lance_scan(common, partition, &output_schema)
+        .map_err(|e| GeneralError(e.to_string()))?;
+
+    Ok((
+        vec![],
+        vec![],
+        Arc::new(SparkPlan::new(spark_plan.plan_id, exec, vec![])),
+    ))
+}

--- a/native/proto/src/proto/operator.proto
+++ b/native/proto/src/proto/operator.proto
@@ -356,6 +356,32 @@ message IcebergScan {
   repeated IcebergFileScanTask file_scan_tasks = 2;
 }
 
+// Common data shared by all partitions for native Lance scans.
+message LanceScanCommon {
+  string scan_id = 1;
+  repeated SparkStructField required_schema = 2;
+  string native_scan_plan_class = 3;
+  string dataset_uri = 4;
+  int64 resolved_version = 5;
+  map<string, string> storage_options = 6;
+  repeated SparkStructField projected_schema = 7;
+  optional string filter_sql = 8;
+  optional int64 limit = 9;
+  optional int64 offset = 10;
+  uint32 batch_size = 11;
+  uint32 descriptor_version = 12;
+}
+
+message LanceScanPartition {
+  uint32 partition_index = 1;
+  repeated uint32 fragment_ids = 2;
+}
+
+message LanceScan {
+  LanceScanCommon common = 1;
+  LanceScanPartition partition = 2;
+}
+
 // Helper message for deduplicating field ID lists
 message ProjectFieldIdList {
   repeated int32 field_ids = 1;


### PR DESCRIPTION
## Which issue does this PR close?

Part of #4632.

## Rationale for this change

Native Lance reads need an optional contrib boundary that does not add Lance dependencies or runtime behavior to default Comet builds. This separates the build and planner wiring from the later native reader implementation, following the existing Delta build-gate pattern.

## What changes are included in this PR?

- Adds an optional `comet-contrib-lance` crate and `contrib-lance` Cargo feature.
- Adds the typed Lance scan payload and a feature-gated native planner dispatch.
- Adds an inert Lance planner entry point that returns `NotImplemented`, allowing Spark fallback until the real reader lands.
- Does not depend on the Lance Rust crate and does not change default Comet runtime behavior.

The native Lance reader prototype in #4633 will be rebased on top of this PR.

## How are these changes tested?

- `cargo check -p datafusion-comet --locked`
- `cargo check -p datafusion-comet --features contrib-lance --locked`
- `cargo check -p datafusion-comet --no-default-features --locked`
- `cargo check -p datafusion-comet --no-default-features --features contrib-lance --locked`
- `cargo clippy -p datafusion-comet --no-default-features --features contrib-lance --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

No runtime test is added because this PR deliberately introduces no executable Lance read path; the feature-gated planner returns `NotImplemented`.