### PR TITLE
ci: retry the Maven wrapper bootstrap in every job that calls ./mvnw directly

### DIFF
--- a/.github/actions/maven-bootstrap/action.yaml
+++ b/.github/actions/maven-bootstrap/action.yaml
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: "Bootstrap Maven"
+description: >
+  Make ./mvnw usable, tolerating a flaky download of the Maven distribution
+  itself. Caches the distribution outside the dependency repository and retries
+  only the wrapper bootstrap, never compilation or test execution.
+
+runs:
+  using: "composite"
+  steps:
+    # Maven itself is stored outside the dependency repository. Keep its cache
+    # independent of pom.xml changes and preserve the macOS cache workaround.
+    - name: Restore Maven distribution
+      id: maven-distribution
+      if: ${{ runner.os != 'macOS' }}
+      uses: actions/cache/restore@v5
+      with:
+        path: |
+          ~/.m2/wrapper/dists
+          /root/.m2/wrapper/dists
+        key: ${{ runner.os }}-${{ runner.arch }}-maven-wrapper-${{ hashFiles('.mvn/wrapper/maven-wrapper.properties') }}
+
+    # Delays use exponential backoff (10s, 20s, 40s) plus 0-4s of random jitter.
+    - name: Bootstrap Maven
+      shell: bash
+      run: |
+        for attempt in 1 2 3 4; do
+          if ./mvnw -B --version; then
+            break
+          fi
+          if [ "$attempt" -eq 4 ]; then
+            echo "::error::Maven bootstrap failed after $attempt attempts; the job was not started."
+            exit 1
+          fi
+          delay=$((10 * (1 << (attempt - 1)) + RANDOM % 5))
+          echo "::warning::Maven bootstrap attempt $attempt failed; retrying in ${delay}s."
+          sleep "$delay"
+        done
+
+    # Save a successful bootstrap even when the work that follows fails.
+    - name: Save Maven distribution
+      if: ${{ runner.os != 'macOS' && steps.maven-distribution.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v5
+      with:
+        path: |
+          ~/.m2/wrapper/dists
+          /root/.m2/wrapper/dists
+        key: ${{ steps.maven-distribution.outputs.cache-primary-key }}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -280,9 +280,18 @@ before any test has started. Once `Required Checks` is a required context
 which is why plain network flakes are worth retrying rather than re-running
 the whole pipeline by hand.
 
-**Maven wrapper bootstrap.** `./.github/actions/java-test` retries
-`./mvnw --version` with exponential backoff, so a failed download of the Maven
-distribution does not surface as a test failure.
+**Maven wrapper bootstrap.** `./mvnw` downloads the Maven distribution itself on
+a cold runner, and a blip from `repo.maven.apache.org` fails the job before
+anything is compiled. `./.github/actions/maven-bootstrap` caches that
+distribution under `~/.m2/wrapper/dists` (keyed on
+`.mvn/wrapper/maven-wrapper.properties`, not `pom.xml`) and retries
+`./mvnw --version` four times with exponential backoff. It retries only the
+bootstrap, never compilation or test execution.
+
+Any job whose first Maven use is a bare `./mvnw` needs this step before it.
+`./.github/actions/java-test` carries its own inline copy rather than calling
+the composite, because a local action invoking another local action is
+deliberately avoided here (see the artifact-upload note above).
 
 ## Merge queue
 

--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -138,6 +138,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-java-maven-
 
+      - name: Bootstrap Maven
+        uses: ./.github/actions/maven-bootstrap
+
       - name: Run scalafix check
         run: |
           ./mvnw -B package -DskipTests scalafix:scalafix -Dscalafix.mode=CHECK -Psemanticdb ${{ matrix.profile.maven_opts }}
@@ -192,6 +195,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-java-maven-
 
+      - name: Bootstrap Maven
+        uses: ./.github/actions/maven-bootstrap
+
       - name: Compile (skip tests)
         run: ./mvnw -B install -DskipTests -Dmaven.test.skip=true -Pspark-4.1
 
@@ -225,6 +231,9 @@ jobs:
           key: ${{ runner.os }}-java-maven-${{ hashFiles('**/pom.xml') }}-celeborn-${{ matrix.celeborn_version }}
           restore-keys: |
             ${{ runner.os }}-java-maven-
+
+      - name: Bootstrap Maven
+        uses: ./.github/actions/maven-bootstrap
 
       - name: Verify reflected Celeborn internals
         env:
@@ -584,6 +593,11 @@ jobs:
           path: ./tpch
           key: tpch-${{ hashFiles('.github/workflows/pr_build_linux.yml') }}
 
+      # Without this, a transient repo.maven.apache.org blip fails the whole
+      # job before anything is compiled.
+      - name: Bootstrap Maven
+        uses: ./.github/actions/maven-bootstrap
+
       - name: Build project
         run: |
           ./mvnw -B -Prelease install -DskipTests
@@ -638,6 +652,11 @@ jobs:
         with:
           path: ./tpcds-sf-1
           key: tpcds-${{ hashFiles('.github/workflows/pr_build_linux.yml') }}
+
+      # Without this, a transient repo.maven.apache.org blip fails the whole
+      # job before anything is compiled.
+      - name: Bootstrap Maven
+        uses: ./.github/actions/maven-bootstrap
 
       - name: Build project
         run: |

--- a/dev/ci/check-ci-config.py
+++ b/dev/ci/check-ci-config.py
@@ -103,6 +103,8 @@ ROUTING_CASES = [
     # to nothing at all and merges having been exercised by no consumer.
     ([".github/actions/upload-artifact-retry/action.yaml"], BUILD_JOBS),
     ([".github/actions/download-artifact-retry/action.yaml"], BUILD_JOBS),
+    # The Maven bootstrap composite is called only from pr_build_linux.yml.
+    ([".github/actions/maven-bootstrap/action.yaml"], {"build_linux"}),
     # Spot checks that the additions above did not widen unrelated routes.
     (["docs/source/user-guide/overview.md"], {"docs"}),
     (["native/core/benches/parquet_read.rs"], {"benchmark"}),

--- a/dev/ci/compute-changes.py
+++ b/dev/ci/compute-changes.py
@@ -55,6 +55,7 @@ FILTERS = {
         ".github/workflows/pr_build_linux.yml",
         ".github/actions/setup-builder/**",
         ".github/actions/java-test/**",
+        ".github/actions/maven-bootstrap/**",
         ".github/actions/rust-test/**",
         ".github/actions/upload-artifact-retry/**",
         ".github/actions/download-artifact-retry/**",


### PR DESCRIPTION
## Which issue does this PR close?

No issue — found while investigating a CI failure on #5850.

## Rationale for this change

`Verify TPC-H Results` failed on #5850 at its `Build project` step, 105 seconds in and before anything was compiled. The check-run annotation names the cause:

```
https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
```

That's `./mvnw` downloading the Maven distribution itself — not a dependency, not a test. Nothing to do with TPC-H, and nothing to do with the PR it failed on (which only touched CI config).

We already handle this. `./.github/actions/java-test` caches the distribution under `~/.m2/wrapper/dists` and retries `./mvnw --version` four times with exponential backoff. The problem is that five jobs in `pr_build_linux.yml` don't go through `java-test` — they call `./mvnw` directly — so they had neither the cache nor the retry:

| Job | First Maven use |
| --- | --- |
| `lint-java` | scalafix check |
| `build-spark-4-1` | compile, skip tests |
| `celeborn-reflection-compatibility` | reflected-internals check |
| `verify-benchmark-results-tpch` | the job that failed |
| `verify-benchmark-results-tpcds` | same shape as TPC-H |

The workflows README claims this failure mode is handled. It is, but only for jobs routed through `java-test`.

This also matters for #5838: under a merge queue these jobs gate the queue, so a bootstrap blip would block *every* merge rather than costing one PR a re-run.

## What changes are included in this PR?

Extracts the restore/retry/save sequence into `./.github/actions/maven-bootstrap` and calls it from all five jobs before their first Maven use.

Registers the new action in the Linux change filter (`FILTERS['build_linux']` in `dev/ci/compute-changes.py`) and pins that routing with a case in `dev/ci/check-ci-config.py`. Per @sunchao's review: without it, a later edit confined to `.github/actions/maven-bootstrap/**` routes to nothing — the `changes` gate reports `build_linux=false`, `ci.yml` skips the whole Linux workflow, and the edit merges without any of the five consumers having run it. This PR didn't expose the gap only because it also edits `pr_build_linux.yml`.

`java-test` keeps its inline copy rather than calling the new composite. A local action invoking another local action is deliberately avoided in this repo — the README already says as much about the artifact-upload wrapper — and converting `java-test` would be a bigger, riskier change than the bug warrants.

The README wording is corrected to say which jobs are actually covered.

## How are these changes tested?

CI on this PR is the test: all five jobs exercise the new step, and `lint-java`, `build-spark-4-1` and `celeborn-reflection-compatibility` are the fast ones that will show it working within a few minutes.

Locally I verified with a script over the parsed workflow that every job invoking `./mvnw` now either uses `java-test` or has `maven-bootstrap` at a lower line number than its first Maven call — all five report OK, none regress.

For the routing: with `.github/actions/maven-bootstrap/action.yaml` as the only changed file, `EVENT_NAME=pull_request dev/ci/compute-changes.py` now reports `build_linux=true` and every other output `false`; drop the filter line and it goes back to `false`, and `check-ci-config.py` fails with exactly that. `check-suites.py`, `check-benchmark-runner.py`, `test-iceberg-shards.py`, `check-ci-config.py`, `actionlint`, `apache-rat:check` and `prettier --check "**/*.md"` are all clean.

The retry path itself can't be exercised without an actual network failure; the logic is copied verbatim from `java-test`, where it has been in use already.

Rebased onto `main` to pick up #5849 — the five red `[expressions]` jobs on the previous CI run were the pre-existing `CometCodegenSuite` decimal-promotion breakage from #5610, not anything in this PR. Those jobs go through `java-test`, which this PR doesn't touch.

## Notes for reviewers

Same gap exists in `ci.yml`'s RAT check and the direct `./mvnw` calls in `pr_benchmark_check.yml`, `pyarrow_udf_test.yml` and `iceberg_spark_test_reusable.yml`. I left those out to keep this reviewable against the failure that prompted it — happy to extend it if you'd rather do them all at once. `ci.yml`'s preflight is arguably the most valuable of those, since it gates the whole pipeline.
