### PR TITLE
test: name the whole dispatched subtree in the decimal promotion assertion

### DIFF
--- a/spark/src/test/scala/org/apache/comet/CometCodegenSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometCodegenSuite.scala
@@ -422,13 +422,21 @@ class CometCodegenSuite
 
     // Promotion rebuilds Hypot as well as the Alias above it. Unlike the original Add, the
     // dispatched copy is not reachable from the original tree, so only the coverage lift can
-    // bring its name back to the projection owner.
+    // bring its names back to the projection owner.
+    //
+    // Every expression in the rebuilt subtree is named, not just the dispatched root: the whole
+    // subtree was bound into the one kernel, so all of it ran in the JVM. `checkoverflow` is the
+    // wrapper promotion added around the decimal `Add`, which is what makes the lifted set
+    // evidence that the promoted copy, rather than the original tree, was the one recorded.
     val proto = QueryPlanSerde.exprToProto(projection, Seq(decimal)).get
     assert(proto.hasJvmScalarUdf)
     assert(proto.getJvmScalarUdf.getClassName === classOf[CometScalaUDFCodegen].getName)
     assert(dispatched.getTagValue(CometExplainInfo.DISPATCHED_SELF).isEmpty)
     assert(dispatched.getTagValue(CometExplainInfo.CODEGEN_DISPATCH_EXPRS).isEmpty)
-    assert(projection.getTagValue(CometExplainInfo.CODEGEN_DISPATCH_EXPRS).contains(Set("hypot")))
+    assert(
+      projection
+        .getTagValue(CometExplainInfo.CODEGEN_DISPATCH_EXPRS)
+        .contains(Set("hypot", "cast", "checkoverflow", "add")))
   }
 
   test("tags copied onto the shared TrueLiteral do not leak into unrelated plans") {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5848.

## Rationale for this change

`CometCodegenSuite."codegen dispatch coverage survives the decimal promotion rewrite"` fails on main and takes the `[expressions]` job down on all five Spark profiles, so every PR opened against main is red for a reason unrelated to its own changes:

```
Some(Set("hypot", "cast", "checkoverflow", "add")) did not contain Set("hypot")
(CometCodegenSuite.scala:431)
```

The behaviour is correct and the assertion is stale. #5610 deliberately started naming every expression in a dispatched subtree rather than only its root: the whole subtree is bound and closure-serialized into one kernel, so all of it ran in the JVM, and naming only the root would let a test assert that a nested `abs` was native while an `abs` was in fact running inside the kernel. That PR regenerated the q78 plan-stability goldens for the wider dispatcher list but did not update this assertion, which predates it.

## What changes are included in this PR?

Expect the promoted subtree's full set in that assertion: `hypot`, its `cast`, the `checkoverflow` wrapper decimal promotion adds around the `add`, and the `add`. The surrounding comment now says why the set has more than the root in it, and why `checkoverflow` appearing is the thing that makes the assertion evidence that the promoted copy, not the original tree, was recorded.

No production code changes.

## How are these changes tested?

`CometCodegenSuite` passes in full (96 tests) on Spark 4.1. The failing assertion was confirmed red on a clean checkout of main first, and the actual set is identical on all five profiles in CI (3.4, 3.5, 4.0, 4.1, 4.2), so no version-specific expectation is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtAqq4YJsk8uk42c7vHk8B
