### PR TITLE
ci: label pull requests by changed paths and title prefix

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,137 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Path rules for the pull request labeler (.github/workflows/label_prs.yml).
+# A label is added when a changed file matches one of its globs; labels are never removed,
+# so hand-applied labels stay. area:ci and documentation apply only when every changed file
+# matches, since most PRs touch a workflow or a doc in passing.
+
+area:shuffle:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'native/shuffle/**'
+          - 'spark/src/main/**/shuffle/**'
+          - 'spark/src/main/scala/org/apache/comet/shuffle/**'
+          - 'common/src/main/**/*Shuffle*'
+
+area:scan:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'native/core/src/parquet/**'
+          - 'native/core/src/cloud/**'
+          - 'native/core/src/execution/operators/scan.rs'
+          - 'native/core/src/execution/operators/csv_scan.rs'
+          - 'native/core/src/execution/operators/iceberg_scan.rs'
+          - 'native/core/src/execution/operators/iceberg_common.rs'
+          - 'spark/src/main/**/parquet/**'
+          - 'common/src/main/**/parquet/**'
+          - 'spark/src/main/scala/org/apache/comet/rules/CometScanRule.scala'
+          - 'spark/src/main/scala/org/apache/comet/rules/CometScanContrib.scala'
+          - 'spark/src/main/scala/org/apache/spark/sql/comet/*Scan*.scala'
+          - 'spark/src/main/scala/org/apache/comet/objectstore/**'
+          - 'spark/src/main/scala/org/apache/comet/serde/operator/*Scan*.scala'
+          - 'contrib/**'
+
+area:writer:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'native/core/src/execution/operators/parquet_writer.rs'
+          - 'native/core/src/execution/operators/iceberg_write.rs'
+          - 'spark/src/main/scala/org/apache/spark/sql/comet/*Write*.scala'
+          - 'spark/src/main/scala/org/apache/spark/sql/comet/*Commit*.scala'
+          - 'spark/src/main/scala/org/apache/comet/serde/operator/*Writ*.scala'
+          - 'spark/src/main/scala/org/apache/comet/serde/operator/CometSink.scala'
+          - 'spark/src/main/scala/org/apache/comet/serde/operator/CometDataWritingCommand.scala'
+          - 'spark/src/main/**/*WriteFiles*'
+
+area:aggregation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'native/spark-expr/src/agg_funcs/**'
+          - 'spark/src/main/scala/org/apache/comet/serde/aggregates.scala'
+          - 'spark/src/main/scala/org/apache/comet/serde/CometAggregateExpressionSerde.scala'
+          - 'native/core/src/execution/merge_as_partial.rs'
+
+area:expressions:
+  - changed-files:
+      - all-globs-to-any-file:
+          - 'native/spark-expr/src/**'
+          - '!native/spark-expr/src/agg_funcs/**'
+          - '!native/spark-expr/src/jvm_udf/**'
+  - changed-files:
+      - all-globs-to-any-file:
+          - 'spark/src/main/scala/org/apache/comet/serde/*.scala'
+          - '!spark/src/main/scala/org/apache/comet/serde/aggregates.scala'
+          - '!spark/src/main/scala/org/apache/comet/serde/CometAggregateExpressionSerde.scala'
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'native/core/src/execution/expressions/**'
+          - 'spark/src/main/scala/org/apache/comet/expressions/**'
+          - 'spark/src/main/scala/org/apache/comet/codegen/**'
+
+area:joins:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'native/core/src/execution/operators/dynamic_filter.rs'
+          - 'native/core/src/execution/operators/dynamic_filter/**'
+          - 'spark/src/main/scala/org/apache/comet/rules/RewriteJoin.scala'
+          - 'spark/src/main/scala/org/apache/comet/rules/CometPlanAdaptiveDynamicPruningFilters.scala'
+          - 'spark/src/main/**/*Join*'
+
+area:ffi:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'native/jni-bridge/**'
+          - 'native/core/src/execution/columnar_to_row.rs'
+          - 'spark/src/main/**/vector/**'
+          - 'common/src/main/**/vector/**'
+          - 'spark/src/main/scala/org/apache/comet/NativeColumnarToRowConverter.scala'
+          - 'spark/src/main/scala/org/apache/spark/sql/comet/CometColumnarToRowExec.scala'
+          - 'spark/src/main/scala/org/apache/spark/sql/comet/CometNativeColumnarToRowExec.scala'
+          - 'spark/src/main/scala/org/apache/spark/sql/comet/CometSparkToColumnarExec.scala'
+
+area:memory:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'native/core/src/execution/memory_pools/**'
+          - 'spark/src/main/**/*MemoryManager*'
+          - 'spark/src/main/**/*MemoryAllocator*'
+          - 'common/src/main/**/*MemoryAllocator*'
+          - 'common/src/main/**/*OutOfMemory*'
+
+area:udf:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'native/spark-expr/src/jvm_udf/**'
+          - 'spark/src/main/scala/org/apache/comet/udf/**'
+          - 'spark/src/main/**/python/**'
+          - 'spark/src/main/**/*MapInBatch*'
+          - '.github/workflows/pyarrow_udf_test.yml'
+
+area:Iceberg:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*[Ii]ceberg*'
+          - '**/*[Ii]ceberg*/**'
+
+area:ci:
+  - changed-files:
+      - any-glob-to-all-files: '{.github/**,dev/ci/**,dev/release/**,dev/*.sh,dev/*.py,dev/*.xml,dev/*.toml}'
+
+documentation:
+  - changed-files:
+      - any-glob-to-all-files: '{docs/**,**/*.md}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Check micro benchmark runner
         run: python3 dev/ci/check-benchmark-runner.py
 
+      - name: Check pull request type labeling
+        run: node --test dev/ci/pr-type-label.test.mjs
+
       - name: Install actionlint
         run: |
           curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash

--- a/.github/workflows/label_prs.yml
+++ b/.github/workflows/label_prs.yml
@@ -28,28 +28,24 @@ permissions:
   contents: read
   pull-requests: write
 
-# One group per pull request, queued rather than cancelled: the labeler action reads the label
-# set and writes it back whole, so two runs writing at once can drop a label the other just
-# added, and the opened run must always complete because the title step runs on open only.
+# One group per pull request with cancellation, so at most one run writes labels at a time:
+# the labeler action reads the label set and writes it back whole, and two runs writing at
+# once can drop a label the other just added. A cancelled or replaced run loses nothing
+# because every step below is safe to repeat on the next event.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  queue: max
+  cancel-in-progress: true
 
 jobs:
   label:
     runs-on: ubuntu-slim
     steps:
-      - name: Label by changed paths
-        uses: actions/labeler@v7
-        with:
-          configuration-path: .github/labeler.yml
-          sync-labels: false
-
       # The type label follows the conventional commit prefix in the title, matching how
-      # maintainers label by hand. Only on open, so later hand edits are not overwritten, and
-      # not for dependabot, whose PRs already carry the dependencies label.
+      # maintainers label by hand. It is added only while the pull request carries no type
+      # label at all, so a hand-picked replacement stays, and a run cut short by a newer push
+      # is completed by that push. Dependabot pull requests already carry their label.
       - name: Label by title prefix
-        if: github.event.action == 'opened' && github.actor != 'dependabot[bot]'
+        if: github.actor != 'dependabot[bot]'
         uses: actions/github-script@v9
         with:
           script: |
@@ -73,7 +69,12 @@ jobs:
               deps: ['dependencies'],
             };
             const labels = byPrefix[match[1].toLowerCase()];
+            const typeLabels = new Set(Object.values(byPrefix).flat());
             const present = new Set(context.payload.pull_request.labels.map((l) => l.name));
+            if ([...present].some((l) => typeLabels.has(l))) {
+              core.info('A type label is already present, leaving it as is');
+              return;
+            }
             const missing = labels.filter((l) => !present.has(l));
             if (missing.length === 0) {
               return;
@@ -84,3 +85,9 @@ jobs:
               issue_number: context.issue.number,
               labels: missing,
             });
+
+      - name: Label by changed paths
+        uses: actions/labeler@v7
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: false

--- a/.github/workflows/label_prs.yml
+++ b/.github/workflows/label_prs.yml
@@ -28,8 +28,11 @@ permissions:
   contents: read
   pull-requests: write
 
+# Pushes replace each other's path-labeling run, but the opened run stays in its own group:
+# the title step runs on open only, and a synchronize run that cancelled it would leave the
+# type label missing with no later event to add it.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event.action }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/label_prs.yml
+++ b/.github/workflows/label_prs.yml
@@ -40,50 +40,44 @@ jobs:
   label:
     runs-on: ubuntu-slim
     steps:
+      # Checks out the base branch, never the pull request's code: under pull_request_target the
+      # default ref is the base commit, and only dev/ci/pr-type-label.mjs is read from it.
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
       # The type label follows the conventional commit prefix in the title, matching how
-      # maintainers label by hand. It is added only while the pull request carries no type
-      # label at all, so a hand-picked replacement stays, and a run cut short by a newer push
-      # is completed by that push. Dependabot pull requests already carry their label.
+      # maintainers label by hand. The decision reads the pull request's current labels, not the
+      # event payload, so a type label a maintainer applied before this run started stays and
+      # a run cut short by a newer push is completed by that push. Dependabot pull requests
+      # already carry their label.
       - name: Label by title prefix
         if: github.actor != 'dependabot[bot]'
         uses: actions/github-script@v9
         with:
           script: |
-            const title = context.payload.pull_request.title.trim();
-            const match = /^(feat|fix|perf|test|docs?|chore|refactor|ci|build|deps)(\([^)]*\))?!?:/i.exec(title);
-            if (!match) {
-              core.info(`No conventional prefix in "${title}", skipping the type label`);
-              return;
-            }
-            const byPrefix = {
-              feat: ['enhancement'],
-              refactor: ['enhancement'],
-              chore: ['enhancement'],
-              fix: ['bug'],
-              perf: ['enhancement', 'performance'],
-              test: ['enhancement', 'test'],
-              doc: ['documentation'],
-              docs: ['documentation'],
-              ci: ['enhancement', 'build'],
-              build: ['enhancement', 'build'],
-              deps: ['dependencies'],
-            };
-            const labels = byPrefix[match[1].toLowerCase()];
-            const typeLabels = new Set(Object.values(byPrefix).flat());
-            const present = new Set(context.payload.pull_request.labels.map((l) => l.name));
-            if ([...present].some((l) => typeLabels.has(l))) {
-              core.info('A type label is already present, leaving it as is');
-              return;
-            }
-            const missing = labels.filter((l) => !present.has(l));
-            if (missing.length === 0) {
+            const { typeLabelsToAdd } = await import(
+              `${process.env.GITHUB_WORKSPACE}/dev/ci/pr-type-label.mjs`
+            );
+            const { data: current } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const labels = typeLabelsToAdd(
+              context.payload.pull_request.title,
+              current.map((label) => label.name),
+            );
+            if (labels.length === 0) {
+              core.info('No type label to add');
               return;
             }
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              labels: missing,
+              labels,
             });
 
       - name: Label by changed paths

--- a/.github/workflows/label_prs.yml
+++ b/.github/workflows/label_prs.yml
@@ -28,12 +28,12 @@ permissions:
   contents: read
   pull-requests: write
 
-# Pushes replace each other's path-labeling run, but the opened run stays in its own group:
-# the title step runs on open only, and a synchronize run that cancelled it would leave the
-# type label missing with no later event to add it.
+# One group per pull request, queued rather than cancelled: the labeler action reads the label
+# set and writes it back whole, so two runs writing at once can drop a label the other just
+# added, and the opened run must always complete because the title step runs on open only.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event.action }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  queue: max
 
 jobs:
   label:

--- a/.github/workflows/label_prs.yml
+++ b/.github/workflows/label_prs.yml
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Label pull requests
+
+# Runs on pull_request_target so it can label pull requests from forks. Nothing from the pull
+# request is checked out or executed: the labeler reads the changed file list through the API
+# and the title step reads the event payload.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Label by changed paths
+        uses: actions/labeler@v7
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: false
+
+      # The type label follows the conventional commit prefix in the title, matching how
+      # maintainers label by hand. Only on open, so later hand edits are not overwritten, and
+      # not for dependabot, whose PRs already carry the dependencies label.
+      - name: Label by title prefix
+        if: github.event.action == 'opened' && github.actor != 'dependabot[bot]'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const title = context.payload.pull_request.title.trim();
+            const match = /^(feat|fix|perf|test|docs?|chore|refactor|ci|build|deps)(\([^)]*\))?!?:/i.exec(title);
+            if (!match) {
+              core.info(`No conventional prefix in "${title}", skipping the type label`);
+              return;
+            }
+            const byPrefix = {
+              feat: ['enhancement'],
+              refactor: ['enhancement'],
+              chore: ['enhancement'],
+              fix: ['bug'],
+              perf: ['enhancement', 'performance'],
+              test: ['enhancement', 'test'],
+              doc: ['documentation'],
+              docs: ['documentation'],
+              ci: ['enhancement', 'build'],
+              build: ['enhancement', 'build'],
+              deps: ['dependencies'],
+            };
+            const labels = byPrefix[match[1].toLowerCase()];
+            const present = new Set(context.payload.pull_request.labels.map((l) => l.name));
+            const missing = labels.filter((l) => !present.has(l));
+            if (missing.length === 0) {
+              return;
+            }
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: missing,
+            });

--- a/dev/ci/pr-type-label.mjs
+++ b/dev/ci/pr-type-label.mjs
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Type label for a pull request from its conventional commit prefix, mirroring how
+// maintainers label by hand. Used by .github/workflows/label_prs.yml and tested by
+// pr-type-label.test.mjs.
+
+export const LABELS_BY_PREFIX = {
+  feat: ['enhancement'],
+  refactor: ['enhancement'],
+  chore: ['enhancement'],
+  fix: ['bug'],
+  perf: ['enhancement', 'performance'],
+  test: ['enhancement', 'test'],
+  doc: ['documentation'],
+  docs: ['documentation'],
+  ci: ['enhancement', 'build'],
+  build: ['enhancement', 'build'],
+  deps: ['dependencies'],
+};
+
+const TYPE_LABELS = new Set(Object.values(LABELS_BY_PREFIX).flat());
+
+const PREFIX = /^(feat|fix|perf|test|docs?|chore|refactor|ci|build|deps)(\([^)]*\))?!?:/i;
+
+// Labels to add for `title` given the pull request's current labels. Empty when the title has
+// no conventional prefix or when any type label is already present, so a choice a maintainer
+// has made stays as it is.
+export function typeLabelsToAdd(title, currentLabels) {
+  const match = PREFIX.exec(title.trim());
+  if (!match) {
+    return [];
+  }
+  const present = new Set(currentLabels);
+  if ([...present].some((label) => TYPE_LABELS.has(label))) {
+    return [];
+  }
+  return LABELS_BY_PREFIX[match[1].toLowerCase()].filter((label) => !present.has(label));
+}

--- a/dev/ci/pr-type-label.test.mjs
+++ b/dev/ci/pr-type-label.test.mjs
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { typeLabelsToAdd } from './pr-type-label.mjs';
+
+test('adds the type label for a conventional title with no labels', () => {
+  assert.deepEqual(typeLabelsToAdd('fix: keep the entry alive', []), ['bug']);
+  assert.deepEqual(typeLabelsToAdd('perf(shuffle)!: reuse contexts', ['area:shuffle']), [
+    'enhancement',
+    'performance',
+  ]);
+  assert.deepEqual(typeLabelsToAdd('chore(deps): bump actions', []), ['enhancement']);
+});
+
+test('leaves a type label a maintainer already applied, whatever the event carried', () => {
+  // The event payload showed no labels, but the pull request has one by the time the run starts.
+  assert.deepEqual(typeLabelsToAdd('fix: keep the entry alive', ['enhancement']), []);
+  assert.deepEqual(typeLabelsToAdd('perf: reuse contexts', ['performance']), []);
+});
+
+test('adds nothing for a title without a conventional prefix', () => {
+  assert.deepEqual(typeLabelsToAdd('Add Lance contrib build gate', []), []);
+  assert.deepEqual(typeLabelsToAdd('[draft] ci: pinned image', []), []);
+});
+
+test('does not repeat labels that are already present', () => {
+  assert.deepEqual(typeLabelsToAdd('test: cover struct columns', ['test']), []);
+});


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5761.

## Rationale for this change

Pull requests are labeled by hand. Open pull requests mostly carry a type label from the title prefix plus one or two `area:*` labels, while most merged pull requests carry none, so the labels are not a reliable view of what changed where and each one costs a maintainer a click. Issues already get `requires-triage` automatically; this does the equivalent for pull requests using the scheme maintainers apply manually.

## What changes are included in this PR?

- `.github/labeler.yml`: path rules for the `area:*` labels (shuffle, scan, writer, aggregation, expressions, joins, ffi, memory, udf, Iceberg, ci) and `documentation`. `area:ci` and `documentation` apply only when every changed file matches, since most pull requests touch a workflow file or a doc in passing. The expressions rule excludes the aggregate and UDF paths so those get their own label.
- `.github/workflows/label_prs.yml`: runs `actions/labeler` on `pull_request_target` so fork pull requests are labeled too. Nothing from the pull request is checked out or executed; the changed file list comes from the API. `sync-labels` is off, so labels are only ever added and hand edits stay. A second step adds the type label from the conventional commit prefix (`feat`, `refactor`, `chore` to `enhancement`; `fix` to `bug`; `perf` to `enhancement` and `performance`; `test` to `enhancement` and `test`; `docs` to `documentation`; `ci` and `build` to `enhancement` and `build`) on open only, and skips dependabot.

The gating labels (`run-spark-*-tests`, `run-iceberg-tests`, `skip-ci`) are not in either file, so the workflow cannot apply them. `ci.yml` already ignores `labeled` events for anything but those labels, so the added labels produce skipped preflight runs and nothing else.

## How are these changes tested?

The path rules were run against the 40 open pull requests that carry `area:*` labels today: 40 label matches, 5 extra labels, 7 missed. The misses are judgment calls such as a change confined to the planner being labeled `area:expressions`, which the rules cannot see; the extras are a second area on a pull request that touches two subsystems. Both YAML files parse, and the action's glob semantics (`any-glob-to-any-file`, `all-globs-to-any-file` with negations, `any-glob-to-all-files` with a brace glob) were checked against the labeler's source. The workflow itself only runs once merged, since it triggers on `pull_request_target`.
