### PR TITLE
ci: gate the Delta contrib build on symbols, not on libcomet size

### DIFF
--- a/dev/verify-contrib-delta-gate.sh
+++ b/dev/verify-contrib-delta-gate.sh
@@ -24,9 +24,9 @@
 #      doesn't pull `delta_kernel` into the dependency tree.
 #   2. Maven: default `mvn ... package` doesn't compile any
 #      `org/apache/comet/contrib/` classes and doesn't pull `io.delta:*` deps.
-#   3. Symbol/size: the resulting `libcomet` (`.so` on Linux, `.dylib` on macOS) from the default build is
-#      meaningfully smaller than the contrib-enabled build, and carries no
-#      `comet_contrib_delta`/`delta_kernel`/etc. external symbols.
+#   3. Symbols: the resulting `libcomet` (`.so` on Linux, `.dylib` on macOS) from the default
+#      build carries no `comet_contrib_delta`/`delta_kernel`/etc. symbols, and the
+#      contrib-enabled build carries some (so the pattern is known to still match).
 #
 # Exit non-zero on the first failure. Designed to be wired into CI so a future
 # change that leaks Delta into core gets caught immediately.
@@ -225,9 +225,9 @@ if [[ -n "$SERVICE_LEAKS" ]]; then
 fi
 green "OK: default build registers no contrib services (empty ServiceLoader registries at runtime)"
 
-# ---- libcomet symbol/size gate -------------------------------------------
+# ---- libcomet symbol gate -------------------------------------------------
 
-hdr "libcomet: default build is smaller and has no Delta symbols"
+hdr "libcomet: default build has no Delta symbols"
 cd "$NATIVE_DIR"
 # The cdylib extension is platform-specific: `libcomet.so` on Linux (CI), `libcomet.dylib` on
 # macOS. Find whichever the build produced; `stat`/`nm` flags also differ across the two.
@@ -251,6 +251,17 @@ delta_syms() {
   nm "$1" 2>/dev/null | grep -ciE 'comet_contrib_delta|delta_kernel|deltadvfilter|deltasynthetic' || true
 }
 
+# `nm` is the only direct measurement this section makes, so a missing `nm` has to fail rather
+# than silently skip -- same anti-vacuous discipline as the cargo-tree and effective-pom guards
+# above. Every image the gate runs on ships one (CI's `amd64/rust` has binutils; macOS has
+# Xcode's). Previously a missing `nm` degraded both symbol checks to no-ops and left the size
+# comparison below as the only enforcement, which is backwards: the size number is the weak
+# signal and the symbols are the strong one.
+if ! command -v nm >/dev/null 2>&1; then
+  red "FAIL: 'nm' not found on PATH; refusing to conclude 'no Delta symbols' vacuously"
+  exit 1
+fi
+
 cargo clean -p comet-contrib-delta -p datafusion-comet >/dev/null 2>&1 || true
 cargo build -j 4 -p datafusion-comet >/dev/null 2>&1
 LIB_DEFAULT="$(comet_lib)"
@@ -259,11 +270,7 @@ if [[ -z "$LIB_DEFAULT" ]]; then
   exit 1
 fi
 SIZE_DEFAULT="$(lib_size "$LIB_DEFAULT")"
-if command -v nm >/dev/null 2>&1; then
-  EXT_SYMS="$(delta_syms "$LIB_DEFAULT")"
-else
-  EXT_SYMS=0
-fi
+EXT_SYMS="$(delta_syms "$LIB_DEFAULT")"
 if [[ "$EXT_SYMS" -ne 0 ]]; then
   red "FAIL: default libcomet contains $EXT_SYMS Delta-related symbols"
   exit 1
@@ -273,34 +280,38 @@ green "OK: default libcomet has 0 Delta symbols (size=$SIZE_DEFAULT bytes)"
 cargo build -j 4 -p datafusion-comet --features contrib-delta >/dev/null 2>&1
 LIB_CONTRIB="$(comet_lib)"
 SIZE_CONTRIB="$(lib_size "$LIB_CONTRIB")"
-if [[ "$SIZE_CONTRIB" -le "$SIZE_DEFAULT" ]]; then
-  red "FAIL: contrib-enabled libcomet (size=$SIZE_CONTRIB) is not larger than default (size=$SIZE_DEFAULT)"
-  red "       (would indicate contrib was being linked into default build too)"
+# The contrib-enabled libcomet MUST contain Delta-related symbols. Without this, a future Rust
+# toolchain that mangles symbols differently (so our grep pattern stops matching) would silently
+# make the default-build check a no-op while still passing -- the gate would lie about being
+# enforced. Asserting both "default has 0" AND "contrib has >0" catches grep-pattern drift.
+CONTRIB_SYMS="$(delta_syms "$LIB_CONTRIB")"
+if [[ "$CONTRIB_SYMS" -lt 1 ]]; then
+  red "FAIL: contrib-enabled libcomet has 0 Delta-related symbols matching our grep pattern."
+  red "      This means the symbol-name pattern in this script has drifted from what"
+  red "      Rust currently emits, and the default-build check above is now a no-op."
+  red "      Inspect the dylib's exports and update the grep pattern."
   exit 1
 fi
-# Sanity check: the contrib-enabled libcomet MUST contain Delta-related symbols.
-# Without this, a future Rust toolchain that mangles symbols differently (so our
-# grep pattern stops matching) would silently make the default-build check a no-op
-# while still passing -- the gate would lie about being enforced. Asserting both
-# "default has 0" AND "contrib has >0" catches grep-pattern drift.
-if command -v nm >/dev/null 2>&1; then
-  CONTRIB_SYMS="$(delta_syms "$LIB_CONTRIB")"
-  if [[ "$CONTRIB_SYMS" -lt 1 ]]; then
-    red "FAIL: contrib-enabled libcomet has 0 Delta-related symbols matching our grep pattern."
-    red "      This means the symbol-name pattern in this script has drifted from what"
-    red "      Rust currently emits, and the default-build check above is now a no-op."
-    red "      Inspect the dylib's exports and update the grep pattern."
-    exit 1
-  fi
-fi
-DIFF_MB=$(( (SIZE_CONTRIB - SIZE_DEFAULT) / 1024 / 1024 ))
-green "OK: contrib-enabled libcomet is ${DIFF_MB} MB larger than default (size=$SIZE_CONTRIB bytes)"
+# Sizes are REPORTED, not asserted. This gate used to require the contrib-enabled lib to be
+# strictly larger than the default one, on the theory that a default build which had quietly
+# linked contrib would show no size gap. That does not survive contact with a 1.5 GB unstripped
+# debug cdylib: `comet-contrib-delta` is a ~75-line stub, so what it actually adds is swamped by
+# how rustc happens to partition the crate into codegen units -- DWARF is re-emitted per unit, so
+# the total moves by ~1 MB in response to source changes that have nothing to do with Delta, and
+# the two builds move independently because only `datafusion-comet` is recompiled for the second
+# one. Measured on apache/datafusion-comet#5810, whose entire native diff is a 20-line
+# `sort_unstable_by` in the Iceberg writer: against its base commit the default lib grew 875 KB
+# while the contrib-enabled lib shrank 396 KB, inverting a gap that had been +1.2 MB one commit
+# earlier and failing the gate. The two symbol checks are the direct measurement of the property
+# we care about -- "the default build links zero Delta symbols" is asserted, not inferred from a
+# byte count -- so nothing is lost by printing the sizes and moving on.
+green "OK: contrib-enabled libcomet has $CONTRIB_SYMS Delta symbols (size=$SIZE_CONTRIB bytes, $((SIZE_CONTRIB - SIZE_DEFAULT)) bytes vs default)"
 
 # ---- Summary --------------------------------------------------------------
 
 hdr "All gate checks passed"
 echo "  default cargo:  no comet-contrib-delta, no delta_kernel"
 echo "  default mvn:    no io.delta:*, no contrib/delta classes"
-echo "  default dylib:  ${DIFF_MB} MB smaller than contrib build, 0 Delta symbols"
+echo "  default dylib:  0 Delta symbols (contrib build has $CONTRIB_SYMS)"
 echo
 echo "Run with: dev/verify-contrib-delta-gate.sh"


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5826.

## Rationale for this change

The `Delta Contrib Build Gate` job is failing pull requests that have nothing to do with Delta. Its last check asserts that the `--features contrib-delta` `libcomet` is strictly larger than the default one, as a proxy for "contrib did not get linked into the default build too". The proxy does not have enough signal to work: `comet-contrib-delta` is currently a 75-line stub, and it is being weighed against a ~1.5 GB unstripped debug cdylib whose byte count moves by roughly a megabyte in response to source changes that have nothing to do with Delta, because rustc re-emits DWARF per codegen unit and a small edit repartitions them. The two measurements also move independently, since the second `cargo build` only recompiles `datafusion-comet` and relinks.

Sizes reported by the gate itself, in bytes:

| Commit | Run | default | contrib | contrib − default |
| --- | --- | ---: | ---: | ---: |
| `424c31aa7` (main) | [34369036621](https://github.com/apache/datafusion-comet/actions/runs/34369036621) | 1,518,487,584 | 1,519,692,952 | +1,205,368 |
| `b5069564b` (#5810) | [34382116782](https://github.com/apache/datafusion-comet/actions/runs/34382116782) | 1,519,362,160 | 1,519,296,760 | **−65,400 (fail)** |
| `pingzh-topk-reader-filters` | [34385681309](https://github.com/apache/datafusion-comet/actions/runs/34385681309) | 1,519,317,344 | 1,519,252,728 | **−64,616 (fail)** |
| `pingzh-topk-reader-filters` | [34406327795](https://github.com/apache/datafusion-comet/actions/runs/34406327795) | 1,519,390,608 | 1,519,258,216 | **−132,392 (fail)** |
| `comet-native-scan-io-observability` | [34414317975](https://github.com/apache/datafusion-comet/actions/runs/34414317975) | 1,519,496,304 | 1,519,992,584 | +496,280 (pass, 40% of the usual margin) |

The second row is the clearest case. `424c31aa7` is the exact base commit of #5810, and the whole native diff between the two is a 20-line `sort_unstable_by` in the Iceberg writer. Against that base the default lib grew 875 KB and the contrib-enabled lib shrank 396 KB. A sort cannot do either of those, and whatever it did add would land in both builds rather than one.

Running the gate locally on macOS puts a number on what the stub is actually worth: 107,712 bytes out of a 428 MB dylib. The +1.2 MB seen on quiet branches is mostly incidental layout, not contrib content, so the margin the check leans on is not the contrib crate. The result is deterministic per commit — two runs on unchanged native sources report byte-identical sizes — so a re-run does not clear a failure.

## What changes are included in this PR?

- Report the two `libcomet` sizes instead of asserting an ordering between them. The invariant the comparison stood in for is already measured directly a few lines away: the default `libcomet` must carry zero symbols matching `comet_contrib_delta|delta_kernel|deltadvfilter|deltasynthetic`, and the contrib-enabled one must carry at least one, which is what keeps the first check from going vacuous if symbol mangling drifts. No coverage is lost. The comment left in place records the measurement above so the check does not get reintroduced.

- Make a missing `nm` fail rather than silently skip. Both symbol checks were wrapped in `if command -v nm`, so on an image without it they degraded to no-ops and the size comparison was left as the only enforcement — backwards, given which of the two is the real measurement, and it would have left nothing at all once the size assertion went. This matches the anti-vacuous guards the script already applies to `cargo tree` and `help:effective-pom`.

Nothing else in the gate changes: the cargo tree, Maven effective-pom, per-Spark `delta-spark` pinning, compiled-class and `META-INF/services` checks are untouched.

## How are these changes tested?

`dev/verify-contrib-delta-gate.sh` was run end to end locally on macOS (JDK 17) and passes all five sections:

```
==> libcomet: default build has no Delta symbols
OK: default libcomet has 0 Delta symbols (size=427719856 bytes)
OK: contrib-enabled libcomet has 1 Delta symbols (size=427827568 bytes, 107712 bytes vs default)
```

That run is also where the 107,712-byte figure above comes from. The one symbol the contrib build carries is `comet_contrib_delta::planner::plan_delta_scan`, so the grep pattern is confirmed to still match what rustc emits, which is what keeps the default-side check honest.

The leak case was then exercised directly, by feeding the contrib-enabled dylib to the default-side assertion — the same thing a default build that had linked contrib would produce:

```
FAIL: default libcomet contains 1 Delta-related symbols
```

So the check that actually enforces the gate still fires, and it is unchanged by this PR.

`shellcheck` reports no new warnings (the one pre-existing `SC2034` for `SPARK_DIR` is unchanged) and `bash -n` is clean.
