### PR TITLE
perf: use Arrow cast for date to timestamp NTZ

### DIFF
--- a/native/spark-expr/src/conversion_funcs/temporal.rs
+++ b/native/spark-expr/src/conversion_funcs/temporal.rs
@@ -19,8 +19,10 @@ use crate::utils::resolve_local_datetime;
 use crate::{SparkCastOptions, SparkResult};
 use arrow::array::timezone::Tz;
 use arrow::array::{ArrayRef, AsArray, TimestampMicrosecondBuilder};
-use arrow::datatypes::{DataType, Date32Type};
+use arrow::compute::cast_with_options;
+use arrow::datatypes::{DataType, Date32Type, TimeUnit};
 use chrono::NaiveDate;
+use datafusion::common::format::DEFAULT_CAST_OPTIONS;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -40,49 +42,46 @@ pub(crate) fn cast_date_to_timestamp(
     cast_options: &SparkCastOptions,
     target_tz: &Option<Arc<str>>,
 ) -> SparkResult<ArrayRef> {
+    if target_tz.is_none() {
+        // TIMESTAMP_NTZ ignores session TZ. Like Spark's daysToMicros, reject overflow.
+        return Ok(cast_with_options(
+            array_ref.as_ref(),
+            &DataType::Timestamp(TimeUnit::Microsecond, None),
+            &DEFAULT_CAST_OPTIONS,
+        )?);
+    }
+
     let date_array = array_ref.as_primitive::<Date32Type>();
     let mut builder = TimestampMicrosecondBuilder::with_capacity(date_array.len());
-
-    if target_tz.is_none() {
-        // TIMESTAMP_NTZ: pure day arithmetic, no session-TZ offset.
-        // Matches Spark: daysToMicros(d, ZoneOffset.UTC)
-        for date in date_array.iter() {
-            match date {
-                Some(d) => builder.append_value((d as i64) * 86_400 * 1_000_000),
-                None => builder.append_null(),
-            }
-        }
+    // TIMESTAMP: midnight in session TZ → UTC epoch μs
+    let tz_str = if cast_options.timezone.is_empty() {
+        "UTC"
     } else {
-        // TIMESTAMP: midnight in session TZ → UTC epoch μs
-        let tz_str = if cast_options.timezone.is_empty() {
-            "UTC"
-        } else {
-            cast_options.timezone.as_str()
-        };
-        // safe to unwrap since we are falling back to UTC above
-        let tz = Tz::from_str(tz_str)?;
-        let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
-        for date in date_array.iter() {
-            match date {
-                Some(d) => {
-                    // safe to unwrap since chrono's range ( 262,143 yrs) is higher than
-                    // number of years possible with days as i32 (~ 6 mil yrs)
-                    // convert date in session timezone to timestamp in UTC
-                    let naive_date = epoch + chrono::Duration::days(d as i64);
-                    let local_midnight = naive_date.and_hms_opt(0, 0, 0).unwrap();
-                    // Use resolve_local_datetime to correctly handle DST transitions:
-                    // - Single: normal case, uses the given offset
-                    // - Ambiguous (fall back): uses the earlier/DST occurrence, matching Spark
-                    // - None (spring forward gap at midnight, e.g. America/Sao_Paulo): uses the
-                    //   pre-transition offset to compute the correct UTC time, matching Spark's
-                    //   LocalDate.atStartOfDay(zoneId) behaviour.
-                    let local_midnight_in_microsec =
-                        resolve_local_datetime(&tz, local_midnight).timestamp_micros();
-                    builder.append_value(local_midnight_in_microsec);
-                }
-                None => {
-                    builder.append_null();
-                }
+        cast_options.timezone.as_str()
+    };
+    // safe to unwrap since we are falling back to UTC above
+    let tz = Tz::from_str(tz_str)?;
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+    for date in date_array.iter() {
+        match date {
+            Some(d) => {
+                // safe to unwrap since chrono's range ( 262,143 yrs) is higher than
+                // number of years possible with days as i32 (~ 6 mil yrs)
+                // convert date in session timezone to timestamp in UTC
+                let naive_date = epoch + chrono::Duration::days(d as i64);
+                let local_midnight = naive_date.and_hms_opt(0, 0, 0).unwrap();
+                // Use resolve_local_datetime to correctly handle DST transitions:
+                // - Single: normal case, uses the given offset
+                // - Ambiguous (fall back): uses the earlier/DST occurrence, matching Spark
+                // - None (spring forward gap at midnight, e.g. America/Sao_Paulo): uses the
+                //   pre-transition offset to compute the correct UTC time, matching Spark's
+                //   LocalDate.atStartOfDay(zoneId) behaviour.
+                let local_midnight_in_microsec =
+                    resolve_local_datetime(&tz, local_midnight).timestamp_micros();
+                builder.append_value(local_midnight_in_microsec);
+            }
+            None => {
+                builder.append_null();
             }
         }
     }
@@ -171,6 +170,8 @@ mod tests {
             Some(-1),    // 1969-12-31
             Some(19723), // 2024-01-01
             None,
+            Some(106_751_991), // largest day count representable in microseconds
+            Some(-106_751_991),
         ]));
 
         // NTZ target: no timezone annotation
@@ -200,8 +201,23 @@ mod tests {
                 "2024-01-01, tz={tz}"
             );
             assert!(ts.is_null(4), "null, tz={tz}");
+            assert_eq!(ts.value(5), 106_751_991i64 * 86_400_000_000);
+            assert_eq!(ts.value(6), -106_751_991i64 * 86_400_000_000);
             // output array has no timezone annotation
             assert_eq!(ts.timezone(), None, "no tz annotation, tz={tz}");
+        }
+
+        for day in [106_751_992, -106_751_992, i32::MIN, i32::MAX] {
+            let dates: ArrayRef = Arc::new(Date32Array::from(vec![None, Some(day)]));
+            assert!(
+                cast_date_to_timestamp(
+                    &dates,
+                    &SparkCastOptions::new(EvalMode::Legacy, "UTC", false),
+                    &ntz_target,
+                )
+                .is_err(),
+                "day={day}"
+            );
         }
     }
 }

--- a/native/spark-expr/src/conversion_funcs/temporal.rs
+++ b/native/spark-expr/src/conversion_funcs/temporal.rs
@@ -16,10 +16,10 @@
 // under the License.
 
 use crate::utils::resolve_local_datetime;
-use crate::{SparkCastOptions, SparkResult};
+use crate::{EvalMode, SparkCastOptions, SparkResult};
 use arrow::array::timezone::Tz;
 use arrow::array::{ArrayRef, AsArray, TimestampMicrosecondBuilder};
-use arrow::compute::cast_with_options;
+use arrow::compute::{cast_with_options, CastOptions};
 use arrow::datatypes::{DataType, Date32Type, TimeUnit};
 use chrono::NaiveDate;
 use datafusion::common::format::DEFAULT_CAST_OPTIONS;
@@ -43,11 +43,14 @@ pub(crate) fn cast_date_to_timestamp(
     target_tz: &Option<Arc<str>>,
 ) -> SparkResult<ArrayRef> {
     if target_tz.is_none() {
-        // TIMESTAMP_NTZ ignores session TZ. Like Spark's daysToMicros, reject overflow.
+        // TIMESTAMP_NTZ ignores session TZ. Only TRY_CAST turns overflow into null.
         return Ok(cast_with_options(
             array_ref.as_ref(),
             &DataType::Timestamp(TimeUnit::Microsecond, None),
-            &DEFAULT_CAST_OPTIONS,
+            &CastOptions {
+                safe: cast_options.eval_mode == EvalMode::Try,
+                ..DEFAULT_CAST_OPTIONS
+            },
         )?);
     }
 
@@ -218,6 +221,63 @@ mod tests {
                 .is_err(),
                 "day={day}"
             );
+        }
+    }
+
+    #[test]
+    fn test_spark_cast_date_to_timestamp_ntz_modes() {
+        use crate::spark_cast;
+        use arrow::array::{Date32Array, TimestampMicrosecondArray};
+        use datafusion::common::ScalarValue;
+        use datafusion::logical_expr::ColumnarValue;
+
+        let target = DataType::Timestamp(TimeUnit::Microsecond, None);
+        let days = vec![
+            Some(0),
+            Some(106_751_992),
+            None,
+            Some(-1),
+            Some(-106_751_992),
+        ];
+        for mode in [EvalMode::Legacy, EvalMode::Ansi, EvalMode::Try] {
+            let options = SparkCastOptions::new(mode, "America/Los_Angeles", false);
+            let result = spark_cast(
+                ColumnarValue::Array(Arc::new(Date32Array::from(days.clone()))),
+                &target,
+                &options,
+            );
+            if mode == EvalMode::Try {
+                let ColumnarValue::Array(actual) = result.unwrap() else {
+                    panic!("expected array");
+                };
+                let expected = TimestampMicrosecondArray::from(vec![
+                    Some(0),
+                    None,
+                    None,
+                    Some(-86_400_000_000),
+                    None,
+                ]);
+                assert_eq!(actual.as_ref(), &expected);
+            } else {
+                assert!(result.is_err(), "mode={mode:?}");
+            }
+
+            for day in &days {
+                let result = spark_cast(
+                    ColumnarValue::Scalar(ScalarValue::Date32(*day)),
+                    &target,
+                    &options,
+                );
+                let micros = day.and_then(|d| i64::from(d).checked_mul(86_400_000_000));
+                if day.is_some() && micros.is_none() && mode != EvalMode::Try {
+                    assert!(result.is_err(), "mode={mode:?}, day={day:?}");
+                } else {
+                    let ColumnarValue::Scalar(actual) = result.unwrap() else {
+                        panic!("expected scalar");
+                    };
+                    assert_eq!(actual, ScalarValue::TimestampMicrosecond(micros, None));
+                }
+            }
         }
     }
 }

--- a/spark/src/test/resources/sql-tests/expressions/cast/cast_timestamp_ntz.sql
+++ b/spark/src/test/resources/sql-tests/expressions/cast/cast_timestamp_ntz.sql
@@ -114,3 +114,14 @@ SELECT try_cast('invalid' as timestamp_ntz), try_cast('T12:34' as timestamp_ntz)
 -- TRY_CAST: valid inputs
 query
 SELECT try_cast('2020-01-01 12:34:56' as timestamp_ntz)
+
+-- TRY_CAST preserves valid rows when other dates overflow the microsecond range.
+statement
+CREATE TABLE test_date_ntz_overflow(days int) USING parquet
+
+statement
+INSERT INTO test_date_ntz_overflow VALUES (0), (106751992), (NULL), (-1), (-106751992)
+
+query
+SELECT days, try_cast(date_from_unix_date(days) AS timestamp_ntz)
+FROM test_date_ntz_overflow ORDER BY days


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5090.

## Rationale for this change

Arrow already provides the date-to-timestamp conversion, so Comet can replace the per-row builder loop with its cast kernel.

## What changes are included in this PR?

Convert Date32 to TIMESTAMP_NTZ with Arrow and select overflow handling by Spark evaluation mode. TRY_CAST returns null for each overflowing date; Legacy and ANSI return an error. For example, TRY_CAST on day counts `[0, 106751992, null]` produces `[1970-01-01 00:00:00, null, null]`.

The timezone-aware conversion continues to use Spark's DST rules. This completes the remaining conversion in #5090; #5177 handled the other locations.

## How are these changes tested?

Three native temporal tests pass, covering boundaries, nulls, session timezones, and mixed arrays and scalar inputs through `spark_cast` in all three modes. The column-based SQL regression passes on Spark 4.1.3 in all four session timezones. Native and JVM builds, Rust formatting, and whitespace checks pass.

Commands:

```sh
cd native && cargo test -p datafusion-comet-spark-expr --lib conversion_funcs::temporal::tests --offline
```

From the repository root:

```sh
./mvnw -o test -Dtest=none '-Dsuites=org.apache.comet.CometSqlFileTestSuite cast_timestamp_ntz.sql' -Dscalastyle.skip=true
```

### Benchmark

Local release-mode kernel comparison on macOS arm64 with Arrow 59.3.0 and Rust 1.96.0, thin LTO and one codegen unit. Inputs contain identical representable dates with deterministic values and irregular null placement. Output equality is checked for both Arrow modes. Timings include allocation and output destruction, with 200 ms warmup and 21 samples per implementation in rotating order. The table shows median time per batch and speedup over the old loop. Measurements were collected after the builds and tests finished. These results measure the conversion kernel only.

| Rows | Nulls | Old loop | Legacy / ANSI | TRY | Strict speedup | TRY speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 1,024 | 0% | 0.947 µs | 0.600 µs | 0.553 µs | 1.58× | 1.71× |
| 1,024 | 10% | 3.651 µs | 0.818 µs | 0.865 µs | 4.46× | 4.22× |
| 1,024 | 50% | 3.811 µs | 0.540 µs | 0.590 µs | 7.06× | 6.46× |
| 1,024 | 100% | 2.520 µs | 0.215 µs | 0.259 µs | 11.71× | 9.72× |
| 8,192 | 0% | 6.633 µs | 3.770 µs | 2.985 µs | 1.76× | 2.22× |
| 8,192 | 10% | 28.296 µs | 5.790 µs | 6.524 µs | 4.89× | 4.34× |
| 8,192 | 50% | 29.842 µs | 3.542 µs | 3.742 µs | 8.43× | 7.97× |
| 8,192 | 100% | 19.107 µs | 0.723 µs | 0.729 µs | 26.42× | 26.21× |
