### PR TITLE
test: expand ANSI coverage for round, conv and elt

### DIFF
--- a/spark/src/test/resources/sql-tests/expressions/math/conv.sql
+++ b/spark/src/test/resources/sql-tests/expressions/math/conv.sql
@@ -21,7 +21,7 @@ statement
 CREATE TABLE test_conv(s string) USING parquet
 
 statement
-INSERT INTO test_conv VALUES ('100'), ('FF'), ('0'), (NULL)
+INSERT INTO test_conv VALUES ('100'), ('FF'), ('0'), ('FFFFFFFFFFFFFFFF'), ('FFFFFFFFFFFFFFFFF'), (NULL)
 
 query
 SELECT s, conv(s, 16, 10) FROM test_conv

--- a/spark/src/test/resources/sql-tests/expressions/math/conv_ansi.sql
+++ b/spark/src/test/resources/sql-tests/expressions/math/conv_ansi.sql
@@ -15,17 +15,23 @@
 -- specific language governing permissions and limitations
 -- under the License.
 
--- Routes elt through the codegen dispatcher so behavior matches Spark exactly.
+-- Config: spark.sql.ansi.enabled=true
+
+-- conv executes Spark's generated code inside Comet's codegen dispatcher.
+statement
+CREATE TABLE test_conv_ansi(id int, s string) USING parquet
 
 statement
-CREATE TABLE test_elt(n int) USING parquet
+INSERT INTO test_conv_ansi VALUES
+ (1, 'FF'), (2, 'FFFFFFFFFFFFFFFF'), (3, NULL), (4, 'FFFFFFFFFFFFFFFFF')
 
-statement
-INSERT INTO test_elt VALUES (1), (2), (0), (-1), (3), (NULL)
-
+-- Valid input, the unsigned 64-bit boundary and NULL must execute inside Comet.
 query
-SELECT n, elt(n, 'a', 'b') FROM test_elt
+SELECT id, conv(s, 16, 10), conv(s, 16, -10) FROM test_conv_ansi WHERE id < 4
 
--- literal arguments
-query
-SELECT elt(1, 'scala', 'java'), elt(2, 'scala', 'java'), elt(2, 'a', 'b', 'c')
+-- One more hex digit exceeds the unsigned 64-bit range.
+query expect_error(ARITHMETIC_OVERFLOW)
+SELECT conv(s, 16, 10) FROM test_conv_ansi WHERE id = 4
+
+query expect_error(ARITHMETIC_OVERFLOW)
+SELECT conv('FFFFFFFFFFFFFFFFF', 16, 10)

--- a/spark/src/test/resources/sql-tests/expressions/math/round.sql
+++ b/spark/src/test/resources/sql-tests/expressions/math/round.sql
@@ -72,3 +72,18 @@ SELECT round(123.456, 2), round(2.5, 0), round(3.5, 0), round(-2.5, 0), round(NU
 
 query
 SELECT round(2.5D, 0), round(3.5D, 0), round(-2.5D, 0), round(2.5F, 0), round(-2.5F, 0)
+
+-- Legacy negative-scale overflow wraps rather than throwing or returning zero (#5070).
+statement
+CREATE TABLE test_round_long_overflow(l bigint) USING parquet
+
+statement
+INSERT INTO test_round_long_overflow VALUES
+ (-5000000000000000000L), (-4999999999999999999L), (0L),
+ (4999999999999999999L), (5000000000000000000L), (NULL)
+
+query
+SELECT l, round(l, -19), round(l, -20) FROM test_round_long_overflow
+
+query
+SELECT round(5000000000000000000L, -19), round(-5000000000000000000L, -19)

--- a/spark/src/test/resources/sql-tests/expressions/math/round_ansi.sql
+++ b/spark/src/test/resources/sql-tests/expressions/math/round_ansi.sql
@@ -1,0 +1,48 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Config: spark.sql.ansi.enabled=true
+
+statement
+CREATE TABLE test_round_ansi(l bigint) USING parquet
+
+statement
+INSERT INTO test_round_ansi VALUES
+ (-5000000000000000000L), (-4999999999999999999L), (0L),
+ (4999999999999999999L), (5000000000000000000L), (NULL)
+
+-- Values just below the half-way boundary round to zero; NULL stays NULL.
+query
+SELECT l, round(l, -19) FROM test_round_ansi
+WHERE l BETWEEN -4999999999999999999L AND 4999999999999999999L OR l IS NULL
+
+-- A larger negative scale rounds even the overflow inputs below to zero.
+query
+SELECT l, round(l, -20) FROM test_round_ansi
+
+-- At scale -19, +/-5e18 rounds to +/-1e19, which cannot fit in a long (#5070).
+query expect_error(ARITHMETIC_OVERFLOW)
+SELECT round(l, -19) FROM test_round_ansi WHERE l = 5000000000000000000L
+
+query expect_error(ARITHMETIC_OVERFLOW)
+SELECT round(l, -19) FROM test_round_ansi WHERE l = -5000000000000000000L
+
+query expect_error(ARITHMETIC_OVERFLOW)
+SELECT round(5000000000000000000L, -19)
+
+query expect_error(ARITHMETIC_OVERFLOW)
+SELECT round(-5000000000000000000L, -19)

--- a/spark/src/test/resources/sql-tests/expressions/string/elt_ansi.sql
+++ b/spark/src/test/resources/sql-tests/expressions/string/elt_ansi.sql
@@ -1,0 +1,49 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Config: spark.sql.ansi.enabled=true
+
+-- elt executes Spark's generated code inside Comet's codegen dispatcher.
+statement
+CREATE TABLE test_elt_ansi(n int) USING parquet
+
+statement
+INSERT INTO test_elt_ansi VALUES (1), (2), (0), (-1), (3), (NULL)
+
+-- Valid one-based indices, a NULL index and a selected NULL value stay inside Comet.
+query
+SELECT n, elt(n, 'a', 'b'), elt(n, 'a', CAST(NULL AS STRING))
+FROM test_elt_ansi WHERE n IN (1, 2) OR n IS NULL
+
+-- Zero, negative and past-the-end indices raise INVALID_ARRAY_INDEX under ANSI.
+query expect_error(INVALID_ARRAY_INDEX)
+SELECT elt(n, 'a', 'b') FROM test_elt_ansi WHERE n = 0
+
+query expect_error(INVALID_ARRAY_INDEX)
+SELECT elt(n, 'a', 'b') FROM test_elt_ansi WHERE n = -1
+
+query expect_error(INVALID_ARRAY_INDEX)
+SELECT elt(n, 'a', 'b') FROM test_elt_ansi WHERE n = 3
+
+query expect_error(INVALID_ARRAY_INDEX)
+SELECT elt(0, 'a', 'b')
+
+query expect_error(INVALID_ARRAY_INDEX)
+SELECT elt(-1, 'a', 'b')
+
+query expect_error(INVALID_ARRAY_INDEX)
+SELECT elt(3, 'a', 'b')


### PR DESCRIPTION
## Which issue does this PR close?

Part of #5076.

## Rationale for this change

The SQL fixtures lack ANSI coverage for `round`, `conv` and `elt`, including long overflow when rounding to a negative scale.

## What changes are included in this PR?

Add ANSI fixtures for rounding overflow, conversion overflow and invalid `elt` indices. Include valid and NULL inputs that check Comet execution, and extend the legacy fixtures with the corresponding boundary cases.

## How are these changes tested?

Nine SQL fixtures passed locally on Spark 4.1.3 / JDK 21: the six `round`/`conv`/`elt` fixtures, `arithmetic_ansi.sql` and both boolean-to-decimal fixtures. The latter already cover the other inputs listed in #5076.

[Fork CI](https://github.com/rich7420/datafusion-comet/actions/runs/34317911082) completed with 44 successful checks, including the Linux and macOS expressions jobs.
