### PR TITLE
test: cover ambiguous exact nested Parquet field matches

### DIFF
--- a/native/core/src/parquet/schema_adapter.rs
+++ b/native/core/src/parquet/schema_adapter.rs
@@ -2281,6 +2281,43 @@ mod test {
         assert!(!is_pure_structural_narrowing(&physical, &target, &opts));
     }
 
+    #[test]
+    fn structural_narrowing_requires_unambiguous_exact_match() -> Result<(), DataFusionError> {
+        use crate::parquet::cast_column::CometCastColumnExpr;
+        use datafusion::physical_expr::expressions::CastExpr;
+
+        // #5707: an exact match must not hide a second case-insensitive match.
+        for (upper, lower) in [("ID", "id"), ("CAFÉ", "café")] {
+            let physical = struct_type(vec![(upper, DataType::Int64), (lower, DataType::Int64)]);
+            let target = struct_type(vec![(lower, DataType::Int64)]);
+            for (physical, target) in [
+                (physical.clone(), target.clone()),
+                (
+                    struct_type(vec![("inner", physical.clone())]),
+                    struct_type(vec![("inner", target.clone())]),
+                ),
+                (list_type(physical), list_type(target)),
+            ] {
+                for case_sensitive in [false, true] {
+                    let mut opts = default_options();
+                    opts.case_sensitive = case_sensitive;
+                    assert_eq!(
+                        is_pure_structural_narrowing(&physical, &target, &opts),
+                        case_sensitive,
+                        "{physical:?} -> {target:?}, case_sensitive={case_sensitive}"
+                    );
+                    let rewritten = rewrite_events_column(physical.clone(), target.clone(), opts)?;
+                    if case_sensitive {
+                        assert!(rewritten.downcast_ref::<CastExpr>().is_some());
+                    } else {
+                        assert!(rewritten.downcast_ref::<CometCastColumnExpr>().is_some());
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// A target field with no name match at all must be denied: DataFusion's
     /// `nested_struct::cast_column` null-fills it unconditionally, while Comet's behavior
     /// additionally depends on `return_null_struct_if_all_fields_missing` at the struct level.

--- a/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
@@ -134,34 +134,37 @@ class CometNativeReaderSuite extends CometTestBase with AdaptiveSparkPlanHelper 
     }
   }
 
-  test("native reader duplicate nested struct fields in case-insensitive mode (non-ASCII)") {
-    withTempPath { path =>
-      // Sibling struct fields that fold to the same name; the nested convert must raise the same
-      // duplicate-field error Spark raises, not panic or resolve arbitrarily.
-      withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
-        spark
-          .range(3)
-          .selectExpr("named_struct('CAFÉ', id, 'café', id) as s")
-          .write
-          .mode("overwrite")
-          .parquet(path.toString)
-      }
-      val readSchema =
-        new StructType().add("s", new StructType().add("Café", LongType, nullable = true))
-      withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
-        val df = spark.read.schema(readSchema).parquet(path.toString)
-        // Confirm Comet's native scan (its nested Struct convert) raises this, not a Spark
-        // fallback that emits the same "duplicate field" substring for the same input.
-        assert(
-          find(df.queryExecution.executedPlan)(_.isInstanceOf[CometNativeScanExec]).isDefined,
-          "expected a CometNativeScanExec so the duplicate error is raised by Comet")
-        val e = intercept[Exception] {
-          df.collect()
+  for (requestedName <- Seq("Café", "café")) {
+    test(s"native reader duplicate nested struct fields: $requestedName (case-insensitive)") {
+      withTempPath { path =>
+        // Sibling struct fields that fold to the same name; the nested convert must raise the same
+        // duplicate-field error Spark raises, not panic or resolve arbitrarily.
+        withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+          spark
+            .range(3)
+            .selectExpr("named_struct('CAFÉ', id, 'café', id) as s")
+            .write
+            .mode("overwrite")
+            .parquet(path.toString)
         }
-        assert(
-          e.getMessage.contains("duplicate field") ||
-            (e.getCause != null && e.getCause.getMessage.contains("duplicate field")),
-          s"Expected duplicate field error, got: ${e.getMessage}")
+        val readSchema =
+          new StructType()
+            .add("s", new StructType().add(requestedName, LongType, nullable = true))
+        withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
+          val df = spark.read.schema(readSchema).parquet(path.toString)
+          // Confirm Comet's native scan (its nested Struct convert) raises this, not a Spark
+          // fallback that emits the same "duplicate field" substring for the same input.
+          assert(
+            find(df.queryExecution.executedPlan)(_.isInstanceOf[CometNativeScanExec]).isDefined,
+            "expected a CometNativeScanExec so the duplicate error is raised by Comet")
+          val e = intercept[Exception] {
+            df.collect()
+          }
+          assert(
+            e.getMessage.contains("duplicate field") ||
+              (e.getCause != null && e.getCause.getMessage.contains("duplicate field")),
+            s"Expected duplicate field error, got: ${e.getMessage}")
+        }
       }
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5707.

## Rationale for this change

Comet can retain DataFusion's generic `CastExpr` for pure structural narrowing of nested Parquet columns, allowing DataFusion's nested leaf pruning to read only the requested fields. Retaining that cast is safe only when DataFusion's exact-name lookup agrees with Spark's configured field-name resolver.

An exact match alone is insufficient: with case-insensitive resolution, a file containing `s: struct<ID: bigint, id: bigint>` and a requested schema of `s: struct<id: bigint>` is ambiguous. DataFusion's generic cast can select the exact `id` field, whereas Spark and Comet's Parquet converter reject the duplicate match. The same problem applies to non-ASCII names such as `CAFÉ` and `café`, and to structs nested inside other structs or lists.

The implementation merged in #5262 already requires exactly one source match under Spark's configured resolver at each nested struct level, in addition to an exact-name match. Ambiguous narrowing therefore falls back to `CometCastColumnExpr`, preserving the existing duplicate-field error. This PR adds the missing regression coverage for that behavior; it does not change production code.

## What changes are included in this PR?

- Add a native regression covering ASCII and non-ASCII sibling names with an exact requested match, directly in a struct and inside nested structs and lists.
- Check both the narrowing predicate and the actual expression-adapter rewrite. Case-insensitive ambiguity must select `CometCastColumnExpr`; case-sensitive exact matches must retain DataFusion's `CastExpr` so valid pruning remains enabled.
- Parameterize the existing native-reader regression to request both mixed-case `Café` and exact-case `café` from `CAFÉ`/`café` siblings. Both reads must raise a duplicate-field error, and the test asserts that the plan uses `CometNativeScanExec`.

## How are these changes tested?

- 14 native structural-narrowing tests passed.
- 2 focused `CometNativeReaderSuite` tests passed on Spark 4.1.
- Rust formatting, Maven Spotless, and `git diff --check` passed.
