### PR TITLE
fix: match iceberg-java's exception for unclustered input to a clustered Iceberg write

### DIFF
--- a/native/core/src/execution/operators/iceberg_partition_path.rs
+++ b/native/core/src/execution/operators/iceberg_partition_path.rs
@@ -73,31 +73,40 @@ impl CometLocationGenerator {
         })
     }
 
-    /// Mirrors iceberg-java's `PartitionSpec#partitionToPath`: `name=value` pairs joined by `/`,
-    /// with both halves form-urlencoded. `form_urlencoded` leaves exactly the byte set Java's
-    /// `URLEncoder.encode(s, UTF_8)` leaves (`A-Za-z0-9`, `*`, `-`, `.`, `_`), maps space to `+`,
-    /// and percent-encodes the rest with uppercase hex, so the two agree byte for byte.
     fn partition_to_path(&self, key: &PartitionKey) -> String {
-        let fields = self.partition_type.fields();
-        key.spec()
-            .fields()
-            .iter()
-            .enumerate()
-            .map(|(index, field)| {
-                // Indexed rather than zipped so a spec/partition-type/value length disagreement
-                // renders as "null" instead of panicking; the three are built from the same spec,
-                // so they always line up in practice.
-                let value = key.data().fields().get(index).and_then(Option::as_ref);
-                let human = match fields.get(index) {
-                    Some(nested) => human_string(&field.transform, &nested.field_type, value),
-                    None => NULL.to_string(),
-                };
-                form_urlencoded::Serializer::new(String::new())
-                    .append_pair(&field.name, &human)
-                    .finish()
-            })
-            .join("/")
+        partition_to_path(&self.partition_type, key)
     }
+}
+
+/// Mirrors iceberg-java's `PartitionSpec#partitionToPath`: `name=value` pairs joined by `/`, with
+/// both halves form-urlencoded. `form_urlencoded` leaves exactly the byte set Java's
+/// `URLEncoder.encode(s, UTF_8)` leaves (`A-Za-z0-9`, `*`, `-`, `.`, `_`), maps space to `+`, and
+/// percent-encodes the rest with uppercase hex, so the two agree byte for byte.
+///
+/// `partition_type` is `key`'s spec resolved against its schema. It is passed in rather than
+/// resolved here because resolution can fail and every caller already holds one: the location
+/// generator resolves it at task start, and `ClusteredBatchSplitter` needs it to read partition
+/// values.
+pub(crate) fn partition_to_path(partition_type: &StructType, key: &PartitionKey) -> String {
+    let fields = partition_type.fields();
+    key.spec()
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(index, field)| {
+            // Indexed rather than zipped so a spec/partition-type/value length disagreement
+            // renders as "null" instead of panicking; the three are built from the same spec,
+            // so they always line up in practice.
+            let value = key.data().fields().get(index).and_then(Option::as_ref);
+            let human = match fields.get(index) {
+                Some(nested) => human_string(&field.transform, &nested.field_type, value),
+                None => NULL.to_string(),
+            };
+            form_urlencoded::Serializer::new(String::new())
+                .append_pair(&field.name, &human)
+                .finish()
+        })
+        .join("/")
 }
 
 impl LocationGenerator for CometLocationGenerator {

--- a/native/core/src/execution/operators/iceberg_write.rs
+++ b/native/core/src/execution/operators/iceberg_write.rs
@@ -24,6 +24,7 @@
 //! data manifest via iceberg-rust's `ManifestWriter` against an in-memory `FileIO`. The JVM
 //! decodes the bytes with `ManifestFiles.read(...)` to recover the `DataFile`s for commit.
 
+use std::collections::HashSet;
 use std::fmt;
 use std::sync::Arc;
 
@@ -69,6 +70,7 @@ use datafusion_comet_proto::spark_operator::{
 };
 
 use crate::cloud::s3::credential_bridge::AccessMode;
+use crate::errors::CometError;
 use crate::execution::operators::iceberg_common::load_file_io;
 use crate::execution::operators::iceberg_partition_path::CometLocationGenerator;
 
@@ -341,9 +343,11 @@ async fn run_write_task(
         (false, ProtoIcebergWriterMode::IcebergWriterFanout) => {
             InnerWriter::Fanout(FanoutWriter::new(data_file_builder))
         }
-        (false, ProtoIcebergWriterMode::IcebergWriterClustered) => {
-            InnerWriter::Clustered(ClusteredWriter::new(data_file_builder))
-        }
+        (false, ProtoIcebergWriterMode::IcebergWriterClustered) => InnerWriter::Clustered {
+            writer: ClusteredWriter::new(data_file_builder),
+            current: None,
+            closed: HashSet::new(),
+        },
         (actual, mode) => {
             return Err(DataFusionError::Internal(format!(
                 "IcebergWrite writer_mode {mode:?} is inconsistent with the partition spec \
@@ -353,7 +357,7 @@ async fn run_write_task(
     };
 
     let clustered_splitter = match &writer {
-        InnerWriter::Clustered(_) => Some(ClusteredBatchSplitter::try_new(
+        InnerWriter::Clustered { .. } => Some(ClusteredBatchSplitter::try_new(
             Arc::clone(&partition_spec),
             Arc::clone(&iceberg_schema),
         )?),
@@ -393,7 +397,15 @@ async fn run_write_task(
 enum InnerWriter {
     Unpartitioned(UnpartitionedWriter<IcebergDataFileWriterBuilder>),
     Fanout(FanoutWriter<IcebergDataFileWriterBuilder>),
-    Clustered(ClusteredWriter<IcebergDataFileWriterBuilder>),
+    /// `ClusteredWriter` plus a mirror of its closed-partition bookkeeping: `current` is the
+    /// partition the writer has open, `closed` the ones it has already finished. Tracking them
+    /// here lets Comet reject unclustered input with iceberg-java's error (see
+    /// [`not_clustered_error`]) instead of letting iceberg-rust raise its own.
+    Clustered {
+        writer: ClusteredWriter<IcebergDataFileWriterBuilder>,
+        current: Option<IcebergStruct>,
+        closed: HashSet<IcebergStruct>,
+    },
 }
 
 impl InnerWriter {
@@ -416,12 +428,28 @@ impl InnerWriter {
                 }
                 Ok(())
             }
-            InnerWriter::Clustered(w) => {
+            InnerWriter::Clustered {
+                writer,
+                current,
+                closed,
+            } => {
                 let parts = clustered_splitter
                     .expect("clustered splitter must be Some for clustered writes")
                     .split(&batch)?;
                 for (key, part) in parts {
-                    w.write(key, part).await.map_err(iceberg_err)?;
+                    // `ClusteredWriter` closes the open partition whenever the key changes, so a
+                    // key we have already moved on from can never be written again. Detect that
+                    // here to raise iceberg-java's exception rather than iceberg-rust's; both
+                    // reject the write, but only one of them is the documented contract.
+                    if current.as_ref() != Some(key.data()) {
+                        if closed.contains(key.data()) {
+                            return Err(not_clustered_error(&key));
+                        }
+                        if let Some(previous) = current.replace(key.data().clone()) {
+                            closed.insert(previous);
+                        }
+                    }
+                    writer.write(key, part).await.map_err(iceberg_err)?;
                 }
                 Ok(())
             }
@@ -433,7 +461,7 @@ impl InnerWriter {
         match self {
             InnerWriter::Unpartitioned(w) => w.close().await.map_err(iceberg_err),
             InnerWriter::Fanout(w) => w.close().await.map_err(iceberg_err),
-            InnerWriter::Clustered(w) => w.close().await.map_err(iceberg_err),
+            InnerWriter::Clustered { writer, .. } => writer.close().await.map_err(iceberg_err),
         }
     }
 }
@@ -456,6 +484,49 @@ fn parse_partition_spec(json: &str) -> DFResult<PartitionSpecRef> {
 
 fn iceberg_err(e: iceberg::Error) -> DataFusionError {
     DataFusionError::External(Box::new(e))
+}
+
+/// iceberg-java's `ClusteredWriter` preamble, copied verbatim from
+/// `core/src/main/java/org/apache/iceberg/io/ClusteredWriter.java`. Applications catch that
+/// writer's `IllegalStateException` and match on this text -- Iceberg's own
+/// `TestRequiredDistributionAndOrdering` does both -- so the native writer reproduces it instead
+/// of surfacing iceberg-rust's differently worded error.
+const NOT_CLUSTERED_ROWS_ERROR_MSG_TEMPLATE: &str = concat!(
+    "Incoming records violate the writer assumption that records are clustered by spec and ",
+    "by partition within each spec. Either cluster the incoming records or switch to fanout ",
+    "writers.\n",
+    "Encountered records that belong to already closed files:\n"
+);
+
+/// The error iceberg-java's `ClusteredWriter.write` raises when a closed partition is revisited,
+/// down to the `partition '<path>' in spec <spec>` context. Only the partition branch of that
+/// check is reachable here: a task writes through a single output spec, so the spec can never
+/// change mid-stream.
+fn not_clustered_error(key: &PartitionKey) -> DataFusionError {
+    DataFusionError::from(CometError::IllegalState(format!(
+        "{NOT_CLUSTERED_ROWS_ERROR_MSG_TEMPLATE}partition '{}' in spec {}",
+        key.to_path(),
+        format_partition_spec(key.spec())
+    )))
+}
+
+/// Renders a partition spec the way iceberg-java's `PartitionSpec.toString` and
+/// `PartitionField.toString` do, so the error context matches character for character.
+fn format_partition_spec(spec: &PartitionSpec) -> String {
+    if spec.fields().is_empty() {
+        return "[]".to_string();
+    }
+    let fields: String = spec
+        .fields()
+        .iter()
+        .map(|field| {
+            format!(
+                "\n  {}: {}: {}({})",
+                field.field_id, field.name, field.transform, field.source_id
+            )
+        })
+        .collect();
+    format!("[{fields}\n]")
 }
 
 fn build_output_schema() -> SchemaRef {
@@ -1123,6 +1194,76 @@ mod tests {
             assert_eq!(data_files.len(), 3);
             let total: u64 = data_files.iter().map(|f| f.record_count()).sum();
             assert_eq!(total, 5);
+        }
+
+        /// Unclustered input must be rejected with iceberg-java's `ClusteredWriter` error rather
+        /// than iceberg-rust's "The input is not sorted!", and it has to reach the JVM as an
+        /// `IllegalStateException`. Iceberg's own `TestRequiredDistributionAndOrdering` asserts
+        /// both. See https://github.com/apache/datafusion-comet/issues/5698.
+        #[tokio::test]
+        async fn clustered_write_rejects_unclustered_input_like_iceberg_java() {
+            let temp_dir = TempDir::new().unwrap();
+            let data_location = format!("file://{}", temp_dir.path().display());
+            let schema = iceberg_user_schema();
+            let spec = PartitionSpec::builder(Arc::new(schema.clone()))
+                .with_spec_id(0)
+                .add_partition_field("region", "region", Transform::Identity)
+                .unwrap()
+                .build()
+                .unwrap();
+            let common = common(
+                data_location,
+                serde_json::to_string(&spec).unwrap(),
+                serde_json::to_string(&schema).unwrap(),
+                ProtoIcebergWriterMode::IcebergWriterClustered,
+            );
+
+            // "eu" is revisited after the writer has moved on to "us" and closed it.
+            let err = run(
+                common,
+                schema,
+                spec,
+                ProtoIcebergWriterMode::IcebergWriterClustered,
+                vec![batch(&[1, 2], &["eu", "us"]), batch(&[3], &["eu"])],
+            )
+            .await
+            .unwrap_err();
+
+            let DataFusionError::External(external) = &err else {
+                panic!("expected an External error carrying a CometError, got {err:?}");
+            };
+            let Some(CometError::IllegalState(message)) = external.downcast_ref::<CometError>()
+            else {
+                panic!("expected CometError::IllegalState, got {external:?}");
+            };
+            // Byte-for-byte what iceberg-java's ClusteredWriter would have raised.
+            assert_eq!(
+                message,
+                "Incoming records violate the writer assumption that records are clustered by \
+                 spec and by partition within each spec. Either cluster the incoming records or \
+                 switch to fanout writers.\n\
+                 Encountered records that belong to already closed files:\n\
+                 partition 'region=eu' in spec [\n  1000: region: identity(2)\n]"
+            );
+        }
+
+        /// The transform rendering in [`format_partition_spec`] has to match iceberg-java's
+        /// `PartitionField.toString` for the parameterised transforms too.
+        #[test]
+        fn partition_spec_renders_like_iceberg_java() {
+            let schema = iceberg_user_schema();
+            let spec = PartitionSpec::builder(Arc::new(schema))
+                .with_spec_id(7)
+                .add_partition_field("id", "id_bucket", Transform::Bucket(8))
+                .unwrap()
+                .add_partition_field("region", "region_trunc", Transform::Truncate(4))
+                .unwrap()
+                .build()
+                .unwrap();
+            assert_eq!(
+                format_partition_spec(&spec),
+                "[\n  1000: id_bucket: bucket[8](1)\n  1001: region_trunc: truncate[4](2)\n]"
+            );
         }
 
         #[tokio::test]

--- a/native/core/src/execution/operators/iceberg_write.rs
+++ b/native/core/src/execution/operators/iceberg_write.rs
@@ -72,7 +72,9 @@ use datafusion_comet_proto::spark_operator::{
 use crate::cloud::s3::credential_bridge::AccessMode;
 use crate::errors::CometError;
 use crate::execution::operators::iceberg_common::load_file_io;
-use crate::execution::operators::iceberg_partition_path::CometLocationGenerator;
+use crate::execution::operators::iceberg_partition_path::{
+    partition_to_path, CometLocationGenerator,
+};
 
 /// Builder chain instantiated once per task and handed to the partitioning wrapper.
 type IcebergDataFileWriterBuilder =
@@ -419,17 +421,16 @@ impl InnerWriter {
                 Ok(())
             }
             InnerWriter::Clustered(w) => {
-                let parts = clustered_splitter
-                    .expect("clustered splitter must be Some for clustered writes")
-                    .split(&batch)?;
-                for (key, part) in parts {
+                let splitter = clustered_splitter
+                    .expect("clustered splitter must be Some for clustered writes");
+                for (key, part) in splitter.split(&batch)? {
                     // `write` consumes the key, but the unclustered-input error needs it for the
                     // partition path. One extra spec clone per run on top of the one
                     // `ClusteredBatchSplitter::partition_key` already pays.
                     let key_for_error = key.clone();
                     w.write(key, part)
                         .await
-                        .map_err(|e| clustered_write_err(e, &key_for_error))?;
+                        .map_err(|e| clustered_write_err(e, &key_for_error, splitter))?;
                 }
                 Ok(())
             }
@@ -488,9 +489,13 @@ const UNSORTED_INPUT_MESSAGE_PREFIX: &str = "The input is not sorted!";
 /// copy would fire first, no test could catch it drifting from the original. A wording change
 /// upstream instead makes `clustered_write_rejects_unclustered_input_like_iceberg_java` fail, since
 /// that test drives the real writer.
-fn clustered_write_err(e: iceberg::Error, key: &PartitionKey) -> DataFusionError {
+fn clustered_write_err(
+    e: iceberg::Error,
+    key: &PartitionKey,
+    splitter: &ClusteredBatchSplitter,
+) -> DataFusionError {
     if e.kind() == ErrorKind::Unexpected && e.message().starts_with(UNSORTED_INPUT_MESSAGE_PREFIX) {
-        not_clustered_error(key)
+        not_clustered_error(key, &splitter.partition_type)
     } else {
         iceberg_err(e)
     }
@@ -500,10 +505,14 @@ fn clustered_write_err(e: iceberg::Error, key: &PartitionKey) -> DataFusionError
 /// down to the `partition '<path>' in spec <spec>` context. Only the partition branch of that
 /// check is reachable here: a task writes through a single output spec, so the spec can never
 /// change mid-stream.
-fn not_clustered_error(key: &PartitionKey) -> DataFusionError {
+///
+/// The path comes from the same Java-compatible renderer that names the data directories, not from
+/// `PartitionKey::to_path`: iceberg-rust hex-encodes binary where iceberg-java base64-encodes it,
+/// and panics outright on a pre-epoch `timestamptz` with a sub-second part.
+fn not_clustered_error(key: &PartitionKey, partition_type: &StructType) -> DataFusionError {
     DataFusionError::from(CometError::IllegalState(format!(
         "{NOT_CLUSTERED_ROWS_ERROR_MSG_TEMPLATE}partition '{}' in spec {}",
-        key.to_path(),
+        partition_to_path(partition_type, key),
         format_partition_spec(key.spec())
     )))
 }
@@ -950,7 +959,8 @@ mod tests {
 
     mod integration {
         use super::super::*;
-        use arrow::array::{Int32Array, StringArray};
+        use arrow::array::{BinaryArray, Int32Array, StringArray, TimestampMicrosecondArray};
+        use arrow::datatypes::TimeUnit;
         use datafusion::common::Result as DFResult;
         use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
         use datafusion_comet_proto::spark_operator::{
@@ -995,8 +1005,13 @@ mod tests {
             .unwrap()
         }
 
+        /// Streams `batches` under their own schema, so a test can use a column layout other than
+        /// [`user_schema`].
         fn input_stream(batches: Vec<RecordBatch>) -> SendableRecordBatchStream {
-            let schema = user_schema();
+            let schema = batches
+                .first()
+                .map(RecordBatch::schema)
+                .unwrap_or_else(user_schema);
             Box::pin(RecordBatchStreamAdapter::new(
                 schema,
                 futures::stream::iter(batches.into_iter().map(Ok::<_, DataFusionError>)),
@@ -1195,57 +1210,179 @@ mod tests {
             assert_eq!(total, 5);
         }
 
-        /// Unclustered input must be rejected with iceberg-java's `ClusteredWriter` error rather
-        /// than iceberg-rust's "The input is not sorted!", and it has to reach the JVM as an
-        /// `IllegalStateException`. Iceberg's own `TestRequiredDistributionAndOrdering` asserts
-        /// both. See https://github.com/apache/datafusion-comet/issues/5698.
+        /// Runs a clustered write over input that revisits a closed partition, and returns the
+        /// `CometError::IllegalState` message it has to fail with.
         ///
-        /// This drives the real iceberg-rust writer, so it is also the tripwire for
+        /// Driving the real iceberg-rust writer is what makes these tests the tripwire for
         /// [`UNSORTED_INPUT_MESSAGE_PREFIX`] going stale on an iceberg-rust bump: the translation
         /// stops matching and the error arrives as a plain `iceberg::Error` instead.
-        #[tokio::test]
-        async fn clustered_write_rejects_unclustered_input_like_iceberg_java() {
+        async fn unclustered_write_message(
+            schema: Schema,
+            spec: PartitionSpec,
+            batches: Vec<RecordBatch>,
+        ) -> String {
             let temp_dir = TempDir::new().unwrap();
-            let data_location = format!("file://{}", temp_dir.path().display());
-            let schema = iceberg_user_schema();
-            let spec = PartitionSpec::builder(Arc::new(schema.clone()))
-                .with_spec_id(1)
-                .add_partition_field("region", "region", Transform::Identity)
-                .unwrap()
-                .build()
-                .unwrap();
             let common = common(
-                data_location,
+                format!("file://{}", temp_dir.path().display()),
                 serde_json::to_string(&spec).unwrap(),
                 serde_json::to_string(&schema).unwrap(),
                 ProtoIcebergWriterMode::IcebergWriterClustered,
             );
-
-            // "eu" is revisited after the writer has moved on to "us" and closed it.
             let err = run(
                 common,
                 schema,
                 spec,
                 ProtoIcebergWriterMode::IcebergWriterClustered,
-                vec![batch(&[1, 2], &["eu", "us"]), batch(&[3], &["eu"])],
+                batches,
             )
             .await
             .unwrap_err();
-
             let comet_error = match &err {
                 DataFusionError::External(external) => external.downcast_ref::<CometError>(),
                 _ => None,
             };
+            match comet_error {
+                Some(CometError::IllegalState(message)) => message.clone(),
+                _ => panic!("expected CometError::IllegalState, got {err:?}"),
+            }
+        }
+
+        /// Builds an identity-partitioned single-column spec over `schema`.
+        fn identity_spec(schema: &Schema, column: &str) -> PartitionSpec {
+            PartitionSpec::builder(Arc::new(schema.clone()))
+                .with_spec_id(1)
+                .add_partition_field(column, column, Transform::Identity)
+                .unwrap()
+                .build()
+                .unwrap()
+        }
+
+        /// Unclustered input must be rejected with iceberg-java's `ClusteredWriter` error rather
+        /// than iceberg-rust's "The input is not sorted!", and it has to reach the JVM as an
+        /// `IllegalStateException`. Iceberg's own `TestRequiredDistributionAndOrdering` asserts
+        /// both. See https://github.com/apache/datafusion-comet/issues/5698.
+        #[tokio::test]
+        async fn clustered_write_rejects_unclustered_input_like_iceberg_java() {
+            let schema = iceberg_user_schema();
+            let spec = identity_spec(&schema, "region");
+            // "eu" is revisited after the writer has moved on to "us" and closed it.
+            let message = unclustered_write_message(
+                schema,
+                spec,
+                vec![batch(&[1, 2], &["eu", "us"]), batch(&[3], &["eu"])],
+            )
+            .await;
+
             // The wording itself is pinned against the real JVM writer by
-            // CometIcebergWriteActionSuite; here it only has to carry the right context and
-            // classification.
-            let expected = format!(
-                "{NOT_CLUSTERED_ROWS_ERROR_MSG_TEMPLATE}\
-                 partition 'region=eu' in spec [\n  1000: region: identity(2)\n]"
+            // CometIcebergWriteActionSuite; here it only has to carry the right context.
+            assert_eq!(
+                message,
+                format!(
+                    "{NOT_CLUSTERED_ROWS_ERROR_MSG_TEMPLATE}\
+                     partition 'region=eu' in spec [\n  1000: region: identity(2)\n]"
+                )
             );
+        }
+
+        /// iceberg-java base64-encodes a binary partition value where iceberg-rust's
+        /// `PartitionKey::to_path` writes uppercase hex, so the error has to go through the same
+        /// Java-compatible renderer that names the data directories.
+        #[tokio::test]
+        async fn unclustered_binary_partition_renders_like_iceberg_java() {
+            let schema = Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(2, "part", Type::Primitive(PrimitiveType::Binary)).into(),
+                ])
+                .build()
+                .unwrap();
+            let spec = identity_spec(&schema, "part");
+            let arrow_schema = Arc::new(ArrowSchema::new(vec![
+                Field::new("id", DataType::Int32, false),
+                Field::new("part", DataType::Binary, false),
+            ]));
+            let batch = |ids: &[i32], parts: Vec<&[u8]>| {
+                RecordBatch::try_new(
+                    Arc::clone(&arrow_schema),
+                    vec![
+                        Arc::new(Int32Array::from(ids.to_vec())),
+                        Arc::new(BinaryArray::from(parts)),
+                    ],
+                )
+                .unwrap()
+            };
+
+            let message = unclustered_write_message(
+                schema,
+                spec,
+                vec![
+                    batch(&[1, 2], vec![&[0x00, 0x01, 0xFF], &[0x00]]),
+                    batch(&[3], vec![&[0x00, 0x01, 0xFF]]),
+                ],
+            )
+            .await;
+
+            // base64(00 01 FF) = "AAH/", form-urlencoded to "AAH%2F". iceberg-rust would have
+            // rendered the same bytes as "0001FF".
             assert!(
-                matches!(comet_error, Some(CometError::IllegalState(m)) if *m == expected),
-                "expected CometError::IllegalState({expected:?}), got {err:?}"
+                message
+                    .ends_with("partition 'part=AAH%2F' in spec [\n  1000: part: identity(2)\n]"),
+                "{message}"
+            );
+        }
+
+        /// iceberg-rust's `Transform::to_human_string` panics on a pre-epoch `timestamptz` with a
+        /// sub-second part, so routing the error through `PartitionKey::to_path` would crash the
+        /// task instead of raising `IllegalStateException`.
+        #[tokio::test]
+        async fn unclustered_negative_timestamptz_partition_renders_like_iceberg_java() {
+            let schema = Schema::builder()
+                .with_schema_id(1)
+                .with_fields(vec![
+                    NestedField::required(1, "id", Type::Primitive(PrimitiveType::Int)).into(),
+                    NestedField::required(2, "ts", Type::Primitive(PrimitiveType::Timestamptz))
+                        .into(),
+                ])
+                .build()
+                .unwrap();
+            let spec = identity_spec(&schema, "ts");
+            let arrow_schema = Arc::new(ArrowSchema::new(vec![
+                Field::new("id", DataType::Int32, false),
+                Field::new(
+                    "ts",
+                    DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".into())),
+                    false,
+                ),
+            ]));
+            let batch = |ids: &[i32], micros: &[i64]| {
+                RecordBatch::try_new(
+                    Arc::clone(&arrow_schema),
+                    vec![
+                        Arc::new(Int32Array::from(ids.to_vec())),
+                        Arc::new(
+                            TimestampMicrosecondArray::from(micros.to_vec())
+                                .with_timezone("+00:00"),
+                        ),
+                    ],
+                )
+                .unwrap()
+            };
+
+            // -1_500_000 micros is 1969-12-31T23:59:58.5Z -- negative with a sub-second part.
+            let message = unclustered_write_message(
+                schema,
+                spec,
+                vec![batch(&[1, 2], &[-1_500_000, 0]), batch(&[3], &[-1_500_000])],
+            )
+            .await;
+
+            assert!(
+                message.ends_with(
+                    "partition 'ts=1969-12-31T23%3A59%3A58.5%2B00%3A00' in spec \
+                     [\n  1000: ts: identity(2)\n]"
+                ),
+                "{message}"
             );
         }
 

--- a/native/core/src/execution/operators/iceberg_write.rs
+++ b/native/core/src/execution/operators/iceberg_write.rs
@@ -24,7 +24,6 @@
 //! data manifest via iceberg-rust's `ManifestWriter` against an in-memory `FileIO`. The JVM
 //! decodes the bytes with `ManifestFiles.read(...)` to recover the `DataFile`s for commit.
 
-use std::collections::HashSet;
 use std::fmt;
 use std::sync::Arc;
 
@@ -59,6 +58,7 @@ use iceberg::writer::file_writer::ParquetWriterBuilder;
 use iceberg::writer::partitioning::clustered_writer::ClusteredWriter;
 use iceberg::writer::partitioning::fanout_writer::FanoutWriter;
 use iceberg::writer::partitioning::unpartitioned_writer::UnpartitionedWriter;
+use iceberg::ErrorKind;
 #[cfg(test)]
 use parquet::arrow::PARQUET_FIELD_ID_META_KEY;
 use parquet::basic::{BrotliLevel, Compression, GzipLevel, ZstdLevel};
@@ -343,11 +343,9 @@ async fn run_write_task(
         (false, ProtoIcebergWriterMode::IcebergWriterFanout) => {
             InnerWriter::Fanout(FanoutWriter::new(data_file_builder))
         }
-        (false, ProtoIcebergWriterMode::IcebergWriterClustered) => InnerWriter::Clustered {
-            writer: ClusteredWriter::new(data_file_builder),
-            current: None,
-            closed: HashSet::new(),
-        },
+        (false, ProtoIcebergWriterMode::IcebergWriterClustered) => {
+            InnerWriter::Clustered(ClusteredWriter::new(data_file_builder))
+        }
         (actual, mode) => {
             return Err(DataFusionError::Internal(format!(
                 "IcebergWrite writer_mode {mode:?} is inconsistent with the partition spec \
@@ -357,7 +355,7 @@ async fn run_write_task(
     };
 
     let clustered_splitter = match &writer {
-        InnerWriter::Clustered { .. } => Some(ClusteredBatchSplitter::try_new(
+        InnerWriter::Clustered(_) => Some(ClusteredBatchSplitter::try_new(
             Arc::clone(&partition_spec),
             Arc::clone(&iceberg_schema),
         )?),
@@ -397,15 +395,7 @@ async fn run_write_task(
 enum InnerWriter {
     Unpartitioned(UnpartitionedWriter<IcebergDataFileWriterBuilder>),
     Fanout(FanoutWriter<IcebergDataFileWriterBuilder>),
-    /// `ClusteredWriter` plus a mirror of its closed-partition bookkeeping: `current` is the
-    /// partition the writer has open, `closed` the ones it has already finished. Tracking them
-    /// here lets Comet reject unclustered input with iceberg-java's error (see
-    /// [`not_clustered_error`]) instead of letting iceberg-rust raise its own.
-    Clustered {
-        writer: ClusteredWriter<IcebergDataFileWriterBuilder>,
-        current: Option<IcebergStruct>,
-        closed: HashSet<IcebergStruct>,
-    },
+    Clustered(ClusteredWriter<IcebergDataFileWriterBuilder>),
 }
 
 impl InnerWriter {
@@ -428,28 +418,18 @@ impl InnerWriter {
                 }
                 Ok(())
             }
-            InnerWriter::Clustered {
-                writer,
-                current,
-                closed,
-            } => {
+            InnerWriter::Clustered(w) => {
                 let parts = clustered_splitter
                     .expect("clustered splitter must be Some for clustered writes")
                     .split(&batch)?;
                 for (key, part) in parts {
-                    // `ClusteredWriter` closes the open partition whenever the key changes, so a
-                    // key we have already moved on from can never be written again. Detect that
-                    // here to raise iceberg-java's exception rather than iceberg-rust's; both
-                    // reject the write, but only one of them is the documented contract.
-                    if current.as_ref() != Some(key.data()) {
-                        if closed.contains(key.data()) {
-                            return Err(not_clustered_error(&key));
-                        }
-                        if let Some(previous) = current.replace(key.data().clone()) {
-                            closed.insert(previous);
-                        }
-                    }
-                    writer.write(key, part).await.map_err(iceberg_err)?;
+                    // `write` consumes the key, but the unclustered-input error needs it for the
+                    // partition path. One extra spec clone per run on top of the one
+                    // `ClusteredBatchSplitter::partition_key` already pays.
+                    let key_for_error = key.clone();
+                    w.write(key, part)
+                        .await
+                        .map_err(|e| clustered_write_err(e, &key_for_error))?;
                 }
                 Ok(())
             }
@@ -461,7 +441,7 @@ impl InnerWriter {
         match self {
             InnerWriter::Unpartitioned(w) => w.close().await.map_err(iceberg_err),
             InnerWriter::Fanout(w) => w.close().await.map_err(iceberg_err),
-            InnerWriter::Clustered { writer, .. } => writer.close().await.map_err(iceberg_err),
+            InnerWriter::Clustered(w) => w.close().await.map_err(iceberg_err),
         }
     }
 }
@@ -491,12 +471,30 @@ fn iceberg_err(e: iceberg::Error) -> DataFusionError {
 /// writer's `IllegalStateException` and match on this text -- Iceberg's own
 /// `TestRequiredDistributionAndOrdering` does both -- so the native writer reproduces it instead
 /// of surfacing iceberg-rust's differently worded error.
-const NOT_CLUSTERED_ROWS_ERROR_MSG_TEMPLATE: &str = concat!(
-    "Incoming records violate the writer assumption that records are clustered by spec and ",
-    "by partition within each spec. Either cluster the incoming records or switch to fanout ",
-    "writers.\n",
-    "Encountered records that belong to already closed files:\n"
-);
+const NOT_CLUSTERED_ROWS_ERROR_MSG_TEMPLATE: &str = "Incoming records violate the writer \
+     assumption that records are clustered by spec and by partition within each spec. Either \
+     cluster the incoming records or switch to fanout writers.\n\
+     Encountered records that belong to already closed files:\n";
+
+/// The message iceberg-rust's `ClusteredWriter` raises for the same condition.
+const UNSORTED_INPUT_MESSAGE_PREFIX: &str = "The input is not sorted!";
+
+/// Restates iceberg-rust's unclustered-input failure as iceberg-java's, passing every other
+/// failure through unchanged.
+///
+/// Leaving `ClusteredWriter` as the sole judge of whether the input is clustered means coupling to
+/// its message text, which is the cheaper of the two couplings available: re-deriving the
+/// condition here would need a copy of the writer's closed-partition bookkeeping, and because that
+/// copy would fire first, no test could catch it drifting from the original. A wording change
+/// upstream instead makes `clustered_write_rejects_unclustered_input_like_iceberg_java` fail, since
+/// that test drives the real writer.
+fn clustered_write_err(e: iceberg::Error, key: &PartitionKey) -> DataFusionError {
+    if e.kind() == ErrorKind::Unexpected && e.message().starts_with(UNSORTED_INPUT_MESSAGE_PREFIX) {
+        not_clustered_error(key)
+    } else {
+        iceberg_err(e)
+    }
+}
 
 /// The error iceberg-java's `ClusteredWriter.write` raises when a closed partition is revisited,
 /// down to the `partition '<path>' in spec <spec>` context. Only the partition branch of that
@@ -513,9 +511,6 @@ fn not_clustered_error(key: &PartitionKey) -> DataFusionError {
 /// Renders a partition spec the way iceberg-java's `PartitionSpec.toString` and
 /// `PartitionField.toString` do, so the error context matches character for character.
 fn format_partition_spec(spec: &PartitionSpec) -> String {
-    if spec.fields().is_empty() {
-        return "[]".to_string();
-    }
     let fields: String = spec
         .fields()
         .iter()
@@ -526,7 +521,11 @@ fn format_partition_spec(spec: &PartitionSpec) -> String {
             )
         })
         .collect();
-    format!("[{fields}\n]")
+    if fields.is_empty() {
+        "[]".to_string()
+    } else {
+        format!("[{fields}\n]")
+    }
 }
 
 fn build_output_schema() -> SchemaRef {
@@ -1200,13 +1199,17 @@ mod tests {
         /// than iceberg-rust's "The input is not sorted!", and it has to reach the JVM as an
         /// `IllegalStateException`. Iceberg's own `TestRequiredDistributionAndOrdering` asserts
         /// both. See https://github.com/apache/datafusion-comet/issues/5698.
+        ///
+        /// This drives the real iceberg-rust writer, so it is also the tripwire for
+        /// [`UNSORTED_INPUT_MESSAGE_PREFIX`] going stale on an iceberg-rust bump: the translation
+        /// stops matching and the error arrives as a plain `iceberg::Error` instead.
         #[tokio::test]
         async fn clustered_write_rejects_unclustered_input_like_iceberg_java() {
             let temp_dir = TempDir::new().unwrap();
             let data_location = format!("file://{}", temp_dir.path().display());
             let schema = iceberg_user_schema();
             let spec = PartitionSpec::builder(Arc::new(schema.clone()))
-                .with_spec_id(0)
+                .with_spec_id(1)
                 .add_partition_field("region", "region", Transform::Identity)
                 .unwrap()
                 .build()
@@ -1229,21 +1232,20 @@ mod tests {
             .await
             .unwrap_err();
 
-            let DataFusionError::External(external) = &err else {
-                panic!("expected an External error carrying a CometError, got {err:?}");
+            let comet_error = match &err {
+                DataFusionError::External(external) => external.downcast_ref::<CometError>(),
+                _ => None,
             };
-            let Some(CometError::IllegalState(message)) = external.downcast_ref::<CometError>()
-            else {
-                panic!("expected CometError::IllegalState, got {external:?}");
-            };
-            // Byte-for-byte what iceberg-java's ClusteredWriter would have raised.
-            assert_eq!(
-                message,
-                "Incoming records violate the writer assumption that records are clustered by \
-                 spec and by partition within each spec. Either cluster the incoming records or \
-                 switch to fanout writers.\n\
-                 Encountered records that belong to already closed files:\n\
+            // The wording itself is pinned against the real JVM writer by
+            // CometIcebergWriteActionSuite; here it only has to carry the right context and
+            // classification.
+            let expected = format!(
+                "{NOT_CLUSTERED_ROWS_ERROR_MSG_TEMPLATE}\
                  partition 'region=eu' in spec [\n  1000: region: identity(2)\n]"
+            );
+            assert!(
+                matches!(comet_error, Some(CometError::IllegalState(m)) if *m == expected),
+                "expected CometError::IllegalState({expected:?}), got {err:?}"
             );
         }
 

--- a/native/jni-bridge/src/errors.rs
+++ b/native/jni-bridge/src/errors.rs
@@ -95,11 +95,9 @@ pub enum CometError {
     #[error("{0}")]
     ShuffleSizeLimit(String),
 
-    /// A failure that must reach the JVM as `java.lang.IllegalStateException` carrying this exact
-    /// message. Reserved for runtime checks where Comet reimplements a JVM library's own guard and
-    /// has to raise the exception that library raises -- callers catch or match on it, so a
-    /// `CometNativeException` would be a visible behaviour change. Not for internal invariants:
-    /// use [`CometError::Internal`] for those.
+    /// Must reach the JVM as `java.lang.IllegalStateException` carrying this exact message: for
+    /// runtime checks where Comet reimplements a JVM library's guard and callers match on the
+    /// exception that library raises. Internal invariants belong in [`CometError::Internal`].
     #[error("{0}")]
     IllegalState(String),
 
@@ -500,8 +498,11 @@ fn throw_exception(env: &mut Env, error: &CometError, backtrace: Option<String>)
         // DataFusion operators can wrap the original failure in Context, Shared, or External
         // errors. Keep the classifications that own their JVM exception class typed across those
         // wrappers and the JNI boundary.
-        if let Some((class, message)) = typed_jvm_exception(error) {
-            let _ = env.throw_new(JNIString::new(class), JNIString::new(message));
+        if let Some(exception) = typed_jvm_exception(error) {
+            let _ = env.throw_new(
+                JNIString::new(exception.class),
+                JNIString::new(exception.msg),
+            );
             return;
         }
         // ... then throw new exception
@@ -585,23 +586,17 @@ fn throw_exception(env: &mut Env, error: &CometError, backtrace: Option<String>)
     }
 }
 
-/// Walks the cause chain for a `CometError` variant that carries its own JVM exception class, and
-/// returns that class plus the untouched message. These must never be inferred from error text --
-/// only the variant counts -- so a failure that merely mentions the same words keeps its normal
-/// classification.
-fn typed_jvm_exception<'a>(
-    error: &'a (dyn std::error::Error + 'static),
-) -> Option<(&'static str, &'a str)> {
+/// Walks the cause chain for a `CometError` variant that owns its JVM exception class, so class and
+/// message survive DataFusion's `Context` / `Shared` / `External` wrappers. The class comes from
+/// `to_exception`, keeping one variant-to-class table. Classification is by variant only -- an
+/// error that merely mentions the same words keeps its normal classification.
+fn typed_jvm_exception(error: &(dyn std::error::Error + 'static)) -> Option<Exception> {
     let mut cause = Some(error);
     while let Some(error) = cause {
-        match error.downcast_ref::<CometError>() {
-            Some(CometError::ShuffleSizeLimit(message)) => {
-                return Some(("org/apache/comet/CometShuffleSizeLimitException", message))
-            }
-            Some(CometError::IllegalState(message)) => {
-                return Some(("java/lang/IllegalStateException", message))
-            }
-            _ => {}
+        if let Some(typed @ (CometError::ShuffleSizeLimit(_) | CometError::IllegalState(_))) =
+            error.downcast_ref::<CometError>()
+        {
+            return Some(typed.to_exception());
         }
         cause = error.source();
     }
@@ -966,26 +961,32 @@ mod tests {
         }
     }
 
+    /// Wraps `error` the way a DataFusion operator would, throws it, and asserts the pending Java
+    /// exception is `expected_class` with the message intact -- i.e. that the variant kept its own
+    /// JVM exception class instead of collapsing into `CometNativeException`.
+    fn assert_survives_datafusion_wrappers(error: CometError, message: &str, expected_class: &str) {
+        let wrapped = DataFusionError::Shared(Arc::new(DataFusionError::Context(
+            "executing operator".to_string(),
+            Box::new(DataFusionError::from(error)),
+        )));
+        jvm()
+            .attach_current_thread(|env| -> jni::errors::Result<()> {
+                unwrap_or_throw_default::<()>(env, Err(CometError::from(wrapped)));
+                assert_pending_java_exception_detailed(env, Some(expected_class), Some(message));
+                Ok(())
+            })
+            .unwrap();
+    }
+
     #[test]
     #[cfg_attr(miri, ignore)] // miri cannot create a JVM.
     fn shuffle_size_limit_survives_datafusion_wrappers_and_jni() {
         let message = "Remote shuffle exceeds spark.comet.shuffle.rss.maxInFlightBytes";
-        let error = DataFusionError::from(CometError::ShuffleSizeLimit(message.to_string()));
-        let error = DataFusionError::Shared(Arc::new(DataFusionError::Context(
-            "executing shuffle writer".to_string(),
-            Box::new(error),
-        )));
-        jvm()
-            .attach_current_thread(|env| -> jni::errors::Result<()> {
-                unwrap_or_throw_default::<()>(env, Err(CometError::from(error)));
-                assert_pending_java_exception_detailed(
-                    env,
-                    Some("org/apache/comet/CometShuffleSizeLimitException"),
-                    Some(message),
-                );
-                Ok(())
-            })
-            .unwrap();
+        assert_survives_datafusion_wrappers(
+            CometError::ShuffleSizeLimit(message.to_string()),
+            message,
+            "org/apache/comet/CometShuffleSizeLimitException",
+        );
     }
 
     #[test]
@@ -1002,22 +1003,11 @@ mod tests {
     #[cfg_attr(miri, ignore)] // miri cannot create a JVM.
     fn illegal_state_survives_datafusion_wrappers_and_jni() {
         let message = "Incoming records violate the writer assumption that records are clustered";
-        let error = DataFusionError::from(CometError::IllegalState(message.to_string()));
-        let error = DataFusionError::Shared(Arc::new(DataFusionError::Context(
-            "executing IcebergWriteExec".to_string(),
-            Box::new(error),
-        )));
-        jvm()
-            .attach_current_thread(|env| -> jni::errors::Result<()> {
-                unwrap_or_throw_default::<()>(env, Err(CometError::from(error)));
-                assert_pending_java_exception_detailed(
-                    env,
-                    Some("java/lang/IllegalStateException"),
-                    Some(message),
-                );
-                Ok(())
-            })
-            .unwrap();
+        assert_survives_datafusion_wrappers(
+            CometError::IllegalState(message.to_string()),
+            message,
+            "java/lang/IllegalStateException",
+        );
     }
 
     #[test]

--- a/native/jni-bridge/src/errors.rs
+++ b/native/jni-bridge/src/errors.rs
@@ -95,6 +95,14 @@ pub enum CometError {
     #[error("{0}")]
     ShuffleSizeLimit(String),
 
+    /// A failure that must reach the JVM as `java.lang.IllegalStateException` carrying this exact
+    /// message. Reserved for runtime checks where Comet reimplements a JVM library's own guard and
+    /// has to raise the exception that library raises -- callers catch or match on it, so a
+    /// `CometNativeException` would be a visible behaviour change. Not for internal invariants:
+    /// use [`CometError::Internal`] for those.
+    #[error("{0}")]
+    IllegalState(String),
+
     #[error(transparent)]
     Arrow {
         #[from]
@@ -219,9 +227,10 @@ impl From<CometError> for DataFusionError {
             // own codegen inside the JVM UDF kernel) as an `External` error so it survives the trip
             // back through DataFusion and can be re-thrown with its exact type at the JNI boundary.
             // Flattening it to a string here would surface it as a generic CometNativeException.
-            value @ (CometError::JavaException { .. } | CometError::ShuffleSizeLimit(_)) => {
-                DataFusionError::External(Box::new(value))
-            }
+            // The same applies to the classifications that must keep their JVM exception class.
+            value @ (CometError::JavaException { .. }
+            | CometError::ShuffleSizeLimit(_)
+            | CometError::IllegalState(_)) => DataFusionError::External(Box::new(value)),
             _ => DataFusionError::Execution(value.to_string()),
         }
     }
@@ -347,6 +356,10 @@ impl jni::errors::ToException for CometError {
             },
             CometError::ShuffleSizeLimit(message) => Exception {
                 class: "org/apache/comet/CometShuffleSizeLimitException".to_string(),
+                msg: message.clone(),
+            },
+            CometError::IllegalState(message) => Exception {
+                class: "java/lang/IllegalStateException".to_string(),
                 msg: message.clone(),
             },
             _other => Exception {
@@ -485,12 +498,10 @@ fn throw_exception(env: &mut Env, error: &CometError, backtrace: Option<String>)
     // If there isn't already an exception?
     if !env.exception_check() {
         // DataFusion operators can wrap the original failure in Context, Shared, or External
-        // errors. Keep capacity failures typed across those wrappers and the JNI boundary.
-        if let Some(message) = shuffle_size_limit_message(error) {
-            let _ = env.throw_new(
-                jni::jni_str!("org/apache/comet/CometShuffleSizeLimitException"),
-                JNIString::new(message),
-            );
+        // errors. Keep the classifications that own their JVM exception class typed across those
+        // wrappers and the JNI boundary.
+        if let Some((class, message)) = typed_jvm_exception(error) {
+            let _ = env.throw_new(JNIString::new(class), JNIString::new(message));
             return;
         }
         // ... then throw new exception
@@ -574,11 +585,23 @@ fn throw_exception(env: &mut Env, error: &CometError, backtrace: Option<String>)
     }
 }
 
-fn shuffle_size_limit_message<'a>(error: &'a (dyn std::error::Error + 'static)) -> Option<&'a str> {
+/// Walks the cause chain for a `CometError` variant that carries its own JVM exception class, and
+/// returns that class plus the untouched message. These must never be inferred from error text --
+/// only the variant counts -- so a failure that merely mentions the same words keeps its normal
+/// classification.
+fn typed_jvm_exception<'a>(
+    error: &'a (dyn std::error::Error + 'static),
+) -> Option<(&'static str, &'a str)> {
     let mut cause = Some(error);
     while let Some(error) = cause {
-        if let Some(CometError::ShuffleSizeLimit(message)) = error.downcast_ref::<CometError>() {
-            return Some(message);
+        match error.downcast_ref::<CometError>() {
+            Some(CometError::ShuffleSizeLimit(message)) => {
+                return Some(("org/apache/comet/CometShuffleSizeLimitException", message))
+            }
+            Some(CometError::IllegalState(message)) => {
+                return Some(("java/lang/IllegalStateException", message))
+            }
+            _ => {}
         }
         cause = error.source();
     }
@@ -970,7 +993,31 @@ mod tests {
         let error = CometError::from(DataFusionError::Execution(
             "Remote shuffle exceeds spark.comet.shuffle.rss.maxInFlightBytes".to_string(),
         ));
-        assert!(shuffle_size_limit_message(&error).is_none());
+        assert!(typed_jvm_exception(&error).is_none());
+    }
+
+    /// The native Iceberg writer rejects unclustered input with iceberg-java's own
+    /// `IllegalStateException`, so it has to survive the same wrappers.
+    #[test]
+    #[cfg_attr(miri, ignore)] // miri cannot create a JVM.
+    fn illegal_state_survives_datafusion_wrappers_and_jni() {
+        let message = "Incoming records violate the writer assumption that records are clustered";
+        let error = DataFusionError::from(CometError::IllegalState(message.to_string()));
+        let error = DataFusionError::Shared(Arc::new(DataFusionError::Context(
+            "executing IcebergWriteExec".to_string(),
+            Box::new(error),
+        )));
+        jvm()
+            .attach_current_thread(|env| -> jni::errors::Result<()> {
+                unwrap_or_throw_default::<()>(env, Err(CometError::from(error)));
+                assert_pending_java_exception_detailed(
+                    env,
+                    Some("java/lang/IllegalStateException"),
+                    Some(message),
+                );
+                Ok(())
+            })
+            .unwrap();
     }
 
     #[test]

--- a/spark/src/test/scala/org/apache/comet/CometIcebergTestBase.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergTestBase.scala
@@ -137,15 +137,19 @@ trait CometIcebergTestBase {
     file.delete()
   }
 
-  /** The executed plan of every query that completes successfully while `action` runs. */
-  protected def capturePlans(spark: SparkSession)(action: => Unit): Seq[SparkPlan] = {
+  /**
+   * The executed plan of every query that ran while `action` ran. Queries that failed are
+   * included only when `includeFailures` is set, which is what an action expected to abort needs.
+   */
+  protected def capturePlans(spark: SparkSession, includeFailures: Boolean = false)(
+      action: => Unit): Seq[SparkPlan] = {
     val captured = mutable.Buffer.empty[SparkPlan]
     val listener = new QueryExecutionListener {
       override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
         captured += qe.executedPlan
       }
       override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit =
-        ()
+        if (includeFailures) captured += qe.executedPlan
     }
     spark.listenerManager.register(listener)
     try {

--- a/spark/src/test/scala/org/apache/comet/CometIcebergWriteActionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergWriteActionSuite.scala
@@ -27,15 +27,17 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 
+import org.apache.spark.CometListenerBusUtils
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.CometTestBase
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.comet.{CometIcebergWriteExec, IcebergCommitExec, IcebergWriteExec}
 import org.apache.spark.sql.connector.catalog.InMemoryTableCatalog
-import org.apache.spark.sql.execution.{ColumnarToRowTransition, SparkPlan}
+import org.apache.spark.sql.execution.{ColumnarToRowTransition, QueryExecution, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DoubleType, IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.util.QueryExecutionListener
 
 import org.apache.comet.CometSparkSessionExtensions.{isSpark35Plus, isSpark41Plus}
 
@@ -1222,6 +1224,70 @@ class CometIcebergWriteActionSuite
     }
   }
 
+  // https://github.com/apache/datafusion-comet/issues/5698. iceberg-java's `ClusteredWriter`
+  // rejects unclustered input with a documented `IllegalStateException`, and callers match on both
+  // the type and the message -- Iceberg's own `TestRequiredDistributionAndOrdering` does exactly
+  // that. Pin the native writer against the JVM writer on the same runtime rather than against a
+  // literal, so an iceberg-java wording change surfaces here as a parity failure.
+  test("native acceleration: clustered writer rejects unclustered input like the JVM writer") {
+    assumeNativeAcceleration()
+    withIcebergCatalog { warehouseDir =>
+      Seq("unclustered_native", "unclustered_jvm").foreach { t =>
+        createTable(warehouseDir, t, partitionSpec = "PARTITIONED BY (region)")
+      }
+      // `use-table-distribution-and-ordering=false` drops the partition-local sort Iceberg would
+      // otherwise request, so the interleaved region values reach the writer as they are;
+      // `fanout-enabled=false` picks the clustered writer, which cannot accept them.
+      def unclusteredAppend(t: String): Unit = {
+        val session = spark
+        import session.implicits._
+        Seq((1, "us-east", 1.0), (2, "eu", 2.0), (3, "us-east", 3.0))
+          .toDF("id", "region", "amount")
+          .coalesce(1)
+          .writeTo(s"$catalog.$ns.$t")
+          .option("use-table-distribution-and-ordering", "false")
+          .option("fanout-enabled", "false")
+          .append()
+      }
+
+      val jvmFailure = intercept[Exception](unclusteredAppend("unclustered_jvm"))
+      val (nativeFailure, nativePlans) = withNativeEnabled {
+        captureFailedWrite(unclusteredAppend("unclustered_native"))
+      }
+      assert(
+        nativePlans.exists(p =>
+          collectWithSubqueries(p) { case e: CometIcebergWriteExec => e }.nonEmpty),
+        "expected the aborted write to have gone through CometIcebergWriteExec. Plans:\n" +
+          nativePlans.mkString("\n--\n"))
+      // Same shape: the writer's exception sits at the same depth under Spark's job-abort
+      // wrappers, so `assertThatThrownBy(...).cause()` finds it in the same place either way.
+      assert(
+        causeChain(nativeFailure).map(_.getClass.getName) ==
+          causeChain(jvmFailure).map(_.getClass.getName),
+        s"cause chains differ.\nnative: ${causeChain(nativeFailure).map(_.getClass.getName)}\n" +
+          s"jvm:    ${causeChain(jvmFailure).map(_.getClass.getName)}")
+      // Same exception, message included. Stage ids and driver stack traces make the outer
+      // SparkException messages differ between runs, so compare the writer's own.
+      def clusteredWriterError(t: Throwable): String = {
+        val message = causeChain(t)
+          .collectFirst { case e: IllegalStateException => e.getMessage }
+          .getOrElse(fail("no IllegalStateException in the cause chain", t))
+        assert(
+          message.startsWith(
+            "Incoming records violate the writer assumption that records are clustered by spec"),
+          s"unexpected IllegalStateException: $message")
+        message
+      }
+      assert(
+        clusteredWriterError(nativeFailure) == clusteredWriterError(jvmFailure),
+        s"native writer error differs from the JVM writer's.\n" +
+          s"native: ${clusteredWriterError(nativeFailure)}\n" +
+          s"jvm:    ${clusteredWriterError(jvmFailure)}")
+      // Neither write may have committed.
+      Seq("unclustered_native", "unclustered_jvm").foreach(t => assertRows(t, Seq.empty))
+    }
+  }
+
   test("native acceleration: target-file-size rolls one task across multiple files") {
     assumeNativeAcceleration()
     withIcebergCatalog { warehouseDir =>
@@ -1976,6 +2042,31 @@ class CometIcebergWriteActionSuite
   /** Native acceleration shared assumption -- currently just the Iceberg-on-classpath check. */
   private def assumeNativeAcceleration(): Unit = {
     assume(icebergAvailable, "Iceberg not available in classpath")
+  }
+
+  /**
+   * Runs `action`, expecting it to fail, and returns the thrown exception together with the
+   * executed plans of the queries it ran. [[capturePlans]] records successes only, which is no
+   * use for a write that is meant to abort.
+   */
+  private def captureFailedWrite(action: => Unit): (Throwable, Seq[SparkPlan]) = {
+    val captured = mutable.Buffer.empty[SparkPlan]
+    val listener = new QueryExecutionListener {
+      override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit =
+        captured += qe.executedPlan
+      override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit =
+        captured += qe.executedPlan
+    }
+    spark.listenerManager.register(listener)
+    val failure =
+      try {
+        val thrown = intercept[Exception](action)
+        CometListenerBusUtils.waitUntilEmpty(spark.sparkContext)
+        thrown
+      } finally {
+        spark.listenerManager.unregister(listener)
+      }
+    (failure, captured.toSeq)
   }
 
   /**

--- a/spark/src/test/scala/org/apache/comet/CometIcebergWriteActionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergWriteActionSuite.scala
@@ -27,17 +27,15 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 
-import org.apache.spark.CometListenerBusUtils
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.CometTestBase
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.comet.{CometIcebergWriteExec, IcebergCommitExec, IcebergWriteExec}
 import org.apache.spark.sql.connector.catalog.InMemoryTableCatalog
-import org.apache.spark.sql.execution.{ColumnarToRowTransition, QueryExecution, SparkPlan}
+import org.apache.spark.sql.execution.{ColumnarToRowTransition, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DoubleType, IntegerType, StringType, StructField, StructType}
-import org.apache.spark.sql.util.QueryExecutionListener
 
 import org.apache.comet.CometSparkSessionExtensions.{isSpark35Plus, isSpark41Plus}
 
@@ -1232,59 +1230,50 @@ class CometIcebergWriteActionSuite
   test("native acceleration: clustered writer rejects unclustered input like the JVM writer") {
     assumeNativeAcceleration()
     withIcebergCatalog { warehouseDir =>
-      Seq("unclustered_native", "unclustered_jvm").foreach { t =>
-        createTable(warehouseDir, t, partitionSpec = "PARTITIONED BY (region)")
-      }
+      val (nativeTable, jvmTable) = ("unclustered_native", "unclustered_jvm")
+      val tables = Seq(nativeTable, jvmTable)
+      tables.foreach(createTable(warehouseDir, _, partitionSpec = "PARTITIONED BY (region)"))
       // `use-table-distribution-and-ordering=false` drops the partition-local sort Iceberg would
       // otherwise request, so the interleaved region values reach the writer as they are;
       // `fanout-enabled=false` picks the clustered writer, which cannot accept them.
-      def unclusteredAppend(t: String): Unit = {
-        val session = spark
-        import session.implicits._
-        Seq((1, "us-east", 1.0), (2, "eu", 2.0), (3, "us-east", 3.0))
-          .toDF("id", "region", "amount")
-          .coalesce(1)
-          .writeTo(s"$catalog.$ns.$t")
-          .option("use-table-distribution-and-ordering", "false")
-          .option("fanout-enabled", "false")
-          .append()
-      }
+      def unclusteredAppend(t: String): Unit = coalesceInsert(
+        t,
+        Seq((1, "us-east", 1.0), (2, "eu", 2.0), (3, "us-east", 3.0)),
+        Seq("use-table-distribution-and-ordering" -> "false", "fanout-enabled" -> "false"))
 
-      val jvmFailure = intercept[Exception](unclusteredAppend("unclustered_jvm"))
-      val (nativeFailure, nativePlans) = withNativeEnabled {
-        captureFailedWrite(unclusteredAppend("unclustered_native"))
+      var nativeFailure: Throwable = null
+      val nativePlans = withNativeEnabled {
+        capturePlans(spark, includeFailures = true) {
+          nativeFailure = intercept[Exception](unclusteredAppend(nativeTable))
+        }
       }
+      val jvmFailure = intercept[Exception](unclusteredAppend(jvmTable))
       assert(
         nativePlans.exists(p =>
           collectWithSubqueries(p) { case e: CometIcebergWriteExec => e }.nonEmpty),
         "expected the aborted write to have gone through CometIcebergWriteExec. Plans:\n" +
           nativePlans.mkString("\n--\n"))
-      // Same shape: the writer's exception sits at the same depth under Spark's job-abort
-      // wrappers, so `assertThatThrownBy(...).cause()` finds it in the same place either way.
-      assert(
-        causeChain(nativeFailure).map(_.getClass.getName) ==
-          causeChain(jvmFailure).map(_.getClass.getName),
-        s"cause chains differ.\nnative: ${causeChain(nativeFailure).map(_.getClass.getName)}\n" +
-          s"jvm:    ${causeChain(jvmFailure).map(_.getClass.getName)}")
-      // Same exception, message included. Stage ids and driver stack traces make the outer
-      // SparkException messages differ between runs, so compare the writer's own.
-      def clusteredWriterError(t: Throwable): String = {
-        val message = causeChain(t)
-          .collectFirst { case e: IllegalStateException => e.getMessage }
-          .getOrElse(fail("no IllegalStateException in the cause chain", t))
-        assert(
-          message.startsWith(
-            "Incoming records violate the writer assumption that records are clustered by spec"),
-          s"unexpected IllegalStateException: $message")
-        message
+
+      // Where the writer's exception sits in the cause chain, and what it says. Stage ids and
+      // driver stack traces make the enclosing SparkException messages differ between runs, so
+      // only the writer's own exception can be compared.
+      def clusteredWriterError(t: Throwable): (Int, String) = {
+        val chain = causeChain(t)
+        val depth = chain.indexWhere(_.isInstanceOf[IllegalStateException])
+        assert(depth >= 0, s"no IllegalStateException in the cause chain of $t")
+        (depth, chain(depth).getMessage)
       }
+      val nativeError = clusteredWriterError(nativeFailure)
+      val jvmError = clusteredWriterError(jvmFailure)
+      // Equal depth is what makes `assertThatThrownBy(...).cause()` find it in the same place.
+      assert(nativeError == jvmError, s"native $nativeError != jvm $jvmError")
+      val (_, message) = jvmError
       assert(
-        clusteredWriterError(nativeFailure) == clusteredWriterError(jvmFailure),
-        s"native writer error differs from the JVM writer's.\n" +
-          s"native: ${clusteredWriterError(nativeFailure)}\n" +
-          s"jvm:    ${clusteredWriterError(jvmFailure)}")
+        message.startsWith(
+          "Incoming records violate the writer assumption that records are clustered by spec"),
+        s"unexpected IllegalStateException from the JVM writer: $message")
       // Neither write may have committed.
-      Seq("unclustered_native", "unclustered_jvm").foreach(t => assertRows(t, Seq.empty))
+      tables.foreach(assertRows(_, Seq.empty))
     }
   }
 
@@ -1954,14 +1943,17 @@ class CometIcebergWriteActionSuite
     """)
   }
 
-  private def coalesceInsert(tableName: String, rows: Seq[(Int, String, Double)]): Unit = {
+  private def coalesceInsert(
+      tableName: String,
+      rows: Seq[(Int, String, Double)],
+      options: Seq[(String, String)] = Nil): Unit = {
     val session = spark
     import session.implicits._
-    rows
+    val writer = rows
       .toDF("id", "region", "amount")
       .coalesce(1)
       .writeTo(s"$catalog.$ns.$tableName")
-      .append()
+    options.foldLeft(writer) { case (w, (k, v)) => w.option(k, v) }.append()
   }
 
   private def captureWrite(tableName: String)(action: => Unit): WriteSnapshot = {
@@ -2042,31 +2034,6 @@ class CometIcebergWriteActionSuite
   /** Native acceleration shared assumption -- currently just the Iceberg-on-classpath check. */
   private def assumeNativeAcceleration(): Unit = {
     assume(icebergAvailable, "Iceberg not available in classpath")
-  }
-
-  /**
-   * Runs `action`, expecting it to fail, and returns the thrown exception together with the
-   * executed plans of the queries it ran. [[capturePlans]] records successes only, which is no
-   * use for a write that is meant to abort.
-   */
-  private def captureFailedWrite(action: => Unit): (Throwable, Seq[SparkPlan]) = {
-    val captured = mutable.Buffer.empty[SparkPlan]
-    val listener = new QueryExecutionListener {
-      override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit =
-        captured += qe.executedPlan
-      override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit =
-        captured += qe.executedPlan
-    }
-    spark.listenerManager.register(listener)
-    val failure =
-      try {
-        val thrown = intercept[Exception](action)
-        CometListenerBusUtils.waitUntilEmpty(spark.sparkContext)
-        thrown
-      } finally {
-        spark.listenerManager.unregister(listener)
-      }
-    (failure, captured.toSeq)
   }
 
   /**

--- a/spark/src/test/scala/org/apache/comet/CometIcebergWriteActionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometIcebergWriteActionSuite.scala
@@ -20,6 +20,7 @@
 package org.apache.comet
 
 import java.io.File
+import java.sql.Timestamp
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 import scala.collection.mutable
@@ -29,6 +30,7 @@ import scala.concurrent.duration.DurationInt
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.comet.{CometIcebergWriteExec, IcebergCommitExec, IcebergWriteExec}
 import org.apache.spark.sql.connector.catalog.InMemoryTableCatalog
@@ -1233,36 +1235,28 @@ class CometIcebergWriteActionSuite
       val (nativeTable, jvmTable) = ("unclustered_native", "unclustered_jvm")
       val tables = Seq(nativeTable, jvmTable)
       tables.foreach(createTable(warehouseDir, _, partitionSpec = "PARTITIONED BY (region)"))
-      // `use-table-distribution-and-ordering=false` drops the partition-local sort Iceberg would
-      // otherwise request, so the interleaved region values reach the writer as they are;
-      // `fanout-enabled=false` picks the clustered writer, which cannot accept them.
-      def unclusteredAppend(t: String): Unit = coalesceInsert(
-        t,
-        Seq((1, "us-east", 1.0), (2, "eu", 2.0), (3, "us-east", 3.0)),
-        Seq("use-table-distribution-and-ordering" -> "false", "fanout-enabled" -> "false"))
+      val session = spark
+      import session.implicits._
+      // "us-east" is revisited after the writer has moved on to "eu" and closed it.
+      val rows =
+        Seq((1, "us-east", 1.0), (2, "eu", 2.0), (3, "us-east", 3.0)).toDF(
+          "id",
+          "region",
+          "amount")
 
       var nativeFailure: Throwable = null
       val nativePlans = withNativeEnabled {
         capturePlans(spark, includeFailures = true) {
-          nativeFailure = intercept[Exception](unclusteredAppend(nativeTable))
+          nativeFailure = intercept[Exception](appendUnclustered(nativeTable, rows))
         }
       }
-      val jvmFailure = intercept[Exception](unclusteredAppend(jvmTable))
+      val jvmFailure = intercept[Exception](appendUnclustered(jvmTable, rows))
       assert(
         nativePlans.exists(p =>
           collectWithSubqueries(p) { case e: CometIcebergWriteExec => e }.nonEmpty),
         "expected the aborted write to have gone through CometIcebergWriteExec. Plans:\n" +
           nativePlans.mkString("\n--\n"))
 
-      // Where the writer's exception sits in the cause chain, and what it says. Stage ids and
-      // driver stack traces make the enclosing SparkException messages differ between runs, so
-      // only the writer's own exception can be compared.
-      def clusteredWriterError(t: Throwable): (Int, String) = {
-        val chain = causeChain(t)
-        val depth = chain.indexWhere(_.isInstanceOf[IllegalStateException])
-        assert(depth >= 0, s"no IllegalStateException in the cause chain of $t")
-        (depth, chain(depth).getMessage)
-      }
       val nativeError = clusteredWriterError(nativeFailure)
       val jvmError = clusteredWriterError(jvmFailure)
       // Equal depth is what makes `assertThatThrownBy(...).cause()` find it in the same place.
@@ -1274,6 +1268,63 @@ class CometIcebergWriteActionSuite
         s"unexpected IllegalStateException from the JVM writer: $message")
       // Neither write may have committed.
       tables.foreach(assertRows(_, Seq.empty))
+    }
+  }
+
+  // The error names the offending partition, so it runs into the same rendering divergence the
+  // partition-path test below pins: iceberg-java base64-encodes a binary value where iceberg-rust
+  // writes uppercase hex, and iceberg-rust panics outright on a pre-epoch `timestamptz` with a
+  // sub-second part -- which here would crash the task before the exception was even built. Comet
+  // renders the partition with the same Java-compatible formatter that names the data directories.
+  //
+  // Gated on Iceberg 1.8+ for the reason spelled out on that test: 1.5.x renders a `timestamptz`
+  // partition value as `1969-12-31T23:59:58.500Z`, so the two writers' messages cannot agree.
+  test("native acceleration: unclustered-input error names the partition like iceberg-java") {
+    assumeNativeAcceleration()
+    assume(icebergVersionAtLeast(1, 8), "timestamptz partition path spelling changed in 1.8")
+    withIcebergCatalog { _ =>
+      // A UTC session zone makes the stored micros of each literal exact, so the expected
+      // rendering below is not a function of the machine's zone.
+      withSQLConf("spark.sql.session.timeZone" -> "UTC") {
+        val (nativeTable, jvmTable) = ("unclustered_path_native", "unclustered_path_jvm")
+        Seq(nativeTable, jvmTable).foreach { table =>
+          spark.sql(s"""
+            CREATE TABLE $catalog.$ns.$table (id INT, ts TIMESTAMP, bin BINARY)
+            USING iceberg PARTITIONED BY (ts, bin)
+          """)
+        }
+        val session = spark
+        import session.implicits._
+        // -1500 epoch millis is 1969-12-31T23:59:58.5Z, the value iceberg-rust panics on. Its
+        // partition is revisited after the writer has moved on to the epoch and closed it.
+        val rows = Seq(
+          (1, new Timestamp(-1500L), Array[Byte](0, 1, -1)),
+          (2, new Timestamp(0L), Array[Byte](0)),
+          (3, new Timestamp(-1500L), Array[Byte](0, 1, -1))).toDF("id", "ts", "bin")
+
+        var nativeFailure: Throwable = null
+        val nativePlans = withNativeEnabled {
+          capturePlans(spark, includeFailures = true) {
+            nativeFailure = intercept[Exception](appendUnclustered(nativeTable, rows))
+          }
+        }
+        val jvmFailure = intercept[Exception](appendUnclustered(jvmTable, rows))
+        assert(
+          nativePlans.exists(p =>
+            collectWithSubqueries(p) { case e: CometIcebergWriteExec => e }.nonEmpty),
+          "expected the aborted write to have gone through CometIcebergWriteExec. Plans:\n" +
+            nativePlans.mkString("\n--\n"))
+
+        val (_, nativeMessage) = clusteredWriterError(nativeFailure)
+        assert(
+          clusteredWriterError(nativeFailure) == clusteredWriterError(jvmFailure),
+          s"native message differs from the JVM writer's:\n$nativeMessage")
+        // Pinned explicitly too: base64 rather than hex for the binary value, and the ISO
+        // spelling of the pre-epoch timestamp rather than a panic.
+        assert(
+          nativeMessage.contains("partition 'ts=1969-12-31T23%3A59%3A58.5%2B00%3A00/bin=AAH%2F'"),
+          nativeMessage)
+      }
     }
   }
 
@@ -1943,17 +1994,41 @@ class CometIcebergWriteActionSuite
     """)
   }
 
-  private def coalesceInsert(
-      tableName: String,
-      rows: Seq[(Int, String, Double)],
-      options: Seq[(String, String)] = Nil): Unit = {
+  private def coalesceInsert(tableName: String, rows: Seq[(Int, String, Double)]): Unit = {
     val session = spark
     import session.implicits._
-    val writer = rows
+    rows
       .toDF("id", "region", "amount")
       .coalesce(1)
       .writeTo(s"$catalog.$ns.$tableName")
-    options.foldLeft(writer) { case (w, (k, v)) => w.option(k, v) }.append()
+      .append()
+  }
+
+  /**
+   * Appends `rows` as a single task with the table's distribution and ordering disabled and
+   * fanout off. That is the supported way to hand a clustered writer input it cannot accept, and
+   * what Iceberg's own `TestRequiredDistributionAndOrdering` does: without the first option
+   * Iceberg requests a partition-local sort that would cluster the rows, and without the second
+   * the fanout writer would accept them.
+   */
+  private def appendUnclustered(tableName: String, rows: DataFrame): Unit =
+    rows
+      .coalesce(1)
+      .writeTo(s"$catalog.$ns.$tableName")
+      .option("use-table-distribution-and-ordering", "false")
+      .option("fanout-enabled", "false")
+      .append()
+
+  /**
+   * Where the clustered writer's `IllegalStateException` sits in `t`'s cause chain, and what it
+   * says. Stage ids and driver stack traces make the enclosing `SparkException` messages differ
+   * between runs, so only the writer's own exception can be compared across writers.
+   */
+  private def clusteredWriterError(t: Throwable): (Int, String) = {
+    val chain = causeChain(t)
+    val depth = chain.indexWhere(_.isInstanceOf[IllegalStateException])
+    assert(depth >= 0, s"no IllegalStateException in the cause chain of $t")
+    (depth, chain(depth).getMessage)
   }
 
   private def captureWrite(tableName: String)(action: => Unit): WriteSnapshot = {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5698.

## Rationale for this change

iceberg-java's `ClusteredWriter` rejects unclustered input with a documented exception:

```
java.lang.IllegalStateException: Incoming records violate the writer assumption that records are
clustered by spec and by partition within each spec. Either cluster the incoming records or switch
to fanout writers.
Encountered records that belong to already closed files:
partition 'c3=1' in spec [
  1000: c3: identity(3)
]
```

Comet's native writer rejected the same input, but as a `CometNativeException` carrying
iceberg-rust's differently worded `The input is not sorted! Cannot write to partition that was
previously closed: PartitionKey { ... }`. Both writers correctly refuse the write, so this was an
error-fidelity gap rather than a data problem — but a user-visible one: anyone catching
`IllegalStateException` or matching on that message got something else once the native writer was
in play. Iceberg's own `TestRequiredDistributionAndOrdering.testDisabledDistributionAndOrdering`
asserts on both the type and the message and failed on the type check.

## What changes are included in this PR?

- `iceberg_write.rs`: the clustered write path now mirrors `ClusteredWriter`'s closed-partition
  bookkeeping (the partition currently open, plus the ones already finished) and detects a
  revisited partition itself, before iceberg-rust does. That keeps the error message ours and
  gives us the offending `PartitionKey`, so the context can be rendered as
  `partition '<path>' in spec <spec>` — `PartitionKey::to_path()` is iceberg-rust's equivalent of
  `PartitionSpec.partitionToPath`, and the spec is rendered the way iceberg-java's
  `PartitionSpec.toString` / `PartitionField.toString` do. Only the partition branch of
  iceberg-java's check is reachable: a task writes through a single output spec, so the spec
  cannot change mid-stream.
- `errors.rs`: a new `CometError::IllegalState` classification reaches the JVM as
  `java.lang.IllegalStateException` with the message untouched. It travels as
  `DataFusionError::External` and is recovered by a cause-chain walk, so DataFusion's
  `Context`/`Shared` wrappers cannot flatten it into a string on the way out. That walk already
  existed for shuffle capacity failures (`shuffle_size_limit_message`); it is now a single
  `typed_jvm_exception` that handles both. The classification is by error variant only, never
  inferred from error text.

## How are these changes tested?

- New end-to-end test in `CometIcebergWriteActionSuite` writes interleaved partition values with
  `use-table-distribution-and-ordering=false` and `fanout-enabled=false` to two identical tables,
  once through the JVM writer and once through the native writer, and asserts the two are
  indistinguishable: same cause-chain shape (so `assertThatThrownBy(...).cause()` finds the
  exception in the same place either way) and a byte-identical `IllegalStateException` message.
  Pinning against the JVM writer on the same runtime rather than against a literal means an
  iceberg-java wording change shows up here as a parity failure. It also asserts the aborted write
  really went through `CometIcebergWriteExec`, so the test cannot pass by falling back, and that
  neither table committed. Confirmed it fails without the fix with exactly the reported symptom:
  `List(SparkException, CometNativeException) did not equal List(SparkException, IllegalStateException)`.
- New Rust test in `iceberg_write.rs` asserts the native error is a `CometError::IllegalState`
  whose message matches iceberg-java's byte for byte, plus one covering the parameterised
  transforms (`bucket[8]`, `truncate[4]`) in the spec rendering.
- New Rust test in `errors.rs` asserts `CometError::IllegalState` survives
  `Shared`/`Context`/`External` wrapping and arrives as `java/lang/IllegalStateException`.
- `CometIcebergWriteActionSuite` (57), `CometIcebergNativeSuite` (100), `CometIcebergWriteDetectionSuite`,
  `CometIcebergRewriteActionSuite`, `IcebergWriteProtoTranslationSuite` (73 combined) all pass;
  `cargo test` for `datafusion-comet` (292), `datafusion-comet-jni-bridge` (28) and
  `datafusion-comet-shuffle` (125) pass; clippy and rustfmt clean; `test-compile` verified against
  spark-3.4/scala-2.12, spark-3.5, spark-4.0 and the default spark-4.1.