### PR TITLE
test: cover date maps in Parquet temporal fuzz tests

### DIFF
--- a/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometFuzzTestSuite.scala
@@ -274,15 +274,14 @@ class CometFuzzTestSuite extends CometFuzzTestBase {
         SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key -> outputTimestampType.toString,
         SQLConf.SESSION_LOCAL_TIMEZONE.key -> defaultTimezone) {
 
-        // TODO test with MapType
-        // https://github.com/apache/datafusion-comet/issues/2945
         val schema = StructType(
           Seq(
             StructField("c0", DataTypes.DateType),
             StructField("c1", DataTypes.createArrayType(DataTypes.DateType)),
             StructField(
               "c2",
-              DataTypes.createStructType(Array(StructField("c3", DataTypes.DateType))))))
+              DataTypes.createStructType(Array(StructField("c3", DataTypes.DateType)))),
+            StructField("c4", MapType(DateType, DateType))))
 
         ParquetGenerator.makeParquetFile(
           random,
@@ -309,10 +308,26 @@ class CometFuzzTestSuite extends CometFuzzTestBase {
                 val columns =
                   df.schema.fields
                     .filter(f => DataTypeSupport.hasTemporalType(f.dataType))
-                    .map(_.name)
 
                 for (col <- columns) {
-                  checkSparkAnswer(s"SELECT $col FROM t1 ORDER BY $col")
+                  // Maps are not orderable; the answer helper compares unordered results too.
+                  val (_, cometPlan) = col.dataType match {
+                    case _: MapType =>
+                      val query = s"SELECT ${col.name} FROM t1"
+                      if (int96TimestampConversion) {
+                        checkSparkAnswer(query)
+                      } else {
+                        checkSparkAnswerAndOperator(query)
+                      }
+                    case _ =>
+                      checkSparkAnswer(s"SELECT ${col.name} FROM t1 ORDER BY ${col.name}")
+                  }
+                  // INT96 timestamp conversion intentionally disables the Comet extension.
+                  if (!int96TimestampConversion) {
+                    assert(
+                      collectNativeScans(cometPlan).size == 1,
+                      s"Expected a Comet scan for ${col.name} in $tz:\n$cometPlan")
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #2945.

## Rationale for this change

The temporal Parquet fuzz tests cover date columns in scalar, array and struct form but omit maps.

## What changes are included in this PR?

Add a `map<date,date>` column to the existing test matrix. Compare maps without `ORDER BY` and assert native scans where Comet is enabled. Preserve the Spark answer checks when INT96 timestamp conversion disables Comet.

## How are these changes tested?

All nine temporal variants pass locally on Spark 4.1.3. [Fork CI](https://github.com/rich7420/datafusion-comet/actions/runs/34576588382) passed, including the scans suites on Spark 3.4–4.2 and macOS Spark 4.0.
