### PR TITLE
fix: dispatch Iceberg system functions wrapped as ApplyFunctionExpression

### DIFF
--- a/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/QueryPlanSerde.scala
@@ -361,6 +361,7 @@ object QueryPlanSerde extends Logging with CometExprShim with CometTypeShim {
     // when `++` is applied directly to a `Map(...)` literal.
     val base: Map[Class[_ <: Expression], CometExpressionSerde[_]] = Map(
       classOf[Alias] -> CometAlias,
+      classOf[ApplyFunctionExpression] -> CometApplyFunctionExpression,
       classOf[AttributeReference] -> CometAttributeReference,
       classOf[BloomFilterMightContain] -> CometBloomFilterMightContain,
       classOf[CheckOverflow] -> CometCheckOverflow,

--- a/spark/src/main/scala/org/apache/comet/serde/icebergFunctions.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/icebergFunctions.scala
@@ -19,7 +19,7 @@
 
 package org.apache.comet.serde
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, Literal}
+import org.apache.spark.sql.catalyst.expressions.{ApplyFunctionExpression, Attribute, Expression, Literal}
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.types._
 
@@ -29,13 +29,16 @@ import org.apache.comet.serde.QueryPlanSerde.{exprToProtoInternal, scalarFunctio
  * Native support for Iceberg's Spark system functions (`bucket`, `truncate`, `years`, `months`,
  * `days`, `hours`).
  *
- * Iceberg exposes each of these through Spark's static magic method, so
- * `V2ExpressionUtils.resolveScalarFunction` binds them as `StaticInvoke(cls, "invoke", args)`
- * where `cls` is one of the per-type implementations under `org.apache.iceberg.spark.functions`
- * (e.g. `BucketFunction$BucketInt`). The same expressions appear in the hash distribution and
- * local sort that Iceberg requests in front of a partitioned write, and in predicates and
- * projections that users write against hidden partitioning, so routing them through
- * [[CometStaticInvoke]] covers shuffle, sort, filter, and projection at once.
+ * Iceberg exposes each of these through Spark's DataSourceV2 catalog function API. Spark's
+ * `V2ExpressionUtils.resolveScalarFunction` resolves them one of two ways: when the per-type
+ * implementation class exposes a static `invoke` "magic method" with a matching signature the
+ * call is lowered to `StaticInvoke(cls, "invoke", args)`; otherwise the call is lowered to
+ * `ApplyFunctionExpression(function, args)`. The magic method is an optional performance opt-in
+ * in the DSv2 API, not a requirement, so any Iceberg release (or third-party V2 catalog) that
+ * omits it lands on the second path. Both paths carry the same class as their identity, so a
+ * single set of handlers keyed by that class name covers them. See [[CometStaticInvoke]] for the
+ * `StaticInvoke` entry point and [[CometApplyFunctionExpression]] for the
+ * `ApplyFunctionExpression` entry point.
  *
  * The list of classes is Iceberg's; `IcebergVersionFunction` is a zero-argument constant and is
  * deliberately left out.
@@ -45,20 +48,20 @@ object CometIcebergSystemFunctions {
   private val FunctionsPackage = "org.apache.iceberg.spark.functions."
 
   /** Every Iceberg system function exposes its static magic method under this name. */
-  private val MagicMethod = "invoke"
+  private[serde] val MagicMethod = "invoke"
 
   private def implementations(
       outer: String,
-      handler: CometExpressionSerde[StaticInvoke],
-      inner: String*): Seq[((String, String), CometExpressionSerde[StaticInvoke])] =
-    inner.map(name => (MagicMethod, s"$FunctionsPackage$outer$$$name") -> handler)
+      handler: CometExpressionSerde[Expression],
+      inner: String*): Seq[(String, CometExpressionSerde[Expression])] =
+    inner.map(name => s"$FunctionsPackage$outer$$$name" -> handler)
 
   /**
-   * Handlers keyed by `(functionName, class name)` of the Iceberg implementation class that
-   * `StaticInvoke` calls, the shape [[CometStaticInvoke]] dispatches on. Iceberg is not on
-   * Comet's compile classpath, which is why the key carries the class name rather than the class.
+   * Handlers keyed by the Iceberg implementation class name that both `StaticInvoke` and
+   * `ApplyFunctionExpression` carry as their identity. Iceberg is not on Comet's compile
+   * classpath, which is why the key is a class name rather than a class.
    */
-  val staticInvokeHandlers: Map[(String, String), CometExpressionSerde[StaticInvoke]] = (
+  val handlers: Map[String, CometExpressionSerde[Expression]] = (
     implementations(
       "BucketFunction",
       CometIcebergBucket,
@@ -113,6 +116,16 @@ object CometIcebergSystemFunctions {
     case Literal(v: Byte, ByteType) if v > 0 => Some(v.toInt)
     case _ => None
   }
+
+  /**
+   * Extracts `(arguments, dataType)` from either wrapping expression. Kept together so a future
+   * shape (e.g. Spark introduces yet another lowering) has a single seam to extend.
+   */
+  private[serde] def unwrap(expr: Expression): Option[(Seq[Expression], DataType)] = expr match {
+    case si: StaticInvoke => Some((si.arguments, si.dataType))
+    case afe: ApplyFunctionExpression => Some((afe.children, afe.dataType))
+    case _ => None
+  }
 }
 
 /**
@@ -120,44 +133,52 @@ object CometIcebergSystemFunctions {
  * parameter followed by the value. The parameter has to be a literal because the native kernel
  * takes it as a constant, and it has to be positive because Iceberg's Java implementation divides
  * by it (zero throws, which the fallback preserves by leaving the expression to Spark).
+ *
+ * Accepts either `StaticInvoke` or `ApplyFunctionExpression` since the same handler is registered
+ * under both entry points; the extractor in [[CometIcebergSystemFunctions.unwrap]] normalizes
+ * both to `(arguments, dataType)`.
  */
 abstract class CometIcebergParameterizedTransform(
     nativeName: String,
     parameterName: String,
     valueTypeSupported: DataType => Boolean)
-    extends CometExpressionSerde[StaticInvoke] {
+    extends CometExpressionSerde[Expression] {
 
-  override def getSupportLevel(expr: StaticInvoke): SupportLevel = expr.arguments match {
-    case Seq(parameter, value) =>
-      if (CometIcebergSystemFunctions.positiveIntLiteral(parameter).isEmpty) {
-        Unsupported(Some(s"$parameterName must be a positive integer literal, got $parameter"))
-      } else if (!valueTypeSupported(value.dataType)) {
-        Unsupported(Some(s"$nativeName does not support input type ${value.dataType}"))
-      } else {
-        Compatible()
-      }
-    case other =>
-      Unsupported(Some(s"expected ($parameterName, value) arguments, got ${other.size}"))
-  }
+  override def getSupportLevel(expr: Expression): SupportLevel =
+    CometIcebergSystemFunctions.unwrap(expr) match {
+      case Some((Seq(parameter, value), _)) =>
+        if (CometIcebergSystemFunctions.positiveIntLiteral(parameter).isEmpty) {
+          Unsupported(Some(s"$parameterName must be a positive integer literal, got $parameter"))
+        } else if (!valueTypeSupported(value.dataType)) {
+          Unsupported(Some(s"$nativeName does not support input type ${value.dataType}"))
+        } else {
+          Compatible()
+        }
+      case Some((other, _)) =>
+        Unsupported(Some(s"expected ($parameterName, value) arguments, got ${other.size}"))
+      case None =>
+        Unsupported(Some(s"unrecognized wrapping expression: ${expr.getClass.getName}"))
+    }
 
   override def convert(
-      expr: StaticInvoke,
+      expr: Expression,
       inputs: Seq[Attribute],
-      binding: Boolean): Option[ExprOuterClass.Expr] = expr.arguments match {
-    case Seq(parameter, value) =>
-      // Normalize to an int literal so the native side always sees an Int32 scalar.
-      val parameterProto = CometIcebergSystemFunctions
-        .positiveIntLiteral(parameter)
-        .flatMap(n => exprToProtoInternal(Literal(n, IntegerType), inputs, binding))
-      val valueProto = exprToProtoInternal(value, inputs, binding)
-      scalarFunctionExprToProtoWithReturnType(
-        nativeName,
-        expr.dataType,
-        failOnError = false,
-        parameterProto,
-        valueProto)
-    case _ => None
-  }
+      binding: Boolean): Option[ExprOuterClass.Expr] =
+    CometIcebergSystemFunctions.unwrap(expr) match {
+      case Some((Seq(parameter, value), returnType)) =>
+        // Normalize to an int literal so the native side always sees an Int32 scalar.
+        val parameterProto = CometIcebergSystemFunctions
+          .positiveIntLiteral(parameter)
+          .flatMap(n => exprToProtoInternal(Literal(n, IntegerType), inputs, binding))
+        val valueProto = exprToProtoInternal(value, inputs, binding)
+        scalarFunctionExprToProtoWithReturnType(
+          nativeName,
+          returnType,
+          failOnError = false,
+          parameterProto,
+          valueProto)
+      case _ => None
+    }
 }
 
 /** `bucket(numBuckets, value)` over the types `BucketFunction.bind` accepts. */
@@ -203,13 +224,14 @@ object CometIcebergTruncate
 
   // Ordered after the parameter check so that `truncate(0, decimal_col)` still reports the width
   // problem, which is the one that changes whether Iceberg's own ArithmeticException is raised.
-  override def getSupportLevel(expr: StaticInvoke): SupportLevel = expr.arguments match {
-    case Seq(parameter, value)
-        if value.dataType.isInstanceOf[DecimalType] &&
-          CometIcebergSystemFunctions.positiveIntLiteral(parameter).isDefined =>
-      Unsupported(Some(DecimalNote))
-    case _ => super.getSupportLevel(expr)
-  }
+  override def getSupportLevel(expr: Expression): SupportLevel =
+    CometIcebergSystemFunctions.unwrap(expr) match {
+      case Some((Seq(parameter, value), _))
+          if value.dataType.isInstanceOf[DecimalType] &&
+            CometIcebergSystemFunctions.positiveIntLiteral(parameter).isDefined =>
+        Unsupported(Some(DecimalNote))
+      case _ => super.getSupportLevel(expr)
+    }
 
   override def getUnsupportedReasons(): Seq[String] = Seq(
     "Iceberg's `truncate(width, value)` system function on a `decimal` column. " + DecimalNote +
@@ -218,30 +240,40 @@ object CometIcebergTruncate
       "decimals, are unaffected.")
 }
 
-/** Shared shape of the single-argument `years`, `months`, `days`, and `hours` transforms. */
+/**
+ * Shared shape of the single-argument `years`, `months`, `days`, and `hours` transforms. Accepts
+ * either wrapping expression via [[CometIcebergSystemFunctions.unwrap]].
+ */
 abstract class CometIcebergTemporalTransform(
     nativeName: String,
     valueTypeSupported: DataType => Boolean)
-    extends CometExpressionSerde[StaticInvoke] {
+    extends CometExpressionSerde[Expression] {
 
-  override def getSupportLevel(expr: StaticInvoke): SupportLevel = expr.arguments match {
-    case Seq(value) if valueTypeSupported(value.dataType) => Compatible()
-    case Seq(value) =>
-      Unsupported(Some(s"$nativeName does not support input type ${value.dataType}"))
-    case other => Unsupported(Some(s"expected one argument, got ${other.size}"))
-  }
+  override def getSupportLevel(expr: Expression): SupportLevel =
+    CometIcebergSystemFunctions.unwrap(expr) match {
+      case Some((Seq(value), _)) if valueTypeSupported(value.dataType) => Compatible()
+      case Some((Seq(value), _)) =>
+        Unsupported(Some(s"$nativeName does not support input type ${value.dataType}"))
+      case Some((other, _)) =>
+        Unsupported(Some(s"expected one argument, got ${other.size}"))
+      case None =>
+        Unsupported(Some(s"unrecognized wrapping expression: ${expr.getClass.getName}"))
+    }
 
   override def convert(
-      expr: StaticInvoke,
+      expr: Expression,
       inputs: Seq[Attribute],
-      binding: Boolean): Option[ExprOuterClass.Expr] = {
-    val valueProto = exprToProtoInternal(expr.arguments.head, inputs, binding)
-    scalarFunctionExprToProtoWithReturnType(
-      nativeName,
-      expr.dataType,
-      failOnError = false,
-      valueProto)
-  }
+      binding: Boolean): Option[ExprOuterClass.Expr] =
+    CometIcebergSystemFunctions.unwrap(expr) match {
+      case Some((Seq(value), returnType)) =>
+        val valueProto = exprToProtoInternal(value, inputs, binding)
+        scalarFunctionExprToProtoWithReturnType(
+          nativeName,
+          returnType,
+          failOnError = false,
+          valueProto)
+      case _ => None
+    }
 }
 
 object CometIcebergYears

--- a/spark/src/main/scala/org/apache/comet/serde/statics.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/statics.scala
@@ -19,7 +19,7 @@
 
 package org.apache.comet.serde
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Base64, ExpressionImplUtils, Literal, StringDecode, TryEval, UrlCodec}
+import org.apache.spark.sql.catalyst.expressions.{ApplyFunctionExpression, Attribute, Base64, Expression, ExpressionImplUtils, Literal, StringDecode, TryEval, UrlCodec}
 import org.apache.spark.sql.catalyst.expressions.objects.{Invoke, StaticInvoke}
 import org.apache.spark.sql.catalyst.util.CharVarcharCodegenUtils
 import org.apache.spark.sql.types.StringType
@@ -53,11 +53,21 @@ object CometStaticInvoke extends CometExpressionSerde[StaticInvoke] {
       // Spark 3.5+ makes `Base64` RuntimeReplaceable, lowering `base64(bin)` to
       // `StaticInvoke(Base64.encode, Seq(child, chunkBase64), ...)`. On Spark 3.4 the `Base64`
       // node survives and is handled directly (see CometBase64).
-      ("encode", classOf[Base64].getName) -> CometBase64StaticInvoke) ++
-      CometIcebergSystemFunctions.staticInvokeHandlers
+      ("encode", classOf[Base64].getName) -> CometBase64StaticInvoke)
 
   private def handlerFor(expr: StaticInvoke): Option[CometExpressionSerde[StaticInvoke]] =
     staticInvokeExpressions.get((expr.functionName, expr.staticObject.getName))
+
+  /**
+   * Iceberg's system functions are keyed by class name only because both the `StaticInvoke` and
+   * `ApplyFunctionExpression` lowerings share the same identity class. Consulted after the
+   * per-`(functionName, class)` allowlist above so the `functionName` filter still applies for
+   * anything not owned by Iceberg.
+   */
+  private def icebergHandlerFor(expr: StaticInvoke): Option[CometExpressionSerde[Expression]] =
+    if (expr.functionName == CometIcebergSystemFunctions.MagicMethod) {
+      CometIcebergSystemFunctions.handlers.get(expr.staticObject.getName)
+    } else None
 
   /** Every Iceberg system function is named `invoke`, so name the declaring class too. */
   private def noNativePathNote(expr: StaticInvoke): String =
@@ -77,42 +87,83 @@ object CometStaticInvoke extends CometExpressionSerde[StaticInvoke] {
    * enrollment stays with the individual handlers.
    */
   override def getSupportLevel(expr: StaticInvoke): SupportLevel =
-    handlerFor(expr).map(_.getSupportLevel(expr)).getOrElse(Compatible())
+    handlerFor(expr)
+      .map(_.getSupportLevel(expr))
+      .orElse(icebergHandlerFor(expr).map(_.getSupportLevel(expr)))
+      .getOrElse(Compatible())
 
   /**
    * `GenerateDocs` only asks the serde registered for the expression class, which is this object,
    * so the per-function handlers' notes have to be collected here or they never reach the
    * compatibility guide.
    */
-  override def getUnsupportedReasons(): Seq[String] =
-    staticInvokeExpressions.values.toSeq.distinct.flatMap(_.getUnsupportedReasons()).distinct
+  override def getUnsupportedReasons(): Seq[String] = {
+    val builtIn: Seq[CometExpressionSerde[_]] = staticInvokeExpressions.values.toSeq
+    val iceberg: Seq[CometExpressionSerde[_]] =
+      CometIcebergSystemFunctions.handlers.values.toSeq
+    (builtIn ++ iceberg).distinct.flatMap(_.getUnsupportedReasons()).distinct
+  }
 
   override def convert(
       expr: StaticInvoke,
       inputs: Seq[Attribute],
       binding: Boolean): Option[ExprOuterClass.Expr] = {
     handlerFor(expr) match {
-      case Some(handler) =>
-        handler.convert(expr, inputs, binding)
+      case Some(handler) => handler.convert(expr, inputs, binding)
       case None =>
-        // Nothing in the allowlist covers this lowering, so run Spark's own implementation inside
-        // the Comet pipeline rather than failing the whole operator back to Spark.
-        // `StaticInvoke.doGenCode` emits a static method call, so the kernel matches Spark by
-        // construction. Spark 4.x keeps lowering more `RuntimeReplaceable` functions this way
-        // (`encode`, `is_valid_utf8`, the `TIME` family, ...) and `lpad` / `rpad` on binary has
-        // lowered to `StaticInvoke(ByteArray, ...)` since Spark 3.4.
-        //
-        // The encoder and deserializer trees that make up most `StaticInvoke` usage in typed
-        // Dataset operations are unaffected: their arguments are `ObjectType`, which
-        // `CometBatchKernelCodegen.isSupportedDataType` rejects, so the dispatcher declines them
-        // and they fall back exactly as before.
-        CometStaticInvokeCodegenDispatch.convert(expr, inputs, binding).orElse {
-          // The dispatcher tags its own reason, but not which static invoke it was.
-          withFallbackReason(expr, noNativePathNote(expr))
-          None
+        icebergHandlerFor(expr) match {
+          case Some(handler) => handler.convert(expr, inputs, binding)
+          case None =>
+            // Nothing in the allowlist covers this lowering, so run Spark's own implementation
+            // inside the Comet pipeline rather than failing the whole operator back to Spark.
+            // `StaticInvoke.doGenCode` emits a static method call, so the kernel matches Spark by
+            // construction. Spark 4.x keeps lowering more `RuntimeReplaceable` functions this way
+            // (`encode`, `is_valid_utf8`, the `TIME` family, ...) and `lpad` / `rpad` on binary
+            // has lowered to `StaticInvoke(ByteArray, ...)` since Spark 3.4.
+            //
+            // The encoder and deserializer trees that make up most `StaticInvoke` usage in typed
+            // Dataset operations are unaffected: their arguments are `ObjectType`, which
+            // `CometBatchKernelCodegen.isSupportedDataType` rejects, so the dispatcher declines
+            // them and they fall back exactly as before.
+            CometStaticInvokeCodegenDispatch.convert(expr, inputs, binding).orElse {
+              // The dispatcher tags its own reason, but not which static invoke it was.
+              withFallbackReason(expr, noNativePathNote(expr))
+              None
+            }
         }
     }
   }
+}
+
+/**
+ * `ApplyFunctionExpression` is the second lowering Spark's
+ * `V2ExpressionUtils.resolveScalarFunction` emits for a DataSourceV2 catalog scalar function:
+ * when the implementation class does not expose a static `invoke` "magic method" with a matching
+ * signature, Spark falls back to this form and calls `function.produceResult(row)` reflectively
+ * at runtime. The magic method is an optional performance opt-in in the DSv2 API, so any V2
+ * catalog function can land here -- Iceberg versions that omit the magic method on a per-type
+ * implementation are the concrete case that motivates the dispatch, but this is not
+ * Iceberg-specific.
+ *
+ * Iceberg's per-type implementation class is the identity shared with the `StaticInvoke` path, so
+ * [[CometIcebergSystemFunctions.handlers]] resolves both forms.
+ */
+object CometApplyFunctionExpression extends CometExpressionSerde[ApplyFunctionExpression] {
+
+  private def handlerFor(
+      expr: ApplyFunctionExpression): Option[CometExpressionSerde[Expression]] =
+    CometIcebergSystemFunctions.handlers.get(expr.function.getClass.getName)
+
+  override def getSupportLevel(expr: ApplyFunctionExpression): SupportLevel =
+    handlerFor(expr)
+      .map(_.getSupportLevel(expr))
+      .getOrElse(Unsupported(Some(s"${expr.function.getClass.getName} has no native handler")))
+
+  override def convert(
+      expr: ApplyFunctionExpression,
+      inputs: Seq[Attribute],
+      binding: Boolean): Option[ExprOuterClass.Expr] =
+    handlerFor(expr).flatMap(_.convert(expr, inputs, binding))
 }
 
 /**

--- a/spark/src/test/scala/org/apache/comet/CometIcebergSystemFunctionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergSystemFunctionSuite.scala
@@ -31,6 +31,7 @@ import org.scalatest.Tag
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{CometTestBase, DataFrame, Row}
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{ApplyFunctionExpression, AttributeReference, Expression, Literal}
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.comet.{CometIcebergWriteExec, CometSortExec}
@@ -344,37 +345,40 @@ class CometIcebergSystemFunctionSuite
     val value = AttributeReference("v", IntegerType)()
     val bucketIntCls =
       Class.forName("org.apache.iceberg.spark.functions.BucketFunction$BucketInt")
-    val bucketInt =
-      bucketIntCls.getDeclaredConstructor().newInstance().asInstanceOf[ScalarFunction[_]]
+    // Iceberg's per-type implementations take the bound input type; there is no no-arg
+    // constructor on any of the runtimes these profiles build against.
+    val bucketInt = bucketIntCls
+      .getDeclaredConstructor(classOf[DataType])
+      .newInstance(IntegerType)
+      .asInstanceOf[ScalarFunction[_]]
     val expr = ApplyFunctionExpression(bucketInt, Seq(Literal(4), value))
     assert(CometApplyFunctionExpression.getSupportLevel(expr) == Compatible())
+
+    // Support level alone would still leave the arguments and result type unread: the wrapper
+    // carries them on `children` / `dataType` rather than the `arguments` / `dataType` the
+    // StaticInvoke path uses, so assert the serialized call to cover that extraction.
+    val proto = CometApplyFunctionExpression.convert(expr, Seq(value), binding = true)
+    assert(
+      proto.exists(_.getScalarFunc.getFunc == "iceberg_bucket"),
+      s"expected a native iceberg_bucket call, got $proto")
 
     // The same argument-shape checks that gate the StaticInvoke path have to gate this one, or a
     // zero-bucket call would land natively and diverge from Iceberg's own ArithmeticException.
     val zeroBuckets = ApplyFunctionExpression(bucketInt, Seq(Literal(0), value))
     assert(CometApplyFunctionExpression.getSupportLevel(zeroBuckets).isInstanceOf[Unsupported])
+
+    // A V2 catalog function Comet has no handler for has to stay on Spark rather than reaching
+    // the Iceberg handlers by argument shape alone: `ApplyFunctionExpression` is the generic DSv2
+    // lowering, so most expressions arriving here belong to some other catalog entirely.
+    val unlisted = ApplyFunctionExpression(new UnlistedScalarFunction, Seq(Literal(4), value))
+    assert(CometApplyFunctionExpression.getSupportLevel(unlisted).isInstanceOf[Unsupported])
+    assert(CometApplyFunctionExpression.convert(unlisted, Seq(value), binding = true).isEmpty)
   }
 
   test("Iceberg handler map is keyed by Iceberg implementation class names") {
-    // Guards against a rename of one of Iceberg's per-type implementation classes silently
-    // dropping the native path: if any of these classes is on the classpath, its name has to be
-    // in the handler map.
-    val expected = Seq(
-      "org.apache.iceberg.spark.functions.BucketFunction$BucketInt" -> CometIcebergBucket,
-      "org.apache.iceberg.spark.functions.BucketFunction$BucketLong" -> CometIcebergBucket,
-      "org.apache.iceberg.spark.functions.TruncateFunction$TruncateInt" -> CometIcebergTruncate,
-      "org.apache.iceberg.spark.functions.TruncateFunction$TruncateString" -> CometIcebergTruncate)
-    expected.foreach { case (className, expectedHandler) =>
-      assert(
-        CometIcebergSystemFunctions.handlers.get(className).contains(expectedHandler),
-        s"missing handler for $className")
-    }
-  }
-
-  test("Iceberg handler map is keyed by Iceberg implementation class names") {
-    // Guards against a rename of one of Iceberg's per-type implementation classes silently
-    // dropping the native path: if any of these classes is on the classpath, its name has to be
-    // in the handler map.
+    // The map is keyed by class name because Iceberg is not on Comet's compile classpath, so a
+    // rename on Iceberg's side would silently drop the native path rather than fail to compile.
+    // These names are the ones both lowerings carry as their identity.
     val expected = Seq(
       "org.apache.iceberg.spark.functions.BucketFunction$BucketInt" -> CometIcebergBucket,
       "org.apache.iceberg.spark.functions.BucketFunction$BucketLong" -> CometIcebergBucket,
@@ -530,4 +534,18 @@ class CometIcebergSystemFunctionSuite
       spark.sparkContext.parallelize(randomRows ++ boundaryRows, 3),
       sourceSchema)
   }
+}
+
+/**
+ * A DataSourceV2 catalog scalar function with no static `invoke` magic method, so Spark's
+ * `V2ExpressionUtils.resolveScalarFunction` would lower a call to it as
+ * `ApplyFunctionExpression`. Stands in for the third-party catalogs that share that lowering with
+ * Iceberg but have no native handler in Comet.
+ */
+private class UnlistedScalarFunction extends ScalarFunction[Integer] {
+  override def inputTypes(): Array[DataType] = Array(IntegerType, IntegerType)
+  override def resultType(): DataType = IntegerType
+  override def name(): String = "unlisted"
+  override def canonicalName(): String = "test.unlisted"
+  override def produceResult(input: InternalRow): Integer = input.getInt(0)
 }

--- a/spark/src/test/scala/org/apache/comet/CometIcebergSystemFunctionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergSystemFunctionSuite.scala
@@ -31,16 +31,17 @@ import org.scalatest.Tag
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{CometTestBase, DataFrame, Row}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, Literal}
+import org.apache.spark.sql.catalyst.expressions.{ApplyFunctionExpression, AttributeReference, Expression, Literal}
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.comet.{CometIcebergWriteExec, CometSortExec}
 import org.apache.spark.sql.comet.execution.shuffle.{CometNativeShuffle, CometShuffleExchangeExec}
+import org.apache.spark.sql.connector.catalog.functions.ScalarFunction
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
-import org.apache.comet.serde.{CometExpressionSerde, CometIcebergBucket, CometIcebergTruncate, CometStaticInvoke, Compatible, SupportLevel, Unsupported}
+import org.apache.comet.serde.{CometApplyFunctionExpression, CometExpressionSerde, CometIcebergBucket, CometIcebergSystemFunctions, CometIcebergTruncate, CometStaticInvoke, Compatible, SupportLevel, Unsupported}
 
 /**
  * Native support for Iceberg's system functions (`bucket`, `truncate`, `years`, `months`, `days`,
@@ -283,7 +284,7 @@ class CometIcebergSystemFunctionSuite
     val float = AttributeReference("f", FloatType)()
     val date = AttributeReference("d", DateType)()
     def level(
-        serde: CometExpressionSerde[StaticInvoke],
+        serde: CometExpressionSerde[_ >: StaticInvoke <: Expression],
         cls: Class[_],
         args: Expression*): SupportLevel =
       serde.getSupportLevel(StaticInvoke(cls, IntegerType, "invoke", args, propagateNull = false))
@@ -333,6 +334,57 @@ class CometIcebergSystemFunctionSuite
     assert(
       level(CometStaticInvoke, truncateInt, Literal(10), decimal) ==
         Unsupported(Some(CometIcebergTruncate.DecimalNote)))
+  }
+
+  test("ApplyFunctionExpression reaches the same handlers as StaticInvoke") {
+    // Spark's `V2ExpressionUtils.resolveScalarFunction` wraps a DSv2 catalog scalar function as
+    // `ApplyFunctionExpression` when the implementation class does not expose a static `invoke`
+    // magic method. Iceberg's per-type functions carry the same class as their identity on both
+    // paths, so a single set of handlers keyed by class name must cover both.
+    val value = AttributeReference("v", IntegerType)()
+    val bucketIntCls =
+      Class.forName("org.apache.iceberg.spark.functions.BucketFunction$BucketInt")
+    val bucketInt =
+      bucketIntCls.getDeclaredConstructor().newInstance().asInstanceOf[ScalarFunction[_]]
+    val expr = ApplyFunctionExpression(bucketInt, Seq(Literal(4), value))
+    assert(CometApplyFunctionExpression.getSupportLevel(expr) == Compatible())
+
+    // The same argument-shape checks that gate the StaticInvoke path have to gate this one, or a
+    // zero-bucket call would land natively and diverge from Iceberg's own ArithmeticException.
+    val zeroBuckets = ApplyFunctionExpression(bucketInt, Seq(Literal(0), value))
+    assert(CometApplyFunctionExpression.getSupportLevel(zeroBuckets).isInstanceOf[Unsupported])
+  }
+
+  test("Iceberg handler map is keyed by Iceberg implementation class names") {
+    // Guards against a rename of one of Iceberg's per-type implementation classes silently
+    // dropping the native path: if any of these classes is on the classpath, its name has to be
+    // in the handler map.
+    val expected = Seq(
+      "org.apache.iceberg.spark.functions.BucketFunction$BucketInt" -> CometIcebergBucket,
+      "org.apache.iceberg.spark.functions.BucketFunction$BucketLong" -> CometIcebergBucket,
+      "org.apache.iceberg.spark.functions.TruncateFunction$TruncateInt" -> CometIcebergTruncate,
+      "org.apache.iceberg.spark.functions.TruncateFunction$TruncateString" -> CometIcebergTruncate)
+    expected.foreach { case (className, expectedHandler) =>
+      assert(
+        CometIcebergSystemFunctions.handlers.get(className).contains(expectedHandler),
+        s"missing handler for $className")
+    }
+  }
+
+  test("Iceberg handler map is keyed by Iceberg implementation class names") {
+    // Guards against a rename of one of Iceberg's per-type implementation classes silently
+    // dropping the native path: if any of these classes is on the classpath, its name has to be
+    // in the handler map.
+    val expected = Seq(
+      "org.apache.iceberg.spark.functions.BucketFunction$BucketInt" -> CometIcebergBucket,
+      "org.apache.iceberg.spark.functions.BucketFunction$BucketLong" -> CometIcebergBucket,
+      "org.apache.iceberg.spark.functions.TruncateFunction$TruncateInt" -> CometIcebergTruncate,
+      "org.apache.iceberg.spark.functions.TruncateFunction$TruncateString" -> CometIcebergTruncate)
+    expected.foreach { case (className, expectedHandler) =>
+      assert(
+        CometIcebergSystemFunctions.handlers.get(className).contains(expectedHandler),
+        s"missing handler for $className")
+    }
   }
 
   test("an unlisted static invoke routes through the codegen dispatcher") {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #.

## Rationale for this change

Spark's `V2ExpressionUtils.resolveScalarFunction` has two lowerings for a DataSourceV2 catalog scalar function. When the per-type implementation class exposes a static `invoke` "magic method" with a matching signature, Spark wraps the call as `StaticInvoke`; when it does not, Spark falls back to `ApplyFunctionExpression` and calls `function.produceResult(row)` reflectively at runtime. The magic method is an optional performance opt-in in the DSv2 API rather than a requirement, so any V2 catalog function -- Iceberg or otherwise -- can land on the second path.

Comet only recognized `StaticInvoke`, so a function without a matching magic method fell back to Spark even when we had a native handler for the exact class. Concretely: an Iceberg release (or fork) that omits the magic method on one of its per-type implementations, and any third-party V2 catalog whose `ScalarFunction` implementations do not add the magic method (it is an optional opt-in), land here.

Iceberg's per-type implementation classes are the identity carried on both lowerings, so a single set of handlers keyed by class name covers them.

## What changes are included in this PR?

- `CometIcebergSystemFunctions.handlers` is now keyed by class name only; both the `StaticInvoke` and `ApplyFunctionExpression` entry points consult the same map.
- `CometIcebergParameterizedTransform` and `CometIcebergTemporalTransform` extract `(arguments, dataType)` through a single `unwrap` helper so a future third lowering has one seam to extend.
- New `CometApplyFunctionExpression` serde is registered under `classOf[ApplyFunctionExpression]` in `exprSerdeMap` and routes the second lowering to the same class-name-keyed handler map.

## How are these changes tested?

New unit tests in `CometIcebergSystemFunctionSuite`:

- `ApplyFunctionExpression reaches the same handlers as StaticInvoke` -- constructs an `ApplyFunctionExpression` wrapping Iceberg's `BucketFunction$BucketInt` and verifies `getSupportLevel` returns `Compatible` for a valid call and `Unsupported` for a zero-bucket call, matching the guard on the `StaticInvoke` path.
- `Iceberg handler map is keyed by Iceberg implementation class names` -- guards against a rename of one of Iceberg's per-type implementation classes silently dropping the native path.

The existing `support levels follow Iceberg's bind rules` test continues to exercise the `StaticInvoke` path unchanged; the shared handlers keep both entry points aligned.