### PR TITLE
fix: let AQE optimize queries over Comet caches

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometInMemoryTableScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometInMemoryTableScanExec.scala
@@ -23,8 +23,10 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.columnar.CachedBatchSerializer
-import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan}
+import org.apache.spark.sql.catalyst.plans.logical.Statistics
+import org.apache.spark.sql.columnar.{CachedBatch, CachedBatchSerializer}
+import org.apache.spark.sql.comet.shims.ShimCometInMemoryTableScanExec
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.columnar.{CachedRDDBuilder, InMemoryTableScanExec}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -52,7 +54,14 @@ case class CometInMemoryTableScanExec(
     relationOutput: Seq[Attribute],
     scanOutput: Seq[Attribute])
     extends CometExec
-    with LeafExecNode {
+    with ShimCometInMemoryTableScanExec {
+
+  // Implements InMemoryTableScanLike on Spark 3.5+; Spark 3.4 has no such interface.
+  def isMaterialized: Boolean = cacheBuilder.isCachedColumnBuffersLoaded
+
+  def baseCacheRDD(): RDD[CachedBatch] = cacheBuilder.cachedColumnBuffers
+
+  def runtimeStatistics: Statistics = originalPlan.relation.computeStats()
 
   override lazy val metrics: Map[String, SQLMetric] = Map(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.comet.execution.arrow.{CometArrowStream, CometNative
 import org.apache.spark.sql.comet.execution.shuffle.CometShuffleExchangeExec
 import org.apache.spark.sql.comet.util.Utils
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.adaptive.{AQEShuffleReadExec, BroadcastQueryStageExec, ShuffleQueryStageExec}
+import org.apache.spark.sql.execution.adaptive.{AQEShuffleReadExec, BroadcastQueryStageExec, QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, HashAggregateExec, ObjectHashAggregateExec}
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec, HashJoin, ShuffledHashJoinExec, SortMergeJoinExec}
@@ -836,7 +836,7 @@ abstract class CometNativeExec extends CometExec {
    *   - CometScanExec - Comet scan node
    *   - CometBatchScanExec - Comet scan node
    *   - CometIcebergNativeScanExec - Native Iceberg scan node
-   *   - ShuffleQueryStageExec - AQE shuffle stage node on top of Comet shuffle
+   *   - QueryStageExec - AQE shuffle, broadcast, or table-cache stage
    *   - AQEShuffleReadExec - AQE shuffle read node on top of Comet shuffle
    *   - CometShuffleExchangeExec - Comet shuffle exchange node
    *   - CometUnionExec, etc. which executes its children native plan and produces ColumnarBatches
@@ -858,10 +858,9 @@ abstract class CometNativeExec extends CometExec {
       // input-boundary concept from "this fixed list" to "any leaf Comet exec".
       case _: CometLeafExec =>
         func(plan)
-      case _: CometScanExec | _: CometBatchScanExec | _: ShuffleQueryStageExec |
-          _: AQEShuffleReadExec | _: CometShuffleExchangeExec | _: CometUnionExec |
-          _: CometTakeOrderedAndProjectExec | _: CometCoalesceExec | _: ReusedExchangeExec |
-          _: CometBroadcastExchangeExec | _: BroadcastQueryStageExec |
+      case _: CometScanExec | _: CometBatchScanExec | _: QueryStageExec | _: AQEShuffleReadExec |
+          _: CometShuffleExchangeExec | _: CometUnionExec | _: CometTakeOrderedAndProjectExec |
+          _: CometCoalesceExec | _: ReusedExchangeExec | _: CometBroadcastExchangeExec |
           _: CometSparkToColumnarExec | _: CometLocalTableScanExec |
           _: CometInMemoryTableScanExec =>
         func(plan)

--- a/spark/src/main/spark-3.4/org/apache/spark/sql/comet/shims/ShimCometInMemoryTableScanExec.scala
+++ b/spark/src/main/spark-3.4/org/apache/spark/sql/comet/shims/ShimCometInMemoryTableScanExec.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet.shims
+
+import org.apache.spark.sql.execution.LeafExecNode
+
+// Spark 3.4 has no InMemoryTableScanLike or table-cache query stages.
+trait ShimCometInMemoryTableScanExec extends LeafExecNode

--- a/spark/src/main/spark-3.5/org/apache/spark/sql/comet/shims/ShimCometInMemoryTableScanExec.scala
+++ b/spark/src/main/spark-3.5/org/apache/spark/sql/comet/shims/ShimCometInMemoryTableScanExec.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet.shims
+
+import org.apache.spark.sql.execution.columnar.InMemoryTableScanLike
+
+trait ShimCometInMemoryTableScanExec extends InMemoryTableScanLike

--- a/spark/src/main/spark-4.x/org/apache/spark/sql/comet/shims/ShimCometInMemoryTableScanExec.scala
+++ b/spark/src/main/spark-4.x/org/apache/spark/sql/comet/shims/ShimCometInMemoryTableScanExec.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.comet.shims
+
+import org.apache.spark.sql.execution.columnar.InMemoryTableScanLike
+
+trait ShimCometInMemoryTableScanExec extends InMemoryTableScanLike

--- a/spark/src/test/scala/org/apache/comet/exec/CometInMemoryCacheSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometInMemoryCacheSuite.scala
@@ -211,9 +211,10 @@ class CometInMemoryCacheSuite extends CometTestBase {
           assert(batches.forall(
             _.getClass.getName == "org.apache.spark.sql.comet.execution.arrow.CometCachedBatch"))
           assert(batches.map(_.numRows.toLong).sum == 60000L)
-          assert(relation.cacheBuilder.rowCountStats.value == 60000L)
-          assert(relation.cacheBuilder.sizeInBytesStats.value == batches.map(_.sizeInBytes).sum)
-          assert(relation.cacheBuilder.sizeInBytesStats.value > 1024L)
+          val stats = relation.computeStats()
+          assert(stats.rowCount.contains(BigInt(60000)))
+          assert(stats.sizeInBytes == batches.map(_.sizeInBytes).sum)
+          assert(stats.sizeInBytes > 1024L)
         }
       }
     }

--- a/spark/src/test/scala/org/apache/comet/exec/CometInMemoryCacheSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometInMemoryCacheSuite.scala
@@ -24,18 +24,22 @@ import java.{util => ju}
 import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.spark.CometDriverPlugin
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.{CometTestBase, Row}
 import org.apache.spark.sql.catalyst.expressions.{And, Attribute, Expression, GreaterThanOrEqual, LessThan, Literal}
 import org.apache.spark.sql.columnar.{CachedBatch, SimpleMetricsCachedBatch}
-import org.apache.spark.sql.comet.CometInMemoryTableScanExec
+import org.apache.spark.sql.comet.{CometBroadcastHashJoinExec, CometInMemoryTableScanExec, CometSortExec, CometSortMergeJoinExec}
 import org.apache.spark.sql.comet.execution.arrow.CometCachedBatchHelper
+import org.apache.spark.sql.execution.SortExec
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AQEShuffleReadExec, QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.columnar.{CometInMemoryRelationHelper, InMemoryRelation}
-import org.apache.spark.sql.execution.exchange.{Exchange, ReusedExchangeExec}
+import org.apache.spark.sql.execution.exchange.{Exchange, ReusedExchangeExec, ShuffleExchangeLike}
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, SortMergeJoinExec}
+import org.apache.spark.sql.functions.max
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.storage.StorageLevel
 
 import org.apache.comet.{CometArrowAllocator, CometConf}
-import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
+import org.apache.comet.CometSparkSessionExtensions.{isSpark35Plus, isSpark40Plus}
 import org.apache.comet.vector.CometVector
 
 class CometInMemoryCacheSuite extends CometTestBase {
@@ -86,6 +90,133 @@ class CometInMemoryCacheSuite extends CometTestBase {
       .map(_.getClass.getName)
       .distinct()
       .collect()
+  }
+
+  // The tests below are ported from Spark 4.1.2's AdaptiveQueryExecSuite; see each source link.
+  private def withAQECache(f: => Unit): Unit = {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+      SQLConf.CAN_CHANGE_CACHED_PLAN_OUTPUT_PARTITIONING.key -> "true",
+      SQLConf.SHUFFLE_PARTITIONS.key -> "3",
+      CometConf.COMET_SHUFFLE_MODE.key -> "jvm",
+      CometConf.COMET_EXEC_IN_MEMORY_CACHE_ENABLED.key -> "true",
+      "spark.comet.sparkToColumnar.enabled" -> "true") {
+      try {
+        f
+      } finally {
+        spark.catalog.clearCache()
+      }
+    }
+  }
+
+  // https://github.com/apache/spark/blob/v4.1.2/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala#L3114-L3154
+  test("AQE SPARK-42101: cold and warm Comet cache materialization") {
+    assume(isSpark35Plus, "Table-cache query stages require Spark 3.5+")
+    withAQECache {
+      withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+        val left = spark.range(0, 10, 1, 2).selectExpr("cast(id as string) c1")
+        val right = spark.range(0, 10, 1, 2).selectExpr("cast(id as string) c2")
+        val cached = left.join(right, $"c1" === $"c2").cache()
+        val builder = spark.sharedState.cacheManager
+          .lookupCachedData(cached)
+          .get
+          .cachedRepresentation
+          .cacheBuilder
+
+        Seq(true, false).foreach { firstAccess =>
+          val df = cached.groupBy("c1").agg(max($"c2"))
+          val adaptive = df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+          assert(!adaptive.isFinalPlan)
+          assert(builder.isCachedColumnBuffersLoaded != firstAccess)
+          assert(
+            collect(adaptive) { case s: ShuffleExchangeLike => s }.size ==
+              (if (firstAccess) 1 else 0))
+          assert(collect(adaptive) { case s: CometInMemoryTableScanExec => s }.size == 1)
+
+          checkAnswer(df, (0L until 10L).map(i => Row(i.toString, i.toString)))
+          assert(adaptive.isFinalPlan)
+          assert(builder.isCachedColumnBuffersLoaded)
+          assert(collect(adaptive) { case s: ShuffleExchangeLike => s }.isEmpty)
+          assert(collect(adaptive) { case s @ (_: CometSortExec | _: SortExec) => s }.isEmpty)
+          assert(collect(adaptive) { case s: CometInMemoryTableScanExec => s }.size == 1)
+        }
+      }
+    }
+  }
+
+  // https://github.com/apache/spark/blob/v4.1.2/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala#L3156-L3176
+  test("AQE SPARK-42101: preserve shuffle partitions beside a table cache stage") {
+    assume(isSpark35Plus, "Table-cache query stages require Spark 3.5+")
+    withAQECache {
+      withSQLConf(
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+        SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM.key -> "1") {
+        val cached = Seq(1, 2).toDF("c1").repartition(3, $"c1").cache()
+        val df = cached.join(Seq(1, 2).toDF("c2"), $"c1" === $"c2")
+        checkAnswer(df, Seq(Row(1, 1), Row(2, 2)))
+        val plan = df.queryExecution.executedPlan
+        assert(plan.asInstanceOf[AdaptiveSparkPlanExec].isFinalPlan)
+        // Match by name because this suite must also compile on Spark 3.4.
+        assert(collect(plan) {
+          case s: QueryStageExec if s.getClass.getSimpleName == "TableCacheQueryStageExec" => s
+        }.size == 1)
+        assert(collect(plan) { case s: CometInMemoryTableScanExec => s }.size == 1)
+        assert(collect(plan) { case s: ShuffleQueryStageExec => s }.size == 1)
+        assert(collect(plan) { case s: AQEShuffleReadExec => s }.isEmpty)
+      }
+    }
+  }
+
+  // https://github.com/apache/spark/blob/v4.1.2/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala#L2780-L2832
+  test("AQE SPARK-37742: use valid Comet cache statistics for join selection") {
+    withAQECache {
+      // Comet reports compressed Arrow bytes, so use a threshold below the compressed
+      // large cache as well as below its logical estimate. The single-row side still fits.
+      withSQLConf(
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "1024",
+        SQLConf.ADAPTIVE_OPTIMIZER_EXCLUDED_RULES.key ->
+          "org.apache.spark.sql.execution.adaptive.AQEPropagateEmptyRelation") {
+        withTempView("cache_large", "cache_other", "cache_small") {
+          val key = "00112233445566778899"
+          Seq.fill(60000)(key).toDF("key").createOrReplaceTempView("cache_large")
+          Seq
+            .fill(60000)("11223344556677889900")
+            .toDF("key")
+            .createOrReplaceTempView("cache_other")
+          Seq(key).toDF("key").createOrReplaceTempView("cache_small")
+          val cached = spark.sql("SELECT key AS newKey FROM cache_large").cache()
+          val relation =
+            spark.sharedState.cacheManager.lookupCachedData(cached).get.cachedRepresentation
+          assert(!relation.cacheBuilder.isCachedColumnBuffersLoaded)
+          val df = spark.sql("""
+            SELECT t3.newKey FROM
+              (SELECT t1.newKey FROM (SELECT key AS newKey FROM cache_large) t1
+               JOIN cache_small t2 ON t1.newKey = t2.key) t3
+            JOIN cache_other t4 ON t3.newKey = t4.key
+            UNION
+            SELECT t1.newKey FROM (SELECT key AS newKey FROM cache_large) t1
+            JOIN cache_other t2 ON t1.newKey = t2.key
+          """)
+          checkAnswer(df, Seq.empty[Row])
+          val plan = df.queryExecution.executedPlan
+          assert(plan.asInstanceOf[AdaptiveSparkPlanExec].isFinalPlan)
+          assert(collect(plan) { case s: CometInMemoryTableScanExec => s }.nonEmpty)
+          assert(collect(plan) {
+            case j @ (_: CometBroadcastHashJoinExec | _: BroadcastHashJoinExec) => j
+          }.size == 1)
+          assert(collect(plan) { case j @ (_: CometSortMergeJoinExec | _: SortMergeJoinExec) =>
+            j
+          }.size == 2)
+          val batches = relation.cacheBuilder.cachedColumnBuffers.collect()
+          assert(batches.forall(
+            _.getClass.getName == "org.apache.spark.sql.comet.execution.arrow.CometCachedBatch"))
+          assert(batches.map(_.numRows.toLong).sum == 60000L)
+          assert(relation.cacheBuilder.rowCountStats.value == 60000L)
+          assert(relation.cacheBuilder.sizeInBytesStats.value == batches.map(_.sizeInBytes).sum)
+          assert(relation.cacheBuilder.sizeInBytesStats.value > 1024L)
+        }
+      }
+    }
   }
 
   test("CometInMemoryTableScan over CometCachedBatch") {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5245.

## Rationale for this change

A pipeline that caches a join and then aggregates it on the same join key can perform a redundant shuffle on its first action. The join's output may already satisfy the aggregation's partitioning requirements, but that partitioning is only known after the cache is materialized.

For example, with AQE and Comet cache scans enabled and broadcast joins disabled:

```python
from pyspark.sql import functions as F

left = spark.range(250_000).selectExpr("cast(id as string) c1")
right = spark.range(250_000).selectExpr("cast(id as string) c2")
q1 = left.join(right, left.c1 == right.c2).cache()

# First action: the cache has not been populated yet.
q2 = q1.groupBy("c1").agg(F.max("c2"))
result = q2.collect()
```

Before this patch, AQE does not recognize the Comet cache scan as a table cache stage, so the outer query can retain a shuffle and sorts planned before the cache was materialized. This patch lets AQE materialize the cache as a stage and replan the aggregation using its resulting partitioning. The regression test verifies that the redundant outer shuffle and sorts are removed.

## What changes are included in this PR?

`CometInMemoryTableScanExec` implements Spark's `InMemoryTableScanLike` interface on Spark 3.5 and later. Shared methods expose whether the cache is materialized, its underlying RDD, and its runtime statistics. Small inheritance shims preserve compatibility with Spark 3.4, which lacks the interface.

Comet's native input traversal treats `QueryStageExec` as an input boundary, allowing it to consume table cache stages. Three regressions adapted from Spark's `AdaptiveQueryExecSuite` cover cold and warm cache access, partition preservation beside a cache stage, and statistics used for join selection. The statistics assertions use `computeStats()`, which also works on Spark 4.2.

## How are these changes tested?

### Benchmark

An exploratory run used Spark 3.5.9 on an Apple M4 with `local[4]`. The workload cached a join of two 250,000-row inputs, then grouped and aggregated the result. Cold timing includes query planning and cache materialization; warm timing uses the populated cache. Four JVMs ran in before/after/after/before order, with three warm-up cycles per JVM and 10 measured samples per variant and phase. All measured samples are included.

**The timing comparison is inconclusive:** competing builds caused substantial variation, and both variants used a debug native library. The ratios below compare observed medians.

| Phase | Before median (ms) | After median (ms) | Observed speedup ratio (before / after) | Before range (ms) | After range (ms) |
|---|---:|---:|---:|---:|---:|
| Cold cache | 4201.2 | 770.4 | 5.45× | 1231.9–17868.9 | 696.3–8435.3 |
| Warm cache | 127.0 | 100.8 | 1.26× | 80.2–467.6 | 84.2–140.4 |

Every measured cycle returned the expected 250,000 groups and checksum of 1,388,890. Cold outer-query shuffles decreased from two to one. Cold task counts increased from 34 to 49 because the cache stage explicitly materializes the cached relation. Warm queries had one outer shuffle in both variants.

A small pilot and an interrupted million-row attempt are excluded from the table; the latter lacked a matching after-run. A release build on a quiet machine is needed to quantify the latency benefit.

### Manually Testing

for:
```scala
import org.apache.spark.sql.functions._

val left = spark.range(0, 250000, 1, 16)
  .selectExpr("cast(id as string) c1")
val right = spark.range(0, 250000, 1, 16)
  .selectExpr("cast(id as string) c2")

val q1 = left.join(right, left("c1") === right("c2")).cache()
val q2 = q1.groupBy("c1").agg(max("c2"))

val result = q2.collect()
```

before:

<details>
<img width="219" height="984" alt="image" src="https://github.com/user-attachments/assets/90ad382a-2d88-4d8f-ac24-144aded00bd8" />
</details>

```sql
SortAggregate
  WholeStageCodegen (2)
    CometColumnarToRow
      InputAdapter
        CometSort
          AQEShuffleRead
            ShuffleQueryStage
              CometColumnarExchange hashpartitioning(c1#2, 16)
                SortAggregate
                  WholeStageCodegen (1)
                    CometColumnarToRow
                      InputAdapter
                        CometSort
                          CometInMemoryTableScan 
```

after:

<details>
<img width="423" height="777" alt="image" src="https://github.com/user-attachments/assets/b05ee630-580b-43ac-8e7c-f4c200ab0950" />
</details>

```sql
SortAggregate
  SortAggregate
    WholeStageCodegen (1)
      CometColumnarToRow
        InputAdapter
          TableCacheQueryStage
            CometInMemoryTableScan
```