### PR TITLE
test: cover round expression routing configurations

### DIFF
--- a/spark/src/test/resources/sql-tests/expressions/math/round.sql
+++ b/spark/src/test/resources/sql-tests/expressions/math/round.sql
@@ -15,9 +15,13 @@
 -- specific language governing permissions and limitations
 -- under the License.
 
+-- Config: spark.comet.exec.scalaUDF.codegen.enabled=true
+-- ConfigMatrix: spark.comet.expression.round.allowIncompatible=false,true
+
 -- Integral and non-negative-scale decimal inputs round natively. Float and double inputs have no
 -- native implementation (Spark rounds them through BigDecimal built from Double.toString), so they
--- route through the codegen dispatcher and must match Spark exactly.
+-- route through the codegen dispatcher and must match Spark exactly. Enabling allowIncompatible
+-- must not change either route.
 
 statement
 CREATE TABLE test_round(d double, f float, dec decimal(10,4), i int, l bigint) USING parquet
@@ -93,3 +97,17 @@ SELECT l, round(l, -19), round(l, -20) FROM test_round_long_overflow
 
 query
 SELECT round(5000000000000000000L, -19), round(-5000000000000000000L, -19)
+
+-- Disabling the dispatcher leaves supported types native and sends float/double inputs to Spark,
+-- even with allowIncompatible enabled.
+statement
+SET spark.comet.exec.scalaUDF.codegen.enabled=false
+
+query expect_native(round)
+SELECT round(dec, 2), round(i, -1), round(l, -1) FROM test_round
+
+query expect_fallback(round: spark.comet.exec.scalaUDF.codegen.enabled=false)
+SELECT round(d, 2) FROM test_round
+
+query expect_fallback(round: spark.comet.exec.scalaUDF.codegen.enabled=false)
+SELECT round(f, 2) FROM test_round


### PR DESCRIPTION
## Which issue does this PR close?

Part of #4616.

## Rationale for this change

The `round` SQL tests do not pin routing with the codegen dispatcher disabled or distinguish native and dispatched null-scale handling.

## What changes are included in this PR?

Add a separate dispatcher-disabled fixture that checks native integral/decimal rounding and float/double fallback reasons. Assert native null-scale handling for decimal and integral inputs, and dispatched handling for float/double inputs.

## How are these changes tested?

All three round SQL fixtures pass locally on Spark 4.1 (3 tests, no failures or skips). The tests also catch injected regressions in dispatcher routing and native null-scale handling. Cross-version CI for this revision is pending.
