### PR TITLE
fix: preserve ANSI errors for rejected TIMESTAMP_NTZ casts

### DIFF
--- a/native/spark-expr/src/conversion_funcs/string.rs
+++ b/native/spark-expr/src/conversion_funcs/string.rs
@@ -1825,20 +1825,12 @@ fn timestamp_ntz_parser_inner(value: &str, eval_mode: EvalMode) -> SparkResult<O
 
     for (re, ts_type) in patterns {
         if re.is_match(value) {
-            return match parse_to_timestamp_info(value, ts_type)? {
-                Some(info) => match local_datetime_to_micros(&info)? {
-                    some @ Some(_) => Ok(some),
-                    None if eval_mode == EvalMode::Ansi => {
-                        Err(SparkError::InvalidInputInCastToDatetime {
-                            value: value.to_string(),
-                            from_type: "STRING".to_string(),
-                            to_type: "TIMESTAMP_NTZ".to_string(),
-                        })
-                    }
-                    None => Ok(None),
-                },
-                None => Ok(None),
-            };
+            if let Some(info) = parse_to_timestamp_info(value, ts_type)? {
+                if let Some(timestamp) = local_datetime_to_micros(&info)? {
+                    return Ok(Some(timestamp));
+                }
+            }
+            break;
         }
     }
 
@@ -2476,6 +2468,29 @@ mod tests {
         // In Legacy mode, same input should return None (null).
         let result = timestamp_ntz_parser("2023-02-29", EvalMode::Legacy, false, false);
         assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn test_cast_string_to_timestamp_ntz_out_of_range_year() {
+        for value in ["294249-01-01", "294249-01-01 00:00:00", "-290310-01-01"] {
+            let array: ArrayRef = Arc::new(StringArray::from(vec![value]));
+            match cast_string_to_timestamp_ntz(&array, EvalMode::Ansi, true, false) {
+                Err(SparkError::InvalidInputInCastToDatetime {
+                    value: actual,
+                    from_type,
+                    to_type,
+                }) => {
+                    assert_eq!(actual, value);
+                    assert_eq!(from_type, "STRING");
+                    assert_eq!(to_type, "TIMESTAMP_NTZ");
+                }
+                other => panic!("Expected ANSI cast error for {value}, got {other:?}"),
+            }
+            for mode in [EvalMode::Legacy, EvalMode::Try] {
+                let result = cast_string_to_timestamp_ntz(&array, mode, true, false).unwrap();
+                assert!(result.is_null(0), "Expected NULL for {value} in {mode:?}");
+            }
+        }
     }
 
     #[test]

--- a/spark/src/test/scala/org/apache/comet/CometNativeCastSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometNativeCastSuite.scala
@@ -1541,6 +1541,16 @@ class CometNativeCastSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  Seq(DataTypes.TimestampType, DataTypes.TimestampNTZType).foreach { toType =>
+    test(s"cast StringType to $toType - out-of-range years") {
+      withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+        Seq("294249-01-01", "294249-01-01 00:00:00", "-290310-01-01").foreach { value =>
+          castTimestampTest(Seq(value).toDF("a"), toType, assertNative = true)
+        }
+      }
+    }
+  }
+
   test("cast StringType to TimestampNTZType") {
     representativeTimezones.foreach { tz =>
       withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> tz) {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5749.

## Rationale for this change

`CAST(string AS TIMESTAMP_NTZ)` can silently return NULL under ANSI mode when the input matches a supported timestamp pattern but the timestamp decoder rejects it. For example, casting a Parquet-backed string column containing `294249-01-01` raises `CAST_INVALID_INPUT` in Spark 4.1.3, while Comet previously returned NULL. The equivalent Comet cast to `TIMESTAMP` already raises an error.

The discrepancy comes from `timestamp_ntz_parser_inner`: a `None` returned by `parse_to_timestamp_info` was mapped directly to `Ok(None)`, bypassing the evaluation-mode check. Six-digit years outside the decoder's allowed range reach this branch because they pass the timestamp pattern check.
## What changes are included in this PR?

The NTZ parser now returns immediately only when decoding and conversion to microseconds both succeed. If either rejects a recognized input, parsing stops and falls through to the existing evaluation-mode handling, which produces `InvalidInputInCastToDatetime` for ANSI mode and NULL for legacy and try modes. Unrecognized input continues through the same handling. This removes the duplicated ANSI error construction and ensures decoder rejection and conversion rejection follow the same policy without changing the accepted timestamp formats or year limits.

Regression coverage includes `294249-01-01`, `294249-01-01 00:00:00`, and `-290310-01-01`. Native tests check the ANSI error's value and source/target types, plus NULL results in legacy and try modes. Spark comparison tests exercise both `TIMESTAMP` and `TIMESTAMP_NTZ` using Parquet-backed columns to prevent constant folding. Each malformed value is checked separately so an exception from one value cannot hide another case.

## How are these changes tested?

- Focused NTZ Rust unit tests: 5 passed.
- Spark 4.1.3 out-of-range-year regressions: 2 passed, covering ANSI, legacy, and try casts.
- Native build, Rust formatting, Spotless, and `git diff --check` passed.
