### PR TITLE
fix: gate array distinct and union signed-zero semantics by Spark version

### DIFF
--- a/docs/source/user-guide/latest/compatibility/floating-point.md
+++ b/docs/source/user-guide/latest/compatibility/floating-point.md
@@ -46,3 +46,14 @@ ordering. Nested keys can therefore produce different ordering or rank results f
 The existing `spark.comet.exec.strictFloatingPoint=true` fallback policy is unchanged, including
 its conservative fallback for scalar floating-point sort keys. Narrowing that scalar-sort
 admission policy is tracked in [#5506](https://github.com/apache/datafusion-comet/issues/5506).
+
+## Array distinct and union
+
+`array_distinct` and `array_union` fall back to Spark when their element type contains
+`FLOAT` or `DOUBLE` and the running Spark version predates SPARK-54918. Native execution
+is enabled for Spark 4.0.5+, 4.1.4+, and 4.2+, which normalize signed zeros in these
+functions. Spark 3.4 and 3.5 retain the fallback. Other element types remain native.
+
+Setting `spark.comet.expression.ArrayDistinct.allowIncompatible=true` or
+`spark.comet.expression.ArrayUnion.allowIncompatible=true` opts into native execution on
+older versions, where positive and negative zero may be deduplicated differently from Spark.

--- a/docs/source/user-guide/latest/compatibility/floating-point.md
+++ b/docs/source/user-guide/latest/compatibility/floating-point.md
@@ -54,6 +54,25 @@ admission policy is tracked in [#5506](https://github.com/apache/datafusion-come
 is enabled for Spark 4.0.5+, 4.1.4+, and 4.2+, which normalize signed zeros in these
 functions. Spark 3.4 and 3.5 retain the fallback. Other element types remain native.
 
-Setting `spark.comet.expression.ArrayDistinct.allowIncompatible=true` or
-`spark.comet.expression.ArrayUnion.allowIncompatible=true` opts into native execution on
-older versions, where positive and negative zero may be deduplicated differently from Spark.
+The check is based on the element type, not the values. It also applies to NULL or empty
+floating-point arrays and columns that never contain negative zero. The entire projection
+falls back to Spark, introducing a `CometColumnarToRow` transition and moving unrelated
+expressions in the same projection out of Comet. For example,
+`SELECT id + 1, array_distinct(a), i[0] + 5` evaluates all three expressions in a Spark `Project`.
+
+This can have a substantial cost. In a [reviewer's local measurement on Spark 4.1.3](https://github.com/apache/datafusion-comet/pull/5750#pullrequestreview-5153510242)
+with a release build, `sum(cardinality(array_distinct(d)))` over two million rows of
+`array<double>` took 93 ms with native opt-in and 1355 ms with the default projection fallback
+(best of five runs, about 15 times slower). These are workload-specific measurements, not a
+general performance guarantee. Keeping the expression in Comet through the JVM codegen
+dispatcher was slower still in that measurement, so distinct and union use projection fallback.
+
+If signed zeros cannot occur in your data, setting
+`spark.comet.expression.ArrayDistinct.allowIncompatible=true` or
+`spark.comet.expression.ArrayUnion.allowIncompatible=true` restores native execution on older
+versions. These options accept the difference in deduplicating positive and negative zero.
+
+The gate uses the runtime Spark version. A vendor backport that retains an older version
+number may still fall back: checking only for a `KnownFloatingPointNormalized` wrapper would
+miss Spark's normalization of array constructors and conditional branches, which can lack
+that top-level wrapper.

--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -151,7 +151,7 @@ The tables below list every Spark built-in expression with its current status.
 | `array_append` | ✅ | Native |  |
 | `array_compact` | ✅ | — |  |
 | `array_contains` | ✅ | Native | NaN/signed-zero handling may differ ([details](compatibility/floating-point.md)) |
-| `array_distinct` | ✅ | Native | NaN/signed-zero handling may differ ([details](compatibility/floating-point.md)) |
+| `array_distinct` | ✅ | Native | Floating-point elements fall back on Spark versions without SPARK-54918 ([details](compatibility/floating-point.md)) |
 | `array_except` | ✅ | Hybrid | Routes through the JVM codegen dispatcher by default; the incompatible native path is opt-in via allowIncompatible ([details](compatibility/expressions/array.md)) |
 | `array_insert` | ✅ | Native |  |
 | `array_intersect` | ✅ | Hybrid | Routes through the JVM codegen dispatcher by default; the incompatible native path is opt-in via allowIncompatible ([details](compatibility/expressions/array.md)) |
@@ -162,7 +162,7 @@ The tables below list every Spark built-in expression with its current status.
 | `array_prepend` | ✅ | — |  |
 | `array_remove` | ✅ | Native |  |
 | `array_repeat` | ✅ | Native |  |
-| `array_union` | ✅ | Native | NaN/signed-zero handling may differ ([details](compatibility/floating-point.md)) |
+| `array_union` | ✅ | Native | Floating-point elements fall back on Spark versions without SPARK-54918 ([details](compatibility/floating-point.md)) |
 | `arrays_overlap` | ✅ | Native |  |
 | `arrays_zip` | ✅ | Native |  |
 | `element_at` | ✅ | Native |  |

--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -62,7 +62,7 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
     // through CometArrayFilter -> CometArrayCompact -> DataFusion's array_compact. On Spark
     // 4.0+ the rewrite is wrapped in KnownNotContainsNull, stripped by Spark4xCometExprShim.
     classOf[ArrayContains] -> CometArrayContains,
-    classOf[ArrayDistinct] -> CometScalarFunction("array_distinct"),
+    classOf[ArrayDistinct] -> CometArrayDistinct,
     classOf[ArrayExcept] -> CometArrayExcept,
     classOf[ArrayFilter] -> CometArrayFilter,
     classOf[ArrayInsert] -> CometArrayInsert,

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -22,8 +22,10 @@ package org.apache.comet.serde
 import scala.annotation.tailrec
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.sql.catalyst.expressions.{And, ArrayAggregate, ArrayAppend, ArrayContains, ArrayExcept, ArrayExists, ArrayFilter, ArrayForAll, ArrayInsert, ArrayIntersect, ArrayJoin, ArrayMax, ArrayMin, ArrayPosition, ArrayRemove, ArraySort, ArraysOverlap, ArraysZip, ArrayTransform, ArrayUnion, Attribute, BoundReference, Cast, CreateArray, ElementAt, EmptyRow, Expression, Flatten, GetArrayItem, IsNotNull, IsNull, LambdaFunction, Literal, NamedLambdaVariable, Reverse, Sequence, Size, Slice, SortArray, ZipWith}
+import org.apache.spark.SPARK_VERSION
+import org.apache.spark.sql.catalyst.expressions.{And, ArrayAggregate, ArrayAppend, ArrayContains, ArrayDistinct, ArrayExcept, ArrayExists, ArrayFilter, ArrayForAll, ArrayInsert, ArrayIntersect, ArrayJoin, ArrayMax, ArrayMin, ArrayPosition, ArrayRemove, ArraySort, ArraysOverlap, ArraysZip, ArrayTransform, ArrayUnion, Attribute, BoundReference, Cast, CreateArray, ElementAt, EmptyRow, Expression, Flatten, GetArrayItem, IsNotNull, IsNull, LambdaFunction, Literal, NamedLambdaVariable, Reverse, Sequence, Size, Slice, SortArray, ZipWith}
 import org.apache.spark.sql.catalyst.util.GenericArrayData
+import org.apache.spark.sql.comet.util.Utils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
@@ -516,7 +518,42 @@ object CometSlice extends CometExpressionSerde[Slice] {
   }
 }
 
+private[comet] object ArraySetSupport {
+  val signedZeroReason =
+    "Floating-point array elements require Spark with SPARK-54918 " +
+      "(4.0.5+, 4.1.4+, or 4.2+) for matching signed-zero semantics"
+
+  def normalizesSignedZero(version: String): Boolean = {
+    Utils.majorMinorPatchVersion(version).exists {
+      case (4, 0, patch) => patch >= 5
+      case (4, 1, patch) => patch >= 4
+      case (major, minor, _) => major > 4 || (major == 4 && minor >= 2)
+    }
+  }
+
+  def supportLevel(dataType: DataType): SupportLevel = {
+    if (SupportLevel.containsType(dataType, classOf[FloatType], classOf[DoubleType]) &&
+      !normalizesSignedZero(SPARK_VERSION)) {
+      Incompatible(Some(signedZeroReason))
+    } else {
+      Compatible()
+    }
+  }
+}
+
+object CometArrayDistinct extends CometScalarFunction[ArrayDistinct]("array_distinct") {
+  override def getIncompatibleReasons(): Seq[String] = Seq(ArraySetSupport.signedZeroReason)
+
+  override def getSupportLevel(expr: ArrayDistinct): SupportLevel =
+    ArraySetSupport.supportLevel(expr.dataType)
+}
+
 object CometArrayUnion extends CometExpressionSerde[ArrayUnion] {
+  override def getIncompatibleReasons(): Seq[String] = Seq(ArraySetSupport.signedZeroReason)
+
+  override def getSupportLevel(expr: ArrayUnion): SupportLevel =
+    ArraySetSupport.supportLevel(expr.dataType)
+
   override def convert(
       expr: ArrayUnion,
       inputs: Seq[Attribute],

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -519,7 +519,7 @@ object CometSlice extends CometExpressionSerde[Slice] {
 }
 
 private[comet] object ArraySetSupport {
-  val signedZeroReason =
+  val signedZeroReason: String =
     "Floating-point array elements require Spark with SPARK-54918 " +
       "(4.0.5+, 4.1.4+, or 4.2+) for matching signed-zero semantics"
 

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -523,6 +523,8 @@ private[comet] object ArraySetSupport {
     "Floating-point array elements require Spark with SPARK-54918 " +
       "(4.0.5+, 4.1.4+, or 4.2+) for matching signed-zero semantics"
 
+  // A top-level KnownFloatingPointNormalized marker is insufficient: Spark also normalizes
+  // CreateArray, If, CaseWhen, and Coalesce recursively without wrapping the resulting array.
   def normalizesSignedZero(version: String): Boolean = {
     Utils.majorMinorPatchVersion(version).exists {
       case (4, 0, patch) => patch >= 5
@@ -541,6 +543,9 @@ private[comet] object ArraySetSupport {
   }
 }
 
+// Distinct and union use Spark projection fallback instead of CodegenDispatchFallback.
+// PR #5750's measurements found codegen dispatch slower than projection fallback for these
+// array-valued results. The native implementation remains available through opt-in.
 object CometArrayDistinct extends CometScalarFunction[ArrayDistinct]("array_distinct") {
   override def getIncompatibleReasons(): Seq[String] = Seq(ArraySetSupport.signedZeroReason)
 

--- a/spark/src/main/scala/org/apache/spark/sql/comet/util/Utils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/util/Utils.scala
@@ -51,6 +51,9 @@ import org.apache.comet.vector.CometVector
 object Utils extends CometTypeShim with Logging {
   private val VariantExtensionName = "arrow.parquet.variant"
 
+  def majorMinorPatchVersion(version: String): Option[(Int, Int, Int)] =
+    org.apache.spark.util.VersionUtils.majorMinorPatchVersion(version)
+
   def getConfPath(confFileName: String): String = {
     sys.env
       .get(COMET_CONF_DIR_ENV)

--- a/spark/src/test/resources/sql-tests/expressions/array/array_distinct.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_distinct.sql
@@ -121,30 +121,26 @@ INSERT INTO test_array_distinct_double VALUES
   (array(CAST('NaN' AS DOUBLE), NULL, CAST('NaN' AS DOUBLE), NULL, 1.0)),
   (array(CAST('Infinity' AS DOUBLE), CAST('-Infinity' AS DOUBLE), CAST('Infinity' AS DOUBLE), 0.0))
 
-query
+query spark_answer_only
 SELECT array_distinct(arr) FROM test_array_distinct_double
 
 -- NaN deduplication
-query
+query spark_answer_only
 SELECT array_distinct(array(CAST('NaN' AS DOUBLE), CAST('NaN' AS DOUBLE), 1.0, 1.0))
 
 -- NaN with NULL
-query
+query spark_answer_only
 SELECT array_distinct(array(CAST('NaN' AS DOUBLE), NULL, CAST('NaN' AS DOUBLE), NULL, 1.0))
 
 -- Infinity
-query
+query spark_answer_only
 SELECT array_distinct(array(CAST('Infinity' AS DOUBLE), CAST('-Infinity' AS DOUBLE), CAST('Infinity' AS DOUBLE), 0.0))
 
--- negative zero (literal). Spark's NormalizeFloatingNumbers rewrites -0.0 to 0.0 at
--- analysis time, so both Spark and Comet collapse it and agree here.
-query ignore(https://issues.apache.org/jira/browse/SPARK-54918)
+-- Signed zeros use Spark fallback on versions without SPARK-54918.
+query spark_answer_only
 SELECT array_distinct(array(0.0, double('-0.0'), 1.0))
 
--- negative zero (column-sourced). NormalizeFloatingNumbers does not touch parquet
--- columns, so Spark keeps -0.0 distinct from 0.0 while Comet (DataFusion) collapses
--- them: array_distinct([0.0, -0.0, 1.0]) is [0.0, -0.0, 1.0] in Spark but [0.0, 1.0]
--- in Comet. Skip until Spark normalizes these zeros (Spark 4.2+, SPARK-54918).
+-- Signed zeros use Spark fallback on versions without SPARK-54918.
 statement
 CREATE TABLE test_array_distinct_dbl_negzero(arr array<double>) USING parquet
 
@@ -152,7 +148,7 @@ statement
 INSERT INTO test_array_distinct_dbl_negzero VALUES
   (array(0.0, double('-0.0'), 1.0))
 
-query ignore(https://issues.apache.org/jira/browse/SPARK-54918)
+query spark_answer_only
 SELECT array_distinct(arr) FROM test_array_distinct_dbl_negzero
 
 -- ===== FLOAT arrays =====
@@ -170,15 +166,14 @@ INSERT INTO test_array_distinct_float VALUES
   (array(CAST('NaN' AS FLOAT), NULL, CAST('NaN' AS FLOAT), NULL, CAST(1.0 AS FLOAT))),
   (array(CAST('Infinity' AS FLOAT), CAST('-Infinity' AS FLOAT), CAST('Infinity' AS FLOAT), CAST(0.0 AS FLOAT)))
 
-query
+query spark_answer_only
 SELECT array_distinct(arr) FROM test_array_distinct_float
 
 -- Float NaN deduplication
-query
+query spark_answer_only
 SELECT array_distinct(array(CAST('NaN' AS FLOAT), CAST('NaN' AS FLOAT), CAST(1.0 AS FLOAT)))
 
--- negative zero (column-sourced). Same divergence as the double case above, skipped
--- until Spark normalizes these zeros (Spark 4.2+, SPARK-54918).
+-- Signed zeros use Spark fallback on versions without SPARK-54918.
 statement
 CREATE TABLE test_array_distinct_flt_negzero(arr array<float>) USING parquet
 
@@ -186,7 +181,7 @@ statement
 INSERT INTO test_array_distinct_flt_negzero VALUES
   (array(CAST(0.0 AS FLOAT), float('-0.0'), CAST(1.0 AS FLOAT)))
 
-query ignore(https://issues.apache.org/jira/browse/SPARK-54918)
+query spark_answer_only
 SELECT array_distinct(arr) FROM test_array_distinct_flt_negzero
 
 -- ===== DECIMAL arrays =====

--- a/spark/src/test/resources/sql-tests/expressions/array/array_distinct.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_distinct.sql
@@ -15,6 +15,9 @@
 -- specific language governing permissions and limitations
 -- under the License.
 
+-- No negative zeros in this fixture; signed-zero compatibility is tested in array_set_signed_zero*.
+-- Config: spark.comet.expression.ArrayDistinct.allowIncompatible=true
+
 -- ===== INT arrays =====
 
 statement
@@ -121,35 +124,20 @@ INSERT INTO test_array_distinct_double VALUES
   (array(CAST('NaN' AS DOUBLE), NULL, CAST('NaN' AS DOUBLE), NULL, 1.0)),
   (array(CAST('Infinity' AS DOUBLE), CAST('-Infinity' AS DOUBLE), CAST('Infinity' AS DOUBLE), 0.0))
 
-query spark_answer_only
+query
 SELECT array_distinct(arr) FROM test_array_distinct_double
 
 -- NaN deduplication
-query spark_answer_only
+query
 SELECT array_distinct(array(CAST('NaN' AS DOUBLE), CAST('NaN' AS DOUBLE), 1.0, 1.0))
 
 -- NaN with NULL
-query spark_answer_only
+query
 SELECT array_distinct(array(CAST('NaN' AS DOUBLE), NULL, CAST('NaN' AS DOUBLE), NULL, 1.0))
 
 -- Infinity
-query spark_answer_only
+query
 SELECT array_distinct(array(CAST('Infinity' AS DOUBLE), CAST('-Infinity' AS DOUBLE), CAST('Infinity' AS DOUBLE), 0.0))
-
--- Signed zeros use Spark fallback on versions without SPARK-54918.
-query spark_answer_only
-SELECT array_distinct(array(0.0, double('-0.0'), 1.0))
-
--- Signed zeros use Spark fallback on versions without SPARK-54918.
-statement
-CREATE TABLE test_array_distinct_dbl_negzero(arr array<double>) USING parquet
-
-statement
-INSERT INTO test_array_distinct_dbl_negzero VALUES
-  (array(0.0, double('-0.0'), 1.0))
-
-query spark_answer_only
-SELECT array_distinct(arr) FROM test_array_distinct_dbl_negzero
 
 -- ===== FLOAT arrays =====
 
@@ -166,23 +154,12 @@ INSERT INTO test_array_distinct_float VALUES
   (array(CAST('NaN' AS FLOAT), NULL, CAST('NaN' AS FLOAT), NULL, CAST(1.0 AS FLOAT))),
   (array(CAST('Infinity' AS FLOAT), CAST('-Infinity' AS FLOAT), CAST('Infinity' AS FLOAT), CAST(0.0 AS FLOAT)))
 
-query spark_answer_only
+query
 SELECT array_distinct(arr) FROM test_array_distinct_float
 
 -- Float NaN deduplication
-query spark_answer_only
+query
 SELECT array_distinct(array(CAST('NaN' AS FLOAT), CAST('NaN' AS FLOAT), CAST(1.0 AS FLOAT)))
-
--- Signed zeros use Spark fallback on versions without SPARK-54918.
-statement
-CREATE TABLE test_array_distinct_flt_negzero(arr array<float>) USING parquet
-
-statement
-INSERT INTO test_array_distinct_flt_negzero VALUES
-  (array(CAST(0.0 AS FLOAT), float('-0.0'), CAST(1.0 AS FLOAT)))
-
-query spark_answer_only
-SELECT array_distinct(arr) FROM test_array_distinct_flt_negzero
 
 -- ===== DECIMAL arrays =====
 

--- a/spark/src/test/resources/sql-tests/expressions/array/array_except.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_except.sql
@@ -72,10 +72,10 @@ INSERT INTO test_except_float VALUES
 query
 SELECT a, b, array_except(a, b) FROM test_except_float
 
--- negative zero (column-sourced). Spark keeps -0.0 distinct from 0.0 while Comet
--- (DataFusion) collapses them, so array_except([0.0, -0.0, 1.0], [0.0]) is [-0.0, 1.0]
--- in Spark but [1.0] in Comet. NormalizeFloatingNumbers only rewrites literals, not
--- parquet columns. Skip until Spark normalizes these zeros (Spark 4.2+, SPARK-54918).
+statement
+SET spark.comet.expression.ArrayExcept.allowIncompatible=false
+
+-- Signed zeros exercise the default Spark-compatible dispatch.
 statement
 CREATE TABLE test_except_dbl_negzero(a array<double>, b array<double>) USING parquet
 
@@ -84,7 +84,7 @@ INSERT INTO test_except_dbl_negzero VALUES
   (array(0.0, double('-0.0'), 1.0), array(0.0)),
   (array(0.0, 1.0), array(double('-0.0')))
 
-query ignore(https://issues.apache.org/jira/browse/SPARK-54918)
+query spark_answer_only
 SELECT a, b, array_except(a, b) FROM test_except_dbl_negzero
 
 statement
@@ -94,5 +94,5 @@ statement
 INSERT INTO test_except_flt_negzero VALUES
   (array(cast(0.0 as float), float('-0.0'), cast(1.0 as float)), array(cast(0.0 as float)))
 
-query ignore(https://issues.apache.org/jira/browse/SPARK-54918)
+query spark_answer_only
 SELECT a, b, array_except(a, b) FROM test_except_flt_negzero

--- a/spark/src/test/resources/sql-tests/expressions/array/array_except.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_except.sql
@@ -71,28 +71,3 @@ INSERT INTO test_except_float VALUES
 
 query
 SELECT a, b, array_except(a, b) FROM test_except_float
-
-statement
-SET spark.comet.expression.ArrayExcept.allowIncompatible=false
-
--- Signed zeros exercise the default Spark-compatible dispatch.
-statement
-CREATE TABLE test_except_dbl_negzero(a array<double>, b array<double>) USING parquet
-
-statement
-INSERT INTO test_except_dbl_negzero VALUES
-  (array(0.0, double('-0.0'), 1.0), array(0.0)),
-  (array(0.0, 1.0), array(double('-0.0')))
-
-query spark_answer_only
-SELECT a, b, array_except(a, b) FROM test_except_dbl_negzero
-
-statement
-CREATE TABLE test_except_flt_negzero(a array<float>, b array<float>) USING parquet
-
-statement
-INSERT INTO test_except_flt_negzero VALUES
-  (array(cast(0.0 as float), float('-0.0'), cast(1.0 as float)), array(cast(0.0 as float)))
-
-query spark_answer_only
-SELECT a, b, array_except(a, b) FROM test_except_flt_negzero

--- a/spark/src/test/resources/sql-tests/expressions/array/array_intersect.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_intersect.sql
@@ -156,11 +156,10 @@ INSERT INTO test_intersect_dbl VALUES
 query
 SELECT a, b, array_intersect(a, b) FROM test_intersect_dbl
 
--- Signed-zero membership. Spark keeps -0.0 distinct from 0.0 while Comet (DataFusion)
--- collapses them, so array_intersect([-0.0], [0.0]) is [] in Spark but [0.0] in Comet,
--- and array_intersect([-0.0], [-0.0]) is [-0.0] in Spark but [0.0] in Comet.
--- NormalizeFloatingNumbers only rewrites literals, not parquet columns. Skip until
--- Spark normalizes these zeros (Spark 4.2+, SPARK-54918).
+statement
+SET spark.comet.expression.ArrayIntersect.allowIncompatible=false
+
+-- Signed zeros exercise the default Spark-compatible dispatch.
 statement
 CREATE TABLE test_intersect_flt_negzero(a array<float>, b array<float>) USING parquet
 
@@ -171,7 +170,7 @@ INSERT INTO test_intersect_flt_negzero VALUES
   (array(float('0.0')), array(float('-0.0'))),
   (array(float('-0.0')), array(float('-0.0')))
 
-query ignore(https://issues.apache.org/jira/browse/SPARK-54918)
+query spark_answer_only
 SELECT a, b, array_intersect(a, b) FROM test_intersect_flt_negzero
 
 statement
@@ -184,8 +183,11 @@ INSERT INTO test_intersect_dbl_negzero VALUES
   (array(double('0.0')), array(double('-0.0'))),
   (array(double('-0.0')), array(double('-0.0')))
 
-query ignore(https://issues.apache.org/jira/browse/SPARK-54918)
+query spark_answer_only
 SELECT a, b, array_intersect(a, b) FROM test_intersect_dbl_negzero
+
+statement
+SET spark.comet.expression.ArrayIntersect.allowIncompatible=true
 
 -- decimal arrays
 statement

--- a/spark/src/test/resources/sql-tests/expressions/array/array_intersect.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_intersect.sql
@@ -121,7 +121,7 @@ query
 SELECT a, b, array_intersect(a, b) FROM test_intersect_long
 
 -- Float arrays with NaN, Infinity, and -Infinity. Signed-zero membership cases are
--- isolated below (see the SPARK-54918 note).
+-- covered in array_set_signed_zero*.sql.
 statement
 CREATE TABLE test_intersect_float(a array<float>, b array<float>) USING parquet
 
@@ -138,7 +138,7 @@ INSERT INTO test_intersect_float VALUES
 query
 SELECT a, b, array_intersect(a, b) FROM test_intersect_float
 
--- Double arrays with NaN, Infinity, and -Infinity. Signed-zero cases isolated below.
+-- Double arrays with NaN, Infinity, and -Infinity. Signed-zero cases are in array_set_signed_zero*.sql.
 statement
 CREATE TABLE test_intersect_dbl(a array<double>, b array<double>) USING parquet
 
@@ -155,39 +155,6 @@ INSERT INTO test_intersect_dbl VALUES
 
 query
 SELECT a, b, array_intersect(a, b) FROM test_intersect_dbl
-
-statement
-SET spark.comet.expression.ArrayIntersect.allowIncompatible=false
-
--- Signed zeros exercise the default Spark-compatible dispatch.
-statement
-CREATE TABLE test_intersect_flt_negzero(a array<float>, b array<float>) USING parquet
-
-statement
-INSERT INTO test_intersect_flt_negzero VALUES
-  (array(cast(0.0 as float), float('-0.0')), array(cast(0.0 as float))),
-  (array(float('-0.0')), array(float('0.0'))),
-  (array(float('0.0')), array(float('-0.0'))),
-  (array(float('-0.0')), array(float('-0.0')))
-
-query spark_answer_only
-SELECT a, b, array_intersect(a, b) FROM test_intersect_flt_negzero
-
-statement
-CREATE TABLE test_intersect_dbl_negzero(a array<double>, b array<double>) USING parquet
-
-statement
-INSERT INTO test_intersect_dbl_negzero VALUES
-  (array(0.0, double('-0.0')), array(0.0)),
-  (array(double('-0.0')), array(double('0.0'))),
-  (array(double('0.0')), array(double('-0.0'))),
-  (array(double('-0.0')), array(double('-0.0')))
-
-query spark_answer_only
-SELECT a, b, array_intersect(a, b) FROM test_intersect_dbl_negzero
-
-statement
-SET spark.comet.expression.ArrayIntersect.allowIncompatible=true
 
 -- decimal arrays
 statement

--- a/spark/src/test/resources/sql-tests/expressions/array/array_set_signed_zero.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_set_signed_zero.sql
@@ -1,0 +1,82 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- MinSparkVersion: 4.2
+
+-- SPARK-54918 normalizes signed zeros. Require native execution, including except/intersect.
+-- Config: spark.comet.expression.ArrayExcept.allowIncompatible=true
+-- Config: spark.comet.expression.ArrayIntersect.allowIncompatible=true
+
+statement
+CREATE TABLE test_array_set_signed_zero_float(a array<float>, b array<float>) USING parquet
+
+statement
+INSERT INTO test_array_set_signed_zero_float VALUES
+  (array(float('0.0'), float('-0.0'), float('1.0')), array(float('0.0'))),
+  (array(float('0.0'), float('1.0')), array(float('-0.0'))),
+  (array(float('-0.0')), array(float('0.0'))),
+  (array(float('0.0')), array(float('-0.0'))),
+  (array(float('-0.0')), array(float('-0.0'))),
+  (array(float('0.0'), float('-0.0')), array(float('0.0')))
+
+query
+SELECT array_distinct(array(float('0.0'), float('-0.0'), float('1.0')))
+
+query
+SELECT array_union(array(float('0.0')), array(float('-0.0')))
+
+query
+SELECT a, b, array_distinct(a) FROM test_array_set_signed_zero_float
+
+query
+SELECT a, b, array_union(a, b) FROM test_array_set_signed_zero_float
+
+query
+SELECT a, b, array_except(a, b) FROM test_array_set_signed_zero_float
+
+query
+SELECT a, b, array_intersect(a, b) FROM test_array_set_signed_zero_float
+
+statement
+CREATE TABLE test_array_set_signed_zero_double(a array<double>, b array<double>) USING parquet
+
+statement
+INSERT INTO test_array_set_signed_zero_double VALUES
+  (array(double('0.0'), double('-0.0'), double('1.0')), array(double('0.0'))),
+  (array(double('0.0'), double('1.0')), array(double('-0.0'))),
+  (array(double('-0.0')), array(double('0.0'))),
+  (array(double('0.0')), array(double('-0.0'))),
+  (array(double('-0.0')), array(double('-0.0'))),
+  (array(double('0.0'), double('-0.0')), array(double('0.0')))
+
+query
+SELECT array_distinct(array(double('0.0'), double('-0.0'), double('1.0')))
+
+query
+SELECT array_union(array(double('0.0')), array(double('-0.0')))
+
+query
+SELECT a, b, array_distinct(a) FROM test_array_set_signed_zero_double
+
+query
+SELECT a, b, array_union(a, b) FROM test_array_set_signed_zero_double
+
+query
+SELECT a, b, array_except(a, b) FROM test_array_set_signed_zero_double
+
+query
+SELECT a, b, array_intersect(a, b) FROM test_array_set_signed_zero_double

--- a/spark/src/test/resources/sql-tests/expressions/array/array_set_signed_zero_spark_3.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_set_signed_zero_spark_3.sql
@@ -1,0 +1,80 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- MaxSparkVersion: 3.5
+
+-- Spark 3 keeps positive and negative zero distinct; these cases can be removed with Spark 3 support.
+
+statement
+CREATE TABLE test_array_set_signed_zero_float(a array<float>, b array<float>) USING parquet
+
+statement
+INSERT INTO test_array_set_signed_zero_float VALUES
+  (array(float('0.0'), float('-0.0'), float('1.0')), array(float('0.0'))),
+  (array(float('0.0'), float('1.0')), array(float('-0.0'))),
+  (array(float('-0.0')), array(float('0.0'))),
+  (array(float('0.0')), array(float('-0.0'))),
+  (array(float('-0.0')), array(float('-0.0'))),
+  (array(float('0.0'), float('-0.0')), array(float('0.0')))
+
+query expect_fallback(SPARK-54918)
+SELECT array_distinct(array(float('0.0'), float('-0.0'), float('1.0')))
+
+query expect_fallback(SPARK-54918)
+SELECT array_union(array(float('0.0')), array(float('-0.0')))
+
+query expect_fallback(SPARK-54918)
+SELECT a, b, array_distinct(a) FROM test_array_set_signed_zero_float
+
+query expect_fallback(SPARK-54918)
+SELECT a, b, array_union(a, b) FROM test_array_set_signed_zero_float
+
+query spark_answer_only
+SELECT a, b, array_except(a, b) FROM test_array_set_signed_zero_float
+
+query spark_answer_only
+SELECT a, b, array_intersect(a, b) FROM test_array_set_signed_zero_float
+
+statement
+CREATE TABLE test_array_set_signed_zero_double(a array<double>, b array<double>) USING parquet
+
+statement
+INSERT INTO test_array_set_signed_zero_double VALUES
+  (array(double('0.0'), double('-0.0'), double('1.0')), array(double('0.0'))),
+  (array(double('0.0'), double('1.0')), array(double('-0.0'))),
+  (array(double('-0.0')), array(double('0.0'))),
+  (array(double('0.0')), array(double('-0.0'))),
+  (array(double('-0.0')), array(double('-0.0'))),
+  (array(double('0.0'), double('-0.0')), array(double('0.0')))
+
+query expect_fallback(SPARK-54918)
+SELECT array_distinct(array(double('0.0'), double('-0.0'), double('1.0')))
+
+query expect_fallback(SPARK-54918)
+SELECT array_union(array(double('0.0')), array(double('-0.0')))
+
+query expect_fallback(SPARK-54918)
+SELECT a, b, array_distinct(a) FROM test_array_set_signed_zero_double
+
+query expect_fallback(SPARK-54918)
+SELECT a, b, array_union(a, b) FROM test_array_set_signed_zero_double
+
+query spark_answer_only
+SELECT a, b, array_except(a, b) FROM test_array_set_signed_zero_double
+
+query spark_answer_only
+SELECT a, b, array_intersect(a, b) FROM test_array_set_signed_zero_double

--- a/spark/src/test/resources/sql-tests/expressions/array/array_set_signed_zero_spark_3.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_set_signed_zero_spark_3.sql
@@ -43,10 +43,10 @@ SELECT a, b, array_distinct(a) FROM test_array_set_signed_zero_float
 query expect_fallback(SPARK-54918)
 SELECT a, b, array_union(a, b) FROM test_array_set_signed_zero_float
 
-query spark_answer_only
+query
 SELECT a, b, array_except(a, b) FROM test_array_set_signed_zero_float
 
-query spark_answer_only
+query
 SELECT a, b, array_intersect(a, b) FROM test_array_set_signed_zero_float
 
 statement
@@ -73,8 +73,8 @@ SELECT a, b, array_distinct(a) FROM test_array_set_signed_zero_double
 query expect_fallback(SPARK-54918)
 SELECT a, b, array_union(a, b) FROM test_array_set_signed_zero_double
 
-query spark_answer_only
+query
 SELECT a, b, array_except(a, b) FROM test_array_set_signed_zero_double
 
-query spark_answer_only
+query
 SELECT a, b, array_intersect(a, b) FROM test_array_set_signed_zero_double

--- a/spark/src/test/resources/sql-tests/expressions/array/array_set_signed_zero_spark_4_0_4_1.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_set_signed_zero_spark_4_0_4_1.sql
@@ -1,0 +1,81 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- MinSparkVersion: 4.0
+-- MaxSparkVersion: 4.1
+
+-- These lines received SPARK-54918 in 4.0.5 and 4.1.4. Accept the runtime-dependent fallback.
+
+statement
+CREATE TABLE test_array_set_signed_zero_float(a array<float>, b array<float>) USING parquet
+
+statement
+INSERT INTO test_array_set_signed_zero_float VALUES
+  (array(float('0.0'), float('-0.0'), float('1.0')), array(float('0.0'))),
+  (array(float('0.0'), float('1.0')), array(float('-0.0'))),
+  (array(float('-0.0')), array(float('0.0'))),
+  (array(float('0.0')), array(float('-0.0'))),
+  (array(float('-0.0')), array(float('-0.0'))),
+  (array(float('0.0'), float('-0.0')), array(float('0.0')))
+
+query spark_answer_only
+SELECT array_distinct(array(float('0.0'), float('-0.0'), float('1.0')))
+
+query spark_answer_only
+SELECT array_union(array(float('0.0')), array(float('-0.0')))
+
+query spark_answer_only
+SELECT a, b, array_distinct(a) FROM test_array_set_signed_zero_float
+
+query spark_answer_only
+SELECT a, b, array_union(a, b) FROM test_array_set_signed_zero_float
+
+query spark_answer_only
+SELECT a, b, array_except(a, b) FROM test_array_set_signed_zero_float
+
+query spark_answer_only
+SELECT a, b, array_intersect(a, b) FROM test_array_set_signed_zero_float
+
+statement
+CREATE TABLE test_array_set_signed_zero_double(a array<double>, b array<double>) USING parquet
+
+statement
+INSERT INTO test_array_set_signed_zero_double VALUES
+  (array(double('0.0'), double('-0.0'), double('1.0')), array(double('0.0'))),
+  (array(double('0.0'), double('1.0')), array(double('-0.0'))),
+  (array(double('-0.0')), array(double('0.0'))),
+  (array(double('0.0')), array(double('-0.0'))),
+  (array(double('-0.0')), array(double('-0.0'))),
+  (array(double('0.0'), double('-0.0')), array(double('0.0')))
+
+query spark_answer_only
+SELECT array_distinct(array(double('0.0'), double('-0.0'), double('1.0')))
+
+query spark_answer_only
+SELECT array_union(array(double('0.0')), array(double('-0.0')))
+
+query spark_answer_only
+SELECT a, b, array_distinct(a) FROM test_array_set_signed_zero_double
+
+query spark_answer_only
+SELECT a, b, array_union(a, b) FROM test_array_set_signed_zero_double
+
+query spark_answer_only
+SELECT a, b, array_except(a, b) FROM test_array_set_signed_zero_double
+
+query spark_answer_only
+SELECT a, b, array_intersect(a, b) FROM test_array_set_signed_zero_double

--- a/spark/src/test/resources/sql-tests/expressions/array/array_union.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_union.sql
@@ -131,7 +131,7 @@ CREATE TABLE test_union_dbl(a array<double>, b array<double>) USING parquet
 statement
 INSERT INTO test_union_dbl VALUES (array(1.0, 2.0), array(2.0, 3.0)), (array(1.0, double('NaN')), array(double('NaN'), 2.0)), (array(double('NaN'), 1.0), array(2.0, 3.0)), (array(1.0, 2.0), array(double('NaN'), 3.0)), (array(double('NaN'), double('NaN')), array(double('NaN'))), (array(double('Infinity'), 1.0), array(double('Infinity'))), (array(double('-Infinity')), array(double('Infinity'))), (array(1.0, NULL), array(2.0, NULL))
 
-query
+query spark_answer_only
 SELECT a, b, array_union(a, b) FROM test_union_dbl
 
 -- float arrays with special values
@@ -141,20 +141,17 @@ CREATE TABLE test_union_float(a array<float>, b array<float>) USING parquet
 statement
 INSERT INTO test_union_float VALUES (array(cast(1.0 as float), cast(2.0 as float)), array(cast(2.0 as float), cast(3.0 as float))), (array(cast(1.0 as float), float('NaN')), array(float('NaN'), cast(2.0 as float))), (array(float('NaN'), float('NaN')), array(float('NaN'))), (array(float('Infinity'), cast(1.0 as float)), array(float('Infinity'))), (array(float('-Infinity')), array(float('Infinity'))), (array(cast(1.0 as float), NULL), array(cast(2.0 as float), NULL))
 
-query
+query spark_answer_only
 SELECT a, b, array_union(a, b) FROM test_union_float
 
--- negative zero (column-sourced). Spark keeps -0.0 distinct from 0.0 while Comet
--- (DataFusion) collapses them, so array_union([0.0], [-0.0]) is [0.0, -0.0] in Spark
--- but [0.0] in Comet. NormalizeFloatingNumbers only rewrites literals, not parquet
--- columns. Skip until Spark normalizes these zeros (Spark 4.2+, SPARK-54918).
+-- Signed zeros use Spark fallback on versions without SPARK-54918.
 statement
 CREATE TABLE test_union_dbl_negzero(a array<double>, b array<double>) USING parquet
 
 statement
 INSERT INTO test_union_dbl_negzero VALUES (array(0.0), array(double('-0.0')))
 
-query ignore(https://issues.apache.org/jira/browse/SPARK-54918)
+query spark_answer_only
 SELECT a, b, array_union(a, b) FROM test_union_dbl_negzero
 
 statement
@@ -163,7 +160,7 @@ CREATE TABLE test_union_flt_negzero(a array<float>, b array<float>) USING parque
 statement
 INSERT INTO test_union_flt_negzero VALUES (array(cast(0.0 as float)), array(float('-0.0')))
 
-query ignore(https://issues.apache.org/jira/browse/SPARK-54918)
+query spark_answer_only
 SELECT a, b, array_union(a, b) FROM test_union_flt_negzero
 
 -- boolean arrays

--- a/spark/src/test/resources/sql-tests/expressions/array/array_union.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_union.sql
@@ -15,6 +15,9 @@
 -- specific language governing permissions and limitations
 -- under the License.
 
+-- No negative zeros in this fixture; signed-zero compatibility is tested in array_set_signed_zero*.
+-- Config: spark.comet.expression.ArrayUnion.allowIncompatible=true
+
 statement
 CREATE TABLE test_array_union(a array<int>, b array<int>) USING parquet
 
@@ -131,7 +134,7 @@ CREATE TABLE test_union_dbl(a array<double>, b array<double>) USING parquet
 statement
 INSERT INTO test_union_dbl VALUES (array(1.0, 2.0), array(2.0, 3.0)), (array(1.0, double('NaN')), array(double('NaN'), 2.0)), (array(double('NaN'), 1.0), array(2.0, 3.0)), (array(1.0, 2.0), array(double('NaN'), 3.0)), (array(double('NaN'), double('NaN')), array(double('NaN'))), (array(double('Infinity'), 1.0), array(double('Infinity'))), (array(double('-Infinity')), array(double('Infinity'))), (array(1.0, NULL), array(2.0, NULL))
 
-query spark_answer_only
+query
 SELECT a, b, array_union(a, b) FROM test_union_dbl
 
 -- float arrays with special values
@@ -141,27 +144,8 @@ CREATE TABLE test_union_float(a array<float>, b array<float>) USING parquet
 statement
 INSERT INTO test_union_float VALUES (array(cast(1.0 as float), cast(2.0 as float)), array(cast(2.0 as float), cast(3.0 as float))), (array(cast(1.0 as float), float('NaN')), array(float('NaN'), cast(2.0 as float))), (array(float('NaN'), float('NaN')), array(float('NaN'))), (array(float('Infinity'), cast(1.0 as float)), array(float('Infinity'))), (array(float('-Infinity')), array(float('Infinity'))), (array(cast(1.0 as float), NULL), array(cast(2.0 as float), NULL))
 
-query spark_answer_only
+query
 SELECT a, b, array_union(a, b) FROM test_union_float
-
--- Signed zeros use Spark fallback on versions without SPARK-54918.
-statement
-CREATE TABLE test_union_dbl_negzero(a array<double>, b array<double>) USING parquet
-
-statement
-INSERT INTO test_union_dbl_negzero VALUES (array(0.0), array(double('-0.0')))
-
-query spark_answer_only
-SELECT a, b, array_union(a, b) FROM test_union_dbl_negzero
-
-statement
-CREATE TABLE test_union_flt_negzero(a array<float>, b array<float>) USING parquet
-
-statement
-INSERT INTO test_union_flt_negzero VALUES (array(cast(0.0 as float)), array(float('-0.0')))
-
-query spark_answer_only
-SELECT a, b, array_union(a, b) FROM test_union_flt_negzero
 
 -- boolean arrays
 query

--- a/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
@@ -23,20 +23,77 @@ import scala.util.Random
 
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.CometTestBase
-import org.apache.spark.sql.catalyst.expressions.{ArrayAppend, ArrayExcept, ArrayInsert, ArrayIntersect, ArrayJoin, ArrayRepeat}
+import org.apache.spark.sql.catalyst.expressions.{ArrayAppend, ArrayDistinct, ArrayExcept, ArrayInsert, ArrayIntersect, ArrayJoin, ArrayRepeat, ArrayUnion}
 import org.apache.spark.sql.catalyst.expressions.{ArrayContains, ArrayRemove}
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Cast, CreateArray, ElementAt, Literal, MonotonicallyIncreasingID}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{ArrayType, StringType}
+import org.apache.spark.sql.types.{ArrayType, DoubleType, FloatType, IntegerType, StringType, StructType}
 
 import org.apache.comet.CometSparkSessionExtensions.{isSpark35Plus, isSpark40Plus}
 import org.apache.comet.DataTypeSupport.isComplexType
-import org.apache.comet.serde.{CometArrayExcept, CometArrayJoin, CometArrayRemove, CometArrayReverse, CometFlatten, Compatible, ExprOuterClass, Incompatible}
+import org.apache.comet.serde.{ArraySetSupport, CometArrayDistinct, CometArrayExcept, CometArrayJoin, CometArrayRemove, CometArrayReverse, CometArrayUnion, CometFlatten, Compatible, ExprOuterClass, Incompatible}
 import org.apache.comet.testing.{DataGenOptions, ParquetGenerator, SchemaGenOptions}
 
 class CometArrayExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
+
+  test("array set signed-zero Spark patch versions") {
+    Seq("3.4.9", "3.5.10", "4.0.4", "4.1.3").foreach { version =>
+      assert(!ArraySetSupport.normalizesSignedZero(version), version)
+    }
+    Seq("4.0.5", "4.0.10", "4.1.4", "4.1.10", "4.2.0", "4.2.0-SNAPSHOT", "5.0.0")
+      .foreach { version =>
+        assert(ArraySetSupport.normalizesSignedZero(version), version)
+      }
+  }
+
+  test("array set signed-zero support levels") {
+    val fixed = ArraySetSupport.normalizesSignedZero(org.apache.spark.SPARK_VERSION)
+    Seq(FloatType, DoubleType, ArrayType(FloatType), new StructType().add("x", DoubleType))
+      .foreach { elementType =>
+        val child = AttributeReference("a", ArrayType(elementType))()
+        val expected =
+          if (fixed) Compatible() else Incompatible(Some(ArraySetSupport.signedZeroReason))
+        assert(CometArrayDistinct.getSupportLevel(ArrayDistinct(child)) == expected)
+        assert(CometArrayUnion.getSupportLevel(ArrayUnion(child, child)) == expected)
+      }
+    Seq(IntegerType, StringType, ArrayType(IntegerType)).foreach { elementType =>
+      val child = AttributeReference("a", ArrayType(elementType))()
+      assert(CometArrayDistinct.getSupportLevel(ArrayDistinct(child)) == Compatible())
+      assert(CometArrayUnion.getSupportLevel(ArrayUnion(child, child)) == Compatible())
+    }
+  }
+
+  test("array set signed-zero fallback and native opt-in") {
+    withSQLConf(
+      SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        "org.apache.spark.sql.catalyst.optimizer.ConstantFolding") {
+      Seq("float", "double").foreach { dataType =>
+        Seq(
+          "array_distinct" -> s"array($dataType('0.0'), $dataType('-0.0'))",
+          "array_union" -> s"array($dataType('0.0')), array($dataType('-0.0'))")
+          .foreach { case (function, arguments) =>
+            val query = s"SELECT $function($arguments)"
+            if (ArraySetSupport.normalizesSignedZero(org.apache.spark.SPARK_VERSION)) {
+              checkSparkAnswerAndOperator(query)
+            } else {
+              checkSparkAnswerAndFallbackReason(query, "SPARK-54918")
+            }
+          }
+      }
+      Seq(classOf[ArrayDistinct], classOf[ArrayUnion]).foreach { exprClass =>
+        withSQLConf(CometConf.getExprAllowIncompatConfigKey(exprClass) -> "true") {
+          val query = if (exprClass == classOf[ArrayDistinct]) {
+            "SELECT array_distinct(array(double('1.0'), double('1.0')))"
+          } else {
+            "SELECT array_union(array(double('1.0')), array(double('1.0')))"
+          }
+          checkSparkAnswerAndOperator(query)
+        }
+      }
+    }
+  }
 
   test("array_remove - integer") {
     withSQLConf(CometConf.getExprAllowIncompatConfigKey(classOf[ArrayRemove]) -> "true") {

--- a/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometArrayExpressionSuite.scala
@@ -49,6 +49,7 @@ class CometArrayExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelp
   }
 
   test("array set signed-zero support levels") {
+    // This test covers element-type detection; the preceding test pins the version boundaries.
     val fixed = ArraySetSupport.normalizesSignedZero(org.apache.spark.SPARK_VERSION)
     Seq(FloatType, DoubleType, ArrayType(FloatType), new StructType().add("x", DoubleType))
       .foreach { elementType =>

--- a/spark/src/test/scala/org/apache/comet/CometCodegenFuzzSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCodegenFuzzSuite.scala
@@ -28,7 +28,7 @@ import org.apache.commons.io.FileUtils
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.CometTestBase
 import org.apache.spark.sql.catalyst.CatalystTypeConverters
-import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, Literal}
+import org.apache.spark.sql.catalyst.expressions.{ArrayDistinct, GenericInternalRow, Literal}
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, GenericArrayData}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.internal.SQLConf
@@ -299,17 +299,20 @@ class CometCodegenFuzzSuite
       case _ => false
     }
     spark.udf.register("id_int_arrdistinct", (i: Int) => i)
-    for (field <- arrayStructFields) {
-      val q = s"SELECT id_int_arrdistinct(cardinality(array_distinct(${field.name}))) FROM t1"
-      val df = sql(q)
-      val plan = df.queryExecution.optimizedPlan.toString
-      val planLower = plan.toLowerCase
-      assert(
-        planLower.contains("array_distinct") || planLower.contains("arraydistinct"),
-        s"optimizer eliminated array_distinct on column ${field.name}; coverage would be " +
-          s"vacuous. plan=\n$plan")
-      assertCodegenRan {
-        checkSparkAnswerAndOperator(df)
+    // beforeAll disables negative zero generation, so the native opt-in is safe on older Spark.
+    withSQLConf(CometConf.getExprAllowIncompatConfigKey(classOf[ArrayDistinct]) -> "true") {
+      for (field <- arrayStructFields) {
+        val q = s"SELECT id_int_arrdistinct(cardinality(array_distinct(${field.name}))) FROM t1"
+        val df = sql(q)
+        val plan = df.queryExecution.optimizedPlan.toString
+        val planLower = plan.toLowerCase
+        assert(
+          planLower.contains("array_distinct") || planLower.contains("arraydistinct"),
+          s"optimizer eliminated array_distinct on column ${field.name}; coverage would be " +
+            s"vacuous. plan=\n$plan")
+        assertCodegenRan {
+          checkSparkAnswerAndOperator(df)
+        }
       }
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5701.

## Rationale for this change

Native `array_distinct` and `array_union` can disagree with Spark on signed zeros and noncanonical NaNs. For example, older Spark keeps both zeros in `array_distinct(array(0.0, double('-0.0')))`, while native execution merges them. Native execution can also retain NaNs with different signs or payloads that Spark deduplicates, and nested floating-point elements have signed-zero differences too.

SPARK-54918 normalizes these inputs starting with Spark 4.0.5, 4.1.4, and 4.2. Earlier patch releases and Spark 3.4/3.5 still need fallback, so admission must check the runtime version numerically.

## What changes are included in this PR?

A shared compatibility check makes distinct/union fall back when their element type contains floats or doubles, including nested types, on Spark versions without SPARK-54918. Other types and fixed versions retain native execution. The existing per-expression `allowIncompatible` options remain available, with warnings covering both signed zeros and NaNs.

The fallback covers the whole projection, which can be expensive. A [reviewer's Spark 4.1.3 benchmark](https://github.com/apache/datafusion-comet/pull/5750#pullrequestreview-5153510242) measured 93 ms with native opt-in versus 1355 ms with projection fallback for `sum(cardinality(array_distinct(d)))` over two million `array<double>` rows (release build, best of five). Codegen dispatch was slower in that workload; this does not establish a universal ranking or isolate the cause. Distinct/union use projection fallback.

Version-scoped SQL fixtures verify signed-zero results and execution paths, including default codegen dispatch for except/intersect on Spark 3 and 4.0/4.1. General native fixtures retain opt-in coverage. Documentation explains the compatibility boundary and projection cost. The numeric gate is retained because Spark can normalize array constructors and conditional branches without a top-level normalization marker; vendor backports with old version numbers may still fall back.

## How are these changes tested?

Targeted floating-point regressions and signed-zero SQL fixtures pass on Spark 4.0.4 and 4.1.3; the NaN regression checks native execution on 4.2.0. Prior runs cover signed-zero fixtures on Spark 3.4, 3.5, and 4.2. Formatting passes.
