### PR TITLE
refactor: share one helper for pushing a struct's null mask into its children

### DIFF
--- a/native/common/src/lib.rs
+++ b/native/common/src/lib.rs
@@ -18,10 +18,12 @@
 mod error;
 mod query_context;
 mod schema;
+pub mod struct_nulls;
 pub mod tracing;
 mod utils;
 
 pub use error::{decimal_overflow_error, SparkError, SparkErrorWithContext, SparkResult};
 pub use query_context::{create_query_context_map, QueryContext, QueryContextMap};
 pub use schema::{cast_and_stamp_schema, widen_nested_nullability};
+pub use struct_nulls::{child_with_parent_nulls, children_with_parent_nulls};
 pub use utils::{bytes_to_i128, decode_utf8_spark_lossy};

--- a/native/common/src/struct_nulls.rs
+++ b/native/common/src/struct_nulls.rs
@@ -1,0 +1,163 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Pushing a struct's null mask down into its children.
+//!
+//! Arrow stores a `StructArray`'s children with their own validity, independent of the parent's
+//! null buffer, so at a row where the struct itself is null a child buffer can still hold a value
+//! — parquet writes exactly that for `optional group c { required int32 a; }`, where the child leaf
+//! has nowhere to record a null of its own. Spark's rule is that a field of a null struct is null,
+//! so anything that reads the children has to combine the parent's nulls into them first.
+//!
+//! Getting this wrong is silent: `isnotnull(structCol.field)` reports true for a null struct
+//! (<https://github.com/apache/datafusion-comet/issues/4432>), and hashing a null struct picks up
+//! whatever sits in the child slot
+//! (<https://github.com/apache/datafusion-comet/issues/5753>).
+
+use arrow::array::{make_array, Array, ArrayRef, StructArray};
+use arrow::buffer::NullBuffer;
+use arrow::error::ArrowError;
+use std::sync::Arc;
+
+/// The parent's nulls unioned into one child, or the child unchanged when there is nothing to push.
+///
+/// Skips the work when the parent has no null to contribute, which covers both no null buffer at
+/// all and an all-valid buffer — the latter is what slicing leaves behind. `NullBuffer` stores its
+/// null count, so the test is O(1).
+///
+/// The union only ever adds nulls, so the child's data buffers are untouched and are not
+/// revalidated. Callers on a hot path depend on that: the hash kernels reach this once per element
+/// of an `array<struct<..>>`, and re-checking a string child would rescan its whole UTF-8 values
+/// buffer each time.
+pub fn child_with_parent_nulls(
+    struct_array: &StructArray,
+    ordinal: usize,
+) -> Result<ArrayRef, ArrowError> {
+    let child = struct_array.column(ordinal);
+    match struct_array.nulls() {
+        Some(parent) if parent.null_count() > 0 => {
+            let combined = NullBuffer::union(Some(parent), child.nulls());
+            // SAFETY: only nulls are added; every data buffer and child array is carried over
+            // unchanged, which is the same argument `StructArray::flatten` makes.
+            let data = child.to_data().into_builder().nulls(combined);
+            Ok(make_array(unsafe { data.build_unchecked() }))
+        }
+        _ => Ok(Arc::clone(child)),
+    }
+}
+
+/// Every child with the parent's nulls unioned in, in field order.
+///
+/// `StructArray::flatten` does the same union but also rebuilds `Fields`, re-marking non-nullable
+/// fields as nullable. Callers that only want the arrays would discard that, so this avoids
+/// building it.
+pub fn children_with_parent_nulls(struct_array: &StructArray) -> Result<Vec<ArrayRef>, ArrowError> {
+    match struct_array.nulls() {
+        Some(parent) if parent.null_count() > 0 => (0..struct_array.num_columns())
+            .map(|i| child_with_parent_nulls(struct_array, i))
+            .collect(),
+        _ => Ok(struct_array.columns().to_vec()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Int32Array;
+    use arrow::datatypes::{DataType, Field, Fields};
+
+    fn struct_with(child: ArrayRef, nulls: Option<NullBuffer>) -> StructArray {
+        let fields: Fields = vec![Arc::new(Field::new("a", DataType::Int32, true))].into();
+        StructArray::new(fields, vec![child], nulls)
+    }
+
+    /// The case both bugs came from: the parent is null where the child still holds a value.
+    #[test]
+    fn hidden_child_value_under_a_null_parent_becomes_null() {
+        let child: ArrayRef = Arc::new(Int32Array::from(vec![Some(1), Some(999)]));
+        let sa = struct_with(child, Some(NullBuffer::from(vec![true, false])));
+
+        let out = child_with_parent_nulls(&sa, 0).unwrap();
+        assert!(!out.is_null(0));
+        assert!(out.is_null(1), "a field of a null struct must read as null");
+
+        let all = children_with_parent_nulls(&sa).unwrap();
+        assert_eq!(all.len(), 1);
+        assert!(all[0].is_null(1));
+    }
+
+    /// No null buffer: the child is returned as is, not rebuilt.
+    #[test]
+    fn no_parent_nulls_returns_the_child_itself() {
+        let child: ArrayRef = Arc::new(Int32Array::from(vec![Some(1), Some(2)]));
+        let sa = struct_with(Arc::clone(&child), None);
+
+        let out = child_with_parent_nulls(&sa, 0).unwrap();
+        assert!(
+            Arc::ptr_eq(&out, sa.column(0)),
+            "expected the same array back"
+        );
+        assert_eq!(out.null_count(), 0);
+    }
+
+    /// A present but all-valid buffer, which is what slicing leaves behind, is also skipped.
+    #[test]
+    fn all_valid_parent_buffer_is_skipped() {
+        let child: ArrayRef = Arc::new(Int32Array::from(vec![Some(1), Some(2), Some(3)]));
+        let sa = struct_with(child, Some(NullBuffer::from(vec![true, true, true])));
+
+        let out = child_with_parent_nulls(&sa, 0).unwrap();
+        assert!(
+            Arc::ptr_eq(&out, sa.column(0)),
+            "expected the same array back"
+        );
+    }
+
+    /// A child null the parent does not have must survive the union.
+    #[test]
+    fn child_nulls_are_preserved() {
+        let child: ArrayRef = Arc::new(Int32Array::from(vec![Some(1), None, Some(3)]));
+        let sa = struct_with(child, Some(NullBuffer::from(vec![true, true, false])));
+
+        let out = child_with_parent_nulls(&sa, 0).unwrap();
+        assert!(!out.is_null(0));
+        assert!(out.is_null(1), "the child's own null must remain");
+        assert!(out.is_null(2), "the parent's null must be applied");
+    }
+
+    /// The old guard compared null *counts*, which can match while the nulls sit at different rows.
+    #[test]
+    fn equal_null_counts_at_different_rows_still_need_the_union() {
+        use arrow::array::Int32Array;
+        let child: ArrayRef = Arc::new(Int32Array::from(vec![None, Some(2)]));
+        // parent null at row 1, child null at row 0: counts equal (1 == 1), positions differ.
+        let sa = struct_with(child, Some(NullBuffer::from(vec![true, false])));
+        assert_eq!(sa.null_count(), sa.column(0).null_count());
+
+        let out = child_with_parent_nulls(&sa, 0).unwrap();
+        assert!(out.is_null(0), "child's own null");
+        assert!(out.is_null(1), "parent's null must still be applied");
+        assert_eq!(out.null_count(), 2);
+    }
+
+    /// An empty struct has no children to union into.
+    #[test]
+    fn empty_struct_has_no_children() {
+        let sa = StructArray::new_empty_fields(2, Some(NullBuffer::from(vec![true, false])));
+        assert!(children_with_parent_nulls(&sa).unwrap().is_empty());
+    }
+}

--- a/native/spark-expr/src/array_funcs/get_array_struct_fields.rs
+++ b/native/spark-expr/src/array_funcs/get_array_struct_fields.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::{make_array, Array, GenericListArray, OffsetSizeTrait, StructArray};
-use arrow::buffer::NullBuffer;
+use arrow::array::{Array, GenericListArray, OffsetSizeTrait, StructArray};
 use arrow::datatypes::{DataType, FieldRef, Schema};
 use arrow::record_batch::RecordBatch;
 use datafusion::common::{
@@ -25,6 +24,7 @@ use datafusion::common::{
 };
 use datafusion::logical_expr::ColumnarValue;
 use datafusion::physical_expr::PhysicalExpr;
+use datafusion_comet_common::child_with_parent_nulls;
 use std::hash::Hash;
 use std::{
     fmt::{Debug, Display, Formatter},
@@ -143,26 +143,14 @@ fn get_array_struct_fields<O: OffsetSizeTrait>(
         .expect("A StructType is expected");
 
     let field = Arc::clone(&values.fields()[ordinal]);
-    // Get struct column by ordinal
-    let extracted_column = values.column(ordinal);
-
-    let data = if values.null_count() == extracted_column.null_count() {
-        Arc::clone(extracted_column)
-    } else {
-        // In some cases the column obtained from struct by ordinal doesn't
-        // represent all nulls that imposed by parent values.
-        // This maybe caused by a low level reader bug and needs more investigation.
-        // For this specific case we patch the null buffer for the column by merging nulls buffers
-        // from parent and column
-        let merged_nulls = NullBuffer::union(values.nulls(), extracted_column.nulls());
-        make_array(
-            extracted_column
-                .into_data()
-                .into_builder()
-                .nulls(merged_nulls)
-                .build()?,
-        )
-    };
+    // A field of a null struct is null, and Arrow keeps the children's validity independent of the
+    // parent's, so the parent's nulls have to be unioned in. See
+    // `datafusion_comet_common::struct_nulls`.
+    //
+    // This previously skipped the union when the parent and child null counts matched, which is not
+    // the same question: equal counts can still sit at different rows, and then a null of the
+    // parent's was dropped.
+    let data = child_with_parent_nulls(values, ordinal)?;
 
     let array = GenericListArray::new(
         field,

--- a/native/spark-expr/src/hash_funcs/utils.rs
+++ b/native/spark-expr/src/hash_funcs/utils.rs
@@ -574,6 +574,7 @@ macro_rules! create_hashes_internal {
     ($arrays: ident, $hashes_buffer: ident, $hash_method: ident, $create_dictionary_hash_method: ident, $recursive_hash_method: ident) => {
         use arrow::datatypes::{DataType, TimeUnit};
         use arrow::array::{types::*, *};
+        use datafusion_comet_common::children_with_parent_nulls;
 
         for (i, col) in $arrays.iter().enumerate() {
             // The dictionary fast path hashes each distinct dictionary value once and reuses that
@@ -828,30 +829,10 @@ macro_rules! create_hashes_internal {
                 }
                 DataType::Struct(_) => {
                     let struct_array = col.as_any().downcast_ref::<StructArray>().unwrap();
-                    // Hash each field of the struct - Spark hashes all fields recursively.
-                    //
-                    // Arrow keeps a struct's children validity independent of the parent's, so at a
-                    // row where the struct is null a child buffer can still hold a value. Spark
-                    // hashes a null struct as the seed, so the parent's nulls have to be pushed
-                    // into each child before recursing, the same way #4432 fixed `GetStructField`.
-                    // Without it a null struct hashes whatever happens to sit in the child slot.
-                    // `flatten` does exactly this union, and skips revalidating the child data
-                    // buffers: it only ever adds nulls, so the buffers themselves are unchanged.
-                    // Rebuilding them through the checked builder would rescan every child buffer
-                    // (for a string child, the whole UTF-8 values buffer) on each call, and this
-                    // branch is reached once per element when hashing a list of structs.
-                    //
-                    // Only call it when there is actually a null to push down. `flatten` returns
-                    // early when there is no null buffer at all, but with a buffer present it
-                    // builds a fresh `Fields` with every non-nullable field re-marked nullable,
-                    // which this call site discards. So the case worth skipping is a buffer that
-                    // is present and all-valid -- what slicing leaves behind -- which would
-                    // otherwise pay a `Vec` and an `Arc<[FieldRef]>` for nothing. `NullBuffer`
-                    // caches its null count, so the test itself is O(1).
-                    let columns: Vec<ArrayRef> = match struct_array.nulls() {
-                        Some(nulls) if nulls.null_count() > 0 => struct_array.flatten().1,
-                        _ => struct_array.columns().to_vec(),
-                    };
+                    // Hash each field of the struct - Spark hashes all fields recursively, and a
+                    // null struct hashes as the seed, so the parent's nulls have to reach the
+                    // children first. See `datafusion_comet_common::struct_nulls`.
+                    let columns = children_with_parent_nulls(struct_array)?;
                     if !columns.is_empty() {
                         $recursive_hash_method(&columns, $hashes_buffer)?;
                     }

--- a/native/spark-expr/src/struct_funcs/get_struct_field.rs
+++ b/native/spark-expr/src/struct_funcs/get_struct_field.rs
@@ -15,13 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::{make_array, Array, ArrayRef, StructArray};
-use arrow::buffer::NullBuffer;
+use arrow::array::{Array, StructArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::ColumnarValue;
 use datafusion::physical_expr::PhysicalExpr;
+use datafusion_comet_common::child_with_parent_nulls;
 use std::{
     fmt::{Display, Formatter},
     hash::Hash,
@@ -59,27 +59,6 @@ impl GetStructField {
             ))),
         }
     }
-
-    /// Extract field `ordinal` from a struct array, propagating the parent struct's null mask.
-    ///
-    /// Spark semantics: a field of a NULL struct is NULL. Arrow stores a StructArray's child
-    /// arrays with their own validity, INDEPENDENT of the parent struct's null buffer -- so the
-    /// raw child value at a row where the struct itself is null can be non-null (e.g. parquet
-    /// files where a logically-null struct column still has a populated child buffer). Returning
-    /// the child column verbatim then makes `isnotnull(struct.field)` wrongly true for a null
-    /// struct. Union the struct's null mask into the child's (null where the struct is null OR
-    /// the child is null).
-    fn project_field(struct_array: &StructArray, ordinal: usize) -> DataFusionResult<ArrayRef> {
-        let child = struct_array.column(ordinal);
-        match struct_array.nulls() {
-            Some(_) => {
-                let combined = NullBuffer::union(struct_array.nulls(), child.nulls());
-                let data = child.to_data().into_builder().nulls(combined).build()?;
-                Ok(make_array(data))
-            }
-            None => Ok(Arc::clone(child)),
-        }
-    }
 }
 
 impl PhysicalExpr for GetStructField {
@@ -94,7 +73,7 @@ impl PhysicalExpr for GetStructField {
     fn nullable(&self, input_schema: &Schema) -> DataFusionResult<bool> {
         // A field extracted from a struct is nullable if EITHER the field itself is declared
         // nullable OR the parent struct can be null -- a field of a null struct is null (Spark
-        // semantics, enforced by `project_field` unioning the parent null mask). Reporting only
+        // semantics, enforced by unioning the parent null mask into the child). Reporting only
         // the field's own nullability under-declares: a non-nullable field of a nullable struct
         // then carries the parent's nulls while claiming non-nullable, which fails Arrow's
         // RecordBatch validation downstream with "declared as non-nullable but contains null
@@ -113,13 +92,15 @@ impl PhysicalExpr for GetStructField {
                     .downcast_ref::<StructArray>()
                     .expect("A struct is expected");
 
-                Ok(ColumnarValue::Array(Self::project_field(
+                // A field of a null struct is null, so the parent's null mask has to be unioned
+                // into the child; see `datafusion_comet_common::struct_nulls`.
+                Ok(ColumnarValue::Array(child_with_parent_nulls(
                     struct_array,
                     self.ordinal,
                 )?))
             }
             ColumnarValue::Scalar(ScalarValue::Struct(struct_array)) => Ok(ColumnarValue::Array(
-                Self::project_field(&struct_array, self.ordinal)?,
+                child_with_parent_nulls(&struct_array, self.ordinal)?,
             )),
             value => Err(DataFusionError::Execution(format!(
                 "Expected a struct array, got {value:?}"
@@ -155,7 +136,8 @@ impl Display for GetStructField {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::Int64Array;
+    use arrow::array::{ArrayRef, Int64Array};
+    use arrow::buffer::NullBuffer;
     use arrow::datatypes::Fields;
     use datafusion::physical_expr::expressions::Column;
 
@@ -188,7 +170,7 @@ mod tests {
         assert!(out.is_null(3), "field of a null struct must be null");
     }
 
-    // A NON-nullable field of a NULLABLE struct must report `nullable() == true`: `project_field`
+    // A NON-nullable field of a NULLABLE struct must report `nullable() == true`: the parent mask
     // unions the parent struct's null mask, so the projected column carries nulls wherever the
     // struct is null. Reporting the field's own (non-nullable) flag would make the output schema
     // lie, failing Arrow RecordBatch validation downstream with "declared as non-nullable but


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5768.

## Rationale for this change

Three places implemented the same Spark rule — a field of a null struct is null, so the
parent's nulls have to reach the children before the children are read — and each did it
slightly differently:

| | union when |
|---|---|
| `GetStructField::project_field` | a null buffer is present, via the checked `ArrayData` builder |
| the hash kernels' struct branch | `null_count() > 0`, via `StructArray::flatten` |
| `get_array_struct_fields` | the parent and child null **counts** differ |

The issue was filed as a refactor, on the grounds that all three were correct and the risk
was drift. That turned out to be half right: **the third guard is wrong**. Equal null counts
do not imply the nulls sit at the same rows, so whenever the child had a null of its own at a
different row the counts could match and the parent's null was dropped. There is a test for
exactly that shape, which a count-based check fails.

## What changes are included in this PR?

`datafusion_comet_common::struct_nulls`, with `child_with_parent_nulls` for one field and
`children_with_parent_nulls` for all of them, and the three call sites switched over. Net -41
lines at the call sites.

The three decisions the issue asked about:

- **Shape.** Both, with the plural built on the singular, since `project_field` wants one
  field and the hash path wants all of them.
- **Checked or unchecked.** Unchecked, as `flatten` already did. The union only adds nulls, so
  every data buffer is carried over unchanged and revalidating them is wasted work. This
  matters asymmetrically: `project_field` runs once per batch in `evaluate` and did not care
  either way, while the hash path reaches this **once per element** of an `array<struct<..>>`,
  where re-checking a string child means rescanning its whole UTF-8 values buffer. Unifying on
  checked would have pushed the batch-level caller's cost onto the element-level one.
- **The `null_count() > 0` guard.** Applied to all three. It skips the union when the parent
  has no null to contribute, which covers both no buffer at all and a present-but-all-valid
  buffer — the latter is what slicing leaves behind. `NullBuffer` stores its null count, so the
  test is O(1).

It lives in its own module rather than in `schema.rs`, which is about reconciling declared and
runtime *types* rather than null masks.

## How are these changes tested?

Six unit tests on the helper: a hidden child value under a null parent, no parent null buffer
(asserting the same array comes back rather than a rebuilt one), a present-but-all-valid
buffer, a child's own null surviving the union, an empty struct, and the equal-counts-different-rows
case that pins the guard fix.

Existing coverage for the three call sites passes unchanged: `cargo test` gives 720 + 5 in
`spark-expr` and 40 in `common`, and on the Spark side `CometHashExpressionSuite` (40),
`CometArrayExpressionSuite` (59) and `CometExpressionSuite` (141). `cargo fmt --check` and
`clippy -D warnings` are clean.

## Additional context

Raised by @andygrove reviewing #5754. The two earlier fixes in this area were #4432
(`GetStructField`) and #5754 (the hash kernels); this unifies them with the third site, which
the issue had not accounted for.
