### PR TITLE
fix: keep parquet view types out of the shuffle benchmark input

### DIFF
--- a/native/shuffle/src/bin/shuffle_bench.rs
+++ b/native/shuffle/src/bin/shuffle_bench.rs
@@ -35,7 +35,7 @@
 //!   --partitions 200 --codec lz4
 //! ```
 
-use arrow::datatypes::{DataType, SchemaRef};
+use arrow::datatypes::{DataType, Schema, SchemaRef};
 use clap::Parser;
 use datafusion::execution::config::SessionConfig;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
@@ -446,7 +446,19 @@ async fn execute_shuffle_write(
     data_file: String,
     index_file: String,
 ) -> datafusion::common::Result<(MetricsSet, MetricsSet)> {
-    let config = SessionConfig::new().with_batch_size(batch_size);
+    let mut config = SessionConfig::new().with_batch_size(batch_size);
+    // Comet never hands the shuffle writer view types: the serde maps Spark `String` to `Utf8`,
+    // and the planner casts UDF results back from `Utf8View`/`BinaryView` to the non-view
+    // variants. DataFusion's parquet reader defaults `schema_force_view_types` to true, which
+    // would feed this benchmark a data shape production never produces -- and one the writer
+    // handles far worse, since a batch at or above `batch_size` rows bypasses the
+    // `BatchCoalescer` and an interleaved view array is serialized with the backing data
+    // buffers of every input batch it drew rows from.
+    config
+        .options_mut()
+        .execution
+        .parquet
+        .schema_force_view_types = false;
     let mut runtime_builder = RuntimeEnvBuilder::new();
     if let Some(mem_limit) = memory_limit {
         runtime_builder = runtime_builder.with_memory_limit(mem_limit, 1.0);
@@ -466,6 +478,10 @@ async fn execute_shuffle_write(
         .create_physical_plan()
         .await
         .expect("Failed to create physical plan");
+
+    // The header schema is read separately, straight from the file, so a scan that widens types
+    // is invisible in the output. Check the schema that actually reaches the writer instead.
+    reject_view_types(&parquet_plan.schema());
 
     let input: Arc<dyn ExecutionPlan> = if parquet_plan
         .properties()
@@ -631,6 +647,45 @@ fn parse_hash_columns(s: &str) -> Vec<usize> {
         .collect()
 }
 
+/// Fails the run if the schema reaching the shuffle writer carries Arrow view types.
+///
+/// Comet's serde maps Spark `String` to `Utf8` and its planner casts UDF results back from
+/// `Utf8View`/`BinaryView`, so view arrays do not reach the shuffle writer in production. They
+/// are also the input this writer handles worst: a batch at or above `batch_size` rows bypasses
+/// the `BatchCoalescer`, and an interleaved view array is then serialized carrying the backing
+/// data buffers of every input batch it drew rows from, inflating the written bytes by orders of
+/// magnitude. Numbers measured on that shape describe nothing Comet runs, so refuse the run
+/// rather than report them.
+fn reject_view_types(schema: &Schema) {
+    fn find_view(data_type: &DataType) -> Option<&DataType> {
+        match data_type {
+            DataType::Utf8View | DataType::BinaryView => Some(data_type),
+            DataType::List(field)
+            | DataType::LargeList(field)
+            | DataType::FixedSizeList(field, _)
+            | DataType::Map(field, _) => find_view(field.data_type()),
+            DataType::Struct(fields) => fields.iter().find_map(|f| find_view(f.data_type())),
+            DataType::Dictionary(_, values) => find_view(values),
+            _ => None,
+        }
+    }
+
+    let offenders = schema
+        .fields()
+        .iter()
+        .filter_map(|field| {
+            find_view(field.data_type()).map(|found| format!("{} ({found})", field.name()))
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        offenders.is_empty(),
+        "Execution schema carries Arrow view types that Comet does not produce: {}. \
+         Re-check `schema_force_view_types` before trusting any measurement from this run.",
+        offenders.join(", ")
+    );
+}
+
 fn describe_schema(schema: &arrow::datatypes::Schema) -> String {
     let mut counts = std::collections::HashMap::new();
     for field in schema.fields() {
@@ -645,6 +700,11 @@ fn describe_schema(schema: &arrow::datatypes::Schema) -> String {
             | DataType::UInt64 => "int",
             DataType::Float16 | DataType::Float32 | DataType::Float64 => "float",
             DataType::Utf8 | DataType::LargeUtf8 => "string",
+            // Named rather than folded into "string"/"binary" (or left to fall through to
+            // "other") so that a schema carrying view types is visible in the header instead of
+            // being reported as the plain variant the run is supposed to be measuring.
+            DataType::Utf8View => "stringview",
+            DataType::BinaryView => "binaryview",
             DataType::Boolean => "bool",
             DataType::Date32 | DataType::Date64 => "date",
             DataType::Decimal128(_, _) | DataType::Decimal256(_, _) => "decimal",
@@ -683,5 +743,64 @@ fn format_bytes(bytes: usize) -> String {
         format!("{:.2} KiB", bytes as f64 / 1024.0)
     } else {
         format!("{bytes} B")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reject_view_types;
+    use arrow::datatypes::{DataType, Field, Fields, Schema};
+    use std::sync::Arc;
+
+    fn schema_of(data_type: DataType) -> Schema {
+        Schema::new(vec![
+            Field::new("plain", DataType::Int32, false),
+            Field::new("subject", data_type, true),
+        ])
+    }
+
+    #[test]
+    fn plain_schema_is_accepted() {
+        reject_view_types(&schema_of(DataType::Utf8));
+    }
+
+    #[test]
+    #[should_panic(expected = "subject (Utf8View)")]
+    fn top_level_string_view_is_rejected() {
+        reject_view_types(&schema_of(DataType::Utf8View));
+    }
+
+    #[test]
+    #[should_panic(expected = "subject (BinaryView)")]
+    fn top_level_binary_view_is_rejected() {
+        reject_view_types(&schema_of(DataType::BinaryView));
+    }
+
+    #[test]
+    #[should_panic(expected = "subject (Utf8View)")]
+    fn view_nested_in_a_list_is_rejected() {
+        reject_view_types(&schema_of(DataType::List(Arc::new(Field::new(
+            "item",
+            DataType::Utf8View,
+            true,
+        )))));
+    }
+
+    #[test]
+    #[should_panic(expected = "subject (Utf8View)")]
+    fn view_nested_in_a_struct_is_rejected() {
+        reject_view_types(&schema_of(DataType::Struct(Fields::from(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("b", DataType::Utf8View, true),
+        ]))));
+    }
+
+    #[test]
+    #[should_panic(expected = "subject (Utf8View)")]
+    fn view_behind_a_dictionary_is_rejected() {
+        reject_view_types(&schema_of(DataType::Dictionary(
+            Box::new(DataType::Int32),
+            Box::new(DataType::Utf8View),
+        )));
     }
 }

--- a/native/shuffle/src/bin/shuffle_bench.rs
+++ b/native/shuffle/src/bin/shuffle_bench.rs
@@ -479,8 +479,7 @@ async fn execute_shuffle_write(
         .await
         .expect("Failed to create physical plan");
 
-    // The header schema is read separately, straight from the file, so a scan that widens types
-    // is invisible in the output. Check the schema that actually reaches the writer instead.
+    // The header schema is read straight from the file, so check what reaches the writer.
     reject_view_types(&parquet_plan.schema());
 
     let input: Arc<dyn ExecutionPlan> = if parquet_plan
@@ -647,15 +646,8 @@ fn parse_hash_columns(s: &str) -> Vec<usize> {
         .collect()
 }
 
-/// Fails the run if the schema reaching the shuffle writer carries Arrow view types.
-///
-/// Comet's serde maps Spark `String` to `Utf8` and its planner casts UDF results back from
-/// `Utf8View`/`BinaryView`, so view arrays do not reach the shuffle writer in production. They
-/// are also the input this writer handles worst: a batch at or above `batch_size` rows bypasses
-/// the `BatchCoalescer`, and an interleaved view array is then serialized carrying the backing
-/// data buffers of every input batch it drew rows from, inflating the written bytes by orders of
-/// magnitude. Numbers measured on that shape describe nothing Comet runs, so refuse the run
-/// rather than report them.
+/// Fails the run if the schema reaching the shuffle writer carries Arrow view types, which
+/// Comet does not produce and this writer serializes with every backing buffer attached.
 fn reject_view_types(schema: &Schema) {
     fn find_view(data_type: &DataType) -> Option<&DataType> {
         match data_type {
@@ -700,9 +692,7 @@ fn describe_schema(schema: &arrow::datatypes::Schema) -> String {
             | DataType::UInt64 => "int",
             DataType::Float16 | DataType::Float32 | DataType::Float64 => "float",
             DataType::Utf8 | DataType::LargeUtf8 => "string",
-            // Named rather than folded into "string"/"binary" (or left to fall through to
-            // "other") so that a schema carrying view types is visible in the header instead of
-            // being reported as the plain variant the run is supposed to be measuring.
+            // named, not folded into "string"/"binary", so a view schema is visible in the header
             DataType::Utf8View => "stringview",
             DataType::BinaryView => "binaryview",
             DataType::Boolean => "bool",


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5793.

## Rationale for this change

`shuffle_bench` builds its input with a default `SessionConfig`, and DataFusion defaults `schema_force_view_types` to true, so string and binary columns reach `ShuffleWriterExec` as `Utf8View` and `BinaryView`. Comet does not produce those: the serde maps Spark `String` to `Utf8`, and the planner casts UDF results back from the view variants. The benchmark was measuring a data shape production never produces.

View arrays are also the shape this writer handles worst. `BufBatchWriter` sets `biggest_coalesce_batch_size` to `batch_size - 1`, so a batch at or above `batch_size` rows bypasses the `BatchCoalescer` and is serialized verbatim, and an interleaved view array still references the backing buffers of every input batch it drew rows from. On 4M rows, 200 partitions, no compression, output file against the writer's own `data size` metric:

| batch size | output file | data size | ratio |
| --- | --- | --- | --- |
| 2048 | 33.17 GiB | 236.95 MiB | ~143x |
| 4096 | 14.86 GiB | 242.07 MiB | ~63x |
| 8192 | 7.62 GiB | 242.33 MiB | ~32x |
| 16384 | 4.00 GiB | 243.96 MiB | ~17x |
| 20480 | 294.92 MiB | 245.45 MiB | ~1.2x |

The cliff at 20480 is where a partition's 20000 rows stop exceeding the threshold and go through the coalescer, which compacts the views. Any string-heavy number this benchmark produced was dominated by amplification real Comet does not have. #5198 points at this benchmark for its items 1 and 6.

## What changes are included in this PR?

- Disable `schema_force_view_types` so the input matches what Comet's planner produces.
- `reject_view_types` checks the schema that actually reaches the writer, recursing through list, struct, map and dictionary children. The header schema is read separately through `ParquetRecordBatchReaderBuilder`, so it reported the file's `Utf8` rather than the `Utf8View` that executed and the mismatch was invisible.
- `describe_schema` names `Utf8View` and `BinaryView` instead of folding them into "other".

## How are these changes tested?

Six unit tests on `reject_view_types`: a plain schema, top-level `Utf8View` and `BinaryView`, and views nested behind a list, a struct and a dictionary.

Verified end to end by re-running the sweep: output is now flat at ~238 MiB across every batch size from 2048 to 20480, which is the expected behaviour since output size should not depend on batch size, and encode time at batch size 2048 drops from 7.580s to 0.019s.