### PR TITLE
fix: reject duplicate Parquet field names before decoding

### DIFF
--- a/docs/source/user-guide/latest/compatibility/scans.md
+++ b/docs/source/user-guide/latest/compatibility/scans.md
@@ -62,6 +62,12 @@ The following limitation may produce incorrect results without falling back to S
 
 The following limitations raise an error at scan time rather than falling back to Spark:
 
+- Byte-identical sibling field names, including inside structs, arrays, and maps. Comet rejects
+  the entire file before decoding, even when the duplicate fields are not projected or the read
+  schema uses field IDs. This prevents row multiplication and decoder synchronization errors
+  ([#5783](https://github.com/apache/datafusion-comet/issues/5783)). The check applies in both
+  case-sensitivity modes; names in separate groups do not collide. Disable Comet for the query
+  to use Spark's duplicate-name resolution with an explicit read schema.
 - Invalid UTF-8 bytes in `STRING` columns. Spark permits arbitrary byte sequences in a `STRING`
   column (for example from `CAST(X'C1' AS STRING)`), but Comet's native execution path is built on
   Arrow, whose string type is strictly UTF-8. Reading a Parquet file whose `STRING` column contains

--- a/docs/source/user-guide/latest/compatibility/scans.md
+++ b/docs/source/user-guide/latest/compatibility/scans.md
@@ -62,11 +62,13 @@ The following limitation may produce incorrect results without falling back to S
 
 The following limitations raise an error at scan time rather than falling back to Spark:
 
-- Byte-identical sibling field names, including inside structs, arrays, and maps. Comet rejects
-  the entire file before decoding, even when the duplicate fields are not projected or the read
-  schema uses field IDs. This prevents row multiplication and decoder synchronization errors.
-  The check applies in both case-sensitivity modes; names in separate groups do not collide.
-  Disable Comet for the query to use Spark's duplicate-name resolution with an explicit read schema.
+- Byte-identical sibling field names in selected top-level columns, including inside structs,
+  arrays, and maps. Comet rejects these before decoding to prevent row multiplication and decoder
+  synchronization errors. Unselected top-level columns are skipped, except for field-ID reads,
+  which validate the entire file schema. The check applies in both case-sensitivity modes;
+  names in separate groups do not collide. Disable Comet for the query to use Spark's duplicate-name
+  resolution with an explicit read schema. Spark-compatible resolution is tracked in
+  [#5884](https://github.com/apache/datafusion-comet/issues/5884).
 - Invalid UTF-8 bytes in `STRING` columns. Spark permits arbitrary byte sequences in a `STRING`
   column (for example from `CAST(X'C1' AS STRING)`), but Comet's native execution path is built on
   Arrow, whose string type is strictly UTF-8. Reading a Parquet file whose `STRING` column contains

--- a/docs/source/user-guide/latest/compatibility/scans.md
+++ b/docs/source/user-guide/latest/compatibility/scans.md
@@ -64,10 +64,9 @@ The following limitations raise an error at scan time rather than falling back t
 
 - Byte-identical sibling field names, including inside structs, arrays, and maps. Comet rejects
   the entire file before decoding, even when the duplicate fields are not projected or the read
-  schema uses field IDs. This prevents row multiplication and decoder synchronization errors
-  ([#5783](https://github.com/apache/datafusion-comet/issues/5783)). The check applies in both
-  case-sensitivity modes; names in separate groups do not collide. Disable Comet for the query
-  to use Spark's duplicate-name resolution with an explicit read schema.
+  schema uses field IDs. This prevents row multiplication and decoder synchronization errors.
+  The check applies in both case-sensitivity modes; names in separate groups do not collide.
+  Disable Comet for the query to use Spark's duplicate-name resolution with an explicit read schema.
 - Invalid UTF-8 bytes in `STRING` columns. Spark permits arbitrary byte sequences in a `STRING`
   column (for example from `CAST(X'C1' AS STRING)`), but Comet's native execution path is built on
   Arrow, whose string type is strictly UTF-8. Reading a Parquet file whose `STRING` column contains

--- a/native/core/src/parquet/eager_page_index_reader_factory.rs
+++ b/native/core/src/parquet/eager_page_index_reader_factory.rs
@@ -47,7 +47,8 @@
 //! page-index load back into `FileMetadataCache` instead of bypassing it. Preserve the
 //! duplicate-field validation when replacing this factory.
 
-use arrow::datatypes::{DataType, FieldRef, Schema};
+use crate::parquet::name_fold::{fold_name, fold_schema_names};
+use arrow::datatypes::{DataType, FieldRef, Schema, SchemaRef};
 use async_trait::async_trait;
 use bytes::Bytes;
 use datafusion::common::Result as DFResult;
@@ -165,6 +166,8 @@ pub struct EagerPageIndexReaderFactory {
     // Enable the footer workaround only for scans that project Variant.
     // https://github.com/apache/datafusion-comet/issues/5477
     spark_variant_schema: bool,
+    projected_fields: Option<Arc<HashSet<String>>>,
+    case_sensitive: bool,
 }
 
 impl EagerPageIndexReaderFactory {
@@ -193,7 +196,27 @@ impl EagerPageIndexReaderFactory {
             metadata_cache,
             scan_io_metrics,
             spark_variant_schema: false,
+            projected_fields: None,
+            case_sensitive: true,
         }
+    }
+
+    pub(crate) fn with_required_schema(
+        mut self,
+        schema: &SchemaRef,
+        case_sensitive: bool,
+        use_field_id: bool,
+    ) -> Self {
+        // Field-ID projections can rename columns, so names cannot safely restrict the walk.
+        self.projected_fields = (!use_field_id).then(|| {
+            Arc::new(
+                fold_schema_names(schema, case_sensitive)
+                    .into_iter()
+                    .collect(),
+            )
+        });
+        self.case_sensitive = case_sensitive;
+        self
     }
 
     pub fn with_spark_variant_schema(mut self, enabled: bool) -> Self {
@@ -227,6 +250,8 @@ impl ParquetFileReaderFactory for EagerPageIndexReaderFactory {
             metadata_cache: Arc::clone(&self.metadata_cache),
             metadata_size_hint,
             spark_variant_schema: self.spark_variant_schema,
+            projected_fields: self.projected_fields.clone(),
+            case_sensitive: self.case_sensitive,
         }))
     }
 }
@@ -242,6 +267,8 @@ struct EagerPageIndexReader {
     metadata_cache: Arc<FileMetadataCache>,
     metadata_size_hint: Option<usize>,
     spark_variant_schema: bool,
+    projected_fields: Option<Arc<HashSet<String>>>,
+    case_sensitive: bool,
 }
 
 // Arrow infers ENUM as Binary, losing the distinction from raw binary that Spark needs.
@@ -376,12 +403,21 @@ fn with_spark_arrow_schema(metadata: Arc<ParquetMetaData>) -> ParquetResult<Arc<
 
 // Duplicate sibling names can make the decoder combine distinct leaves into one column,
 // multiplying rows before schema adaptation can reject or resolve the duplicate (#5783).
-// Reject the entire file, including unprojected fields, until the decoder can safely
-// resolve duplicate siblings. Names in separate groups do not collide.
-fn validate_field_names(schema: &Type) -> parquet::errors::Result<()> {
+// Only selected top-level subtrees can reach the decoder. Recurse fully within each selected
+// subtree because nested projection does not safely separate duplicate leaves (#5884).
+fn validate_field_names(
+    schema: &Type,
+    projected_fields: Option<&HashSet<String>>,
+    case_sensitive: bool,
+) -> parquet::errors::Result<()> {
     if let Type::GroupType { fields, .. } = schema {
         let mut names = HashSet::with_capacity(fields.len());
         for field in fields {
+            if projected_fields.is_some_and(|projected| {
+                !projected.contains(&fold_name(field.name(), case_sensitive))
+            }) {
+                continue;
+            }
             if !names.insert(field.name()) {
                 return Err(ParquetError::General(format!(
                     "Comet native scan does not support duplicate Parquet field name '{}' in group '{}'",
@@ -389,7 +425,7 @@ fn validate_field_names(schema: &Type) -> parquet::errors::Result<()> {
                     schema.name()
                 )));
             }
-            validate_field_names(field)?;
+            validate_field_names(field, None, case_sensitive)?;
         }
     }
     Ok(())
@@ -462,6 +498,8 @@ impl AsyncFileReader for EagerPageIndexReader {
         let metadata_size_hint = self.metadata_size_hint;
         let scan_io_metrics = Arc::clone(&self.scan_io_metrics);
         let spark_variant_schema = self.spark_variant_schema;
+        let projected_fields = self.projected_fields.clone();
+        let case_sensitive = self.case_sensitive;
         async move {
             let file_decryption_properties = options
                 .and_then(|o| o.file_decryption_properties())
@@ -522,7 +560,11 @@ impl AsyncFileReader for EagerPageIndexReader {
 
             let metadata = metadata?;
             // Validate cache hits too, before Arrow constructs a decoder for any projection.
-            validate_field_names(metadata.file_metadata().schema_descr().root_schema())?;
+            validate_field_names(
+                metadata.file_metadata().schema_descr().root_schema(),
+                projected_fields.as_deref(),
+                case_sensitive,
+            )?;
             if spark_variant_schema {
                 with_spark_arrow_schema(metadata)
             } else {
@@ -865,6 +907,83 @@ mod tests {
             serialized_reader::{ReadOptionsBuilder, SerializedFileReader},
         },
     };
+
+    #[test]
+    fn projected_fields_skip_unselected_roots() {
+        let schema = parquet::schema::parser::parse_message_type(
+            "message root { optional int64 a; optional int64 a; optional int64 b; }",
+        )
+        .unwrap();
+        let selected = HashSet::from(["b".to_string()]);
+        validate_field_names(&schema, Some(&selected), true).unwrap();
+        validate_field_names(&schema, Some(&HashSet::new()), true).unwrap();
+        let selected = HashSet::from(["a".to_string()]);
+        assert!(validate_field_names(&schema, Some(&selected), true).is_err());
+    }
+
+    #[test]
+    fn projected_fields_match_case_insensitively_and_recurse_fully() {
+        let schema = parquet::schema::parser::parse_message_type(
+            "message root { optional group Selected {
+                optional int64 valid; optional int64 dup; optional int64 dup;
+            } optional int64 unrelated; }",
+        )
+        .unwrap();
+        let selected = HashSet::from(["selected".to_string()]);
+        assert!(validate_field_names(&schema, Some(&selected), false).is_err());
+        let selected = HashSet::from(["unrelated".to_string()]);
+        validate_field_names(&schema, Some(&selected), false).unwrap();
+    }
+
+    #[test]
+    fn duplicate_names_in_list_element_are_rejected() {
+        let schema = parquet::schema::parser::parse_message_type(
+            "message root { optional group a (LIST) { repeated group list {
+                optional group element { optional int64 dup; optional int64 dup; }
+            } } }",
+        )
+        .unwrap();
+        assert!(validate_field_names(&schema, None, true)
+            .unwrap_err()
+            .to_string()
+            .contains("group 'element'"));
+    }
+
+    #[test]
+    fn duplicate_names_in_map_key_value_are_rejected() {
+        let schema = parquet::schema::parser::parse_message_type(
+            "message root { optional group a (MAP) { repeated group key_value {
+                required binary key (UTF8); optional int64 value; optional int64 value;
+            } } }",
+        )
+        .unwrap();
+        assert!(validate_field_names(&schema, None, true)
+            .unwrap_err()
+            .to_string()
+            .contains("group 'key_value'"));
+    }
+
+    #[test]
+    fn repeated_names_in_separate_groups_are_valid() {
+        let schema = parquet::schema::parser::parse_message_type(
+            "message root { optional group a { optional int64 same; }
+                optional group b { optional int64 same; } }",
+        )
+        .unwrap();
+        validate_field_names(&schema, None, true).unwrap();
+    }
+
+    #[test]
+    fn duplicate_root_names_are_rejected() {
+        let schema = parquet::schema::parser::parse_message_type(
+            "message root { optional int64 a; optional int64 a; optional int64 b; }",
+        )
+        .unwrap();
+        assert!(validate_field_names(&schema, None, true)
+            .unwrap_err()
+            .to_string()
+            .contains("group 'root'"));
+    }
 
     #[derive(Debug)]
     struct RecordingRangeStore {

--- a/native/core/src/parquet/eager_page_index_reader_factory.rs
+++ b/native/core/src/parquet/eager_page_index_reader_factory.rs
@@ -44,7 +44,8 @@
 //! the caller's requested policy, unchanged from stock behavior.
 //!
 //! Filed upstream as apache/datafusion#23978. Revert this once the opener merges its deferred
-//! page-index load back into `FileMetadataCache` instead of bypassing it.
+//! page-index load back into `FileMetadataCache` instead of bypassing it. Preserve the
+//! duplicate-field validation when replacing this factory.
 
 use arrow::datatypes::{DataType, FieldRef, Schema};
 use async_trait::async_trait;
@@ -77,7 +78,8 @@ use parquet::file::metadata::{FileMetaData, KeyValue, ParquetMetaDataBuilder};
 use parquet::file::metadata::{
     FooterTail, PageIndexPolicy, ParquetMetaData, ParquetMetaDataReader,
 };
-use parquet::schema::types::{ColumnDescPtr, SchemaDescriptor};
+use parquet::schema::types::{ColumnDescPtr, SchemaDescriptor, Type};
+use std::collections::HashSet;
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::Range;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -372,6 +374,27 @@ fn with_spark_arrow_schema(metadata: Arc<ParquetMetaData>) -> ParquetResult<Arc<
     ))
 }
 
+// Duplicate sibling names can make the decoder combine distinct leaves into one column,
+// multiplying rows before schema adaptation can reject or resolve the duplicate (#5783).
+// Reject the entire file, including unprojected fields, until the decoder can safely
+// resolve duplicate siblings. Names in separate groups do not collide.
+fn validate_field_names(schema: &Type) -> parquet::errors::Result<()> {
+    if let Type::GroupType { fields, .. } = schema {
+        let mut names = HashSet::with_capacity(fields.len());
+        for field in fields {
+            if !names.insert(field.name()) {
+                return Err(ParquetError::General(format!(
+                    "Comet native scan does not support duplicate Parquet field name '{}' in group '{}'",
+                    field.name(),
+                    schema.name()
+                )));
+            }
+            validate_field_names(field)?;
+        }
+    }
+    Ok(())
+}
+
 impl AsyncFileReader for EagerPageIndexReader {
     /// Reads a metadata range, counting its requested size before I/O and its returned
     /// bytes only on success. The returned future borrows this reader; store errors retain
@@ -498,6 +521,8 @@ impl AsyncFileReader for EagerPageIndexReader {
             }
 
             let metadata = metadata?;
+            // Validate cache hits too, before Arrow constructs a decoder for any projection.
+            validate_field_names(metadata.file_metadata().schema_descr().root_schema())?;
             if spark_variant_schema {
                 with_spark_arrow_schema(metadata)
             } else {

--- a/native/core/src/parquet/parquet_exec.rs
+++ b/native/core/src/parquet/parquet_exec.rs
@@ -176,7 +176,8 @@ pub(crate) fn init_datasource_exec(
     // `store_sales`), the page index is re-fetched, uncached, on every open (comet#3978).
     // `EagerPageIndexReaderFactory` forces the page index to load on the first fetch and be
     // cached with the footer, at the cost of losing the skip's benefit when it would have
-    // applied. Filed upstream as apache/datafusion#23978; revert this once that's fixed.
+    // applied. Filed upstream as apache/datafusion#23978; when replacing this factory, preserve
+    // its duplicate-field validation (#5783).
     //
     // Preserve bytes_scanned's existing requested data/Bloom-filter range accounting. Footer
     // and page-index reads through get_metadata bypass it, and coalescing may fetch extra bytes.

--- a/native/core/src/parquet/parquet_exec.rs
+++ b/native/core/src/parquet/parquet_exec.rs
@@ -194,7 +194,8 @@ pub(crate) fn init_datasource_exec(
             scan_io_source,
             parquet_source.metrics(),
         )
-        .with_spark_variant_schema(projects_variant),
+        .with_spark_variant_schema(projects_variant)
+        .with_required_schema(&required_schema, case_sensitive, use_field_id),
     );
     parquet_source = parquet_source.with_parquet_file_reader_factory(reader_factory);
 

--- a/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
@@ -72,35 +72,29 @@ class CometNativeReaderSuite extends CometTestBase with AdaptiveSparkPlanHelper 
       "map value",
       "map('key', named_struct('dup', id, 'dup', id + 100))",
       "map<string, struct<dup: bigint>>")).foreach { case (shape, expression, readType) =>
-    Seq(1, 4096).foreach { batchSize =>
-      test(s"duplicate Parquet field names fail before decoding - $shape - batch $batchSize") {
-        withSQLConf(
-          SQLConf.CASE_SENSITIVE.key -> "true",
-          CometConf.COMET_BATCH_SIZE.key -> batchSize.toString) {
-          withTempPath { path =>
-            withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
-              // Keep all rows in one file so batch size 1 exercises a multi-batch read.
-              spark
-                .range(3)
-                .coalesce(1)
-                .selectExpr(s"$expression as s")
-                .write
-                .parquet(path.toString)
-              // The file is readable by Spark with an explicit schema.
-              assert(
-                spark.read.schema(s"s $readType").parquet(path.toString).collect().length == 3)
-            }
-            val df = spark.read.schema(s"s $readType").parquet(path.toString)
-            assert(
-              find(df.queryExecution.executedPlan)(_.isInstanceOf[CometNativeScanExec]).isDefined)
-            val error = intercept[Exception](df.collect())
-            val messages = Iterator
-              .iterate[Throwable](error)(_.getCause)
-              .takeWhile(_ != null)
-              .map(_.getMessage)
-              .mkString("\n")
-            assert(messages.contains("duplicate Parquet field name 'dup'"), messages)
+    test(s"duplicate Parquet field names fail before decoding - $shape") {
+      withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+        withTempPath { path =>
+          withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
+            spark
+              .range(3)
+              .coalesce(1)
+              .selectExpr(s"$expression as s")
+              .write
+              .parquet(path.toString)
+            // The file is readable by Spark with an explicit schema.
+            assert(spark.read.schema(s"s $readType").parquet(path.toString).collect().length == 3)
           }
+          val df = spark.read.schema(s"s $readType").parquet(path.toString)
+          assert(
+            find(df.queryExecution.executedPlan)(_.isInstanceOf[CometNativeScanExec]).isDefined)
+          val error = intercept[Exception](df.collect())
+          val messages = Iterator
+            .iterate[Throwable](error)(_.getCause)
+            .takeWhile(_ != null)
+            .map(_.getMessage)
+            .mkString("\n")
+          assert(messages.contains("duplicate Parquet field name 'dup'"), messages)
         }
       }
     }
@@ -117,18 +111,69 @@ class CometNativeReaderSuite extends CometTestBase with AdaptiveSparkPlanHelper 
       }
       Seq(true, false).foreach { caseSensitive =>
         withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString) {
-          val df = spark.read.schema("id bigint").parquet(path.toString)
+          val name = if (caseSensitive) "id" else "ID"
+          val df = spark.read.schema(s"$name bigint").parquet(path.toString)
           assert(
             find(df.queryExecution.executedPlan)(_.isInstanceOf[CometNativeScanExec]).isDefined)
           (1 to 2).foreach { _ =>
-            val error = intercept[Exception](df.collect())
-            val messages = Iterator
-              .iterate[Throwable](error)(_.getCause)
-              .takeWhile(_ != null)
-              .map(_.getMessage)
-              .mkString("\n")
-            assert(messages.contains("duplicate Parquet field name 'dup'"), messages)
+            checkAnswer(df, Seq(Row(0L), Row(1L), Row(2L)))
+            checkAnswer(df.where("id > 1000"), Seq.empty)
+            checkAnswer(df.selectExpr("count(*)"), Seq(Row(3L)))
           }
+        }
+      }
+    }
+  }
+
+  test("duplicate Parquet field names - root group and unprojected root duplicates") {
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+      withTempPath { path =>
+        writeDirect(
+          path.toString,
+          "message spark_schema { optional int64 a = 1; optional int64 a = 2; optional int64 b = 3; }",
+          { rc =>
+            rc.startMessage()
+            Seq(("a", 0, 1L), ("a", 1, 2L), ("b", 2, 3L)).foreach { case (name, index, value) =>
+              rc.startField(name, index)
+              rc.addLong(value)
+              rc.endField(name, index)
+            }
+            rc.endMessage()
+          })
+        withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
+          checkAnswer(spark.read.schema("a bigint").parquet(path.toString), Seq(Row(1L)))
+        }
+        val selected = spark.read.schema("a bigint").parquet(path.toString)
+        assert(
+          find(selected.queryExecution.executedPlan)(
+            _.isInstanceOf[CometNativeScanExec]).isDefined)
+        val error = intercept[Exception](selected.collect())
+        val messages = Iterator
+          .iterate[Throwable](error)(_.getCause)
+          .takeWhile(_ != null)
+          .map(_.getMessage)
+          .mkString("\n")
+        assert(messages.contains("duplicate Parquet field name 'a'"), messages)
+        val valid = spark.read.schema("b bigint").parquet(path.toString)
+        assert(
+          find(valid.queryExecution.executedPlan)(_.isInstanceOf[CometNativeScanExec]).isDefined)
+        checkAnswer(valid, Seq(Row(3L)))
+        withSQLConf(SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key -> "true") {
+          val schema = new StructType().add(
+            "renamed_b",
+            LongType,
+            nullable = true,
+            new MetadataBuilder().putLong("parquet.field.id", 3L).build())
+          val byId = spark.read.schema(schema).parquet(path.toString)
+          assert(
+            find(byId.queryExecution.executedPlan)(_.isInstanceOf[CometNativeScanExec]).isDefined)
+          val fieldIdError = intercept[Exception](byId.collect())
+          val fieldIdMessages = Iterator
+            .iterate[Throwable](fieldIdError)(_.getCause)
+            .takeWhile(_ != null)
+            .map(_.getMessage)
+            .mkString("\n")
+          assert(fieldIdMessages.contains("duplicate Parquet field name 'a'"), fieldIdMessages)
         }
       }
     }

--- a/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometNativeReaderSuite.scala
@@ -54,6 +54,109 @@ class CometNativeReaderSuite extends CometTestBase with AdaptiveSparkPlanHelper 
     }
   }
 
+  Seq(
+    ("two children", "named_struct('dup', id, 'dup', id + 100)", "struct<dup: bigint>"),
+    (
+      "three children",
+      "named_struct('dup', id, 'dup', id + 100, 'dup', id + 200)",
+      "struct<dup: bigint>"),
+    (
+      "distinct sibling",
+      "named_struct('dup', id, 'dup', id + 100, 'other', id + 900)",
+      "struct<dup: bigint, other: bigint>"),
+    (
+      "array element",
+      "array(named_struct('dup', id, 'dup', id + 100))",
+      "array<struct<dup: bigint>>"),
+    (
+      "map value",
+      "map('key', named_struct('dup', id, 'dup', id + 100))",
+      "map<string, struct<dup: bigint>>")).foreach { case (shape, expression, readType) =>
+    Seq(1, 4096).foreach { batchSize =>
+      test(s"duplicate Parquet field names fail before decoding - $shape - batch $batchSize") {
+        withSQLConf(
+          SQLConf.CASE_SENSITIVE.key -> "true",
+          CometConf.COMET_BATCH_SIZE.key -> batchSize.toString) {
+          withTempPath { path =>
+            withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
+              // Keep all rows in one file so batch size 1 exercises a multi-batch read.
+              spark
+                .range(3)
+                .coalesce(1)
+                .selectExpr(s"$expression as s")
+                .write
+                .parquet(path.toString)
+              // The file is readable by Spark with an explicit schema.
+              assert(
+                spark.read.schema(s"s $readType").parquet(path.toString).collect().length == 3)
+            }
+            val df = spark.read.schema(s"s $readType").parquet(path.toString)
+            assert(
+              find(df.queryExecution.executedPlan)(_.isInstanceOf[CometNativeScanExec]).isDefined)
+            val error = intercept[Exception](df.collect())
+            val messages = Iterator
+              .iterate[Throwable](error)(_.getCause)
+              .takeWhile(_ != null)
+              .map(_.getMessage)
+              .mkString("\n")
+            assert(messages.contains("duplicate Parquet field name 'dup'"), messages)
+          }
+        }
+      }
+    }
+  }
+
+  test("duplicate Parquet field names - unprojected fields and repeated reads") {
+    withTempPath { path =>
+      withSQLConf(CometConf.COMET_ENABLED.key -> "false", SQLConf.CASE_SENSITIVE.key -> "true") {
+        spark
+          .range(3)
+          .selectExpr("id", "named_struct('dup', id, 'dup', id + 100) as s")
+          .write
+          .parquet(path.toString)
+      }
+      Seq(true, false).foreach { caseSensitive =>
+        withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString) {
+          val df = spark.read.schema("id bigint").parquet(path.toString)
+          assert(
+            find(df.queryExecution.executedPlan)(_.isInstanceOf[CometNativeScanExec]).isDefined)
+          (1 to 2).foreach { _ =>
+            val error = intercept[Exception](df.collect())
+            val messages = Iterator
+              .iterate[Throwable](error)(_.getCause)
+              .takeWhile(_ != null)
+              .map(_.getMessage)
+              .mkString("\n")
+            assert(messages.contains("duplicate Parquet field name 'dup'"), messages)
+          }
+        }
+      }
+    }
+  }
+
+  test(
+    "duplicate Parquet field names - distinct siblings and repeated names in separate groups") {
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+      withTempPath { path =>
+        withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
+          spark
+            .range(3)
+            .selectExpr(
+              "named_struct('dup', id, 'Dup', id + 100) as s",
+              "named_struct('dup', id + 200) as t")
+            .write
+            .parquet(path.toString)
+        }
+        def read = spark.read
+          .schema("s struct<dup: bigint, Dup: bigint>, t struct<dup: bigint>")
+          .parquet(path.toString)
+        assert(
+          find(read.queryExecution.executedPlan)(_.isInstanceOf[CometNativeScanExec]).isDefined)
+        checkSparkAnswer(read)
+      }
+    }
+  }
+
   test("native reader case sensitivity") {
     withTempPath { path =>
       spark.range(10).toDF("a").write.parquet(path.toString)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5783.

## Rationale for this change

Native Parquet scans can silently multiply rows when a struct contains byte-identical sibling names. Resolving or rejecting duplicates after decoding is too late because the decoder has already combined distinct leaves. Reject ambiguous fields before decoding while allowing unrelated duplicate siblings that the reader safely prunes.

## What changes are included in this PR?

- Validate sibling names when loading native-reader metadata, including cache hits, before constructing the decoder. Cover nested structs, arrays, and maps in both case-sensitivity modes.
- Preserve the required schema through validation. Skip unselected top-level columns, and skip unrequested nested fields only when the shared structural-narrowing check establishes that they will be pruned. Keep full-subtree validation when missing fields or type conversions require full decoding. Field-ID reads validate the entire file schema.
- Keep full nested validation for embedded Arrow schema hints and synthesized Spark variant schemas because they can change the schema the decoder sees.
- Document the supported projection behavior and retain explicit rejection of ambiguous decoded fields. Spark-compatible duplicate-name resolution remains separate work.

## How are these changes tested?

The new nested-projection regression reproduced the reported duplicate-field error on the previous implementation. It reads the unique `other` child from a struct containing two `dup` children, compares Spark and Comet results, and checks the exact three rows in both case-sensitivity modes. Additional controls retain duplicate rejection when the reader must decode the full subtree.

A native regression writes a real Parquet footer whose embedded Arrow schema restores a dictionary type. It failed before the conservative schema-hint guard and passes with it.

Orion verification on Spark 4.1.3 / JDK 17 passed:

- Full `CometNativeReaderSuite`: **71 succeeded, 0 failed, 1 existing cancellation** for the NullType limitation tracked by #4199 / SPARK-54220.
- Four focused `projected_fields` Rust tests, including the dictionary-hint regression.
- Native build, Rust formatting, Maven formatting checks, and `git diff --check`.

```sh
(cd native && cargo test -p datafusion-comet projected_fields --lib --offline)
(cd native && cargo build)
./mvnw -B test -Dtest=none \
  -Dsuites=org.apache.comet.exec.CometNativeReaderSuite
```

These are local Orion results for the follow-up changes. Earlier full CI results belong to the previously published head.
