### PR TITLE
fix: dispatch map lookups with normalized keys and nondeterministic null-guarded children

### DIFF
--- a/docs/source/user-guide/latest/expressions.md
+++ b/docs/source/user-guide/latest/expressions.md
@@ -148,7 +148,7 @@ The tables below list every Spark built-in expression with its current status.
 | Function | Status | Implementation | Notes |
 | --- | --- | --- | --- |
 | `array` | ✅ | Native |  |
-| `array_append` | ✅ | Native |  |
+| `array_append` | ✅ | Hybrid |  |
 | `array_compact` | ✅ | — |  |
 | `array_contains` | ✅ | Native | NaN/signed-zero handling may differ ([details](compatibility/floating-point.md)) |
 | `array_distinct` | ✅ | Native | NaN/signed-zero handling may differ ([details](compatibility/floating-point.md)) |
@@ -164,8 +164,8 @@ The tables below list every Spark built-in expression with its current status.
 | `array_repeat` | ✅ | Native |  |
 | `array_union` | ✅ | Native | NaN/signed-zero handling may differ ([details](compatibility/floating-point.md)) |
 | `arrays_overlap` | ✅ | Native |  |
-| `arrays_zip` | ✅ | Native |  |
-| `element_at` | ✅ | Native |  |
+| `arrays_zip` | ✅ | Hybrid |  |
+| `element_at` | ✅ | Hybrid |  |
 | `flatten` | ✅ | Native | Binary/struct/map elements fall back |
 | `get` | ✅ | — |  |
 | `sequence` | ✅ | Hybrid | Integral types run natively; date/timestamp sequences use codegen dispatch |
@@ -202,7 +202,7 @@ The tables below list every Spark built-in expression with its current status.
 | `cardinality` | ✅ | Native |  |
 | `concat` | ✅ | Hybrid | Binary/array children fall back |
 | `reverse` | ✅ | Hybrid | Binary-element arrays fall back (Incompatible) ([details](compatibility/expressions/array.md)) |
-| `size` | ✅ | Native |  |
+| `size` | ✅ | Hybrid |  |
 
 ---
 
@@ -395,12 +395,12 @@ The type-name conversion functions (`bigint`, `binary`, `boolean`, `date`, `deci
 
 | Function | Status | Implementation | Notes |
 | --- | --- | --- | --- |
-| `element_at` | ✅ | Native |  |
+| `element_at` | ✅ | Hybrid |  |
 | `map` | ✅ | Codegen dispatch | Routed through the JVM codegen dispatcher |
 | `map_concat` | ✅ | Codegen dispatch |  |
 | `map_contains_key` | ✅ | — |  |
 | `map_entries` | ✅ | Native |  |
-| `map_from_arrays` | ✅ | Native |  |
+| `map_from_arrays` | ✅ | Hybrid |  |
 | `map_from_entries` | ✅ | Hybrid | BinaryType key/value falls back (Incompatible) ([details](compatibility/expressions/map.md)) |
 | `map_keys` | ✅ | Native |  |
 | `map_values` | ✅ | Native |  |

--- a/spark/src/main/scala/org/apache/comet/serde/arrays.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/arrays.scala
@@ -51,7 +51,37 @@ object CometArrayRemove
   }
 }
 
-object CometArrayAppend extends CometExpressionSerde[ArrayAppend] with ArraysBase {
+/**
+ * Shared gate for serdes whose native NULL guard (`CASE WHEN child IS NOT NULL`) serializes the
+ * child twice: a stateful child drifts between the two copies, so it is declined and runs through
+ * the JVM codegen dispatcher, where Spark evaluates it once. Nullability is not consulted: a
+ * non-nullable stateful child only stays in step because DataFusion skips the filter when the
+ * guard matches every row, which is not a contract to lean on.
+ */
+private[serde] object NullGuardSupport {
+
+  val nondeterministicReason: String =
+    "a nondeterministic operand: the native NULL guard serializes the operand twice, " +
+      "and the two copies of a stateful operand drift apart"
+
+  /** `Unsupported` when any of `children` is nondeterministic, otherwise `None`. */
+  def nondeterministicChild(children: Seq[Expression]): Option[SupportLevel] =
+    children
+      .find(child => !child.deterministic)
+      .map(_ => Unsupported(Some(nondeterministicReason)))
+}
+
+object CometArrayAppend
+    extends CometExpressionSerde[ArrayAppend]
+    with ArraysBase
+    with CodegenDispatchFallback {
+
+  override def getUnsupportedReasons(): Seq[String] =
+    Seq(NullGuardSupport.nondeterministicReason)
+
+  // Only the array operand sits under the NULL guard, so only it needs the decline.
+  override def getSupportLevel(expr: ArrayAppend): SupportLevel =
+    NullGuardSupport.nondeterministicChild(Seq(expr.children.head)).getOrElse(Compatible())
 
   override def convert(
       expr: ArrayAppend,
@@ -614,7 +644,7 @@ object CometArrayReverse extends CometExpressionSerde[Reverse] with ArraysBase {
 
 }
 
-object CometElementAt extends CometExpressionSerde[ElementAt] {
+object CometElementAt extends CometExpressionSerde[ElementAt] with CodegenDispatchFallback {
 
   /**
    * Under ANSI, neither native shape reproduces Spark for a nullable nondeterministic operand.
@@ -623,8 +653,9 @@ object CometElementAt extends CometExpressionSerde[ElementAt] {
    * whole batch first, so a throwing index fires on rows whose operand is NULL. `convert`
    * reproduces the short-circuit with a `CASE WHEN <operand> IS NOT NULL` guard, but that guard
    * serializes the operand twice, which a stateful operand cannot survive: the two copies advance
-   * its state independently and silently move values and NULLs. Declining leaves the lookup on
-   * Spark. Lifting this needs a native lookup that evaluates the operand once and masks the index
+   * its state independently and silently move values and NULLs. Declining routes the lookup
+   * through the JVM codegen dispatcher, where Spark's own `doGenCode` evaluates the operand once.
+   * Lifting this needs a native lookup that evaluates the operand once and masks the index
    * evaluation with the result, at which point the guard becomes unnecessary for every operand.
    */
   private val eagerIndexReason: String =
@@ -634,6 +665,8 @@ object CometElementAt extends CometExpressionSerde[ElementAt] {
   /** True when `convert` has to wrap the lookup to reproduce Spark's NULL short-circuit. */
   private def needsNullGuard(expr: ElementAt): Boolean =
     expr.failOnError && expr.left.nullable
+
+  override def getUnsupportedReasons(): Seq[String] = eagerIndexReason +: MapKeySupport.reasons
 
   override def getSupportLevel(expr: ElementAt): SupportLevel = {
     if (needsNullGuard(expr) && !expr.left.deterministic) {
@@ -764,14 +797,19 @@ object CometArrayFilter extends CometExpressionSerde[ArrayFilter] {
   }
 }
 
-object CometSize extends CometExpressionSerde[Size] {
+object CometSize extends CometExpressionSerde[Size] with CodegenDispatchFallback {
+
+  override def getUnsupportedReasons(): Seq[String] =
+    Seq(NullGuardSupport.nondeterministicReason)
 
   override def getSupportLevel(expr: Size): SupportLevel = {
-    expr.child.dataType match {
-      case _: ArrayType => Compatible()
-      case _: MapType => Compatible()
-      case other =>
-        Unsupported(Some(s"Unsupported child data type: $other"))
+    NullGuardSupport.nondeterministicChild(Seq(expr.child)).getOrElse {
+      expr.child.dataType match {
+        case _: ArrayType => Compatible()
+        case _: MapType => Compatible()
+        case other =>
+          Unsupported(Some(s"Unsupported child data type: $other"))
+      }
     }
   }
 
@@ -843,10 +881,12 @@ object CometArrayPosition extends CometExpressionSerde[ArrayPosition] with Array
   }
 }
 
-object CometArraysZip extends CometExpressionSerde[ArraysZip] {
+object CometArraysZip extends CometExpressionSerde[ArraysZip] with CodegenDispatchFallback {
 
   override def getUnsupportedReasons(): Seq[String] = Seq(
-    "Not all input data types are supported; falls back to Spark for unsupported types")
+    "Not all input data types are supported; unsupported types run through the JVM codegen " +
+      "dispatcher",
+    NullGuardSupport.nondeterministicReason)
 
   private def isTypeSupported(dt: DataType): Boolean = {
     import DataTypes._
@@ -862,13 +902,13 @@ object CometArraysZip extends CometExpressionSerde[ArraysZip] {
   }
 
   override def getSupportLevel(expr: ArraysZip): SupportLevel = {
-    val inputTypes = expr.children.map(_.dataType).toSet
-    for (dt <- inputTypes) {
-      if (!isTypeSupported(dt)) {
-        return Unsupported(Some(s"Unsupported child data type: $dt"))
-      }
+    NullGuardSupport.nondeterministicChild(expr.children).getOrElse {
+      expr.children
+        .map(_.dataType)
+        .collectFirst { case dt if !isTypeSupported(dt) => dt }
+        .map(dt => Unsupported(Some(s"Unsupported child data type: $dt")))
+        .getOrElse(Compatible())
     }
-    Compatible()
   }
 
   override def convert(

--- a/spark/src/main/scala/org/apache/comet/serde/maps.scala
+++ b/spark/src/main/scala/org/apache/comet/serde/maps.scala
@@ -29,7 +29,8 @@ import org.apache.comet.shims.CometTypeShim
 
 /**
  * Shared gate for the native map kernels that compare a lookup key against a map's stored keys
- * (`map_extract`, reached from both `GetMapValue` and `ElementAt`).
+ * (`map_extract`, reached from both `GetMapValue` and `ElementAt`). Both consumers mix in
+ * `CodegenDispatchFallback`, so a declined key type runs through Spark's own `doGenCode`.
  */
 private[serde] object MapKeySupport {
 
@@ -45,6 +46,8 @@ private[serde] object MapKeySupport {
     "Comet's native `map_extract` casts the lookup key to the map's exact Arrow key type, which " +
       "cannot reproduce Spark's equality for a complex key type (for example a `NULL` inside the " +
       "lookup key aborts the cast against a non-nullable nested component)."
+
+  val reasons: Seq[String] = Seq(floatingPointReason, collationReason, complexKeyReason)
 
   /**
    * The `SupportLevel` for a map-consuming expression whose stored-key type is `keyType`. Spark
@@ -114,7 +117,9 @@ object CometMapValues extends CometExpressionSerde[MapValues] {
   }
 }
 
-object CometMapExtract extends CometExpressionSerde[GetMapValue] {
+object CometMapExtract extends CometExpressionSerde[GetMapValue] with CodegenDispatchFallback {
+
+  override def getUnsupportedReasons(): Seq[String] = MapKeySupport.reasons
 
   override def getSupportLevel(expr: GetMapValue): SupportLevel = expr.child.dataType match {
     case MapType(keyType, _, _) => MapKeySupport.keySupport(keyType)
@@ -151,19 +156,26 @@ private object MapKeyDedupPolicySupport {
       .equalsIgnoreCase(SQLConf.MapKeyDedupPolicy.LAST_WIN.toString)
 }
 
-object CometMapFromArrays extends CometExpressionSerde[MapFromArrays] {
+object CometMapFromArrays
+    extends CometExpressionSerde[MapFromArrays]
+    with CodegenDispatchFallback {
 
   override def getIncompatibleReasons(): Seq[String] =
     Seq(MapKeyDedupPolicySupport.incompatibleReason)
+
+  override def getUnsupportedReasons(): Seq[String] =
+    Seq(NullGuardSupport.nondeterministicReason)
 
   override def getCompatibleNotes(): Seq[String] =
     Seq(MapKeyDedupPolicySupport.nullKeyReason)
 
   override def getSupportLevel(expr: MapFromArrays): SupportLevel = {
-    if (MapKeyDedupPolicySupport.isLastWin) {
-      Incompatible(Some(MapKeyDedupPolicySupport.incompatibleReason))
-    } else {
-      Compatible(None)
+    NullGuardSupport.nondeterministicChild(expr.children).getOrElse {
+      if (MapKeyDedupPolicySupport.isLastWin) {
+        Incompatible(Some(MapKeyDedupPolicySupport.incompatibleReason))
+      } else {
+        Compatible(None)
+      }
     }
   }
 

--- a/spark/src/test/resources/sql-tests/expressions/array/array_append_nondeterministic_child.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/array_append_nondeterministic_child.sql
@@ -1,0 +1,55 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- `CometArrayAppend` reproduces Spark's NULL propagation with a `CASE WHEN array IS NOT NULL`
+-- guard that serializes the array twice. A stateful array advances each copy independently, so
+-- the guard and the `array_append` see different rows and the result silently drifts from Spark.
+-- The serde declines a nondeterministic array and routes it through the JVM codegen
+-- dispatcher, which evaluates it once. A deterministic nullable array keeps the native guard.
+--
+-- Spark 4.0 rewrites `array_append` to `array_insert(-1)` before serde, so `CometArrayAppend` is
+-- only reachable on Spark 3.x.
+
+-- MaxSparkVersion: 3.5
+
+statement
+CREATE TABLE test_array_append_nondet(_1 int) USING parquet
+
+statement
+INSERT INTO test_array_append_nondet VALUES
+  (0), (1), (2), (3), (4), (5), (6), (7), (8), (9), (10), (11), (12), (13), (14), (15)
+
+-- Spark returns [1, 2] on every row whose array is non-NULL and NULL on the rest.
+query expect_dispatch(array_append)
+SELECT _1, array_append(IF(monotonically_increasing_id() % 2 = 0, array(1), CAST(NULL AS ARRAY<INT>)), 2) AS a
+FROM test_array_append_nondet
+
+-- A deterministic nullable array stays on the native guarded path.
+-- A non-nullable stateful array is declined too, rather than relying on the guard matching
+-- every row.
+query expect_dispatch(array_append)
+SELECT _1, array_append(array(monotonically_increasing_id()), 2) AS a
+FROM test_array_append_nondet
+
+-- Only the array operand sits under the guard; a stateful item stays native.
+query expect_native(array_append)
+SELECT _1, array_append(array(1), monotonically_increasing_id()) AS a
+FROM test_array_append_nondet
+
+query expect_native(array_append)
+SELECT _1, array_append(IF(_1 % 2 = 0, array(1), CAST(NULL AS ARRAY<INT>)), 2) AS a
+FROM test_array_append_nondet

--- a/spark/src/test/resources/sql-tests/expressions/array/arrays_zip_nondeterministic_child.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/arrays_zip_nondeterministic_child.sql
@@ -1,0 +1,51 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- `CometArraysZip` reproduces Spark's NULL propagation with a `CASE WHEN` guard over every
+-- child's `IS NOT NULL`, which serializes each child twice. A stateful child advances each copy
+-- independently, so the guard and the `arrays_zip` see different rows and the result silently
+-- drifts from Spark. The serde declines a nondeterministic child and routes it through
+-- the JVM codegen dispatcher, which evaluates it once. A deterministic nullable child keeps the
+-- native guard.
+
+statement
+CREATE TABLE test_arrays_zip_nondet(_1 int) USING parquet
+
+statement
+INSERT INTO test_arrays_zip_nondet VALUES
+  (0), (1), (2), (3), (4), (5), (6), (7), (8), (9), (10), (11), (12), (13), (14), (15)
+
+-- Spark returns [{1, 2}] on every row whose first array is non-NULL and NULL on the rest.
+query expect_dispatch(arrays_zip)
+SELECT _1, arrays_zip(IF(monotonically_increasing_id() % 2 = 0, array(1), CAST(NULL AS ARRAY<INT>)), array(2)) AS z
+FROM test_arrays_zip_nondet
+
+-- The guard covers every child, so a stateful second child is declined the same way.
+query expect_dispatch(arrays_zip)
+SELECT _1, arrays_zip(array(2), IF(monotonically_increasing_id() % 2 = 0, array(1), CAST(NULL AS ARRAY<INT>))) AS z
+FROM test_arrays_zip_nondet
+
+-- A deterministic nullable child stays on the native guarded path.
+-- A non-nullable stateful child is declined too, rather than relying on the guard matching
+-- every row.
+query expect_dispatch(arrays_zip)
+SELECT _1, arrays_zip(array(monotonically_increasing_id()), array(2)) AS z
+FROM test_arrays_zip_nondet
+
+query expect_native(arrays_zip)
+SELECT _1, arrays_zip(IF(_1 % 2 = 0, array(1), CAST(NULL AS ARRAY<INT>)), array(2)) AS z
+FROM test_arrays_zip_nondet

--- a/spark/src/test/resources/sql-tests/expressions/array/element_at_ansi.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/element_at_ansi.sql
@@ -101,14 +101,16 @@ query
 SELECT id, element_at(CASE WHEN id <> 2 THEN array(1) END, 1) AS v
 FROM ansi_element_at_null
 
--- A nondeterministic operand is declined outright. Neither native shape reproduces Spark: the
+-- A nondeterministic operand has no native shape that reproduces Spark: the
 -- `CASE WHEN <array> IS NOT NULL` guard serializes the operand twice, so a stateful operand's two
 -- copies drift, and the unguarded lookup evaluates the index over the whole batch, raising
--- DIVIDE_BY_ZERO at id = 2 on the very row whose array is NULL. `rand(7L) < 2` is always true, so
+-- DIVIDE_BY_ZERO at id = 2 on the very row whose array is NULL. The serde declines it and the
+-- lookup runs through the JVM codegen dispatcher, where Spark's own `ElementAt.doGenCode`
+-- evaluates the operand once and short-circuits the index. `rand(7L) < 2` is always true, so
 -- both operands are NULL on every row and Spark returns NULL without evaluating either index.
 -- The non-ANSI spelling stays native and is covered in element_at.sql.
 -- https://github.com/apache/datafusion-comet/issues/5544
-query expect_fallback(nullable nondeterministic array or map operand)
+query expect_dispatch(element_at)
 SELECT id,
        element_at(IF(monotonically_increasing_id() % 2 = 0, CAST(NULL AS ARRAY<INT>), array(1)), 1) AS v1,
        element_at(IF(rand(7L) < 2, CAST(NULL AS ARRAY<INT>), array(1)), 1 + (id % (id - 2))) AS v2

--- a/spark/src/test/resources/sql-tests/expressions/array/size_nondeterministic_child.sql
+++ b/spark/src/test/resources/sql-tests/expressions/array/size_nondeterministic_child.sql
@@ -1,0 +1,47 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- `CometSize` reproduces Spark's NULL propagation with a `CASE WHEN child IS NOT NULL` guard
+-- that serializes the child twice. A stateful child advances each copy independently, so the
+-- guard and the `size` see different rows and the result silently drifts from Spark. The serde
+-- declines any nondeterministic child and routes it through the JVM codegen dispatcher, which
+-- evaluates the child once. A deterministic nullable child keeps the native guard.
+
+-- ConfigMatrix: spark.sql.legacy.sizeOfNull=true,false
+
+statement
+CREATE TABLE test_size_nondet(_1 int) USING parquet
+
+statement
+INSERT INTO test_size_nondet VALUES
+  (0), (1), (2), (3), (4), (5), (6), (7), (8), (9), (10), (11), (12), (13), (14), (15)
+
+-- Spark returns 1 on every row whose array is non-NULL and the sentinel on the rest.
+query expect_dispatch(size)
+SELECT _1, size(IF(monotonically_increasing_id() % 2 = 0, array(1), CAST(NULL AS ARRAY<INT>))) AS s
+FROM test_size_nondet
+
+-- A non-nullable stateful child is declined too, rather than relying on the guard matching
+-- every row.
+query expect_dispatch(size)
+SELECT _1, size(array(monotonically_increasing_id())) AS s
+FROM test_size_nondet
+
+-- A deterministic nullable child stays on the native guarded path.
+query expect_native(size)
+SELECT _1, size(IF(_1 % 2 = 0, array(1), CAST(NULL AS ARRAY<INT>))) AS s
+FROM test_size_nondet

--- a/spark/src/test/resources/sql-tests/expressions/map/element_at_map.sql
+++ b/spark/src/test/resources/sql-tests/expressions/map/element_at_map.sql
@@ -52,30 +52,54 @@ SELECT element_at(mi, CAST(1 AS BIGINT)), element_at(mi, CAST(2 AS SMALLINT)) FR
 query
 SELECT element_at(map('a', 1, 'b', 2), 'a'), element_at(map('a', 1, 'b', 2), 'missing'), element_at(map('a', 1, 'b', 2), NULL)
 
--- Map key types whose Spark equality Comet's native `map_extract` cannot reproduce fall back to
--- Spark. These stay on the constructor path here because the SQL harness excludes
--- `ConstantFolding`; `CometMapExpressionSuite` covers the folded-literal form of each.
+-- Map key types whose Spark equality Comet's native `map_extract` cannot reproduce are routed
+-- through the JVM codegen dispatcher, where Spark's own `ElementAt.doGenCode` supplies the key
+-- normalization and interpreted-ordering equality. These stay on the constructor path here because
+-- the SQL harness excludes `ConstantFolding`; `CometMapExpressionSuite` covers the folded-literal
+-- form of each.
 
 -- Spark stores `-0.0` map keys as `+0.0` and compares with `nanSafeCompareDoubles`, so a `-0.0`
 -- lookup finds the `+0.0` key. Native lookup compares the raw Arrow values.
-query expect_fallback(Spark normalizes floating-point map keys)
+query expect_dispatch(element_at)
 SELECT element_at(map(CAST(0 AS DOUBLE), 7), CAST(-0.0 AS DOUBLE))
 
-query expect_fallback(Spark normalizes floating-point map keys)
+query expect_dispatch(element_at)
 SELECT element_at(map(CAST(0 AS FLOAT), 7), CAST(-0.0 AS FLOAT))
 
+-- Spark's `nanSafeCompareDoubles` treats NaN as equal to itself, so a NaN lookup finds a NaN key.
+query expect_dispatch(element_at)
+SELECT element_at(map(CAST('NaN' AS DOUBLE), 7), CAST('NaN' AS DOUBLE))
+
 -- The floating-point decline walks every nesting level of the key type, so an array-of-double key
--- falls back for the same reason.
-query expect_fallback(Spark normalizes floating-point map keys)
+-- is dispatched for the same reason.
+query expect_dispatch(element_at)
 SELECT element_at(map(array(CAST(0 AS DOUBLE)), 7), array(CAST(-0.0 AS DOUBLE)))
 
 -- A complex key type: `map_extract` casts the lookup key to the map's exact Arrow key type, so a
 -- NULL inside the lookup key would abort the cast instead of missing the lookup.
-query expect_fallback(casts the lookup key to the map's exact Arrow key type)
+query expect_dispatch(element_at)
 SELECT element_at(map(array(1), 7), array(CAST(NULL AS INT)))
 
-query expect_fallback(casts the lookup key to the map's exact Arrow key type)
+query expect_dispatch(element_at)
 SELECT element_at(map(named_struct('a', 1), 7), named_struct('a', 1))
+
+-- A struct-keyed map column with a per-row lookup key, including a NULL inside the lookup struct
+-- and a NULL key.
+statement
+CREATE TABLE test_element_at_struct_key(m map<struct<a:int, b:string>, int>, k int) USING parquet
+
+statement
+INSERT INTO test_element_at_struct_key VALUES
+  (map(named_struct('a', 1, 'b', 'x'), 7), 1),
+  (map(named_struct('a', 2, 'b', 'y'), 8), 3),
+  (map(named_struct('a', 3, 'b', 'z'), 9), NULL),
+  (NULL, 1)
+
+query expect_dispatch(element_at)
+SELECT element_at(m, named_struct('a', k, 'b', 'x')),
+       element_at(m, named_struct('a', k, 'b', CAST(NULL AS STRING))),
+       element_at(m, CAST(NULL AS STRUCT<a:int, b:string>))
+FROM test_element_at_struct_key
 
 -- `BinaryType` keys need no decline: Arrow compares them by content, as Spark's ordering does.
 query

--- a/spark/src/test/resources/sql-tests/expressions/map/element_at_map_collation.sql
+++ b/spark/src/test/resources/sql-tests/expressions/map/element_at_map_collation.sql
@@ -19,8 +19,9 @@
 
 -- Spark 4.0+ supports string collations. Spark compares a map key under its declared collation,
 -- so a `UTF8_LCASE` map matches `A1` against a dynamic `a1` lookup and returns `7`. Comet's native
--- `map_extract` compares string keys as `UTF8_BINARY`, so `CometElementAt` declines the lookup and
--- Spark evaluates the projection. The `element_at` form is used rather than `m[key]` because
+-- `map_extract` compares string keys as `UTF8_BINARY`, so `CometElementAt` declines the native
+-- lookup and routes it through the JVM codegen dispatcher, where Spark's own `ElementAt.doGenCode`
+-- compares under the declared collation. The `element_at` form is used rather than `m[key]` because
 -- Spark's `SimplifyExtractValueOps` rewrites `map(...)[key]` over a literal map into a `CASE`
 -- before it can reach the native map lookup.
 
@@ -30,6 +31,6 @@ CREATE TABLE test_element_at_collation(k string) USING parquet
 statement
 INSERT INTO test_element_at_collation VALUES ('a1'), ('A1'), ('zz'), (NULL)
 
-query expect_fallback(cannot honour a non-default collation)
+query expect_dispatch(element_at)
 SELECT element_at(map(CAST('A1' AS STRING COLLATE UTF8_LCASE), 7), CAST(k AS STRING COLLATE UTF8_LCASE))
 FROM test_element_at_collation

--- a/spark/src/test/resources/sql-tests/expressions/map/get_map_value.sql
+++ b/spark/src/test/resources/sql-tests/expressions/map/get_map_value.sql
@@ -31,9 +31,11 @@ SELECT m['x'], m['missing'] FROM test_map
 query spark_answer_only
 SELECT map('a', 1, 'b', 2)['a'], map('a', 1, 'b', 2)['missing'], map('a', 1, 'b', 2)[NULL]
 
--- Map key types whose Spark equality Comet's native `map_extract` cannot reproduce fall back to
--- Spark. `x[key]` routes through `GetMapValue` / `CometMapExtract` (the `element_at` form in
--- `element_at_map.sql` exercises the same guard on `CometElementAt`). A `map<double,int>` column
+-- Map key types whose Spark equality Comet's native `map_extract` cannot reproduce are routed
+-- through the JVM codegen dispatcher, where Spark's own `GetMapValue.doGenCode` supplies the key
+-- normalization and interpreted-ordering equality. `x[key]` routes through `GetMapValue` /
+-- `CometMapExtract` (the `element_at` form in `element_at_map.sql` exercises the same guard on
+-- `CometElementAt`). A `map<double,int>` column
 -- is used rather than a `map(...)` literal because Spark's `SimplifyExtractValueOps` rewrites
 -- `map(...)[key]` over a literal map into a `CASE` before it can reach the native lookup. Spark
 -- stores a `-0.0` key as `+0.0` and finds it with `nanSafeCompareDoubles`, so it returns `7` for a
@@ -44,5 +46,31 @@ CREATE TABLE test_map_double(m map<double, int>) USING parquet
 statement
 INSERT INTO test_map_double VALUES (map(CAST(0 AS DOUBLE), 7)), (map(CAST(1 AS DOUBLE), 8)), (NULL)
 
-query expect_fallback(Spark normalizes floating-point map keys)
+query expect_dispatch(getmapvalue)
 SELECT m[CAST(-0.0 AS DOUBLE)] FROM test_map_double
+
+-- A NaN key is found by a NaN lookup, as `nanSafeCompareDoubles` treats NaN as equal to itself.
+statement
+INSERT INTO test_map_double VALUES (map(CAST('NaN' AS DOUBLE), 9))
+
+query expect_dispatch(getmapvalue)
+SELECT m[CAST('NaN' AS DOUBLE)] FROM test_map_double
+
+-- A struct-keyed map column with a per-row lookup key, including a NULL inside the lookup struct
+-- and a NULL key. Native `map_extract` would cast the lookup key to the map's exact Arrow key type,
+-- which cannot reproduce Spark's equality for a complex key, so the lookup is dispatched.
+statement
+CREATE TABLE test_map_struct_key(m map<struct<a:int, b:string>, int>, k int) USING parquet
+
+statement
+INSERT INTO test_map_struct_key VALUES
+  (map(named_struct('a', 1, 'b', 'x'), 7), 1),
+  (map(named_struct('a', 2, 'b', 'y'), 8), 3),
+  (map(named_struct('a', 3, 'b', 'z'), 9), NULL),
+  (NULL, 1)
+
+query expect_dispatch(getmapvalue)
+SELECT m[named_struct('a', k, 'b', 'x')],
+       m[named_struct('a', k, 'b', CAST(NULL AS STRING))],
+       m[CAST(NULL AS STRUCT<a:int, b:string>)]
+FROM test_map_struct_key

--- a/spark/src/test/resources/sql-tests/expressions/map/map_from_arrays_dedup_policy.sql
+++ b/spark/src/test/resources/sql-tests/expressions/map/map_from_arrays_dedup_policy.sql
@@ -17,10 +17,14 @@
 
 -- Verifies that `map_from_arrays` falls back to Spark when `spark.sql.mapKeyDedupPolicy` is set
 -- to `LAST_WIN`. Spark's ArrayBasedMapBuilder keeps the last occurrence of each duplicate key;
--- Comet's native `map` scalar has no LAST_WIN path, so it must fall back. The default `EXCEPTION`
--- mode agrees with Comet and is covered by `map_from_arrays.sql`.
+-- Comet's native `map` scalar has no LAST_WIN path. `CometMapFromArrays` mixes in
+-- `CodegenDispatchFallback`, so its native `Incompatible` normally routes through the JVM codegen
+-- dispatcher; we disable the dispatcher here so the incompat branch surfaces as a genuine Spark
+-- fallback rather than in-pipeline codegen. The default `EXCEPTION` mode agrees with Comet and is
+-- covered by `map_from_arrays.sql`.
 
 -- Config: spark.sql.mapKeyDedupPolicy=LAST_WIN
+-- Config: spark.comet.exec.scalaUDF.codegen.enabled=false
 
 statement
 CREATE TABLE test_map_from_arrays_dedup(k array<string>, v array<int>) USING parquet

--- a/spark/src/test/resources/sql-tests/expressions/map/map_from_arrays_nondeterministic_child.sql
+++ b/spark/src/test/resources/sql-tests/expressions/map/map_from_arrays_nondeterministic_child.sql
@@ -1,0 +1,51 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- `CometMapFromArrays` reproduces Spark's NULL propagation with a `CASE WHEN keys IS NOT NULL AND
+-- values IS NOT NULL` guard that serializes both children twice. A stateful child advances each
+-- copy independently, so the guard and the `map` see different rows and the result silently
+-- drifts from Spark. The serde declines a nondeterministic child and routes it through
+-- the JVM codegen dispatcher, which evaluates it once. A deterministic nullable child keeps the
+-- native guard.
+
+statement
+CREATE TABLE test_map_from_arrays_nondet(_1 int) USING parquet
+
+statement
+INSERT INTO test_map_from_arrays_nondet VALUES
+  (0), (1), (2), (3), (4), (5), (6), (7), (8), (9), (10), (11), (12), (13), (14), (15)
+
+-- Spark returns {1 -> 2} on every row whose keys array is non-NULL and NULL on the rest.
+query expect_dispatch(map_from_arrays)
+SELECT _1, map_from_arrays(IF(monotonically_increasing_id() % 2 = 0, array(1), CAST(NULL AS ARRAY<INT>)), array(2)) AS m
+FROM test_map_from_arrays_nondet
+
+-- The guard covers both children, so a stateful values array is declined the same way.
+query expect_dispatch(map_from_arrays)
+SELECT _1, map_from_arrays(array(1), IF(monotonically_increasing_id() % 2 = 0, array(2), CAST(NULL AS ARRAY<INT>))) AS m
+FROM test_map_from_arrays_nondet
+
+-- A deterministic nullable child stays on the native guarded path.
+-- A non-nullable stateful child is declined too, rather than relying on the guard matching
+-- every row.
+query expect_dispatch(map_from_arrays)
+SELECT _1, map_from_arrays(array(monotonically_increasing_id()), array(2)) AS m
+FROM test_map_from_arrays_nondet
+
+query expect_native(map_from_arrays)
+SELECT _1, map_from_arrays(IF(_1 % 2 = 0, array(1), CAST(NULL AS ARRAY<INT>)), array(2)) AS m
+FROM test_map_from_arrays_nondet

--- a/spark/src/test/scala/org/apache/comet/CometMapExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometMapExpressionSuite.scala
@@ -299,30 +299,33 @@ class CometMapExpressionSuite extends CometTestBase {
 
   // Finding E: a map nested inside a map value is handed to the JVM dispatcher whole, so its double
   // keys never revisit `CometLiteral`. The guard has to live on the lookup instead. The outer key
-  // type is INT, so inspecting only the outermost map would admit the query; the fallback comes
-  // from the inner `element_at`, whose child is `MapType(DoubleType, IntegerType)`. Constant folding
-  // is on here, which is the only configuration where the inner map becomes such a literal, so this
-  // regression cannot be expressed in a SQL fixture (the harness disables folding). The direct
-  // single-level double-key lookups live in `element_at_map.sql` / `get_map_value.sql`.
-  test("nested map lookup with floating-point keys falls back") {
+  // type is INT, so inspecting only the outermost map would admit the query; the dispatch comes
+  // from the `element_at` whose child is `MapType(DoubleType, IntegerType)`, which takes the whole
+  // nested lookup with it. Constant folding is on here, which is the only configuration where the
+  // inner map becomes such a literal, so this regression cannot be expressed in a SQL fixture (the
+  // harness disables folding). The direct single-level double-key lookups live in
+  // `element_at_map.sql` / `get_map_value.sql`.
+  test("nested map lookup with floating-point keys is dispatched") {
     withParquetTable((1 until 4).map(i => (i, i.toLong)), "tbl") {
       val negZero = "CAST(concat('-', CAST(_1 - 1 AS STRING), '.0') AS DOUBLE)"
-      checkSparkAnswerAndFallbackReason(
+      checkSparkAnswerAndImpl(
         "SELECT _1 AS id, element_at(element_at(map(1, map(CAST(0 AS DOUBLE), 7)), _1), " +
           s"$negZero) AS v FROM tbl",
-        "Spark normalizes floating-point map keys")
+        native = Seq.empty,
+        dispatched = Seq("element_at"))
     }
   }
 
   // Finding E for a collated inner key. Same folding-on-only bypass as the double-key case above;
   // the direct single-level collated lookup lives in `element_at_map_collation.sql`.
-  test("nested map lookup with collated string keys falls back") {
+  test("nested map lookup with collated string keys is dispatched") {
     assume(isSpark40Plus)
     withParquetTable(Seq(("a1", 0)), "tbl") {
-      checkSparkAnswerAndFallbackReason(
+      checkSparkAnswerAndImpl(
         "SELECT element_at(element_at(map(1, map(CAST('A1' AS STRING COLLATE UTF8_LCASE), 7)), 1), " +
           "CAST(_1 AS STRING COLLATE UTF8_LCASE)) AS v FROM tbl",
-        "cannot honour a non-default collation")
+        native = Seq.empty,
+        dispatched = Seq("element_at"))
     }
   }
 
@@ -395,39 +398,45 @@ class CometMapExpressionSuite extends CometTestBase {
 
   // Direct single-level folded map with floating-point keys: `map(CAST(0 AS DOUBLE), 7)` folds to a
   // literal and `element_at` with a dynamic `-0.0` lookup must match Spark's `+0.0`-normalized key.
-  // Native `map_extract` compares raw Arrow values, so `MapKeySupport` declines it at `element_at`.
-  // Spark returns 7, NULL, NULL. (`element_at_map.sql` covers the folding-off constructor form.)
-  test("folded map literal with floating-point keys in element_at falls back (multirow)") {
+  // Native `map_extract` compares raw Arrow values, so `MapKeySupport` declines it at `element_at`
+  // and the lookup runs through the JVM codegen dispatcher. Spark returns 7, NULL, NULL.
+  // (`element_at_map.sql` covers the folding-off constructor form.)
+  test("folded map literal with floating-point keys in element_at is dispatched (multirow)") {
     withParquetTable((1 until 4).map(i => (i, i.toLong)), "tbl") {
       val lookup = "CAST(concat('-', CAST(_1 - 1 AS STRING), '.0') AS DOUBLE)"
-      checkSparkAnswerAndFallbackReason(
+      checkSparkAnswerAndImpl(
         s"SELECT _1 AS id, element_at(map(CAST(0 AS DOUBLE), 7), $lookup) AS v FROM tbl",
-        "Spark normalizes floating-point map keys")
+        native = Seq.empty,
+        dispatched = Seq("element_at"))
     }
   }
 
   // Direct single-level folded map with collated string keys. Native lookup is bytewise, so a
-  // case-insensitive `a1` lookup against a stored `A1` cannot match; `MapKeySupport` declines it.
-  test("folded map literal with collated string keys in element_at falls back (multirow)") {
+  // case-insensitive `a1` lookup against a stored `A1` cannot match; `MapKeySupport` declines it
+  // and the dispatcher compares under the declared collation.
+  test("folded map literal with collated string keys in element_at is dispatched (multirow)") {
     assume(isSpark40Plus)
     withParquetTable(Seq(("a1", 0)), "tbl") {
-      checkSparkAnswerAndFallbackReason(
+      checkSparkAnswerAndImpl(
         "SELECT element_at(map(CAST('A1' AS STRING COLLATE UTF8_LCASE), 7), " +
           "CAST(_1 AS STRING COLLATE UTF8_LCASE)) AS v FROM tbl",
-        "cannot honour a non-default collation")
+        native = Seq.empty,
+        dispatched = Seq("element_at"))
     }
   }
 
   // Folded map with a complex (array) key. Spark permits a dynamic lookup array containing a NULL
   // element; native `map_extract` casts the lookup to the key's exact Arrow type and cannot
-  // reproduce Spark's equality, so `MapKeySupport` declines every complex key type. Spark returns
-  // 7, NULL, NULL. (`element_at_map.sql` covers the constructor form with a non-null lookup.)
-  test("folded map literal with complex array key in element_at falls back (multirow)") {
+  // reproduce Spark's equality, so `MapKeySupport` declines every complex key type and the lookup
+  // is dispatched. Spark returns 7, NULL, NULL. (`element_at_map.sql` covers the constructor form
+  // with a non-null lookup.)
+  test("folded map literal with complex array key in element_at is dispatched (multirow)") {
     withParquetTable((1 until 4).map(i => (i, i.toLong)), "tbl") {
-      checkSparkAnswerAndFallbackReason(
+      checkSparkAnswerAndImpl(
         "SELECT _1 AS id, element_at(map(array(1), 7), " +
           "array(IF(_1 = 2, CAST(NULL AS INT), _1))) AS v FROM tbl",
-        "casts the lookup key to the map's exact Arrow key type")
+        native = Seq.empty,
+        dispatched = Seq("element_at"))
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #5580, closes #5781.

## Rationale for this change

Two serde gaps in the array and map expressions, both resolved by the codegen dispatcher rather than by native changes.

`map_col[key]` and `element_at(map, key)` decline float, collated and complex map keys because the native lookup compares raw Arrow values where Spark normalizes `-0.0`, treats NaN as equal to itself, compares strings by collation and compares complex keys with interpreted ordering. The declines are right, but neither serde mixed in `CodegenDispatchFallback`, so the whole projection fell back to Spark instead of running Spark's own generated code inside the Comet pipeline.

`size`, `array_append`, `arrays_zip` and `map_from_arrays` reproduce Spark's NULL propagation with a `CASE WHEN child IS NOT NULL` guard that serializes the child twice. A stateful child advances each copy independently, so the guard and the operation see different rows and the answer is silently wrong: on a 16-row table with `IF(monotonically_increasing_id() % 2 = 0, array(1), NULL)` as the operand, `size` returned -1 on five rows where Spark returns 1, `arrays_zip` returned `[null, 2]` for `[1, 2]`, `array_append` returned `[2]` for `[1, 2]` and `map_from_arrays` returned NULL for `{1 -> 2}`. `element_at` had the same shape and was fixed in #5766 for its ANSI arm; these four are not ANSI-gated, so the wrong answers were reachable in every configuration.

## What changes are included in this PR?

- `CometMapExtract` and `CometElementAt` mix in `CodegenDispatchFallback`, so the declined key types run through the dispatcher. `CometElementAt`'s ANSI arm for a nondeterministic operand dispatches the same way.
- A shared `NullGuardSupport` gate declines any nondeterministic child in `CometSize`, `CometArrayAppend` (the array operand only; the item is not under the guard), `CometArraysZip` and `CometMapFromArrays`, and all four mix in `CodegenDispatchFallback`, so Spark's generated code evaluates the child once. Nullability is not consulted: a non-nullable stateful child only stays correct today because DataFusion skips the filter when the guard matches every row, which is not a contract to rely on.
- `getUnsupportedReasons` lists updated for the doc generator, and the six affected rows in the expressions guide move from Native to Hybrid.

## How are these changes tested?

SQL-file fixtures over parquet tables, all asserting Spark's answer and the execution path:

- Four new `*_nondeterministic_child.sql` fixtures, one per serde, with the stateful operand (dispatched), a non-nullable stateful operand (dispatched), and a deterministic nullable operand (native). `array_append` also pins that a stateful item stays native, and its fixture is capped at Spark 3.5 because 4.x rewrites `array_append` to `array_insert`. Before the change, the stateful cases failed as result mismatches with the values above.
- `element_at_map.sql` and `get_map_value.sql` flip their fallback cases to dispatch and add NaN lookups and a struct-keyed map column with a per-row key, a NULL inside the key and a NULL key. `element_at_map_collation.sql` flips the same way and passes on the Spark 4.0 profile. `element_at_ansi.sql` pins the dispatched nondeterministic arm.
- `map_from_arrays_dedup_policy.sql` disables the dispatcher so its LAST_WIN fallback assertion keeps meaning what it says, matching the existing `map_from_entries` fixture.
- `CometMapExpressionSuite` renames five fallback tests to dispatch tests through the helper that checks the dispatch tag.

578 of 578 across `CometSqlFileTestSuite`, `CometArrayExpressionSuite` and `CometMapExpressionSuite` on Spark 3.5, the map fixtures on the Spark 4.0 profile, and `test-compile` on 4.0.

## What this does not cover

`array_append` keeps its item inside the native NULL guard's `THEN` branch, which DataFusion evaluates only on the rows where the array is not NULL, while Spark's codegen evaluates the item on every row. A nondeterministic item is now declined to the dispatcher for that reason. A deterministic item that raises under ANSI on a row whose array is NULL, such as `1 / (_1 - 1)`, still runs natively and returns cleanly where Spark raises; closing that needs the item evaluated outside the guard or a broader decline, and is left for a follow-up.
