### PR TITLE
fix: preserve join and generator semantics in plan identity

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -1501,6 +1501,7 @@ object CometExplodeExec extends CometOperatorSerde[GenerateExec] {
       op.output,
       op.generator,
       op.generatorOutput,
+      op.outer,
       op.child,
       SerializedPlan(None))
   }
@@ -1512,6 +1513,7 @@ case class CometExplodeExec(
     override val output: Seq[Attribute],
     generator: Generator,
     generatorOutput: Seq[Attribute],
+    outer: Boolean,
     child: SparkPlan,
     override val serializedPlanOpt: SerializedPlan)
     extends CometUnaryExec {
@@ -1530,6 +1532,7 @@ case class CometExplodeExec(
         this.output == other.output &&
         this.generator == other.generator &&
         this.generatorOutput == other.generatorOutput &&
+        this.outer == other.outer &&
         this.child == other.child &&
         this.serializedPlanOpt == other.serializedPlanOpt
       case _ =>
@@ -1537,7 +1540,8 @@ case class CometExplodeExec(
     }
   }
 
-  override def hashCode(): Int = Objects.hashCode(output, generator, generatorOutput, child)
+  override def hashCode(): Int =
+    Objects.hashCode(output, generator, generatorOutput, Boolean.box(outer), child)
 
   override lazy val metrics: Map[String, SQLMetric] =
     CometMetricNode.baselineMetrics(sparkContext) ++
@@ -2381,6 +2385,7 @@ object CometBroadcastHashJoinExec extends CometOperatorSerde[HashJoin] with Come
       op.joinType,
       op.condition,
       op.buildSide,
+      nativeOp.getHashJoin.getNullAwareAntiJoin,
       op.left,
       op.right,
       SerializedPlan(None))
@@ -2453,6 +2458,7 @@ case class CometHashJoinExec(
         this.output == other.output &&
         this.leftKeys == other.leftKeys &&
         this.rightKeys == other.rightKeys &&
+        this.joinType == other.joinType &&
         this.condition == other.condition &&
         this.buildSide == other.buildSide &&
         this.left == other.left &&
@@ -2464,7 +2470,7 @@ case class CometHashJoinExec(
   }
 
   override def hashCode(): Int =
-    Objects.hashCode(output, leftKeys, rightKeys, condition, buildSide, left, right)
+    Objects.hashCode(output, leftKeys, rightKeys, joinType, condition, buildSide, left, right)
 
   override lazy val metrics: Map[String, SQLMetric] = {
     val joinMetrics = CometMetricNode.joinMetrics(sparkContext)
@@ -2486,6 +2492,7 @@ case class CometBroadcastHashJoinExec(
     joinType: JoinType,
     condition: Option[Expression],
     buildSide: BuildSide,
+    isNullAwareAntiJoin: Boolean,
     override val left: SparkPlan,
     override val right: SparkPlan,
     override val serializedPlanOpt: SerializedPlan)
@@ -2600,8 +2607,10 @@ case class CometBroadcastHashJoinExec(
         this.output == other.output &&
         this.leftKeys == other.leftKeys &&
         this.rightKeys == other.rightKeys &&
+        this.joinType == other.joinType &&
         this.condition == other.condition &&
         this.buildSide == other.buildSide &&
+        this.isNullAwareAntiJoin == other.isNullAwareAntiJoin &&
         this.left == other.left &&
         this.right == other.right &&
         this.serializedPlanOpt == other.serializedPlanOpt
@@ -2611,7 +2620,16 @@ case class CometBroadcastHashJoinExec(
   }
 
   override def hashCode(): Int =
-    Objects.hashCode(output, leftKeys, rightKeys, condition, buildSide, left, right)
+    Objects.hashCode(
+      output,
+      leftKeys,
+      rightKeys,
+      joinType,
+      condition,
+      buildSide,
+      Boolean.box(isNullAwareAntiJoin),
+      left,
+      right)
 
   override lazy val metrics: Map[String, SQLMetric] = {
     val joinMetrics = CometMetricNode.joinMetrics(sparkContext)
@@ -2792,6 +2810,7 @@ case class CometSortMergeJoinExec(
         this.output == other.output &&
         this.leftKeys == other.leftKeys &&
         this.rightKeys == other.rightKeys &&
+        this.joinType == other.joinType &&
         this.condition == other.condition &&
         this.left == other.left &&
         this.right == other.right &&
@@ -2802,7 +2821,7 @@ case class CometSortMergeJoinExec(
   }
 
   override def hashCode(): Int =
-    Objects.hashCode(output, leftKeys, rightKeys, condition, left, right)
+    Objects.hashCode(output, leftKeys, rightKeys, joinType, condition, left, right)
 
   override lazy val metrics: Map[String, SQLMetric] =
     CometMetricNode.sortMergeJoinMetrics(sparkContext)

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -2124,6 +2124,12 @@ case class CometHashAggregateExec(
 
 trait CometHashJoin {
 
+  // Only BroadcastHashJoinExec can be null-aware (NOT IN subqueries).
+  protected def isNullAware(join: HashJoin): Boolean = join match {
+    case bhj: BroadcastHashJoinExec => bhj.isNullAwareAntiJoin
+    case _ => false
+  }
+
   def doConvert(
       join: HashJoin,
       builder: Operator.Builder,
@@ -2138,11 +2144,7 @@ trait CometHashJoin {
       return None
     }
 
-    // Only BroadcastHashJoinExec can be null-aware (NOT IN subqueries).
-    val isNullAwareAntiJoin = join match {
-      case bhj: BroadcastHashJoinExec => bhj.isNullAwareAntiJoin
-      case _ => false
-    }
+    val isNullAwareAntiJoin = isNullAware(join)
 
     val joinKeys = join.leftKeys ++ join.rightKeys
     if (joinKeys.exists(key => isStringCollationType(key.dataType))) {
@@ -2386,10 +2388,7 @@ object CometBroadcastHashJoinExec extends CometOperatorSerde[HashJoin] with Come
       op.joinType,
       op.condition,
       op.buildSide,
-      op match {
-        case bhj: BroadcastHashJoinExec => bhj.isNullAwareAntiJoin
-        case _ => false
-      },
+      isNullAware(op),
       op.left,
       op.right,
       SerializedPlan(None))

--- a/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/operators.scala
@@ -1524,7 +1524,8 @@ case class CometExplodeExec(
   override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
     this.copy(child = newChild)
 
-  override def stringArgs: Iterator[Any] = Iterator(generator, generatorOutput, output, child)
+  override def stringArgs: Iterator[Any] =
+    Iterator(generator, generatorOutput, outer, output, child)
 
   override def equals(obj: Any): Boolean = {
     obj match {
@@ -1541,7 +1542,7 @@ case class CometExplodeExec(
   }
 
   override def hashCode(): Int =
-    Objects.hashCode(output, generator, generatorOutput, Boolean.box(outer), child)
+    Objects.hashCode(output, generator, generatorOutput, outer: java.lang.Boolean, child)
 
   override lazy val metrics: Map[String, SQLMetric] =
     CometMetricNode.baselineMetrics(sparkContext) ++
@@ -2385,7 +2386,10 @@ object CometBroadcastHashJoinExec extends CometOperatorSerde[HashJoin] with Come
       op.joinType,
       op.condition,
       op.buildSide,
-      nativeOp.getHashJoin.getNullAwareAntiJoin,
+      op match {
+        case bhj: BroadcastHashJoinExec => bhj.isNullAwareAntiJoin
+        case _ => false
+      },
       op.left,
       op.right,
       SerializedPlan(None))
@@ -2627,7 +2631,7 @@ case class CometBroadcastHashJoinExec(
       joinType,
       condition,
       buildSide,
-      Boolean.box(isNullAwareAntiJoin),
+      isNullAwareAntiJoin: java.lang.Boolean,
       left,
       right)
 

--- a/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometAggregateSuite.scala
@@ -1352,15 +1352,9 @@ class CometAggregateSuite extends CometTestBase with AdaptiveSparkPlanHelper {
             assert(reusedPlan.isInstanceOf[AdaptiveSparkPlanExec])
           }
           // Adaptive-aware traversal must find reuse above Final, not just a shared Partial stage.
-          val reusedFinalAggregates = collect(reusedPlan) {
-            case reused: ReusedExchangeExec if collect(reused.child) {
-                  case agg: CometHashAggregateExec if agg.modes.contains(Final) => agg
-                }.nonEmpty =>
-              reused
+          assertExchangeReuseOver(reusedPlan, "Expected equivalent aggregate reuse") {
+            case agg: CometHashAggregateExec if agg.modes.contains(Final) => agg
           }
-          assert(
-            reusedFinalAggregates.nonEmpty,
-            s"Expected equivalent aggregate reuse:\n$reusedPlan")
         }
       }
     }

--- a/spark/src/test/scala/org/apache/comet/exec/CometGenerateExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometGenerateExecSuite.scala
@@ -19,14 +19,86 @@
 
 package org.apache.comet.exec
 
-import org.apache.spark.sql.CometTestBase
+import org.apache.spark.sql.{CometTestBase, DataFrame, Row}
+import org.apache.spark.sql.comet.CometExplodeExec
+import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.internal.SQLConf
 
 import org.apache.comet.CometConf
 
 class CometGenerateExecSuite extends CometTestBase {
 
   import testImplicits._
+
+  for (generator <- Seq("explode", "posexplode");
+    input <- Seq("s.arr", "slice(s.arr, 1, 10)");
+    adaptive <- Seq(false, true)) {
+    test(
+      s"#5824 generator identity preserves exchange reuse: $generator($input), AQE=$adaptive") {
+      withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString,
+        SQLConf.EXCHANGE_REUSE_ENABLED.key -> "true",
+        SQLConf.SHUFFLE_PARTITIONS.key -> "2",
+        CometConf.COMET_SHUFFLE_ENABLED.key -> "true",
+        CometConf.COMET_SHUFFLE_MODE.key -> "native",
+        CometConf.COMET_EXEC_EXPLODE_ENABLED.key -> "true") {
+        val rows = Seq(
+          (1, Array[Integer](10, 20)),
+          (2, Array.empty[Integer]),
+          (3, null.asInstanceOf[Array[Integer]]),
+          (4, Array[Integer](null)))
+        val data = rows.toDF("k", "arr").selectExpr("k", "named_struct('arr', arr) AS s")
+        withTempPath { path =>
+          data.write.parquet(path.getAbsolutePath)
+          withParquetTable(path.getAbsolutePath, "t") {
+            val outputs = if (generator == "posexplode") "(pos, v)" else "v"
+            def branch(outer: Boolean): DataFrame = {
+              val function = if (outer) s"${generator}_outer" else generator
+              sql(s"SELECT k, $function($input) AS $outputs FROM t").repartition(2, col("k"))
+            }
+            def nativeGenerator(df: DataFrame): CometExplodeExec =
+              collectFirst(df.queryExecution.executedPlan) { case generate: CometExplodeExec =>
+                generate
+              }.getOrElse(fail("Expected native generator"))
+
+            val ordinary = branch(false)
+            val outer = branch(true)
+            // Computed inputs avoid InferFiltersFromGenerate masking unequal semantics.
+            checkSparkAnswerAndOperator(ordinary.unionAll(outer), classOf[ReusedExchangeExec])
+            val populated = if (generator == "posexplode") {
+              Seq(Row(1, 0, 10), Row(1, 1, 20), Row(4, 0, null))
+            } else {
+              Seq(Row(1, 10), Row(1, 20), Row(4, null))
+            }
+            val padded = if (generator == "posexplode") {
+              Seq(Row(2, null, null), Row(3, null, null))
+            } else {
+              Seq(Row(2, null), Row(3, null))
+            }
+            checkAnswer(ordinary.unionAll(outer), populated ++ populated ++ padded)
+            assert(!nativeGenerator(ordinary).sameResult(nativeGenerator(outer)))
+
+            val same = branch(false)
+            assert(nativeGenerator(ordinary).sameResult(nativeGenerator(same)))
+            assert(
+              nativeGenerator(ordinary).semanticHash() == nativeGenerator(same).semanticHash())
+            val (_, reusedPlan) =
+              checkSparkAnswerAndOperator(ordinary.unionAll(same), classOf[ReusedExchangeExec])
+            val reusedGenerators = collect(reusedPlan) {
+              case reused: ReusedExchangeExec if collect(reused.child) {
+                    case generate: CometExplodeExec => generate
+                  }.nonEmpty =>
+                reused
+            }
+            assert(
+              reusedGenerators.nonEmpty,
+              s"Expected equivalent post-generator reuse:\n$reusedPlan")
+          }
+        }
+      }
+    }
+  }
 
   test("posexplode with a computed array from Parquet") {
     withSQLConf(CometConf.COMET_EXEC_EXPLODE_ENABLED.key -> "true") {

--- a/spark/src/test/scala/org/apache/comet/exec/CometGenerateExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometGenerateExecSuite.scala
@@ -21,6 +21,7 @@ package org.apache.comet.exec
 
 import org.apache.spark.sql.{CometTestBase, DataFrame, Row}
 import org.apache.spark.sql.comet.CometExplodeExec
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
@@ -34,8 +35,7 @@ class CometGenerateExecSuite extends CometTestBase {
   for (generator <- Seq("explode", "posexplode");
     input <- Seq("s.arr", "slice(s.arr, 1, 10)");
     adaptive <- Seq(false, true)) {
-    test(
-      s"#5824 generator identity preserves exchange reuse: $generator($input), AQE=$adaptive") {
+    test(s"generator identity preserves exchange reuse: $generator($input), AQE=$adaptive") {
       withSQLConf(
         SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString,
         SQLConf.EXCHANGE_REUSE_ENABLED.key -> "true",
@@ -85,15 +85,12 @@ class CometGenerateExecSuite extends CometTestBase {
               nativeGenerator(ordinary).semanticHash() == nativeGenerator(same).semanticHash())
             val (_, reusedPlan) =
               checkSparkAnswerAndOperator(ordinary.unionAll(same), classOf[ReusedExchangeExec])
-            val reusedGenerators = collect(reusedPlan) {
-              case reused: ReusedExchangeExec if collect(reused.child) {
-                    case generate: CometExplodeExec => generate
-                  }.nonEmpty =>
-                reused
+            if (adaptive) {
+              assert(reusedPlan.isInstanceOf[AdaptiveSparkPlanExec])
             }
-            assert(
-              reusedGenerators.nonEmpty,
-              s"Expected equivalent post-generator reuse:\n$reusedPlan")
+            assertExchangeReuseOver(reusedPlan, "Expected equivalent post-generator reuse") {
+              case generate: CometExplodeExec => generate
+            }
           }
         }
       }

--- a/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, IsNot
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
 import org.apache.spark.sql.comet.{CometBroadcastExchangeExec, CometBroadcastHashJoinExec, CometBroadcastNestedLoopJoinExec, CometFilterExec, CometHashJoinExec, CometNativeScanExec, CometSortMergeJoinExec, CometUnionExec}
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.adaptive.AQEShuffleReadExec
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AQEShuffleReadExec}
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{ArrayType, IntegerType, MetadataBuilder, StructField, StructType}
@@ -57,7 +57,7 @@ class CometJoinSuite extends CometTestBase {
       "MERGE" -> classOf[CometSortMergeJoinExec],
       "BROADCAST" -> classOf[CometBroadcastHashJoinExec]);
     adaptive <- Seq(false, true)) {
-    test(s"#5824 join identity preserves exchange reuse: $hint, AQE=$adaptive") {
+    test(s"join identity preserves exchange reuse: $hint, AQE=$adaptive") {
       withSQLConf(
         SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString,
         SQLConf.EXCHANGE_REUSE_ENABLED.key -> "true",
@@ -92,15 +92,12 @@ class CometJoinSuite extends CometTestBase {
             assert(nativeJoin(semi).semanticHash() == nativeJoin(same).semanticHash())
             val (_, reusedPlan) =
               checkSparkAnswerAndOperator(semi.unionAll(same), classOf[ReusedExchangeExec])
-            val reusedJoins = collect(reusedPlan) {
-              case reused: ReusedExchangeExec if collect(reused.child) {
-                    case join if joinClass.isInstance(join) => join
-                  }.nonEmpty =>
-                reused
+            if (adaptive) {
+              assert(reusedPlan.isInstanceOf[AdaptiveSparkPlanExec])
             }
-            assert(
-              reusedJoins.nonEmpty,
-              s"Expected equivalent post-join exchange reuse:\n$reusedPlan")
+            assertExchangeReuseOver(reusedPlan, "Expected equivalent post-join exchange reuse") {
+              case join if joinClass.isInstance(join) => join
+            }
           }
         }
       }
@@ -108,7 +105,7 @@ class CometJoinSuite extends CometTestBase {
   }
 
   for (adaptive <- Seq(false, true)) {
-    test(s"#5824 null-aware anti join identity preserves exchange reuse: AQE=$adaptive") {
+    test(s"null-aware anti join identity preserves exchange reuse: AQE=$adaptive") {
       withSQLConf(
         SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString,
         SQLConf.EXCHANGE_REUSE_ENABLED.key -> "true",
@@ -134,15 +131,12 @@ class CometJoinSuite extends CometTestBase {
             assert(nativeJoin(nullAware).semanticHash() == nativeJoin(same).semanticHash())
             val (_, reusedPlan) =
               checkSparkAnswerAndOperator(nullAware.unionAll(same), classOf[ReusedExchangeExec])
-            val reusedJoins = collect(reusedPlan) {
-              case reused: ReusedExchangeExec if collect(reused.child) {
-                    case join: CometBroadcastHashJoinExec => join
-                  }.nonEmpty =>
-                reused
+            if (adaptive) {
+              assert(reusedPlan.isInstanceOf[AdaptiveSparkPlanExec])
             }
-            assert(
-              reusedJoins.nonEmpty,
-              s"Expected equivalent null-aware join reuse:\n$reusedPlan")
+            assertExchangeReuseOver(reusedPlan, "Expected equivalent null-aware join reuse") {
+              case join: CometBroadcastHashJoinExec => join
+            }
           }
         }
       }

--- a/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometJoinSuite.scala
@@ -25,7 +25,7 @@ import org.scalatest.Tag
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.parquet.hadoop.util.HadoopInputFile
-import org.apache.spark.sql.{CometTestBase, Row}
+import org.apache.spark.sql.{CometTestBase, DataFrame, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, IsNotNull}
@@ -33,6 +33,7 @@ import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
 import org.apache.spark.sql.comet.{CometBroadcastExchangeExec, CometBroadcastHashJoinExec, CometBroadcastNestedLoopJoinExec, CometFilterExec, CometHashJoinExec, CometNativeScanExec, CometSortMergeJoinExec, CometUnionExec}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.adaptive.AQEShuffleReadExec
+import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{ArrayType, IntegerType, MetadataBuilder, StructField, StructType}
 
@@ -47,6 +48,103 @@ class CometJoinSuite extends CometTestBase {
     super.test(testName, testTags: _*) {
       withSQLConf(CometConf.COMET_SHUFFLE_ENABLED.key -> "true") {
         testFun
+      }
+    }
+  }
+
+  for ((hint, joinClass) <- Seq(
+      "SHUFFLE_HASH" -> classOf[CometHashJoinExec],
+      "MERGE" -> classOf[CometSortMergeJoinExec],
+      "BROADCAST" -> classOf[CometBroadcastHashJoinExec]);
+    adaptive <- Seq(false, true)) {
+    test(s"#5824 join identity preserves exchange reuse: $hint, AQE=$adaptive") {
+      withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString,
+        SQLConf.EXCHANGE_REUSE_ENABLED.key -> "true",
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+        SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+        SQLConf.SHUFFLE_PARTITIONS.key -> "2",
+        CometConf.COMET_EXEC_SORT_MERGE_JOIN_ENABLED.key -> "true",
+        CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+        withParquetTable(Seq((0, 10), (1, 11), (2, 12)), "l") {
+          withParquetTable(Seq((0, 100), (1, 101)), "r") {
+            def branch(joinType: String): DataFrame =
+              sql(s"""SELECT /*+ $hint(r) */ l._1, l._2 FROM l
+                     |$joinType JOIN r ON l._1 = r._1
+                     |WHERE l._1 IS NOT NULL""".stripMargin)
+                .repartition(2, $"_2")
+
+            def nativeJoin(df: DataFrame): SparkPlan =
+              collectFirst(df.queryExecution.executedPlan) {
+                case join if joinClass.isInstance(join) => join
+              }.getOrElse(fail(s"Expected native $hint join"))
+
+            val semi = branch("LEFT SEMI")
+            val anti = branch("LEFT ANTI")
+            // The explicit null check defeats InferFiltersFromConstraints masking this bug.
+            // Shuffle on the payload: a join-key shuffle can be optimized away.
+            checkSparkAnswerAndOperator(semi.unionAll(anti), classOf[ReusedExchangeExec])
+            checkAnswer(semi.unionAll(anti), Seq(Row(0, 10), Row(1, 11), Row(2, 12)))
+            assert(!nativeJoin(semi).sameResult(nativeJoin(anti)))
+
+            val same = branch("LEFT SEMI")
+            assert(nativeJoin(semi).sameResult(nativeJoin(same)))
+            assert(nativeJoin(semi).semanticHash() == nativeJoin(same).semanticHash())
+            val (_, reusedPlan) =
+              checkSparkAnswerAndOperator(semi.unionAll(same), classOf[ReusedExchangeExec])
+            val reusedJoins = collect(reusedPlan) {
+              case reused: ReusedExchangeExec if collect(reused.child) {
+                    case join if joinClass.isInstance(join) => join
+                  }.nonEmpty =>
+                reused
+            }
+            assert(
+              reusedJoins.nonEmpty,
+              s"Expected equivalent post-join exchange reuse:\n$reusedPlan")
+          }
+        }
+      }
+    }
+  }
+
+  for (adaptive <- Seq(false, true)) {
+    test(s"#5824 null-aware anti join identity preserves exchange reuse: AQE=$adaptive") {
+      withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptive.toString,
+        SQLConf.EXCHANGE_REUSE_ENABLED.key -> "true",
+        SQLConf.SHUFFLE_PARTITIONS.key -> "2",
+        CometConf.COMET_SHUFFLE_MODE.key -> "native") {
+        withParquetTable(Seq((Some(0), 10), (Some(1), 11), (None, 12)), "l") {
+          withParquetTable(Seq(Tuple1(0)), "r") {
+            def branch(predicate: String): DataFrame =
+              sql(s"SELECT l._1, l._2 FROM l WHERE $predicate").repartition(2, $"_2")
+            val anti = branch(
+              "NOT EXISTS (SELECT /*+ BROADCAST(r) */ 1 FROM r " +
+                "WHERE r._1 = l._1 AND r._1 IS NOT NULL)")
+            val nullAware = branch("l._1 NOT IN (SELECT r._1 FROM r WHERE r._1 IS NOT NULL)")
+            checkSparkAnswerAndOperator(anti.unionAll(nullAware), classOf[ReusedExchangeExec])
+            checkAnswer(anti.unionAll(nullAware), Seq(Row(1, 11), Row(1, 11), Row(null, 12)))
+            def nativeJoin(df: DataFrame): CometBroadcastHashJoinExec =
+              collectFirst(df.queryExecution.executedPlan) {
+                case join: CometBroadcastHashJoinExec => join
+              }.getOrElse(fail("Expected native broadcast hash join"))
+            assert(!nativeJoin(anti).sameResult(nativeJoin(nullAware)))
+            val same = branch("l._1 NOT IN (SELECT r._1 FROM r WHERE r._1 IS NOT NULL)")
+            assert(nativeJoin(nullAware).sameResult(nativeJoin(same)))
+            assert(nativeJoin(nullAware).semanticHash() == nativeJoin(same).semanticHash())
+            val (_, reusedPlan) =
+              checkSparkAnswerAndOperator(nullAware.unionAll(same), classOf[ReusedExchangeExec])
+            val reusedJoins = collect(reusedPlan) {
+              case reused: ReusedExchangeExec if collect(reused.child) {
+                    case join: CometBroadcastHashJoinExec => join
+                  }.nonEmpty =>
+                reused
+            }
+            assert(
+              reusedJoins.nonEmpty,
+              s"Expected equivalent null-aware join reuse:\n$reusedPlan")
+          }
+        }
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/CometTestBase.scala
@@ -43,6 +43,7 @@ import org.apache.spark.sql.comet.CometPlanChecker
 import org.apache.spark.sql.comet.execution.shuffle.{CometColumnarShuffle, CometNativeShuffle, CometShuffleExchangeExec}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.internal._
 import org.apache.spark.sql.test._
 import org.apache.spark.sql.types.{DecimalType, StructType}
@@ -66,6 +67,14 @@ abstract class CometTestBase
 
   protected val shuffleManager: String =
     "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager"
+
+  protected def assertExchangeReuseOver[T](plan: SparkPlan, clue: String)(
+      pf: PartialFunction[SparkPlan, T]): Unit = {
+    val reused = collect(plan) {
+      case exchange: ReusedExchangeExec if collect(exchange.child)(pf).nonEmpty => exchange
+    }
+    assert(reused.nonEmpty, s"$clue:\n$plan")
+  }
 
   protected def sparkConf: SparkConf = {
     val conf = new SparkConf()


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5824.

## Rationale for this change

Exchange reuse can treat plans with different semantics as equivalent. Semi/anti join branches can return one branch twice, while ordinary/outer generator branches can lose the outer rows. A null probe also exposes a broadcast anti-join collision between NOT EXISTS and NOT IN.

## What changes are included in this PR?

- Include `joinType` in equality and hashing for shuffled hash, broadcast hash, and sort-merge joins.
- Preserve `GenerateExec.outer` in generator identity and explain output.
- Derive the null-aware anti-join flag directly from Spark's operator and preserve it in broadcast join identity.
- Share post-operator exchange-reuse assertions through `CometTestBase`, including the existing aggregate regressions. AQE-enabled cases explicitly require an adaptive plan.

Native execution and protobuf schemas are unchanged. Hashing uses the repository's boxed-type ascription convention for Scala 2.12 compatibility.

## How are these changes tested?

Added 16 parameterized regressions in the existing join and generator suites. They cover all three join strategies, nested/sliced arrays, explode/posexplode, null and empty arrays, null-aware anti joins, and AQE off/on. Tests compare Spark results and explicit expected rows, require native operators, and verify equivalent plans still reuse post-operator exchanges.

The regressions reproduced incorrect results before the fix. The shared assertion is also exercised by five existing aggregate canonicalization cases.

Local validation of the revised patch:

- Spark 4.1: full join, generator, and aggregate suites passed 193 tests, with 0 failures and 2 pre-existing ignored aggregate-metrics tests. Packaging passed.
- Focused 21-case runs passed on Spark 4.1 and Spark 3.5/Scala 2.12, with no failures or skips.
- Semantic and syntactic Scalafix, Spotless, Scalastyle, Apache RAT, Prettier, and suite-registration checks passed.

These are local results; GitHub CI is separate.

Focused command (21 cases across all four helper call sites):

```sh
./mvnw test -Pspark-4.1 -Dtest=none \
  '-Dsuites=org.apache.comet.exec.CometJoinSuite identity preserves exchange reuse,org.apache.comet.exec.CometGenerateExecSuite identity preserves exchange reuse,org.apache.comet.exec.CometAggregateSuite aggregate canonicalization preserves'
```
