### PR TITLE
bench: measure nested types as native shuffle hash partitioning keys

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometShuffleBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometShuffleBenchmark.scala
@@ -27,17 +27,20 @@ import scala.util.Random
 import org.apache.spark.SparkConf
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.sql.{Column, SaveMode, SparkSession}
+import org.apache.spark.sql.comet.execution.shuffle.{CometNativeShuffle, CometShuffleExchangeExec}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 import org.apache.comet.CometConf
 import org.apache.comet.CometSparkSessionExtensions
+import org.apache.comet.CometSparkSessionExtensions.isSpark40Plus
 import org.apache.comet.testing.{DataGenOptions, FuzzDataGenerator, SchemaGenOptions}
 
 // spotless:off
 /**
  * Benchmark to measure Comet shuffle performance. To run this benchmark:
  * `SPARK_GENERATE_BENCHMARK_FILES=1 make benchmark-org.apache.spark.sql.benchmark.CometShuffleBenchmark`
+ * Add `-- --nested-hash-only` to run just the nested hash key cases.
  * Results will be written to "spark/benchmarks/CometShuffleBenchmark-**results.txt".
  */
 // spotless:on
@@ -479,17 +482,13 @@ object CometShuffleBenchmark extends CometBenchmarkBase {
    * Nested hash partitioning keys, which native shuffle admits only when
    * `spark.comet.shuffle.native.partitioning.hash.nested.enabled` is on.
    *
-   * The shapes are chosen to separate the two code paths in the native Murmur3 kernel.
-   * `hash_list_with_primitive_elements!` vectorizes a list whose elements are primitives, but a
-   * list whose elements are themselves nested falls through to `hash_list_array!`, which slices a
-   * one-element array and re-enters `create_murmur3_hashes` per element; a struct additionally
-   * copies its column vector per call. `array<struct<..>>` is the shape that pays that, and it is
-   * the one where native hashing loses to letting Spark do the whole shuffle. A map nested in a
-   * struct does not: `hash_funcs/utils.rs` specializes common scalar key/value pairs, so it stays
-   * on a batched path.
+   * Primitive arrays use the typed element path; arrays of structs exercise recursive hashing.
+   * Map cases include a singleton control and variable cardinalities in both input key orders,
+   * covering normalization as well as the specialized scalar key/value hash loop.
    *
-   * Each case is compared against Spark doing the whole shuffle, which is what the config's
-   * default trades against: if the native path is slower, falling back is the better default.
+   * Compare native with Comet JVM shuffle to evaluate the default `auto` mode with nested hashing
+   * disabled. The all-Spark arm also changes scan and projection execution. These are end-to-end
+   * shuffle measurements, not isolated hash-kernel timings.
    */
   def shuffleNestedHashKeyBenchmark(
       name: String,
@@ -532,16 +531,44 @@ object CometShuffleBenchmark extends CometBenchmarkBase {
           }
         }
 
-        // Nested keys are rejected by the native gate unless the config is on, so without it this
-        // case would silently measure a fallback rather than the native hashing path.
-        benchmark.addCase("Comet (Native Shuffle)") { _ =>
-          withSQLConf(
+        def containsMap(dataType: DataType): Boolean = dataType match {
+          case _: MapType => true
+          case ArrayType(elementType, _) => containsMap(elementType)
+          case StructType(fields) => fields.exists(f => containsMap(f.dataType))
+          case _ => false
+        }
+
+        // Spark 3.x does not normalize map partitioning keys for native hashing.
+        if (containsMap(spark.sql(query).schema("k").dataType) && !isSpark40Plus) {
+          val message = s"Skipping native shuffle for $name: map keys require Spark 4.0+"
+          benchmark.out.println(message)
+        } else {
+          val nativeConfigs = Seq(
             CometConf.COMET_ENABLED.key -> "true",
             CometConf.COMET_EXEC_ENABLED.key -> "true",
             CometConf.COMET_SHUFFLE_ENABLED.key -> "true",
             CometConf.COMET_SHUFFLE_MODE.key -> "native",
-            CometConf.COMET_SHUFFLE_NATIVE_HASH_PARTITIONING_NESTED_ENABLED.key -> "true") {
-            spark.sql(query).repartition(partitionNum, Column("k")).noop()
+            CometConf.COMET_SHUFFLE_NATIVE_HASH_PARTITIONING_NESTED_ENABLED.key -> "true")
+          // Check outside the timer: enabling the gate alone does not prove native admission.
+          withSQLConf(nativeConfigs: _*) {
+            val plan =
+              spark.sql(query).repartition(partitionNum, Column("k")).queryExecution.executedPlan
+            val nativeExchanges = collect(plan) {
+              case exchange: CometShuffleExchangeExec
+                  if exchange.shuffleType == CometNativeShuffle =>
+                exchange
+            }
+            require(
+              nativeExchanges.size == 1,
+              s"Expected one native shuffle for $name, found ${nativeExchanges.size}:\n$plan")
+            benchmark.out.println(
+              s"Verified native exchange for $name ($partitionNum partitions):")
+            benchmark.out.println(plan.treeString)
+          }
+          benchmark.addCase("Comet (Native Shuffle)") { _ =>
+            withSQLConf(nativeConfigs: _*) {
+              spark.sql(query).repartition(partitionNum, Column("k")).noop()
+            }
           }
         }
 
@@ -550,7 +577,43 @@ object CometShuffleBenchmark extends CometBenchmarkBase {
     }
   }
 
+  private def runNestedHashKeyBenchmarks(): Unit = {
+    runBenchmarkWithTable("Nested hash partitioning key", 1024 * 1024 * 1) { v =>
+      val shapes = Seq(
+        "struct<int, string>" -> "named_struct('a', c1, 'b', CAST(c1 AS STRING))",
+        "array<int>" -> "ARRAY_REPEAT(c1, 10)",
+        "struct<array<int>, string>" ->
+          "named_struct('a', ARRAY_REPEAT(c1, 10), 'b', CAST(c1 AS STRING))",
+        "array<struct<int, string>>" ->
+          "ARRAY_REPEAT(named_struct('a', c1, 'b', CAST(c1 AS STRING)), 10)",
+        "struct<map<string, int>, int>" ->
+          "named_struct('m', MAP(CAST(c1 AS STRING), c1), 'i', c1)")
+      // Distinct keys, variable entry counts, and opposite input orders exercise map sorting.
+      val mapShapes = for {
+        maxEntries <- Seq(10, 50)
+        reverse <- Seq(false, true)
+      } yield {
+        val indices = s"sequence(1, 2 + pmod(c1, ${maxEntries - 1}))"
+        val ordered = if (reverse) s"reverse($indices)" else indices
+        val map = s"map_from_arrays(transform($ordered, x -> CAST(c1 + x AS STRING)), " +
+          s"transform($ordered, x -> c1 + x))"
+        val order = if (reverse) "reversed" else "forward"
+        s"struct<map<string, int>, int> (2-$maxEntries entries, $order)" ->
+          s"named_struct('m', $map, 'i', c1)"
+      }
+      (shapes ++ mapShapes).foreach { case (name, keyExpr) =>
+        Seq(5, manyPartitions).foreach { partitionNum =>
+          shuffleNestedHashKeyBenchmark(name, keyExpr, v, partitionNum)
+        }
+      }
+    }
+  }
+
   override def runCometBenchmark(mainArgs: Array[String]): Unit = {
+    if (mainArgs.contains("--nested-hash-only")) {
+      runNestedHashKeyBenchmarks()
+      return
+    }
 
     // nested type shuffle
     val numRows = 1000
@@ -567,24 +630,7 @@ object CometShuffleBenchmark extends CometBenchmarkBase {
       }
     }
 
-    runBenchmarkWithTable("Nested hash partitioning key", 1024 * 1024 * 1) { v =>
-      // Shapes whose leaves are primitives take the vectorized element path; the last two force
-      // the per-element path in the native kernel.
-      val shapes = Seq(
-        "struct<int, string>" -> "named_struct('a', c1, 'b', CAST(c1 AS STRING))",
-        "array<int>" -> "ARRAY_REPEAT(c1, 10)",
-        "struct<array<int>, string>" ->
-          "named_struct('a', ARRAY_REPEAT(c1, 10), 'b', CAST(c1 AS STRING))",
-        "array<struct<int, string>>" ->
-          "ARRAY_REPEAT(named_struct('a', c1, 'b', CAST(c1 AS STRING)), 10)",
-        "struct<map<string, int>, int>" ->
-          "named_struct('m', MAP(CAST(c1 AS STRING), c1), 'i', c1)")
-      shapes.foreach { case (name, keyExpr) =>
-        Seq(5, manyPartitions).foreach { partitionNum =>
-          shuffleNestedHashKeyBenchmark(name, keyExpr, v, partitionNum)
-        }
-      }
-    }
+    runNestedHashKeyBenchmarks()
 
     runBenchmarkWithTable("Shuffle on array", 1024 * 1024 * 1) { v =>
       benchmarkTypes.foreach { dataType =>

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometShuffleBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometShuffleBenchmark.scala
@@ -475,6 +475,81 @@ object CometShuffleBenchmark extends CometBenchmarkBase {
     }
   }
 
+  /**
+   * Nested hash partitioning keys, which native shuffle admits only when
+   * `spark.comet.shuffle.native.partitioning.hash.nested.enabled` is on.
+   *
+   * The shapes are chosen to separate the two code paths in the native Murmur3 kernel.
+   * `hash_list_with_primitive_elements!` vectorizes a list whose elements are primitives, but a
+   * list whose elements are themselves nested falls through to `hash_list_array!`, which slices a
+   * one-element array and re-enters `create_murmur3_hashes` per element; a struct additionally
+   * copies its column vector per call. `array<struct<..>>` is the shape that pays that, and it is
+   * the one where native hashing loses to letting Spark do the whole shuffle. A map nested in a
+   * struct does not: `hash_funcs/utils.rs` specializes common scalar key/value pairs, so it stays
+   * on a batched path.
+   *
+   * Each case is compared against Spark doing the whole shuffle, which is what the config's
+   * default trades against: if the native path is slower, falling back is the better default.
+   */
+  def shuffleNestedHashKeyBenchmark(
+      name: String,
+      keyExpr: String,
+      values: Int,
+      partitionNum: Int): Unit = {
+    val benchmark =
+      microBenchmark(s"Nested hash key: $name ($partitionNum Partition)", values)
+
+    withTempPath { dir =>
+      withTempTable("parquetV1Table") {
+        // `tbl`'s `value` spans the full Long range, so a direct cast to INT overflows under ANSI
+        // mode. `pmod` keeps the key varied (a constant would hash every row alike, which would
+        // not measure partitioning at all) while staying in range.
+        prepareTable(dir, spark.sql(s"SELECT CAST(pmod(value, 1000000) AS INT) AS c1 FROM $tbl"))
+        val query = s"SELECT $keyExpr AS k, c1 FROM parquetV1Table"
+
+        benchmark.addCase("Spark") { _ =>
+          withSQLConf(CometConf.COMET_ENABLED.key -> "false") {
+            spark.sql(query).repartition(partitionNum, Column("k")).noop()
+          }
+        }
+
+        benchmark.addCase("Comet (Spark Shuffle)") { _ =>
+          withSQLConf(
+            CometConf.COMET_ENABLED.key -> "true",
+            CometConf.COMET_EXEC_ENABLED.key -> "true",
+            CometConf.COMET_SHUFFLE_ENABLED.key -> "false") {
+            spark.sql(query).repartition(partitionNum, Column("k")).noop()
+          }
+        }
+
+        benchmark.addCase("Comet (JVM Shuffle)") { _ =>
+          withSQLConf(
+            CometConf.COMET_ENABLED.key -> "true",
+            CometConf.COMET_EXEC_ENABLED.key -> "true",
+            CometConf.COMET_SHUFFLE_ENABLED.key -> "true",
+            CometConf.COMET_SHUFFLE_MODE.key -> "jvm") {
+            spark.sql(query).repartition(partitionNum, Column("k")).noop()
+          }
+        }
+
+        // Nested keys are rejected by the native gate unless the config is on, so without it this
+        // case would silently measure a fallback rather than the native hashing path.
+        benchmark.addCase("Comet (Native Shuffle)") { _ =>
+          withSQLConf(
+            CometConf.COMET_ENABLED.key -> "true",
+            CometConf.COMET_EXEC_ENABLED.key -> "true",
+            CometConf.COMET_SHUFFLE_ENABLED.key -> "true",
+            CometConf.COMET_SHUFFLE_MODE.key -> "native",
+            CometConf.COMET_SHUFFLE_NATIVE_HASH_PARTITIONING_NESTED_ENABLED.key -> "true") {
+            spark.sql(query).repartition(partitionNum, Column("k")).noop()
+          }
+        }
+
+        benchmark.run()
+      }
+    }
+  }
+
   override def runCometBenchmark(mainArgs: Array[String]): Unit = {
 
     // nested type shuffle
@@ -489,6 +564,25 @@ object CometShuffleBenchmark extends CometBenchmarkBase {
         }
       } finally {
         new java.io.File(filename).delete()
+      }
+    }
+
+    runBenchmarkWithTable("Nested hash partitioning key", 1024 * 1024 * 1) { v =>
+      // Shapes whose leaves are primitives take the vectorized element path; the last two force
+      // the per-element path in the native kernel.
+      val shapes = Seq(
+        "struct<int, string>" -> "named_struct('a', c1, 'b', CAST(c1 AS STRING))",
+        "array<int>" -> "ARRAY_REPEAT(c1, 10)",
+        "struct<array<int>, string>" ->
+          "named_struct('a', ARRAY_REPEAT(c1, 10), 'b', CAST(c1 AS STRING))",
+        "array<struct<int, string>>" ->
+          "ARRAY_REPEAT(named_struct('a', c1, 'b', CAST(c1 AS STRING)), 10)",
+        "struct<map<string, int>, int>" ->
+          "named_struct('m', MAP(CAST(c1 AS STRING), c1), 'i', c1)")
+      shapes.foreach { case (name, keyExpr) =>
+        Seq(5, manyPartitions).foreach { partitionNum =>
+          shuffleNestedHashKeyBenchmark(name, keyExpr, v, partitionNum)
+        }
       }
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5787.

## Rationale for this change

Native shuffle can admit nested hash partitioning keys with
`spark.comet.shuffle.native.partitioning.hash.nested.enabled` (#5567), but the existing shuffle
benchmarks do not measure that path. The array/struct benchmarks lack a native arm, and the
deeply nested benchmark uses keyless, round-robin repartitioning. This is separate from
#2904, which measured columnar/JVM shuffle throughput with keyless repartitioning.

With the default shuffle mode `auto`, disabling nested native hashing selects Comet JVM
shuffle for these shapes. The relevant configuration comparison is therefore Comet JVM
versus Comet native shuffle. The all-Spark arm also changes scan and projection execution;
Comet with Spark shuffle represents the fallback under explicitly selected `native` mode.

## What changes are included in this PR?

Adds a shared nested-key benchmark with Spark, Comet Spark shuffle, Comet JVM shuffle and
Comet native shuffle arms, at 5 and 201 partitions. Coverage includes a simple struct,
a primitive array, a struct containing a primitive array, an array of structs, and a struct
containing a string-to-int map. The map cases retain a singleton control and add variable
2–10 and 2–50 entry maps in forward and reversed input order. Each map has distinct keys;
reversing the order preserves its key/value pairs.

The native arm explicitly enables nested hashing. Spark versions below 4.0 skip native
map-containing keys because they do not insert the required map normalization. For admitted
cases, an untimed physical-plan check requires exactly one `CometNativeShuffle` exchange
and records the plan before benchmarking, so unexpected fallback fails rather than being
reported under a native label. Map plans on Spark 4.1 show the inserted `mapsort` expression.

`--nested-hash-only` runs this section directly without a temporary driver.

## How are these changes tested?

The following table measures the benchmark source in `8d9eede01` in one complete run on
2026-09-09: Apple M4 Max, Spark 4.1.3,
Zulu JDK 17.0.16, `local[5]`, 1,048,576 rows and a 20 GiB JVM heap. Times are best milliseconds
from the existing harness (at least five iterations, 500 ms warmup and measurement floors).
`JVM/native` is Comet JVM time divided by Comet native time; values above 1 favor native.
All four columns come from this run. No earlier measurements are mixed in.

Input-file preparation is outside the timer; planning, scan, key construction, shuffle and
no-op sink consumption are timed. Results therefore characterize these complete operations,
not isolated hashing or sorting cost. Shapes run sequentially on a local machine, and some
cases have substantial variance; the raw output retains averages and standard deviations.

The native library was rebuilt in release mode and matched by SHA-256 to the library copied
into the JVM classes. Current worktree classes were used for both Comet modules. The local
Arrow 59.2.0 lockfile workaround was used for this run and is excluded from the PR.

| Key shape | Partitions | Spark | Comet Spark shuffle | Comet JVM shuffle | Comet native shuffle | JVM/native |
|---|---:|---:|---:|---:|---:|---:|
| `struct<int, string>` | 5 | 105 | 93 | 127 | 42 | 3.02x |
| `struct<int, string>` | 201 | 134 | 119 | 635 | 89 | 7.13x |
| `array<int>` | 5 | 84 | 81 | 143 | 64 | 2.23x |
| `array<int>` | 201 | 149 | 131 | 571 | 110 | 5.19x |
| `struct<array<int>, string>` | 5 | 99 | 99 | 176 | 56 | 3.14x |
| `struct<array<int>, string>` | 201 | 148 | 144 | 420 | 118 | 3.56x |
| `array<struct<int, string>>` | 5 | 174 | 192 | 456 | 637 | 0.72x |
| `array<struct<int, string>>` | 201 | 267 | 288 | 835 | 1369 | 0.61x |
| `struct<map<string, int>, int>` | 5 | 245 | 200 | 447 | 186 | 2.40x |
| `struct<map<string, int>, int>` | 201 | 233 | 242 | 596 | 245 | 2.43x |
| `struct<map<string, int>, int> (2-10 entries, forward)` | 5 | 499 | 558 | 880 | 571 | 1.54x |
| `struct<map<string, int>, int> (2-10 entries, forward)` | 201 | 649 | 1372 | 2971 | 1657 | 1.79x |
| `struct<map<string, int>, int> (2-10 entries, reversed)` | 5 | 1053 | 1083 | 1612 | 1174 | 1.37x |
| `struct<map<string, int>, int> (2-10 entries, reversed)` | 201 | 1494 | 1432 | 2037 | 1238 | 1.65x |
| `struct<map<string, int>, int> (2-50 entries, forward)` | 5 | 2554 | 1961 | 4225 | 3031 | 1.39x |
| `struct<map<string, int>, int> (2-50 entries, forward)` | 201 | 3264 | 2319 | 2429 | 2145 | 1.13x |
| `struct<map<string, int>, int> (2-50 entries, reversed)` | 5 | 1623 | 1849 | 2870 | 2567 | 1.12x |
| `struct<map<string, int>, int> (2-50 entries, reversed)` | 201 | 2196 | 1926 | 2107 | 2449 | 0.86x |

The array-of-struct cases are slower under native than JVM shuffle in this run. The larger
map cases also show that the singleton control does not establish a general map benefit:
with 2–50 entries in reversed input order at 201 partitions, native is 2,449 ms versus
2,107 ms for JVM shuffle. Differences between forward and reversed rows can also reflect machine load and
JIT/GC effects within this sequential run; they do not isolate sorting cost.

Validation:

- Spark 4.1.3 reactor `test-compile`, Spotless and Scalastyle passed.
- Release native build completed; all 18 full-size groups (72 arms) ran successfully,
  with 18 native exchange checks recorded.
- Spark 3.5.9 clean reactor package, Spotless and Scalastyle passed.
- A 32-row Spark 3.5.9 smoke run verified native struct admission and explicit native-map
  skips at both 5 and 201 partitions (14 measured arms). Its timings are not in this table.

Raw build logs, physical plans, benchmark output and source/native checksums are retained
in the local validation bundle.

## Additional context

This benchmark remains independent of the kernel optimization in #5778, tracked by #5777.
Native admission is checked directly in the harness; timing differences alone are not
used as evidence of native execution.
