### PR TITLE
chore: add_benches hash function aggregators

### DIFF
--- a/native/spark-expr/Cargo.toml
+++ b/native/spark-expr/Cargo.toml
@@ -244,6 +244,14 @@ name = "abs"
 harness = false
 
 [[bench]]
+name = "murmur3"
+harness = false
+
+[[bench]]
+name = "xxhash64"
+harness = false
+
+[[bench]]
 name = "isnan"
 harness = false
 

--- a/native/spark-expr/benches/aggregate.rs
+++ b/native/spark-expr/benches/aggregate.rs
@@ -19,7 +19,8 @@ use arrow::array::builder::{Decimal128Builder, Int64Builder, StringBuilder};
 use arrow::array::{ArrayRef, Int64Array, RecordBatch};
 use arrow::datatypes::SchemaRef;
 use arrow::datatypes::{DataType, Field, Schema};
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use datafusion::common::ScalarValue;
 use datafusion::datasource::memory::MemorySourceConfig;
 use datafusion::datasource::source::DataSourceExec;
 use datafusion::execution::TaskContext;
@@ -28,16 +29,23 @@ use datafusion::functions_aggregate::sum::sum_udaf;
 use datafusion::logical_expr::function::AccumulatorArgs;
 use datafusion::logical_expr::{AggregateUDF, AggregateUDFImpl, EmitTo};
 use datafusion::physical_expr::aggregate::AggregateExprBuilder;
-use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::expressions::{Column, StatsType};
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy};
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion_comet_spark_expr::{AvgDecimal, EvalMode, SumDecimal, SumInteger};
+use datafusion_comet_spark_expr::{
+    hllpp_precision, ApproxPercentile, Avg, AvgDecimal, Correlation, Covariance, EvalMode,
+    HllPlusPlus, SparkPercentile, Stddev, SumDecimal, SumInteger, Variance,
+};
 use futures::StreamExt;
 use std::hint::black_box;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::Runtime;
+
+#[path = "common/mod.rs"]
+mod common;
+use common::{f64_array, i64_array, NULL_RATIOS, ROW_COUNTS};
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("aggregate");
@@ -266,6 +274,202 @@ fn criterion_benchmark(c: &mut Criterion) {
         });
     }
 
+    group.finish();
+
+    bench_statistical_aggregates(c);
+}
+
+/// Benchmarks for the Comet-owned aggregate kernels in `agg_funcs/` not covered above:
+/// `avg`, `variance` (pop/samp), `stddev` (pop/samp), `covariance` (pop/samp), `correlation`,
+/// `percentile`, `approx_percentile`, and `hll_plus_plus`. Each drives the `Accumulator` directly
+/// (`update_batch` + `evaluate`) so it measures the accumulator hot path, not scan/grouping.
+fn bench_statistical_aggregates(c: &mut Criterion) {
+    bench_f64_one_arg(c, "avg", DataType::Float64, || {
+        Box::new(Avg::new("avg", DataType::Float64))
+    });
+
+    bench_f64_one_arg(c, "variance_pop", DataType::Float64, || {
+        Box::new(Variance::new(
+            "var",
+            DataType::Float64,
+            StatsType::Population,
+            true,
+        ))
+    });
+    bench_f64_one_arg(c, "variance_samp", DataType::Float64, || {
+        Box::new(Variance::new(
+            "var",
+            DataType::Float64,
+            StatsType::Sample,
+            true,
+        ))
+    });
+
+    bench_f64_one_arg(c, "stddev_pop", DataType::Float64, || {
+        Box::new(Stddev::new(
+            "stddev",
+            DataType::Float64,
+            StatsType::Population,
+            true,
+        ))
+    });
+    bench_f64_one_arg(c, "stddev_samp", DataType::Float64, || {
+        Box::new(Stddev::new(
+            "stddev",
+            DataType::Float64,
+            StatsType::Sample,
+            true,
+        ))
+    });
+
+    bench_f64_two_arg(c, "covariance_pop", || {
+        Box::new(Covariance::new(
+            "covar",
+            DataType::Float64,
+            StatsType::Population,
+            true,
+        ))
+    });
+    bench_f64_two_arg(c, "covariance_samp", || {
+        Box::new(Covariance::new(
+            "covar",
+            DataType::Float64,
+            StatsType::Sample,
+            true,
+        ))
+    });
+    bench_f64_two_arg(c, "correlation", || {
+        Box::new(Correlation::new("corr", DataType::Float64, true))
+    });
+
+    bench_f64_one_arg(c, "percentile", DataType::Float64, || {
+        Box::new(SparkPercentile::try_new(0.5).unwrap())
+    });
+    bench_f64_one_arg(c, "approx_percentile", DataType::Float64, || {
+        Box::new(ApproxPercentile::new(
+            vec![0.5],
+            10_000,
+            DataType::Float64,
+            false,
+        ))
+    });
+
+    // hll_plus_plus counts approximate distinct values; feed it an Int64 key column.
+    let hll_fields = [Arc::new(Field::new("x", DataType::Int64, true))];
+    let precision = hllpp_precision(0.05);
+    let mut group = c.benchmark_group("hll_plus_plus");
+    for rows in ROW_COUNTS {
+        for (null_ratio, tag) in NULL_RATIOS {
+            let arrays = vec![i64_array(rows, null_ratio, |i| (i % 4096) as i64)];
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!("{rows}/{tag}")),
+                &arrays,
+                |b, arrays| {
+                    b.iter(|| {
+                        black_box(drive_accumulator(
+                            &HllPlusPlus::new(precision),
+                            &hll_fields,
+                            DataType::Int64,
+                            arrays,
+                        ))
+                    })
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+/// Build a fresh accumulator for `udf`, feed it `arrays` once, and return the aggregate result.
+/// A new accumulator is built per call because accumulators are stateful and cannot be reused.
+fn drive_accumulator(
+    udf: &dyn AggregateUDFImpl,
+    input_fields: &[Arc<Field>],
+    return_type: DataType,
+    arrays: &[ArrayRef],
+) -> ScalarValue {
+    let schema = Schema::new(
+        input_fields
+            .iter()
+            .map(|f| f.as_ref().clone())
+            .collect::<Vec<_>>(),
+    );
+    let acc_args = AccumulatorArgs {
+        return_field: Arc::new(Field::new("agg", return_type, true)),
+        schema: &schema,
+        ignore_nulls: false,
+        order_bys: &[],
+        name: "agg",
+        is_distinct: false,
+        is_reversed: false,
+        exprs: &[],
+        expr_fields: input_fields,
+    };
+    let mut acc = udf.accumulator(acc_args).unwrap();
+    acc.update_batch(arrays).unwrap();
+    acc.evaluate().unwrap()
+}
+
+/// Drive an aggregate that takes a single Float64 input column.
+fn bench_f64_one_arg(
+    c: &mut Criterion,
+    name: &str,
+    return_type: DataType,
+    make: impl Fn() -> Box<dyn AggregateUDFImpl>,
+) {
+    let fields = [Arc::new(Field::new("x", DataType::Float64, true))];
+    let mut group = c.benchmark_group(name);
+    for rows in ROW_COUNTS {
+        for (null_ratio, tag) in NULL_RATIOS {
+            let arrays = vec![f64_array(rows, null_ratio, |i| (i as f64).sin() * 1000.0)];
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!("{rows}/{tag}")),
+                &arrays,
+                |b, arrays| {
+                    b.iter(|| {
+                        black_box(drive_accumulator(
+                            make().as_ref(),
+                            &fields,
+                            return_type.clone(),
+                            arrays,
+                        ))
+                    })
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+/// Drive an aggregate that takes two Float64 input columns (covariance / correlation).
+fn bench_f64_two_arg(c: &mut Criterion, name: &str, make: impl Fn() -> Box<dyn AggregateUDFImpl>) {
+    let fields = [
+        Arc::new(Field::new("x", DataType::Float64, true)),
+        Arc::new(Field::new("y", DataType::Float64, true)),
+    ];
+    let mut group = c.benchmark_group(name);
+    for rows in ROW_COUNTS {
+        for (null_ratio, tag) in NULL_RATIOS {
+            let arrays = vec![
+                f64_array(rows, null_ratio, |i| (i as f64).sin() * 1000.0),
+                f64_array(rows, null_ratio, |i| (i as f64).cos() * 1000.0),
+            ];
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!("{rows}/{tag}")),
+                &arrays,
+                |b, arrays| {
+                    b.iter(|| {
+                        black_box(drive_accumulator(
+                            make().as_ref(),
+                            &fields,
+                            DataType::Float64,
+                            arrays,
+                        ))
+                    })
+                },
+            );
+        }
+    }
     group.finish();
 }
 

--- a/native/spark-expr/benches/murmur3.rs
+++ b/native/spark-expr/benches/murmur3.rs
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! `murmur3` is Spark's hash for hash-partitioned shuffle and hash aggregation, run per row on
+//! every partition key. The benchmark hashes a representative multi-column key (int + string +
+//! double), which is how Spark composes shuffle keys, across row counts and null ratios.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use datafusion::common::ScalarValue;
+use datafusion::physical_plan::ColumnarValue;
+use datafusion_comet_spark_expr::spark_murmur3_hash;
+use std::hint::black_box;
+
+#[path = "common/mod.rs"]
+mod common;
+use common::{f64_array, i64_array, string_array, NULL_RATIOS, ROW_COUNTS};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("spark_murmur3_hash");
+    for rows in ROW_COUNTS {
+        for (null_ratio, tag) in NULL_RATIOS {
+            // Trailing Int32 scalar is the seed; preceding columns are the key being hashed.
+            let args = vec![
+                ColumnarValue::Array(i64_array(rows, null_ratio, |i| i as i64)),
+                ColumnarValue::Array(string_array(rows, null_ratio, |i| format!("k{}", i % 1024))),
+                ColumnarValue::Array(f64_array(rows, null_ratio, |i| i as f64 * 1.5)),
+                ColumnarValue::Scalar(ScalarValue::Int32(Some(42))),
+            ];
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!("{rows}/{tag}")),
+                &args,
+                |b, args| b.iter(|| black_box(spark_murmur3_hash(black_box(args)).unwrap())),
+            );
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/native/spark-expr/benches/xxhash64.rs
+++ b/native/spark-expr/benches/xxhash64.rs
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! `xxhash64` is the alternative Spark hash (e.g. `xxhash64()` and bucketing). Same shape as the
+//! murmur3 benchmark: a representative multi-column key across row counts and null ratios.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use datafusion::common::ScalarValue;
+use datafusion::physical_plan::ColumnarValue;
+use datafusion_comet_spark_expr::spark_xxhash64;
+use std::hint::black_box;
+
+#[path = "common/mod.rs"]
+mod common;
+use common::{f64_array, i64_array, string_array, NULL_RATIOS, ROW_COUNTS};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("spark_xxhash64");
+    for rows in ROW_COUNTS {
+        for (null_ratio, tag) in NULL_RATIOS {
+            // Trailing Int64 scalar is the seed; preceding columns are the key being hashed.
+            let args = vec![
+                ColumnarValue::Array(i64_array(rows, null_ratio, |i| i as i64)),
+                ColumnarValue::Array(string_array(rows, null_ratio, |i| format!("k{}", i % 1024))),
+                ColumnarValue::Array(f64_array(rows, null_ratio, |i| i as f64 * 1.5)),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(42))),
+            ];
+            group.bench_with_input(
+                BenchmarkId::from_parameter(format!("{rows}/{tag}")),
+                &args,
+                |b, args| b.iter(|| black_box(spark_xxhash64(black_box(args)).unwrap())),
+            );
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
Which issue does this PR close?
Part of https://github.com/apache/datafusion-comet/issues/5396

Rationale for this change
What changes are included in this PR?
benches for hash functions and aggregated functions (custom comet kernels only). I added new agg benches to existing bench file to keep things simple and consistent with the repo approach

How are these changes tested?
Benches only 